### PR TITLE
Add link on main OSM copyright page pointing to Contributors page on wiki

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1140,6 +1140,12 @@ en:
       </ul>
 
       <p>
+        For further details of these, and other sources that have been used
+        to help improve OpenStreetMap, please see the <a
+        href="http://wiki.openstreetmap.org/wiki/Contributors">Contributors
+        page</a> on the OpenStreetMap Wiki.
+      </p>
+      <p>
         Inclusion of data in OpenStreetMap does not imply that the original
         data provider endorses OpenStreetMap, provides any warranty, or
         accepts any liability.


### PR DESCRIPTION
http://wiki.openstreetmap.org/wiki/Contributors contains useful additional information about the sources already mentioned on http://www.openstreetmap.org/copyright together with details of further sources (including some with attribution statements) that are not currently mentioned on http://www.openstreetmap.org/copyright .

The further attribution statements should certainly be discoverable by users viewing http://www.openstreetmap.org/copyright , and the additional information is helpful too. Hence my suggestion to add a link.
