### PR TITLE
Make it clear that notes are for map improvements

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2102,7 +2102,7 @@ en:
       map_data_zoom_in_tooltip: Zoom in to see map data
     notes:
       new:
-        intro: "In order to improve the map the information you enter is shown to other mappers, so please be as descriptive and precise as possible when moving the marker to the correct position and entering your note below."
+        intro: "Spotted a mistake or something missing? Let other mappers know so we can fix it. Move the marker to the correct position and type a note to explain the problem. (Please don't enter personal information here.)"
         add: Add Note
       show:
         anonymous_warning: This note includes comments from anonymous users which should be independently verified.


### PR DESCRIPTION
...and use friendlier-sounding language. Should help avoid instances like http://www.openstreetmap.org/note/114639 and http://www.openstreetmap.org/note/114640, though I'm sorely tempted to add "amenity=brian" and "amenity=george" in response to these.
