### PR TITLE
API: query changesets by ids

### DIFF
--- a/app/controllers/changeset_controller.rb
+++ b/app/controllers/changeset_controller.rb
@@ -418,11 +418,13 @@ private
   # query changesets by a list of ids
   # (either specified as array or comma-separated string)
   def conditions_ids(changesets, ids)
-    if ids.nil? or ids.empty?
+    if ids.nil?
       return changesets
+    elsif ids.empty?
+      raise OSM::APIBadUserInput.new("No changesets were given to search for")
     else
-      ids = ids.split(',').collect { |n| n.to_i } if ids.kind_of?(String)
-      return changesets.where("id IN (?)", ids)
+      ids = ids.split(',').collect { |n| n.to_i }
+      return changesets.where(:id => ids)
     end
   end
 

--- a/test/functional/changeset_controller_test.rb
+++ b/test/functional/changeset_controller_test.rb
@@ -1548,9 +1548,8 @@ EOF
     assert_response :success, "can't get changesets by id (as comma-separated string)"
     assert_changesets [1,2,3]
 
-    get :query, :changesets => [1,2,3]
-    assert_response :success, "can't get changesets by id (as array)"
-    assert_changesets [1,2,3]
+    get :query, :changesets => ''
+    assert_response :bad_request, "should be a bad request since changesets is empty"
   end
 
   ##


### PR DESCRIPTION
Make changesets query-able by specifying a list of ids, e.g., `/api/0.6/changesets?changesets=1,2,3`. (Related to #534, #584.)
