### PR TITLE
Added RDFa support for browse/node

### DIFF
--- a/app/views/browse/_node_details.html.erb
+++ b/app/views/browse/_node_details.html.erb
@@ -1,14 +1,14 @@
 <% if node_details.redacted? %>
 <p><%= t 'browse.redacted.message_html', :type => t('browse.redacted.type.node'), :redaction_link => link_to(t('browse.redacted.redaction', :id => node_details.redaction.id), node_details.redaction), :version => node_details.version %></p>
 <% else %>
-<table class="browse_details" id="<%= node_details.version %>">
+<table class="browse_details" id="<%= node_details.version %>" typeof="geo:Point">
 
   <%= render :partial => "common_details", :object => node_details %>
 
   <% if node_details.visible -%>
   <tr>
     <th><%= t 'browse.node_details.coordinates' %></th>
-    <td><div class="geo"><%= link_to(content_tag(:span, number_with_delimiter(node_details.lat), :class => "latitude") + ", " + content_tag(:span, number_with_delimiter(node_details.lon), :class => "longitude"), {:controller => 'site', :action => 'index', :lat => h(node_details.lat), :lon => h(node_details.lon), :zoom => "18"}) %></div></td>
+    <td><div class="geo"><%= link_to(content_tag(:span, number_with_delimiter(node_details.lat), :class => "latitude", :property => "geo:lat") + ", " + content_tag(:span, number_with_delimiter(node_details.lon), :class => "longitude", :property => "geo:long"), {:controller => 'site', :action => 'index', :lat => h(node_details.lat), :lon => h(node_details.lon), :zoom => "18"}) %></div></td>
   </tr>
   <% end -%>
 

--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= I18n.locale %>" lang="<%= I18n.locale %>" dir="<%= dir %>"
-  xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#">
+  prefix="geo: http://www.w3.org/2003/01/geo/wgs84_pos#">
   <%= render :partial => "layouts/head" %>
   <body class="<%= params[:controller] %> <%= params[:controller] %>-<%= params[:action] %>">
     <div id="small-title">

--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= I18n.locale %>" lang="<%= I18n.locale %>" dir="<%= dir %>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<%= I18n.locale %>" lang="<%= I18n.locale %>" dir="<%= dir %>"
+  xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#">
   <%= render :partial => "layouts/head" %>
   <body class="<%= params[:controller] %> <%= params[:controller] %>-<%= params[:action] %>">
     <div id="small-title">


### PR DESCRIPTION
RDFa allows HTML to contain rich semantics. The RDFa added here allows for RDFa-aware processors to extract the latitude and longitude of points.

The vocabulary used is the [W3C's Basic Geo WGS84 vocabulary](http://www.w3.org/2003/01/geo/). This vocabulary is in widespread use (for instance, on dbpedia.org, an RDF version of Wikipedia).

RDFa works perfectly well with the existing geo microformat.
