### PR TITLE
Use 'data-remote' attribute for AJAX links

### DIFF
--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -39,7 +39,7 @@
         <li><%= link_to t('layouts.view'), {:controller => 'site', :action => 'index'}, {:id => 'viewanchor', :title => t('layouts.view_tooltip'), :class => viewclass} %></li>
         <li><%= link_to h(t('layouts.edit')) + content_tag(:span, "▾", :class => "menuicon"), {:controller => 'site', :action => 'edit'}, {:id => 'editanchor', :title => t('javascripts.site.edit_tooltip'), :class => editclass} %></li>
         <li><%= link_to t('layouts.history'), {:controller => 'changeset', :action => 'list' }, {:id => 'historyanchor', :title => t('javascripts.site.history_tooltip'), :class => historyclass} %></li>
-        <li><%= link_to t('layouts.export'), {:controller => 'site', :action => 'export'}, {:id => 'exportanchor', :title => t('layouts.export_tooltip'), :class => exportclass} %></li>
+        <li><%= link_to t('layouts.export'), {:controller => 'export', :action => 'start'}, {:id => 'exportanchor', :title => t('layouts.export_tooltip'), :class => exportclass, :data => {:remote => true}} %></li>
       </ul>
     </div>
 

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -280,13 +280,8 @@ end
   });
 
   $(document).ready(function () {
-    $("#exportanchor").click(function (e) {
-      $.ajax({ url: "<%= url_for :controller => :export, :action => :start %>" });
-      e.preventDefault();
-    });
-
     <% if params[:action] == 'export' -%>
-    $.ajax({ url: "<%= url_for :controller => :export, :action => :start %>" });
+    $("#exportanchor").click();
     <% end -%>
 
     <% if params[:query] -%>


### PR DESCRIPTION
This takes advantage of Rails UJS adapter to make the AJAX
requests automatically and avoids the need to interpolate
a `url_for` into embedded JS.

Tested both links manually as well as the /export route.
