### PR TITLE
Make iD default editor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -422,6 +422,24 @@ class ApplicationController < ActionController::Base
     request.body.rewind
   end
 
+  def preferred_editor
+    editor = if params[:editor]
+      params[:editor]
+    elsif @user and @user.preferred_editor
+      @user.preferred_editor
+    else
+      DEFAULT_EDITOR
+    end
+
+    if request.env['HTTP_USER_AGENT'] =~ /MSIE/ and editor == 'id'
+      editor = 'potlatch2'
+    end
+
+    editor
+  end
+
+  helper_method :preferred_editor
+
 private 
 
   # extract authorisation credentials from headers, returns user = nil if none

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -52,7 +52,7 @@ class SiteController < ApplicationController
   end
 
   def edit
-    editor = params[:editor] || @user.preferred_editor || DEFAULT_EDITOR
+    editor = preferred_editor
 
     if editor == "remote"
       render :action => :index

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,16 +57,6 @@ module ApplicationHelper
     content_tag(tag, capture(&block), :class => "hide_unless_administrator")
   end
 
-  def preferred_editor
-    if params[:editor]
-      params[:editor]
-    elsif @user and @user.preferred_editor
-      @user.preferred_editor
-    else
-      DEFAULT_EDITOR
-    end
-  end
-
   def scale_to_zoom(scale)
     Math.log(360.0 / (scale.to_f * 512.0)) / Math.log(2.0)
   end

--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -73,7 +73,7 @@ defaults: &defaults
   # URL of Nominatim instance to use for geocoding
   nominatim_url: "http://nominatim.openstreetmap.org/"
   # Default editor
-  default_editor: "potlatch2"
+  default_editor: "id"
   # OAuth consumer key for Potlatch 2
   #potlatch2_key: ""
   # OAuth consumer key for the web site


### PR DESCRIPTION
This makes iD the default editor on OSM. It's already the first option in the drop down, but this PR makes iD the editor that users land in when they just click the "Edit" label.

I hope to get this merged, now that [initial concerns](https://github.com/openstreetmap/openstreetmap-website/pull/262) were addressed with the 1.1. release of iD [that was just rolled out on OpenStreetMap.org](https://github.com/openstreetmap/openstreetmap-website/pull/424):
- Improved performance
- Added relation support
