### PR TITLE
Fix bug allowing created elements to reference deleted ones.

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -248,6 +248,9 @@ class Relation < ActiveRecord::Base
       model = Kernel.const_get(m[0].capitalize)
       # get the element with that ID
       element = model.find_by(:id => m[1])
+      # if found, lock the element to ensure it can't be deleted until
+      # after the current transaction commits.
+      element.lock!('for share') unless element.nil?
 
       # and check that it is OK to use.
       unless element && element.visible? && element.preconditions_ok?

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -250,7 +250,7 @@ class Relation < ActiveRecord::Base
       element = model.find_by(:id => m[1])
       # if found, lock the element to ensure it can't be deleted until
       # after the current transaction commits.
-      element.lock!('for share') unless element.nil?
+      element.lock!("for share") unless element.nil?
 
       # and check that it is OK to use.
       unless element && element.visible? && element.preconditions_ok?

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -246,11 +246,10 @@ class Relation < ActiveRecord::Base
 
       # use reflection to look up the appropriate class
       model = Kernel.const_get(m[0].capitalize)
-      # get the element with that ID
-      element = model.find_by(:id => m[1])
-      # if found, lock the element to ensure it can't be deleted until
-      # after the current transaction commits.
-      element.lock!("for share") unless element.nil?
+      # get the element with that ID. and, if found, lock the element to
+      # ensure it can't be deleted until after the current transaction
+      # commits.
+      element = model.lock("for share").find_by(:id => m[1])
 
       # and check that it is OK to use.
       unless element && element.visible? && element.preconditions_ok?

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -199,7 +199,9 @@ class Way < ActiveRecord::Base
     new_nds = (nds - old_nodes).sort.uniq
 
     unless new_nds.empty?
-      db_nds = Node.where(:id => new_nds, :visible => true)
+      # NOTE: nodes are locked here to ensure they can't be deleted before
+      # the current transaction commits.
+      db_nds = Node.where(:id => new_nds, :visible => true).lock('for share')
 
       if db_nds.length < new_nds.length
         missing = new_nds - db_nds.collect(&:id)

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -201,7 +201,7 @@ class Way < ActiveRecord::Base
     unless new_nds.empty?
       # NOTE: nodes are locked here to ensure they can't be deleted before
       # the current transaction commits.
-      db_nds = Node.where(:id => new_nds, :visible => true).lock('for share')
+      db_nds = Node.where(:id => new_nds, :visible => true).lock("for share")
 
       if db_nds.length < new_nds.length
         missing = new_nds - db_nds.collect(&:id)


### PR DESCRIPTION
The bug allows a newly-created element to refer to a deleted one if the transactions for both overlap. Precisely, the issue is that the check that an element exists does not prevent a concurrent transaction from altering that row.

Because "deleting" an element in the OSM database does not remove the row, we cannot rely on FK constraints to ensure the correct behaviour. Instead, this fix relies on manually locking referenced elements.

Note that this "fix" is suboptimal, as it does not allow any updates to the referenced elements. Updates which do not delete the row could safely be done, but will be prevented.

Also, it's not clear what the negative performance impact of this change will be.