### PR TITLE
Unconditionally unbind moveend event

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -134,10 +134,7 @@ OSM.History = function(map) {
 
   page.unload = function() {
     map.removeLayer(group);
-
-    if (window.location.pathname === '/history') {
-      map.off("moveend", update)
-    }
+    map.off("moveend", update);
 
     $("#history_tab").removeClass("current");
   };


### PR DESCRIPTION
Can't rely on checking location.pathname -- inside unload, it already contains
the new path. Fortunately, checking is unnecessary.

Fixes TypeError: Cannot call method 'split' of undefined.
