### PR TITLE
Fixes #258 (Fix gap for iconless nodes in history view)

### DIFF
--- a/app/assets/stylesheets/browse.css.scss
+++ b/app/assets/stylesheets/browse.css.scss
@@ -10,7 +10,6 @@ a.node, a.way, a.relation {
 a.node::before, a.way::before, a.relation::before {
   display: inline-block;
   width: 25px;
-  vertical-align:3px;
 }
 
 /* Deleted objects */


### PR DESCRIPTION
Inlining tag-icons via `::before` and `content: url(...)` instead of `padding` and `background-image`.

That way, tag combinations without an icon do not get any additional markup at all. And #258 should be fixed.
