### PR TITLE
Don't zoom in when clicking a note

### DIFF
--- a/app/assets/javascripts/index/note.js.erb
+++ b/app/assets/javascripts/index/note.js.erb
@@ -67,7 +67,7 @@ OSM.Note = function (map) {
     if (!window.location.hash || window.location.hash.match(/^#?c[0-9]+$/)) {
       OSM.router.moveListenerOff();
       map.once('moveend', OSM.router.moveListenerOn);
-      map.getZoom() > 15 ? map.panTo(latLng) : map.setView(latLng, 16);
+      map.panTo(latLng);
     }
 
     if (!map.hasLayer(halo)) {


### PR DESCRIPTION
This fixes the issue reported in #643 where clicking a note would zoom in to level 16.
