### PR TITLE
Rescue to StandardError instead of Exception

### DIFF
--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -511,7 +511,7 @@ module OSM
     end
 
     return nil
-  rescue Exception
+  rescue
     return nil
   end
 


### PR DESCRIPTION
Rescuing to `Exception` broadens error handling and is potentially more difficult to track than simply calling `rescue` which is delivered to `StandardError`.