### PR TITLE
Store an optional redaction 'mode' with each redaction.

### DIFF
--- a/app/controllers/old_controller.rb
+++ b/app/controllers/old_controller.rb
@@ -57,12 +57,12 @@ class OldController < ApplicationController
       # if a redaction ID was specified, then set this element to
       # be redacted in that redaction.
       redaction = Redaction.find(redaction_id.to_i)
-      @old_element.redact!(redaction)
+      @old_element.redact!(redaction,params['mode'])
       
     else
       # if no redaction ID was provided, then this is an unredact
       # operation.
-      @old_element.redact!(nil)
+      @old_element.redact!(nil,nil)
     end
     
     # just return an empty 200 OK for success

--- a/db/migrate/20120709113205_add_redaction_modes.rb
+++ b/db/migrate/20120709113205_add_redaction_modes.rb
@@ -1,0 +1,13 @@
+class AddRedactionModes < ActiveRecord::Migration
+  def up
+    [:nodes, :ways, :relations].each do |tbl|
+      add_column tbl, :redaction_mode, :string, :null => true
+    end
+  end
+
+  def down
+    [:nodes, :ways, :relations].each do |tbl|
+      remove_column tbl, :redaction_mode
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -696,7 +696,8 @@ CREATE TABLE nodes (
     "timestamp" timestamp without time zone NOT NULL,
     tile bigint NOT NULL,
     version bigint NOT NULL,
-    redaction_id integer
+    redaction_id integer,
+    redaction_mode character varying(255)
 );
 
 
@@ -849,7 +850,8 @@ CREATE TABLE relations (
     "timestamp" timestamp without time zone NOT NULL,
     version bigint NOT NULL,
     visible boolean DEFAULT true NOT NULL,
-    redaction_id integer
+    redaction_id integer,
+    redaction_mode character varying(255)
 );
 
 
@@ -1061,7 +1063,8 @@ CREATE TABLE ways (
     "timestamp" timestamp without time zone NOT NULL,
     version bigint NOT NULL,
     visible boolean DEFAULT true NOT NULL,
-    redaction_id integer
+    redaction_id integer,
+    redaction_mode character varying(255)
 );
 
 
@@ -2262,6 +2265,8 @@ INSERT INTO schema_migrations (version) VALUES ('20120318201948');
 INSERT INTO schema_migrations (version) VALUES ('20120328090602');
 
 INSERT INTO schema_migrations (version) VALUES ('20120404205604');
+
+INSERT INTO schema_migrations (version) VALUES ('20120709113205');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 

--- a/lib/not_redactable.rb
+++ b/lib/not_redactable.rb
@@ -5,7 +5,7 @@ module NotRedactable
     false
   end
 
-  def redact!(r)
+  def redact!(r, m = nil)
     raise OSM::APICannotRedactError.new
   end
 end

--- a/lib/redactable.rb
+++ b/lib/redactable.rb
@@ -11,12 +11,13 @@ module Redactable
     not self.redaction.nil?
   end
 
-  def redact!(redaction)
+  def redact!(redaction, mode = nil)
     # check that this version isn't the current version
     raise OSM::APICannotRedactError.new if self.is_latest_version?
 
     # make the change
     self.redaction = redaction
+    self.redaction_mode = mode
     self.save!
   end
 end

--- a/test/functional/old_node_controller_test.rb
+++ b/test/functional/old_node_controller_test.rb
@@ -259,6 +259,17 @@ class OldNodeControllerTest < ActionController::TestCase
     assert_select "osm node[id=#{node.node_id}][version=#{node.version}]", 1, "node #{node.node_id} version #{node.version} should still be present in the history for moderators when passing flag."
   end
 
+  ##
+  # test that a moderator can optionally pass a mode
+  # to the redaction
+  def test_redact_node_with_mode
+    node = nodes(:node_with_versions_v3)
+    basic_authorization(users(:moderator_user).email, "test")
+
+    do_redact_node_with_mode(node, redactions(:example), "hidden")
+    assert_response :success, "should be OK to redact old version with a mode."
+  end
+
   # testing that if the moderator drops auth, he can't see the
   # redacted stuff any more.
   def test_redact_node_is_redacted
@@ -287,6 +298,14 @@ class OldNodeControllerTest < ActionController::TestCase
     
     # now redact it
     post :redact, :id => node.node_id, :version => node.version, :redaction => redaction.id
+  end
+
+  def do_redact_node_with_mode(node, redaction, mode)
+    get :version, :id => node.node_id, :version => node.version
+    assert_response :success, "should be able to get version #{node.version} of node #{node.node_id}."
+
+    # now redact it, with a mode
+    post :redact, :id => node.node_id, :version => node.version, :redaction => redaction.id, :mode => mode
   end
 
   def check_current_version(node_id)

--- a/test/unit/redaction_test.rb
+++ b/test/unit/redaction_test.rb
@@ -33,4 +33,14 @@ class RedactionTest < ActiveSupport::TestCase
     assert_equal(true, n.redacted?, "Expected node to be redacted after redact! call.")
   end
 
+  def test_can_set_mode
+    n = nodes(:node_with_versions_v3)
+    r = redactions(:example)
+    m = "hidden"
+    assert_equal(nil, n.redaction_mode, "Expected node not to have a redaction mode already.")
+    assert_nothing_raised(OSM::APICannotRedactError) do
+      n.redact!(r, m)
+    end
+    assert_equal(m, n.redaction_mode, "Expected node to be redacted with a mode.")
+  end
 end


### PR DESCRIPTION
The licence-change bot considers two types of redaction, visible and hidden, depending on the
exact reasons for the redaction, but there is scope for more redaction modes in future.

I think it's worth storing these modes for now, even though they aren't currently used by either the API or the web interface.
