### PR TITLE
Add X-UA-Compatible meta tag

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,4 +1,5 @@
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0"/>
   <%= javascript_include_tag "application" %>
   <!--[if lt IE 7]><%= javascript_include_tag "pngfix" %><![endif]--> <!-- thanks, microsoft! -->


### PR DESCRIPTION
Rails 4 removed the `BestStandardsSupport` middleware, because supposedly a HTML5 doctype accomplishes the same thing. But not quite -- without X-UA-Compatible, the UI for changing compatibility mode is still visible, and users can get themselves into a bad state (see https://github.com/openstreetmap/openstreetmap-website/pull/498#issuecomment-28483550)
