### PR TITLE
Changing approach to layout in order to fix some weird css problems.

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -48,7 +48,8 @@ h2 {
 
 #left {
   position: absolute;
-  top: 0px;
+  top: 30px;
+  bottom: 0;
   width: 185px;
   font-size: 11px;
   line-height: 12px;
@@ -61,7 +62,7 @@ h2 {
   min-width: 170px;
   padding: 5px;
   text-align: center;
-  margin: 25px 0 5px 0;
+  margin: auto;
 }
 
 #logo img {
@@ -305,8 +306,11 @@ h2 {
 /* Rules for tabbed navigation bar */
 
 #top-bar {
-  border-bottom: 1px solid #ccc;
+  position: absolute;
+  top: 0;
   height: 29px;
+  border-bottom: 1px solid #ccc;
+  background: white;
 }
 
 #tabnav {
@@ -424,6 +428,13 @@ body.site-export #tabnav a#exportanchor {
   padding: 5px;
 }
 
+.site-index #map .SimpleLayerSwitcher,
+.site-index #map .olControlSimplePanZoom,
+.site-export #map .olControlSimplePanZoom,
+.site-export #map .SimpleLayerSwitcher {
+  top: 40px !important;
+}
+
 /* Rules for edit menu */
 
 .menuicon {
@@ -472,7 +483,7 @@ body.site-export #tabnav a#exportanchor {
 #sidebar {
   display: none;
   position: absolute;
-  margin: 0px;
+  margin: 30px 0px 0px 0px;
   padding: 0px;
   width: 30%;
   top: 0px;
@@ -496,7 +507,7 @@ body.site-export #tabnav a#exportanchor {
   height: 29px;
   font-size: 14px;
   line-height: 15px;
-  background: #bbb;
+  background: #ccc;
 }
 
 /* Rules for the map key which appears in the popout sidebar */
@@ -608,15 +619,20 @@ body.site-export #tabnav a#exportanchor {
 /* Rules for the main content area */
 
 #content {
-  padding: 10px;
-  margin: 0px;
-  position: absolute;
-  bottom: 0px;
+  padding: 20px;
+  margin: 30px 0 0 0;
+}
+
+.site-edit #content {
+  border: 0;
+  padding: 0;
 }
 
 .site-index #content,
-.site-edit #content,
 .site-export #content {
+  position: fixed;
+  margin-top: 0;
+  left: 0; right: 0; top: 0; bottom: 0;
   border: 0px;
   padding: 0px;
 }
@@ -924,7 +940,7 @@ p#contributorGuidance {
 #accountForm .user_map {
   position: relative;
   width: 500px;
-  height: 400px; 
+  height: 400px;
   border: 1px solid #ccc;
 }
 
@@ -964,7 +980,7 @@ p#contributorGuidance {
 .user-view .user_map {
   position: relative;
   width: 400px;
-  height: 400px; 
+  height: 400px;
   border: 1px solid #ccc;
 }
 

--- a/app/assets/stylesheets/large.css
+++ b/app/assets/stylesheets/large.css
@@ -6,12 +6,6 @@
   display: none;
 }
 
