### PR TITLE
Use uniform abbreviations for CC licenses

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1076,7 +1076,7 @@ en:
       intro_3_html: |
         The cartography in our map tiles, and our documentation, are
         licensed under the <a href="http://creativecommons.org/licenses/by-sa/2.0/">Creative
-        Commons Attribution-ShareAlike 2.0</a> license (CC-BY-SA).
+        Commons Attribution-ShareAlike 2.0</a> license (CC BY-SA).
       credit_title_html: How to credit OpenStreetMap
       credit_1_html: |
         We require that you use the credit &ldquo;&copy; OpenStreetMap
@@ -1084,7 +1084,7 @@ en:
       credit_2_html: |
         You must also make it clear that the data is available under the Open
         Database License, and if using our map tiles, that the cartography is
-        licensed as CC-BY-SA. You may do this by linking to
+        licensed as CC BY-SA. You may do this by linking to
         <a href="http://www.openstreetmap.org/copyright">this copyright page</a>.
         Alternatively, and as a requirement if you are distributing OSM in a
         data form, you can name and link directly to the license(s). In media
@@ -1119,7 +1119,7 @@ en:
         <a href="http://data.wien.gv.at/">Stadt Wien</a> (under
         <a href="http://creativecommons.org/licenses/by/3.0/at/deed.de">CC BY</a>),
         <a href="http://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Land Vorarlberg</a> and
-        Land Tirol (under <a href="http://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC-BY AT with amendments</a>).
+        Land Tirol (under <a href="http://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC BY AT with amendments</a>).
       contributors_ca_html: |
         <strong>Canada</strong>: Contains data from
         GeoBase&reg;, GeoGratis (&copy; Department of Natural


### PR DESCRIPTION
We have both "CC-BY" and "CC BY" on the copyright page. Creative Commmons itself uses the CC BY or CC BY-SA form.
