### PR TITLE
Message won't get lost if user forgets subject

### DIFF
--- a/app/controllers/message_controller.rb
+++ b/app/controllers/message_controller.rb
@@ -26,6 +26,8 @@ class MessageController < ApplicationController
           flash[:notice] = t 'message.new.message_sent'
           Notifier.message_notification(@message).deliver
           redirect_to :controller => 'message', :action => 'inbox', :display_name => @user.display_name
+        else
+          @body = @message.body
         end
       end
     else


### PR DESCRIPTION
This addresses issue #668 where a message submitted without a subject resets the form with a blank message. The form already uses @body and we can refill the form with the message if a save fails.
