### PR TITLE
Fixing incorrectly shown nodes on browse/* maps

### DIFF
--- a/app/assets/javascripts/map.js.erb
+++ b/app/assets/javascripts/map.js.erb
@@ -142,7 +142,7 @@ function addObjectToMap(object, zoom, callback) {
     url: OSM.apiUrl(object),
     dataType: "xml",
     success: function (xml) {
-      objectLayer = new L.OSM.DataLayer(xml, {
+      objectLayer = new L.OSM.DataLayer(null, {
         style: {
           strokeColor: "blue",
           strokeWidth: 3,
@@ -152,6 +152,17 @@ function addObjectToMap(object, zoom, callback) {
           pointRadius: 6
         }
       });
+      objectLayer.interestingNode = function(node, ways, relations) {
+        if (object.type === "node")
+          return true;
+        if (object.type === "relation") {
+          for (var i=0; i<relations.length; i++)
+            if (relations[i].members.indexOf(node) != -1)
+              return true;
+        }
+        return false;
+      };
+      objectLayer.addData(xml);
 
       var bounds = objectLayer.getBounds();
 


### PR DESCRIPTION
Previously, tagged nodes of ways were shown on browse/way and browse/relation pages.

Now, nodes are not shown on browse/way pages and only nodes which are direct members of the relation are shown on browse/relation pages.

This depends on a some [improvements](https://github.com/jfirebaugh/leaflet-osm/pull/1) of the leaflet-osm plugin.

Use the following relation as a test-bench: http://master.apis.dev.openstreetmap.org/browse/relation/4294968148

this is wrong:
![wrong](https://f.cloud.github.com/assets/1927298/500911/9d0fa47e-bc85-11e2-96af-ec12aafa5ea3.png)
this is correct: 
![right](https://f.cloud.github.com/assets/1927298/500915/c6439242-bc85-11e2-8c23-bac9f56a721d.png)
