### PR TITLE
Move changeset comment to just after changeset info, & style as if a quote

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -1023,6 +1023,10 @@ header .search_form {
     padding: $lineheight/2 $lineheight;
     border-bottom: 1px solid #ddd;
 
+    .changesetcomment {
+      font-style: italic;
+    }
+
     h4:first-child {
       margin-top: 0;
     }

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,11 +1,3 @@
-<h4>
-  <% if common_details.changeset.tags['comment'].present? %>
-    <%= linkify(h(common_details.changeset.tags['comment'])) %>
-  <% else %>
-    <%= t 'browse.no_comment' %>
-  <% end %>
-</h4>
-
 <div class="details">
   <%=
       t "browse.#{common_details.visible? ? :edited : :deleted}_by_html",
@@ -21,6 +13,14 @@
   &middot;
   <%= t 'browse.in_changeset' %>
   #<%= link_to common_details.changeset_id, :action => :changeset, :id => common_details.changeset_id %>
+</div>
+
+<div class="details changesetcomment">
+  <% if common_details.changeset.tags['comment'].present? %>
+    &quot;<%= linkify(h(common_details.changeset.tags['comment'])) %>&quot;
+  <% else %>
+    <%= t 'browse.no_comment' %>
+  <% end %>
 </div>
 
 <% if @type == "node" %>


### PR DESCRIPTION
The current browse pane for a way (or node etc) looks a bit odd with the changeset comment coming first, as if the comment was about the object one is looking at, which is often not the case. This could be rather confusing. In this PR I have moved it to just under the changeset metadata, and also styled it as a quote (in italiics, with quotemarks).
