### PR TITLE
Search sidebar: don't scroll heading ('close' stays visible)

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -711,9 +711,9 @@ a.donate {
   display: none;
   position: relative;
   float: left;
-  overflow: auto;
   border-right: 1px solid $keyline;
   width: 33.3333%;
+  height: 100%;
   ul {
     margin-bottom: 0;
     &:last-child {
@@ -751,6 +751,8 @@ a.donate {
 #sidebar_content {
   position: relative;
   margin-bottom: 20px;
+  overflow: auto;
+  height: 100%;
   width: 100%;
   h4 {
     padding: 0 $lineheight $lineheight/2 $lineheight;


### PR DESCRIPTION
Here's the problem:
(a) On the OSM homepage, search for something that has many results (e.g. "pub")
(b) Scroll down in the list of results.
(c) Now decide you want to close the search results sidebar. Unfortunately, the "Close" link is now scrolled out of reach, and you have to tediously scroll back up just to close the thing.

This patch changes behaviour so it's the content (#sidebar_content) that scrolls, rather than the outer container (#sidebar), meaning that the heading block stays visible.
