### PR TITLE
Remove @midnode assign

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -30,9 +30,6 @@ class BrowseController < ApplicationController
     @way = Way.find(params[:id], :include => [:way_tags, {:changeset => :user}, {:nodes => [:node_tags, {:ways => :way_tags}]}, :containing_relation_members])
     @next = Way.visible.where("id > ?", @way.id).order("id ASC").first
     @prev = Way.visible.where("id < ?", @way.id).order("id DESC").first
-
-    # Used for edit link, takes approx middle node of way
-    @midnode = @way.nodes[@way.nodes.length/2]
   rescue ActiveRecord::RecordNotFound
     render :action => "not_found", :status => :not_found
   end

--- a/app/views/browse/way.html.erb
+++ b/app/views/browse/way.html.erb
@@ -12,6 +12,4 @@
 <hr />
 <%= link_to(t('browse.way.download_xml'), :controller => "way", :action => "read") %>
 | <%= link_to(t('browse.way.view_history'), :action => "way_history") %>
-<% unless @midnode.nil? -%>
-| <%= link_to(t('browse.way.edit'), :controller => "site", :action => "edit", :way => @way.id, :lat => @midnode.lat, :lon => @midnode.lon, :zoom => 16) %>
-<% end -%>
+| <%= link_to(t('browse.way.edit'), :controller => "site", :action => "edit", :way => @way.id) %>


### PR DESCRIPTION
It does not appear to be necessary and no other edit links make use of it.
SiteController#edit will calculate a precise center coordinate.
