### PR TITLE
Fix hidden text behind the search icon

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -398,7 +398,7 @@ table {
     font-size: $typeheight;
     line-height: 1.1;
     height: 25px;
-    padding: 2px 0px 2px $lineheight/4;
+    padding: 2px 22px 2px $lineheight/4;
     box-shadow: inset #DDD 0px 1px 3px;
 
     transition: 300ms linear;


### PR DESCRIPTION
When you input long texts in the search box, the search icon hide the end of it

![openstreetmap_20131121_025322](https://f.cloud.github.com/assets/1282371/1589767/f88b01ba-5279-11e3-9b3b-e044ddec80b5.png)
