### PR TITLE
Don't raise APIAlreadyDeletedError when deleting with if-unused

### DIFF
--- a/lib/diff_reader.rb
+++ b/lib/diff_reader.rb
@@ -241,7 +241,7 @@ class DiffReader
           if action_attributes["if-unused"]
             begin
               old.delete_with_history!(new, @changeset.user)
-            rescue OSM::APIPreconditionFailedError => ex
+            rescue OSM::APIAlreadyDeletedError, OSM::APIPreconditionFailedError => ex
               xml_result["new_id"] = old.id.to_s
               xml_result["new_version"] = old.version.to_s
             end


### PR DESCRIPTION
related: openstreetmap/iD#2475

The object is obviously unused if it's already been deleted.. No need to reject a user's changeset for this error.
