### PR TITLE
fix typo in diary form html

### DIFF
--- a/app/views/diary_entry/edit.html.erb
+++ b/app/views/diary_entry/edit.html.erb
@@ -19,7 +19,7 @@
         <label class="standard-label"><%= t 'diary_entry.edit.body' -%></label>
         <%= richtext_area :diary_entry, :body, :cols => 80, :rows => 20, :format => @diary_entry.body_format %>
       </div>
-      <div clas='form-row'>
+      <div class='form-row'>
         <label class="standard-label"><%= t 'diary_entry.edit.language' -%></label>
         <%= f.collection_select :language_code, Language.order(:english_name), :code, :name %>
     </div>


### PR DESCRIPTION
was: `clas='form-row'` is `class='…`
