### PR TITLE
Implement API endpoint to query permissions.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jquery-rails'
 gem 'rails-i18n', ">= 0.6.3"
 gem 'dynamic_form'
 gem 'rinku', '>= 1.2.2', :require => 'rails_rinku'
-gem 'oauth-plugin', '>= 0.4.0.1'
+gem 'oauth-plugin', :git => 'git://github.com/tomhughes/oauth-plugin.git' # while waiting for release of version 0.4.0.1
 gem 'open_id_authentication', '>= 1.1.0'
 gem 'validates_email_format_of', '>= 1.5.1'
 gem 'composite_primary_keys', '>= 5.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/tomhughes/oauth-plugin.git
+  revision: 6c929fdc10d00f69743e01c704663f5cdd887a3d
+  specs:
+    oauth-plugin (0.4.0)
+      multi_json
+      oauth (~> 0.4.4)
+      oauth2 (>= 0.5.0)
+      rack
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -72,11 +82,6 @@ GEM
     multipart-post (1.1.5)
     nokogiri (1.5.2)
     oauth (0.4.6)
-    oauth-plugin (0.4.0.1)
-      multi_json
-      oauth (~> 0.4.4)
-      oauth2 (>= 0.5.0)
-      rack
     oauth2 (0.7.0)
       faraday (~> 0.8)
       httpauth (~> 0.1)
@@ -165,7 +170,7 @@ DEPENDENCIES
   jquery-rails
   libxml-ruby (>= 2.0.5)
   memcached (>= 1.4.1)
-  oauth-plugin (>= 0.4.0.1)
+  oauth-plugin!
   open_id_authentication (>= 1.1.0)
   paperclip (~> 2.0)
   pg

--- a/app/views/api/permissions.builder
+++ b/app/views/api/permissions.builder
@@ -1,0 +1,9 @@
+# create list of permissions
+xml.instruct! :xml, :version=>"1.0"
+xml.osm("version" => "#{API_VERSION}", "generator" => "OpenStreetMap Server") do
+  xml.permissions do
+    @permissions.each do |permission|
+      xml.permission :name => permission
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ OpenStreetMap::Application.routes.draw do
   # API
   match 'api/capabilities' => 'api#capabilities', :via => :get
   match 'api/0.6/capabilities' => 'api#capabilities', :via => :get
+  match 'api/0.6/permissions' => 'api#permissions', :via => :get
 
   match 'api/0.6/changeset/create' => 'changeset#create', :via => :put
   match 'api/0.6/changeset/:id/upload' => 'changeset#upload', :via => :post, :id => /\d+/

--- a/test/functional/api_controller_test.rb
+++ b/test/functional/api_controller_test.rb
@@ -298,4 +298,42 @@ class ApiControllerTest < ActionController::TestCase
       end
     end
   end
+
+  def test_permissions_anonymous
+    get :permissions
+    assert_response :success
+    assert_select "osm > permissions", :count => 1 do
+      assert_select "permission", :count => 0
+    end
+  end
+
+  def test_permissions_basic_auth
+    basic_authorization(users(:normal_user).email, "test")
+    get :permissions
+    assert_response :success
+    assert_select "osm > permissions", :count => 1 do
+      assert_select "permission", :count => ClientApplication.all_permissions.size
+      ClientApplication.all_permissions.each do |p|
+        assert_select "permission[name=#{p}]", :count => 1
+      end
+    end
+  end
+
+  def test_permissions_oauth
+    @token =  AccessToken.new do |token|
+      # Just to test a few
+      token.allow_read_prefs = true
+      token.allow_write_api = true
+      token.allow_read_gpx = false
+    end
+    @request.env["oauth.token"] = @token
+    get :permissions
+    assert_response :success
+    assert_select "osm > permissions", :count => 1 do
+      assert_select "permission", :count => 2
+      assert_select "permission[name=allow_read_prefs]", :count => 1
+      assert_select "permission[name=allow_write_api]", :count => 1
+      assert_select "permission[name=allow_read_gpx]", :count => 0
+    end
+  end
 end


### PR DESCRIPTION
This commit adds an API endpoint where a api client can query which permissions have been granted. Primary use is to find out what can be done with an access token (since a user can always check off permissions during Oauth authentication/authorization). We suggested this feature on the openstreetmap-dev-list:

http://lists.openstreetmap.org/pipermail/dev/2012-April/024858.html

This feature allows for more user-friendly Oauth client applications as they can e.g. find out whether they can write to the map without actually changing it (thus creating a changeset) and to give feedback to the authenticating user.

Remark: we found 3 failing tests in the original code, which are still failing (test_changes_simple, test_changes_zoom_valid, test_hours_valid).
