### PR TITLE
Update nl.yml

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -989,15 +989,15 @@ nl:
     close: Sluiten
     edit_help: Verplaats de kaar en zoom in op een plaats die u wilt bewerken. Klik er daarna op.
     key: 
-      title: Toets toewijzen
-      tooltip: Toets toewijzen
-      tooltip_disabled: Kaart sleutel is alleen beschikbaar voor standaardlaag
+      title: Legende
+      tooltip: Legende
+      tooltip_disabled: Legende is enkel beschikbaar voor standaardlaag
     map: 
       base: 
         cycle_map: Fietskaart
         mapquest: MapQuest Open
         standard: Standaard
-        transport_map: Transport Map
+        transport_map: Transport Kaart
       copyright: © <a href='%{copyright_url}'>OpenStreetMapbijdragers</a>
       layers: 
         data: Kaartgegevens
@@ -1013,7 +1013,7 @@ nl:
     notes: 
       new: 
         add: Opmerking toevoegen
-        intro: Om de kaar te verbeteren, worden de gegevens die u opgeeft weergegeven aan andere kaartmakers. Maak uw opmerkingen zo beschrijvend mogelijk en plaats de markering zo precies als mogelijk.
+        intro: Om de kaart te verbeteren, worden de gegevens die u opgeeft weergegeven aan andere kaartmakers. Maak uw opmerkingen zo beschrijvend mogelijk en plaats de markering zo precies als mogelijk.
       show: 
         anonymous_warning: In deze opmerking staan reacties van anonieme gebruikers die moeten worden gecontroleerd.
         closed_by: opgelost door <a href='%{user_url}'>%{user}</a> om %{time}
@@ -1039,7 +1039,7 @@ nl:
       format: "Formaat:"
       image: Afbeelding
       image_size: Afbeelding geeft standaardlaag weer op
-      include_marker: Marker opnemen
+      include_marker: Marker invoegen
       link: Koppeling of HTML
       long_link: Koppeling
       paste_html: Plak de HTML om op te nemen in website


### PR DESCRIPTION
Lines 992-994: incorrect translation. IN this context "Map Key" should be translated by "Legende".
Line 1000: "Transport map" => "Transport Kaart"
Line 1000: typo in the word "kaart" (was "kaar")
Line 1033-1050: I don't know how to fix this but the NL strings don't fit in the space provided for the EN version, which creates a button mess. I suggest to arrange 3 buttons vertically.
Line 1042: "invoegen" is more appropriate than "opnemen"
Line 1002: there is no tooltip for the "Layers" feature. Correct tooltip would be "Kaartlagen".
Line 996: in the "base" section the "Humanitarian" map is not listed. Correct NL name would be "Humanitair".

Note: there are numerous tags which could have a better NL translation, but this is beyond the scope of this file change request. If you need help, let me know.
