### PR TITLE
Make iD default

### DIFF
--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -73,7 +73,7 @@ defaults: &defaults
   # URL of Nominatim instance to use for geocoding
   nominatim_url: "http://nominatim.openstreetmap.org/"
   # Default editor
-  default_editor: "potlatch2"
+  default_editor: "iD"
   # OAuth consumer key for Potlatch 2
   #potlatch2_key: ""
   # OAuth consumer key for the web site


### PR DESCRIPTION
Let's make iD default. If a user misses the drop down, and just clicks on "Edit" they should go to iD, not Potlatch 2.
- We had a great testing period
- iD's doing much more to onboard new users and we want to particularly reach new users who might miss that there's a drop down.
- iD is the first one in drop down list but isn't default.

This PR just modifies the example config.

![](http://cl.ly/image/2w3m0U1E1Q03/Screen%20Shot%202013-05-07%20at%2010.29.22%20AM.png)

_iD in edit drop down on osm.org right now_
