### PR TITLE
Remove myopenid from openid providers

### DIFF
--- a/app/views/user/login.html.erb
+++ b/app/views/user/login.html.erb
@@ -44,7 +44,6 @@
           <li><%= link_to image_tag("openid.png", :alt => t("user.login.openid_providers.openid.title")), "#", :id => "openid_open_url", :title => t("user.login.openid_providers.openid.title") %></li>
           <li><%= openid_button "google", "gmail.com" %></li>
           <li><%= openid_button "yahoo", "me.yahoo.com" %></li>
-          <li><%= openid_button "myopenid", "myopenid.com" %></li>
           <li><%= openid_button "wordpress", "wordpress.com" %></li>
           <li><%= openid_button "aol", "aol.com" %></li>
         </ul>

--- a/config/locales/ast.yml
+++ b/config/locales/ast.yml
@@ -1666,9 +1666,6 @@ ast:
         google: 
           alt: Coneutar con una OpenID de Google
           title: Coneutar con Google
-        myopenid: 
-          alt: Coneutar con una OpenID de myOpenID
-          title: Coneutar con myOpenID
         openid: 
           alt: Coneutar con una URL OpenID
           title: Coneutar con OpenID

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1063,9 +1063,6 @@ az:
         google: 
           alt: Google OpenID ilə hesabınıza daxil olun
           title: Google ilə hesaba giriş
-        myopenid: 
-          alt: myOpenID OpenID ilə hesabınıza daxil olun
-          title: myOpenID ilə hesaba giriş
         openid: 
           alt: OpenID URL ilə hesabınıza daxil olun
           title: OpenID ilə hesaba giriş

--- a/config/locales/be-Tarask.yml
+++ b/config/locales/be-Tarask.yml
@@ -1277,9 +1277,6 @@ be-Tarask:
         google: 
           alt: Увайсьці ў сыстэму з дапамогай Google OpenID
           title: Увайсьці ў сыстэму з дапамогай Google
-        myopenid: 
-          alt: Увайсьці ў сыстэму з дапамогай myOpenID OpenID
-          title: Увайсьці ў сыстэму з дапамогай myOpenID
         openid: 
           alt: Увайсьці ў сыстэму з дапамогай URL-адрасу OpenID
           title: Увайсьці ў сыстэму з дапамогай OpenID

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1670,9 +1670,6 @@ be:
         google: 
           alt: Уваход праз Google OpenID
           title: Уваход праз Google
-        myopenid: 
-          alt: Уваход праз myOpenID OpenID
-          title: Уваход праз myOpenID
         openid: 
           alt: Увайсці з дапамогай OpenID URL
           title: Уваход праз OpenID

--- a/config/locales/br.yml
+++ b/config/locales/br.yml
@@ -1671,9 +1671,6 @@ br:
         google: 
           alt: Keverañ gant ur Google OpenID
           title: Keverañ gant Google
-        myopenid: 
-          alt: Kevreañ gant ur myOpenID OpenID
-          title: Kevreañ gant myOpenID
         openid: 
           alt: Kevreañ gant un OpenID URL
           title: Kevreañ gant OpenID

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -1466,9 +1466,6 @@ bs:
         google: 
           alt: Prijavite se sa Google OtvorenimID
           title: Prijavite se sa Google računom
-        myopenid: 
-          alt: Prijavite se sa MojOtvoreniID OtvorenimID
-          title: Prijavite se sa MojOtvoreniID
         openid: 
           alt: Prijavite se sa URL OtvorenogID
           title: Prijavite se sa otvorenimID

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1694,9 +1694,6 @@ ca:
         google: 
           alt: Inicia sessió amb un OpenID de Google
           title: Inicia sessió amb Google
-        myopenid: 
-          alt: Inicia sessió amb un myOpenID OpenID
-          title: Inicia sessió amb myOpenID
         openid: 
           alt: Inicia sessió amb un URL d'OpenID
           title: Inicia sessió amb OpenID

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1698,9 +1698,6 @@ cs:
         google: 
           alt: Přihlášení pomocí Google OpenID
           title: Přihlášení pomocí Google
-        myopenid: 
-          alt: Přihlášení pomocí myOpenID OpenID
-          title: Přihlášení pomocí myOpenID
         openid: 
           alt: Přihlášení pomocí OpenID URL
           title: Přihlášení pomocí OpenID

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1682,9 +1682,6 @@ da:
         google: 
           alt: Log på med et Google OpenID
           title: Log på med Google
