### PR TITLE
Fix print CSS (fixes #379)

### DIFF
--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -1,41 +1,33 @@
-#small-title {
-  display: none;
-}
-
-#left {
-  display: none;
-}
-
-#greeting {
-  display: none;
-}
-
-#tabnav {
-  display: none;
-}
-
-#sidebar {
-  display: none;
-}
-
-#permalink {
-  display: none;
-}
-
-#editmenu {
-  display: none;
-}
-
+#small-title,
+#left,
+#greeting,
+#tabnav,
+#sidebar,
+#permalink,
+#editmenu,
 .leaflet-control {
   display: none;
 }
 
+html {
+  height: 100%;
+}
+
 #map {
+  position: absolute !important;
+  top: 0;
+  bottom: 40px;
+  left: 0;
+  right: 0;
   border: 1px solid black;
-  margin: auto !important;
 }
 
 #attribution {
+  position: absolute !important;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40px;
   font-size: 12px;
   text-align: center;
 }


### PR DESCRIPTION
Tested on Chrome and Firefox. Broken in Opera, but AFAICT,
it always has been, and Opera can't print Leaflet maps
on other sites either.
