### PR TITLE
Add vendorer gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,11 @@ gem 'httpclient'
 # Load memcache in case we are using it
 gem 'memcached', '>= 1.4.1'
 
+# Gems useful for development
+group :development do
+  gem 'vendorer'
+end
+
 # Gems needed for running tests
 group :test do
   gem 'timecop'


### PR DESCRIPTION
I think it's appropriate to add vendorer to the Gemfile. Although it's not needed by every developer, I don't think it introduces any additional dependencies.

My ulterior motive for doing so is to slightly simplify the installation docs!