-        myopenid: 
-          alt: Log på med et myOpenID OpenID
-          title: Log på med myOpenID
         openid: 
           alt: Log på med en OpenID-URL
           title: Log på med OpenID

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1711,9 +1711,6 @@ de:
         google: 
           alt: Mit einer OpenID von Google anmelden
           title: Mit Google anmelden
-        myopenid: 
-          alt: Mit einer OpenID von myOpenID anmelden
-          title: Mit myOpenID anmelden
         openid: 
           alt: Mit einer OpenID-URL anmelden
           title: Mit OpenID anmelden

--- a/config/locales/diq.yml
+++ b/config/locales/diq.yml
@@ -697,9 +697,6 @@ diq:
         google: 
           alt: Google OpenID ya dekewê de
           title: Google ya dekewê de
-        myopenid: 
-          alt: myOpenID OpenID ya dekewê de
-          title: myOpenID ya dekewê de
         openid: 
           alt: OpenID URL ya dekewê de
           title: OpenID ya dekewê de

--- a/config/locales/dsb.yml
+++ b/config/locales/dsb.yml
@@ -1679,9 +1679,6 @@ dsb:
         google: 
           alt: Z OpenID z Google pśizjawiś
           title: Z Google pśizjawiś
-        myopenid: 
-          alt: Z OpenID z myOpenID pśizjawiś
-          title: Z myOpenID pśizjawiś
         openid: 
           alt: Z OpenID-URL se pśizjawiś
           title: Z OpenID se pśizjawiś

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1618,9 +1618,6 @@ el:
         google: 
           alt: Σύνδεση με ένα Google OpenID
           title: Σύνδεση με Google
-        myopenid: 
-          alt: Σύνδεση με ένα myOpenID OpenID
-          title: Σύνδεση με myOpenID
         openid: 
           alt: Σύνδεση με ένα URL OpenID
           title: Σύνδεση με OpenID

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1644,9 +1644,6 @@ en:
         yahoo:
           title: Login with Yahoo
           alt: Login with a Yahoo OpenID
-        myopenid:
-          title: Login with myOpenID
-          alt: Login with a myOpenID OpenID
         wordpress:
           title: Login with Wordpress
           alt: Login with a Wordpress OpenID

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1699,9 +1699,6 @@ es:
         google: 
           alt: Iniciar sesión con OpenID de Google
           title: Iniciar sesión con Google
-        myopenid: 
-          alt: Iniciar sesión un OpenID de myOpendID
-          title: Iniciar sesión con myOpendID
         openid: 
           alt: Iniciar sesión con una URL OpenID
           title: Iniciar sesión con OpenID

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1509,9 +1509,6 @@ et:
         google: 
           alt: Sisene Google'i OpenID tunnusega
           title: Sisene Google'i tunnusega
-        myopenid: 
-          alt: Sisene MyOpenID OpenID tunnusega
-          title: Sisene MyOpenID tunnusega
         openid: 
           alt: Sisene OpenID URL abil
           title: Sisene OpenID tunnusega

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1683,9 +1683,6 @@ fa:
         google: 
           alt: ورود با یک OpenID گوگل
           title: ورود با گوگل
-        myopenid: 
-          alt: ورود با یک OpenID myOpenID
-          title: ورود با myOpenID
         openid: 
           alt: ورود با یک آدرس OpenID
           title: ورود با OpenID

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1651,9 +1651,6 @@ fi:
         google: 
           alt: Kirjaudu sisään Googlen OpenID-tunnuksella
           title: Kirjaudu sisään Google-tunnuksella
-        myopenid: 
-          alt: Kirjaudu sisään myOpenID:n OpenID-tunnuksella
-          title: Kirjaudu sisään myOpenID-tunnuksella
         openid: 
           alt: Kirjaudu sisään OpenID-tunnuksen URL-osoitteella
           title: Kirjaudu sisään OpenID-tunnuksella

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1707,9 +1707,6 @@ fr:
         google: 
           alt: Connexion avec un OpenID Google
           title: Connexion avec Google
-        myopenid: 
-          alt: Connexion avec un OpenID myOpenID
-          title: Connexion avec myOpenID
         openid: 
           alt: Connexion avec une URL OpenID
           title: Connexion avec OpenID

--- a/config/locales/fur.yml
+++ b/config/locales/fur.yml
@@ -1220,9 +1220,6 @@ fur:
         google: 
           alt: Jentre cuntun OpenID di Google
           title: Jentre cun Google
