### PR TITLE
Tighten White-space usage for Nomination "View details" with float:right

### DIFF
--- a/app/helpers/geocoder_helper.rb
+++ b/app/helpers/geocoder_helper.rb
@@ -19,7 +19,7 @@ module GeocoderHelper
     html << result[:suffix] if result[:suffix]
 
     if result[:type] and result[:id]
-      html << content_tag(:small, :class => ["deemphasize", "search_details", "clearfix"]) do
+      html << content_tag(:small, :class => ["deemphasize", "search_details"]) do
         link_to(t("browse.#{result[:type]}_history.view_details"), :controller => :browse, :action => result[:type], :id => result[:id])
       end
     end

--- a/app/views/geocoder/results.html.erb
+++ b/app/views/geocoder/results.html.erb
@@ -3,7 +3,7 @@
 <% else %>
   <ul class='results-list'>
   <% @results.each do |result| %>
-    <li><p class="inner12 search_results_entry"><%= result_to_html(result) %></p></li>
+    <li><p class="inner12 search_results_entry clearfix"><%= result_to_html(result) %></p></li>
   <% end %>
 </ul>
   <% if @more_params %>


### PR DESCRIPTION
Tighten vertical white-space by allowing Nomination "View details" results to `float:right` with the result.  The `margin-left:0.5em;` ensures there is a single-character spacing between the result and view details.  The `margin-top:0.2em;` is a kludge; as variants of `vertical-align:baseline` don't seem to be working and it looks odd unless the baselines are matching.  Help/suggestions appreciated!
![osm-nomination-view-details](https://f.cloud.github.com/assets/27120/1119530/c15667fc-1a7a-11e3-8a6f-d4226c4aff88.png)
