### PR TITLE
Make it easier to test RTL layout

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,4 +87,12 @@ module ApplicationHelper
       end
     end
   end
+
+  def dir
+    if dir = params[:dir]
+      dir == "rtl" ? "rtl" : "ltr"
+    else
+      I18n.t("html.dir")
+    end
+  end
 end

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -2,10 +2,10 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0"/>
   <%= javascript_include_tag "application" %>
   <!--[if lt IE 7]><%= javascript_include_tag "pngfix" %><![endif]--> <!-- thanks, microsoft! -->
-  <%= stylesheet_link_tag "small-#{t 'html.dir'}", :media => "only screen and (max-width:641px)" %>
-  <%= stylesheet_link_tag "large-#{t 'html.dir'}", :media => "screen and (min-width: 642px)" %>
-  <%= stylesheet_link_tag "print-#{t 'html.dir'}", :media => "print" %>
-  <!--[if IE]><%= stylesheet_link_tag "large-#{t 'html.dir'}", :media => "screen" %><![endif]--> <!-- IE is totally broken with CSS media queries -->
+  <%= stylesheet_link_tag "small-#{dir}", :media => "only screen and (max-width:641px)" %>
+  <%= stylesheet_link_tag "large-#{dir}", :media => "screen and (min-width: 642px)" %>
+  <%= stylesheet_link_tag "print-#{dir}", :media => "print" %>
+  <!--[if IE]><%= stylesheet_link_tag "large-#{dir}", :media => "screen" %><![endif]--> <!-- IE is totally broken with CSS media queries -->
   <%= favicon_link_tag "favicon.ico" %>
   <%= favicon_link_tag "osm_logo.png", :rel => "apple-touch-icon", :type => "image/png" %>
   <%= tag("link", { :rel => "publisher", :href => "https://plus.google.com/111953119785824514010" }) %>

--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= I18n.locale %>" lang="<%= I18n.locale %>" dir="<%= t'html.dir' %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= I18n.locale %>" lang="<%= I18n.locale %>" dir="<%= dir %>">
   <%= render :partial => "layouts/head" %>
   <body class="<%= params[:controller] %> <%= params[:controller] %>-<%= params[:action] %>">
     <div id="small-title">

--- a/app/views/layouts/slim.html.erb
+++ b/app/views/layouts/slim.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= I18n.locale %>" lang="<%= I18n.locale %>" dir="<%= t'html.dir' %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= I18n.locale %>" lang="<%= I18n.locale %>" dir="<%= dir %>">
   <%= render :partial => "layouts/head" %>
   <body class="slim">
     <div id="slim_container">


### PR DESCRIPTION
Instead of fiddling with browser or user settings so the site appears in
Arabic or Hebrew, you can add a dir=rtl param to the URL.
