### PR TITLE
Append "Details" link to Nominatim search results

### DIFF
--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -177,17 +177,11 @@ class GeocoderController < ApplicationController
       prefix = t "geocoder.search_osm_nominatim.prefix_format", :name => prefix_name
       object_type = place.attributes["osm_type"].to_s
       object_id = place.attributes["osm_id"].to_s
-      if object_type != ''
-        suffix = " [<a href='browse/%s/%s'>%s</a>]" % [ object_type, object_id, t ("browse.%s_history.view_details" % object_type) ]
-      else
-        suffix = ""
-      end
 
       @results.push({:lat => lat, :lon => lon,
                      :min_lat => min_lat, :max_lat => max_lat,
                      :min_lon => min_lon, :max_lon => max_lon,
                      :prefix => prefix, :name => name,
-                     :suffix => suffix,
                      :type => object_type, :id => object_id})
       @more_params[:exclude].push(place.attributes["place_id"].to_s)
     end

--- a/app/helpers/geocoder_helper.rb
+++ b/app/helpers/geocoder_helper.rb
@@ -16,6 +16,7 @@ module GeocoderHelper
     html << result[:prefix] if result[:prefix]
     html << " " if result[:prefix] and result[:name]
     html << link_to(result[:name], url, html_options) if result[:name]
+    html << (" [" + link_to(t("browse.#{result[:type]}_history.view_details"), :controller => :browse, :action => result[:type], :id => result[:id]) + "]")  if (result[:type] && result[:id])
     html << result[:suffix] if result[:suffix]
 
     return raw(html)


### PR DESCRIPTION
After using the OSM homepage search box to find some item (eg by the name of a business), it's very useful to be able to see the item's details - either to check whether editing is needed, or to read shop contact details, etc. This patch adds a simple "Details" link to Nominatim search results which makes it easy to get the info. (At present I use the "Browse map data" option, or just click "Edit", to see the details, but both of those are wasteful since they pull down much more data than one needs.)
