### PR TITLE
remove dots on the end of emailed URLs

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1152,8 +1152,8 @@ en:
     friend_notification:
       subject: "[OpenStreetMap] %{user} added you as a friend"
       had_added_you: "%{user} has added you as a friend on OpenStreetMap."
-      see_their_profile: "You can see their profile at %{userurl}."
-      befriend_them: "You can also add them as a friend at %{befriendurl}."
+      see_their_profile: "You can see their profile at %{userurl}"
+      befriend_them: "You can also add them as a friend at %{befriendurl}"
     gpx_notification:
       greeting: "Hi,"
       your_gpx_file: "It looks like your GPX file"


### PR DESCRIPTION
dots on the end of the emailed URLs are annoying in an unnecessary kind of way. e.g. if you try to copy & paste the URL into your browser it breaks.
