### PR TITLE
Remove the date people accepted Contributor terms on OSM personal page

### DIFF
--- a/app/views/user/view.html.erb
+++ b/app/views/user/view.html.erb
@@ -80,15 +80,15 @@
 
 <p><b><%= t 'user.view.mapper since' %></b> <%= l @this_user.creation_time, :format => :friendly %> <%= t 'user.view.ago', :time_in_words_ago => time_ago_in_words(@this_user.creation_time) %></p>
 
+<% if @this_user.terms_agreed.nil? -%>
 <p><b><%= t 'user.view.ct status' %></b>
-<% if not @this_user.terms_agreed.nil? -%>
-<%= t 'user.view.ct accepted', :ago =>time_ago_in_words(@this_user.terms_agreed)  %> 
-<% elsif not @this_user.terms_seen? -%>
+<% if not @this_user.terms_seen? -%>
 <%= t 'user.view.ct undecided' %>
 <% else -%>
 <%= t 'user.view.ct declined' %>
 <% end -%>
 </p>
+<% end -%>
 
 <% if @user and @user.administrator? -%>
   <p><b><%= t 'user.view.email address' %></b> <%= @this_user.email %></p>  


### PR DESCRIPTION
Cleans up the user page a bit. This is not needed any longer for people who have accepted.
