### PR TITLE
Hide the view/edit/history bar on a few vital pages

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -332,8 +332,8 @@ body.site-index #tabnav a#viewanchor,
 body.site-edit #tabnav a#editanchor,
 body.changeset-list #tabnav a#historyanchor,
 body.site-export #tabnav a#exportanchor {
-  border-bottom: 1px solid #aaa;
-  background: #9ed485;
+  background: #cbeea7;
+  border-bottom:1px solid #9ed485;
   color: #000;
 }
 
@@ -360,7 +360,9 @@ body.user,
 body.diary_entry,
 body.message {
     #tabnav {
-        display:none;
+        #editanchor, #historyanchor, #exportanchor {
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
This hides the tab nav on user pages, diary pages, and message pages. On those pages, none of the buttons are functional and they're confusing because often the page has edit functionality of its own - for instance, a big 'Edit' link that does nothing at the top of a Diary entry that has an 'Edit this entry' link hidden at the bottom.
