### PR TITLE
Fix bottom space forgotten when read a message

### DIFF
--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -1698,6 +1698,7 @@ header .search_form {
 
 .message-read .message-buttons {
   margin-top: $lineheight;
+  margin-bottom: $lineheight * 1.5;
   padding-top: $lineheight;
   border-top: 1px solid $lightgrey;
 }


### PR DESCRIPTION
We forgot to add the bottom space on the page to read a message (http://www.openstreetmap.org/message/read/###). The error can be seen only on long messages.

The value of `$lineheight` is insufficient, but with a value of `30px` is solved.

![img](https://f.cloud.github.com/assets/1282371/1927804/37779d00-7e69-11e3-8b64-cafe0296a68a.png)
