### PR TITLE
Updated robots.txt for new routes (no more /browse)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,18 +2,18 @@ Sitemap: http://www.openstreetmap.org/sitemap.xml.gz
 
 User-agent: *
 Disallow: /user/*/traces/
-Disallow: /user/*/edits
+Disallow: /user/*/history
 Allow: /user/
 Disallow: /traces/tag/
 Disallow: /traces/page/
 Disallow: /api/
 Disallow: /edit
-Disallow: /browse/node/*/history
-Disallow: /browse/way/*/history
-Disallow: /browse/relation/*/history
-Allow: /browse/node/
-Allow: /browse/way/
-Allow: /browse/relation/
+Disallow: /node/*/history
+Disallow: /way/*/history
+Disallow: /relation/*/history
+Allow: /node/
+Allow: /way/
+Allow: /relation/
 Disallow: /browse
 Disallow: /login
 Disallow: /geocoder


### PR DESCRIPTION
Updated for changes done in
3cd5f45e08d977d04a778ab8802f71df85edc314 and
61bb31ebdddc9e7c317a1c6784a68874d5a0ef80

Test search queries listing the pages that were not suppose to be indexed by robots:
https://www.google.si/search?q=site%3Awww.openstreetmap.org+inurl%3Auser+inurl%3Ahistory
https://www.google.si/search?q=site%3Awww.openstreetmap.org+inurl%3Anode+inurl%3Ahistory
