### PR TITLE
Disable automatic gravatar opt-in, as it violates the privacy policy

### DIFF
--- a/db/migrate/20131029121300_set_default_gravatar_to_false_for_privacy.rb
+++ b/db/migrate/20131029121300_set_default_gravatar_to_false_for_privacy.rb
@@ -1,0 +1,9 @@
+class SetDefaultGravatarToFalseForPrivacy < ActiveRecord::Migration
+  def up
+    change_column :users, :image_use_gravatar, :boolean, :default => false
+  end
+
+  def down
+    change_column :users, :image_use_gravatar, :boolean, :default => true
+  end
+end


### PR DESCRIPTION
Currently there is an automatic opt-in for all new users to have gravatar enabled.

This transmits the users unsalted md5 hash of their email address over an unencrypted
link the the third party site gravatar.com before the user has a chance to opt-out.

This is in clear violation of the OpenStreetMap privacy policy, which states:
"The registered email address for an OSM user account, will never intentionally
be published on the internet anywhere, shared with third party organisations, ..."

One can still explicitly opt-in to the use by setting the "use gravatar" option
on ones settings page, if one wishes.