### PR TITLE
remove SOTM US from the banner rotation

### DIFF
--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -70,9 +70,6 @@
           <%= ad = [{:image => 'sotm-birmingham-ad.png',
                      :title => 'State of the Map Birmingham',
                      :href =>'http://stateofthemap.org/'},
-                    {:image => 'sotm-us-ad.png',
-                     :title => 'State of the Map USA',
-                     :href =>'http://stateofthemap.us/'},
                     {:image => 'donate-ad.png',
                      :title => 'Server Donation Drive',
                      :href =>'http://donate.openstreetmap.org/'}].sample


### PR DESCRIPTION
Remove SOTM US image from the from the front page banner rotation, leaving only main SOTM and server donation drive ads.
