### PR TITLE
Don't focus the text area on touch devices to avoid flashing the keyboard

### DIFF
--- a/app/assets/javascripts/index/notes.js.erb
+++ b/app/assets/javascripts/index/notes.js.erb
@@ -47,7 +47,10 @@ $(document).ready(function () {
   });
 
   map.on("popupopen", function (e) {
-    $(e.popup._container).find(".comment").focus();
+    //Don't focus the text area on touch devices to avoid flashing the keyboard
+    if (!('ontouchstart' in document.documentElement)) {
+      $(e.popup._container).find(".comment").focus();
+    }
   });
 
   map.on("popupclose", function (e) {


### PR DESCRIPTION
Currently the keyboard slide out & hides again quickly.
