### PR TITLE
Do not fit map to search result (object) twice.

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -195,7 +195,7 @@ function setPositionLink(map) {
       }
 
       if (data.type && data.id) {
-        addObjectToMap(data, map, { zoom: true, style: { opacity: 0.2, fill: false } });
+        addObjectToMap(data, map, { zoom: false, style: { opacity: 0.2, fill: false } });
       }
 
       map.markerLayer.clearLayers();


### PR DESCRIPTION
When clicking on search results the respective osm object is loaded asynchronously and afterwards shown on the map. Some objects (e.g. administrative boundaries) can take a few seconds to load (or more). If a user already panned/zoomed the map in the meantime, his actions are reverted when the map fits to the object again. This can be quite annoying.

There is actually no need for this behaviour, because a good geocoder does already return an appropriate bounding box of the search result.
