### PR TITLE
More specific boundary type in search results

### DIFF
--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -174,6 +174,10 @@ class GeocoderController < ApplicationController
       name = place.attributes["display_name"].to_s
       min_lat,max_lat,min_lon,max_lon = place.attributes["boundingbox"].to_s.split(",")
       prefix_name = t "geocoder.search_osm_nominatim.prefix.#{klass}.#{type}", :default => type.gsub("_", " ").capitalize
+      if klass == 'boundary' and type == 'administrative'
+        rank = (place.attributes["place_rank"].to_i + 1)/2
+        prefix_name = t "geocoder.search_osm_nominatim.admin_levels.level#{rank}", :default => prefix_name
+      end
       prefix = t "geocoder.search_osm_nominatim.prefix_format", :name => prefix_name
       object_type = place.attributes["osm_type"]
       object_id = place.attributes["osm_id"]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -922,6 +922,14 @@ en:
           waterfall: "Waterfall"
           water_point: "Water Point"
           weir: "Weir"
+      admin_levels:
+        level2: "Country Boundary"
+        level4: "State Boundary"
+        level5: "Region Boundary"
+        level6: "County Boundary"
+        level8: "City Boundary"
+        level9: "Village Boundary"
+        level10: "Suburb Boundary"
     description:
       title:
         osm_nominatim: 'Location from <a href="http://nominatim.openstreetmap.org/">OpenStreetMap Nominatim</a>'


### PR DESCRIPTION
Replaces 'administrative boundary' with a marginally more informative description which is guessed from the admin level.
