### PR TITLE
Introduce geo url to Share panel

### DIFF
--- a/app/assets/javascripts/leaflet.map.js.erb
+++ b/app/assets/javascripts/leaflet.map.js.erb
@@ -170,6 +170,23 @@ L.OSM.Map = L.Map.extend({
     return str;
   },
 
+  getGeoUrl: function(marker) {
+    var precision = OSM.zoomPrecision(this.getZoom()),
+        latLng,
+        params = {};
+
+    if (marker && this.hasLayer(marker)) {
+      latLng = marker.getLatLng().wrap();
+    } else {
+      latLng = this.getCenter();
+    }
+
+    params.mlat = latLng.lat.toFixed(precision);
+    params.mlon = latLng.lng.toFixed(precision);
+
+    return 'geo:' + params.mlat + ',' + params.mlon;
+  },
+
   addObject: function(object, callback) {
     var objectStyle = {
       color: "#FF6200",

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -73,6 +73,10 @@ L.OSM.share = function (options) {
         .attr('id', 'short_link')
         .text(I18n.t('javascripts.share.short_link')))
       .append($('<a>')
+        .attr('for', 'geo_input')
+        .attr('id', 'geo_link')
+        .text(I18n.t('javascripts.share.geo_link')))
+      .append($('<a>')
         .attr('for', 'embed_html')
         .attr('href', '#')
         .text(I18n.t('javascripts.share.embed')))
@@ -104,6 +108,14 @@ L.OSM.share = function (options) {
       .appendTo($form)
       .append($('<input>')
         .attr('id', 'short_input')
+        .attr('type', 'text')
+        .on('click', select));
+
+    $('<div>')
+      .attr('class', 'form-row share-tab')
+      .appendTo($form)
+      .append($('<input>')
+        .attr('id', 'geo_input')
         .attr('type', 'text')
         .on('click', select));
 
@@ -287,8 +299,10 @@ L.OSM.share = function (options) {
 
       $('#short_input').val(map.getShortUrl(marker));
       $('#long_input').val(map.getUrl(marker));
+      $('#geo_input').val(map.getGeoUrl(marker));
       $('#short_link').attr('href', map.getShortUrl(marker));
       $('#long_link').attr('href', map.getUrl(marker));
+      $('#geo_link').attr('href', map.getGeoUrl(marker));
 
       var params = {
         bbox: bounds.toBBoxString(),

--- a/app/assets/stylesheets/common.css.scss
+++ b/app/assets/stylesheets/common.css.scss
@@ -694,7 +694,7 @@ nav.secondary {
     display: none;
     position: relative;
     float: right;
-    width: 250px;
+    width: 270px;
     height: 100%;
     background: white;
     overflow: auto;
@@ -789,6 +789,7 @@ nav.secondary {
       text-decoration: none;
       background-color: $lightblue;
       padding: 5px 10px;
+      border-right: 1px solid #fff;
     }
 
     a:first-child {
@@ -797,7 +798,6 @@ nav.secondary {
     }
 
     a:last-child {
-      border-left: 1px solid #fff;
       border-radius: 0 4px 4px 0;
     }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2086,6 +2086,7 @@ en:
       link: "Link or HTML"
       long_link: "Link"
       short_link: "Short Link"
+      geo_link: "geo:"
       embed: "HTML"
       custom_dimensions: "Set custom dimensions"
       format: "Format:"


### PR DESCRIPTION
Here's a pull request that addresses #799. A simple "geo:" tab has been added to the Share panel. The url leaves off the optional components `altitude`, `crs` (since OSM uses WGS84), and `uncertainty`. Consistent with the other tabs, the geo tab uses a zoom-based precision to determine how many decimal places to include.

One enhancement might be to uncheck and disable the "Include marker" checkbox when the geo tab is selected as it's not applicable in that case.

I also confess that I'm not clear on whether it'd be my responsibility to add this to all the config/locales/*.yml files.

I don't have any Android devices, so I don't have the ability to play with this. Is it possible to demo this somewhere for the people who requested the feature?

![image](https://cloud.githubusercontent.com/assets/317680/5987354/a47523aa-a8d9-11e4-9edd-a39ce396c580.png)
