### PR TITLE
Define content type and charset

### DIFF
--- a/public/export/embed.html
+++ b/public/export/embed.html
@@ -1,8 +1,8 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head>
+    <meta charset="utf-8">
     <title>OpenStreetMap Embedded</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style type="text/css">
         html {
             width: 100%;


### PR DESCRIPTION
Embed Content-Type and more importantly charset so that browsers correctly select UTF-8 when web server charset isn't defined.
