### PR TITLE
Remove unnecessary local variable

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -44,6 +44,6 @@ I18n.fallbacks.map("no" => "nb")
 
 I18n.enforce_available_locales = false
 
-Rails.configuration.after_initialize do |app|
+Rails.configuration.after_initialize do
   I18n.available_locales
 end


### PR DESCRIPTION
The local variable `app` was unused and therefore not needed to be declared with initialization
