### PR TITLE
Fixed Attribution in OpenLayers-File

### DIFF
--- a/vendor/assets/openlayers/OpenStreetMap.js
+++ b/vendor/assets/openlayers/OpenStreetMap.js
@@ -53,6 +53,7 @@ OpenLayers.Layer.OSM.CycleMap = OpenLayers.Class(OpenLayers.Layer.OSM, {
         ];
         options = OpenLayers.Util.extend({
             numZoomLevels: 19,
+            attribution: "&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors, Tiles courtesy of <a href='http://www.opencyclemap.org'>Andy Allan</a>",
             buffer: 0,
             transitionEffect: "resize"
         }, options);
@@ -85,6 +86,7 @@ OpenLayers.Layer.OSM.TransportMap = OpenLayers.Class(OpenLayers.Layer.OSM, {
         ];
         options = OpenLayers.Util.extend({
             numZoomLevels: 19,
+            attribution: "&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors, Tiles courtesy of <a href='http://www.opencyclemap.org'>Andy Allan</a>",
             buffer: 0,
             transitionEffect: "resize"
         }, options);


### PR DESCRIPTION
There is still the old openlayers javascript stuff on the osm.org webspace, used by some examples and, as I guess, by many mostly small websites showing osm splippy maps.

The file did not define any attribution for the osm tiles, relying on the openlayers-code to do so.
There are two arguments why that's bad:
1) OpenLayers in the current version is buggy, still showing CC-By-SA as data license, and
2) For Andy Allans transport and cyclemap tiles it's even not enough (probably) to attribute the osm project alone, at least osm.org attributes Alan directly, too.

This Patch adds attribution to the classes following the attribution from osm.org.

An argument on IRC was that this file is deprecated nevertheless and should not be used, but I think as long as it's still on the server it will be used further by existing slippy maps, all being "fixed" by this change as they auto-update their attribution by magic.
