### PR TITLE
Fix P2 interaction with search links

### DIFF
--- a/app/views/site/_potlatch2.html.erb
+++ b/app/views/site/_potlatch2.html.erb
@@ -71,13 +71,13 @@
   doSWF(params.lat, params.lon, params.zoom || 17);
   <% end -%>
 
-  $(document).ready(function () {
-    $("body").on("click", "a.set_position", function () {
-      var data = $(this).data();
+  $("body").on("click", "a.set_position", function (e) {
+    e.preventDefault();
 
-      $("#potlatch").each(function () {
-        this.setPosition(data.lat, data.lon, Math.max(data.zoom || 15, 13));
-      });
+    var data = $(this).data();
+
+    $("#potlatch").each(function () {
+      this.setPosition(data.lat, data.lon, Math.max(data.zoom || 15, 13));
     });
   });
 


### PR DESCRIPTION
Need to prevent the default action so that the page isn't reloaded.

Also, since the click event binding uses delegation, it isn't necessary to
wrap it in $(document).ready().
