### PR TITLE
Added Glow to Search Box

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -407,7 +407,7 @@ table {
   }
 
   input[type="text"]:focus {
-    box-shadow: 0px 0px 7px green;
+    box-shadow: 0px 0px 7px #9ED485;
     outline: none;
   }
   


### PR DESCRIPTION
The black focus border around the search bar really doesn't fit with the theme of the site. A green glow really cleans it up.
