### PR TITLE
Single tab keypress focus on map for keyboard users

### DIFF
--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -16,7 +16,7 @@
 <div id="map-ui">
 </div>
 
-<div id="map">
+<div id="map" tabindex="2">
 </div>
 
 <iframe id="linkloader" style="display: none">


### PR DESCRIPTION
When one goes to the default map page, the first tabindex is set to the search field, which is good. But, to use the keyboard with the map (arrows for scrolling, =/- for zooming), one must press the tab key many times (26?). This modification quickly gets the keyboard to a much-used location via a single keypress.

Perhaps another element should get a `tabindex="3"` attribute to minimize disruption; I've done only minimal focus-testing.
