### PR TITLE
Fix re-opening of the data layer

### DIFF
--- a/app/views/browse/start.js.erb
+++ b/app/views/browse/start.js.erb
@@ -32,7 +32,7 @@ function startBrowse() {
   browseBoxControl.handler.callbacks.done = endDrag;
   map.addControl(browseBoxControl);
 
-  map.events.register("moveend", map, showData);
+  map.events.register("moveend", map, updateData);
   map.events.triggerEvent("moveend");
 
   $("#browse_select_box").click(startDrag);
@@ -42,7 +42,7 @@ function startBrowse() {
   $("#browse_hide_areas_box").click(hideAreas);
 }
 
-function showData() {
+function updateData() {
   if (browseMode == "auto") {
     if (map.getZoom() >= 15) {
         useMap(false);
@@ -77,7 +77,7 @@ function stopBrowse() {
     } 
 
     map.dataLayer.setVisibility(false);
-    map.events.unregister("moveend", map, showData);
+    map.events.unregister("moveend", map, updateData);
   }    
 }
 


### PR DESCRIPTION
browse/start.js.erb redefined the function showData from index.html.erb, which prevented
the data layer from being reopened after closing it.

Rename showData to updateData in start.js.erb to resolve the clash
