### PR TITLE
Link prefixed Wikidata-tags to wikidata.org

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -72,9 +72,9 @@ module BrowseHelper
     elsif wdt = wikidata_links(key, value)
       # IMPORTANT: Note that wikidata_links() returns an array of hashes, unlike for example wikipedia_link(),
       # which just returns one such hash.
-      wdt.map{|w|
-        link_to(w[:title], w[:url], :title => t('browse.tag_details.wikidata_link', :page => w[:title].strip))
-      }.join(";").html_safe
+      wdt.map do |w|
+        link_to(w[:title], w[:url], :title => t("browse.tag_details.wikidata_link", :page => w[:title].strip))
+      end.join(";").html_safe
     elsif url = wiki_link("tag", "#{key}=#{value}")
       link_to h(value), url, :title => t("browse.tag_details.wiki_link.tag", :key => key, :value => value)
     elsif url = telephone_link(key, value)
@@ -169,16 +169,14 @@ module BrowseHelper
         :url => "//www.wikidata.org/wiki/#{value}?uselang=#{I18n.locale}",
         :title => value
       }]
-    elsif (
-      # Key has to be one of the accepted wikidata-tags
-      key =~ /(architect|artist|brand|operator|subject):wikidata/ &&
-      # Value has to be a semicolon-separated list of wikidata-IDs (whitespaces allowed before and after semicolons)
-      value =~ /^[Qq][1-9][0-9]*(\s*;\s*[Qq][1-9][0-9]*)*$/
-    )
+    # Key has to be one of the accepted wikidata-tags
+    elsif key =~ /(architect|artist|brand|operator|subject):wikidata/ &&
+          # Value has to be a semicolon-separated list of wikidata-IDs (whitespaces allowed before and after semicolons)
+          value =~ /^[Qq][1-9][0-9]*(\s*;\s*[Qq][1-9][0-9]*)*$/
       # Splitting at every semicolon to get a separate hash for each wikidata-ID
-      return value.split(";").map { |id|
-        id = {:title => id, :url => "//www.wikidata.org/wiki/#{id.strip}?uselang=#{I18n.locale}" }
-      }
+      return value.split(";").map do |id|
+        { :title => id, :url => "//www.wikidata.org/wiki/#{id.strip}?uselang=#{I18n.locale}" }
+      end
     end
     nil
   end

--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -206,7 +206,7 @@ class BrowseHelperTest < ActionView::TestCase
     assert_equal "Q1568346", links[2][:title]
     I18n.locale = "en"
 
-    # and now with whitespaces…
+    # and now with whitespaces...
     links = wikidata_links("subject:wikidata", "Q6542248 ;\tQ180\n ;\rQ364\t\n\r ;\nQ4006")
     assert_equal 4, links.length
     assert_equal "//www.wikidata.org/wiki/Q6542248?uselang=en", links[0][:url]

--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -146,31 +146,77 @@ class BrowseHelperTest < ActionView::TestCase
     assert_equal "http://wiki.openstreetmap.org/wiki/Tag:highway=primary?uselang=tr", link
   end
 
-  def test_wikidata_link
-    link = wikidata_link("foo", "Test")
-    assert_nil link
+  def test_wikidata_links
+    ### Non-prefixed wikidata-tag (only one value allowed)
 
-    link = wikidata_link("wikidata", "http://www.wikidata.org/wiki/Q1")
-    assert_nil link
+    links = wikidata_links("foo", "Test")
+    assert_nil links
 
-    link = wikidata_link("wikidata", "en:Q1")
-    assert_nil link
+    # No URLs allowed
+    links = wikidata_links("wikidata", "http://www.wikidata.org/wiki/Q1")
+    assert_nil links
 
-    link = wikidata_link("wikidata", "1")
-    assert_nil link
+    # No language-prefixes (as wikidata is multilanguage)
+    links = wikidata_links("wikidata", "en:Q1")
+    assert_nil links
 
-    link = wikidata_link("wikidata", "Q0123")
-    assert_nil link
+    # Needs a leading Q
+    links = wikidata_links("wikidata", "1")
+    assert_nil links
 
-    link = wikidata_link("wikidata", "Q42")
-    assert_equal "//www.wikidata.org/wiki/Q42?uselang=en", link[:url]
-    assert_equal "Q42", link[:title]
+    # No leading zeros allowed
+    links = wikidata_links("wikidata", "Q0123")
+    assert_nil links
 
+    # A valid value
+    links = wikidata_links("wikidata", "Q42")
+    assert_equal 1, links.length
+    assert_equal "//www.wikidata.org/wiki/Q42?uselang=en", links[0][:url]
+    assert_equal "Q42", links[0][:title]
+
+    # the language of the wikidata-page should match the current locale
     I18n.locale = "zh-CN"
