### PR TITLE
Trust Google and Yahoo as OpenID providers to only return valid email

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -127,13 +127,27 @@ class UserController < ApplicationController
       @user.terms_agreed = Time.now.getutc
       @user.terms_seen = true
       @user.openid_url = nil if @user.openid_url and @user.openid_url.empty?
+
+      if (session[:openid_verified])
+        openid_verified = session.delete(:openid_verified)
+        if (openid_verified[:identity_url]) and (openid_verified[:identity_url] == @user.openid_url) and (openid_verified[:email]) and (openid_verified[:email] ==  @user.email)
+          # if we have an email from an OpenID provider that we trust to have verified the email for us, then activate the account directly
+          # without doing our own email verification.
+          @user.status = "active"
+        end
+      end
       
       if @user.save
         flash[:piwik_goal] = PIWIK_SIGNUP_GOAL if defined?(PIWIK_SIGNUP_GOAL)
         flash[:notice] = t 'user.new.flash create success message', :email => @user.email
-        Notifier.signup_confirm(@user, @user.tokens.create(:referer => session.delete(:referer))).deliver
-        session[:token] = @user.tokens.create.token
-        redirect_to :action => 'login', :referer => params[:referer]
+        if @user.status == "active"
+          Notifier.signup_confirm(@user, nil).deliver
+          successful_login(@user)
+        else
+          Notifier.signup_confirm(@user, @user.tokens.create(:referer => session.delete(:referer))).deliver
+          session[:token] = @user.tokens.create.token
+          redirect_to :action => 'login', :referer => params[:referer]
+        end
       else
         render :action => 'new', :referer => params[:referer]
       end
@@ -551,6 +565,9 @@ private
           # the simple registration protocol.
           nickname = sreg["nickname"] || ax["http://axschema.org/namePerson/friendly"].first
           email = sreg["email"] || ax["http://axschema.org/contact/email"].first
+
+          # Check if the openID is from a "trusted" OpenID provider and thus provides a verified email address
+          session[:openid_verified] = openid_email_verified(identity_url, email)
           redirect_to :controller => 'user', :action => 'new', :nickname => nickname, :email => email, :openid => identity_url
         end
       elsif result.missing?
@@ -604,6 +621,20 @@ private
       return openid_url
     end
   end  
+
+  def openid_email_verified(openid_url, email)
+    # OpenID providers Google and Yahoo are guaranteed to return (if at all) an email address that has been verified by
+    # them already. So we can trust the email addresses to be valid and own by the user without having to verify them our
+    # selves.
+    # Store the email in the session to compare agains the user set email address during account creation.
+    openid_verified = Hash.new
+    openid_verified[:identity_url] = openid_url
+    if openid_url.match(/https:\/\/www.google.com\/accounts\/o8\/id?(.*)/) or openid_url.match(/https:\/\/me.yahoo.com\/(.*)/)
+        openid_verified[:email] = email
+    end
+    return openid_verified
+    
+  end
 
   ##
   # process a successful login

--- a/app/models/notifier.rb
+++ b/app/models/notifier.rb
@@ -6,11 +6,17 @@ class Notifier < ActionMailer::Base
 
   def signup_confirm(user, token)
     @locale = user.preferred_language_from(I18n.available_locales)
-    @url = url_for(:host => SERVER_URL,
-                   :controller => "user", :action => "confirm",
-                   :display_name => user.display_name,
-                   :confirm_string => token.token)
-
+    
+    # If we are passed an email address verification token, create the return
+    # address for account activation. Otherwiese the email has already been verified e.g. through a
+    # trusted openID provider and the account is active
+    if token
+      @url = url_for(:host => SERVER_URL,
+                     :controller => "user", :action => "confirm",
+                     :display_name => user.display_name,
+                     :confirm_string => token.token)
+    end
+      
     mail :to => user.email,
          :subject => I18n.t('notifier.signup_confirm.subject', :locale => @locale)
   end

