### PR TITLE
Add iD editor on dev server

### DIFF
--- a/app/views/site/_iD.html.erb
+++ b/app/views/site/_iD.html.erb
@@ -1,0 +1,2 @@
+<iframe id="map" src="<%= ID_URL %>#?map=<%= params[:zoom] || 17 %>/<%= @lat || params[:lat] %>/<%= @lon || params[:lon] %>">
+</div>

--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -82,6 +82,8 @@ defaults: &defaults
   #piwik_location: "piwik.openstreetmap.org"
   #piwik_site: 1
   #piwik_signup_goal: 1
+  # URL for iD editor iframe
+  id_url: "http://geowiki.com/iD/"
 
 development:
   <<: *defaults

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,9 @@ en:
     with_name: "%{name} (%{id})"
   editor:
     default: "Default (currently %{name})"
+    iD:
+      name: "iD"
+      description: "iD (HTML5 editor)"
     potlatch:
       name: "Potlatch 1"
       description: "Potlatch 1 (in-browser editor)"

--- a/lib/editors.rb
+++ b/lib/editors.rb
@@ -1,4 +1,4 @@
 module Editors 
-  ALL_EDITORS = [ "potlatch", "potlatch2", "remote" ]
-  RECOMMENDED_EDITORS = [ "potlatch2", "remote" ]
+  ALL_EDITORS = [ "iD", "potlatch", "potlatch2", "remote" ]
+  RECOMMENDED_EDITORS = [ "iD", "potlatch2", "remote" ]
 end


### PR DESCRIPTION
We'd like to start testing iD as an embedded editor on api06 (or other dev server). This adds it as an iframe to http://geowiki.com/iD/, which is kept updated with the latest code.

Looking at this locally, it appears that the OSM chrome surrounding iD is clipped out (it appears as blank white space); this is likely a bug or browser compatibility issue in iD.
