### PR TITLE
Reset Leaflet styles so that the OSM color scheme is more uniform.

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -1774,6 +1774,7 @@ a.button.submit {
 
   .comment {
     width: 100%;
+    height: 100px;
   }
 
   .buttons {

--- a/app/assets/stylesheets/leaflet-all.css.scss
+++ b/app/assets/stylesheets/leaflet-all.css.scss
@@ -34,3 +34,21 @@ div.leaflet-marker-icon.location-filter.move-marker {
 .user_popup p {
   margin: 0px 2px 0px 55px !important;
 }
+
+.site .leaflet-container a {
+  color: #00f;
+}
+
+.site .leaflet-popup p {
+  margin: 0 0 20px 0;
+}
+
+.leaflet-control-attribution #permalinkanchor {
+  background: image-url("sprite.png") 0 -45px no-repeat;
+  padding-left:20px;
+}
+
+.site .leaflet-control-attribution {
+  box-shadow: none;
+  font-size: inherit;
+}


### PR DESCRIPTION
Also makes note input fields shorter - 100px tall - by default.

![](http://dl.dropbox.com/u/68059/Screenshots/jsebu_a05yyt.png)
