### PR TITLE
Add an imagery blacklist to capabilities

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -287,8 +287,16 @@ class ApiController < ApplicationController
     status['api'] = api_status.to_s
     status['gpx'] = gpx_status.to_s
     api << status
-
     doc.root << api
+    policy = XML::Node.new 'policy'
+    blacklist = XML::Node.new 'imagery'
+    IMAGERY_BLACKLIST.each do |url_regex| 
+      xnd = XML::Node.new 'blacklist'
+      xnd['regex'] = url_regex.to_s
+      blacklist << xnd
+    end
+    policy << blacklist
+    doc.root << policy
 
     render :text => doc.to_s, :content_type => "text/xml"
   end

--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -84,6 +84,11 @@ defaults: &defaults
   require_terms_seen: false
   # Whether to require users to agree to the CTs before editing
   require_terms_agreed: false
+  # Imagery to return in capabilities as blacklisted
+  imagery_blacklist:
+    - ".*\\.googleapis\\.com/.*"
+    - ".*\\.google\\.com/.*"
+    - ".*\\.google\\.ru/.*"
 
 development:
   <<: *defaults


### PR DESCRIPTION
This blacklist is for imagery which is of an incompatible license or ToS but is incorrectly used with some frequency.

This adds a <policy> element to the capabilities XML which contains the blacklist information within it.

@tomhughes, could you deploy this branch on errol for testing?

Also, when doing so could you add `- ".*\\.stamen\\.com/.*"` to application.yml? We need something blocked to test with, and stamen has layers that are unlikely to be in any presets or used.

Fixes [trac 5024](https://trac.openstreetmap.org/ticket/5024)
