### PR TITLE
Updated gem needed because explicit memcached gem was yanked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    memcached (1.4.0)
+    memcached (1.4.1)
     mime-types (1.17.2)
     multi_json (1.1.0)
     multipart-post (1.1.5)


### PR DESCRIPTION
Needs updated gem.

http://rubygems.org/gems/memcached/versions
1.4.0 February 26, 2012 yanked
