### PR TITLE
Change Where am I to Where is this on left sidebar

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1418,7 +1418,7 @@ en:
       get_directions_title: "Find directions between two points"
       from: "From"
       to: "To"
-      where_am_i: "Where am I?"
+      where_am_i: "Where is this?"
       where_am_i_title: Describe the current location using the search engine
       submit_text: "Go"
     key:


### PR DESCRIPTION
Related to #373

"Where am I?" is short for "Where am I looking at?" but prone to be interpreted as "Where am I located right now?"

This pull request changes it to "Where is this?" I considered "Where am I looking at?" but the at? is pushed onto the next line, consuming vertical sidebar space.

It does not make the side text any longer and should be a clearer description of what the feature does.

Current:
![where_am_i](https://f.cloud.github.com/assets/1190866/909150/367a532e-fdb4-11e2-8bf0-0a95db7f03b1.png)

Where am I looking at?:
![where_am_i_looking_at](https://f.cloud.github.com/assets/1190866/909151/3680fe04-fdb4-11e2-942e-08dbcea0cb1e.png)

Where is this?:
![where_is_this](https://f.cloud.github.com/assets/1190866/909152/3683544c-fdb4-11e2-83a3-e5825f38df19.png)
