### PR TITLE
Adding user block start/end timestamps on block page

### DIFF
--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -30,7 +30,8 @@
 </p>
 <% end %>
 
-<p><b><%= t'user_block.show.status' %></b>: <%= block_status(@user_block) %></p>
+<p><b><%= t'user_block.show.status' %></b>: <abbr title="Created: <%= @user_block.created_at %>
+Expires: <%= @user_block.ends_at %>"><%= block_status(@user_block) %></abbr></p>
 
 <p><b><%= t'user_block.show.reason' %></b></p>
 <div class="richtext"><%= @user_block.reason.to_html %></div>


### PR DESCRIPTION
### Background
Re: #923 and DWG experience. It would be great to have more detailed information about the extent of a block on the block page.

## Approach
Similar to the styling of changesets' creation and closing timestamps, this PR adds an abbreviation tag to the status text of a user block detailing the creation and expiration of a user block. The information necessary is already available from `@user_block`.

## Testing
On my local build, the page successfully rendered with the correct information. Attached are two examples:
### A 4 day block:
![Example 4 day block rendering](https://cloud.githubusercontent.com/assets/8998918/8343902/462570be-1aa0-11e5-961d-8a404acdaf2e.png)

### A block that was revoked after ~4 minutes:
![Example block revocation](https://cloud.githubusercontent.com/assets/8998918/8343863/c0e192a2-1a9f-11e5-9296-40f0d996ea0f.png)