### PR TITLE
Fixed wikipedia link reference to specific sections

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -114,16 +114,24 @@ private
         lang = 'en'
       end
     elsif key =~ /^wikipedia:(\S+)$/
-      # Language is in the key, so assume value is a simple title
+      # Language is in the key, so assume value is the title
       lang = $1
     else
       # Not a wikipedia key!
       return nil
     end
 
+    section = ""
+    if value =~ /^([^#]*)(#.*)/ then
+      # Contains a reference to a section of the wikipedia article
+      # Must break it up to correctly build the url
+      value = $1
+      section = $2
+    end
+
     return {
-      :url => "http://#{lang}.wikipedia.org/wiki/#{value}?uselang=#{I18n.locale}",
-      :title => value
+      :url => "http://#{lang}.wikipedia.org/wiki/#{value}?uselang=#{I18n.locale}#{section}",
+      :title => value + section
     }
   end
 end


### PR DESCRIPTION
The wikipedia link wasn't correctly created when they were referencing a section of an article.
Well, it did work, it just broke the reference to the article's section.

There is a good number of values for the `wikipedia=*` key referencing a specific section, [as shown by taginfo](http://taginfo.openstreetmap.org/keys/wikipedia).
