### PR TITLE
Use Konacha for testing JavaScript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,11 @@ group :test do
   gem 'minitest', '~> 4.7.0', :platforms => [:ruby_19, :ruby_20]
 end
 
+group :test, :development do
+  gem 'konacha'
+  gem 'poltergeist'
+end
+
 # Gems needed for compiling assets
 group :assets do
   gem 'sass-rails', '~> 3.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,12 @@ GEM
     arel (3.0.2)
     bigdecimal (1.1.0)
     builder (3.0.4)
+    capybara (2.1.0)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.1)
@@ -43,19 +49,24 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.6.2)
+    colorize (0.5.8)
     composite_primary_keys (5.0.13)
       activerecord (~> 3.2.0, >= 3.2.9)
     deadlock_retry (1.2.0)
     dynamic_form (1.1.4)
     ejs (1.1.1)
     erubis (2.7.0)
+    eventmachine (1.0.3)
     execjs (1.4.0)
       multi_json (~> 1.0)
     faraday (0.8.7)
       multipart-post (~> 1.1)
+    faye-websocket (0.4.7)
+      eventmachine (>= 0.12.0)
     hike (1.2.3)
     htmlentities (4.3.1)
     http_accept_language (1.0.2)
+    http_parser.rb (0.5.3)
     httpauth (0.2.0)
     httpclient (2.3.3)
     i18n (0.6.4)
@@ -74,6 +85,12 @@ GEM
       jsonify (< 0.4.0)
     jwt (0.1.8)
       multi_json (>= 1.5)
+    konacha (3.0.0)
+      actionpack (>= 3.1, < 5)
+      capybara
+      colorize
+      railties (>= 3.1, < 5)
+      sprockets
     libv8 (3.3.10.4)
     libxml-ruby (2.6.0)
     mail (2.4.4)
@@ -110,6 +127,10 @@ GEM
       cocaine (>= 0.0.2)
       mime-types
     pg (0.15.1)
+    poltergeist (1.3.0)
+      capybara (~> 2.1.0)
+      faye-websocket (>= 0.4.4, < 0.5.0)
+      http_parser.rb (~> 0.5.3)
     polyglot (0.3.3)
     psych (2.0.0)
     r2 (0.2.1)
@@ -174,6 +195,8 @@ GEM
       multi_json (~> 1.0, >= 1.0.2)
     validates_email_format_of (1.5.3)
     vendorer (0.1.14)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -193,6 +216,7 @@ DEPENDENCIES
   iconv (= 0.1)
   jquery-rails
   jsonify-rails
+  konacha
   libxml-ruby (>= 2.0.5)
   memcached (>= 1.4.1)
   minitest (~> 4.7.0)
@@ -200,6 +224,7 @@ DEPENDENCIES
   open_id_authentication (>= 1.1.0)
   paperclip (~> 2.0)
   pg
+  poltergeist
   psych
   r2
   rack-cors

