### PR TITLE
Data display feature size limit

### DIFF
--- a/app/views/browse/start.js.erb
+++ b/app/views/browse/start.js.erb
@@ -245,7 +245,7 @@ function loadGML(url, reload) {
     browseDataLayer = new OpenLayers.Layer.GML("Data", url, {
       format: OpenLayers.Format.OSM,
       formatOptions: formatOptions,
-      maxFeatures: 100,
+      maxFeatures: 2000,
       requestSuccess: customDataLoader,
       displayInLayerSwitcher: false,
       styleMap: new OpenLayers.StyleMap({


### PR DESCRIPTION
Make the maximum number of features for data display 2000 items instead of 100.

https://trac.openstreetmap.org/ticket/3697 and https://trac.openstreetmap.org/ticket/3127
