### PR TITLE
Use a param to trigger export rather than a separate action

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -6,10 +6,6 @@ class SiteController < ApplicationController
   before_filter :set_locale
   before_filter :require_user, :only => [:edit]
 
-  def export
-    render :action => 'index'
-  end
-
   def permalink
     lon, lat, zoom = ShortLink::decode(params[:code])
     new_params = params.clone

--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -41,7 +41,7 @@
           :title => t('javascripts.site.history_tooltip'),
           :class => 'geolink bbox'
         } %></li>
-        <li><%= link_to t('layouts.export'), export_path, {
+        <li><%= link_to t('layouts.export'), root_path(:export => true), {
           :id => 'exportanchor',
           :title => t('layouts.export_tooltip'),
           :class => 'geolink llz layers'

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -291,7 +291,7 @@ end
       e.preventDefault();
     });
 
-    <% if params[:action] == 'export' -%>
+    <% if params[:export] -%>
     $("#exportanchor").click();
     <% end -%>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,6 @@ OpenStreetMap::Application.routes.draw do
   match '/copyright' => 'site#copyright', :via => :get
   match '/history' => 'changeset#list', :via => :get
   match '/history/feed' => 'changeset#feed', :via => :get, :format => :atom
-  match '/export' => 'site#export', :via => :get
   match '/login' => 'user#login', :via => [:get, :post]
   match '/logout' => 'user#logout', :via => [:get, :post]
   match '/offline' => 'site#offline', :via => :get

--- a/test/functional/site_controller_test.rb
+++ b/test/functional/site_controller_test.rb
@@ -35,14 +35,6 @@ class SiteControllerTest < ActionController::TestCase
       { :controller => "site", :action => "copyright", :copyright_locale => "locale" }
     )
     assert_routing(
-      { :path => "/export", :method => :get },
-      { :controller => "site", :action => "export" }
-    )
-    assert_recognizes(
-      { :controller => "site", :action => "export", :format => "html" },
-      { :path => "/export.html", :method => :get }
-    )
-    assert_routing(
       { :path => "/offline", :method => :get },
       { :controller => "site", :action => "offline" }
     )
@@ -74,14 +66,6 @@ class SiteControllerTest < ActionController::TestCase
     get :edit
     # Should be redirected
     assert_redirected_to :controller => :user, :action => 'login', :referer => "/edit"
-  end
-  
-  # Get the export page
-  def test_export
-    get :export
-    assert_response :success
-    assert_template 'index'
-    assert_site_partials
   end
   
   # Offline page


### PR DESCRIPTION
In `site/_resize.html.erb` and `site/_search.html.erb`, a
`params[:action]` conditional is used to include code that should only run on
the index action -- but it should be run on the export action too. Cleanest
fix is to eliminate that action entirely.
