### PR TITLE
Bump cocaine version down to 0.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     arel (3.0.2)
     bigdecimal (1.1.0)
     builder (3.0.3)
-    cocaine (0.3.2)
+    cocaine (0.3.1)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)


### PR DESCRIPTION
Version 0.3.2 is not currently installable: 
https://github.com/thoughtbot/cocaine/issues/27
