### PR TITLE
No user diaries tab

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -132,7 +132,7 @@ h2 {
 /* Rules for the menu displayed in the left sidebar */
 
 .left_menu {
-  padding: 5px;
+  padding: 5px 10px;
   margin: 4px 0;
   border-top: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
@@ -154,6 +154,13 @@ h2 {
 .left_menu li {
   margin: 0px;
   padding: 0px;
+}
+
+/* submenus */
+.left_menu ul li ul {
+  font-weight: normal;
+  line-height: 15px;
+  font-size: 12px;
 }
 
 .left_menu a {
@@ -178,7 +185,7 @@ h2 {
  */
 
 .optionalbox {
-  padding: 5px;
+  padding: 5px 10px;
   margin: 4px 0;
   border-top: 1px solid #ccc;
 }
@@ -210,7 +217,7 @@ h2 {
 }
 
 #search_field input[type="text"] {
-  width: 136px;
+  width: 130px;
 }
 
 #search_field input[type="submit"] {

--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -103,12 +103,27 @@
 
       <div id="left_menu" class="left_menu">
         <ul>
-          <li><%= link_to(t('layouts.help_centre'), t('layouts.help_url'), :title => t('layouts.help_title')) %></li>
-          <li><%= link_to(t('layouts.documentation'), t('layouts.wiki_url'), :title => t('layouts.documentation_title')) %></li>
-          <li><%= link_to t('layouts.copyright'), {:controller => 'site', :action => 'copyright'} %></li>
-          <li><a href="http://blogs.openstreetmap.org/" title="<%= t 'layouts.community_blogs_title' %>"><%= t 'layouts.community_blogs' %></a></li>
-          <li><a href="http://www.osmfoundation.org" title="<%= t 'layouts.foundation_title' %>"><%= t 'layouts.foundation' %></a></li>
           <%= yield :left_menu %>
+          <li><%= t'layouts.help' %>
+              <ul>
+              <li><%= link_to(t('layouts.help_centre'), t('layouts.help_url'), :title => t('layouts.help_title')) %></li>
+              <li><%= link_to(t('layouts.documentation'), t('layouts.wiki_url'), :title => t('layouts.documentation_title')) %></li>
+              <li><%= link_to t('layouts.copyright'), {:controller => 'site', :action => 'copyright'} %></li>
+              </ul>
+          </li>
+          <li><%= t'layouts.community' %>
+              <ul>
+              <li><a href="http://blogs.openstreetmap.org/" title="<%= t 'layouts.community_blogs_title' %>"><%= t 'layouts.community_blogs' %></a></li>
+              <li><a href="http://www.osmfoundation.org" title="<%= t 'layouts.foundation_title' %>"><%= t 'layouts.foundation' %></a></li>
+              <li><%= link_to(t('layouts.user_diaries'), {
+                  :controller => 'diary_entry',
+                  :action => 'list',
+                  :display_name => nil
+              }, {
+                  :title => t('layouts.user_diaries_tooltip')
+              }) %></li>
+              </ul>
+          </li>
         </ul>
       </div>
 


### PR DESCRIPTION
Does what it says on the tin: this eliminates the user diaries tab from the website, in an effort to eliminate extraneous content and move us towards true 'no tabs'. The commit:

This eliminates the user diaries tab. I've never understood
why it was there, and think it is of limited utility
given that it displays diary entries in all languages
at once, and user diaries aren't the centerpiece of the site.
