### PR TITLE
Obey the location hash for edit URLs with objects

### DIFF
--- a/app/views/site/_id.html.erb
+++ b/app/views/site/_id.html.erb
@@ -8,6 +8,10 @@
     var mapParams = OSM.mapParams();
     if (mapParams.object) {
       params.id = mapParams.object.type[0] + mapParams.object.id;
+      mapParams = OSM.parseHash(location.hash);
+      if (mapParams.center) {
+        params.map = mapParams.zoom + '/' + mapParams.center.lng + '/' + mapParams.center.lat;
+      }
     } else {
 <% if @lat && @lon -%>
       params.map = '16/<%= @lon %>/<%= @lat %>';


### PR DESCRIPTION
For a link like http://osm.org/edit?node=n#map=19/37.77683/-122.41459,  select
the feature but also respect the map location.

This is the fix for iD. It appears P2 requires internal code modifications.

Refs #620
