### PR TITLE
Remove the notice about the license change in the login page

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -259,10 +259,6 @@ class UserController < ApplicationController
       else
         password_authentication(params[:username], params[:password])
       end
-    elsif params[:notice]
-      flash.now[:notice] = t "user.login.notice_#{params[:notice]}"
-    elsif flash[:notice].nil?
-      flash.now[:notice] =  t 'user.login.notice'
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1587,8 +1587,6 @@ en:
       account not active: "Sorry, your account is not active yet.<br />Please use the link in the account confirmation email to activate your account, or <a href=\"%{reconfirm}\">request a new confirmation email</a>."
       account is suspended: Sorry, your account has been suspended due to suspicious activity.<br />Please contact the <a href="%{webmaster}">webmaster</a> if you wish to discuss this.
       auth failure: "Sorry, could not log in with those details."
-      notice: "<a href=\"http://www.osmfoundation.org/wiki/License/We_Are_Changing_The_License\">Find out more about OpenStreetMap's upcoming license change</a> (<a href=\"http://wiki.openstreetmap.org/wiki/ODbL/We_Are_Changing_The_License\">translations</a>) (<a href=\"http://wiki.openstreetmap.org/wiki/Talk:ODbL/Upcoming\">discussion</a>)"
-      notice_terms: "OpenStreetMap is moving to a new licence on 1st April 2012. It's just as open as our current one, but the legal bits are much better suited to our map database. We'd love to keep your contributions in OpenStreetMap, but we can only do so if you agree to let us distribute them under the new licence. Otherwise, we'll have to remove them from the database.<br /><br />Please log in, then take a few seconds to review and accept the new terms. Thank you!"
       openid missing provider: "Sorry, could not contact your OpenID provider"
       openid invalid: "Sorry, your OpenID seems to be malformed"
       openid_logo_alt: "Log in with an OpenID"


### PR DESCRIPTION
As we are done with the license change there is no need for the notice on the login page about it.
