### PR TITLE
Fix note formatting - prevents note coordinates from falling to the next...

### DIFF
--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -46,7 +46,7 @@
 
     <div>
       <h4><%= t "browse.node_details.coordinates" %></h4>
-      <p><div class="geo"><%= link_to ("<span class='latitude'>#{number_with_delimiter(@note.lat)}</span>, <span class='longitude'>#{number_with_delimiter(@note.lon)}</span>".html_safe), {:controller => 'site', :action => 'index', :lat => h(@note.lat), :lon => h(@note.lon), :zoom => "18"} %></div></p>
+      <p class="geo"><%= link_to ("<span class='latitude'>#{number_with_delimiter(@note.lat)}</span>, <span class='longitude'>#{number_with_delimiter(@note.lon)}</span>".html_safe), {:controller => 'site', :action => 'index', :lat => h(@note.lat), :lon => h(@note.lon), :zoom => "18"} %></p>
     </div>
   </div>
 


### PR DESCRIPTION
... line on the browse page

This issue:

![](http://dl.dropbox.com/u/68059/Screenshots/26hk4bb180~z.png)
