### PR TITLE
Fix VAGRANT.md for rails 4.2.0

### DIFF
--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -38,7 +38,7 @@ To access the web pages you run the following commands then access the site in y
 ```
 vagrant ssh
 cd /srv/openstreetmap-website/
-rails server
+rails server --binding=0.0.0.0
 ```
 
 You edit the code on your computer using the code editor you are used to using, then through shared folders the code is updated on the VM instantly.


### PR DESCRIPTION
Rails 4.2 now binds to 127.0.0.1 by default. Bind to 0.0.0.0 to work with vagrant port forwarding.