### PR TITLE
Add diary entry counter to user page

### DIFF
--- a/app/models/diary_entry.rb
+++ b/app/models/diary_entry.rb
@@ -1,7 +1,7 @@
 class DiaryEntry < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :user, :counter_cache => true
   belongs_to :language, :foreign_key => 'language_code'
-  
+
   has_many :comments, :class_name => "DiaryComment",
                       :include => :user,
                       :order => "diary_comments.id"

--- a/app/views/user/view.html.erb
+++ b/app/views/user/view.html.erb
@@ -12,6 +12,7 @@
     <span class='count-number'><%= number_with_delimiter(@user.traces.size) %></span>
     |
     <%= link_to t('user.view.my diary'), :controller => 'diary_entry', :action => 'list', :display_name => @user.display_name %>
+    <span class='count-number'><%= number_with_delimiter(@user.diary_entries.size) %></span>
     |
     <%= link_to t('user.view.my comments' ), :controller => 'diary_entry', :action => 'comments', :display_name => @user.display_name %>
     |
@@ -95,7 +96,7 @@
 </p>
 
 <% if @user and @user.administrator? -%>
-  <p><b><%= t 'user.view.email address' %></b> <%= @this_user.email %></p>  
+  <p><b><%= t 'user.view.email address' %></b> <%= @this_user.email %></p>
   <% unless @this_user.creation_ip.nil? -%>
   <p><b><%= t 'user.view.created from' %></b> <%= @this_user.creation_ip %></p>
   <% end -%>

--- a/db/migrate/20121005195010_add_diary_entry_counter_caches.rb
+++ b/db/migrate/20121005195010_add_diary_entry_counter_caches.rb
@@ -1,0 +1,13 @@
+class AddDiaryEntryCounterCaches < ActiveRecord::Migration
+  def self.up
+    add_column :users, :diary_entries_count, :integer, :null => false, :default => 0
+
+    DiaryEntry.group(:user_id).pluck(:user_id).each do |user_id|
+      User.reset_counters(user_id, :diary_entries)
+    end
+  end
+
+  def self.down
+    remove_column :users, :diary_entries_count
+  end
+end


### PR DESCRIPTION
This is to fulfill the following feature request:

https://trac.openstreetmap.org/ticket/4511

After I made the patch I thought that maybe we should add a counter for diary entry comments and messages as well just so everything is counted?
