### PR TITLE
Js fixup

### DIFF
--- a/app/assets/javascripts/map.js.erb
+++ b/app/assets/javascripts/map.js.erb
@@ -88,12 +88,14 @@ function getArrowIcon() {
 }
 
 function addMarkerToMap(position, icon, description) {
-   var marker = new OpenLayers.Marker(position.clone().transform(epsg4326, map.getProjectionObject()), icon);
+   var marker = new OpenLayers.Marker(proj(position), icon);
 
    markers.addMarker(marker);
 
    if (description) {
-      marker.events.register("mouseover", marker, function() { openMapPopup(marker, description) });
+       marker.events.register("mouseover", marker, function() {
+           openMapPopup(marker, description);
+       });
    }
 
    return marker;
@@ -155,9 +157,9 @@ function addBoxToMap(boxbounds, id, outline) {
    if (outline) {
      vertices = boxbounds.toGeometry().getVertices();
      vertices.push(new OpenLayers.Geometry.Point(vertices[0].x, vertices[0].y));
-     geometry = new OpenLayers.Geometry.LineString(vertices).transform(epsg4326, map.getProjectionObject());
+     geometry = proj(new OpenLayers.Geometry.LineString(vertices));
    } else {
-     geometry = boxbounds.toGeometry().transform(epsg4326, map.getProjectionObject());
+     geometry = proj(boxbounds.toGeometry());
    }
    var box = new OpenLayers.Feature.Vector(geometry, {}, {
       strokeWidth: 2,
@@ -197,27 +199,19 @@ function removeBoxFromMap(box){
    vectors.removeFeature(box);
 }
 
-function getMapCenter() {
-   return map.getCenter().clone().transform(map.getProjectionObject(), epsg4326);
+function proj(x) {
+    return x.clone().transform(epsg4326, map.getProjectionObject());
+}
+
+function unproj(x) {
+    return x.clone().transform(map.getProjectionObject(), epsg4326);
 }
 
 function setMapCenter(center, zoom) {
-   zoom = parseInt(zoom);
+   zoom = parseInt(zoom, 10);
    var numzoom = map.getNumZoomLevels();
    if (zoom >= numzoom) zoom = numzoom - 1;
-   map.setCenter(center.clone().transform(epsg4326, map.getProjectionObject()), zoom);
-}
-
-function setMapExtent(extent) {
-   map.zoomToExtent(extent.clone().transform(epsg4326, map.getProjectionObject()));
-}
-
-function getMapExtent() {
-   return map.getExtent().clone().transform(map.getProjectionObject(), epsg4326);
-}
-
-function getMapZoom() {
-   return map.getZoom();
+   map.setCenter(proj(center), zoom);
 }
 
 function getEventPosition(event) {
@@ -264,8 +258,4 @@ function setMapLayers(layerConfig) {
          }
       }
    }
-}
-
-function scaleToZoom(scale) {
-   return Math.log(360.0/(scale * 512.0)) / Math.log(2.0);
 }

--- a/app/assets/javascripts/site.js
+++ b/app/assets/javascripts/site.js
@@ -143,23 +143,6 @@ function setArgs(url, args) {
 }
 
 /*
- * Called to get a CSS property for an element.
- */
-function getStyle(el, property) {
-  var style;
-
-  if (el.currentStyle) {
-    style = el.currentStyle[property];
-  } else if( window.getComputedStyle ) {
-    style = document.defaultView.getComputedStyle(el,null).getPropertyValue(property);
-  } else {
-    style = el.style[property];
-  }
-
-  return style;
-}
-
-/*
  * Called to interpolate JavaScript variables in strings using a
  * similar syntax to rails I18n string interpolation - the only
  * difference is that [[foo]] is the placeholder syntax instead

--- a/app/views/browse/_map.html.erb
+++ b/app/views/browse/_map.html.erb
@@ -79,7 +79,7 @@
         var bbox = new OpenLayers.Bounds(minlon, minlat, maxlon, maxlat);
         var centre = bbox.getCenterLonLat();
 
-        setMapExtent(bbox);
+        map.setExtent(proj(bbox));
         addBoxToMap(bbox);
 
         $("#loading").hide();

--- a/app/views/changeset/_map.html.erb
+++ b/app/views/changeset/_map.html.erb
@@ -80,9 +80,9 @@
     selectControl.activate();
 
     <% if ! @bbox.nil? %>
-      setMapExtent(new OpenLayers.Bounds(<%= @bbox %>));
+      map.setExtent(proj(new OpenLayers.Bounds(<%= @bbox %>)));
     <% else %>
-      setMapExtent(bounds);
+      map.setExtent(proj(bounds));
     <% end %>
   }
 

--- a/app/views/site/_search.html.erb
+++ b/app/views/site/_search.html.erb
@@ -15,7 +15,7 @@
     $("#sidebar_title").html("<%= t 'site.sidebar.search_results' %>");
 
     <% if params[:action] == 'index' -%>
-    var extent = getMapExtent();
+    var extent = unproj(map.getExtent());
 
     $("#sidebar_content").load("<%= url_for :controller => :geocoder, :action => :search %>", {
       query: $("#query").val(),

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -144,7 +144,7 @@ end
       <% if bbox %>
         var bbox = new OpenLayers.Bounds(<%= minlon %>, <%= minlat %>, <%= maxlon %>, <%= maxlat %>);
 
-        setMapExtent(bbox);
+        map.setExtent(proj(bbox));
 
         <% if box %>
           $(window).load(function() { addBoxToMap(bbox) });
@@ -153,8 +153,8 @@ end
         var centre = new OpenLayers.LonLat(<%= lon %>, <%= lat %>);
         var zoom = <%= zoom %>;
 
-        <% if params[:scale] and params[:scale].length > 0 then %>
-          zoom = scaleToZoom(<%= params[:scale].to_f %>);
+        <% if params[:scale] and params[:scale].length > 0 and params[:scale].to_f > 0 then %>
+            zoom = <%= Math.log(360.0 / (params[:scale].to_f * 512.0)) / Math.log(2.0) %>;
         <% end %>
 
         setMapCenter(centre, zoom);
@@ -194,36 +194,29 @@ end
     }
   }
 
-  function getPosition() {
-    return getMapCenter();
-  }
-
-  function getZoom() {
-    return getMapZoom();
-  }
-
   function setPosition(lat, lon, zoom, min_lon, min_lat, max_lon, max_lat) {
     var centre = new OpenLayers.LonLat(lon, lat);
 
     if (min_lon && min_lat && max_lon && max_lat) {
       var bbox = new OpenLayers.Bounds(min_lon, min_lat, max_lon, max_lat);
 
-      setMapExtent(bbox);
+      map.setExtent(proj(bbox));
     } else {
       setMapCenter(centre, zoom);
     }
 
-    if (marker)
+    if (marker) {
       removeMarkerFromMap(marker);
+    }
 
     marker = addMarkerToMap(centre, getArrowIcon());
   }
 
   function updateLocation() {
-    var lonlat = getMapCenter();
+    var lonlat = unproj(map.getCenter());
     var zoom = map.getZoom();
     var layers = getMapLayers();
-    var extents = getMapExtent();
+    var extents = unproj(map.getExtent());
     var expiry = new Date();
     var objtype;
     var objid;
@@ -240,7 +233,7 @@ end
   }
 
   function remoteEditHandler(event) {
-    var extent = getMapExtent();
+    var extent = unproj(map.getExtent());
     var loaded = false;
 
     $("#linkloader").load(function () { loaded = true; });

--- a/app/views/user/_map.html.erb
+++ b/app/views/user/_map.html.erb
@@ -26,8 +26,8 @@ end
     var centre = new OpenLayers.LonLat(<%= lon %>, <%= lat %>);
     var zoom = <%= zoom %>;
 
-    <% if params['scale'] and params['scale'].length > 0 then %>
-    zoom = scaleToZoom(<%= params['scale'].to_f() %>);
+    <% if params[:scale] and params[:scale].length > 0 and params[:scale].to_f > 0 then %>
+    zoom = <%= Math.log(360.0 / (params[:scale].to_f * 512.0)) / Math.log(2.0) %>;
     <% end %>
 
     var map = createMap("map");


### PR DESCRIPTION
This commit should have no functional affect: it's the removal of a bunch of functions that were no longer used, and changes the abstraction level of OpenLayers from completely abstracting away `getMapExtent`, etc., to using OpenLayers's functionality directly but providing `proj` and `unproj` to make projections palatable.