-        myopenid: 
-          alt: Jentre cuntun OpenID di myOpenID
-          title: Jentre cun myOpenID
         openid: 
           alt: Jentre cuntune URL OpenID
           title: Jentre cun OpenID

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -1663,9 +1663,6 @@ gl:
         google: 
           alt: Acceder ao sistema cun OpenID de Google
           title: Acceder ao sistema co Google
-        myopenid: 
-          alt: Acceder ao sistema cun OpenID de myOpenID
-          title: Acceder ao sistema con myOpenID
         openid: 
           alt: Acceder ao sistema cun URL OpenID
           title: Acceder ao sistema co OpenID

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1687,9 +1687,6 @@ he:
         google: 
           alt: כניסה עם OpenID של גוגל
           title: כניסה עם חשבון גוגל
-        myopenid: 
-          alt: כניסה עם OpenID של myOpenID
-          title: כניסה עם myOpenID
         openid: 
           alt: כניסה עם כתובת URL של OpenID
           title: כניסה עם OpenID

--- a/config/locales/hsb.yml
+++ b/config/locales/hsb.yml
@@ -1683,9 +1683,6 @@ hsb:
         google: 
           alt: Z OpenID z Google přizjewić
           title: Přizjewjenje z Google
-        myopenid: 
-          alt: Z OpenID z myOpenID přizjewić
-          title: Z myOpenID přizjewić
         openid: 
           alt: Z OpenID-URL přizjewić
           title: Přizjewjenje z OpenID

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1630,9 +1630,6 @@ hu:
         google: 
           alt: Bejelentkezés egy Google OpenID-vel
           title: Bejelentkezés Google-lel
-        myopenid: 
-          alt: Bejelentkezés egy myOpenID OpenID-vel
-          title: Bejelentkezés myOpenID-vel
         openid: 
           alt: Bejelentkezés egy OpenID URL-lel
           title: Bejelentkezés OpenID-vel

--- a/config/locales/ia.yml
+++ b/config/locales/ia.yml
@@ -1580,9 +1580,6 @@ ia:
         google: 
           alt: Aperir session con un OpenID de Google
           title: Aperir session con Google
-        myopenid: 
-          alt: Aperir session con un OpenID de myOpenID
-          title: Aperir session con myOpenID
         openid: 
           alt: Aperir session con un URL de OpenID
           title: Aperir session con OpenID

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1602,9 +1602,6 @@ id:
         google: 
           alt: Login dengan Google OpenID
           title: Login dengan Google
-        myopenid: 
-          alt: Login dengan myOpenID OpenID
-          title: Login dengan myOpenID
         openid: 
           alt: Login menggunakan URL OpenID
           title: Login dengan OpenID

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -864,9 +864,6 @@ is:
         google: 
           alt: Innsrká með Google OpenID
           title: Innsrká með Google OpenID
-        myopenid: 
-          alt: Innsrká með myOpenID OpenID
-          title: Innsrká með myOpenID OpenID
         openid: 
           alt: Innskrá með OpenID slóð
           title: Innskrá með OpenID slóð

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1696,9 +1696,6 @@ it:
         google: 
           alt: Accedi con un OpenID di Google
           title: Accedi con Google
-        myopenid: 
-          alt: Accedi con un OpenID di myOpenID
-          title: Accedi con myOpenID
         openid: 
           alt: Accedi con un indirizzo URL OpenID
           title: Accedi con OpenID

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1683,9 +1683,6 @@ ja:
         google: 
           alt: Google の OpenID でログイン
           title: Google アカウントでログイン
-        myopenid: 
-          alt: myOpenID の OpenID でログイン
-          title: myOpenID でログイン
         openid: 
           alt: OpenID の URL でログイン
           title: OpenID でログイン

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -968,9 +968,6 @@ ka:
         google: 
           alt: შესვლა Google OpenID-ის საშუალებით
           title: შესვლა Google-ის საშუალებით
-        myopenid: 
-          alt: შესვლა myOpenID OpenID-ის საშუალებით
-          title: შესვლა myOpenID-ის საშუალებით
         openid: 
           alt: შესვლა OpenID URL-ის საშუალებით
           title: შესვლა OpenID-ის საშუალებით

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1673,9 +1673,6 @@ ko:
         google: 
           alt: Google OpenID로 로그인
           title: Google로 로그인
