### PR TITLE
Page titles: put specific page title at the start not the end

### DIFF
--- a/app/helpers/title_helper.rb
+++ b/app/helpers/title_helper.rb
@@ -6,7 +6,7 @@ module TitleHelper
   def set_title(title = false)
     if title
       @title = @@coder.decode(title.gsub("<bdi>", "\u202a").gsub("</bdi>", "\u202c"))
-      response.headers["X-Page-Title"] = t('layouts.project_name.title') + ' | ' + @title
+      response.headers["X-Page-Title"] = @title + ' | ' + t('layouts.project_name.title')
     else
       @title = title
       response.headers["X-Page-Title"] = t('layouts.project_name.title')

--- a/test/helpers/title_helper_test.rb
+++ b/test/helpers/title_helper_test.rb
@@ -7,11 +7,11 @@ class TitleHelperTest < ActionView::TestCase
     assert_nil @title
 
     set_title("Test Title")
-    assert_equal "OpenStreetMap | Test Title", response.header["X-Page-Title"]
+    assert_equal "Test Title | OpenStreetMap", response.header["X-Page-Title"]
     assert_equal "Test Title", @title
 
     set_title("Test & Title")
-    assert_equal "OpenStreetMap | Test & Title", response.header["X-Page-Title"]
+    assert_equal "Test & Title | OpenStreetMap", response.header["X-Page-Title"]
     assert_equal "Test & Title", @title
   end
 end


### PR DESCRIPTION
Discussed in #835 - might be better to put the more specific part of the page title at the start rather than the end, so that the different pages are easier to distinguish when you have lots of tabs.

(This doesn't solve all of #835. Independent PRs may come later...)
