### PR TITLE
Simplify new-note marker placement - always in the centre

### DIFF
--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -108,13 +108,7 @@ OSM.NewNote = function(map) {
     var mapSize = map.getSize();
     var markerPosition;
 
-    if (mapSize.y > 800) {
-      markerPosition = [mapSize.x / 2, mapSize.y / 2];
-    } else if (mapSize.y > 400) {
-      markerPosition = [mapSize.x / 2, 400];
-    } else {
-      markerPosition = [mapSize.x / 2, mapSize.y];
-    }
+    markerPosition = [mapSize.x / 2, mapSize.y / 2];
 
     newNote = L.marker(map.containerPointToLatLng(markerPosition), {
       icon: noteIcons["new"],


### PR DESCRIPTION
This removes a tweak added in 40b3c82, which we believe is no longer relevant now the new-note dialogue is sidebar rather than bubble.

I've tested this with various screen sizes (inc mobile-sized) on my laptop with Firefox and Chromium. It looks good and doesn't incur scrolling (as the comment on 40b3c82 might suggest).

Fixes #1028