-/* Rules for the main content area */
-
-#content {
-  top: 30px;
-}
-
 /* Rules for OpenLayers maps */
 
 .olControlZoom {

--- a/app/assets/stylesheets/ltr.css.scss
+++ b/app/assets/stylesheets/ltr.css.scss
@@ -6,6 +6,10 @@ html body {
   text-align: left;
 }
 
+/* Rules for the left sidebar */
+
+#left { border-right: 1px solid #ccc;}
+
 /* Rules for the menu displayed in the left sidebar */
 
 .left_menu {
@@ -43,7 +47,8 @@ html body {
 /* Rules for tabbed navigation bar */
 
 #top-bar {
-  margin-left: 185px;
+  left: 185px;
+  right: 0;
 }
 
 #tabnav a,
@@ -66,12 +71,6 @@ html body {
   left: 15px
 }
 
-/* Rules for OpenLayers maps */
-
-#map {
-  border-left: 1px solid #ccc;
-}
-
 /* Rules for attribution text under the main map shown on printouts */
 
 .attribution_license {
@@ -86,7 +85,7 @@ html body {
 
 #sidebar {
   left: 0px;
-  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
 }
 
 #sidebar #sidebar_title {
@@ -100,11 +99,11 @@ html body {
 /* Rules for the main content area */
 
 #content {
+  margin-left: 185px;
   border-left: 1px solid #ccc;
-  left: 185px;
-  right: 0px;
   text-align: left;
 }
+
 
 #slim_header img {
   margin-right: 5px;

--- a/app/assets/stylesheets/rtl.css.scss
+++ b/app/assets/stylesheets/rtl.css.scss
@@ -40,10 +40,15 @@ html body {
   text-align: right;
 }
 
+/* Rules for the left sidebar */
+
+#left { border-left: 1px solid #ccc;}
+
 /* Rules for tabbed navigation bar */
 
 #top-bar {
-  margin-right: 185px
+  right: 185px;
+  left: 0;
 }
 
 #tabnav a,
@@ -86,7 +91,7 @@ html body {
 
 #sidebar {
   right: 0px;
-  border-right: 1px solid #ccc;
+  border-left: 1px solid #ccc;
 }
 
 #sidebar #sidebar_title {
@@ -101,8 +106,7 @@ html body {
 
 #content {
   border-right: 1px solid #ccc;
-  right: 185px;
-  left: 0px;
+  margin-right: 185px;
   text-align: right;
 }
 

--- a/app/assets/stylesheets/small.css.scss
+++ b/app/assets/stylesheets/small.css.scss
@@ -19,14 +19,16 @@ h1 {
 /* Rules for tabbed navigation bar */
 #top-bar {
   margin: 0px;
-  height: 19px;
+  height: 39px;
+  left: 0;
+  padding: 0;
 }
 
 #tabnav {
   height: 14px;
   margin: 0px;
   padding-top: 5px;
-  margin-top: 18px;
+  margin-top: 20px;
   font-size: 10px;
   line-height: 10px;
 }
@@ -46,7 +48,8 @@ h1 {
   height: 16px;
   display: block;
   position: absolute;
-  top: 0;
+  top: 5px;
+  left: 5px;
   padding: 2px;
   width: 110px; /* TODO: find better fix for overlap */
   background-color: #fff;
@@ -61,15 +64,15 @@ h1 {
   position: absolute;
   left: 18px;
   font-size: 12px;
-  margin: 2px;
+  margin: 0;
 }
 
 /* Rules for greeting bar in the top right corner */
 
 #greeting {
   position: absolute;
-  top: 0px;
-  right: 0px;
+  top: 5px;
+  right: 5px;
   height: 14px;
   font-size: 12px;
   line-height: 12px;
@@ -95,12 +98,16 @@ h1 {
   display: none;
 }
 
+.site-index #map .SimpleLayerSwitcher,
+.site-index #map .olControlZoom,
+.site-export #map .olControlZoom,
+.site-export #map .SimpleLayerSwitcher {
+  top: 50px !important;
+}
+
 /* Rules for the main content area */
 
 #content {
-  left: 0px;
-  right: 0px;
-  top: 38px;
   margin-left: 0px;
   margin-right: 0px;
   border-left: 0px;
@@ -108,11 +115,7 @@ h1 {
 }
 
 .site-index #content {
-  left: 0px;
-  right: 0px;
-  top: 38px;
-  bottom: 0px;
-  padding-bottom: 0px;
+  margin-top: 40px;
 }
 
 /* Rules for search sidebar when shown */


### PR DESCRIPTION
Hi,

this pull request is based on #144, but _only_ with the positioning changes, not any other changes. To quote from #144,

> I moved away from an absolute-positioned #content divs everywhere. This was causing some weird problems when users scrolled down, [like not showing bottom padding](http://cl.ly/image/3l2d402o1e2X), and [prematurely cutting off the left keyline](http://cl.ly/image/2i1c441C1X1X). Now, the content area is `position: relative` most of the time, and `position: fixed` when the full screen map is in place. Using `position:fixed` on the big map is nice because you can now scroll down to see more sidebar content, [but you won't end up with an ugly block of white space under the map](http://cl.ly/image/0f051s0v1E3G).
