### PR TITLE
Allow CORS on OAuth endpoints. 

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -9,5 +9,6 @@ Rails.configuration.middleware.use Rack::Cors do
   allow do
     origins "*"
     resource "/api/*", :headers => :any, :methods => [:get, :post, :put, :delete]
+    resource "/oauth/*", :headers => :any, :methods => [:get, :post, :put, :delete]
   end
 end


### PR DESCRIPTION
This makes it more possible to write a browser-side authenticate dance for Javascript editors.
