### PR TITLE
Quote object type in search during prefix lookup

### DIFF
--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -160,7 +160,7 @@ class GeocoderController < ApplicationController
       type = place.attributes["type"].to_s
       name = place.attributes["display_name"].to_s
       min_lat,max_lat,min_lon,max_lon = place.attributes["boundingbox"].to_s.split(",")
-      prefix_name = t "geocoder.search_osm_nominatim.prefix.#{klass}.#{type}", :default => type.gsub("_", " ").capitalize
+      prefix_name = t "geocoder.search_osm_nominatim.prefix.#{klass}.'#{type}'", :default => type.gsub("_", " ").capitalize
       if klass == 'boundary' and type == 'administrative'
         rank = (place.attributes["place_rank"].to_i + 1) / 2
         prefix_name = t "geocoder.search_osm_nominatim.admin_levels.level#{rank}", :default => prefix_name


### PR DESCRIPTION
Fixes displaying of search results that have an empty type, e.g. [Stele, Rue de la Chapelle](http://www.openstreetmap.org/?query=stele, rue de la chapelle).
