### PR TITLE
Refactor user creation actions

### DIFF
--- a/app/views/user/new.html.erb
+++ b/app/views/user/new.html.erb
@@ -6,7 +6,7 @@
 
 <%= error_messages_for 'user' %>
 
-<%= form_for :user, :url => { :action => 'terms' } do %>
+<%= form_for :user, :url => { :action => 'create' } do %>
   <%= hidden_field_tag('referer', h(@referer)) unless @referer.nil? %>
 
   <div id="signupForm" class="standard-form">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,7 +134,8 @@ OpenStreetMap::Application.routes.draw do
   match '/key' => 'site#key', :via => :get
   match '/id' => 'site#id', :via => :get
   match '/user/new' => 'user#new', :via => :get
-  match '/user/terms' => 'user#terms', :via => [:get, :post]
+  match '/user/new' => 'user#create', :via => :post
+  match '/user/terms' => 'user#terms', :via => :get
   match '/user/save' => 'user#save', :via => :post
   match '/user/:display_name/confirm/resend' => 'user#confirm_resend', :via => :get
   match '/user/:display_name/confirm' => 'user#confirm', :via => [:get, :post]

--- a/test/functional/user_controller_test.rb
+++ b/test/functional/user_controller_test.rb
@@ -55,11 +55,12 @@ class UserControllerTest < ActionController::TestCase
     )
 
     assert_routing(
-      { :path => "/user/terms", :method => :get },
-      { :controller => "user", :action => "terms" }
+      { :path => "/user/new", :method => :post },
+      { :controller => "user", :action => "create" }
     )
+
     assert_routing(
-      { :path => "/user/terms", :method => :post },
+      { :path => "/user/terms", :method => :get },
       { :controller => "user", :action => "terms" }
     )
 
@@ -202,7 +203,7 @@ class UserControllerTest < ActionController::TestCase
       end
       assert_select "body", :count => 1 do
         assert_select "div#content", :count => 1 do
-          assert_select "form[action='/user/terms'][method=post]", :count => 1 do
+          assert_select "form[action='/user/new'][method=post]", :count => 1 do
             assert_select "input[id=user_email]", :count => 1
             assert_select "input[id=user_email_confirmation]", :count => 1
             assert_select "input[id=user_display_name]", :count => 1
@@ -320,6 +321,23 @@ class UserControllerTest < ActionController::TestCase
     assert_template 'new'
     assert_select "div#errorExplanation"
     assert_select "div#signupForm > fieldset > div.form-row > div.field_with_errors > input#user_display_name"
+  end
+
+  def test_user_terms_new_user
+    get :terms, {}, { "new_user" => User.new }
+    assert_response :success
+    assert_template :terms
+  end
+
+  def test_user_terms_seen
+    user = users(:normal_user)
+
+    # Set the username cookie
+    @request.cookies["_osm_username"] = user.display_name
+
+    get :terms, {}, { "user" => user }
+    assert_response :redirect
+    assert_redirected_to :action => :account, :display_name => user.display_name
   end
 
   def test_user_lost_password

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -21,7 +21,7 @@ class UserCreationTest < ActionController::IntegrationTest
       display_name = "#{localer.to_s}_new_tester"
       assert_difference('User.count', 0) do
         assert_difference('ActionMailer::Base.deliveries.size', 0) do
-          post '/user/terms',
+          post '/user/new',
             {:user => { :email => dup_email, :email_confirmation => dup_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest"}},
             {"HTTP_ACCEPT_LANGUAGE" => localer.to_s}
         end
@@ -41,7 +41,7 @@ class UserCreationTest < ActionController::IntegrationTest
       email = "#{locale.to_s}_new_tester"
       assert_difference('User.count', 0) do
         assert_difference('ActionMailer::Base.deliveries.size', 0) do
-          post '/user/terms',
+          post '/user/new',
           {:user => {:email => email, :email_confirmation => email, :display_name => dup_display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest"}},
           {"HTTP_ACCEPT_LANGUAGE" => locale.to_s}
         end
@@ -61,13 +61,12 @@ class UserCreationTest < ActionController::IntegrationTest
 
       assert_difference('User.count', 0) do
         assert_difference('ActionMailer::Base.deliveries.size', 0) do
-          post "/user/terms",
+          post "/user/new",
             {:user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest"}}
           end
       end
 
-      assert_response :success
-      assert_template 'user/terms'
+      assert_redirected_to "/user/terms"
 
       assert_difference('User.count') do
         assert_difference('ActionMailer::Base.deliveries.size', 1) do
@@ -108,10 +107,9 @@ class UserCreationTest < ActionController::IntegrationTest
     referer = "/traces/mine"
     assert_difference('User.count') do
       assert_difference('ActionMailer::Base.deliveries.size', 1) do
-        post "/user/terms",
+        post "/user/new",
         {:user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => password, :pass_crypt_confirmation => password}, :referer => referer }
-        assert_response :success
-        assert_template 'terms'
+        assert_redirected_to "/user/terms"
         post_via_redirect "/user/save",
         {:user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => password, :pass_crypt_confirmation => password} }
       end
@@ -154,13 +152,12 @@ class UserCreationTest < ActionController::IntegrationTest
     password = "testtest"
     assert_difference('User.count') do
       assert_difference('ActionMailer::Base.deliveries.size', 1) do
-        post "/user/terms",
+        post "/user/new",
           {:user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :openid_url => "http://localhost:1123/john.doe?openid.success=newuser", :pass_crypt => "", :pass_crypt_confirmation => ""}}
         assert_response :redirect
         res = openid_request(@response.redirect_url)
-        post '/user/terms', res
-        assert_response :success
-        assert_template 'terms'
+        get "/user/new", res
+        assert_redirected_to "/user/terms"
         post '/user/save',
           {:user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :openid_url => "http://localhost:1123/john.doe?openid.success=newuser", :pass_crypt => password, :pass_crypt_confirmation => password}}
         assert_response :redirect
@@ -181,11 +178,11 @@ class UserCreationTest < ActionController::IntegrationTest
     password = "testtest2"
     assert_difference('User.count',0) do
       assert_difference('ActionMailer::Base.deliveries.size',0) do
-        post "/user/terms",
+        post "/user/new",
           {:user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :openid_url => "http://localhost:1123/john.doe?openid.failure=newuser", :pass_crypt => "", :pass_crypt_confirmation => ""}}
         assert_response :redirect
         res = openid_request(@response.redirect_url)
-        post '/user/terms', res
+        get '/user/new', res
         assert_response :success
         assert_template 'user/new'
       end
@@ -202,13 +199,12 @@ class UserCreationTest < ActionController::IntegrationTest
     referer = "/traces/mine"
     assert_difference('User.count') do
       assert_difference('ActionMailer::Base.deliveries.size', 1) do
-	post "/user/terms",
+        post "/user/new",
           {:user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :openid_url => "http://localhost:1123/john.doe?openid.success=newuser", :pass_crypt => "", :pass_crypt_confirmation => ""}, :referer => referer }
-	assert_response :redirect
+        assert_response :redirect
         res = openid_request(@response.location)
-        post '/user/terms', res
-        assert_response :success
-        assert_template 'terms'
+        get "/user/new", res
+        assert_redirected_to "/user/terms"
         post_via_redirect "/user/save",
           {:user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :openid_url => "http://localhost:1123/john.doe?openid.success=newuser", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest"} }
       end


### PR DESCRIPTION
Create a separate #create action that handles POSTs to
/user/new. This simplifies the other actions and ensures that the URL is
/user/new when validation errors occur, rather than /user/terms.

Fixes #398