--- a/config/initializers/konacha.rb
+++ b/config/initializers/konacha.rb
@@ -1,0 +1,5 @@
+Konacha.configure do |config|
+  require 'capybara/poltergeist'
+  config.spec_dir = "test/javascripts"
+  config.driver   = :poltergeist
+end if defined?(Konacha)

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -1,0 +1,135 @@
+//= require jquery
+//= require jquery.cookie
+//= require osm
+
+describe("OSM", function () {
+  describe(".apiUrl", function () {
+    it("returns a URL for a way", function () {
+      expect(OSM.apiUrl({type: "way", id: 10})).to.eq("/api/0.6/way/10/full");
+    });
+
+    it("returns a URL for a node", function () {
+      expect(OSM.apiUrl({type: "node", id: 10})).to.eq("/api/0.6/node/10");
+    });
+
+    it("returns a URL for a specific version", function () {
+      expect(OSM.apiUrl({type: "node", id: 10, version: 2})).to.eq("/api/0.6/node/10/2");
+    });
+  });
+
+  describe(".mapParams", function () {
+    beforeEach(function () {
+      delete OSM.home;
+      delete OSM.location;
+      document.cookie = "_osm_location=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+
+      // Test with another cookie set.
+      document.cookie = "_osm_session=deadbeef";
+    });
+
+    it("parses marker params", function () {
+      var params = OSM.mapParams("?mlat=57.6247&mlon=-3.6845");
+      expect(params).to.have.property("mlat", 57.6247);
+      expect(params).to.have.property("mlon", -3.6845);
+      expect(params).to.have.property("marker", true);
+    });
+
+    it("parses object params", function () {
+      var params = OSM.mapParams("?node=1");
+      expect(params).to.have.property("object");
+      expect(params).to.have.property("object_zoom", true);
+      expect(params.object).to.eql({type: "node", id: 1});
+
+      params = OSM.mapParams("?way=1");
+      expect(params).to.have.property("object");
+      expect(params).to.have.property("object_zoom", true);
+      expect(params.object).to.eql({type: "way", id: 1});
+
+      params = OSM.mapParams("?relation=1");
+      expect(params).to.have.property("object");
+      expect(params).to.have.property("object_zoom", true);
+      expect(params.object).to.eql({type: "relation", id: 1});
+    });
+
+    it("parses bbox params", function () {
+      var params = OSM.mapParams("?bbox=-3.6845,57.6247,-3.7845,57.7247");
+      expect(params).to.have.property("bbox", true);
+      expect(params).to.have.property("minlon", -3.6845);
+      expect(params).to.have.property("minlat", 57.6247);
+      expect(params).to.have.property("maxlon", -3.7845);
+      expect(params).to.have.property("maxlat", 57.7247);
+      expect(params).to.have.property("box", false);
+
+      params = OSM.mapParams("?minlon=-3.6845&minlat=57.6247&maxlon=-3.7845&maxlat=57.7247");
+      expect(params).to.have.property("bbox", true);
+      expect(params).to.have.property("minlon", -3.6845);
+      expect(params).to.have.property("minlat", 57.6247);
+      expect(params).to.have.property("maxlon", -3.7845);
+      expect(params).to.have.property("maxlat", 57.7247);
+      expect(params).to.have.property("box", false);
+
+      params = OSM.mapParams("?bbox=-3.6845,57.6247,-3.7845,57.7247&box=yes");
+      expect(params).to.have.property("box", true);
+
+      params = OSM.mapParams("?minlon=-3.6845&minlat=57.6247&maxlon=-3.7845&maxlat=57.7247&box=yes");
+      expect(params).to.have.property("box", true);
+    });
+
+    it("infers lat/long from bbox", function () {
+      var params = OSM.mapParams("?bbox=-3.6845,57.6247,-3.7845,57.7247");
+      expect(params).to.have.property("lat", 57.6747);
+      expect(params).to.have.property("lon", -3.7344999999999997);
+
+      params = OSM.mapParams("?minlon=-3.6845&minlat=57.6247&maxlon=-3.7845&maxlat=57.7247");
+      expect(params).to.have.property("lat", 57.6747);
+      expect(params).to.have.property("lon", -3.7344999999999997);
+    });
+
+    it("parses lat/lon params", function () {
+      var params = OSM.mapParams("?lat=57.6247&lon=-3.6845");
+      expect(params).to.have.property("lat", 57.6247);
+      expect(params).to.have.property("lon", -3.6845);
+
+      params = OSM.mapParams("?mlat=57.6247&mlon=-3.6845");
+      expect(params).to.have.property("lat", 57.6247);
+      expect(params).to.have.property("lon", -3.6845);
+    });
+
+    it("sets lat/lon from OSM.home", function () {
+      OSM.home = {lat: 57.6247, lon: -3.6845};
+      var params = OSM.mapParams("?");
+      expect(params).to.have.property("lat", 57.6247);
+      expect(params).to.have.property("lon", -3.6845);
+    });
+
+    it("sets bbox from OSM.location", function () {
+      OSM.location = {minlon: -3.6845, minlat: 57.6247, maxlon: -3.7845, maxlat: 57.7247};
+      var params = OSM.mapParams("?");
+      expect(params).to.have.property("bbox", true);
+      expect(params).to.have.property("minlon", -3.6845);
+      expect(params).to.have.property("minlat", 57.6247);
+      expect(params).to.have.property("maxlon", -3.7845);
+      expect(params).to.have.property("maxlat", 57.7247);
+    });
+
+    it("parses params from the _osm_location cookie", function () {
+      document.cookie = "_osm_location=-3.6845|57.6247|5|M";
+      var params = OSM.mapParams("?");
+      expect(params).to.have.property("lat", 57.6247);
+      expect(params).to.have.property("lon", -3.6845);
+      expect(params).to.have.property("zoom", 5);
+      expect(params).to.have.property("layers", "M");
+    });
+
+    it("defaults lat/lon to London", function () {
+      var params = OSM.mapParams("?");
+      expect(params).to.have.property("lat", 51.5);
+      expect(params).to.have.property("lon", -0.1);
+    });
+
+    it("parses layers param", function () {
+      var params = OSM.mapParams("?layers=M");
+      expect(params).to.have.property("layers", "M");
+    });
+  });
+});


### PR DESCRIPTION
As previously discussed on the mailing list.

One concern raised there was that we needed to have the ability to
run specs from the command line without opening a browser window.
I've configured konacha to use poltergeist, a PhantomJS-based driver,
so the `konacha:run` rake task is completely headless.

We seem to have general consensus that testing the OSM.org JS would
be a good thing. What needs to happen to adopt konacha (or any other
technology)?
