### PR TITLE
Run unload method before pushing the new state

### DIFF
--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -113,8 +113,8 @@ OSM.Router = function(map, rts) {
       var path = url.replace(/#.*/, ''),
         route = routes.recognize(path);
       if (!route) return false;
-      window.history.pushState(OSM.parseHash(url), document.title, url);
       currentRoute.run('unload');
+      window.history.pushState(OSM.parseHash(url), document.title, url);
       currentPath = path;
       currentRoute = route;
       currentRoute.run('pushstate', currentPath);


### PR DESCRIPTION
If running unload causes any hash changes, those should not end up on the new
URL.

Fixes #622