-        myopenid: 
-          alt: myOpenID OpenID로 로그인
-          title: myOpenID로 로그인
         openid: 
           alt: OpenID URL로 로그인
           title: OpenID로 로그인

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1483,9 +1483,6 @@ lt:
         google: 
           alt: Prisijungti su Google OpenID
           title: Prisijungti su Google
-        myopenid: 
-          alt: Prisijungti su myOpenID OpenID
-          title: Prisijungti su OpenID
         openid: 
           alt: Prisijungti su savo OpenID URL
           title: Prisijungti su OpenID

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1671,9 +1671,6 @@ lv:
         google: 
           alt: Pieteikties ar Google OpenID
           title: Pieteikties ar Google
-        myopenid: 
-          alt: Pieteikties ar myOpenID OpenID
-          title: Pieteikties ar myOpenID
         openid: 
           alt: Pieteikties ar OpenID URL
           title: Pieteikšanās, izmantojot OpenID

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -1683,9 +1683,6 @@ mk:
         google: 
           alt: Најава со OpenID од Google
           title: Најава со Google
-        myopenid: 
-          alt: Најава со OpenID од myOpenID
-          title: Најава со myOpenID
         openid: 
           alt: Најава со URL за OpenID
           title: Најава со OpenID

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1652,9 +1652,6 @@ ms:
         google: 
           alt: Log masuk dengan OpenID Google
           title: Log masuk dengan Google
-        myopenid: 
-          alt: Log masuk dengan OpenID myOpenID
-          title: Log masuk dengan myOpenID
         openid: 
           alt: Log masuk dengan URL OpenID
           title: Log masuk dengan OpenID

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -1667,9 +1667,6 @@ nb:
         google: 
           alt: Logg inn med en Google OpenID
           title: Logg inn med Google
-        myopenid: 
-          alt: Logg inn med en myOpenID OpenID
-          title: Logg inn med myOpenID
         openid: 
           alt: Logg inn med en OpenID-URL
           title: Logg inn med OpenID

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1686,9 +1686,6 @@ nl:
         google: 
           alt: Aanmelden met een Google OpenID
           title: Aanmelden met Google
-        myopenid: 
-          alt: Aanmelden met een myOpenID OpenID
-          title: Aanmelden met myOpenID
         openid: 
           alt: Aanmelden met een OpenID URL
           title: Aanmelden met OpenID

--- a/config/locales/nn.yml
+++ b/config/locales/nn.yml
@@ -1408,9 +1408,6 @@ nn:
         google: 
           alt: Logg inn med ein Google OpenID
           title: Logg inn med Google
-        myopenid: 
-          alt: Logg inn med ein myOpenID OpenID
-          title: Logg inn med myOpenID
         openid: 
           alt: Logg inn med ein OpenID-URL
           title: Logg inn med OpenID

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -1599,9 +1599,6 @@ oc:
         google: 
           alt: Connexion amb un OpenID Google
           title: Connexion amb Google
-        myopenid: 
-          alt: Connexion amb un OpenID myOpenID
-          title: Connexion amb myOpenID
         openid: 
           alt: Connexion amb una URL OpenID
           title: Connexion amb OpenID

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1694,9 +1694,6 @@ pl:
         google: 
           alt: Zaloguj używając Google OpenID
           title: Zaloguj używając Google
-        myopenid: 
-          alt: Zaloguj używając myOpenID OpenID
-          title: Zaloguj używając myOpenID
         openid: 
           alt: Zaloguj używając adresu URL OpenID
           title: Zaloguj używając OpenID

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1698,9 +1698,6 @@ pt-BR:
         google: 
           alt: Login como uma OpenID do Google
           title: Login com Google
-        myopenid: 
-          alt: Login com uma OpenID da myOpenID
-          title: Login com myOpenID
         openid: 
           alt: Login com uma URL do OpenID
           title: Login com OpenID

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1685,9 +1685,6 @@ pt:
         google: 
           alt: Iniciar sessão com OpenID do Google
           title: Iniciar sessão com Google
-        myopenid: 
-          alt: Iniciar sessão com um OpenID do myOpendID
-          title: Iniciar sessão com myOpendID
         openid: 
           alt: Iniciar sessão com um endereço URL de OpenID
           title: Iniciar sessão com OpenID

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1713,9 +1713,6 @@ ru:
         google: 
           alt: Войти с помощью  Google OpenID
           title: Войти с помощью  Google
