### PR TITLE
User cleanup

### DIFF
--- a/app/views/user/view.html.erb
+++ b/app/views/user/view.html.erb
@@ -92,7 +92,7 @@
 <div id="description"><%= @this_user.description.to_html %></div>
 
 <p class='deemphasize'><small>
-<%= t 'user.view.mapper since' %> <%= l @this_user.creation_time, :format => :friendly %>
+<%= t 'user.view.mapper since' %> <%= l @this_user.creation_time.to_date, :format => :long %>
 /
 <%= t 'user.view.ct status' %>
 <% if not @this_user.terms_agreed.nil? -%>


### PR DESCRIPTION
Basic reworking of user page elements - deemphasizes header text and joined/terms dates, emphasizes bio.

Before:

![](http://dl.dropbox.com/u/68059/Screenshots/n3fxxvf7w-d5.png)

After:

![](http://dl.dropbox.com/u/68059/Screenshots/yex_4xhpfw3b.png)
