### PR TITLE
fix history sidebar for small screens.

### DIFF
--- a/app/assets/stylesheets/small.css.scss
+++ b/app/assets/stylesheets/small.css.scss
@@ -112,6 +112,8 @@ h1 {
   border-right: 0px;
 }
 
+.site-export #content,
+.site-edit #content,
 .site-index #content {
   margin-top: 40px;
 }


### PR DESCRIPTION
This properly positions the sidebar in the small layout. Before, the top margin was wrong.
