### PR TITLE
Instruct iD to load gpx file

### DIFF
--- a/app/views/site/_id.html.erb
+++ b/app/views/site/_id.html.erb
@@ -28,6 +28,8 @@
 
     if (hashParams.gpx) {
       params.gpx = hashParams.gpx;
+    } else if (OSM.params().gpx) {
+      params.gpx = '/trace/'+OSM.params().gpx+'/data';
     }
 
     $('#id-embed').attr('src', '<%= id_url :locale => params[:locale] %>#' + querystring.stringify(params));


### PR DESCRIPTION
See https://github.com/openstreetmap/iD/issues/970#issuecomment-43439476. When one clicks on the edit link of an uploaded GPX file, this instructs the iD editor to load the respective GPX data from the appropriate URL (https://github.com/openstreetmap/iD/pull/2011).