-        myopenid: 
-          alt: Войти с помощью MyOpenID OpenID
-          title: Войти с помощью MyOpenID
         openid: 
           alt: Войти с помощью OpenID URL
           title: Войти с помощью OpenID

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1574,9 +1574,6 @@ sk:
         google: 
           alt: Prihlásenie pomocou Google OpenID
           title: Prihlásenie pomocou Google
-        myopenid: 
-          alt: Prihlásenie pomocou myOpenID OpenID
-          title: Prihlásenie pomocou myOpenID
         openid: 
           alt: Prihlásenie pomocou OpenID URL
           title: Prihlásenie pomocou OpenID

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1613,9 +1613,6 @@ sl:
         google: 
           alt: Prijava z Google OpenID
           title: Prijava z Googlom
-        myopenid: 
-          alt: Prijava z myOpenID OpenID-jem
-          title: Prijava z myOpenID
         openid: 
           alt: Prijavite se z OpenID povezavo
           title: Prijava z OpenID

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -1369,9 +1369,6 @@ sr-Latn:
         google: 
           alt: Prijavite se preko Gugla
           title: Prijava putem Gugla
-        myopenid: 
-          alt: Prijavite se preko myOpenID-ja
-          title: Prijava putem myOpenID-ja
         openid: 
           alt: Prijavite se s OpenID-jem
           title: Prijava putem OpenID-ja

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1632,9 +1632,6 @@ sr:
         google: 
           alt: Пријавите се преко Гугла
           title: Пријава путем Гугла
-        myopenid: 
-          alt: Пријавите се преко myOpenID-ја
-          title: Пријава путем myOpenID-ја
         openid: 
           alt: Пријавите се с OpenID-јем
           title: Пријава путем OpenID-ја

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1700,9 +1700,6 @@ sv:
         google: 
           alt: Logga in med ett Google OpenID
           title: Logga in med Google
-        myopenid: 
-          alt: Logga in med myOpenID OpenID
-          title: Logga in med myOpenID
         openid: 
           alt: Logga in med en OpenID-URL
           title: Logga in med OpenID

--- a/config/locales/tl.yml
+++ b/config/locales/tl.yml
@@ -1420,9 +1420,6 @@ tl:
         google: 
           alt: Lumagda sa pamamagitan ng OpenID ng Google
           title: Lumagda sa pamamagitan ng Google
-        myopenid: 
-          alt: Lumagda sa pamamagitan ng OpenID ng myOpenID
-          title: Lumagda sa pamamagitan ng myOpenID
         openid: 
           alt: Lumagda sa pamamagitan ng isang URL ng OpenID
           title: Lumagda sa pamamagitan ng OpenID

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1358,9 +1358,6 @@ tr:
         google: 
           alt: Google OpenID ile giriş
           title: Google ile giriş
-        myopenid: 
-          alt: myOpenID OpenID ile giriş
-          title: MyOpenID ile giriş
         openid: 
           alt: OpenID URL ile giriş
           title: OpenID kullanarak oturum aç

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1685,9 +1685,6 @@ uk:
         google: 
           alt: Увійти з Google OpenID
           title: Увійти з Google
-        myopenid: 
-          alt: Увійти з myOpenID OpenID
-          title: Увійти з myOpenID
         openid: 
           alt: Увійти з допомогою OpenID URL
           title: Увійти з допомогою OpenID

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1667,9 +1667,6 @@ vi:
         google: 
           alt: Đăng nhập với OpenID của Google
           title: Đăng nhập với Google
-        myopenid: 
-          alt: Đăng nhập với OpenID của myOpenID
-          title: Đăng nhập với myOpenID
         openid: 
           alt: Đăng nhập dùng URL OpenID
           title: Đăng nhập dùng OpenID

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1696,9 +1696,6 @@ zh-CN:
         google: 
           alt: 使用Google OpenID登录
           title: Google登录
-        myopenid: 
-          alt: 使用myOpenID OpenID登录
-          title: myOpenID登录
         openid: 
           alt: 使用OpenID URL登录
           title: OpenID登录

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1638,9 +1638,6 @@ zh-TW:
         google: 
           alt: 使用 Google OpenID 登入
           title: 使用 Google 登入
-        myopenid: 
-          alt: 使用 myOpenID OpenID 登入
-          title: 使用 myOpenID 登入
         openid: 
           alt: 使用 OpenID URL 登入
           title: 使用 OpenID 登入


### PR DESCRIPTION
MyOpenID shut down in February but I noticed it's still an OpenID option on the login page. This PR removes the button as well as associated translations. I checked to see if there was anything else specifically associated with MyOpenID but didn't notice any other code specific to it.
