### PR TITLE
fixing reload-languages script to work with Rails 3

### DIFF
--- a/script/locale/reload-languages
+++ b/script/locale/reload-languages
@@ -2,4 +2,4 @@
 
 require File.dirname(__FILE__) + '/../../config/environment'
 
-Language.load(RAILS_ROOT + "/config/languages.yml")
+Language.load(Rails.root.join('config', 'languages.yml'))


### PR DESCRIPTION
"Railties now deprecates: RAILS_ROOT in favor of Rails.root"

http://edgeguides.rubyonrails.org/3_0_release_notes.html#railties
