### PR TITLE
Add some text and links wrt trademarks to the copyright page

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -15,9 +15,15 @@ fieldset,img { border: 0; }
 
 legend { color: #000; }
 
-sup { vertical-align: text-top; }
+sup { 
+  vertical-align: super; 
+  font-size: smaller; 
+}
 
-sub { vertical-align: text-bottom; }
+sub { 
+  vertical-align: sub; 
+  font-size: smaller; 
+}
 
 table {
   border-collapse: collapse;

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -71,3 +71,6 @@
 <h3><%= t "license_page.legal_babble.infringement_title_html", :locale => @locale %></h3>
 <p><%= t "license_page.legal_babble.infringement_1_html", :locale => @locale %></p>
 <p><%= t "license_page.legal_babble.infringement_2_html", :locale => @locale %></p>
+
+<h3><%= t "license_page.legal_babble.trademarks_title_html", :locale => @locale %></h3>
+<p><%= t "license_page.legal_babble.trademarks_1_html", :locale => @locale %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1080,7 +1080,7 @@ en:
         <a href="http://dmca.openstreetmap.org/">on-line filing page</a>.
       trademarks_title_html: <span id="trademarks"></span>Trademarks
       trademarks_1_html: |
-        OpenStreetMap and the looking glass logo are registered trademarks of the OpenStreetMap Foundation. If you have questions about your use of the marks, please send your questions to the <a href="http://wiki.osmfoundation.org/wiki/Licensing_Working_Group">LWG</a>.
+        OpenStreetMap and the looking glass logo are registered trademarks of the OpenStreetMap Foundation. If you have questions about your use of the marks, please send your questions to the <a href="http://wiki.osmfoundation.org/wiki/Licensing_Working_Group">Licence Working Group</a>.
   welcome_page:
     title: Welcome!
     introduction_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -966,7 +966,7 @@ en:
     legal_babble:
       title_html: Copyright and License
       intro_1_html: |
-        OpenStreetMap<sup><a href="#trademarks">TM</a></sup> is <i>open data</i>, licensed under the <a
+        OpenStreetMap<sup><a href="#trademarks">&reg;</a></sup> is <i>open data</i>, licensed under the <a
         href="http://opendatacommons.org/licenses/odbl/">Open Data
         Commons Open Database License</a> (ODbL) by the  <a
         href="http://osmfoundation.org/">OpenStreetMap Foundation</a> (OSMF).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -966,7 +966,7 @@ en:
     legal_babble:
       title_html: Copyright and License
       intro_1_html: |
-        OpenStreetMap is <i>open data</i>, licensed under the <a
+        OpenStreetMap<sup><a href="#trademarks">TM</a></sup> is <i>open data</i>, licensed under the <a
         href="http://opendatacommons.org/licenses/odbl/">Open Data
         Commons Open Database License</a> (ODbL) by the  <a
         href="http://osmfoundation.org/">OpenStreetMap Foundation</a> (OSMF).
@@ -1078,6 +1078,9 @@ en:
         to our <a href="http://www.osmfoundation.org/wiki/License/Takedown_procedure">takedown
         procedure</a> or file directly at our
         <a href="http://dmca.openstreetmap.org/">on-line filing page</a>.
+      trademarks_title_html: <span id="trademarks"></span>Trademarks
+      trademarks_1_html: |
+        OpenStreetMap and the looking glass logo are registered trademarks of the OpenStreetMap Foundation. If you have questions about your use of the marks, please send your questions to the <a href="http://wiki.osmfoundation.org/wiki/Licensing_Working_Group">LWG</a>.
   welcome_page:
     title: Welcome!
     introduction_html: |


### PR DESCRIPTION
Use conventional styling fur super- and subscripts.

Added some minimal text to the copyright page wrt trademarks, currently
pointing to the LWG, one day it should refer to a formal policy.

LWG and CWG pls review. In particular I personally find the use of the TM superscript a bit ugly, but haven't come up with a better solution yet. 