### PR TITLE
Add "translators" to community_driven_html

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1140,7 +1140,7 @@ en:
       OpenStreetMap's community is diverse, passionate, and growing every day.
       Our contributors include enthusiast mappers, GIS professionals, engineers
       running the OSM servers, humanitarians mapping disaster-affected areas,
-      and many more.
+      translators, and many more.
       To learn more about the community, see the <a href='%{diary_path}'>user diaries</a>,
       <a href='http://blogs.openstreetmap.org/'>community blogs</a>, and
       the <a href='http://www.osmfoundation.org/'>OSM Foundation</a> website.


### PR DESCRIPTION
A little tribute to the people at translatewiki.net and elsewhere,
who contribute OSM translations. Hopefully, this would encourage
more translators to contribute.
