### PR TITLE
Replace blogs.osm.org with blog.osm.org

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1212,7 +1212,7 @@ en:
       running the OSM servers, humanitarians mapping disaster-affected areas,
       and many more.
       To learn more about the community, see the <a href='%{diary_path}'>user diaries</a>,
-      <a href='http://blogs.openstreetmap.org/'>community blogs</a>, and
+      <a href='//blog.openstreetmap.org/'>OpenStreetMap blog</a>, and
       the <a href='http://www.osmfoundation.org/'>OSM Foundation</a> website.
     open_data_title: Open Data
     open_data_html: |


### PR DESCRIPTION
Fixes #260.
