### PR TITLE
added missing wording for note "not found" and "timeout"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
         way: way
         relation: relation
         changeset: changeset
+        note: note
     timeout:
       sorry: "Sorry, the data for the %{type} with the id %{id}, took too long to retrieve."
       type:
@@ -169,6 +170,7 @@ en:
         way: way
         relation: relation
         changeset: changeset
+        note: note
     redacted:
       redaction: "Redaction %{id}"
       message_html: "Version %{version} of this %{type} cannot be shown as it has been redacted. Please see %{redaction_link} for details."


### PR DESCRIPTION
Found by me in 
https://github.com/openstreetmap/openstreetmap-website/issues/1031#issuecomment-130560940

Probably a missing string even in the fallback language should get tested somehow. 