--- a/app/views/notifier/signup_confirm.html.erb
+++ b/app/views/notifier/signup_confirm.html.erb
@@ -1,11 +1,17 @@
 <p><%= t'notifier.signup_confirm_html.greeting' %></p>
 
+<% if @url %>
 <p><%= t'notifier.signup_confirm_html.hopefully_you' %>
    <%= SERVER_URL %>.</p>
 
 <p><%= t'notifier.signup_confirm_html.click_the_link' %></p>
 
 <p><%= raw(link_to @url, @url) %></p>
+<% else %>
+<p><%= t'notifier.signup_confirm_html.created_account' %>
+    <%= SERVER_URL %>.</p>
+<p><%= t'notifier.signup_confirm_html.welcome' %></p>
+<% end %>
 
 <p><%= raw(t'notifier.signup_confirm_html.introductory_video', :introductory_video_link => link_to(t('notifier.signup_confirm_html.video_to_openstreetmap'), "http://showmedo.com/videos/video?name=1800000&fromSeriesID=180")) %>
    <%= raw(t'notifier.signup_confirm_html.more_videos', :more_videos_link => link_to(t('notifier.signup_confirm_html.more_videos_here'), "http://showmedo.com/videos/series?name=mS2P1ZqS6")) %></p>

--- a/app/views/notifier/signup_confirm.text.erb
+++ b/app/views/notifier/signup_confirm.text.erb
@@ -1,5 +1,6 @@
 <%= t'notifier.signup_confirm_plain.greeting' %>
 
+<% if @url %>
 <%= t'notifier.signup_confirm_plain.hopefully_you' %>
 <%= SERVER_URL %>
 
@@ -7,6 +8,11 @@
 <%= t'notifier.signup_confirm_plain.click_the_link_2' %>
 
 <%= @url %>
+<% else %>
+<%= t'notifier.signup_confirm_plain.created_account' %>
+<%= SERVER_URL %>
+<%= t'notifier.signup_confirm_plain.welcome' %>
+<% end %>
 
 <%= t'notifier.signup_confirm_plain.introductory_video' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1143,10 +1143,12 @@ en:
     signup_confirm_plain:
       greeting: "Hi there!"
       hopefully_you: "Someone (hopefully you) would like to create an account over at"
+      created_account: "You have just created a new account over at"
       # next two translations run-on : please word wrap appropriately
       click_the_link_1: "If this is you, welcome! Please click the link below to confirm your"
       click_the_link_2: "account and read on for more information about OpenStreetMap."
-      introductory_video: "You can watch an introductory video to OpenStreetMap here:"
+      welcome: "We would like to welcome you and provide you with some additional information to get you started."
+      introductory_video: "You can watch an introductory video to OpenStreetMap here:"      
       more_videos: "There are more videos here:"
       the_wiki: "Get reading about OpenStreetMap on the wiki:"
       the_wiki_url: "http://wiki.openstreetmap.org/wiki/Beginners%27_Guide"
@@ -1163,7 +1165,9 @@ en:
     signup_confirm_html:
       greeting: "Hi there!"
       hopefully_you: "Someone (hopefully you) would like to create an account over at"
+      created_account: "You have just created a new account over at"
       click_the_link: "If this is you, welcome! Please click the link below to confirm that account and read on for more information about OpenStreetMap"
+      welcome: "We would like to welcome you and provide you with some additional information to get you started."
       introductory_video: "You can watch an %{introductory_video_link}."
       video_to_openstreetmap: "introductory video to OpenStreetMap"
       more_videos: "There are %{more_videos_link}."


### PR DESCRIPTION
Both Google and Yahoo guarantee that the email address they return during the OpenID
authentication are emails that they have already verified[1].

Therefore special case these OpenID providers and automatically activate the new users
account without requiring a separate email verification step.

This therefore reduces the signup procedure by one step and makes it easier for new users
of these OpenID providers (which cover the majority of users).

This might be particularly useful should the decision be made that the notes / openstreetbugs
feature require an account signup to post notes in future.

[1] http://stackoverflow.com/questions/5639419/are-email-addresses-returned-by-the-google-or-yahoo-openid-providers-verified-ad
