### PR TITLE
Auto-uncheck the data and notes layers at low zoom

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -132,15 +132,18 @@ L.OSM.layers = function(options) {
         var label = $('<label>')
           .appendTo(item);
 
+        var checked = map.hasLayer(layer);
+
         var input = $('<input>')
           .attr('type', 'checkbox')
-          .prop('checked', map.hasLayer(layer))
+          .prop('checked', checked)
           .appendTo(label);
 
         label.append(name);
 
         input.on('change', function() {
-          if (input.is(':checked')) {
+          checked = input.is(':checked');
+          if (checked) {
             map.addLayer(layer);
           } else {
             map.removeLayer(layer);
@@ -155,6 +158,16 @@ L.OSM.layers = function(options) {
         map.on('zoomend', function() {
           var disabled = map.getBounds().getSize() >= maxArea;
           $(input).prop('disabled', disabled);
+
+          if (disabled && $(input).is(':checked')) {
+            $(input).prop('checked', !disabled)
+              .trigger('change');
+            checked = true;
+          } else if (!disabled && !$(input).is(':checked') && checked) {
+            $(input).prop('checked', true)
+              .trigger('change');
+          }
+
           $(item).attr('class', disabled ? 'disabled' : '');
           item.attr('data-original-title', disabled ?
             I18n.t('javascripts.site.' + refName + '_zoom_in_tooltip') : '');


### PR DESCRIPTION
Reenable them when returning to high zoom in the same session.

Fixes #592
