### PR TITLE
Move copyright link to attribution control

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -22,27 +22,29 @@ $(document).ready(function () {
 
   map.hash = L.hash(map);
 
+  var copyright = I18n.t('javascripts.map.copyright', {copyright_url: '/copyright'});
+
   var layers = [
     new L.OSM.Mapnik({
-      attribution: '',
+      attribution: copyright,
       code: "M",
       keyid: "mapnik",
       name: I18n.t("javascripts.map.base.standard")
     }),
     new L.OSM.CycleMap({
-      attribution: "Tiles courtesy of <a href='http://www.opencyclemap.org/' target='_blank'>Andy Allan</a>",
+      attribution: copyright + ". Tiles courtesy of <a href='http://www.opencyclemap.org/' target='_blank'>Andy Allan</a>",
       code: "C",
       keyid: "cyclemap",
       name: I18n.t("javascripts.map.base.cycle_map")
     }),
     new L.OSM.TransportMap({
-      attribution: "Tiles courtesy of <a href='http://www.opencyclemap.org/' target='_blank'>Andy Allan</a>",
+      attribution: copyright + ". Tiles courtesy of <a href='http://www.opencyclemap.org/' target='_blank'>Andy Allan</a>",
       code: "T",
       keyid: "transportmap",
       name: I18n.t("javascripts.map.base.transport_map")
     }),
     new L.OSM.MapQuestOpen({
-      attribution: "Tiles courtesy of <a href='http://www.mapquest.com/' target='_blank'>MapQuest</a> <img src='http://developer.mapquest.com/content/osm/mq_logo.png'>",
+      attribution: copyright + ". Tiles courtesy of <a href='http://www.mapquest.com/' target='_blank'>MapQuest</a> <img src='http://developer.mapquest.com/content/osm/mq_logo.png'>",
       code: "Q",
       keyid: "mapquest",
       name: I18n.t("javascripts.map.base.mapquest")

--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -44,7 +44,6 @@
           <ul>
             <li><%= link_to(t('layouts.help_centre'), t('layouts.help_url'), :title => t('layouts.help_title')) %></li>
             <li><%= link_to(t('layouts.documentation'), t('layouts.wiki_url'), :title => t('layouts.documentation_title')) %></li>
-            <li><%= link_to t('layouts.copyright'), copyright_path %></li>
           </ul>
         </li>
         <li>
@@ -59,6 +58,9 @@
         </li>
         <li>
           <h4><%= t'layouts.data' %></h4>
+          <ul>
+            <li><%= link_to t('layouts.copyright'), copyright_path %></li>
+          </ul>
           <ul>
             <li><%= link_to t('layouts.export_data'), export_path %></li>
           </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2085,6 +2085,7 @@ en:
         notes: Map Notes
         data: Map Data
         overlays: Enable overlays for troubleshooting the map
+      copyright: "© <a href='%{copyright_url}'>OpenStreetMap contributors</a>"
     site:
       edit_tooltip: Edit the map
       edit_disabled_tooltip: Zoom in to edit the map


### PR DESCRIPTION
Its current location, under "Help" in the sidebar, feels a bit out of place -- information about OSM copyright and license is not really "Help".

Placing it in the standard Leaflet attribution control also has the benefit of being something we can point to as a canonical example of an acceptable way to attribute OSM.