+    links = wikidata_links("wikidata", "Q1234")
+    assert_equal 1, links.length
+    assert_equal "//www.wikidata.org/wiki/Q1234?uselang=zh-CN", links[0][:url]
+    assert_equal "Q1234", links[0][:title]
+    I18n.locale = "en"
 
-    link = wikidata_link("wikidata", "Q1234")
-    assert_equal "//www.wikidata.org/wiki/Q1234?uselang=zh-CN", link[:url]
-    assert_equal "Q1234", link[:title]
+    ### Prefixed wikidata-tags
+
+    # Not anything is accepted as prefix (only limited set)
+    links = wikidata_links("anything:wikidata", "Q13")
+    assert_nil links
+
+    # This for example is an allowed key
+    links = wikidata_links("operator:wikidata", "Q24")
+    assert_equal "//www.wikidata.org/wiki/Q24?uselang=en", links[0][:url]
+    assert_equal "Q24", links[0][:title]
+
+    # another allowed key, this time with multiple values and I18n
+
+    I18n.locale = "dsb"
+    links = wikidata_links("brand:wikidata", "Q936;Q2013;Q1568346")
+    assert_equal 3, links.length
+    assert_equal "//www.wikidata.org/wiki/Q936?uselang=dsb", links[0][:url]
+    assert_equal "Q936", links[0][:title]
+    assert_equal "//www.wikidata.org/wiki/Q2013?uselang=dsb", links[1][:url]
+    assert_equal "Q2013", links[1][:title]
+    assert_equal "//www.wikidata.org/wiki/Q1568346?uselang=dsb", links[2][:url]
+    assert_equal "Q1568346", links[2][:title]
+    I18n.locale = "en"
+
+    # and now with whitespaces…
+    links = wikidata_links("subject:wikidata", "Q6542248 ;\tQ180\n ;\rQ364\t\n\r ;\nQ4006")
+    assert_equal 4, links.length
+    assert_equal "//www.wikidata.org/wiki/Q6542248?uselang=en", links[0][:url]
+    assert_equal "Q6542248 ", links[0][:title]
+    assert_equal "//www.wikidata.org/wiki/Q180?uselang=en", links[1][:url]
+    assert_equal "\tQ180\n ", links[1][:title]
+    assert_equal "//www.wikidata.org/wiki/Q364?uselang=en", links[2][:url]
+    assert_equal "\rQ364\t\n\r ", links[2][:title]
+    assert_equal "//www.wikidata.org/wiki/Q4006?uselang=en", links[3][:url]
+    assert_equal "\nQ4006", links[3][:title]
   end
 
   def test_wikipedia_link


### PR DESCRIPTION
This is a follow-up to #786, in which I've linked the basic wikidata-tags to [wikidata.org](https://wikidata.org)

With this pull-request, also the other wikidata-tags (see [the proposal's wiki-page](https://wiki.openstreetmap.org/wiki/Proposed_features/Wikidata)) get linked.

I decided against a catch-all to discourage misspelled keys. If other prefixes will get popular, one could add them easily in the future.

So tags with the following keys are the only ones that get linked:
* architect:wikidata
* artist:wikidata
* brand:wikidata
* ~~name:etymology:wikidata~~
* ~~old_name:etymology:wikidata~~
* operator:wikidata
* subject:wikidata

The reason that it took longer than expected to implement it, was the following:
The basic tag allows only exactly one value, because both OSM and WikiData follow the rule, that one object in reality translates to exactly one object in the database. That makes it a simple 1:1-mapping.
But with the other tags it's more complicated, because one object can have multiple operators, can be named after more than one thing, can cover multiple subjects, …

The only example I currently found was a [cathedral named "Peter and Paul"](http://www.openstreetmap.org/way/38103012) after the apostles [Paul](https://www.wikidata.org/wiki/Q9200) and [Peter](https://www.wikidata.org/wiki/Q33923), which is perfectly valid.

It took some time until I got a satisfying solution, but finally I decided to allow a semicolon-separated list of wikidata-IDs and display them as multiple links to wikidata which are separated by semicolons:
![arbeitsflche 1_002](https://cloud.githubusercontent.com/assets/3904348/3666654/098e6d90-11f5-11e4-8183-8084b38a12da.png)
![arbeitsflche 1_003](https://cloud.githubusercontent.com/assets/3904348/3666661/1f04c28c-11f5-11e4-92dd-cbfea6a817b8.png)