### PR TITLE
Changing the note search limit from 9999 to 10000

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -309,10 +309,10 @@ private
   # Get the maximum number of results to return
   def result_limit
     if params[:limit]
-      if params[:limit].to_i > 0 and params[:limit].to_i < 10000
+      if params[:limit].to_i > 0 and params[:limit].to_i <= 10000
         params[:limit].to_i
       else
-        raise OSM::APIBadUserInput.new("Note limit must be between 1 and 9999")
+        raise OSM::APIBadUserInput.new("Note limit must be between 1 and 10000")
       end
     else
       100

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -632,7 +632,7 @@ class NotesControllerTest < ActionController::TestCase
     get :index, {:bbox => '1,1,1.7,1.7', :limit => '0', :format => 'json'}
     assert_response :bad_request
 
-    get :index, {:bbox => '1,1,1.7,1.7', :limit => '10000', :format => 'json'}
+    get :index, {:bbox => '1,1,1.7,1.7', :limit => '10001', :format => 'json'}
     assert_response :bad_request
   end
 
@@ -709,7 +709,7 @@ class NotesControllerTest < ActionController::TestCase
     get :search, {:q => 'no match', :limit => '0', :format => 'json'}
     assert_response :bad_request
 
-    get :search, {:q => 'no match', :limit => '10000', :format => 'json'}
+    get :search, {:q => 'no match', :limit => '10001', :format => 'json'}
     assert_response :bad_request
   end
 
@@ -743,7 +743,7 @@ class NotesControllerTest < ActionController::TestCase
     get :feed, {:bbox => "1,1,1.2,1.2", :limit => '0', :format => "rss"}
     assert_response :bad_request
 
-    get :feed, {:bbox => "1,1,1.2,1.2", :limit => '10000', :format => "rss"}
+    get :feed, {:bbox => "1,1,1.2,1.2", :limit => '10001', :format => "rss"}
     assert_response :bad_request
   end
 


### PR DESCRIPTION
The documentation says the limit is 10000 which seems like a nicer round number anyway.
