### PR TITLE
Introduce Geo URI to Share panel, take 2.

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -170,6 +170,23 @@ L.OSM.Map = L.Map.extend({
     return str;
   },
 
+  getGeoUrl: function(marker) {
+    var precision = OSM.zoomPrecision(this.getZoom()),
+        latLng,
+        params = {};
+
+    if (marker && this.hasLayer(marker)) {
+      latLng = marker.getLatLng().wrap();
+    } else {
+      latLng = this.getCenter();
+    }
+
+    params.mlat = latLng.lat.toFixed(precision);
+    params.mlon = latLng.lng.toFixed(precision);
+
+    return 'geo:' + params.mlat + ',' + params.mlon;
+  },
+
   addObject: function(object, callback) {
     var objectStyle = {
       color: "#FF6200",

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -170,7 +170,7 @@ L.OSM.Map = L.Map.extend({
     return str;
   },
 
-  getGeoUrl: function(marker) {
+  getGeoUri: function(marker) {
     var precision = OSM.zoomPrecision(this.getZoom()),
         latLng,
         params = {};
@@ -183,8 +183,9 @@ L.OSM.Map = L.Map.extend({
 
     params.mlat = latLng.lat.toFixed(precision);
     params.mlon = latLng.lng.toFixed(precision);
+    params.zoom = this.getZoom();
 
-    return 'geo:' + params.mlat + ',' + params.mlon;
+    return 'geo:' + params.mlat + ',' + params.mlon + '?z=' + params.zoom;
   },
 
   addObject: function(object, callback) {

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -73,10 +73,6 @@ L.OSM.share = function (options) {
         .attr('id', 'short_link')
         .text(I18n.t('javascripts.share.short_link')))
       .append($('<a>')
-        .attr('for', 'geo_input')
-        .attr('id', 'geo_link')
-        .text(I18n.t('javascripts.share.geo_link')))
-      .append($('<a>')
         .attr('for', 'embed_html')
         .attr('href', '#')
         .text(I18n.t('javascripts.share.embed')))
@@ -114,14 +110,6 @@ L.OSM.share = function (options) {
     $('<div>')
       .attr('class', 'form-row share-tab')
       .appendTo($form)
-      .append($('<input>')
-        .attr('id', 'geo_input')
-        .attr('type', 'text')
-        .on('click', select));
-
-    $('<div>')
-      .attr('class', 'form-row share-tab')
-      .appendTo($form)
       .append(
         $('<textarea>')
           .attr('id', 'embed_html')
@@ -131,6 +119,21 @@ L.OSM.share = function (options) {
           .attr('class', 'deemphasize')
           .text(I18n.t('javascripts.share.paste_html'))
           .appendTo($linkSection));
+
+    // Geo URI
+
+    var $geoUriSection = $('<div>')
+      .attr('class', 'section share-geo-uri')
+      .appendTo($ui);
+
+    $('<h4>')
+      .text(I18n.t('javascripts.share.geo_uri'))
+      .appendTo($geoUriSection);
+
+    $('<div>')
+      .appendTo($geoUriSection)
+      .append($('<a>')
+        .attr('id', 'geo_uri'));
 
     // Image
 
@@ -312,10 +315,8 @@ L.OSM.share = function (options) {
 
       $('#short_input').val(map.getShortUrl(marker));
       $('#long_input').val(map.getUrl(marker));
-      $('#geo_input').val(map.getGeoUrl(marker));
       $('#short_link').attr('href', map.getShortUrl(marker));
       $('#long_link').attr('href', map.getUrl(marker));
-      $('#geo_link').attr('href', map.getGeoUrl(marker));
 
       var params = {
         bbox: bounds.toBBoxString(),
@@ -333,6 +334,12 @@ L.OSM.share = function (options) {
           '" style="border: 1px solid black"></iframe><br/>' +
           '<small><a href="' + escapeHTML(map.getUrl(marker)) + '">' +
           escapeHTML(I18n.t('javascripts.share.view_larger_map')) + '</a></small>');
+
+      // Geo URI
+
+      $('#geo_uri')
+        .attr('href', map.getGeoUrl(marker))
+        .html(map.getGeoUrl(marker));
 
       // Image
 

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -73,6 +73,10 @@ L.OSM.share = function (options) {
         .attr('id', 'short_link')
         .text(I18n.t('javascripts.share.short_link')))
       .append($('<a>')
+        .attr('for', 'geo_input')
+        .attr('id', 'geo_link')
+        .text(I18n.t('javascripts.share.geo_link')))
+      .append($('<a>')
         .attr('for', 'embed_html')
         .attr('href', '#')
         .text(I18n.t('javascripts.share.embed')))
@@ -104,6 +108,14 @@ L.OSM.share = function (options) {
       .appendTo($form)
       .append($('<input>')
         .attr('id', 'short_input')
+        .attr('type', 'text')
+        .on('click', select));
+
+    $('<div>')
+      .attr('class', 'form-row share-tab')
+      .appendTo($form)
+      .append($('<input>')
+        .attr('id', 'geo_input')
         .attr('type', 'text')
         .on('click', select));
 
@@ -300,8 +312,10 @@ L.OSM.share = function (options) {
 
       $('#short_input').val(map.getShortUrl(marker));
       $('#long_input').val(map.getUrl(marker));
+      $('#geo_input').val(map.getGeoUrl(marker));
       $('#short_link').attr('href', map.getShortUrl(marker));
       $('#long_link').attr('href', map.getUrl(marker));
+      $('#geo_link').attr('href', map.getGeoUrl(marker));
 
       var params = {
         bbox: bounds.toBBoxString(),

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -338,8 +338,8 @@ L.OSM.share = function (options) {
       // Geo URI
 
       $('#geo_uri')
-        .attr('href', map.getGeoUrl(marker))
-        .html(map.getGeoUrl(marker));
+        .attr('href', map.getGeoUri(marker))
+        .html(map.getGeoUri(marker));
 
       // Image
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -626,7 +626,7 @@ nav.secondary {
     display: none;
     position: relative;
     float: right;
-    width: 270px;
+    width: 250px;
     height: 100%;
     background: white;
     overflow: auto;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -626,7 +626,7 @@ nav.secondary {
     display: none;
     position: relative;
     float: right;
-    width: 250px;
+    width: 270px;
     height: 100%;
     background: white;
     overflow: auto;
@@ -721,6 +721,7 @@ nav.secondary {
       text-decoration: none;
       background-color: $lightblue;
       padding: 5px 10px;
+      border-right: 1px solid #fff;
     }
 
     a:first-child {
@@ -729,7 +730,6 @@ nav.secondary {
     }
 
     a:last-child {
-      border-left: 1px solid #fff;
       border-radius: 0 4px 4px 0;
     }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2149,7 +2149,7 @@ en:
       link: "Link or HTML"
       long_link: "Link"
       short_link: "Short Link"
-      geo_link: "geo:"
+      geo_uri: "Geo URI"
       embed: "HTML"
       custom_dimensions: "Set custom dimensions"
       format: "Format:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2149,6 +2149,7 @@ en:
       link: "Link or HTML"
       long_link: "Link"
       short_link: "Short Link"
+      geo_link: "geo:"
       embed: "HTML"
       custom_dimensions: "Set custom dimensions"
       format: "Format:"


### PR DESCRIPTION
A second attempt at addressing #799. Abandons the previous idea of adding a _geo:_ button in the __Link or HTML__ section of the __Share__ panel. Adds a small block between __Link or HTML__ and __Image__,

Makes #884 obsolete.