### PR TITLE
Added information about sources for Slovenia

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -61,6 +61,7 @@
   <li><%= t "license_page.legal_babble.contributors_fr_html", :locale => @locale %></li>
   <li><%= t "license_page.legal_babble.contributors_nl_html", :locale => @locale %></li>
   <li><%= t "license_page.legal_babble.contributors_nz_html", :locale => @locale %></li>
+  <li><%= t "license_page.legal_babble.contributors_si_html", :locale => @locale %></li>
   <li><%= t "license_page.legal_babble.contributors_za_html", :locale => @locale %></li>
   <li><%= t "license_page.legal_babble.contributors_gb_html", :locale => @locale %></li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1043,6 +1043,10 @@ en:
       contributors_nz_html: |
         <strong>New Zealand</strong>: Contains data sourced from
         Land Information New Zealand. Crown Copyright reserved.
+      contributors_si_html: |
+        <strong>Slovenia</strong>: Contains public information of Slovenia
+        (<a href="http://www.gu.gov.si/en/">Surveying and Mapping Authority</a> and
+        <a href="http://www.mkgp.gov.si/en/">Ministry of Agriculture, Forestry and Food</a>)
       contributors_za_html: |
         <strong>South Africa</strong>: Contains data sourced from
         <a href="http://www.ngi.gov.za/">Chief Directorate:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -911,6 +911,10 @@ sl:
       intro_1_html: OpenStreetMap so <i>prosti podatki</i> z <a href="http://opendatacommons.org/licenses/odbl/1.0/">Open
         Data Commons Open Database License</a> (ODbL) licenco.
       contributors_title_html: Naši sodelavci
+      contributors_si_html: |
+        <strong>Slovenija</strong>: Vsebuje javne informacije Slovenije
+        (<a href="http://www.gu.gov.si/si/">Geodetska uprava</a> in
+        <a href="http://www.mkgp.gov.si/si/">Ministrstvo za kmetijstvo, gozdarstvo in prehrano</a>)
       infringement_title_html: Kršitev avtorskih pravic
   welcome_page:
     title: Dobrodošli!


### PR DESCRIPTION
Surveying and Mapping Authority data was used for quite a while for administrative borders:
http://wiki.openstreetmap.org/wiki/Geodetska_uprava_Republike_Slovenije
http://wiki.openstreetmap.org/wiki/Tag:source%3DGURS

Ministry of Agriculture, Forestry and Food was started being used recenty with community import:
http://wiki.openstreetmap.org/wiki/Slovenia_Landcover_Import_-_RABA-KGZ
http://wiki.openstreetmap.org/wiki/Tag:source%3DRABA-KGZ
tagwatch project: https://taginfo.openstreetmap.org/projects/raba_kgz_import

Both are listed in wiki with more details:
http://wiki.openstreetmap.org/wiki/Contributors#Slovenia