### PR TITLE
Replace trace.trace_paging_nav.previous / next

### DIFF
--- a/app/views/trace/_trace_paging_nav.html.erb
+++ b/app/views/trace/_trace_paging_nav.html.erb
@@ -2,17 +2,17 @@
 
 <% if @traces.size > 1 %>
 <% if @page > 1 %>
-<%= link_to t('trace.trace_paging_nav.previous'), params.merge({ :page => @page - 1 }) %>
+<%= link_to t('trace.trace_paging_nav.older'), params.merge({ :page => @page - 1 }) %>
 <% else %>
-<%= t('trace.trace_paging_nav.previous') %>
+<%= t('trace.trace_paging_nav.older') %>
 <% end %>
 
 | <%= t('trace.trace_paging_nav.showing_page', :page => @page) %> |
 
 <% if @traces.size < @page_size %>
-<%= t('trace.trace_paging_nav.next') %>
+<%= t('trace.trace_paging_nav.newer') %>
 <% else %>
-<%= link_to t('trace.trace_paging_nav.next'), params.merge({ :page => @page + 1 }) %>
+<%= link_to t('trace.trace_paging_nav.newer'), params.merge({ :page => @page + 1 }) %>
 <% end %>
 <% end %>
 </p>


### PR DESCRIPTION
Replace trace.trace_paging_nav.previous by trace.trace_paging_nav.older
Replace trace.trace_paging_nav.next by trace.trace_paging_nav.newer

previous and next are undefined, and older and newer are defined.
