### PR TITLE
non-sticky popup in user map fix

### DIFF
--- a/public/javascripts/map.js
+++ b/public/javascripts/map.js
@@ -99,7 +99,7 @@ function addMarkerToMap(position, icon, description) {
 
    if (description) {
       marker.events.register("mouseover", marker, function() { openMapPopup(marker, description) });
-      marker.events.register("mouseout", marker, function() { closeMapPopup() });
+//      marker.events.register("mouseout", marker, function() { closeMapPopup() });
    }
 
    return marker;


### PR DESCRIPTION
prevent map popup from disappearing on mouseout, allowing the user to click on the name of the nearby mapper in the map on the user page.
