### PR TITLE
Fix two issues with the remember_me_openid checkbox

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -276,12 +276,13 @@ class UserController < ApplicationController
 
   def login
     if params[:username] or using_open_id?
-      session[:remember_me] ||= params[:remember_me]
       session[:referer] ||= params[:referer]
 
       if using_open_id?
+        session[:remember_me] ||= params[:remember_me_openid]
         openid_authentication(params[:openid_url])
       else
+        session[:remember_me] ||= params[:remember_me]
         password_authentication(params[:username], params[:password])
       end
     end

--- a/app/views/user/login.html.erb
+++ b/app/views/user/login.html.erb
@@ -54,7 +54,7 @@
             <span class="minorNote">(<a href="<%= t 'user.account.openid.link' %>" target="_new"><%= t 'user.account.openid.link text' %></a>)</span>
           </div>
 
-          <div id="remember_me_openid_div" class='form-row'>
+          <div class='form-row'>
             <%= check_box_tag "remember_me_openid", "yes", false, :tabindex => 5 %>
             <label class="standard-label" for="remember_me_openid"><%= t 'user.login.remember' %></label>
           </div>

--- a/app/views/user/login.html.erb
+++ b/app/views/user/login.html.erb
@@ -54,7 +54,7 @@
             <span class="minorNote">(<a href="<%= t 'user.account.openid.link' %>" target="_new"><%= t 'user.account.openid.link text' %></a>)</span>
           </div>
 
-          <div id="remember_me_openid" class='form-row'>
+          <div id="remember_me_openid_div" class='form-row'>
             <%= check_box_tag "remember_me_openid", "yes", false, :tabindex => 5 %>
             <label class="standard-label" for="remember_me_openid"><%= t 'user.login.remember' %></label>
           </div>


### PR DESCRIPTION
1. It didn't work, the code only checked the `remember_me` parameter, not the `remember_me_openid` one. I've verified this by checking the cookies that it set: checking the normal login "Remember me" button sets a cookie valid for 28 days (even when actually using OpenID), checking only the other "Remember me" button set a cookie that was valid for only the current session.
2. The HTML element did not have a unique id, making the label next to it not work for selecting the checkbox. Fixed this by renaming the outer `<div>` with the same id to `remember_me_openid_div`.