### PR TITLE
Adding ability to add a website to user profile

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ActiveRecord::Base
 
   attr_accessible :display_name, :email, :email_confirmation, :openid_url,
                   :pass_crypt, :pass_crypt_confirmation, :consider_pd,
-                  :image_use_gravatar
+                  :image_use_gravatar, :user
 
   after_initialize :set_defaults
   before_save :encrypt_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,7 @@ class User < ActiveRecord::Base
   validates_numericality_of :home_lon, :allow_nil => true
   validates_numericality_of :home_zoom, :only_integer => true, :allow_nil => true
   validates_inclusion_of :preferred_editor, :in => Editors::ALL_EDITORS, :allow_nil => true
+  validates_format_of :url, :with => URI::regexp(%w(http https))
 
   attr_accessible :display_name, :email, :email_confirmation, :openid_url,
                   :pass_crypt, :pass_crypt_confirmation, :consider_pd,

--- a/app/views/user/account.html.erb
+++ b/app/views/user/account.html.erb
@@ -40,6 +40,11 @@
   </tr>
 
   <tr>
+    <td class="fieldName" ><%= t 'user.account.website' %></td>
+    <td><%= f.url_field :url, {:id => "website", :class="website"} %></td>
+  </tr>
+
+  <tr>
     <td class="fieldName"><%= t 'user.account.public editing.heading' %></td>
     <td>
       <% if @user.data_public? %>

--- a/app/views/user/view.html.erb
+++ b/app/views/user/view.html.erb
@@ -146,7 +146,12 @@
       </p>
     </div>
 
-    <div class='user-description'><%= @this_user.description.to_html %></div>
+    <div class='user-description'>
+        <%= @this_user.description.to_html %>
+        <% unless @this_user.url.nil? || @this_user.url.empty? || @this_user.blocks.exists? %>
+          <div class="user-website"><%= link_to t('user.view.website'), @this_user.url, { :rel => "me" } %></div>
+        <% end %>
+    </div>
 
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1731,6 +1731,7 @@ en:
       friends_diaries: "friends' diary entries"
       nearby_changesets: "nearby user changesets"
       nearby_diaries: "nearby user diary entries"
+      website: "Website"
     popup:
       your location: "Your location"
       nearby mapper: "Nearby mapper"
@@ -1786,6 +1787,7 @@ en:
       return to profile: Return to profile
       flash update success confirm needed: "User information updated successfully. Check your email for a note to confirm your new email address."
       flash update success: "User information updated successfully."
+      website: "Web site:"
     confirm:
       heading: Confirm a user account
       press confirm button: "Press the confirm button below to activate your account."

--- a/db/migrate/20121202163003_add_url_to_user_model.rb
+++ b/db/migrate/20121202163003_add_url_to_user_model.rb
@@ -1,0 +1,5 @@
+class AddUrlToUserModel < ActiveRecord::Migration
+  def change
+    add_column :users, :url, :string
+  end
+end


### PR DESCRIPTION
A wide variety of other websites allow users to link back to their website. OpenStreetMap contributors often have their own blogs. Allowing them to link to them helps verify their identity and improve the trust others place in them.
