### PR TITLE
Fix off-by-one error in user notes list

### DIFF
--- a/app/views/notes/_notes_paging_nav.html.erb
+++ b/app/views/notes/_notes_paging_nav.html.erb
@@ -8,7 +8,7 @@
 
 | <%= t('changeset.changeset_paging_nav.showing_page', :page => @page) %> |
 
-<% if @notes.size < @page_size %>
+<% if @notes.size <= @page_size %>
 <%= t('changeset.changeset_paging_nav.next') %>
 <% else %>
 <%= link_to t('changeset.changeset_paging_nav.next'), params.merge({ :page => @page + 1 }) %>


### PR DESCRIPTION
I noticed that the "Next" link was mistakenly active while looking at a user who has exactly 10 notes:  
https://www.openstreetmap.org/user/texaskdog/notes
