### PR TITLE
Change "Subway Station" to "Rapid Transit" in en.yml locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -759,7 +759,7 @@ en:
           spur: "Railway Spur"
           station: "Railway Station"
           stop: "Railway Stop"
-          subway: "Subway Station"
+          subway: "Rapid Transit"
           subway_entrance: "Subway Entrance"
           switch: "Railway Points"
           tram: "Tramway"


### PR DESCRIPTION
This pull request fixes issue #934.