### PR TITLE
Penalize users who post multiple diaries before posting a change set

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -213,6 +213,7 @@ class User < ActiveRecord::Base
     diary_comment_score = self.diary_comments.inject(0) { |s,c| s += c.body.spam_score }
 
     score = self.description.spam_score / 4.0
+    score += self.diary_entries.length*30 if self.changesets.size < 1
     score += diary_entry_score / self.diary_entries.length if self.diary_entries.length > 0
     score += diary_comment_score / self.diary_comments.length if self.diary_comments.length > 0
     score -= changeset_score


### PR DESCRIPTION
Penalize users who post multiple diaries before posting a change set.

If I read the code correctly, 30 should suspend the user on the second entry, in the case that they are posting entries that do not have high spam scores.
