### PR TITLE
Add an og:image meta tag

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -15,6 +15,7 @@
   <%= tag("link", { :rel => "publisher", :href => "https://plus.google.com/111953119785824514010" }) %>
   <%= tag("link", { :rel => "search", :type => "application/opensearchdescription+xml", :title => "OpenStreetMap Search", :href => asset_path("osm.xml") }) %>
   <%= tag("meta", { :name => "description", :content => "OpenStreetMap is the free wiki world map." }) %>
+  <%= tag("meta", :property => "og:image", :content => image_path("osm_logo.png")) %>
   <% if flash[:piwik_goal] -%>
   <%= tag("meta", :name => "piwik-goal", :content => flash[:piwik_goal]) %>
   <% end -%>  


### PR DESCRIPTION
Without this, links to OpenStreetMap.org shared via Facebook default to the ad
image.

Fixes systemed/iD#1644
