### PR TITLE
Google OAuth support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem "actionpack-page_caching"
 # Omniauth for authentication
 gem "omniauth"
 gem "omniauth-openid"
+gem "openstreetmap-omniauth-google-oauth2", ">= 0.2.6.1", :require => "omniauth-google-oauth2"
 
 # Markdown formatting support
 gem "redcarpet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,11 +150,21 @@ GEM
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
+    omniauth-oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      multi_json (~> 1.3)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     omniauth-openid (1.0.1)
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
     openstreetmap-i18n-js (3.0.0.rc5.3)
       i18n
+    openstreetmap-omniauth-google-oauth2 (0.2.6.1)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.1.1)
     paperclip (4.2.1)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -305,6 +315,7 @@ DEPENDENCIES
   omniauth
   omniauth-openid
   openstreetmap-i18n-js (>= 3.0.0.rc5.3)
+  openstreetmap-omniauth-google-oauth2 (>= 0.2.6.1)
   paperclip (~> 4.0)
   pg
   poltergeist

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -48,7 +48,7 @@ module UserHelper
     image_tag "openid_small.png", :alt => t("user.login.openid_logo_alt"), :class => "openid_logo"
   end
 
-  def auth_button(name, provider, options)
+  def auth_button(name, provider, options = {})
     link_to(
       image_tag("#{name}.png", :alt => t("user.login.auth_providers.#{name}.alt")),
       auth_path(options.merge(:provider => provider)),

--- a/app/views/user/account.html.erb
+++ b/app/views/user/account.html.erb
@@ -48,7 +48,7 @@
   <fieldset>
     <div class="form-row">
       <label class="standard-label"><%= t 'user.account.external auth' %></label>
-      <%= f.select :auth_provider, { "None" => "", "OpenID" => "openid" } %>
+      <%= f.select :auth_provider, Auth::PROVIDERS %>
       <%= f.text_field :auth_uid %>
       <span class="form-help deemphasize">(<a href="<%= t 'user.account.openid.link' %>" target="_new"><%= t 'user.account.openid.link text' %></a>)</span>
     </diV>

--- a/app/views/user/login.html.erb
+++ b/app/views/user/login.html.erb
@@ -42,7 +42,9 @@
 
         <ul class='clearfix' id="login_auth_buttons">
           <li><%= link_to image_tag("openid.png", :alt => t("user.login.auth_providers.openid.title")), "#", :id => "openid_open_url", :title => t("user.login.auth_providers.openid.title") %></li>
-          <li><%= auth_button "google", "openid", :openid_url => "https://www.google.com/accounts/o8/id" %></li>
+          <% if defined?(GOOGLE_AUTH_ID) -%>
+          <li><%= auth_button "google", "google" %></li>
+          <% end -%>
           <li><%= auth_button "yahoo", "openid", :openid_url => "yahoo.com" %></li>
           <li><%= auth_button "wordpress", "openid", :openid_url => "wordpress.com" %></li>
           <li><%= auth_button "aol", "openid", :openid_url => "aol.com" %></li>

--- a/app/views/user/new.html.erb
+++ b/app/views/user/new.html.erb
@@ -45,7 +45,7 @@
       <label for="openid_url" class="standard-label">
         <%= raw t 'user.new.external auth' %>
       </label>
-      <%= select(:user, :auth_provider, { "None" => "", "OpenID" => "openid" }, { :default => "", :tabindex => 4 }) %>
+      <%= select(:user, :auth_provider, Auth::PROVIDERS, { :default => "", :tabindex => 4 }) %>
       <%= text_field(:user, :auth_uid, { :tabindex => 5 }) %>
       <%= error_message_on(:user, :auth_uid) %>
     </div>

--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -88,6 +88,10 @@ defaults: &defaults
     - ".*\\.google\\.ru/.*"
   # URL of Overpass instance to use for feature queries
   overpass_url: "//overpass-api.de/api/interpreter"
+  # External authentication credentials
+  #google_auth_id: ""
+  #google_auth_secret: ""
+  #google_openid_realm: ""
 
 development:
   <<: *defaults

--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -103,3 +103,7 @@ test:
   <<: *defaults
   # Geonames credentials for testing
   geonames_username: "dummy"
+  # External authentication credentials for testing
+  google_auth_id: "dummy"
+  google_auth_secret: "dummy"
+  google_openid_realm: "https://www.openstreetmap.org"

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -19,8 +19,16 @@ else
   openid_store = OpenID::Store::Filesystem.new(Rails.root.join("tmp/openids"))
 end
 
+openid_options = { :name => "openid", :store => openid_store }
+google_options = { :name => "google", :scope => "email", :access_type => "online" }
+
+if defined?(GOOGLE_OPENID_REALM)
+  google_options[:openid_realm] = GOOGLE_OPENID_REALM
+end
+
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :openid, :name => "openid", :store => openid_store
+  provider :openid, openid_options
+  provider :google_oauth2, GOOGLE_AUTH_ID, GOOGLE_AUTH_SECRET, google_options if defined?(GOOGLE_AUTH_ID)
 end
 
 # Pending fix for: https://github.com/intridea/omniauth/pull/795

--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -1,0 +1,4 @@
+module Auth
+  PROVIDERS = { "None" => "", "OpenID" => "openid" }
+  PROVIDERS["Google"] = "google" if defined?(GOOGLE_AUTH_ID)
+end

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -1321,7 +1321,7 @@ class UserControllerTest < ActionController::TestCase
     get :list, :page => 3
     assert_response :success
     assert_template :list
-    assert_select "table#user_list tr", :count => 19
+    assert_select "table#user_list tr", :count => 20
   end
 
   def test_list_post_confirm

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -49,7 +49,7 @@ inactive_user:
   terms_seen: true
   languages: en
   email_valid: false
-  
+
 second_public_user:
   id: 4
   email: public@OpenStreetMap.org
@@ -248,3 +248,17 @@ german_user:
   terms_agreed: "2010-01-01 11:22:33"
   terms_seen: true
   languages: de
+
+google_user:
+  id: 19
+  email: google-user@example.com
+  status: active
+  pass_crypt: <%= Digest::MD5.hexdigest('test') %>
+  creation_time: "2008-05-01 01:23:45"
+  display_name: googleuser
+  data_public: true
+  auth_provider: google
+  auth_uid: 123456789
+  terms_agreed: "2010-01-01 11:22:33"
+  terms_seen: true
+  languages: en

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -13,6 +13,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     I18n.locale = "en"
 
     OmniAuth.config.mock_auth[:openid] = nil
+    OmniAuth.config.mock_auth[:google] = nil
     OmniAuth.config.test_mode = false
   end
 
@@ -241,6 +242,123 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_equal register_email.to[0], new_email
     # Check that the confirm account url is correct
     confirm_regex = Regexp.new("/user/redirect_tester_openid/confirm\\?confirm_string=([a-zA-Z0-9]*)")
+    register_email.parts.each do |part|
+      assert_match confirm_regex, part.body.to_s
+    end
+    confirm_string = register_email.parts[0].body.match(confirm_regex)[1]
+
+    # Check the page
+    assert_response :success
+    assert_template "user/confirm"
+
+    ActionMailer::Base.deliveries.clear
+
+    # Go to the confirmation page
+    get "/user/#{display_name}/confirm", :confirm_string => confirm_string
+    assert_response :success
+    assert_template "user/confirm"
+
+    post "/user/#{display_name}/confirm", :confirm_string => confirm_string
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+    assert_template "site/welcome"
+  end
+
+  def test_user_create_google_success
+    OmniAuth.config.add_mock(:google, :uid => "123454321", :extra => {
+                               :id_info => { "openid_id" => "http://localhost:1123/new.tester" }
+                             })
+
+    new_email = "newtester-google@osm.org"
+    display_name = "new_tester-google"
+    password = "testtest"
+    assert_difference("User.count") do
+      assert_difference("ActionMailer::Base.deliveries.size", 1) do
+        post "/user/new",
+             :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" }
+        assert_response :redirect
+        assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
+        follow_redirect!
+        assert_response :redirect
+        assert_redirected_to auth_success_path(:provider => "google")
+        follow_redirect!
+        assert_response :redirect
+        assert_redirected_to "/user/terms"
+        post "/user/save",
+             :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password }
+        assert_response :redirect
+        follow_redirect!
+      end
+    end
+
+    # Check the page
+    assert_response :success
+    assert_template "user/confirm"
+
+    ActionMailer::Base.deliveries.clear
+  end
+
+  def test_user_create_google_failure
+    OmniAuth.config.mock_auth[:google] = :connection_failed
+
+    new_email = "newtester-google2@osm.org"
+    display_name = "new_tester-google2"
+    assert_difference("User.count", 0) do
+      assert_difference("ActionMailer::Base.deliveries.size", 0) do
+        post "/user/new",
+             :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" }
+        assert_response :redirect
+        assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
+        follow_redirect!
+        assert_response :redirect
+        assert_redirected_to auth_success_path(:provider => "google")
+        follow_redirect!
+        assert_response :redirect
+        assert_redirected_to auth_failure_path(:strategy => "google", :message => "connection_failed", :origin => "/user/new")
+        follow_redirect!
+        assert_response :redirect
+        follow_redirect!
+        assert_response :success
+        assert_template "user/new"
+      end
+    end
+
+    ActionMailer::Base.deliveries.clear
+  end
+
+  def test_user_create_google_redirect
+    OmniAuth.config.add_mock(:google, :uid => "123454321", :extra => {
+                               :id_info => { "openid_id" => "http://localhost:1123/new.tester" }
+                             })
+
+    new_email = "redirect_tester_google@osm.org"
+    display_name = "redirect_tester_google"
+    # nothing special about this page, just need a protected page to redirect back to.
+    referer = "/traces/mine"
+    assert_difference("User.count") do
+      assert_difference("ActionMailer::Base.deliveries.size", 1) do
+        post "/user/new",
+             :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer
+        assert_response :redirect
+        assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
+        follow_redirect!
+        assert_response :redirect
+        assert_redirected_to auth_success_path(:provider => "google")
+        follow_redirect!
+        assert_response :redirect
+        assert_redirected_to "/user/terms"
+        post_via_redirect "/user/save",
+                          :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" }
+      end
+    end
+
+    # Check the e-mail
+    register_email = ActionMailer::Base.deliveries.first
+
+    assert_equal register_email.to[0], new_email
+    # Check that the confirm account url is correct
+    confirm_regex = Regexp.new("/user/redirect_tester_google/confirm\\?confirm_string=([a-zA-Z0-9]*)")
     register_email.parts.each do |part|
       assert_match confirm_regex, part.body.to_s
     end

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class UserLoginTest < ActionDispatch::IntegrationTest
-  fixtures :users
+  fixtures :users, :user_blocks
 
   def setup
     OmniAuth.config.test_mode = true

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -163,7 +163,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_visible
-    assert_equal 16, User.visible.count
+    assert_equal 17, User.visible.count
     assert_raise ActiveRecord::RecordNotFound do
       User.visible.find(users(:suspended_user).id)
     end
@@ -173,7 +173,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_active
-    assert_equal 15, User.active.count
+    assert_equal 16, User.active.count
     assert_raise ActiveRecord::RecordNotFound do
       User.active.find(users(:inactive_user).id)
     end
@@ -186,7 +186,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_identifiable
-    assert_equal 17, User.identifiable.count
+    assert_equal 18, User.identifiable.count
     assert_raise ActiveRecord::RecordNotFound do
       User.identifiable.find(users(:normal_user).id)
     end


### PR DESCRIPTION
This replaces our existing OpenID based support for logging in with Google with an OAuth based approach, which will resolve #897 and deal with the forthcoming remove of OpenID support by Google.

It's not ready for merging quite yet because it requires a small patch to the `omniauth-google-oauth2` gem to support transparent upgrading of OpenID logins to OAuth logins.