### PR TITLE
API: Enable output of elevation in GPS data

### DIFF
--- a/app/models/tracepoint.rb
+++ b/app/models/tracepoint.rb
@@ -16,6 +16,9 @@ class Tracepoint < ActiveRecord::Base
     el1['lat'] = self.lat.to_s
     el1['lon'] = self.lon.to_s
     el1 << (XML::Node.new("time") << self.timestamp.xmlschema) if print_timestamp
+    if self.altitude
+      el1 << (XML::Node.new('ele') << self.altitude.to_s)
+    end
     return el1
   end
 end


### PR DESCRIPTION
This Pull Request enables the API call `/api/0.6/trackpoints` to output the elevation ("ele") data associated with the GPS points it is returning. At present, it's possible to download individual (public) traces in order to get at the ele data, but this is much more awkward than the bulk API call and would not include trackpoints from semi-public traces.

The output conforms with GPX. All rake tests pass, on my machine.

There are a couple of potential counter-arguments to this modification. One is that GPS elevation data is not very accurate/helpful. I would argue that we have quite a large volume of GPS data, and the volume of GPS "ele" data likely makes it possible to perform very good analysis of means and outliers (as one already does with lat/lon data). It should be a rich source for [statistical analysis](http://mcld.co.uk/blog/blog.php?416). I am motivated here by the idea of using GPS elevations to check for issues in OSM "ele" node tagging.

Another possible counter-argument is that this increases the filesize of GPS query results, and so the bandwidth usage for that API call. I'm not in a position to judge the impact of that, but the change is small.

I hope this seems OK to you.
