### PR TITLE
Remove Banner Ad section post-SOTM2013 (Birmingham)

### DIFF
--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -70,18 +70,6 @@
         </li>
         <%= yield :left_menu %>
       </ul>
-      <div class='ad-container inner11'>
-        <div class='ads'>
-          <%= ad = [{:image => 'sotm-birmingham-ad.png',
-                     :title => 'State of the Map Birmingham',
-                     :href =>'http://stateofthemap.org/'}].sample
-
-              link_to ad[:href], :title => ad[:title] do
-                image_tag ad[:image], :class => :ad
-              end
-          %>
-        </div>
-      </div>
       <a title="<%= h(t('layouts.make_a_donation.title')) %>" href="http://donate.openstreetmap.org/" class="donate">
         <span class='icon donate'></span>
         <span><%= h(t('layouts.make_a_donation.text')) %></span>


### PR DESCRIPTION
Remove Banner Advert section post-SOTM2013 (Birmingham) and there are no other current adverts to rotate.
