### PR TITLE
Making the disabled state of the primary menu items more disabled

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -290,7 +290,15 @@ h2 {
 #tabnav a:visited.disabled,
 #tabnav a:link:hover.disabled,
 #tabnav a:visited:hover.disabled {
-  color: #888;
+  color: #ccc;
+  cursor: default;
+}
+
+#tabnav a:link.disabled:hover,
+#tabnav a:visited.disabled:hover,
+#tabnav a:link:hover.disabled:hover,
+#tabnav a:visited:hover.disabled:hover {
+  text-decoration: none;
 }
 
 /* Rules for greeting bar in the top right corner */


### PR DESCRIPTION
This commit makes it a little more obvious that the primary menu items at the top have a disabled vs enabled state. I found this initially confusing myself.

Here's a quick link of what this commit looks like:
https://skitch.com/fallsemo/8k67t/screenshot-2012-03-17screen-shot-2012-03-17-at-3.01.31-pm
