### PR TITLE
Restore Copyright & License link

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -39,6 +39,7 @@
       <li class="compact-hide <%= current_page_class(diary_path) %>"><%= link_to t('layouts.user_diaries'), diary_path %></li>
       <li class="compact-hide <%= current_page_class(help_path) %>"><%= link_to t('layouts.help'), help_path %></li>
       <li class="compact-hide <%= current_page_class(about_path) %>"><%= link_to t('layouts.about'), about_path %></li>
+      <li class="compact-hide <%= current_page_class(copyright_path) %>"><%= link_to t('layouts.copyright'), copyright_path %></li>
       <li id="compact-secondary-nav" class="dropdown">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">More <b class="caret"></b></a>
         <ul class="dropdown-menu">
@@ -46,6 +47,7 @@
           <li class="<%= current_page_class(diary_path) %>"><%= link_to t('layouts.user_diaries'), diary_path %></li>
           <li class="<%= current_page_class(help_path) %>"><%= link_to t('layouts.help'), help_path %></li>
           <li class="<%= current_page_class(about_path) %>"><%= link_to t('layouts.about'), about_path %></li>
+          <li class="<%= current_page_class(copyright_path) %>"><%= link_to t('layouts.copyright'), copyright_path %></li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
The copyright and license is an important part of OpenStreetMap.
This restores the copyright & license link to the menu, placing
it in the top-right with the other pages which do not display a map.

Fixes #548

Fixes comments in https://github.com/openstreetmap/openstreetmap-website/pull/498#issuecomment-26741518
