### PR TITLE
Make search use HTTPS automatically

### DIFF
--- a/app/assets/opensearch/osm.xml
+++ b/app/assets/opensearch/osm.xml
@@ -7,7 +7,7 @@
 	<InputEncoding>UTF-8</InputEncoding>
 	<OutputEncoding>UTF-8</OutputEncoding>
 	<Image width="16" height="16">data:image/png,%89PNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%10%00%00%00%10%08%06%00%00%00%1F%F3%FFa%00%00%00%19tEXtSoftware%00www.inkscape.org%9B%EE%3C%1A%00%00%01'IDATx%9C%9D%93%B1q%C30%0CE%1F%5Dd%80l%90I%C4*%A7%22%95%CF%85J%97%AE%B2%82%3DC%CE%03%A0%B3%9B%B8f%95%A3%17H%93%05%5C%A7%C8%0A%3F%05E%8A%92l%E7.%D0%E9N%02%81%07%E0Cr%FCaf%A6%FC%BC%5E%AF%DD%F4%3C%3Bt%C5%87%99)%84P%0E%DA%B6%BD%0AI%00%A1%A8%A8%1E%263S%D7u%C9'F%FE%9B%80%0C%C9%C9%22%BD'%B0%0A%AC%86%2CJ%DB%0E%22%11%8F%2F%D4%B3%22%8D%F34%CE%13u%06R%0C%40%D7u%AA%01%C5r%40%0Dq%88%C6%F9i%E8%7C%8CX%5D%A9M%95%D6%A3%A2Ti%C3Xx%CA%9C%F5mf3h%11%B6%07%B8%0APh%97%DD%1E%9E%5E%08!%D0%B6m%F1%87%108%1E%8EY5%007%03%5Cv%7B%00%3E%BF%3E%F8~x%1E%CD%B89l%00%F0I%0FWw%00%20%DB%AEJr%B6%E5%FB%09%80%C6y%CE%7D%91%1AP%B6p%2B%D9%BB%06%18V%3A%B5E%9F%AC%5B%95%AFY%3F%EE%20%A2mW%AA%93%DFN%3F%A0%E1%9B%F0u%E5%BC%BC%89%88%BC.%1F%D5'%DF%FD%C1%EE%F8%FFg%BFp%96%DF%E2%DCw%25%2B%00%00%00%00IEND%AEB%60%82</Image>
-	<Url type="text/html" method="get" template="http://www.openstreetmap.org/search">
+	<Url type="text/html" method="get" template="https://www.openstreetmap.org/search">
 	  <Param name="query" value="{searchTerms}"/>
 	</Url>
 	<Query role="example" searchTerms="Reigate" />


### PR DESCRIPTION
Currently users end up having a HTTP search function even if they install it to their browsers from the HTTPS site. This is a unexpected backdraw in privacy. Since search requests are private data they should always be sent via HTTPS.
