### PR TITLE
joined osm logo png with svg in picture element

### DIFF
--- a/app/assets/images/osm_logo.svg
+++ b/app/assets/images/osm_logo.svg
@@ -1,3336 +1,413 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="256"
-   height="256"
-   id="svg3038"
-   version="1.1"
-   inkscape:version="0.46"
-   sodipodi:docname="osm_logo_soft_freds_version.svg"
-   inkscape:export-filename="/home/fred/bla.png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   sodipodi:version="0.32"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
-  <defs
-     id="defs3040">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient8729">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop8731" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop8733" />
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="L">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient6846">
-      <stop
-         id="stop6848"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.93050194;"
-         offset="0.5"
-         id="stop6852" />
-      <stop
-         id="stop6850"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
+    <linearGradient id="s">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset=".5" stop-color="#fff" stop-opacity=".931"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient6589">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop6591" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop6593" />
+    <linearGradient id="v">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5862">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864" />
-      <stop
-         id="stop5876"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866" />
+    <linearGradient id="h">
+      <stop offset="0" stop-color="#f9e295"/>
+      <stop offset=".125" stop-color="#f7dd84"/>
+      <stop offset=".206" stop-color="#fff"/>
+      <stop offset=".301" stop-color="#f4ce51"/>
+      <stop offset=".341" stop-color="#f9e7aa"/>
+      <stop offset="1" stop-color="#efbb0e"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5762">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop5764" />
-      <stop
-         id="stop5770"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop5766" />
+    <linearGradient id="e">
+      <stop offset="0" stop-color="#2d3335"/>
+      <stop offset=".5" stop-color="#4c464a"/>
+      <stop offset="1" stop-color="#384042"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5745">
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0;"
-         offset="0"
-         id="stop5747" />
-      <stop
-         id="stop5753"
-         offset="0.83932751"
-         style="stop-color:#d0e9f2;stop-opacity:0;" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0.28185329;"
-         offset="0.94308507"
-         id="stop5755" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:1;"
-         offset="1"
-         id="stop5749" />
+    <linearGradient id="d">
+      <stop offset="0" stop-color="#d0e9f2" stop-opacity="0"/>
+      <stop offset=".839" stop-color="#d0e9f2" stop-opacity="0"/>
+      <stop offset=".943" stop-color="#d0e9f2" stop-opacity=".282"/>
+      <stop offset="1" stop-color="#d0e9f2"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient4680">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684" />
+    <linearGradient id="c">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective3046" />
-    <inkscape:perspective
-       id="perspective3056"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3844"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3871"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3897"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3926"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3953"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3979"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4005"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4028"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4054"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4083"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4132"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4158"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4184"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4219"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4276"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4302"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4328"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4354"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4386"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4413"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4439"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4465"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4497"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4523"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4549"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4575"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4601"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4627"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4653"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4837"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7"
-       id="linearGradient4686-3"
-       x1="94.25"
-       y1="-94.671967"
-       x2="9"
-       y2="-179.96893"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4680-7">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-2" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-7" />
+    <linearGradient id="ac" x1="94.25" x2="9" y1="-94.672" y2="-179.969" xlink:href="#a" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="a">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7"
-       id="linearGradient4742-3"
-       x1="50.75"
-       y1="-114.4375"
-       x2="35.75"
-       y2="-30.4375"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4846">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4848" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4850" />
+    <linearGradient id="ad" x1="50.75" x2="35.75" y1="-114.438" y2="-30.438" xlink:href="#a" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="ae" x1="77.625" x2="115.25" y1="-163.125" y2="-74.625" xlink:href="#a" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="af" x1="56.5" x2="125.719" y1="-50.438" y2="7.063" xlink:href="#a" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="ag" x1="35" x2="180.75" y1="-163.297" y2="-146.797" xlink:href="#a" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="ah" x1="57" x2="179" y1="-141.109" y2="-41.609" xlink:href="#a" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="ai" x1="156" x2="208.25" y1="-26.5" y2="39.75" xlink:href="#a" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="aj" x1="142.75" x2="235" y1="-169.297" y2="-77.297" xlink:href="#a" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="U" x1="214.25" x2="166.5" y1="-161.359" y2="-113.719" xlink:href="#b" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="b">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7"
-       id="linearGradient4734-3"
-       x1="77.625"
-       y1="-163.125"
-       x2="115.25"
-       y2="-74.625"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4853">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4855" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4857" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7"
-       id="linearGradient4726-9"
-       x1="56.5"
-       y1="-50.4375"
-       x2="125.71875"
-       y2="7.0625"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4860">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4862" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4864" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7"
-       id="linearGradient4710-2"
-       x1="35"
-       y1="-163.29688"
-       x2="180.75"
-       y2="-146.79688"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4867">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4869" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4871" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7"
-       id="linearGradient4718-4"
-       x1="57.000099"
-       y1="-141.10941"
-       x2="179"
-       y2="-41.609402"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4874">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4876" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4878" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7"
-       id="linearGradient4694-4"
-       x1="156"
-       y1="-26.5"
-       x2="208.25"
-       y2="39.75"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4881">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4883" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4885" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7"
-       id="linearGradient4702-4"
-       x1="142.75"
-       y1="-169.29688"
-       x2="235"
-       y2="-77.296875"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4888">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4890" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4892" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9"
-       id="linearGradient4806-9"
-       x1="214.25"
-       y1="-161.35938"
-       x2="166.5"
-       y2="-113.71875"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4744-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4746-3" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4748-8" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9"
-       id="linearGradient4790-3"
-       x1="53.25"
-       y1="-126.5"
-       x2="57.65625"
-       y2="-62.46875"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9"
-       id="linearGradient4758-2"
-       x1="39.5"
-       y1="6.6250248"
-       x2="75.71875"
-       y2="-17.124975"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9"
-       id="linearGradient4750-9"
-       x1="102"
-       y1="-162.34375"
-       x2="85.3125"
-       y2="-121.4375"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9"
-       id="linearGradient4782-5"
-       x1="117.75"
-       y1="-78.09375"
-       x2="63.5"
-       y2="-14.75"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9"
-       id="linearGradient4798-4"
-       x1="180.68745"
-       y1="-125.125"
-       x2="133.93745"
-       y2="-60.74995"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9"
-       id="linearGradient4766-3"
-       x1="170.75"
-       y1="-23.5"
-       x2="130.21875"
-       y2="33.375"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9"
-       id="linearGradient4774-9"
-       x1="213.5"
-       y1="-76"
-       x2="181.75005"
-       y2="-5.6563001"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       y2="-5.6563001"
-       x2="181.75005"
-       y1="-76"
-       x1="213.5"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4965"
-       xlink:href="#linearGradient4744-9"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective5148"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680"
-       id="linearGradient5168"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-10)" />
-    <inkscape:perspective
-       id="perspective5179"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5201"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5201-7"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5201-72"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5201-0"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5260"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5296"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5339"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5383">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5385" />
+    <linearGradient id="V" x1="53.25" x2="57.656" y1="-126.5" y2="-62.469" xlink:href="#b" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="W" x1="39.5" x2="75.719" y1="6.625" y2="-17.125" xlink:href="#b" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="X" x1="102" x2="85.313" y1="-162.344" y2="-121.438" xlink:href="#b" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="Y" x1="117.75" x2="63.5" y1="-78.094" y2="-14.75" xlink:href="#b" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="Z" x1="180.687" x2="133.937" y1="-125.125" y2="-60.75" xlink:href="#b" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="aa" x1="170.75" x2="130.219" y1="-23.5" y2="33.375" xlink:href="#b" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="ab" x1="213.5" x2="181.75" y1="-76" y2="-5.656" gradientUnits="userSpaceOnUse" xlink:href="#b"/>
+    <linearGradient id="T" x1="210.172" x2="9" y1="72.064" y2="-213.253" xlink:href="#c" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 -10)"/>
+    <clipPath id="R">
+      <path fill="#ceeeab" d="M9 12.25s7.5 13 11.75 27.75S27 65.5 27 65.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 167.5 26 167.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 116 218 116s1.75-10.5 6.75-23.75S235 65.5 235 65.5s-4.75-15.25-7.5-29.75S219.25 10 219.25 10 195 19 187.5 20.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z"/>
     </clipPath>
-    <inkscape:perspective
-       id="perspective5412"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5426">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5428" />
+    <clipPath id="S">
+      <path fill="#ceeeab" d="M9 12.25s7.5 13 11.75 27.75S27 65.5 27 65.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 167.5 26 167.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 116 218 116s1.75-10.5 6.75-23.75S235 65.5 235 65.5s-4.75-15.25-7.5-29.75S219.25 10 219.25 10 195 19 187.5 20.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z"/>
     </clipPath>
-    <inkscape:perspective
-       id="perspective5452"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5466">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5468" />
+    <clipPath id="Q">
+      <path fill="#ceeeab" d="M9 12.25s7.5 13 11.75 27.75S27 65.5 27 65.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 167.5 26 167.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 116 218 116s1.75-10.5 6.75-23.75S235 65.5 235 65.5s-4.75-15.25-7.5-29.75S219.25 10 219.25 10 195 19 187.5 20.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z"/>
     </clipPath>
-    <inkscape:perspective
-       id="perspective5614"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5638"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5638-1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5638-3"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5679"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5701"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5723"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5745"
-       id="radialGradient5751"
-       cx="128"
-       cy="86"
-       fx="128"
-       fy="86"
-       r="47"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0212766,0,0,-1.0212766,-212.7234,173.82979)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5762"
-       id="linearGradient5768"
-       x1="123"
-       y1="150.375"
-       x2="133"
-       y2="150.375"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,46,0)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5762"
-       id="linearGradient5778"
-       x1="128"
-       y1="134.35938"
-       x2="130.875"
-       y2="143.35938"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-210,0)" />
-    <inkscape:perspective
-       id="perspective5788"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5762-9"
-       id="linearGradient5768-1"
-       x1="123"
-       y1="150.375"
-       x2="133"
-       y2="150.375"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,256,0)" />
-    <linearGradient
-       id="linearGradient5762-9">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop5764-6" />
-      <stop
-         id="stop5770-3"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop5766-6" />
+    <radialGradient id="aI" cx="128" cy="86" r="47" xlink:href="#d" fx="128" fy="86" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.02 0 0 -1.02 -212.72 173.83)"/>
+    <linearGradient id="aK" x1="123" x2="133" y1="150.375" y2="150.375" xlink:href="#e" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-1 0 0 1 46 0)"/>
+    <linearGradient id="aJ" x1="128" x2="130.875" y1="134.359" y2="143.359" xlink:href="#e" gradientUnits="userSpaceOnUse" gradientTransform="translate(-210)"/>
+    <linearGradient id="f">
+      <stop offset="0" stop-color="#2d3335"/>
+      <stop offset=".5" stop-color="#4c464a"/>
+      <stop offset="1" stop-color="#384042"/>
     </linearGradient>
-    <linearGradient
-       y2="150.375"
-       x2="133"
-       y1="150.375"
-       x1="123"
-       gradientTransform="matrix(-2,0,0,1.7699115,174,-86.65044)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5798"
-       xlink:href="#linearGradient5762-9"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective5829"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       y2="150.375"
-       x2="133"
-       y1="150.375"
-       x1="123"
-       gradientTransform="matrix(-2,0,0,1.7699115,384,-86.65044)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5798-4"
-       xlink:href="#linearGradient5762-9-6"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient5762-9-6">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop5764-6-6" />
-      <stop
-         id="stop5770-3-7"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop5766-6-2" />
+    <linearGradient id="aM" x1="123" x2="133" y1="150.375" y2="150.375" gradientTransform="matrix(-2 0 0 1.77 174 -86.65)" gradientUnits="userSpaceOnUse" xlink:href="#f"/>
+    <linearGradient id="g">
+      <stop offset="0" stop-color="#2d3335"/>
+      <stop offset=".5" stop-color="#4c464a"/>
+      <stop offset="1" stop-color="#384042"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5862"
-       id="linearGradient5868"
-       x1="120"
-       y1="186.5"
-       x2="136"
-       y2="186.5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-210,0)" />
-    <inkscape:perspective
-       id="perspective5886"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5862-1"
-       id="linearGradient5868-4"
-       x1="120"
-       y1="186.5"
-       x2="136"
-       y2="186.5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient5862-1">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864-0" />
-      <stop
-         id="stop5876-0"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874-6"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870-4"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872-4" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866-3" />
+    <linearGradient id="aL" x1="120" x2="136" y1="186.5" y2="186.5" xlink:href="#h" gradientUnits="userSpaceOnUse" gradientTransform="translate(-210)"/>
+    <linearGradient id="i">
+      <stop offset="0" stop-color="#f9e295"/>
+      <stop offset=".125" stop-color="#f7dd84"/>
+      <stop offset=".206" stop-color="#fff"/>
+      <stop offset=".301" stop-color="#f4ce51"/>
+      <stop offset=".341" stop-color="#f9e7aa"/>
+      <stop offset="1" stop-color="#efbb0e"/>
     </linearGradient>
-    <linearGradient
-       y2="186.5"
-       x2="136"
-       y1="186.5"
-       x1="120"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5899"
-       xlink:href="#linearGradient5862-1"
-       inkscape:collect="always"
-       gradientTransform="translate(-210,67)" />
-    <inkscape:perspective
-       id="perspective5936"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       y2="186.5"
-       x2="136"
-       y1="186.5"
-       x1="120"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5899-3"
-       xlink:href="#linearGradient5862-1-4"
-       inkscape:collect="always"
-       gradientTransform="translate(0,69)" />
-    <linearGradient
-       id="linearGradient5862-1-4">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864-0-7" />
-      <stop
-         id="stop5876-0-2"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874-6-1"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870-4-7"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872-4-9" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866-3-5" />
+    <linearGradient id="aN" x1="120" x2="136" y1="186.5" y2="186.5" gradientUnits="userSpaceOnUse" xlink:href="#i" gradientTransform="translate(-210 67)"/>
+    <linearGradient id="j">
+      <stop offset="0" stop-color="#f9e295"/>
+      <stop offset=".125" stop-color="#f7dd84"/>
+      <stop offset=".206" stop-color="#fff"/>
+      <stop offset=".301" stop-color="#f4ce51"/>
+      <stop offset=".341" stop-color="#f9e7aa"/>
+      <stop offset="1" stop-color="#efbb0e"/>
     </linearGradient>
-    <inkscape:perspective
-       id="perspective5936-8"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       y2="186.5"
-       x2="136"
-       y1="186.5"
-       x1="120"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5899-9"
-       xlink:href="#linearGradient5862-1-5"
-       inkscape:collect="always"
-       gradientTransform="translate(0,69)" />
-    <linearGradient
-       id="linearGradient5862-1-5">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864-0-5" />
-      <stop
-         id="stop5876-0-21"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874-6-5"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870-4-9"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872-4-91" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866-3-6" />
+    <linearGradient id="k">
+      <stop offset="0" stop-color="#f9e295"/>
+      <stop offset=".125" stop-color="#f7dd84"/>
+      <stop offset=".206" stop-color="#fff"/>
+      <stop offset=".301" stop-color="#f4ce51"/>
+      <stop offset=".341" stop-color="#f9e7aa"/>
+      <stop offset="1" stop-color="#efbb0e"/>
     </linearGradient>
-    <inkscape:perspective
-       id="perspective6014"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       y2="186.5"
-       x2="136"
-       y1="186.5"
-       x1="120"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5899-0"
-       xlink:href="#linearGradient5862-1-53"
-       inkscape:collect="always"
-       gradientTransform="translate(0,67)" />
-    <linearGradient
-       id="linearGradient5862-1-53">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864-0-2" />
-      <stop
-         id="stop5876-0-1"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874-6-9"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870-4-76"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872-4-8" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866-3-2" />
+    <linearGradient id="l">
+      <stop offset="0" stop-color="#f9e295"/>
+      <stop offset=".125" stop-color="#f7dd84"/>
+      <stop offset=".206" stop-color="#fff"/>
+      <stop offset=".301" stop-color="#f4ce51"/>
+      <stop offset=".341" stop-color="#f9e7aa"/>
+      <stop offset="1" stop-color="#efbb0e"/>
     </linearGradient>
-    <inkscape:perspective
-       id="perspective6080"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient5745-3">
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0;"
-         offset="0"
-         id="stop5747-3" />
-      <stop
-         id="stop5753-6"
-         offset="0.83932751"
-         style="stop-color:#d0e9f2;stop-opacity:0;" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0.28185329;"
-         offset="0.94308507"
-         id="stop5755-9" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:1;"
-         offset="1"
-         id="stop5749-0" />
+    <linearGradient id="q">
+      <stop offset="0" stop-color="#d0e9f2" stop-opacity="0"/>
+      <stop offset=".839" stop-color="#d0e9f2" stop-opacity="0"/>
+      <stop offset=".943" stop-color="#d0e9f2" stop-opacity=".282"/>
+      <stop offset="1" stop-color="#d0e9f2"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5762-8">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop5764-5" />
-      <stop
-         id="stop5770-1"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop5766-2" />
+    <linearGradient id="p">
+      <stop offset="0" stop-color="#2d3335"/>
+      <stop offset=".5" stop-color="#4c464a"/>
+      <stop offset="1" stop-color="#384042"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient6096">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop6098" />
-      <stop
-         id="stop6100"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop6102" />
+    <linearGradient id="o">
+      <stop offset="0" stop-color="#f9e295"/>
+      <stop offset=".125" stop-color="#f7dd84"/>
+      <stop offset=".206" stop-color="#fff"/>
+      <stop offset=".301" stop-color="#f4ce51"/>
+      <stop offset=".341" stop-color="#f9e7aa"/>
+      <stop offset="1" stop-color="#efbb0e"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5862-3">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864-8" />
-      <stop
-         id="stop5876-09"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874-2"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870-3"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872-1" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866-8" />
+    <linearGradient id="n">
+      <stop offset="0" stop-color="#2d3335"/>
+      <stop offset=".5" stop-color="#4c464a"/>
+      <stop offset="1" stop-color="#384042"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5762-9-4">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop5764-6-1" />
-      <stop
-         id="stop5770-3-6"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop5766-6-3" />
+    <linearGradient id="m">
+      <stop offset="0" stop-color="#f9e295"/>
+      <stop offset=".125" stop-color="#f7dd84"/>
+      <stop offset=".206" stop-color="#fff"/>
+      <stop offset=".301" stop-color="#f4ce51"/>
+      <stop offset=".341" stop-color="#f9e7aa"/>
+      <stop offset="1" stop-color="#efbb0e"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5862-1-55">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864-0-0" />
-      <stop
-         id="stop5876-0-12"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874-6-6"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870-4-4"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872-4-85" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866-3-62" />
+    <linearGradient id="aH" x1="120" x2="136" y1="186.5" y2="186.5" xlink:href="#m" gradientUnits="userSpaceOnUse" gradientTransform="rotate(44.92 104.81 51.4) scale(1.4)"/>
+    <linearGradient id="aS" x1="123" x2="133" y1="150.375" y2="150.375" xlink:href="#n" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-1.97 -1.97 -1.74 1.74 596.19 167.51)"/>
+    <linearGradient id="aR" x1="120" x2="136" y1="186.5" y2="186.5" xlink:href="#o" gradientUnits="userSpaceOnUse" gradientTransform="rotate(44.92 217.23 98.19) scale(1.4)"/>
+    <linearGradient id="aQ" x1="123" x2="133" y1="150.375" y2="150.375" xlink:href="#p" gradientUnits="userSpaceOnUse" gradientTransform="scale(1.4) rotate(-135 157.13 -11.72)"/>
+    <linearGradient id="aP" x1="128" x2="130.875" y1="134.359" y2="143.359" xlink:href="#p" gradientUnits="userSpaceOnUse" gradientTransform="rotate(44.92 217.23 98.19) scale(1.4)"/>
+    <radialGradient id="aO" cx="128" cy="86" r="47" xlink:href="#q" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 1 1 -1 -40.84 43.25)" fx="128" fy="86"/>
+    <linearGradient id="r">
+      <stop offset="0" stop-color="#2d3335"/>
+      <stop offset=".5" stop-color="#4c464a"/>
+      <stop offset="1" stop-color="#384042"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5862-1-55"
-       id="linearGradient6241"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9842718,0.9842718,-0.9842718,0.9842718,66.992154,-59.215687)"
-       x1="120"
-       y1="186.5"
-       x2="136"
-       y2="186.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5762-9-4"
-       id="linearGradient6244"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.9685436,-1.9685436,-1.742074,1.742074,596.18632,167.51089)"
-       x1="123"
-       y1="150.375"
-       x2="133"
-       y2="150.375" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5862-3"
-       id="linearGradient6247"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.98427179,0.98427179,-0.98427179,0.98427179,132.93836,-125.1619)"
-       x1="120"
-       y1="186.5"
-       x2="136"
-       y2="186.5" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5762-8"
-       id="linearGradient6250"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.98427179,-0.98427179,-0.98427179,0.98427179,384.91194,126.81168)"
-       x1="123"
-       y1="150.375"
-       x2="133"
-       y2="150.375" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5762-8"
-       id="linearGradient6253"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.98427179,0.98427179,-0.98427179,0.98427179,132.93836,-125.1619)"
-       x1="128"
-       y1="134.35938"
-       x2="130.875"
-       y2="143.35938" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5745-3"
-       id="radialGradient6256"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0052137,1.0052137,1.0052137,-1.0052137,-40.83796,43.253296)"
-       cx="128"
-       cy="86"
-       fx="128"
-       fy="86"
-       r="47" />
-    <inkscape:perspective
-       id="perspective6269"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5762-9-4-6"
-       id="linearGradient6244-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.9685436,-1.9685436,-1.742074,1.742074,596.18632,177.51089)"
-       x1="123"
-       y1="150.375"
-       x2="133"
-       y2="150.375" />
-    <linearGradient
-       id="linearGradient5762-9-4-6">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop5764-6-1-0" />
-      <stop
-         id="stop5770-3-6-7"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop5766-6-3-4" />
+    <linearGradient id="aT" x1="108.003" x2="133" y1="167.727" y2="150.375" gradientTransform="matrix(-1.97 -1.97 -1.74 1.74 596.19 167.51)" gradientUnits="userSpaceOnUse" xlink:href="#c"/>
+    <radialGradient id="aW" cx="159.613" cy="72.588" r="38.417" xlink:href="#s" fx="159.613" fy="72.588" gradientTransform="matrix(1.2 0 0 .84 -46.35 24.53)" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="t">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       y2="150.375"
-       x2="133"
-       y1="167.7272"
-       x1="108.00327"
-       gradientTransform="matrix(-1.9685436,-1.9685436,-1.742074,1.742074,596.18632,167.51089)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6279"
-       xlink:href="#linearGradient4680"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective6314"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6846"
-       id="radialGradient6427"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-46.348455,24.528408)"
-       gradientUnits="userSpaceOnUse" />
-    <inkscape:perspective
-       id="perspective6437"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-9"
-       id="radialGradient6427-8"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1,0,0,0.69209216,-1.4142136,17.754313)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4744-9-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4746-3-8" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4748-8-3" />
+    <radialGradient id="aV" cx="159.613" cy="72.588" r="38.417" fy="72.588" fx="159.613" gradientTransform="matrix(1.2 0 0 .84 -45.92 25.81)" gradientUnits="userSpaceOnUse" xlink:href="#t"/>
+    <linearGradient id="u">
+      <stop offset="0" stop-color="#d0e9f2" stop-opacity="0"/>
+      <stop offset=".839" stop-color="#d0e9f2" stop-opacity="0"/>
+      <stop offset=".943" stop-color="#d0e9f2" stop-opacity=".282"/>
+      <stop offset="1" stop-color="#d0e9f2"/>
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-9"
-       id="radialGradient6445"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1,0,0,0.69209216,-1.4142136,17.754313)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-9"
-       id="radialGradient6453"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1,0,0,0.69209216,-1.4142136,17.754313)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-9"
-       id="radialGradient6461"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1,0,0,0.69209216,-1.4142136,17.754313)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-9"
-       id="radialGradient6469"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1,0,0,0.69209216,-1.4142136,17.754313)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       r="38.416904"
-       fy="72.588303"
-       fx="159.61317"
-       cy="72.588303"
-       cx="159.61317"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-45.919787,25.814437)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6482"
-       xlink:href="#linearGradient4744-9-9"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective6551"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5745-3-3"
-       id="radialGradient6256-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0052137,1.0052137,1.0052137,-1.0052137,-40.83796,53.253296)"
-       cx="128"
-       cy="86"
-       fx="128"
-       fy="86"
-       r="47" />
-    <linearGradient
-       id="linearGradient5745-3-3">
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0;"
-         offset="0"
-         id="stop5747-3-0" />
-      <stop
-         id="stop5753-6-1"
-         offset="0.83932751"
-         style="stop-color:#d0e9f2;stop-opacity:0;" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0.28185329;"
-         offset="0.94308507"
-         id="stop5755-9-4" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:1;"
-         offset="1"
-         id="stop5749-0-8" />
+    <linearGradient id="aU" x1="126.643" x2="179.961" y1="29.815" y2="137.196" xlink:href="#v" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 -10)"/>
+    <linearGradient id="w">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6589"
-       id="linearGradient6595"
-       x1="126.64295"
-       y1="29.814894"
-       x2="179.96115"
-       y2="137.19565"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-10)" />
-    <inkscape:perspective
-       id="perspective6605"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6589-6"
-       id="linearGradient6595-6"
-       x1="126.64295"
-       y1="29.814894"
-       x2="179.96115"
-       y2="137.19565"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient6589-6">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop6591-6" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop6593-1" />
+    <linearGradient id="aX" x1="126.643" x2="179.961" y1="29.815" y2="137.196" gradientTransform="matrix(-.5 .2 .2 -.43 276.16 123.42)" gradientUnits="userSpaceOnUse" xlink:href="#w"/>
+    <linearGradient id="x">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(-0.50295302,0.19839946,0.19720153,-0.43253662,276.15635,123.41729)"
-       y2="137.19565"
-       x2="179.96115"
-       y1="29.814894"
-       x1="126.64295"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6614"
-       xlink:href="#linearGradient6589-6"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective6643"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6589-2"
-       id="linearGradient6595-8"
-       x1="126.64295"
-       y1="29.814894"
-       x2="179.96115"
-       y2="137.19565"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient6589-2">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop6591-9" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop6593-6" />
+    <linearGradient id="y">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <inkscape:perspective
-       id="perspective6681"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-4"
-       id="radialGradient6427-9"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4744-9-4">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4746-3-3" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4748-8-7" />
+    <linearGradient id="z">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-4"
-       id="radialGradient6689"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-4"
-       id="radialGradient6697"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-4"
-       id="radialGradient6705"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-4"
-       id="radialGradient6713"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       r="38.416904"
-       fy="72.588303"
-       fx="159.61317"
-       cy="72.588303"
-       cx="159.61317"
-       gradientTransform="matrix(1.2124778,0,0,0.83914634,-47.895492,34.408018)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6726"
-       xlink:href="#linearGradient4744-9-4"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective6681-6"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-49"
-       id="radialGradient6427-0"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4744-9-49">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4746-3-1" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4748-8-2" />
+    <linearGradient id="A">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset=".5" stop-color="#fff" stop-opacity=".931"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-49"
-       id="radialGradient6689-2"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-49"
-       id="radialGradient6697-2"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-49"
-       id="radialGradient6705-4"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-49"
-       id="radialGradient6713-6"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       r="38.416904"
-       fy="72.588303"
-       fx="159.61317"
-       cy="72.588303"
-       cx="159.61317"
-       gradientTransform="matrix(1.2124778,0,0,0.83914634,-47.895492,34.408018)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6726-0"
-       xlink:href="#linearGradient4744-9-49"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective6863"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient6589-6-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop6591-6-7" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop6593-1-2" />
+    <linearGradient id="B">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
     </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6846-8"
-       id="radialGradient6427-6"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914634,-47.895493,34.408019)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient6846-8">
-      <stop
-         id="stop6848-8"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.93050194;"
-         offset="0.5"
-         id="stop6852-9" />
-      <stop
-         id="stop6850-8"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6846-8"
-       id="radialGradient6876"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient6878">
-      <stop
-         id="stop6880"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.93050194;"
-         offset="0.5"
-         id="stop6882" />
-      <stop
-         id="stop6884"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6846-8"
-       id="radialGradient6886"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient6888">
-      <stop
-         id="stop6890"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.93050194;"
-         offset="0.5"
-         id="stop6892" />
-      <stop
-         id="stop6894"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6846-8"
-       id="radialGradient6896"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient6898">
-      <stop
-         id="stop6900"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.93050194;"
-         offset="0.5"
-         id="stop6902" />
-      <stop
-         id="stop6904"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6846-8"
-       id="radialGradient6906"
-       cx="159.61317"
-       cy="72.588303"
-       fx="159.61317"
-       fy="72.588303"
-       r="38.416904"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.895494,34.408017)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient6908">
-      <stop
-         id="stop6910"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.93050194;"
-         offset="0.5"
-         id="stop6912" />
-      <stop
-         id="stop6914"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <radialGradient
-       r="38.416904"
-       fy="72.588303"
-       fx="159.61317"
-       cy="72.588303"
-       cx="159.61317"
-       gradientTransform="matrix(1.2124778,0,0,0.83914634,-47.466825,35.694048)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6482-8"
-       xlink:href="#linearGradient4744-9-9-1"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4744-9-9-1">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4746-3-8-6" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4748-8-3-8" />
-    </linearGradient>
-    <radialGradient
-       r="38.416904"
-       fy="72.588303"
-       fx="159.61317"
-       cy="72.588303"
-       cx="159.61317"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.466826,35.694046)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6920"
-       xlink:href="#linearGradient4744-9-9-1"
-       inkscape:collect="always" />
-    <radialGradient
-       r="38.416904"
-       fy="72.588303"
-       fx="159.61317"
-       cy="72.588303"
-       cx="159.61317"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.466826,35.694046)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6928"
-       xlink:href="#linearGradient4744-9-9-1"
-       inkscape:collect="always" />
-    <radialGradient
-       r="38.416904"
-       fy="72.588303"
-       fx="159.61317"
-       cy="72.588303"
-       cx="159.61317"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.466826,35.694046)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6936"
-       xlink:href="#linearGradient4744-9-9-1"
-       inkscape:collect="always" />
-    <radialGradient
-       r="38.416904"
-       fy="72.588303"
-       fx="159.61317"
-       cy="72.588303"
-       cx="159.61317"
-       gradientTransform="matrix(1.2124778,0,0,0.83914635,-47.466826,35.694046)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient6944"
-       xlink:href="#linearGradient4744-9-9-1"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient5862-1-55-2">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864-0-0-9" />
-      <stop
-         id="stop5876-0-12-6"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874-6-6-4"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870-4-4-5"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872-4-85-5" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866-3-62-4" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4680-0">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-5" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-76" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5762-9-4-5">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop5764-6-1-3" />
-      <stop
-         id="stop5770-3-6-73"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop5766-6-3-2" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5862-3-3">
-      <stop
-         style="stop-color:#f9e295;stop-opacity:1;"
-         offset="0"
-         id="stop5864-8-0" />
-      <stop
-         id="stop5876-09-8"
-         offset="0.125"
-         style="stop-color:#f7dd84;stop-opacity:1;" />
-      <stop
-         id="stop5874-2-6"
-         offset="0.20580582"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5870-3-6"
-         offset="0.30112621"
-         style="stop-color:#f4ce51;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f9e7aa;stop-opacity:1;"
-         offset="0.3412039"
-         id="stop5872-1-9" />
-      <stop
-         style="stop-color:#efbb0e;stop-opacity:1;"
-         offset="1"
-         id="stop5866-8-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5762-8-9">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop5764-5-3" />
-      <stop
-         id="stop5770-1-7"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop5766-2-1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6987">
-      <stop
-         style="stop-color:#2d3335;stop-opacity:1;"
-         offset="0"
-         id="stop6989" />
-      <stop
-         id="stop6991"
-         offset="0.5"
-         style="stop-color:#4c464a;stop-opacity:1;" />
-      <stop
-         style="stop-color:#384042;stop-opacity:1;"
-         offset="1"
-         id="stop6993" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5745-3-5">
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0;"
-         offset="0"
-         id="stop5747-3-7" />
-      <stop
-         id="stop5753-6-0"
-         offset="0.83932751"
-         style="stop-color:#d0e9f2;stop-opacity:0;" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0.28185329;"
-         offset="0.94308507"
-         id="stop5755-9-2" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:1;"
-         offset="1"
-         id="stop5749-0-6" />
-    </linearGradient>
-    <filter
-       inkscape:collect="always"
-       id="filter7286">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.2868936"
-         id="feGaussianBlur7288" />
+    <filter id="aG">
+      <feGaussianBlur stdDeviation="4.287"/>
     </filter>
-    <inkscape:perspective
-       id="perspective7298"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-6"
-       id="linearGradient5168-6"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4680-6">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-3" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-2" />
+    <linearGradient id="C">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
     </linearGradient>
-    <inkscape:perspective
-       id="perspective7298-3"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-4"
-       id="linearGradient5168-60"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4680-4">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-36" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-3" />
+    <linearGradient id="D">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
     </linearGradient>
-    <inkscape:perspective
-       id="perspective7298-9"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-2"
-       id="linearGradient5168-4"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4680-2">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-9" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-38" />
+    <linearGradient id="E">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-2"
-       id="linearGradient7376"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,-0.08087767,0,1,0,203.0563)"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346" />
-    <inkscape:perspective
-       id="perspective7716"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient4680-7-3">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-2-2" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-7-2" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7725">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7727" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop7729" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7732">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7734" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop7736" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7739">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7741" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop7743" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7746">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7748" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop7750" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7753">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7755" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop7757" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7760">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7762" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop7764" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7767">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7769" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop7771" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4680-22">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-27" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-36" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5426-1">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5428-0" />
+    <clipPath id="al">
+      <path fill="#ceeeab" d="M9 12.25s7.5 13 11.75 27.75S27 65.5 27 65.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 167.5 26 167.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 116 218 116s1.75-10.5 6.75-23.75S235 65.5 235 65.5s-4.75-15.25-7.5-29.75S219.25 10 219.25 10 195 19 187.5 20.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z"/>
     </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5383-0">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5385-7" />
+    <clipPath id="am">
+      <path fill="#ceeeab" d="M9 12.25s7.5 13 11.75 27.75S27 65.5 27 65.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 167.5 26 167.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 116 218 116s1.75-10.5 6.75-23.75S235 65.5 235 65.5s-4.75-15.25-7.5-29.75S219.25 10 219.25 10 195 19 187.5 20.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z"/>
     </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5466-2">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5468-3" />
+    <clipPath id="an">
+      <path fill="#ceeeab" d="M9 12.25s7.5 13 11.75 27.75S27 65.5 27 65.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 167.5 26 167.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 116 218 116s1.75-10.5 6.75-23.75S235 65.5 235 65.5s-4.75-15.25-7.5-29.75S219.25 10 219.25 10 195 19 187.5 20.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z"/>
     </clipPath>
-    <inkscape:perspective
-       id="perspective8183"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5466-2-3">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5468-3-2" />
+    <linearGradient id="ao" x1="210.172" x2="9" y1="72.064" y2="-213.253" gradientTransform="translate(0 192)" xlink:href="#F" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="F">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="ap" x1="214.25" x2="166.5" y1="-161.359" y2="-113.719" xlink:href="#G" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="G">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="aq" x1="53.25" x2="57.656" y1="-126.5" y2="-62.469" xlink:href="#G" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="ar" x1="39.5" x2="75.719" y1="6.625" y2="-17.125" xlink:href="#G" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="as" x1="102" x2="85.313" y1="-162.344" y2="-121.438" xlink:href="#G" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="at" x1="117.75" x2="63.5" y1="-78.094" y2="-14.75" xlink:href="#G" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="au" x1="180.687" x2="133.937" y1="-125.125" y2="-60.75" xlink:href="#G" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="av" x1="170.75" x2="130.219" y1="-23.5" y2="33.375" xlink:href="#G" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="aw" x1="213.5" x2="181.75" y1="-76" y2="-5.656" gradientUnits="userSpaceOnUse" xlink:href="#G"/>
+    <linearGradient id="ax" x1="94.25" x2="9" y1="-94.672" y2="-179.969" xlink:href="#H" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="H">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="ay" x1="50.75" x2="35.75" y1="-114.438" y2="-30.438" xlink:href="#H" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="az" x1="77.625" x2="115.25" y1="-163.125" y2="-74.625" xlink:href="#H" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="aA" x1="56.5" x2="125.719" y1="-50.438" y2="7.063" xlink:href="#H" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="aB" x1="35" x2="180.75" y1="-163.297" y2="-146.797" xlink:href="#H" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="aC" x1="57" x2="179" y1="-141.109" y2="-41.609" xlink:href="#H" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="aD" x1="156" x2="208.25" y1="-26.5" y2="39.75" xlink:href="#H" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="aE" x1="142.75" x2="235" y1="-169.297" y2="-77.297" xlink:href="#H" gradientUnits="userSpaceOnUse"/>
+    <linearGradient id="I">
+      <stop offset="0" stop-color="#d0e9f2" stop-opacity="0"/>
+      <stop offset=".839" stop-color="#d0e9f2" stop-opacity="0"/>
+      <stop offset=".943" stop-color="#d0e9f2" stop-opacity=".282"/>
+      <stop offset="1" stop-color="#d0e9f2"/>
+    </linearGradient>
+    <clipPath id="ak">
+      <path fill="url(#J)" d="M123.623 141.062c20.832 20.243 54.607 19.29 75.44-2.132 20.83-21.42 20.83-55.196 0-75.44-20.833-20.242-54.608-19.288-75.44 2.133-20.832 21.42-20.832 55.196 0 75.44z"/>
     </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5383-0-0">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5385-7-8" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath5426-1-6">
-      <path
-         style="fill:#ceeeab;fill-opacity:1;stroke:none"
-         d="m 9,12.25 c 0,0 7.5,13 11.75,27.75 C 25,54.75 27,65.5 27,65.5 c 0,0 -5.5,12.75 -8.25,24.75 -2.75,12 -5.75,23 -5.75,23 0,0 5.75,16 9.25,30 3.5,14 3.75,24.25 3.75,24.25 0,0 -4,10.25 -7.5,24.25 -3.5,14 -5,30.75 -5,30.75 0,0 9.25,-2 28.5,1.25 19.25,3.25 32.25,6 32.25,6 0,0 12.75,-2.75 24,-6.25 11.25,-3.5 16.25,-6.5 16.25,-6.5 0,0 5.5,0.5 22.5,6.25 17,5.75 29.25,8.5 29.25,8.5 0,0 13,-2.75 26,-5.75 13,-3 26.5,-8 26.5,-8 0,0 -0.75,-5 4.25,-24.5 5,-19.5 8.75,-28 8.75,-28 0,0 -0.5,-4.5 -3.75,-19.75 C 224.75,130.5 218,116 218,116 c 0,0 1.75,-10.5 6.75,-23.75 C 229.75,79 235,65.5 235,65.5 c 0,0 -4.75,-15.25 -7.5,-29.75 C 224.75,21.25 219.25,10 219.25,10 c 0,0 -24.25,9 -31.75,10.5 -7.5,1.5 -21,5.25 -21,5.25 0,0 -9.75,-4.25 -22,-8.5 -12.25,-4.25 -29.75,-5.5 -29.75,-5.5 0,0 -3.25,3.5 -22,8 -18.75,4.5 -27.5,5.75 -27.5,5.75 0,0 -18.5,-9 -31.5,-11.5 -13,-2.5 -24,-2 -24.75,-1.75 z"
-         id="path5428-0-9" />
-    </clipPath>
-    <linearGradient
-       gradientTransform="translate(0,192)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-22-2"
-       id="linearGradient5168-2-9"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4680-22-2">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-27-3" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-36-5" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-7-8"
-       id="linearGradient4806-9-8-4"
-       x1="214.25"
-       y1="-161.35938"
-       x2="166.5"
-       y2="-113.71875"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4744-9-7-8">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4746-3-0-1" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4748-8-4-0" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-7-8"
-       id="linearGradient4790-3-9-7"
-       x1="53.25"
-       y1="-126.5"
-       x2="57.65625"
-       y2="-62.46875"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-7-8"
-       id="linearGradient4758-2-6-2"
-       x1="39.5"
-       y1="6.6250248"
-       x2="75.71875"
-       y2="-17.124975"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-7-8"
-       id="linearGradient4750-9-9-4"
-       x1="102"
-       y1="-162.34375"
-       x2="85.3125"
-       y2="-121.4375"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-7-8"
-       id="linearGradient4782-5-5-9"
-       x1="117.75"
-       y1="-78.09375"
-       x2="63.5"
-       y2="-14.75"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-7-8"
-       id="linearGradient4798-4-1-9"
-       x1="180.68745"
-       y1="-125.125"
-       x2="133.93745"
-       y2="-60.74995"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4744-9-7-8"
-       id="linearGradient4766-3-6-2"
-       x1="170.75"
-       y1="-23.5"
-       x2="130.21875"
-       y2="33.375"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       y2="-5.6563001"
-       x2="181.75005"
-       y1="-76"
-       x1="213.5"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4965-0-3"
-       xlink:href="#linearGradient4744-9-7-8"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7-3-6"
-       id="linearGradient4686-3-4-6"
-       x1="94.25"
-       y1="-94.671967"
-       x2="9"
-       y2="-179.96893"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4680-7-3-6">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-2-2-7" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-7-2-7" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7-3-6"
-       id="linearGradient4742-3-4-4"
-       x1="50.75"
-       y1="-114.4375"
-       x2="35.75"
-       y2="-30.4375"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient8255">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop8257" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop8259" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7-3-6"
-       id="linearGradient4734-3-7-6"
-       x1="77.625"
-       y1="-163.125"
-       x2="115.25"
-       y2="-74.625"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient8262">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop8264" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop8266" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7-3-6"
-       id="linearGradient4726-9-4-9"
-       x1="56.5"
-       y1="-50.4375"
-       x2="125.71875"
-       y2="7.0625"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient8269">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop8271" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop8273" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7-3-6"
-       id="linearGradient4710-2-1-6"
-       x1="35"
-       y1="-163.29688"
-       x2="180.75"
-       y2="-146.79688"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient8276">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop8278" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop8280" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7-3-6"
-       id="linearGradient4718-4-6-0"
-       x1="57.000099"
-       y1="-141.10941"
-       x2="179"
-       y2="-41.609402"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient8283">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop8285" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop8287" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7-3-6"
-       id="linearGradient4694-4-1-9"
-       x1="156"
-       y1="-26.5"
-       x2="208.25"
-       y2="39.75"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient8290">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop8292" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop8294" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-7-3-6"
-       id="linearGradient4702-4-6-9"
-       x1="142.75"
-       y1="-169.29688"
-       x2="235"
-       y2="-77.296875"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient8297">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop8299" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop8301" />
-    </linearGradient>
-    <inkscape:perspective
-       id="perspective8581"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5745-3-1"
-       id="radialGradient6256-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0052137,1.0052137,1.0052137,-1.0052137,-40.83796,53.253296)"
-       cx="128"
-       cy="86"
-       fx="128"
-       fy="86"
-       r="47" />
-    <linearGradient
-       id="linearGradient5745-3-1">
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0;"
-         offset="0"
-         id="stop5747-3-73" />
-      <stop
-         id="stop5753-6-08"
-         offset="0.83932751"
-         style="stop-color:#d0e9f2;stop-opacity:0;" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:0.28185329;"
-         offset="0.94308507"
-         id="stop5755-9-5" />
-      <stop
-         style="stop-color:#d0e9f2;stop-opacity:1;"
-         offset="1"
-         id="stop5749-0-4" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath8617">
-      <path
-         style="fill:url(#radialGradient8621);fill-opacity:1;stroke:none"
-         d="m 123.62289,141.06193 c 20.83191,20.24317 54.6071,19.28863 75.439,-2.132 20.8319,-21.42064 20.8319,-55.195816 0,-75.438984 -20.83191,-20.243167 -54.60709,-19.288643 -75.439,2.131999 -20.83189,21.42063 -20.8319,55.195815 0,75.438985 z"
-         id="path8619"
-         sodipodi:nodetypes="csssc" />
-    </clipPath>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5745-3-1"
-       id="radialGradient8621"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.80254238,0.77986154,0.80254238,-0.82522321,-10.401684,73.423363)"
-       cx="128"
-       cy="86"
-       fx="128"
-       fy="86"
-       r="47" />
-    <inkscape:perspective
-       id="perspective8631"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <filter
-       inkscape:collect="always"
-       id="filter8661">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="6.3109704"
-         id="feGaussianBlur8663" />
+    <radialGradient id="J" cx="128" cy="86" r="47" xlink:href="#I" gradientUnits="userSpaceOnUse" gradientTransform="matrix(.8 .78 .8 -.83 -10.4 73.42)" fx="128" fy="86"/>
+    <filter id="N">
+      <feGaussianBlur stdDeviation="6.311"/>
     </filter>
-    <inkscape:perspective
-       id="perspective8673"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-62"
-       id="linearGradient5168-8"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4680-62">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4682-7" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4684-0" />
+    <linearGradient id="K">
+      <stop offset="0"/>
+      <stop offset="1" stop-opacity="0"/>
     </linearGradient>
-    <inkscape:perspective
-       id="perspective8711"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <filter
-       inkscape:collect="always"
-       id="filter8725">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="4.4575"
-         id="feGaussianBlur8727" />
+    <filter id="P">
+      <feGaussianBlur stdDeviation="4.457"/>
     </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient8729"
-       id="linearGradient8735"
-       x1="122"
-       y1="245.448"
-       x2="122"
-       y2="4.302"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-2"
-       id="linearGradient8742"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,181.99999)"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath8750">
-      <path
-         id="path8752"
-         d="m 9,22.578406 c 0,0 7.5,12.393417 11.75,26.799687 C 25,63.784363 27,74.372608 27,74.372608 c 0,0 -5.5,13.194827 -8.25,25.417241 C 16,112.01226 13,123.2549 13,123.2549 c 0,0 5.75,15.53495 9.25,29.25188 3.5,13.71692 3.75,23.94671 3.75,23.94671 0,0 -4,10.57351 -7.5,24.85658 -3.5,14.28307 -5,31.15439 -5,31.15439 0,0 9.25,-2.74812 28.5,-1.05502 19.25,1.69311 32.25,3.3917 32.25,3.3917 0,0 12.75,-3.78119 24,-8.19107 11.25,-4.40987 16.25,-7.81426 16.25,-7.81426 0,0 5.5,0.0552 22.5,4.43025 17,4.37508 29.25,6.13433 29.25,6.13433 0,0 13,-3.80141 26,-7.85282 13,-4.05141 26.5,-10.14326 26.5,-10.14326 0,0 -0.75,-4.93934 4.25,-24.84373 5,-19.90438 8.75,-28.70768 8.75,-28.70768 0,0 -0.5145,-4.4553 -3.75,-19.4467 -1.75,-8.10847 -2.25,-4.06803 -2.25,-4.06803 0,0 16.264,-26.15535 16.5,-40.334481 C 242.5,78.94347 235,57.550053 235,57.550053 c 0,0 -4.75,-14.865832 -7.5,-29.143418 -2.75,-14.277586 -8.25,-25.0827591 -8.25,-25.0827591 0,0 -24.25,10.9612831 -31.75,13.0678661 -7.5,2.106582 -21,6.948431 -21,6.948431 0,0 -9.75,-3.461443 -22,-6.720691 -12.25,-3.259249 -29.75,-3.09389 -29.75,-3.09389 0,0 -3.25,3.762853 -22,9.779309 -18.75,6.016456 -27.5,7.974136 -27.5,7.974136 0,0 -18.5,-7.503763 -31.5,-8.952353 -13,-1.448591 -24,-0.05894 -24.75,0.251722 z"
-         style="opacity:0.03913042;fill:url(#linearGradient8754);fill-opacity:1;stroke:none"
-         sodipodi:nodetypes="cscscscscscscscscscscscscscscscsc" />
+    <linearGradient id="O" x1="122" x2="122" y1="245.448" y2="4.302" xlink:href="#L" gradientUnits="userSpaceOnUse"/>
+    <clipPath id="aF">
+      <path fill="url(#M)" d="M9 22.578s7.5 12.394 11.75 26.8S27 74.373 27 74.373s-5.5 13.194-8.25 25.417C16 112.012 13 123.255 13 123.255s5.75 15.535 9.25 29.252c3.5 13.717 3.75 23.946 3.75 23.946s-4 10.574-7.5 24.857-5 31.154-5 31.154 9.25-2.748 28.5-1.055c19.25 1.693 32.25 3.39 32.25 3.39s12.75-3.78 24-8.19 16.25-7.814 16.25-7.814 5.5.055 22.5 4.43 29.25 6.134 29.25 6.134 13-3.8 26-7.852c13-4.052 26.5-10.144 26.5-10.144s-.75-4.94 4.25-24.843c5-19.904 8.75-28.707 8.75-28.707s-.514-4.455-3.75-19.447c-1.75-8.108-2.25-4.068-2.25-4.068s16.264-26.155 16.5-40.334C242.5 78.944 235 57.55 235 57.55s-4.75-14.866-7.5-29.143c-2.75-14.278-8.25-25.083-8.25-25.083S195 14.284 187.5 16.392c-7.5 2.106-21 6.948-21 6.948s-9.75-3.46-22-6.72-29.75-3.094-29.75-3.094-3.25 3.762-22 9.78c-18.75 6.015-27.5 7.973-27.5 7.973s-18.5-7.505-31.5-8.953c-13-1.45-24-.06-24.75.25z" opacity=".039"/>
     </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4680-2"
-       id="linearGradient8754"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,-0.08087767,0,1,0,203.05629)"
-       x1="210.17188"
-       y1="72.064125"
-       x2="9"
-       y2="-213.25346" />
+    <linearGradient id="M" x1="210.172" x2="9" y1="72.064" y2="-213.253" xlink:href="#E" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 -.08 0 1 0 203.06)"/>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1.8066556"
-     inkscape:cx="34.80086"
-     inkscape:cy="49.324241"
-     inkscape:current-layer="layer5"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1551"
-     inkscape:window-height="1121"
-     inkscape:window-x="0"
-     inkscape:window-y="25"
-     inkscape:window-maximized="0" />
-  <metadata
-     id="metadata3043">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:groupmode="layer"
-     id="layer8"
-     inkscape:label="map_shadow"
-     style="display:inline">
-    <g
-       id="g8737"
-       transform="translate(0,-10)">
-      <path
-         clip-path="none"
-         transform="matrix(1,6.864071e-2,0,0.848698,-6.6011175e-8,36.913089)"
-         id="path5604-26-0-3"
-         d="M 174.28125,35.875 C 156.6825,35.875 139.08909,42.514475 125.5625,55.78125 C 125.39528,55.944528 125.22813,56.084367 125.0625,56.25 C 103.00655,78.305948 98.853795,111.50122 112.59375,137.75 L 110.3125,139.375 C 112.56129,143.61488 115.25415,147.6818 118.40625,151.5 L 105.09375,164.84375 C 103.75238,164.258 102.30517,163.81044 100.53125,163.46875 L 97.6875,166.3125 C 96.578031,165.82863 95.549481,165.49662 94.625,165.4375 L 30.5,229.5625 C 30.46313,230.66337 30.72615,231.74988 31.15625,232.84375 L 30.625,233.375 L 29.53125,234.46875 C 30.246688,238.20655 31.541682,241.29169 35,244.75 C 38.458318,248.20832 41.420414,249.38027 45.28125,250.21875 L 46.375,249.125 L 47.09375,248.40625 C 48.181953,248.8685 49.223649,249.19242 50.1875,249.25 L 114.3125,185.125 C 114.06964,184.15025 113.69207,183.18954 113.28125,182.21875 L 116.28125,179.21875 C 116.03142,177.48677 115.60454,176.02072 114.96875,174.625 L 128.25,161.34375 C 132.0682,164.49585 136.13512,167.18872 140.375,169.4375 L 142,167.15625 C 168.24878,180.8962 201.44405,176.74344 223.5,154.6875 C 223.66563,154.52186 223.80547,154.35472 223.96875,154.1875 C 250.66292,126.97054 250.51736,83.267352 223.5,56.25 C 209.91004,42.660041 192.09307,35.875 174.28125,35.875 z M 173.78125,39.15625 C 173.88592,39.15775 173.98908,39.15425 174.09375,39.15625 C 175.04294,39.17465 175.98913,39.22152 176.9375,39.28125 C 177.89594,39.34161 178.8563,39.428763 179.8125,39.53125 C 179.9062,39.5413 180.00004,39.55205 180.09375,39.5625 C 180.18775,39.57298 180.28105,39.58287 180.375,39.59375 C 180.5207,39.61063 180.66687,39.63839 180.8125,39.65625 C 181.7087,39.766152 182.60741,39.884369 183.5,40.03125 C 184.11909,40.133124 184.72687,40.255367 185.34375,40.375 C 185.6867,40.44144 186.03282,40.49058 186.375,40.5625 C 187.0987,40.714611 187.81147,40.885892 188.53125,41.0625 C 188.8443,41.13931 189.15653,41.199811 189.46875,41.28125 C 189.54185,41.30031 189.61445,41.32444 189.6875,41.34375 C 190.6434,41.596587 191.58423,41.860044 192.53125,42.15625 C 192.60365,42.17886 192.67766,42.19588 192.75,42.21875 C 193.69741,42.518592 194.65684,42.844291 195.59375,43.1875 C 195.64685,43.20695 195.69698,43.23041 195.75,43.25 C 196.70458,43.602395 197.65174,43.977633 198.59375,44.375 C 198.64525,44.39672 198.69853,44.41564 198.75,44.4375 C 199.69184,44.837551 200.63491,45.273781 201.5625,45.71875 C 201.6045,45.73891 201.6455,45.761 201.6875,45.78125 C 202.62288,46.232337 203.54958,46.690779 204.46875,47.1875 C 204.50185,47.20538 204.52945,47.23206 204.56245,47.25 C 205.48926,47.752833 206.40387,48.263321 207.31245,48.8125 C 207.34455,48.83189 207.37415,48.85555 207.40615,48.875 C 208.31425,49.425934 209.20552,49.996562 210.09365,50.59375 C 210.6426,50.962824 211.17785,51.36329 211.71865,51.75 C 212.08335,52.010827 212.45156,52.262412 212.8124,52.53125 C 212.8309,52.54506 212.8564,52.54867 212.8749,52.5625 C 213.75254,53.217706 214.61511,53.922431 215.46865,54.625 C 217.21133,56.059371 218.90007,57.587673 220.53115,59.21875 C 222.15163,60.83923 223.66733,62.519314 225.09365,64.25 C 225.10265,64.26124 225.11565,64.27 225.12485,64.28125 C 225.82806,65.135607 226.53159,65.996485 227.18735,66.875 C 227.47012,67.253769 227.72592,67.648223 227.99985,68.03125 C 228.36958,68.548307 228.73999,69.069236 229.0936,69.59375 C 229.1098,69.61774 229.14,69.63224 229.1561,69.65625 C 229.75422,70.545876 230.32314,71.434083 230.87485,72.34375 C 230.89435,72.37582 230.91795,72.40541 230.93735,72.4375 C 231.48294,73.340419 232.00002,74.266573 232.49985,75.1875 C 232.51775,75.22044 232.54455,75.24829 232.56235,75.28125 C 233.06035,76.202462 233.51643,77.124994 233.9686,78.0625 C 233.9888,78.10444 234.011,78.14552 234.0311,78.1875 C 234.47721,79.117367 234.91137,80.055804 235.31235,81 C 235.33415,81.05123 235.35325,81.104977 235.37485,81.15625 C 235.76965,82.092372 236.14946,83.051461 236.49985,84 C 236.51925,84.05253 236.54305,84.103686 236.56235,84.15625 C 236.90996,85.10461 237.22793,86.040882 237.5311,87 C 237.5538,87.07167 237.5712,87.147026 237.5936,87.21875 C 237.88758,88.159922 238.15494,89.112572 238.4061,90.0625 C 238.4256,90.13603 238.4494,90.207672 238.4686,90.28125 C 238.5493,90.590804 238.61118,90.908382 238.68735,91.21875 C 238.86396,91.938529 239.03524,92.651296 239.18735,93.375 C 239.25925,93.717177 239.30841,94.063299 239.37485,94.40625 C 239.49448,95.023132 239.61673,95.630911 239.7186,96.25 C 239.86548,97.142594 239.9837,98.041302 240.0936,98.9375 C 240.1115,99.083459 240.1392,99.228963 240.1561,99.375 C 240.1669,99.46829 240.1769,99.562929 240.1873,99.65625 C 240.1978,99.75023 240.2085,99.843493 240.2185,99.9375 C 240.32099,100.8937 240.40814,101.85406 240.4685,102.8125 C 240.5277,103.75494 240.57511,104.71299 240.5935,105.65625 C 240.5955,105.76038 240.5915,105.86462 240.5935,105.96875 C 240.6089,107.02208 240.5975,108.0726 240.5623,109.125 C 240.5307,110.05556 240.4776,110.97779 240.40605,111.90625 C 240.39605,112.03118 240.38515,112.15637 240.37485,112.28125 C 240.29875,113.19932 240.20894,114.11665 240.0936,115.03125 C 239.973,115.98751 239.81965,116.95518 239.6561,117.90625 C 239.6419,117.98865 239.6393,118.07392 239.6249,118.15625 C 239.6029,118.2811 239.5852,118.40651 239.5624,118.53125 C 239.39714,119.43903 239.2045,120.34852 238.9999,121.25 C 238.9693,121.38463 238.9376,121.52178 238.9062,121.65625 C 238.69845,122.54491 238.46486,123.43135 238.2187,124.3125 C 238.05479,124.89922 237.86842,125.47955 237.68745,126.0625 C 237.51204,126.62662 237.34761,127.18974 237.1562,127.75 C 236.86153,128.61381 236.55145,129.45882 236.2187,130.3125 C 236.1581,130.46799 236.09304,130.62612 236.0312,130.78125 C 235.9863,130.89371 235.9517,131.01273 235.9062,131.125 C 235.5501,132.00362 235.17807,132.8526 234.7812,133.71875 C 234.40422,134.54222 234.0076,135.34519 233.5937,136.15625 C 233.5132,136.31403 233.42563,136.46772 233.3437,136.625 C 232.92842,137.4224 232.51372,138.21595 232.06245,139 C 231.96725,139.16556 231.87805,139.33506 231.7812,139.5 C 231.58213,139.83885 231.36205,140.16384 231.1562,140.5 C 230.79455,141.09093 230.41383,141.66777 230.0312,142.25 C 230.0262,142.257 230.0362,142.2738 230.0312,142.2812 C 229.54039,143.02694 229.02527,143.76939 228.49995,144.49995 C 228.04268,145.13587 227.54591,145.75123 227.06245,146.37495 C 226.86549,146.62904 226.70126,146.90421 226.49995,147.1562 C 226.36593,147.32399 226.22965,147.48935 226.0937,147.6562 C 225.93019,147.85684 225.76,148.05071 225.5937,148.24995 C 225.03708,148.917 224.46291,149.5678 223.87495,150.2187 C 223.26864,150.88974 222.63964,151.56575 221.99995,152.2187 C 221.83899,152.38296 221.69428,152.55562 221.5312,152.7187 C 200.40085,173.84905 169.27251,177.21358 144.3437,163.87495 L 144.4687,163.68745 C 140.76453,161.79084 137.20703,159.54699 133.8437,156.9062 C 133.30478,156.48305 132.77833,156.03638 132.24995,155.5937 C 131.73554,155.16273 131.22265,154.7308 130.7187,154.2812 C 130.6258,154.1976 130.52998,154.1154 130.43745,154.0312 C 129.61572,153.28344 128.82556,152.51306 128.0312,151.7187 C 127.23684,150.92434 126.46647,150.13418 125.7187,149.31245 C 125.6345,149.21995 125.55231,149.12407 125.4687,149.0312 C 125.0191,148.52725 124.58717,148.01436 124.1562,147.49995 C 123.71352,146.97157 123.26685,146.44512 122.8437,145.9062 C 120.20291,142.54287 117.95906,138.98536 116.06245,135.2812 L 115.87495,135.4062 C 102.53632,110.47739 105.90085,79.349046 127.0312,58.2187 C 127.19428,58.05562 127.36694,57.910915 127.5312,57.74995 C 128.18415,57.110265 128.86016,56.481261 129.5312,55.87495 C 130.1821,55.286994 130.8329,54.712816 131.49995,54.1562 C 131.77209,53.929114 132.03772,53.690576 132.31245,53.4687 C 132.65592,53.191271 133.02754,52.956742 133.37495,52.68745 C 133.99867,52.203987 134.61403,51.707219 135.24995,51.24995 C 135.98748,50.719619 136.74695,50.21386 137.49995,49.7187 C 138.08218,49.336066 138.65902,48.955346 139.24995,48.5937 C 139.69662,48.32034 140.1423,48.042584 140.5937,47.7812 C 141.27515,47.386414 141.96454,47.023727 142.6562,46.6562 C 142.83226,46.56265 143.01076,46.46674 143.18745,46.37495 C 144.1327,45.883975 145.06888,45.40925 146.0312,44.9687 C 146.89735,44.571825 147.74633,44.1998 148.62495,43.8437 C 148.77776,43.78177 148.94054,43.74815 149.0937,43.68745 C 150.06209,43.303428 151.01838,42.928541 151.99995,42.5937 C 152.56021,42.402293 153.12333,42.237857 153.68745,42.06245 C 154.2704,41.881482 154.85073,41.695111 155.43745,41.5312 C 156.3186,41.285037 157.20504,41.051454 158.0937,40.8437 C 158.1648,40.82706 158.24127,40.82884 158.31245,40.81245 C 158.72838,40.71671 159.14509,40.618551 159.56245,40.5312 C 160.23458,40.390375 160.91827,40.244039 161.5937,40.12495 C 161.676,40.11046 161.76133,40.10786 161.8437,40.0937 C 162.79477,39.930149 163.76244,39.776798 164.7187,39.6562 C 166.68235,39.408555 168.64857,39.254564 170.62495,39.18745 C 171.67735,39.15181 172.72787,39.14082 173.7812,39.1562 L 173.78125,39.15625 z"
-         style="opacity:0.7;fill:#2d3335;fill-opacity:1;stroke:none;filter:url(#filter8661)" />
-      <path
-         transform="matrix(1,0,0,0.846566,0,37.660073)"
-         sodipodi:nodetypes="cscscscscscscscscscscscscscscscsc"
-         id="path3834-49-7"
-         d="M 9,17.25 C 9,17.25 16.5,28.25 20.75,43 C 25,57.75 27,68.5 27,68.5 C 27,68.5 21.5,81.25 18.75,93.25 C 16,105.25 13,118.25 13,118.25 C 13,118.25 18.75,134.25 22.25,148.25 C 25.75,162.25 26,170.5 26,170.5 C 26,170.5 22,180.75 18.5,194.75 C 15,208.75 13.5,225.5 13.5,225.5 C 13.5,225.5 22.75,223.5 42,226.75 C 61.25,230 74.25,232.75 74.25,232.75 C 74.25,232.75 87,230 98.25,226.5 C 109.5,223 114.5,220 114.5,220 C 114.5,220 120,220.5 137,226.25 C 154,232 166.25,234.75 166.25,234.75 C 166.25,234.75 179.25,232 192.25,229 C 205.25,226 218.75,221 218.75,221 C 218.75,221 218,216 223,196.5 C 228,177 231.75,168.5 231.75,168.5 C 231.75,168.5 231.25,166 228,150.75 C 224.75,135.5 218,121 218,121 C 218,121 219.75,108.5 224.75,95.25 C 229.75,82 235,68.5 235,68.5 C 235,68.5 230.25,53.25 227.5,38.75 C 224.75,24.25 219.25,15 219.25,15 C 219.25,15 195,24 187.5,25.5 C 180,27 166.5,30.75 166.5,30.75 C 166.5,30.75 156.75,26.5 144.5,22.25 C 132.25,18 114.75,16.75 114.75,16.75 C 114.75,16.75 111.5,20.25 92.75,24.75 C 74,29.25 65.25,30.5 65.25,30.5 C 65.25,30.5 46.75,21.5 33.75,19 C 20.75,16.5 9.75,17 9,17.25 z"
-         style="opacity:0.5;fill:url(#linearGradient8735);fill-opacity:1;stroke:none;filter:url(#filter8725)" />
+  <path fill="#2d3335" d="M174.28 35.875c-17.597 0-35.19 6.64-48.718 19.906-.167.165-.334.304-.5.47-22.055 22.056-26.208 55.25-12.468 81.5l-2.28 1.625c2.247 4.24 4.94 8.307 8.092 12.125l-13.312 13.344c-1.342-.586-2.79-1.034-4.563-1.375l-2.843 2.843c-1.11-.484-2.138-.816-3.062-.875L30.5 229.563c-.037 1.1.226 2.187.656 3.28l-.53.532-1.095 1.094c.717 3.737 2.012 6.822 5.47 10.28 3.458 3.458 6.42 4.63 10.28 5.47l1.095-1.095.72-.72c1.087.464 2.13.787 3.093.845l64.124-64.125c-.242-.975-.62-1.935-1.03-2.906l3-3c-.25-1.733-.677-3.2-1.313-4.595l13.28-13.28c3.818 3.15 7.885 5.844 12.125 8.093l1.625-2.282c26.25 13.74 59.444 9.587 81.5-12.47.166-.164.305-.33.47-.5 26.693-27.215 26.547-70.92-.47-97.936-13.59-13.59-31.407-20.375-49.22-20.375zm-.5 3.28c.106.003.21 0 .314 0 .95.02 1.895.067 2.844.126.958.062 1.918.15 2.875.25l.28.032c.095.01.188.02.282.032.146.017.292.044.438.062.896.11 1.794.228 2.687.375.62.103 1.227.225 1.844.345.343.066.69.116 1.03.188.725.152 1.437.323 2.157.5.314.076.627.137.94.218.072.02.144.044.218.064.955.253 1.896.516 2.843.812.074.023.148.04.22.063.947.3 1.907.624 2.844.968l.156.062c.955.352 1.902.728 2.844 1.125.05.022.105.04.156.063.942.4 1.885.836 2.813 1.28.042.02.083.043.125.063.935.452 1.862.91 2.78 1.407.034.018.06.045.094.063.927.503 1.842 1.013 2.75 1.563.033.02.062.043.094.062.908.55 1.8 1.122 2.688 1.72.55.368 1.084.768 1.625 1.155.363.26.732.512 1.092.78.02.015.044.02.063.032.878.656 1.74 1.36 2.594 2.063 1.74 1.434 3.43 2.963 5.06 4.594 1.622 1.62 3.137 3.3 4.564 5.03.01.01.022.02.03.03.704.856 1.408 1.716 2.063 2.595.283.38.54.773.813 1.156.37.518.74 1.04 1.094 1.564.016.024.046.038.062.062.598.89 1.167 1.778 1.72 2.688.018.032.042.06.06.094.547.902 1.064 1.83 1.564 2.75.018.032.045.06.062.093.498.922.954 1.845 1.407 2.782l.06.126c.447.93.88 1.868 1.282 2.812.022.05.04.105.063.156.395.936.774 1.895 1.125 2.844.02.053.043.104.062.156.348.95.666 1.885.97 2.844.022.072.04.147.062.22.294.94.56 1.893.812 2.843.02.073.043.145.063.218.08.31.14.628.217.94.177.72.348 1.43.5 2.155.072.342.12.688.188 1.03.12.618.242 1.226.344 1.845.145.893.264 1.79.374 2.688.018.145.045.29.062.437l.03.28c.012.095.022.188.032.282.103.957.19 1.917.25 2.876.06.942.107 1.9.126 2.843 0 .104-.002.21 0 .313.015 1.052.004 2.103-.032 3.155-.03.93-.084 1.853-.156 2.78l-.03.376c-.077.92-.167 1.837-.282 2.75-.12.958-.274 1.925-.438 2.876-.014.083-.017.168-.03.25-.023.125-.04.25-.064.375-.165.91-.358 1.82-.562 2.72-.03.135-.062.272-.094.406-.208.89-.44 1.775-.687 2.656-.165.587-.352 1.168-.533 1.75-.175.565-.34 1.128-.53 1.688-.295.864-.606 1.71-.938 2.563l-.19.468c-.044.114-.078.233-.124.345-.356.88-.728 1.728-1.125 2.594-.376.822-.772 1.625-1.186 2.436-.08.158-.168.312-.25.47-.416.796-.83 1.59-1.282 2.374-.095.166-.184.335-.28.5-.2.34-.42.664-.626 1-.36.59-.742 1.168-1.125 1.75-.004.007.006.024 0 .03-.49.747-1.005 1.49-1.53 2.22-.457.636-.954 1.25-1.438 1.875-.197.254-.36.53-.562.78-.134.17-.27.334-.406.5-.164.202-.334.396-.5.595-.557.667-1.13 1.318-1.72 1.97-.605.67-1.234 1.346-1.874 2-.16.163-.306.336-.47.5-21.13 21.13-52.257 24.494-77.186 11.155l.125-.188c-3.705-1.896-7.263-4.14-10.626-6.78-.54-.424-1.066-.87-1.594-1.313-.514-.43-1.027-.863-1.53-1.313-.094-.082-.19-.165-.283-.25-.82-.747-1.61-1.517-2.406-2.31-.793-.796-1.564-1.586-2.31-2.408-.085-.092-.168-.188-.25-.28-.45-.505-.883-1.018-1.314-1.532-.442-.528-.89-1.055-1.312-1.594-2.64-3.363-4.885-6.92-6.782-10.625l-.187.126c-13.34-24.93-9.974-56.057 11.156-77.187.164-.164.337-.31.5-.47.654-.64 1.33-1.27 2-1.875.652-.588 1.303-1.162 1.97-1.72.272-.226.538-.464.812-.686.344-.28.716-.513 1.063-.783.624-.483 1.24-.98 1.875-1.437.737-.53 1.497-1.036 2.25-1.53.582-.384 1.16-.765 1.75-1.126.447-.274.892-.55 1.344-.813.68-.394 1.37-.756 2.062-1.124.176-.093.355-.19.53-.28.947-.492 1.883-.967 2.845-1.407.867-.398 1.716-.77 2.595-1.126.153-.062.316-.096.47-.157.967-.384 1.923-.758 2.905-1.093.56-.192 1.123-.356 1.687-.532.583-.18 1.164-.367 1.75-.53.882-.247 1.768-.48 2.657-.688.07-.017.147-.015.218-.032.416-.095.833-.193 1.25-.28.673-.142 1.356-.288 2.032-.407.082-.015.167-.017.25-.03.95-.165 1.918-.318 2.875-.44 1.962-.246 3.93-.4 5.905-.468 1.052-.035 2.103-.046 3.156-.03z" transform="matrix(1 .07 0 .85 0 26.91)" opacity=".7" filter="url(#N)"/>
+  <path fill="url(#O)" d="M9 17.25s7.5 11 11.75 25.75S27 68.5 27 68.5s-5.5 12.75-8.25 24.75-5.75 25-5.75 25 5.75 16 9.25 30S26 170.5 26 170.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-2.5-3.75-17.75S218 121 218 121s1.75-12.5 6.75-25.75S235 68.5 235 68.5s-4.75-15.25-7.5-29.75S219.25 15 219.25 15 195 24 187.5 25.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z" transform="matrix(1 0 0 .85 0 27.66)" opacity=".5" filter="url(#P)"/>
+  <path fill="#ceeeab" d="M9 2.25s7.5 13 11.75 27.75S27 55.5 27 55.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 157.5 26 157.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 106 218 106s1.75-10.5 6.75-23.75S235 55.5 235 55.5s-4.75-15.25-7.5-29.75S219.25 0 219.25 0 195 9 187.5 10.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5S9.75 2 9 2.25z"/>
+  <g clip-path="url(#Q)" transform="translate(0 -10)">
+    <path fill="#a6dd8b" d="M110.75 5.5l-4.25 7c-.75 9-2.25 13.75-8.5 16.5s-12.25 3.5-11 7.5 13 9.25 14.25 13 8.25 1.75 11 7 2 15.25-3.75 17.25-17.5.5-20.25 9.5-4.75 10.5-9 12.75-7.25 10.5-3.5 16.5 12.25-1.25 15-6.5S98 97.25 98 97.25h23.75l59-1.75 3.25-3.75s3.25 4 2.75 8.75-3.75 14.75.25 17.25 19.5-2 24-7-4.75-28.25-10.5-29.5-18.5-1.75-17-7 11.75 4.5 17.25 3.25 16.75-21 12-25.25-24.25-5.25-25.75-8 21-8 22.25-11-2.5-7.25-6.25-8.5S189 41 182 40.5s-20 5.75-17.25 11.5-6 11-14.5 6.5-24.75-13-21.75-24S150 15.75 150 15.75L110.75 5.5zM97.187 112.72c-1.594.145-4.468 4.686-4.937 7.03-.5 2.5-3.25 6.75-3.5 12.25s4.75 6.75 8.75 6.5 2.75-6.75 2-15c-.25 0-.5-10.25-2-10.75-.094-.03-.206-.04-.313-.03zm92.72 51.655c-6.336.295-6.626 7.47-7.407 8.875-1.25 2.25 2.25 13.75 2 18s-4.75 5.25-9.5 9.75.5 16 11.25 31l44.75 1.25-1-35s4.75-4.25-20.75-24.25c-9.563-7.5-15.542-9.802-19.344-9.625zm-149.97 16.53c-4.03-.1-8.28 5.72-9.687 7.595-1.5 2-6.25 5-17 9.5l-14.5 34.25 53 4.25s1.75-11-4.25-15.75S30.25 215 29.25 207.5s9.25-10 13.75-14.25S45 182 40.75 181c-.266-.063-.544-.087-.813-.094z"/>
+  </g>
+  <path fill="#aac3e7" d="M158.53 75.344c-4.76-.015-9.03.97-11.53 3.156-8 7-35 .75-48.5 7s-13.25 38-14.75 44.5-17.5 20.75-20 23.5-13.25 7.25-19.5 8.5-12.75 7.25-15.5 11c-2.02 2.756-7.406 6.45-10.125 8.22-.046.18-.08.347-.125.53-.134.535-.247 1.083-.375 1.625 4.98-1.605 11.18-8.18 16.625-13.625 6.25-6.25 20-7.75 27.75-11.5S76.75 138.5 89 134.5s21.25 11.75 24.25 18.5 1.75 12.75 3.75 17 11 11.75 11.5 13.5-5 6.5-6.25 8.5-10.5 7-11.75 8.75c-.966 1.352-1.923 6.773-2.313 9.22.414-.17.755-.312 1.126-.47.483-2.53 1.515-7.078 2.937-8.5 2-2 11.25-4.5 12.5-8.5s7-6.5 7-6.5 2.75 4 16 14c8.833 6.667 12.758 15.534 14.406 20.72.674.17 1.533.408 2.03.53-1.22-4.32-4.835-16.24-8.936-20.75-5-5.5-18.5-10.75-22.75-22S108 144.25 115 138.25s16.5-4 28.5 7.5 46.25 5.75 57.75 3.75c9.955-1.73 20.834 14.883 23.906 26.03.59-2.094 1.127-4 1.656-5.75-1.738-1.925-3.697-4.62-5.312-8.28-3.75-8.5-12-13.25-12-13.25s8.75-5 14.75-7.75c1.617-.74 3.006-1.677 4.188-2.656-.163-.774-.26-1.256-.438-2.094-.03-.146-.062-.292-.094-.438-4.765 5.563-19.232 9.616-21.656 10.938-2.75 1.5-18.25 3-35.75 4.5s-26.75-7.5-34.25-14.75-13-36-3-38 20 13.75 30 17 21.5-15.75 19.75-27c-1.203-7.734-13.997-12.625-24.47-12.656zm-53.343 13.28c1.276.002 5.86 1.595 6.563 2.376 2.25 2.5 2 7.25 0 8s-12.75 8-10.5 14.25 1.75 18-3.5 18-8 0-10-2.5-2-12 0-19.75 3.5-15 8-18.25c3.094-2.234 6.632-2.128 9.438-2.125zm13.594 73.095c.204.012 1.907 3.514 4.72 7.03 3 3.75 3.25 8.25 3.25 8.25s-4.25-4.75-6-8-2-7.25-2-7.25c0-.03.018-.032.03-.03z"/>
+  <path fill="none" stroke="#6d7f42" d="M122.75 62.25c6.25.5 12.25-2.25 10.75-6.5s-12.5-7.25-13.25-3 2 10.5 2.5 9.5zM108.75 46.75c-8.5-5.5-8.5-7.25-7-8s10.25 5 12.75 8-2.25 2-5.75 0z" opacity=".387" stroke-linecap="round" stroke-linejoin="round"/>
+  <g fill="none" stroke="#6d7f42" clip-path="url(#R)" transform="translate(0 -10)">
+    <path d="M15.75 151.25c33-2.5 38.25-3.5 36.25-10.25s-8.75-23.5-23-22.5-22.75-6.75-22.75-6.75" opacity=".387" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M17.5 177.25c18.25-10 28.75-8.5 35-11.5s13.25-5.75 15.75-9.5 5.75-11.5 5.75-18-3.5-36 3.25-43.5 17.25-26 26-23.25 12.25 9.75 22 9.5S147 77 149.5 68.75s-15.75-16-16-23 5.5-14.25 20.25-17 23.5-11.5 23.5-11.5" opacity=".387"/>
+    <path d="M14.5 161c15.25-1.5 22.25 3.5 31.5 1.75s13.25-3 17.75-5.75 6-3.75 6.25-6.5 1-12.5-3-22S54.5 97 58.75 89.75 64 68.25 74.5 65.25 95.5 59 102.25 64s12.75 14.25 20 14.5S134 77 136.75 74s4.5-10.25 1.75-13.75-15.5-5.5-17.25-9.5-10.75-17-.25-26.75 36.25-8.25 36.25-8.25" opacity=".387" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M21.25 159c13.75 1 21.5 4.25 33.5-.5s13.5-5.25 13.75-8.75-.25-15.75-3-20-13-13.75-15.75-24.25.25-41 8.5-48.25 32-7.25 37.5-10.5 5.25-16.75 13-24.5 27-12.25 27-12.25M190 18.5c11.75 5 39 9.75 47.25 40.25M9.75 214c19-12.5 36-1.25 49-4s38.25-37.25 46-37 5.5-11.75 8.5-13.25 5.5 6 11.75 8 24.5-2.75 23.5-5.75-7-7.75-5.5-8.5 8.5 5 12.75 3.5 43.75-1 48.5-13.5 21.5-13.5 21.5-13.5M77.5 233.5c13.5-11.5 23.25-25 28.5-27s12.75-3.75 15.75-8 2.5-10.75 5.25-12 3.75 5.75 8.75 6 36.75-5 42.75-11.75 32.25-12.5 32.5-14.5-1-4.75.25-5.5 24.75-6 24.75-6M168.75 236c9-13.75 20.5-41 29.5-42s10.25-2.5 12.5-4.25 17 2.25 17 2.25" opacity=".387" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <g fill="none" stroke="#d38484" stroke-width="2" clip-path="url(#S)" transform="translate(0 -10)" stroke-linecap="round">
+    <path d="M57.75 20l-8.5 28.25 18 6.25L75 90.75 54 113l9 10.5L51 135l.5 4.5L71.75 164l14-6.75 20.5 18.5L95.75 204l10.25 8.5-2.75 13"/>
+    <path d="M105.75 212.25l12.5-27.75 11-7 27.5 15.75 20.5-3.75-.25-15.75-10.25-6 12.75-26.25 5.75-3.75 38.75-10"/>
+  </g>
+  <g>
+    <g opacity=".504">
+      <path fill="#b1e479" d="M219.25 330s-24.25 9-31.75 10.5-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75c0 0 7.5 13 11.75 27.75S27 385.5 27 385.5l51.47 5.125 48.968-4 52.25 12.03c10.385-4.417 52.116-4.9 55.312-13.155 0 0-4.75-15.25-7.5-29.75S219.25 330 219.25 330z"/>
+      <path fill="#87d531" d="M27 385.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23l50.97 16.375 53.718-15.75 52.25 17.53C186.3 447.15 202.334 442.29 218 436c0 0 1.75-10.5 6.75-23.75S235 385.5 235 385.5c-3.196 8.256-44.927 8.74-55.313 13.156l-52.25-12.03-47.968 4L27 385.5z"/>
+      <path fill="#ceeeab" d="M231.75 485.5c-17.9 7.67-35.943 14.904-54.313 21.406l-52.25-18.53-50.218 9L26 487.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28z"/>
+      <path fill="#b9e787" d="M13 433.25s5.75 16 9.25 30S26 487.5 26 487.5l48.97 9.875 50.218-9 52.25 18.53c18.37-6.5 36.413-13.734 54.312-21.405 0 0-.5-4.5-3.75-19.75S218 436 218 436c-15.666 6.288-31.698 11.15-48.063 15.406l-52.25-17.53-53.718 15.75L13 433.25z"/>
+    </g>
+    <g opacity=".522">
+      <path fill="#83d32b" d="M13.72 332.03c-2.73-.006-4.44.126-4.72.22 0 0 7.5 13 11.75 27.75S27 385.5 27 385.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 487.5 26 487.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6l1.5-53.25L63.5 450l16-59.75c-2.22-15.48-9.068-30.046-14.25-44.75 0 0-18.5-9-31.5-11.5-8.125-1.563-15.483-1.957-20.03-1.97z"/>
+      <path fill="#b1e479" d="M114.75 331.75s-3.25 3.5-22 8-27.5 5.75-27.5 5.75c5.182 14.704 12.03 29.27 14.25 44.75L63.5 450l12.25 46.5-1.5 53.25s12.75-2.75 24-6.25 16.25-6.5 16.25-6.5l11.25-48.5-8.25-54.25 11.75-45c-3.44-9.727-8.064-56.93-14.5-57.5z"/>
+      <path fill="#a4df62" d="M219.25 330s-24.25 9-31.75 10.5-21 5.25-21 5.25c4.924-1.358 11.437 45.392 14.25 52.25l-11.25 53.25 9.5 55-12.75 45.5s13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 436 218 436s1.75-10.5 6.75-23.75S235 385.5 235 385.5s-4.75-15.25-7.5-29.75-8.25-25.75-8.25-25.75z"/>
+      <path fill="#ceeeab" d="M114.75 331.75c6.436.57 11.06 47.773 14.5 57.5l-11.75 45 8.25 53.25L114.5 537s5.5.5 22.5 6.25 29.25 8.5 29.25 8.5l12.75-45.5-9.5-55L180.75 398c-2.813-6.858-9.326-53.608-14.25-52.25 0 0-9.75-4.25-22-8.5s-29.75-5.5-29.75-5.5z"/>
+    </g>
+    <path fill="url(#T)" d="M9-189.75s7.5 13 11.75 27.75S27-136.5 27-136.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26-34.5 26-34.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6S87 25 98.25 21.5 114.5 15 114.5 15s5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8S218 11 223-8.5s8.75-28 8.75-28-.5-4.5-3.75-19.75S218-86 218-86s1.75-10.5 6.75-23.75S235-136.5 235-136.5s-4.75-15.25-7.5-29.75-8.25-25.75-8.25-25.75-24.25 9-31.75 10.5-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z" opacity=".039" transform="translate(0 192)"/>
+  </g>
+  <g>
+    <g opacity=".27">
+      <path fill="url(#U)" d="M219.25-182s-24.25 9-31.75 10.5-21 5.25-21 5.25c4.924-1.358 11.437 45.392 14.25 52.25l-.063.28c11.808-4.073 51.21-4.766 54.313-12.78 0 0-4.75-15.25-7.5-29.75S219.25-182 219.25-182z" transform="translate(0 182)"/>
+      <path fill="url(#V)" d="M27-126.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23l50.625 16.28 15.78-58.905L27-126.5z" transform="translate(0 182)"/>
+      <path fill="url(#W)" d="M26-24.5S22-14.25 18.5-.25s-5 30.75-5 30.75.147-.045.438-.094c2.033-.338 11.218-1.5 28.062 1.344 19.25 3.25 32.25 6 32.25 6l1.47-52.5-.75.125L26-24.5z" transform="translate(0 182)"/>
+      <path fill="url(#X)" d="M114.75-180.25s-3.25 3.5-22 8-27.5 5.75-27.5 5.75c5.182 14.704 12.03 29.27 14.25 44.75l-.094.313 48.03-3.938 1.126.25c-3.362-13.323-7.796-54.592-13.812-55.125z" transform="translate(0 182)"/>
+      <path fill="url(#Y)" d="M117.594-78.094L63.97-62.374l-.345-.095-.125.47 12.25 46.5-.03.75 49.468-8.875.53.188.032-.063-8.25-54.25.094-.344z" transform="translate(0 182)"/>
+      <path fill="url(#Z)" d="M128.563-125.125c.234.928.463 1.742.687 2.375l-11.656 44.656.093-.03L169.5-60.75l11.187-52.97c-.356.124-.695.247-1 .376l-51.125-11.78z" transform="translate(0 182)"/>
+      <path fill="url(#aa)" d="M125.53-23.5L114.5 25s5.5.5 22.5 6.25c2.125.72 4.163 1.406 6.125 2.03 1.962.627 3.855 1.187 5.625 1.72 10.617 3.2 17.5 4.75 17.5 4.75l12.72-45.406c-.514.182-1.02.38-1.532.562L125.53-23.5z" transform="translate(0 182)"/>
+      <path fill="url(#ab)" d="M218-76c-15.666 6.288-31.698 11.15-48.063 15.406l-.437-.156 9.5 55-.03.094c17.838-6.36 35.38-13.387 52.78-20.844 0 0-.5-4.5-3.75-19.75S218-76 218-76z" transform="translate(0 182)"/>
+    </g>
+    <g opacity=".043">
+      <path fill="url(#ac)" d="M13.72-179.97c-1.107-.002-1.973.033-2.72.064-.445.018-.855.04-1.156.062-.03.002-.066-.002-.094 0-.398.033-.656.063-.75.094 0 0 7.5 13 11.75 27.75S27-126.5 27-126.5l51.47 5.125.936-.063.094-.312c-2.22-15.48-9.068-30.046-14.25-44.75 0 0-18.5-9-31.5-11.5-1.018-.196-2.01-.37-3-.53-.596-.098-1.167-.198-1.75-.282-.237-.035-.453-.062-.688-.094-1.306-.182-2.588-.34-3.812-.47-.735-.076-1.395-.127-2.094-.186-.685-.06-1.353-.112-2-.157-.992-.066-1.89-.117-2.78-.155-1.457-.063-2.77-.09-3.907-.094z" transform="translate(0 182)"/>
+      <path fill="url(#ad)" d="M13-78.75s5.75 16 9.25 30S26-24.5 26-24.5l48.97 9.875.75-.125.03-.75L63.5-62l.125-.47L13-78.75z" transform="translate(0 182)"/>
+      <path fill="url(#ae)" d="M127.438-125.375l-47.97 4h-.062L63.626-62.47l.343.095 53.624-15.72 11.656-44.655c-.224-.633-.453-1.447-.688-2.375l-1.125-.25z" transform="translate(0 182)"/>
+      <path fill="url(#af)" d="M125.188-23.625l-49.47 8.875-1.468 52.5S87 35 98.25 31.5 114.5 25 114.5 25l11.22-48.438-.532-.187z" transform="translate(0 182)"/>
+      <path fill="url(#ag)" d="M114.75-180.25c6.016.533 10.45 41.802 13.813 55.125l51.125 11.78c.304-.128.643-.25 1-.374l.062-.28c-2.813-6.858-9.326-53.608-14.25-52.25 0 0-.613-.254-1.72-.72-3.315-1.393-11.093-4.593-20.28-7.78-12.25-4.25-29.75-5.5-29.75-5.5z" transform="translate(0 182)"/>
+      <path fill="url(#ah)" d="M117.688-78.125l-.094.03-.094.345 8.25 53.25-.22 1L177.44-5.094c.512-.18 1.02-.38 1.53-.562L179-5.75l-9.5-55-51.813-17.375z" transform="translate(0 182)"/>
+      <path fill="url(#ai)" d="M231.75-26.5c-17.4 7.457-34.942 14.484-52.78 20.844L166.25 39.75s13-2.75 26-5.75 26.5-8 26.5-8S218 21 223 1.5s8.75-28 8.75-28z" transform="translate(0 182)"/>
+      <path fill="url(#aj)" d="M235-126.5c-3.102 8.014-42.505 8.707-54.313 12.78L169.5-60.75l.438.156C186.3-64.85 202.334-69.712 218-76c0 0 1.75-10.5 6.75-23.75S235-126.5 235-126.5z" transform="translate(0 182)"/>
     </g>
   </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer4"
-     inkscape:label="map_details"
-     sodipodi:insensitive="true"
-     style="display:inline">
-    <path
-       style="fill:#ceeeab;fill-opacity:1;stroke:none"
-       d="M 9,2.25 C 9,2.25 16.5,15.25 20.75,30 C 25,44.75 27,55.5 27,55.5 C 27,55.5 21.5,68.25 18.75,80.25 C 16,92.25 13,103.25 13,103.25 C 13,103.25 18.75,119.25 22.25,133.25 C 25.75,147.25 26,157.5 26,157.5 C 26,157.5 22,167.75 18.5,181.75 C 15,195.75 13.5,212.5 13.5,212.5 C 13.5,212.5 22.75,210.5 42,213.75 C 61.25,217 74.25,219.75 74.25,219.75 C 74.25,219.75 87,217 98.25,213.5 C 109.5,210 114.5,207 114.5,207 C 114.5,207 120,207.5 137,213.25 C 154,219 166.25,221.75 166.25,221.75 C 166.25,221.75 179.25,219 192.25,216 C 205.25,213 218.75,208 218.75,208 C 218.75,208 218,203 223,183.5 C 228,164 231.75,155.5 231.75,155.5 C 231.75,155.5 231.25,151 228,135.75 C 224.75,120.5 218,106 218,106 C 218,106 219.75,95.5 224.75,82.25 C 229.75,69 235,55.5 235,55.5 C 235,55.5 230.25,40.25 227.5,25.75 C 224.75,11.25 219.25,0 219.25,0 C 219.25,0 195,9 187.5,10.5 C 180,12 166.5,15.75 166.5,15.75 C 166.5,15.75 156.75,11.5 144.5,7.25 C 132.25,3 114.75,1.75 114.75,1.75 C 114.75,1.75 111.5,5.25 92.75,9.75 C 74,14.25 65.25,15.5 65.25,15.5 C 65.25,15.5 46.75,6.5 33.75,4 C 20.75,1.5 9.75,2 9,2.25 z"
-       id="path3834-9" />
-    <g
-       id="g5438"
-       clip-path="url(#clipPath5466)"
-       transform="translate(0,-10)">
-      <path
-         style="fill:#a6dd8b;fill-opacity:1;stroke:none"
-         d="M 110.75,5.5 L 106.5,12.5 C 105.75,21.5 104.25,26.25 98,29 C 91.75,31.75 85.75,32.5 87,36.5 C 88.25,40.5 100,45.75 101.25,49.5 C 102.5,53.25 109.5,51.25 112.25,56.5 C 115,61.75 114.25,71.75 108.5,73.75 C 102.75,75.75 91,74.25 88.25,83.25 C 85.5,92.25 83.5,93.75 79.25,96 C 75,98.25 72,106.5 75.75,112.5 C 79.5,118.5 88,111.25 90.75,106 C 93.5,100.75 98,97.25 98,97.25 L 121.75,97.25 L 180.75,95.5 L 184,91.75 C 184,91.75 187.25,95.75 186.75,100.5 C 186.25,105.25 183,115.25 187,117.75 C 191,120.25 206.5,115.75 211,110.75 C 215.5,105.75 206.25,82.5 200.5,81.25 C 194.75,80 182,79.5 183.5,74.25 C 185,69 195.25,78.75 200.75,77.5 C 206.25,76.25 217.5,56.5 212.75,52.25 C 208,48 188.5,47 187,44.25 C 185.5,41.5 208,36.25 209.25,33.25 C 210.5,30.25 206.75,26 203,24.75 C 199.25,23.5 189,41 182,40.5 C 175,40 162,46.25 164.75,52 C 167.5,57.75 158.75,63 150.25,58.5 C 141.75,54 125.5,45.5 128.5,34.5 C 131.5,23.5 150,15.75 150,15.75 L 110.75,5.5 z M 97.1875,112.71875 C 95.592651,112.86523 92.71875,117.40625 92.25,119.75 C 91.75,122.25 89,126.5 88.75,132 C 88.5,137.5 93.5,138.75 97.5,138.5 C 101.5,138.25 100.25,131.75 99.5,123.5 C 99.25,123.5 99,113.25 97.5,112.75 C 97.40625,112.7188 97.293823,112.709 97.1875,112.7188 L 97.1875,112.71875 z M 189.90625,164.375 C 183.5708,164.67041 183.28125,171.84375 182.5,173.25 C 181.25,175.5 184.75,187 184.5,191.25 C 184.25,195.5 179.75,196.5 175,201 C 170.25,205.5 175.5,217 186.25,232 L 231,233.25 L 230,198.25 C 230,198.25 234.75,194 209.25,174 C 199.6875,166.5 193.70752,164.19775 189.90625,164.375 z M 39.9375,180.90625 C 35.908264,180.80371 31.65625,186.625 30.25,188.5 C 28.75,190.5 24,193.5 13.25,198 L -1.25,232.25 L 51.75,236.5 C 51.75,236.5 53.5,225.5 47.5,220.75 C 41.5,216 30.25,215 29.25,207.5 C 28.25,200 38.5,197.5 43,193.25 C 47.5,189 45,182 40.75,181 C 40.484375,180.9375 40.206116,180.9131 39.9375,180.9063 L 39.9375,180.90625 z"
-         id="path5436" />
-    </g>
-    <path
-       style="fill:#aac3e7;fill-opacity:1;stroke:none"
-       d="M 158.53125,75.34375 C 153.77142,75.329407 149.5,76.3125 147,78.5 C 139,85.5 112,79.25 98.5,85.5 C 85,91.75 85.25,123.5 83.75,130 C 82.25,136.5 66.25,150.75 63.75,153.5 C 61.25,156.25 50.5,160.75 44.25,162 C 38,163.25 31.5,169.25 28.75,173 C 26.728876,175.75608 21.343981,179.45031 18.625,181.21875 C 18.5792,181.40003 18.54564,181.56743 18.5,181.75 C 18.366311,182.28475 18.25288,182.83331 18.125,183.375 C 23.104513,181.77018 29.304508,175.19549 34.75,169.75 C 41,163.5 54.75,162 62.5,158.25 C 70.25,154.5 76.75,138.5 89,134.5 C 101.25,130.5 110.25,146.25 113.25,153 C 116.25,159.75 115,165.75 117,170 C 119,174.25 128,181.75 128.5,183.5 C 129,185.25 123.5,190 122.25,192 C 121,194 111.75,199 110.5,200.75 C 109.53432,202.10195 108.57684,207.52314 108.1875,209.96875 C 108.60053,209.79955 108.94168,209.65822 109.3125,209.5 C 109.7965,206.97067 110.82799,202.42201 112.25,201 C 114.25,199 123.5,196.5 124.75,192.5 C 126,188.5 131.75,186 131.75,186 C 131.75,186 134.5,190 147.75,200 C 156.58333,206.66667 160.5081,215.53356 162.15625,220.71875 C 162.82985,220.8894 163.6892,221.12815 164.1875,221.25 C 162.96635,216.93129 159.35104,205.01115 155.25,200.5 C 150.25,195 136.75,189.75 132.5,178.5 C 128.25,167.25 108,144.25 115,138.25 C 122,132.25 131.5,134.25 143.5,145.75 C 155.5,157.25 189.75,151.5 201.25,149.5 C 211.20453,147.76878 222.08445,164.38321 225.15625,175.53125 C 225.74525,173.43558 226.28288,171.52906 226.8125,169.78125 C 225.07444,167.85545 223.11528,165.16129 221.5,161.5 C 217.75,153 209.5,148.25 209.5,148.25 C 209.5,148.25 218.25,143.25 224.25,140.5 C 225.86703,139.75886 227.25627,138.82287 228.4375,137.84375 C 228.27516,137.06972 228.17857,136.5879 228,135.75 C 227.9689,135.60389 227.938,135.45846 227.9063,135.3125 C 223.14065,140.8749 208.67404,144.92782 206.25005,146.25 C 203.50005,147.75 188.00005,149.25 170.50005,150.75 C 153.00005,152.25 143.75005,143.25 136.25005,136 C 128.75005,128.75 123.25005,100 133.25005,98 C 143.25005,96 153.25005,111.75 163.25005,115 C 173.25005,118.25 184.75005,99.25 183.00005,88 C 181.79693,80.265625 169.00292,75.375305 158.5313,75.34375 L 158.53125,75.34375 z M 105.1875,88.625 C 106.46283,88.6265 111.04688,90.21875 111.75,91 C 114,93.5 113.75,98.25 111.75,99 C 109.75,99.75 99,107 101.25,113.25 C 103.5,119.5 103,131.25 97.75,131.25 C 92.5,131.25 89.75,131.25 87.75,128.75 C 85.75,126.25 85.75,116.75 87.75,109 C 89.75,101.25 91.25,94 95.75,90.75 C 98.84375,88.51562 102.38177,88.621643 105.1875,88.625 L 105.1875,88.625 z M 118.78125,161.71875 C 118.9845,161.73245 120.6875,165.23438 123.5,168.75 C 126.5,172.5 126.75,177 126.75,177 C 126.75,177 122.5,172.25 120.75,169 C 119,165.75 118.75,161.75 118.75,161.75 C 118.75,161.7188 118.7678,161.7177 118.7812,161.7188 L 118.78125,161.71875 z"
-       id="path5280" />
-    <path
-       style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 122.75,62.25 C 129,62.75 135,60 133.5,55.75 C 132,51.5 121,48.5 120.25,52.75 C 119.5,57 122.25,63.25 122.75,62.25 z"
-       id="path5319" />
-    <path
-       style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 108.75,46.75 C 100.25,41.25 100.25,39.5 101.75,38.75 C 103.25,38 112,43.75 114.5,46.75 C 117,49.75 112.25,48.75 108.75,46.75 z"
-       id="path5321" />
-    <g
-       id="g5373"
-       clip-path="url(#clipPath5383)"
-       transform="translate(0,-10)">
-      <path
-         id="path5323"
-         d="M 15.75,151.25 C 48.75,148.75 54,147.75 52,141 C 50,134.25 43.25,117.5 29,118.5 C 14.75,119.5 6.25,111.75 6.25,111.75"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path5311"
-         d="M 17.5,177.25 C 35.75,167.25 46.25,168.75 52.5,165.75 C 58.75,162.75 65.75,160 68.25,156.25 C 70.75,152.5 74,144.75 74,138.25 C 74,131.75 70.5,102.25 77.25,94.75 C 84,87.25 94.5,68.75 103.25,71.5 C 112,74.25 115.5,81.25 125.25,81 C 135,80.75 147,77 149.5,68.75 C 152,60.5 133.75,52.75 133.5,45.75 C 133.25,38.75 139,31.5 153.75,28.75 C 168.5,26 177.25,17.25 177.25,17.25"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-opacity:1" />
-      <path
-         id="path5313"
-         d="M 14.5,161 C 29.75,159.5 36.75,164.5 46,162.75 C 55.25,161 59.25,159.75 63.75,157 C 68.25,154.25 69.75,153.25 70,150.5 C 70.25,147.75 71,138 67,128.5 C 63,119 54.5,97 58.75,89.75 C 63,82.5 64,68.25 74.5,65.25 C 85,62.25 95.5,59 102.25,64 C 109,69 115,78.25 122.25,78.5 C 129.5,78.75 134,77 136.75,74 C 139.5,71 141.25,63.75 138.5,60.25 C 135.75,56.75 123,54.75 121.25,50.75 C 119.5,46.75 110.5,33.75 121,24 C 131.5,14.25 157.25,15.75 157.25,15.75"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path5315"
-         d="M 21.25,159 C 35,160 42.75,163.25 54.75,158.5 C 66.75,153.75 68.25,153.25 68.5,149.75 C 68.75,146.25 68.25,134 65.5,129.75 C 62.75,125.5 52.5,116 49.75,105.5 C 47,95 50,64.5 58.25,57.25 C 66.5,50 90.25,50 95.75,46.75 C 101.25,43.5 101,30 108.75,22.25 C 116.5,14.5 135.75,9.9999997 135.75,9.9999997"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path5317"
-         d="M 190,18.5 C 201.75,23.5 229,28.25 237.25,58.75"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path5325"
-         d="M 9.75,214 C 28.75,201.5 45.75,212.75 58.75,210 C 71.75,207.25 97,172.75 104.75,173 C 112.5,173.25 110.25,161.25 113.25,159.75 C 116.25,158.25 118.75,165.75 125,167.75 C 131.25,169.75 149.5,165 148.5,162 C 147.5,159 141.5,154.25 143,153.5 C 144.5,152.75 151.5,158.5 155.75,157 C 160,155.5 199.5,156 204.25,143.5 C 209,131 225.75,130 225.75,130"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         sodipodi:nodetypes="csssssssc"
-         id="path5327"
-         d="M 77.5,233.5 C 91,222 100.75,208.5 106,206.5 C 111.25,204.5 118.75,202.75 121.75,198.5 C 124.75,194.25 124.25,187.75 127,186.5 C 129.75,185.25 130.75,192.25 135.75,192.5 C 140.75,192.75 172.5,187.5 178.5,180.75 C 184.5,174 210.75,168.25 211,166.25 C 211.25,164.25 210,161.5 211.25,160.75 C 212.5,160 236,154.75 236,154.75"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path5329"
-         d="M 168.75,236 C 177.75,222.25 189.25,195 198.25,194 C 207.25,193 208.5,191.5 210.75,189.75 C 213,188 227.75,192 227.75,192"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       id="g5400"
-       clip-path="url(#clipPath5426)"
-       transform="translate(0,-10)">
-      <path
-         id="path5387"
-         d="M 57.75,20 L 49.25,48.25 L 67.25,54.5 L 75,90.75 L 54,113 L 63,123.5 L 51,135 L 51.5,139.5 L 71.75,164 L 85.75,157.25 L 106.25,175.75 L 95.75,204 L 106,212.5 L 103.25,225.5"
-         style="fill:none;stroke:#d38484;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path5389"
-         d="M 105.75,212.25 L 118.25,184.5 L 129.25,177.5 L 156.75,193.25 L 177.25,189.5 L 177,173.75 L 166.75,167.75 L 179.5,141.5 L 185.25,137.75 L 224,127.75"
-         style="fill:none;stroke:#d38484;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-  </g>
-  <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     transform="translate(0,192)"
-     sodipodi:insensitive="true"
-     style="display:inline">
-    <g
-       id="g4199"
-       transform="translate(0,320)"
-       style="opacity:0.5043478">
-      <path
-         sodipodi:nodetypes="cscscscscscccccsc"
-         id="path3834-4"
-         transform="translate(0,-192)"
-         d="M 219.25,10 C 219.25,10 195,19 187.5,20.5 C 180,22 166.5,25.75 166.5,25.75 C 166.5,25.75 156.75,21.5 144.5,17.25 C 132.25,13 114.75,11.75 114.75,11.75 C 114.75,11.75 111.5,15.25 92.75,19.75 C 74.000003,24.25 65.25,25.5 65.25,25.5 C 65.25,25.5 46.75,16.5 33.75,14 C 20.75,11.5 9.75,12 9,12.25 C 9,12.25 16.5,25.25 20.75,40 C 25,54.75 27,65.5 27,65.5 L 78.46875,70.625 L 127.4375,66.625 L 179.6875,78.65625 C 190.07319,74.238496 231.80421,73.755785 235,65.5 C 235,65.5 230.25,50.25 227.5,35.75 C 224.75,21.25 219.25,10 219.25,10 z"
-         style="fill:#b1e479;fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="cscccccsccccc"
-         id="path3834-7-2"
-         transform="translate(0,-192)"
-         d="M 27,65.5 C 27,65.5 21.5,78.25 18.75,90.25 C 16,102.25 13,113.25 13,113.25 L 63.96875,129.625 L 117.6875,113.875 L 169.9375,131.40625 C 186.30214,127.14964 202.33444,122.28803 218,116 C 218,116 219.75,105.5 224.75,92.25 C 229.75,79 235,65.5 235,65.5 C 231.80421,73.75579 190.07319,74.2385 179.6875,78.65625 L 127.4375,66.625 L 79.46875,70.625 L 27,65.5 z"
-         style="fill:#87d531;fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26"
-         transform="translate(0,-192)"
-         d="M 231.75,165.5 C 213.85059,173.17118 195.80681,180.40405 177.4375,186.90625 L 125.1875,168.375 L 74.96875,177.375 L 26,167.5 C 26,167.5 22,177.75 18.5,191.75 C 15,205.75 13.5,222.5 13.5,222.5 C 13.5,222.5 22.75,220.5 42,223.75 C 61.25,227 74.25,229.75 74.25,229.75 C 74.25,229.75 87.000003,227 98.25,223.5 C 109.5,220 114.5,217 114.5,217 C 114.5,217 120,217.5 137,223.25 C 154,229 166.25,231.75 166.25,231.75 C 166.25,231.75 179.25,229 192.25,226 C 205.25,223 218.75,218 218.75,218 C 218.75,218 218,213 223,193.5 C 228,174 231.75,165.5 231.75,165.5 z"
-         style="fill:#ceeeab;fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="cscccccsccccc"
-         id="path3834-7-26-0"
-         transform="translate(0,-192)"
-         d="M 13,113.25 C 13,113.25 18.75,129.25 22.25,143.25 C 25.75,157.25 26,167.5 26,167.5 L 74.96875,177.375 L 125.1875,168.375 L 177.4375,186.90625 C 195.80681,180.40405 213.85059,173.17118 231.75,165.5 C 231.75,165.5 231.25,161 228,145.75 C 224.75,130.5 218,116 218,116 C 202.33444,122.28803 186.30214,127.14964 169.9375,131.40625 L 117.6875,113.875 L 63.96875,129.625 L 13,113.25 z"
-         style="fill:#b9e787;fill-opacity:1;stroke:none" />
-    </g>
-    <g
-       id="g4205"
-       style="opacity:0.52173911"
-       transform="translate(0,140)">
-      <path
-         sodipodi:nodetypes="ccscscscscscccccsc"
-         id="path3834-2"
-         d="M 13.71875,0.03125 C 10.989746,0.02425 9.28125,0.15625 9,0.25 C 9,0.25 16.5,13.25 20.75,28 C 25,42.75 27,53.5 27,53.5 C 27,53.5 21.5,66.25 18.75,78.25 C 16,90.25 13,101.25 13,101.25 C 13,101.25 18.75,117.25 22.25,131.25 C 25.75,145.25 26,155.5 26,155.5 C 26,155.5 22,165.75 18.5,179.75 C 15,193.75 13.5,210.5 13.5,210.5 C 13.5,210.5 22.75,208.5 42,211.75 C 61.25,215 74.25,217.75 74.25,217.75 L 75.75,164.5 L 63.5,118 L 79.5,58.25 C 77.279793,42.77003 70.432295,28.20354 65.25,13.5 C 65.25,13.5 46.75,4.5 33.75,2 C 25.625,0.4375 18.26709,0.04346 13.71875,0.03125 z"
-         style="fill:#83d32b;fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="cscccccsccccc"
-         id="path3834-6-2"
-         d="M 114.75,-0.25 C 114.75,-0.25 111.5,3.25 92.75,7.75 C 74,12.25 65.25,13.5 65.25,13.5 C 70.432295,28.20354 77.279793,42.77003 79.5,58.25 L 63.5,118 L 75.75,164.5 L 74.25,217.75 C 74.25,217.75 87,215 98.25,211.5 C 109.5,208 114.5,205 114.5,205 L 125.75,156.5 L 117.5,102.25 L 129.25,57.25 C 125.81031,47.52322 121.18553,0.32024 114.75,-0.25 z"
-         style="fill:#b1e479;fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-6-6"
-         d="M 219.25,-2 C 219.25,-2 195,7 187.5,8.5 C 180,10 166.5,13.75 166.5,13.75 C 171.42395,12.39167 177.93679,59.14247 180.75,66 L 169.5,119.25 L 179,174.25 L 166.25,219.75 C 166.25,219.75 179.25,217 192.25,214 C 205.25,211 218.75,206 218.75,206 C 218.75,206 218,201 223,181.5 C 228,162 231.75,153.5 231.75,153.5 C 231.75,153.5 231.25,149 228,133.75 C 224.75,118.5 218,104 218,104 C 218,104 219.75,93.5 224.75,80.25 C 229.75,67 235,53.5 235,53.5 C 235,53.5 230.25,38.25 227.5,23.75 C 224.75,9.25 219.25,-2 219.25,-2 z"
-         style="fill:#a4df62;fill-opacity:1;stroke:none"
-         sodipodi:nodetypes="cscccccscscscscsc" />
-      <path
-         sodipodi:nodetypes="cccccscccccsc"
-         id="path3834-6-6-9"
-         d="M 114.75,-0.25 C 121.18553,0.32024 125.81031,47.52322 129.25,57.25 L 117.5,102.25 L 125.75,155.5 L 114.5,205 C 114.5,205 120,205.5 137,211.25 C 154,217 166.25,219.75 166.25,219.75 L 179,174.25 L 169.5,119.25 L 180.75,66 C 177.93679,59.14247 171.42395,12.39167 166.5,13.75 C 166.5,13.75 156.75,9.5 144.5,5.25 C 132.25,1 114.75,-0.25 114.75,-0.25 z"
-         style="fill:#ceeeab;fill-opacity:1;stroke:none" />
-    </g>
-    <path
-       style="opacity:0.03913042;fill:url(#linearGradient5168);fill-opacity:1;stroke:none"
-       d="M 9,-189.75 C 9,-189.75 16.5,-176.75 20.75,-162 C 25,-147.25 27,-136.5 27,-136.5 C 27,-136.5 21.5,-123.75 18.75,-111.75 C 16,-99.75 13,-88.75 13,-88.75 C 13,-88.75 18.75,-72.75 22.25,-58.75 C 25.75,-44.75 26,-34.5 26,-34.5 C 26,-34.5 22,-24.25 18.5,-10.25 C 15,3.75 13.5,20.5 13.5,20.5 C 13.5,20.5 22.75,18.5 42,21.75 C 61.25,25 74.25,27.75 74.25,27.75 C 74.25,27.75 87,25 98.25,21.5 C 109.5,18 114.5,15 114.5,15 C 114.5,15 120,15.5 137,21.25 C 154,27 166.25,29.75 166.25,29.75 C 166.25,29.75 179.25,27 192.25,24 C 205.25,21 218.75,16 218.75,16 C 218.75,16 218,11 223,-8.5 C 228,-28 231.75,-36.5 231.75,-36.5 C 231.75,-36.5 231.25,-41 228,-56.25 C 224.75,-71.5 218,-86 218,-86 C 218,-86 219.75,-96.5 224.75,-109.75 C 229.75,-123 235,-136.5 235,-136.5 C 235,-136.5 230.25,-151.75 227.5,-166.25 C 224.75,-180.75 219.25,-192 219.25,-192 C 219.25,-192 195,-183 187.5,-181.5 C 180,-180 166.5,-176.25 166.5,-176.25 C 166.5,-176.25 156.75,-180.5 144.5,-184.75 C 132.25,-189 114.75,-190.25 114.75,-190.25 C 114.75,-190.25 111.5,-186.75 92.75,-182.25 C 74,-177.75 65.25,-176.5 65.25,-176.5 C 65.25,-176.5 46.75,-185.5 33.75,-188 C 20.75,-190.5 9.75,-190 9,-189.75 z"
-       id="path3834-49" />
-  </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="grid_shade"
-     style="display:inline"
-     sodipodi:insensitive="true">
-    <g
-       transform="translate(0,182)"
-       id="g4808"
-       style="opacity:0.2695656">
-      <path
-         id="path3834-4-9"
-         d="M 219.25,-182 C 219.25,-182 195,-173 187.5,-171.5 C 180,-170 166.5,-166.25 166.5,-166.25 C 171.42395,-167.60833 177.93679,-120.85753 180.75,-114 L 180.6875,-113.71875 C 192.49544,-117.79254 231.89797,-118.48643 235,-126.5 C 235,-126.5 230.25,-141.75 227.5,-156.25 C 224.75,-170.75 219.25,-182 219.25,-182 z"
-         style="fill:url(#linearGradient4806-9);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-2-4-9"
-         d="M 27,-126.5 C 27,-126.5 21.5,-113.75 18.75,-101.75 C 16,-89.75 13,-78.75 13,-78.75 L 63.625,-62.46875 L 79.40625,-121.375 L 27,-126.5 z"
-         style="fill:url(#linearGradient4790-3);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26-9-7"
-         d="M 26,-24.5 C 26,-24.5 22,-14.25 18.5,-0.25 C 15,13.75 13.5,30.5 13.5,30.5 C 13.5,30.5 13.646973,30.4546 13.9375,30.4063 C 15.971191,30.06792 25.15625,28.9063 42,31.75005 C 61.25,35.00005 74.25,37.75005 74.25,37.75005 L 75.71875,-14.74995 L 74.96875,-14.62495 L 26,-24.5 z"
-         style="fill:url(#linearGradient4758-2);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-4-9-6"
-         d="M 114.75,-180.25 C 114.75,-180.25 111.5,-176.75 92.75,-172.25 C 74.000003,-167.75 65.25,-166.5 65.25,-166.5 C 70.432295,-151.79646 77.279793,-137.22997 79.5,-121.75 L 79.40625,-121.4375 L 127.4375,-125.375 L 128.5625,-125.125 C 125.20002,-138.4478 120.76647,-179.71689 114.75,-180.25 z"
-         style="fill:url(#linearGradient4750-9);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26-0-0-9"
-         d="M 117.59375,-78.09375 L 63.96875,-62.375 L 63.625,-62.46875 L 63.5,-62 L 75.75,-15.5 L 75.71875,-14.75 L 125.1875,-23.625 L 125.71875,-23.4375 L 125.74995,-23.5 L 117.49995,-77.75 L 117.59365,-78.09375 L 117.59375,-78.09375 z"
-         style="fill:url(#linearGradient4782-5);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-2-4-3"
-         d="M 128.5625,-125.125 C 128.7967,-124.19705 129.02602,-123.38337 129.25,-122.75 L 117.59375,-78.09375 L 117.68745,-78.12495 L 169.49995,-60.74995 L 180.68745,-113.7187 C 180.33054,-113.59556 179.99216,-113.47332 179.68745,-113.3437 L 128.56245,-125.12495 L 128.5625,-125.125 z"
-         style="fill:url(#linearGradient4798-4);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26-9-85"
-         d="M 125.53125,-23.5 L 114.5,25 C 114.5,25 120,25.5 137,31.25 C 139.125,31.96875 141.16309,32.65576 143.125,33.28125 C 145.08691,33.90674 146.98047,34.4668 148.75,35 C 159.36719,38.19922 166.25,39.75 166.25,39.75 L 178.96875,-5.65625 C 178.45649,-5.47361 177.95026,-5.27525 177.4375,-5.09375 L 125.53125,-23.5 z"
-         style="fill:url(#linearGradient4766-3);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26-0-0-3"
-         d="M 218,-76 C 202.33444,-69.71197 186.30214,-64.85036 169.9375,-60.59375 L 169.5,-60.75 L 179,-5.75 L 178.9688,-5.6563 C 196.80782,-12.01643 214.35028,-19.043 231.75005,-26.50005 C 231.75005,-26.50005 231.25005,-31.00005 228.00005,-46.25005 C 224.75,-61.5 218,-76 218,-76 z"
-         style="fill:url(#linearGradient4965);fill-opacity:1;stroke:none" />
-    </g>
-    <g
-       transform="translate(0,182)"
-       id="g4818"
-       style="opacity:0.04347827">
-      <path
-         id="path3834-4-9-1"
-         d="M 13.71875,-179.96875 C 12.61251,-179.97175 11.746535,-179.93665 11,-179.90625 C 10.55476,-179.88815 10.144586,-179.86725 9.84375,-179.84375 C 9.81446,-179.84175 9.7778,-179.84575 9.75,-179.84375 C 9.352051,-179.81105 9.09375,-179.78125 9,-179.75005 C 9,-179.75005 16.5,-166.75005 20.75,-152.00005 C 25,-137.25 27,-126.5 27,-126.5 L 78.46875,-121.375 L 79.40625,-121.4375 L 79.5,-121.75 C 77.279793,-137.22997 70.432295,-151.79646 65.25,-166.5 C 65.25,-166.5 46.75,-175.5 33.75,-178 C 32.731734,-178.19582 31.73976,-178.37068 30.75,-178.53125 C 30.154387,-178.62795 29.583119,-178.72763 29,-178.8125 C 28.763416,-178.8469 28.546809,-178.8737 28.3125,-178.9062 C 27.006022,-179.08805 25.724495,-179.24659 24.5,-179.37495 C 23.765447,-179.45195 23.105404,-179.50254 22.40625,-179.56245 C 21.721361,-179.62155 21.053311,-179.67434 20.40625,-179.7187 C 19.414378,-179.7865 18.515844,-179.83704 17.625,-179.87495 C 16.168632,-179.93805 14.855835,-179.96565 13.71875,-179.96865 L 13.71875,-179.96875 z"
-         style="fill:url(#linearGradient4686-3);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26-0-0-7"
-         d="M 13,-78.75 C 13,-78.75 18.75,-62.75 22.25,-48.75 C 25.75,-34.75 26,-24.5 26,-24.5 L 74.96875,-14.625 L 75.71875,-14.75 L 75.75,-15.5 L 63.5,-62 L 63.625,-62.46875 L 13,-78.75 z"
-         style="fill:url(#linearGradient4742-3);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-2-4-6"
-         d="M 127.4375,-125.375 L 79.46875,-121.375 L 79.40625,-121.375 L 63.625,-62.46875 L 63.96875,-62.375 L 117.59375,-78.09375 L 129.25,-122.75 C 129.02602,-123.38337 128.7967,-124.19705 128.5625,-125.125 L 127.4375,-125.375 L 127.4375,-125.375 z"
-         style="fill:url(#linearGradient4734-3);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26-9-8"
-         d="M 125.1875,-23.625 L 75.71875,-14.75 L 74.25,37.75 C 74.25,37.75 87.000003,35 98.25,31.5 C 109.5,28 114.5,25 114.5,25 L 125.71875,-23.4375 L 125.1875,-23.625 z"
-         style="fill:url(#linearGradient4726-9);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-4-9-2"
-         d="M 114.75,-180.25 C 120.76647,-179.71689 125.20002,-138.4478 128.5625,-125.125 L 179.6875,-113.34375 C 179.99221,-113.47337 180.33059,-113.59561 180.6875,-113.71875 L 180.75,-114 C 177.93679,-120.85753 171.42395,-167.60833 166.5,-166.25 C 166.5,-166.25 165.88672,-166.50391 164.78125,-166.96875 C 161.46484,-168.36328 153.6875,-171.5625 144.5,-174.75 C 132.25,-179 114.75,-180.25 114.75,-180.25 z"
-         style="fill:url(#linearGradient4710-2);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26-0-0-0"
-         d="M 117.6875,-78.125 L 117.5938,-78.0938 L 117.5001,-77.75005 L 125.7501,-24.50005 L 125.53135,-23.50005 L 177.4376,-5.0938 C 177.95036,-5.2753 178.45659,-5.47366 178.96885,-5.6563 L 179,-5.75 L 169.5,-60.75 L 117.6875,-78.125 L 117.6875,-78.125 z"
-         style="fill:url(#linearGradient4718-4);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-26-9-9"
-         d="M 231.75,-26.5 C 214.35023,-19.04295 196.80777,-12.01638 178.96875,-5.65625 L 166.25,39.75 C 166.25,39.75 179.25,37 192.25,34 C 205.25,31 218.75,26 218.75,26 C 218.75,26 218,21 223,1.5 C 228,-18 231.75,-26.5 231.75,-26.5 z"
-         style="fill:url(#linearGradient4694-4);fill-opacity:1;stroke:none" />
-      <path
-         id="path3834-7-2-4-5"
-         d="M 235,-126.5 C 231.89797,-118.48643 192.49544,-117.79254 180.6875,-113.71875 L 169.5,-60.75 L 169.9375,-60.59375 C 186.30214,-64.85036 202.33444,-69.71197 218,-76 C 218,-76 219.75,-86.5 224.75,-99.75 C 229.75,-113 235,-126.5 235,-126.5 z"
-         style="fill:url(#linearGradient4702-4);fill-opacity:1;stroke:none" />
-    </g>
-  </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer7"
-     inkscape:label="mag_zoom"
-     sodipodi:insensitive="true"
-     style="display:inline">
-    <g
-       style="display:inline"
-       id="g8102"
-       transform="matrix(1.2525366,3.539823e-2,0,1.2525366,-27.80947,-48.34395)"
-       clip-path="url(#clipPath8617)">
-      <path
-         id="path3834-9-1"
-         d="M 9,12.25 C 9,12.25 16.5,25.25 20.75,40 C 25,54.75 27,65.5 27,65.5 C 27,65.5 21.5,78.25 18.75,90.25 C 16,102.25 13,113.25 13,113.25 C 13,113.25 18.75,129.25 22.25,143.25 C 25.75,157.25 26,167.5 26,167.5 C 26,167.5 22,177.75 18.5,191.75 C 15,205.75 13.5,222.5 13.5,222.5 C 13.5,222.5 22.75,220.5 42,223.75 C 61.25,227 74.25,229.75 74.25,229.75 C 74.25,229.75 87,227 98.25,223.5 C 109.5,220 114.5,217 114.5,217 C 114.5,217 120,217.5 137,223.25 C 154,229 166.25,231.75 166.25,231.75 C 166.25,231.75 179.25,229 192.25,226 C 205.25,223 218.75,218 218.75,218 C 218.75,218 218,213 223,193.5 C 228,174 231.75,165.5 231.75,165.5 C 231.75,165.5 231.25,161 228,145.75 C 224.75,130.5 218,116 218,116 C 218,116 219.75,105.5 224.75,92.25 C 229.75,79 235,65.5 235,65.5 C 235,65.5 230.25,50.25 227.5,35.75 C 224.75,21.25 219.25,10 219.25,10 C 219.25,10 195,19 187.5,20.5 C 180,22 166.5,25.75 166.5,25.75 C 166.5,25.75 156.75,21.5 144.5,17.25 C 132.25,13 114.75,11.75 114.75,11.75 C 114.75,11.75 111.5,15.25 92.75,19.75 C 74,24.25 65.25,25.5 65.25,25.5 C 65.25,25.5 46.75,16.5 33.75,14 C 20.75,11.5 9.75,12 9,12.25 z"
-         style="fill:#ceeeab;fill-opacity:1;stroke:none" />
-      <g
-         clip-path="url(#clipPath5466-2-3)"
-         id="g5438-0">
-        <path
-           id="path5436-7"
-           d="M 110.75,5.5 L 106.5,12.5 C 105.75,21.5 104.25,26.25 98,29 C 91.75,31.75 85.75,32.5 87,36.5 C 88.25,40.5 100,45.75 101.25,49.5 C 102.5,53.25 109.5,51.25 112.25,56.5 C 115,61.75 114.25,71.75 108.5,73.75 C 102.75,75.75 91,74.25 88.25,83.25 C 85.5,92.25 83.5,93.75 79.25,96 C 75,98.25 72,106.5 75.75,112.5 C 79.5,118.5 88,111.25 90.75,106 C 93.5,100.75 98,97.25 98,97.25 L 121.75,97.25 L 180.75,95.5 L 184,91.75 C 184,91.75 187.25,95.75 186.75,100.5 C 186.25,105.25 183,115.25 187,117.75 C 191,120.25 206.5,115.75 211,110.75 C 215.5,105.75 206.25,82.5 200.5,81.25 C 194.75,80 182,79.5 183.5,74.25 C 185,69 195.25,78.75 200.75,77.5 C 206.25,76.25 217.5,56.5 212.75,52.25 C 208,48 188.5,47 187,44.25 C 185.5,41.5 208,36.25 209.25,33.25 C 210.5,30.25 206.75,26 203,24.75 C 199.25,23.5 189,41 182,40.5 C 175,40 162,46.25 164.75,52 C 167.5,57.75 158.75,63 150.25,58.5 C 141.75,54 125.5,45.5 128.5,34.5 C 131.5,23.5 150,15.75 150,15.75 L 110.75,5.5 z M 97.1875,112.71875 C 95.592651,112.86523 92.71875,117.40625 92.25,119.75 C 91.75,122.25 89,126.5 88.75,132 C 88.5,137.5 93.5,138.75 97.5,138.5 C 101.5,138.25 100.25,131.75 99.5,123.5 C 99.25,123.5 99,113.25 97.5,112.75 C 97.40625,112.7188 97.293823,112.709 97.1875,112.7188 L 97.1875,112.71875 z M 189.90625,164.375 C 183.5708,164.67041 183.28125,171.84375 182.5,173.25 C 181.25,175.5 184.75,187 184.5,191.25 C 184.25,195.5 179.75,196.5 175,201 C 170.25,205.5 175.5,217 186.25,232 L 231,233.25 L 230,198.25 C 230,198.25 234.75,194 209.25,174 C 199.6875,166.5 193.70752,164.19775 189.90625,164.375 z M 39.9375,180.90625 C 35.908264,180.80371 31.65625,186.625 30.25,188.5 C 28.75,190.5 24,193.5 13.25,198 L -1.25,232.25 L 51.75,236.5 C 51.75,236.5 53.5,225.5 47.5,220.75 C 41.5,216 30.25,215 29.25,207.5 C 28.25,200 38.5,197.5 43,193.25 C 47.5,189 45,182 40.75,181 C 40.484375,180.9375 40.206116,180.9131 39.9375,180.9063 L 39.9375,180.90625 z"
-           style="fill:#a6dd8b;fill-opacity:1;stroke:none" />
+  <g>
+    <g transform="matrix(1.25 .04 0 1.25 -27.81 -48.34)" clip-path="url(#ak)">
+      <path fill="#ceeeab" d="M9 12.25s7.5 13 11.75 27.75S27 65.5 27 65.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 167.5 26 167.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 116 218 116s1.75-10.5 6.75-23.75S235 65.5 235 65.5s-4.75-15.25-7.5-29.75S219.25 10 219.25 10 195 19 187.5 20.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z"/>
+      <g clip-path="url(#al)">
+        <path fill="#a6dd8b" d="M110.75 5.5l-4.25 7c-.75 9-2.25 13.75-8.5 16.5s-12.25 3.5-11 7.5 13 9.25 14.25 13 8.25 1.75 11 7 2 15.25-3.75 17.25-17.5.5-20.25 9.5-4.75 10.5-9 12.75-7.25 10.5-3.5 16.5 12.25-1.25 15-6.5S98 97.25 98 97.25h23.75l59-1.75 3.25-3.75s3.25 4 2.75 8.75-3.75 14.75.25 17.25 19.5-2 24-7-4.75-28.25-10.5-29.5-18.5-1.75-17-7 11.75 4.5 17.25 3.25 16.75-21 12-25.25-24.25-5.25-25.75-8 21-8 22.25-11-2.5-7.25-6.25-8.5S189 41 182 40.5s-20 5.75-17.25 11.5-6 11-14.5 6.5-24.75-13-21.75-24S150 15.75 150 15.75L110.75 5.5zM97.187 112.72c-1.594.145-4.468 4.686-4.937 7.03-.5 2.5-3.25 6.75-3.5 12.25s4.75 6.75 8.75 6.5 2.75-6.75 2-15c-.25 0-.5-10.25-2-10.75-.094-.03-.206-.04-.313-.03zm92.72 51.655c-6.336.295-6.626 7.47-7.407 8.875-1.25 2.25 2.25 13.75 2 18s-4.75 5.25-9.5 9.75.5 16 11.25 31l44.75 1.25-1-35s4.75-4.25-20.75-24.25c-9.563-7.5-15.542-9.802-19.344-9.625zm-149.97 16.53c-4.03-.1-8.28 5.72-9.687 7.595-1.5 2-6.25 5-17 9.5l-14.5 34.25 53 4.25s1.75-11-4.25-15.75S30.25 215 29.25 207.5s9.25-10 13.75-14.25S45 182 40.75 181c-.266-.063-.544-.087-.813-.094z"/>
       </g>
-      <path
-         id="path5280-4"
-         d="M 158.53125,85.34375 C 153.77142,85.329407 149.5,86.3125 147,88.5 C 139,95.5 112,89.25 98.5,95.5 C 85,101.75 85.25,133.5 83.75,140 C 82.25,146.5 66.25,160.75 63.75,163.5 C 61.25,166.25 50.5,170.75 44.25,172 C 38,173.25 31.5,179.25 28.75,183 C 26.728876,185.75608 21.343981,189.45031 18.625,191.21875 C 18.5792,191.40003 18.54564,191.56743 18.5,191.75 C 18.366311,192.28475 18.25288,192.83331 18.125,193.375 C 23.104513,191.77018 29.304508,185.19549 34.75,179.75 C 41,173.5 54.75,172 62.5,168.25 C 70.25,164.5 76.75,148.5 89,144.5 C 101.25,140.5 110.25,156.25 113.25,163 C 116.25,169.75 115,175.75 117,180 C 119,184.25 128,191.75 128.5,193.5 C 129,195.25 123.5,200 122.25,202 C 121,204 111.75,209 110.5,210.75 C 109.53432,212.10195 108.57684,217.52314 108.1875,219.96875 C 108.60053,219.79955 108.94168,219.65822 109.3125,219.5 C 109.7965,216.97067 110.82799,212.42201 112.25,211 C 114.25,209 123.5,206.5 124.75,202.5 C 126,198.5 131.75,196 131.75,196 C 131.75,196 134.5,200 147.75,210 C 156.58333,216.66667 160.5081,225.53356 162.15625,230.71875 C 162.82985,230.8894 163.6892,231.12815 164.1875,231.25 C 162.96635,226.93129 159.35104,215.01115 155.25,210.5 C 150.25,205 136.75,199.75 132.5,188.5 C 128.25,177.25 108,154.25 115,148.25 C 122,142.25 131.5,144.25 143.5,155.75 C 155.5,167.25 189.75,161.5 201.25,159.5 C 211.20453,157.76878 222.08445,174.38321 225.15625,185.53125 C 225.74525,183.43558 226.28288,181.52906 226.8125,179.78125 C 225.07444,177.85545 223.11528,175.16129 221.5,171.5 C 217.75,163 209.5,158.25 209.5,158.25 C 209.5,158.25 218.25,153.25 224.25,150.5 C 225.86703,149.75886 227.25627,148.82287 228.4375,147.84375 C 228.27516,147.06972 228.17857,146.5879 228,145.75 C 227.9689,145.60389 227.938,145.45846 227.9063,145.3125 C 223.14065,150.8749 208.67404,154.92782 206.25005,156.25 C 203.50005,157.75 188.00005,159.25 170.50005,160.75 C 153.00005,162.25 143.75005,153.25 136.25005,146 C 128.75005,138.75 123.25005,110 133.25005,108 C 143.25005,106 153.25005,121.75 163.25005,125 C 173.25005,128.25 184.75005,109.25 183.00005,98 C 181.79693,90.265625 169.00292,85.375305 158.5313,85.34375 L 158.53125,85.34375 z M 105.1875,98.625 C 106.46283,98.6265 111.04688,100.21875 111.75,101 C 114,103.5 113.75,108.25 111.75,109 C 109.75,109.75 99,117 101.25,123.25 C 103.5,129.5 103,141.25 97.75,141.25 C 92.5,141.25 89.75,141.25 87.75,138.75 C 85.75,136.25 85.75,126.75 87.75,119 C 89.75,111.25 91.25,104 95.75,100.75 C 98.84375,98.51562 102.38177,98.621643 105.1875,98.625 L 105.1875,98.625 z M 118.78125,171.71875 C 118.9845,171.73245 120.6875,175.23438 123.5,178.75 C 126.5,182.5 126.75,187 126.75,187 C 126.75,187 122.5,182.25 120.75,179 C 119,175.75 118.75,171.75 118.75,171.75 C 118.75,171.7188 118.7678,171.7177 118.7812,171.7188 L 118.78125,171.71875 z"
-         style="fill:#aac3e7;fill-opacity:1;stroke:none" />
-      <path
-         id="path5319-8"
-         d="M 122.75,72.25 C 129,72.75 135,70 133.5,65.75 C 132,61.5 121,58.5 120.25,62.75 C 119.5,67 122.25,73.25 122.75,72.25 z"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         id="path5321-0"
-         d="M 108.75,56.75 C 100.25,51.25 100.25,49.5 101.75,48.75 C 103.25,48 112,53.75 114.5,56.75 C 117,59.75 112.25,58.75 108.75,56.75 z"
-         style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <g
-         clip-path="url(#clipPath5383-0-0)"
-         id="g5373-1">
-        <path
-           style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 15.75,151.25 C 48.75,148.75 54,147.75 52,141 C 50,134.25 43.25,117.5 29,118.5 C 14.75,119.5 6.25,111.75 6.25,111.75"
-           id="path5323-8" />
-        <path
-           style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-opacity:1"
-           d="M 17.5,177.25 C 35.75,167.25 46.25,168.75 52.5,165.75 C 58.75,162.75 65.75,160 68.25,156.25 C 70.75,152.5 74,144.75 74,138.25 C 74,131.75 70.5,102.25 77.25,94.75 C 84,87.25 94.5,68.75 103.25,71.5 C 112,74.25 115.5,81.25 125.25,81 C 135,80.75 147,77 149.5,68.75 C 152,60.5 133.75,52.75 133.5,45.75 C 133.25,38.75 139,31.5 153.75,28.75 C 168.5,26 177.25,17.25 177.25,17.25"
-           id="path5311-7" />
-        <path
-           style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 14.5,161 C 29.75,159.5 36.75,164.5 46,162.75 C 55.25,161 59.25,159.75 63.75,157 C 68.25,154.25 69.75,153.25 70,150.5 C 70.25,147.75 71,138 67,128.5 C 63,119 54.5,97 58.75,89.75 C 63,82.5 64,68.25 74.5,65.25 C 85,62.25 95.5,59 102.25,64 C 109,69 115,78.25 122.25,78.5 C 129.5,78.75 134,77 136.75,74 C 139.5,71 141.25,63.75 138.5,60.25 C 135.75,56.75 123,54.75 121.25,50.75 C 119.5,46.75 110.5,33.75 121,24 C 131.5,14.25 157.25,15.75 157.25,15.75"
-           id="path5313-3" />
-        <path
-           style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 21.25,159 C 35,160 42.75,163.25 54.75,158.5 C 66.75,153.75 68.25,153.25 68.5,149.75 C 68.75,146.25 68.25,134 65.5,129.75 C 62.75,125.5 52.5,116 49.75,105.5 C 47,95 50,64.5 58.25,57.25 C 66.5,50 90.25,50 95.75,46.75 C 101.25,43.5 101,30 108.75,22.25 C 116.5,14.5 135.75,9.9999997 135.75,9.9999997"
-           id="path5315-4" />
-        <path
-           style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 190,18.5 C 201.75,23.5 229,28.25 237.25,58.75"
-           id="path5317-7" />
-        <path
-           style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 9.75,214 C 28.75,201.5 45.75,212.75 58.75,210 C 71.75,207.25 97,172.75 104.75,173 C 112.5,173.25 110.25,161.25 113.25,159.75 C 116.25,158.25 118.75,165.75 125,167.75 C 131.25,169.75 149.5,165 148.5,162 C 147.5,159 141.5,154.25 143,153.5 C 144.5,152.75 151.5,158.5 155.75,157 C 160,155.5 199.5,156 204.25,143.5 C 209,131 225.75,130 225.75,130"
-           id="path5325-1" />
-        <path
-           style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 77.5,233.5 C 91,222 100.75,208.5 106,206.5 C 111.25,204.5 118.75,202.75 121.75,198.5 C 124.75,194.25 124.25,187.75 127,186.5 C 129.75,185.25 130.75,192.25 135.75,192.5 C 140.75,192.75 172.5,187.5 178.5,180.75 C 184.5,174 210.75,168.25 211,166.25 C 211.25,164.25 210,161.5 211.25,160.75 C 212.5,160 236,154.75 236,154.75"
-           id="path5327-3"
-           sodipodi:nodetypes="csssssssc" />
-        <path
-           style="opacity:0.38695655;fill:none;stroke:#6d7f42;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 168.75,236 C 177.75,222.25 189.25,195 198.25,194 C 207.25,193 208.5,191.5 210.75,189.75 C 213,188 227.75,192 227.75,192"
-           id="path5329-4" />
+      <path fill="#aac3e7" d="M158.53 85.344c-4.76-.015-9.03.97-11.53 3.156-8 7-35 .75-48.5 7s-13.25 38-14.75 44.5-17.5 20.75-20 23.5-13.25 7.25-19.5 8.5-12.75 7.25-15.5 11c-2.02 2.756-7.406 6.45-10.125 8.22-.046.18-.08.347-.125.53-.134.535-.247 1.083-.375 1.625 4.98-1.605 11.18-8.18 16.625-13.625 6.25-6.25 20-7.75 27.75-11.5S76.75 148.5 89 144.5s21.25 11.75 24.25 18.5 1.75 12.75 3.75 17 11 11.75 11.5 13.5-5 6.5-6.25 8.5-10.5 7-11.75 8.75c-.966 1.352-1.923 6.773-2.313 9.22.414-.17.755-.312 1.126-.47.483-2.53 1.515-7.078 2.937-8.5 2-2 11.25-4.5 12.5-8.5s7-6.5 7-6.5 2.75 4 16 14c8.833 6.667 12.758 15.534 14.406 20.72.674.17 1.533.408 2.03.53-1.22-4.32-4.835-16.24-8.936-20.75-5-5.5-18.5-10.75-22.75-22S108 154.25 115 148.25s16.5-4 28.5 7.5 46.25 5.75 57.75 3.75c9.955-1.73 20.834 14.883 23.906 26.03.59-2.094 1.127-4 1.656-5.75-1.738-1.925-3.697-4.62-5.312-8.28-3.75-8.5-12-13.25-12-13.25s8.75-5 14.75-7.75c1.617-.74 3.006-1.677 4.188-2.656-.163-.774-.26-1.256-.438-2.094-.03-.146-.062-.292-.094-.438-4.765 5.563-19.232 9.616-21.656 10.938-2.75 1.5-18.25 3-35.75 4.5s-26.75-7.5-34.25-14.75-13-36-3-38 20 13.75 30 17 21.5-15.75 19.75-27c-1.203-7.734-13.997-12.625-24.47-12.656zm-53.343 13.28c1.276.002 5.86 1.595 6.563 2.376 2.25 2.5 2 7.25 0 8s-12.75 8-10.5 14.25 1.75 18-3.5 18-8 0-10-2.5-2-12 0-19.75 3.5-15 8-18.25c3.094-2.234 6.632-2.128 9.438-2.125zm13.594 73.095c.204.012 1.907 3.514 4.72 7.03 3 3.75 3.25 8.25 3.25 8.25s-4.25-4.75-6-8-2-7.25-2-7.25c0-.03.018-.032.03-.03z"/>
+      <path fill="none" stroke="#6d7f42" d="M122.75 72.25c6.25.5 12.25-2.25 10.75-6.5s-12.5-7.25-13.25-3 2 10.5 2.5 9.5zM108.75 56.75c-8.5-5.5-8.5-7.25-7-8s10.25 5 12.75 8-2.25 2-5.75 0z" opacity=".387" stroke-linecap="round" stroke-linejoin="round"/>
+      <g fill="none" stroke="#6d7f42" clip-path="url(#am)">
+        <path d="M15.75 151.25c33-2.5 38.25-3.5 36.25-10.25s-8.75-23.5-23-22.5-22.75-6.75-22.75-6.75" opacity=".387" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M17.5 177.25c18.25-10 28.75-8.5 35-11.5s13.25-5.75 15.75-9.5 5.75-11.5 5.75-18-3.5-36 3.25-43.5 17.25-26 26-23.25 12.25 9.75 22 9.5S147 77 149.5 68.75s-15.75-16-16-23 5.5-14.25 20.25-17 23.5-11.5 23.5-11.5" opacity=".387"/>
+        <path d="M14.5 161c15.25-1.5 22.25 3.5 31.5 1.75s13.25-3 17.75-5.75 6-3.75 6.25-6.5 1-12.5-3-22S54.5 97 58.75 89.75 64 68.25 74.5 65.25 95.5 59 102.25 64s12.75 14.25 20 14.5S134 77 136.75 74s4.5-10.25 1.75-13.75-15.5-5.5-17.25-9.5-10.75-17-.25-26.75 36.25-8.25 36.25-8.25" opacity=".387" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M21.25 159c13.75 1 21.5 4.25 33.5-.5s13.5-5.25 13.75-8.75-.25-15.75-3-20-13-13.75-15.75-24.25.25-41 8.5-48.25 32-7.25 37.5-10.5 5.25-16.75 13-24.5 27-12.25 27-12.25M190 18.5c11.75 5 39 9.75 47.25 40.25M9.75 214c19-12.5 36-1.25 49-4s38.25-37.25 46-37 5.5-11.75 8.5-13.25 5.5 6 11.75 8 24.5-2.75 23.5-5.75-7-7.75-5.5-8.5 8.5 5 12.75 3.5 43.75-1 48.5-13.5 21.5-13.5 21.5-13.5M77.5 233.5c13.5-11.5 23.25-25 28.5-27s12.75-3.75 15.75-8 2.5-10.75 5.25-12 3.75 5.75 8.75 6 36.75-5 42.75-11.75 32.25-12.5 32.5-14.5-1-4.75.25-5.5 24.75-6 24.75-6M168.75 236c9-13.75 20.5-41 29.5-42s10.25-2.5 12.5-4.25 17 2.25 17 2.25" opacity=".387" stroke-linecap="round" stroke-linejoin="round"/>
       </g>
-      <g
-         clip-path="url(#clipPath5426-1-6)"
-         id="g5400-4">
-        <path
-           style="fill:none;stroke:#d38484;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 57.75,20 L 49.25,48.25 L 67.25,54.5 L 75,90.75 L 54,113 L 63,123.5 L 51,135 L 51.5,139.5 L 71.75,164 L 85.75,157.25 L 106.25,175.75 L 95.75,204 L 106,212.5 L 103.25,225.5"
-           id="path5387-2" />
-        <path
-           style="fill:none;stroke:#d38484;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="M 105.75,212.25 L 118.25,184.5 L 129.25,177.5 L 156.75,193.25 L 177.25,189.5 L 177,173.75 L 166.75,167.75 L 179.5,141.5 L 185.25,137.75 L 224,127.75"
-           id="path5389-4" />
+      <g fill="none" stroke="#d38484" stroke-width="2" clip-path="url(#an)" stroke-linecap="round">
+        <path d="M57.75 20l-8.5 28.25 18 6.25L75 90.75 54 113l9 10.5L51 135l.5 4.5L71.75 164l14-6.75 20.5 18.5L95.75 204l10.25 8.5-2.75 13"/>
+        <path d="M105.75 212.25l12.5-27.75 11-7 27.5 15.75 20.5-3.75-.25-15.75-10.25-6 12.75-26.25 5.75-3.75 38.75-10"/>
       </g>
-      <path
-         id="path3834-49-6"
-         d="M 9,12.25 C 9,12.25 16.5,25.25 20.75,40 C 25,54.75 27,65.5 27,65.5 C 27,65.5 21.5,78.25 18.75,90.25 C 16,102.25 13,113.25 13,113.25 C 13,113.25 18.75,129.25 22.25,143.25 C 25.75,157.25 26,167.5 26,167.5 C 26,167.5 22,177.75 18.5,191.75 C 15,205.75 13.5,222.5 13.5,222.5 C 13.5,222.5 22.75,220.5 42,223.75 C 61.25,227 74.25,229.75 74.25,229.75 C 74.25,229.75 87,227 98.25,223.5 C 109.5,220 114.5,217 114.5,217 C 114.5,217 120,217.5 137,223.25 C 154,229 166.25,231.75 166.25,231.75 C 166.25,231.75 179.25,229 192.25,226 C 205.25,223 218.75,218 218.75,218 C 218.75,218 218,213 223,193.5 C 228,174 231.75,165.5 231.75,165.5 C 231.75,165.5 231.25,161 228,145.75 C 224.75,130.5 218,116 218,116 C 218,116 219.75,105.5 224.75,92.25 C 229.75,79 235,65.5 235,65.5 C 235,65.5 230.25,50.25 227.5,35.75 C 224.75,21.25 219.25,10 219.25,10 C 219.25,10 195,19 187.5,20.5 C 180,22 166.5,25.75 166.5,25.75 C 166.5,25.75 156.75,21.5 144.5,17.25 C 132.25,13 114.75,11.75 114.75,11.75 C 114.75,11.75 111.5,15.25 92.75,19.75 C 74,24.25 65.25,25.5 65.25,25.5 C 65.25,25.5 46.75,16.5 33.75,14 C 20.75,11.5 9.75,12 9,12.25 z"
-         style="opacity:0.03913042;fill:url(#linearGradient5168-2-9);fill-opacity:1;stroke:none" />
-      <g
-         style="opacity:0.2695656;display:inline"
-         id="g4808-4"
-         transform="translate(0,192)">
-        <path
-           style="fill:url(#linearGradient4806-9-8-4);fill-opacity:1;stroke:none"
-           d="M 219.25,-182 C 219.25,-182 195,-173 187.5,-171.5 C 180,-170 166.5,-166.25 166.5,-166.25 C 171.42395,-167.60833 177.93679,-120.85753 180.75,-114 L 180.6875,-113.71875 C 192.49544,-117.79254 231.89797,-118.48643 235,-126.5 C 235,-126.5 230.25,-141.75 227.5,-156.25 C 224.75,-170.75 219.25,-182 219.25,-182 z"
-           id="path3834-4-9-9" />
-        <path
-           style="fill:url(#linearGradient4790-3-9-7);fill-opacity:1;stroke:none"
-           d="M 27,-126.5 C 27,-126.5 21.5,-113.75 18.75,-101.75 C 16,-89.75 13,-78.75 13,-78.75 L 63.625,-62.46875 L 79.40625,-121.375 L 27,-126.5 z"
-           id="path3834-7-2-4-9-8" />
-        <path
-           style="fill:url(#linearGradient4758-2-6-2);fill-opacity:1;stroke:none"
-           d="M 26,-24.5 C 26,-24.5 22,-14.25 18.5,-0.25 C 15,13.75 13.5,30.5 13.5,30.5 C 13.5,30.5 13.646973,30.4546 13.9375,30.4063 C 15.971191,30.06792 25.15625,28.9063 42,31.75005 C 61.25,35.00005 74.25,37.75005 74.25,37.75005 L 75.71875,-14.74995 L 74.96875,-14.62495 L 26,-24.5 z"
-           id="path3834-7-26-9-7-4" />
-        <path
-           style="fill:url(#linearGradient4750-9-9-4);fill-opacity:1;stroke:none"
-           d="M 114.75,-180.25 C 114.75,-180.25 111.5,-176.75 92.75,-172.25 C 74.000003,-167.75 65.25,-166.5 65.25,-166.5 C 70.432295,-151.79646 77.279793,-137.22997 79.5,-121.75 L 79.40625,-121.4375 L 127.4375,-125.375 L 128.5625,-125.125 C 125.20002,-138.4478 120.76647,-179.71689 114.75,-180.25 z"
-           id="path3834-4-9-6-2" />
-        <path
-           style="fill:url(#linearGradient4782-5-5-9);fill-opacity:1;stroke:none"
-           d="M 117.59375,-78.09375 L 63.96875,-62.375 L 63.625,-62.46875 L 63.5,-62 L 75.75,-15.5 L 75.71875,-14.75 L 125.1875,-23.625 L 125.71875,-23.4375 L 125.74995,-23.5 L 117.49995,-77.75 L 117.59365,-78.09375 L 117.59375,-78.09375 z"
-           id="path3834-7-26-0-0-9-5" />
-        <path
-           style="fill:url(#linearGradient4798-4-1-9);fill-opacity:1;stroke:none"
-           d="M 128.5625,-125.125 C 128.7967,-124.19705 129.02602,-123.38337 129.25,-122.75 L 117.59375,-78.09375 L 117.68745,-78.12495 L 169.49995,-60.74995 L 180.68745,-113.7187 C 180.33054,-113.59556 179.99216,-113.47332 179.68745,-113.3437 L 128.56245,-125.12495 L 128.5625,-125.125 z"
-           id="path3834-7-2-4-3-7" />
-        <path
-           style="fill:url(#linearGradient4766-3-6-2);fill-opacity:1;stroke:none"
-           d="M 125.53125,-23.5 L 114.5,25 C 114.5,25 120,25.5 137,31.25 C 139.125,31.96875 141.16309,32.65576 143.125,33.28125 C 145.08691,33.90674 146.98047,34.4668 148.75,35 C 159.36719,38.19922 166.25,39.75 166.25,39.75 L 178.96875,-5.65625 C 178.45649,-5.47361 177.95026,-5.27525 177.4375,-5.09375 L 125.53125,-23.5 z"
-           id="path3834-7-26-9-85-2" />
-        <path
-           style="fill:url(#linearGradient4965-0-3);fill-opacity:1;stroke:none"
-           d="M 218,-76 C 202.33444,-69.71197 186.30214,-64.85036 169.9375,-60.59375 L 169.5,-60.75 L 179,-5.75 L 178.9688,-5.6563 C 196.80782,-12.01643 214.35028,-19.043 231.75005,-26.50005 C 231.75005,-26.50005 231.25005,-31.00005 228.00005,-46.25005 C 224.75,-61.5 218,-76 218,-76 z"
-           id="path3834-7-26-0-0-3-7" />
+      <path fill="url(#ao)" d="M9 12.25s7.5 13 11.75 27.75S27 65.5 27 65.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23 5.75 16 9.25 30S26 167.5 26 167.5s-4 10.25-7.5 24.25-5 30.75-5 30.75 9.25-2 28.5 1.25 32.25 6 32.25 6 12.75-2.75 24-6.25 16.25-6.5 16.25-6.5 5.5.5 22.5 6.25 29.25 8.5 29.25 8.5 13-2.75 26-5.75 26.5-8 26.5-8-.75-5 4.25-24.5 8.75-28 8.75-28-.5-4.5-3.75-19.75S218 116 218 116s1.75-10.5 6.75-23.75S235 65.5 235 65.5s-4.75-15.25-7.5-29.75S219.25 10 219.25 10 195 19 187.5 20.5s-21 5.25-21 5.25-9.75-4.25-22-8.5-29.75-5.5-29.75-5.5-3.25 3.5-22 8-27.5 5.75-27.5 5.75-18.5-9-31.5-11.5-24-2-24.75-1.75z" opacity=".039"/>
+      <g opacity=".27">
+        <path fill="url(#ap)" d="M219.25-182s-24.25 9-31.75 10.5-21 5.25-21 5.25c4.924-1.358 11.437 45.392 14.25 52.25l-.063.28c11.808-4.073 51.21-4.766 54.313-12.78 0 0-4.75-15.25-7.5-29.75S219.25-182 219.25-182z" transform="translate(0 192)"/>
+        <path fill="url(#aq)" d="M27-126.5s-5.5 12.75-8.25 24.75-5.75 23-5.75 23l50.625 16.28 15.78-58.905L27-126.5z" transform="translate(0 192)"/>
+        <path fill="url(#ar)" d="M26-24.5S22-14.25 18.5-.25s-5 30.75-5 30.75.147-.045.438-.094c2.033-.338 11.218-1.5 28.062 1.344 19.25 3.25 32.25 6 32.25 6l1.47-52.5-.75.125L26-24.5z" transform="translate(0 192)"/>
+        <path fill="url(#as)" d="M114.75-180.25s-3.25 3.5-22 8-27.5 5.75-27.5 5.75c5.182 14.704 12.03 29.27 14.25 44.75l-.094.313 48.03-3.938 1.126.25c-3.362-13.323-7.796-54.592-13.812-55.125z" transform="translate(0 192)"/>
+        <path fill="url(#at)" d="M117.594-78.094L63.97-62.374l-.345-.095-.125.47 12.25 46.5-.03.75 49.468-8.875.53.188.032-.063-8.25-54.25.094-.344z" transform="translate(0 192)"/>
+        <path fill="url(#au)" d="M128.563-125.125c.234.928.463 1.742.687 2.375l-11.656 44.656.093-.03L169.5-60.75l11.187-52.97c-.356.124-.695.247-1 .376l-51.125-11.78z" transform="translate(0 192)"/>
+        <path fill="url(#av)" d="M125.53-23.5L114.5 25s5.5.5 22.5 6.25c2.125.72 4.163 1.406 6.125 2.03 1.962.627 3.855 1.187 5.625 1.72 10.617 3.2 17.5 4.75 17.5 4.75l12.72-45.406c-.514.182-1.02.38-1.532.562L125.53-23.5z" transform="translate(0 192)"/>
+        <path fill="url(#aw)" d="M218-76c-15.666 6.288-31.698 11.15-48.063 15.406l-.437-.156 9.5 55-.03.094c17.838-6.36 35.38-13.387 52.78-20.844 0 0-.5-4.5-3.75-19.75S218-76 218-76z" transform="translate(0 192)"/>
       </g>
-      <g
-         style="opacity:0.04347827;display:inline"
-         id="g4818-4"
-         transform="translate(0,192)">
-        <path
-           style="fill:url(#linearGradient4686-3-4-6);fill-opacity:1;stroke:none"
-           d="M 13.71875,-179.96875 C 12.61251,-179.97175 11.746535,-179.93665 11,-179.90625 C 10.55476,-179.88815 10.144586,-179.86725 9.84375,-179.84375 C 9.81446,-179.84175 9.7778,-179.84575 9.75,-179.84375 C 9.352051,-179.81105 9.09375,-179.78125 9,-179.75005 C 9,-179.75005 16.5,-166.75005 20.75,-152.00005 C 25,-137.25 27,-126.5 27,-126.5 L 78.46875,-121.375 L 79.40625,-121.4375 L 79.5,-121.75 C 77.279793,-137.22997 70.432295,-151.79646 65.25,-166.5 C 65.25,-166.5 46.75,-175.5 33.75,-178 C 32.731734,-178.19582 31.73976,-178.37068 30.75,-178.53125 C 30.154387,-178.62795 29.583119,-178.72763 29,-178.8125 C 28.763416,-178.8469 28.546809,-178.8737 28.3125,-178.9062 C 27.006022,-179.08805 25.724495,-179.24659 24.5,-179.37495 C 23.765447,-179.45195 23.105404,-179.50254 22.40625,-179.56245 C 21.721361,-179.62155 21.053311,-179.67434 20.40625,-179.7187 C 19.414378,-179.7865 18.515844,-179.83704 17.625,-179.87495 C 16.168632,-179.93805 14.855835,-179.96565 13.71875,-179.96865 L 13.71875,-179.96875 z"
-           id="path3834-4-9-1-4" />
-        <path
-           style="fill:url(#linearGradient4742-3-4-4);fill-opacity:1;stroke:none"
-           d="M 13,-78.75 C 13,-78.75 18.75,-62.75 22.25,-48.75 C 25.75,-34.75 26,-24.5 26,-24.5 L 74.96875,-14.625 L 75.71875,-14.75 L 75.75,-15.5 L 63.5,-62 L 63.625,-62.46875 L 13,-78.75 z"
-           id="path3834-7-26-0-0-7-0" />
-        <path
-           style="fill:url(#linearGradient4734-3-7-6);fill-opacity:1;stroke:none"
-           d="M 127.4375,-125.375 L 79.46875,-121.375 L 79.40625,-121.375 L 63.625,-62.46875 L 63.96875,-62.375 L 117.59375,-78.09375 L 129.25,-122.75 C 129.02602,-123.38337 128.7967,-124.19705 128.5625,-125.125 L 127.4375,-125.375 L 127.4375,-125.375 z"
-           id="path3834-7-2-4-6-5" />
-        <path
-           style="fill:url(#linearGradient4726-9-4-9);fill-opacity:1;stroke:none"
-           d="M 125.1875,-23.625 L 75.71875,-14.75 L 74.25,37.75 C 74.25,37.75 87.000003,35 98.25,31.5 C 109.5,28 114.5,25 114.5,25 L 125.71875,-23.4375 L 125.1875,-23.625 z"
-           id="path3834-7-26-9-8-6" />
-        <path
-           style="fill:url(#linearGradient4710-2-1-6);fill-opacity:1;stroke:none"
-           d="M 114.75,-180.25 C 120.76647,-179.71689 125.20002,-138.4478 128.5625,-125.125 L 179.6875,-113.34375 C 179.99221,-113.47337 180.33059,-113.59561 180.6875,-113.71875 L 180.75,-114 C 177.93679,-120.85753 171.42395,-167.60833 166.5,-166.25 C 166.5,-166.25 165.88672,-166.50391 164.78125,-166.96875 C 161.46484,-168.36328 153.6875,-171.5625 144.5,-174.75 C 132.25,-179 114.75,-180.25 114.75,-180.25 z"
-           id="path3834-4-9-2-0" />
-        <path
-           style="fill:url(#linearGradient4718-4-6-0);fill-opacity:1;stroke:none"
-           d="M 117.6875,-78.125 L 117.5938,-78.0938 L 117.5001,-77.75005 L 125.7501,-24.50005 L 125.53135,-23.50005 L 177.4376,-5.0938 C 177.95036,-5.2753 178.45659,-5.47366 178.96885,-5.6563 L 179,-5.75 L 169.5,-60.75 L 117.6875,-78.125 L 117.6875,-78.125 z"
-           id="path3834-7-26-0-0-0-0" />
-        <path
-           style="fill:url(#linearGradient4694-4-1-9);fill-opacity:1;stroke:none"
-           d="M 231.75,-26.5 C 214.35023,-19.04295 196.80777,-12.01638 178.96875,-5.65625 L 166.25,39.75 C 166.25,39.75 179.25,37 192.25,34 C 205.25,31 218.75,26 218.75,26 C 218.75,26 218,21 223,1.5 C 228,-18 231.75,-26.5 231.75,-26.5 z"
-           id="path3834-7-26-9-9-4" />
-        <path
-           style="fill:url(#linearGradient4702-4-6-9);fill-opacity:1;stroke:none"
-           d="M 235,-126.5 C 231.89797,-118.48643 192.49544,-117.79254 180.6875,-113.71875 L 169.5,-60.75 L 169.9375,-60.59375 C 186.30214,-64.85036 202.33444,-69.71197 218,-76 C 218,-76 219.75,-86.5 224.75,-99.75 C 229.75,-113 235,-126.5 235,-126.5 z"
-           id="path3834-7-2-4-5-0" />
+      <g opacity=".043">
+        <path fill="url(#ax)" d="M13.72-179.97c-1.107-.002-1.973.033-2.72.064-.445.018-.855.04-1.156.062-.03.002-.066-.002-.094 0-.398.033-.656.063-.75.094 0 0 7.5 13 11.75 27.75S27-126.5 27-126.5l51.47 5.125.936-.063.094-.312c-2.22-15.48-9.068-30.046-14.25-44.75 0 0-18.5-9-31.5-11.5-1.018-.196-2.01-.37-3-.53-.596-.098-1.167-.198-1.75-.282-.237-.035-.453-.062-.688-.094-1.306-.182-2.588-.34-3.812-.47-.735-.076-1.395-.127-2.094-.186-.685-.06-1.353-.112-2-.157-.992-.066-1.89-.117-2.78-.155-1.457-.063-2.77-.09-3.907-.094z" transform="translate(0 192)"/>
+        <path fill="url(#ay)" d="M13-78.75s5.75 16 9.25 30S26-24.5 26-24.5l48.97 9.875.75-.125.03-.75L63.5-62l.125-.47L13-78.75z" transform="translate(0 192)"/>
+        <path fill="url(#az)" d="M127.438-125.375l-47.97 4h-.062L63.626-62.47l.343.095 53.624-15.72 11.656-44.655c-.224-.633-.453-1.447-.688-2.375l-1.125-.25z" transform="translate(0 192)"/>
+        <path fill="url(#aA)" d="M125.188-23.625l-49.47 8.875-1.468 52.5S87 35 98.25 31.5 114.5 25 114.5 25l11.22-48.438-.532-.187z" transform="translate(0 192)"/>
+        <path fill="url(#aB)" d="M114.75-180.25c6.016.533 10.45 41.802 13.813 55.125l51.125 11.78c.304-.128.643-.25 1-.374l.062-.28c-2.813-6.858-9.326-53.608-14.25-52.25 0 0-.613-.254-1.72-.72-3.315-1.393-11.093-4.593-20.28-7.78-12.25-4.25-29.75-5.5-29.75-5.5z" transform="translate(0 192)"/>
+        <path fill="url(#aC)" d="M117.688-78.125l-.094.03-.094.345 8.25 53.25-.22 1L177.44-5.094c.512-.18 1.02-.38 1.53-.562L179-5.75l-9.5-55-51.813-17.375z" transform="translate(0 192)"/>
+        <path fill="url(#aD)" d="M231.75-26.5c-17.4 7.457-34.942 14.484-52.78 20.844L166.25 39.75s13-2.75 26-5.75 26.5-8 26.5-8S218 21 223 1.5s8.75-28 8.75-28z" transform="translate(0 192)"/>
+        <path fill="url(#aE)" d="M235-126.5c-3.102 8.014-42.505 8.707-54.313 12.78L169.5-60.75l.438.156C186.3-64.85 202.334-69.712 218-76c0 0 1.75-10.5 6.75-23.75S235-126.5 235-126.5z" transform="translate(0 192)"/>
       </g>
     </g>
   </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer6"
-     inkscape:label="Mag Shadow"
-     style="display:inline"
-     sodipodi:insensitive="true">
-    <path
-       style="fill:#2d3335;fill-opacity:1;stroke:none;filter:url(#filter7286)"
-       d="M 174.28125,35.875 C 156.6825,35.875 139.08909,42.514475 125.5625,55.78125 C 125.39528,55.944528 125.22813,56.084367 125.0625,56.25 C 103.00655,78.305948 98.853795,111.50122 112.59375,137.75 L 110.3125,139.375 C 112.56129,143.61488 115.25415,147.6818 118.40625,151.5 L 105.09375,164.84375 C 103.75238,164.258 102.30517,163.81044 100.53125,163.46875 L 97.6875,166.3125 C 96.578031,165.82863 95.549481,165.49662 94.625,165.4375 L 30.5,229.5625 C 30.46313,230.66337 30.72615,231.74988 31.15625,232.84375 L 30.625,233.375 L 29.53125,234.46875 C 30.246688,238.20655 31.541682,241.29169 35,244.75 C 38.458318,248.20832 41.420414,249.38027 45.28125,250.21875 L 46.375,249.125 L 47.09375,248.40625 C 48.181953,248.8685 49.223649,249.19242 50.1875,249.25 L 114.3125,185.125 C 114.06964,184.15025 113.69207,183.18954 113.28125,182.21875 L 116.28125,179.21875 C 116.03142,177.48677 115.60454,176.02072 114.96875,174.625 L 128.25,161.34375 C 132.0682,164.49585 136.13512,167.18872 140.375,169.4375 L 142,167.15625 C 168.24878,180.8962 201.44405,176.74344 223.5,154.6875 C 223.66563,154.52186 223.80547,154.35472 223.96875,154.1875 C 250.66292,126.97054 250.51736,83.267352 223.5,56.25 C 209.91004,42.660041 192.09307,35.875 174.28125,35.875 z M 173.78125,39.15625 C 173.88592,39.15775 173.98908,39.15425 174.09375,39.15625 C 175.04294,39.17465 175.98913,39.22152 176.9375,39.28125 C 177.89594,39.34161 178.8563,39.428763 179.8125,39.53125 C 179.9062,39.5413 180.00004,39.55205 180.09375,39.5625 C 180.18775,39.57298 180.28105,39.58287 180.375,39.59375 C 180.5207,39.61063 180.66687,39.63839 180.8125,39.65625 C 181.7087,39.766152 182.60741,39.884369 183.5,40.03125 C 184.11909,40.133124 184.72687,40.255367 185.34375,40.375 C 185.6867,40.44144 186.03282,40.49058 186.375,40.5625 C 187.0987,40.714611 187.81147,40.885892 188.53125,41.0625 C 188.8443,41.13931 189.15653,41.199811 189.46875,41.28125 C 189.54185,41.30031 189.61445,41.32444 189.6875,41.34375 C 190.6434,41.596587 191.58423,41.860044 192.53125,42.15625 C 192.60365,42.17886 192.67766,42.19588 192.75,42.21875 C 193.69741,42.518592 194.65684,42.844291 195.59375,43.1875 C 195.64685,43.20695 195.69698,43.23041 195.75,43.25 C 196.70458,43.602395 197.65174,43.977633 198.59375,44.375 C 198.64525,44.39672 198.69853,44.41564 198.75,44.4375 C 199.69184,44.837551 200.63491,45.273781 201.5625,45.71875 C 201.6045,45.73891 201.6455,45.761 201.6875,45.78125 C 202.62288,46.232337 203.54958,46.690779 204.46875,47.1875 C 204.50185,47.20538 204.52945,47.23206 204.56245,47.25 C 205.48926,47.752833 206.40387,48.263321 207.31245,48.8125 C 207.34455,48.83189 207.37415,48.85555 207.40615,48.875 C 208.31425,49.425934 209.20552,49.996562 210.09365,50.59375 C 210.6426,50.962824 211.17785,51.36329 211.71865,51.75 C 212.08335,52.010827 212.45156,52.262412 212.8124,52.53125 C 212.8309,52.54506 212.8564,52.54867 212.8749,52.5625 C 213.75254,53.217706 214.61511,53.922431 215.46865,54.625 C 217.21133,56.059371 218.90007,57.587673 220.53115,59.21875 C 222.15163,60.83923 223.66733,62.519314 225.09365,64.25 C 225.10265,64.26124 225.11565,64.27 225.12485,64.28125 C 225.82806,65.135607 226.53159,65.996485 227.18735,66.875 C 227.47012,67.253769 227.72592,67.648223 227.99985,68.03125 C 228.36958,68.548307 228.73999,69.069236 229.0936,69.59375 C 229.1098,69.61774 229.14,69.63224 229.1561,69.65625 C 229.75422,70.545876 230.32314,71.434083 230.87485,72.34375 C 230.89435,72.37582 230.91795,72.40541 230.93735,72.4375 C 231.48294,73.340419 232.00002,74.266573 232.49985,75.1875 C 232.51775,75.22044 232.54455,75.24829 232.56235,75.28125 C 233.06035,76.202462 233.51643,77.124994 233.9686,78.0625 C 233.9888,78.10444 234.011,78.14552 234.0311,78.1875 C 234.47721,79.117367 234.91137,80.055804 235.31235,81 C 235.33415,81.05123 235.35325,81.104977 235.37485,81.15625 C 235.76965,82.092372 236.14946,83.051461 236.49985,84 C 236.51925,84.05253 236.54305,84.103686 236.56235,84.15625 C 236.90996,85.10461 237.22793,86.040882 237.5311,87 C 237.5538,87.07167 237.5712,87.147026 237.5936,87.21875 C 237.88758,88.159922 238.15494,89.112572 238.4061,90.0625 C 238.4256,90.13603 238.4494,90.207672 238.4686,90.28125 C 238.5493,90.590804 238.61118,90.908382 238.68735,91.21875 C 238.86396,91.938529 239.03524,92.651296 239.18735,93.375 C 239.25925,93.717177 239.30841,94.063299 239.37485,94.40625 C 239.49448,95.023132 239.61673,95.630911 239.7186,96.25 C 239.86548,97.142594 239.9837,98.041302 240.0936,98.9375 C 240.1115,99.083459 240.1392,99.228963 240.1561,99.375 C 240.1669,99.46829 240.1769,99.562929 240.1873,99.65625 C 240.1978,99.75023 240.2085,99.843493 240.2185,99.9375 C 240.32099,100.8937 240.40814,101.85406 240.4685,102.8125 C 240.5277,103.75494 240.57511,104.71299 240.5935,105.65625 C 240.5955,105.76038 240.5915,105.86462 240.5935,105.96875 C 240.6089,107.02208 240.5975,108.0726 240.5623,109.125 C 240.5307,110.05556 240.4776,110.97779 240.40605,111.90625 C 240.39605,112.03118 240.38515,112.15637 240.37485,112.28125 C 240.29875,113.19932 240.20894,114.11665 240.0936,115.03125 C 239.973,115.98751 239.81965,116.95518 239.6561,117.90625 C 239.6419,117.98865 239.6393,118.07392 239.6249,118.15625 C 239.6029,118.2811 239.5852,118.40651 239.5624,118.53125 C 239.39714,119.43903 239.2045,120.34852 238.9999,121.25 C 238.9693,121.38463 238.9376,121.52178 238.9062,121.65625 C 238.69845,122.54491 238.46486,123.43135 238.2187,124.3125 C 238.05479,124.89922 237.86842,125.47955 237.68745,126.0625 C 237.51204,126.62662 237.34761,127.18974 237.1562,127.75 C 236.86153,128.61381 236.55145,129.45882 236.2187,130.3125 C 236.1581,130.46799 236.09304,130.62612 236.0312,130.78125 C 235.9863,130.89371 235.9517,131.01273 235.9062,131.125 C 235.5501,132.00362 235.17807,132.8526 234.7812,133.71875 C 234.40422,134.54222 234.0076,135.34519 233.5937,136.15625 C 233.5132,136.31403 233.42563,136.46772 233.3437,136.625 C 232.92842,137.4224 232.51372,138.21595 232.06245,139 C 231.96725,139.16556 231.87805,139.33506 231.7812,139.5 C 231.58213,139.83885 231.36205,140.16384 231.1562,140.5 C 230.79455,141.09093 230.41383,141.66777 230.0312,142.25 C 230.0262,142.257 230.0362,142.2738 230.0312,142.2812 C 229.54039,143.02694 229.02527,143.76939 228.49995,144.49995 C 228.04268,145.13587 227.54591,145.75123 227.06245,146.37495 C 226.86549,146.62904 226.70126,146.90421 226.49995,147.1562 C 226.36593,147.32399 226.22965,147.48935 226.0937,147.6562 C 225.93019,147.85684 225.76,148.05071 225.5937,148.24995 C 225.03708,148.917 224.46291,149.5678 223.87495,150.2187 C 223.26864,150.88974 222.63964,151.56575 221.99995,152.2187 C 221.83899,152.38296 221.69428,152.55562 221.5312,152.7187 C 200.40085,173.84905 169.27251,177.21358 144.3437,163.87495 L 144.4687,163.68745 C 140.76453,161.79084 137.20703,159.54699 133.8437,156.9062 C 133.30478,156.48305 132.77833,156.03638 132.24995,155.5937 C 131.73554,155.16273 131.22265,154.7308 130.7187,154.2812 C 130.6258,154.1976 130.52998,154.1154 130.43745,154.0312 C 129.61572,153.28344 128.82556,152.51306 128.0312,151.7187 C 127.23684,150.92434 126.46647,150.13418 125.7187,149.31245 C 125.6345,149.21995 125.55231,149.12407 125.4687,149.0312 C 125.0191,148.52725 124.58717,148.01436 124.1562,147.49995 C 123.71352,146.97157 123.26685,146.44512 122.8437,145.9062 C 120.20291,142.54287 117.95906,138.98536 116.06245,135.2812 L 115.87495,135.4062 C 102.53632,110.47739 105.90085,79.349046 127.0312,58.2187 C 127.19428,58.05562 127.36694,57.910915 127.5312,57.74995 C 128.18415,57.110265 128.86016,56.481261 129.5312,55.87495 C 130.1821,55.286994 130.8329,54.712816 131.49995,54.1562 C 131.77209,53.929114 132.03772,53.690576 132.31245,53.4687 C 132.65592,53.191271 133.02754,52.956742 133.37495,52.68745 C 133.99867,52.203987 134.61403,51.707219 135.24995,51.24995 C 135.98748,50.719619 136.74695,50.21386 137.49995,49.7187 C 138.08218,49.336066 138.65902,48.955346 139.24995,48.5937 C 139.69662,48.32034 140.1423,48.042584 140.5937,47.7812 C 141.27515,47.386414 141.96454,47.023727 142.6562,46.6562 C 142.83226,46.56265 143.01076,46.46674 143.18745,46.37495 C 144.1327,45.883975 145.06888,45.40925 146.0312,44.9687 C 146.89735,44.571825 147.74633,44.1998 148.62495,43.8437 C 148.77776,43.78177 148.94054,43.74815 149.0937,43.68745 C 150.06209,43.303428 151.01838,42.928541 151.99995,42.5937 C 152.56021,42.402293 153.12333,42.237857 153.68745,42.06245 C 154.2704,41.881482 154.85073,41.695111 155.43745,41.5312 C 156.3186,41.285037 157.20504,41.051454 158.0937,40.8437 C 158.1648,40.82706 158.24127,40.82884 158.31245,40.81245 C 158.72838,40.71671 159.14509,40.618551 159.56245,40.5312 C 160.23458,40.390375 160.91827,40.244039 161.5937,40.12495 C 161.676,40.11046 161.76133,40.10786 161.8437,40.0937 C 162.79477,39.930149 163.76244,39.776798 164.7187,39.6562 C 166.68235,39.408555 168.64857,39.254564 170.62495,39.18745 C 171.67735,39.15181 172.72787,39.14082 173.7812,39.1562 L 173.78125,39.15625 z"
-       id="path5604-26-0"
-       transform="matrix(1,8.087767e-2,0,1,0,-21.056305)"
-       clip-path="url(#clipPath8750)" />
+  <g>
+    <path fill="#2d3335" d="M174.28 35.875c-17.597 0-35.19 6.64-48.718 19.906-.167.165-.334.304-.5.47-22.055 22.056-26.208 55.25-12.468 81.5l-2.28 1.625c2.247 4.24 4.94 8.307 8.092 12.125l-13.312 13.344c-1.342-.586-2.79-1.034-4.563-1.375l-2.843 2.843c-1.11-.484-2.138-.816-3.062-.875L30.5 229.563c-.037 1.1.226 2.187.656 3.28l-.53.532-1.095 1.094c.717 3.737 2.012 6.822 5.47 10.28 3.458 3.458 6.42 4.63 10.28 5.47l1.095-1.095.72-.72c1.087.464 2.13.787 3.093.845l64.124-64.125c-.242-.975-.62-1.935-1.03-2.906l3-3c-.25-1.733-.677-3.2-1.313-4.595l13.28-13.28c3.818 3.15 7.885 5.844 12.125 8.093l1.625-2.282c26.25 13.74 59.444 9.587 81.5-12.47.166-.164.305-.33.47-.5 26.693-27.215 26.547-70.92-.47-97.936-13.59-13.59-31.407-20.375-49.22-20.375zm-.5 3.28c.106.003.21 0 .314 0 .95.02 1.895.067 2.844.126.958.062 1.918.15 2.875.25l.28.032c.095.01.188.02.282.032.146.017.292.044.438.062.896.11 1.794.228 2.687.375.62.103 1.227.225 1.844.345.343.066.69.116 1.03.188.725.152 1.437.323 2.157.5.314.076.627.137.94.218.072.02.144.044.218.064.955.253 1.896.516 2.843.812.074.023.148.04.22.063.947.3 1.907.624 2.844.968l.156.062c.955.352 1.902.728 2.844 1.125.05.022.105.04.156.063.942.4 1.885.836 2.813 1.28.042.02.083.043.125.063.935.452 1.862.91 2.78 1.407.034.018.06.045.094.063.927.503 1.842 1.013 2.75 1.563.033.02.062.043.094.062.908.55 1.8 1.122 2.688 1.72.55.368 1.084.768 1.625 1.155.363.26.732.512 1.092.78.02.015.044.02.063.032.878.656 1.74 1.36 2.594 2.063 1.74 1.434 3.43 2.963 5.06 4.594 1.622 1.62 3.137 3.3 4.564 5.03.01.01.022.02.03.03.704.856 1.408 1.716 2.063 2.595.283.38.54.773.813 1.156.37.518.74 1.04 1.094 1.564.016.024.046.038.062.062.598.89 1.167 1.778 1.72 2.688.018.032.042.06.06.094.547.902 1.064 1.83 1.564 2.75.018.032.045.06.062.093.498.922.954 1.845 1.407 2.782l.06.126c.447.93.88 1.868 1.282 2.812.022.05.04.105.063.156.395.936.774 1.895 1.125 2.844.02.053.043.104.062.156.348.95.666 1.885.97 2.844.022.072.04.147.062.22.294.94.56 1.893.812 2.843.02.073.043.145.063.218.08.31.14.628.217.94.177.72.348 1.43.5 2.155.072.342.12.688.188 1.03.12.618.242 1.226.344 1.845.145.893.264 1.79.374 2.688.018.145.045.29.062.437l.03.28c.012.095.022.188.032.282.103.957.19 1.917.25 2.876.06.942.107 1.9.126 2.843 0 .104-.002.21 0 .313.015 1.052.004 2.103-.032 3.155-.03.93-.084 1.853-.156 2.78l-.03.376c-.077.92-.167 1.837-.282 2.75-.12.958-.274 1.925-.438 2.876-.014.083-.017.168-.03.25-.023.125-.04.25-.064.375-.165.91-.358 1.82-.562 2.72-.03.135-.062.272-.094.406-.208.89-.44 1.775-.687 2.656-.165.587-.352 1.168-.533 1.75-.175.565-.34 1.128-.53 1.688-.295.864-.606 1.71-.938 2.563l-.19.468c-.044.114-.078.233-.124.345-.356.88-.728 1.728-1.125 2.594-.376.822-.772 1.625-1.186 2.436-.08.158-.168.312-.25.47-.416.796-.83 1.59-1.282 2.374-.095.166-.184.335-.28.5-.2.34-.42.664-.626 1-.36.59-.742 1.168-1.125 1.75-.004.007.006.024 0 .03-.49.747-1.005 1.49-1.53 2.22-.457.636-.954 1.25-1.438 1.875-.197.254-.36.53-.562.78-.134.17-.27.334-.406.5-.164.202-.334.396-.5.595-.557.667-1.13 1.318-1.72 1.97-.605.67-1.234 1.346-1.874 2-.16.163-.306.336-.47.5-21.13 21.13-52.257 24.494-77.186 11.155l.125-.188c-3.705-1.896-7.263-4.14-10.626-6.78-.54-.424-1.066-.87-1.594-1.313-.514-.43-1.027-.863-1.53-1.313-.094-.082-.19-.165-.283-.25-.82-.747-1.61-1.517-2.406-2.31-.793-.796-1.564-1.586-2.31-2.408-.085-.092-.168-.188-.25-.28-.45-.505-.883-1.018-1.314-1.532-.442-.528-.89-1.055-1.312-1.594-2.64-3.363-4.885-6.92-6.782-10.625l-.187.126c-13.34-24.93-9.974-56.057 11.156-77.187.164-.164.337-.31.5-.47.654-.64 1.33-1.27 2-1.875.652-.588 1.303-1.162 1.97-1.72.272-.226.538-.464.812-.686.344-.28.716-.513 1.063-.783.624-.483 1.24-.98 1.875-1.437.737-.53 1.497-1.036 2.25-1.53.582-.384 1.16-.765 1.75-1.126.447-.274.892-.55 1.344-.813.68-.394 1.37-.756 2.062-1.124.176-.093.355-.19.53-.28.947-.492 1.883-.967 2.845-1.407.867-.398 1.716-.77 2.595-1.126.153-.062.316-.096.47-.157.967-.384 1.923-.758 2.905-1.093.56-.192 1.123-.356 1.687-.532.583-.18 1.164-.367 1.75-.53.882-.247 1.768-.48 2.657-.688.07-.017.147-.015.218-.032.416-.095.833-.193 1.25-.28.673-.142 1.356-.288 2.032-.407.082-.015.167-.017.25-.03.95-.165 1.918-.318 2.875-.44 1.962-.246 3.93-.4 5.905-.468 1.052-.035 2.103-.046 3.156-.03z" transform="matrix(1 .08 0 1 0 -21.06)" clip-path="url(#aF)" filter="url(#aG)"/>
   </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer5"
-     inkscape:label="Magnifying Galss"
-     style="display:inline">
-    <path
-       style="fill:url(#linearGradient6241);fill-opacity:1;stroke:none"
-       d="M 48.010249,227.45683 L 43.202749,232.01466 C 38.19646,226.69951 32.962779,221.30836 28.123445,215.88155 L 32.613667,211.80898 C 39.442824,218.34324 41.486314,220.33887 48.010249,227.45683 z"
-       id="rect5757-8-7-7-9"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#d0e9f2;fill-opacity:0.47593581;stroke:none"
-       d="M -95.5,225 C -66.78119,225 -43.5,248.28119 -43.5,277 C -43.5,305.71881 -66.78119,329 -95.5,329 C -124.21881,329 -147.5,305.71881 -147.5,277 C -147.5,248.28119 -124.21881,225 -95.5,225 z"
-       id="path5604-9-1-8"
-       sodipodi:nodetypes="csssc" />
-    <g
-       id="g6060">
-      <path
-         sodipodi:nodetypes="csssccsssc"
-         id="path5604"
-         d="M -82,136 C -109.61424,136 -132,113.61424 -132,86 C -132,58.38576 -109.61424,36 -82,36 C -54.38576,36 -32,58.38576 -32,86 C -32,113.61424 -54.38576,136 -82,136 z M -82,133 C -55.49033,133 -34,112.50967 -34,86 C -34,59.49033 -55.49033,39 -82,39 C -108.50967,39 -130,59.49033 -130,86 C -130,112.50967 -108.50967,133 -82,133 z"
-         style="fill:#2d3335;fill-opacity:1;stroke:none" />
-      <path
-         id="path5604-2"
-         d="M -82.00007,136 C -109.61431,136 -132.00007,113.61424 -132.00007,86 C -132.00007,85.831721 -132.00207,85.667887 -132.00007,85.5 C -131.72953,112.88199 -109.44603,135 -82.00007,135 C -54.55411,135 -32.27061,112.88199 -32.00007,85.5 C -31.99807,85.667887 -32.00007,85.831721 -32.00007,86 C -32.00007,113.61424 -54.38583,136 -82.00007,136 z M -130.00007,85.5 C -130.00207,85.33281 -130.00007,85.167675 -130.00007,85 C -130.00007,58.49033 -108.50974,38 -82.00007,38 C -55.4904,38 -34.00007,58.49033 -34.00007,85 C -34.00007,85.167675 -33.99807,85.33281 -34.00007,85.5 C -34.26955,59.23424 -55.65808,39 -82.00007,39 C -108.34206,39 -129.73058,59.23424 -130.00007,85.5 z"
-         style="fill:#9eaaac;fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="csssc"
-         id="path5604-9"
-         d="M -82,134 C -55.49033,134 -34,112.50967 -34,86 C -34,59.49033 -55.49033,38 -82,38 C -108.50967,38 -130,59.49033 -130,86 C -130,112.50967 -108.50967,134 -82,134 z"
-         style="fill:#d0e9f2;fill-opacity:0.47593581;stroke:none" />
-      <path
-         sodipodi:nodetypes="csssc"
-         id="path5604-9-1"
-         d="M -82,134 C -55.49033,134 -34,112.50966 -34,86 C -34,59.490325 -55.49033,38 -82,38 C -108.50967,38 -130,59.490325 -130,86 C -130,112.50966 -108.50967,134 -82,134 z"
-         style="fill:url(#radialGradient5751);fill-opacity:1;stroke:none" />
-      <path
-         id="path5604-9-1-8-8"
-         d="M -96.4375,130.71875 L -97.28125,135.71875 C -92.45117,137.2009 -87.31584,138 -82,138 C -76.68416,138 -71.54883,137.2009 -66.71875,135.71875 L -67.5625,130.71875 C -72.11472,132.1879 -76.95892,133 -82,133 C -87.04108,133 -91.88528,132.1879 -96.4375,130.71875 L -96.4375,130.71875 z"
-         style="fill:url(#linearGradient5778);fill-opacity:1;stroke:none" />
-      <path
-         id="rect5757"
-         d="M -82,136.25 C -80.24321,136.25 -78.5686,136.54816 -77,137.0625 L -77,163.6875 C -78.5686,164.20184 -80.24321,164.5 -82,164.5 C -83.75679,164.5 -85.4314,164.20184 -87,163.6875 L -87,137.0625 C -85.4314,136.54816 -83.75679,136.25 -82,136.25 z"
-         style="fill:url(#linearGradient5768);fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="cccsccc"
-         id="rect5757-8-7"
-         d="M -82,150.5 C -78.48642,150.5 -76.3872,151.15272 -74,152.93805 L -74,220.06195 C -77.1372,220.97228 -78.48642,221.5 -82,221.5 C -85.51358,221.5 -86.8628,220.97228 -90,220.06195 L -90,152.93805 C -87.3628,151.15272 -85.51358,150.5 -82,150.5 z"
-         style="fill:url(#linearGradient5868);fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="cccsccc"
-         id="rect5757-8"
-         d="M -82,154.5 C -78.48642,154.5 -74.7622,155.27772 -72,156.93805 L -72,222.06195 C -74.0122,223.84728 -78.48642,224.5 -82,224.5 C -85.51358,224.5 -89.8628,224.34728 -92,222.06195 L -92,156.93805 C -90.1128,155.27772 -85.51358,154.5 -82,154.5 z"
-         style="fill:url(#linearGradient5798);fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="cccsccc"
-         id="rect5757-8-7-7"
-         d="M -82,217.5 C -78.48642,217.5 -76.1372,218.27772 -74,219.93805 L -74,225.06195 C -76.3872,226.59728 -78.48642,227.5 -82,227.5 C -85.51358,227.5 -87.7378,226.59728 -90,225.06195 L -90,219.93805 C -87.6128,218.02772 -85.51358,217.5 -82,217.5 z"
-         style="fill:url(#linearGradient5899);fill-opacity:1;stroke:none" />
-      <path
-         id="rect5757-8-7-7-0"
-         d="M -82,221.5 C -85.51358,221.5 -87.6128,221.77717 -90,223.9375 L -90,225.0625 C -87.7378,226.59783 -85.51358,227.5 -82,227.5 C -78.48642,227.5 -76.3872,226.59783 -74,225.0625 L -74,223.9375 C -76.5122,221.90217 -78.48642,221.5 -82,221.5 z"
-         style="fill:#e0bb41;fill-opacity:1;stroke:none" />
-    </g>
-    <path
-       style="fill:#2d3335;fill-opacity:1;stroke:none"
-       d="M 125.06419,134.68586 C 97.884272,107.50594 97.884272,63.438594 125.06419,36.258677 C 152.24411,9.078759 196.31145,9.078759 223.49137,36.258677 C 250.67129,63.438594 250.67129,107.50594 223.49137,134.68586 C 196.31145,161.86577 152.24411,161.86577 125.06419,134.68586 z M 128.01701,131.73304 C 154.10973,157.82576 195.4301,158.81003 221.52283,132.71731 C 247.61555,106.62459 246.63127,65.304212 220.53855,39.211492 C 194.44583,13.118772 153.12545,12.1345 127.03273,38.22722 C 100.94001,64.319941 101.92428,105.64032 128.01701,131.73304 L 128.01701,131.73304 z"
-       id="path5604-26"
-       sodipodi:nodetypes="csssccsssc" />
-    <path
-       style="fill:#9eaaac;fill-opacity:1;stroke:none"
-       d="M 125.06412,134.68579 C 97.884203,107.50587 97.884203,63.438525 125.06412,36.258608 C 125.22975,36.092975 125.38904,35.92975 125.55626,35.766472 C 98.871221,62.984077 99.034108,106.68723 126.04839,133.70151 C 153.06268,160.7158 196.76583,160.87869 223.98344,134.19365 C 223.82016,134.36087 223.65693,134.52015 223.4913,134.68579 C 196.31138,161.8657 152.24404,161.8657 125.06412,134.68579 z M 127.5248,37.735015 C 127.68739,37.568487 127.8519,37.407917 128.01694,37.24288 C 154.10966,11.150159 195.43004,12.134431 221.52276,38.227151 C 247.61548,64.319872 248.59975,105.64025 222.50703,131.73297 C 222.34199,131.89801 222.18142,132.06252 222.01489,132.22511 C 247.6023,106.10722 246.46616,65.139101 220.53848,39.211423 C 194.61081,13.283745 153.6427,12.14762 127.5248,37.735015 L 127.5248,37.735015 z"
-       id="path5604-2-9" />
-    <path
-       style="fill:#d0e9f2;fill-opacity:0.47593581;stroke:none"
-       d="M 127.03273,132.71731 C 153.12545,158.81003 195.4301,158.81003 221.52283,132.71731 C 247.61555,106.62459 247.61555,64.319941 221.52283,38.22722 C 195.4301,12.1345 153.12545,12.1345 127.03273,38.22722 C 100.94001,64.319941 100.94001,106.62459 127.03273,132.71731 z"
-       id="path5604-9-13"
-       sodipodi:nodetypes="csssc" />
-    <path
-       style="fill:url(#radialGradient6256);fill-opacity:1;stroke:none"
-       d="M 127.03273,132.71731 C 153.12545,158.81003 195.43011,158.81002 221.52283,132.71731 C 247.61555,106.62459 247.61555,64.319941 221.52283,38.22722 C 195.4301,12.1345 153.12546,12.134495 127.03273,38.22722 C 100.94002,64.319931 100.94001,106.62459 127.03273,132.71731 z"
-       id="path5604-9-1-3"
-       sodipodi:nodetypes="csssc" />
-    <path
-       style="fill:url(#linearGradient6253);fill-opacity:1;stroke:none"
-       d="M 116.05195,115.27725 L 110.30011,119.36813 C 113.59539,125.58108 117.86341,131.42217 123.09565,136.6544 C 128.32788,141.88663 134.16897,146.15466 140.38192,149.44993 L 144.4728,143.69809 C 138.54613,140.66352 132.9788,136.69483 128.01701,131.73304 C 123.05521,126.77125 119.08653,121.20391 116.05195,115.27725 L 116.05195,115.27725 z"
-       id="path5604-9-1-8-8-1" />
-    <path
-       style="fill:url(#linearGradient6250);fill-opacity:1;stroke:none"
-       d="M 124.81812,134.93192 C 126.54728,136.66108 127.90208,138.60282 128.93976,140.653 L 102.73352,166.85924 C 100.68334,165.82156 98.741603,164.46676 97.012444,162.7376 C 95.283285,161.00844 93.928484,159.0667 92.890806,157.01652 L 119.09704,130.81029 C 121.14722,131.84796 123.08896,133.20276 124.81812,134.93192 z"
-       id="rect5757-5" />
-    <path
-       style="fill:url(#linearGradient6247);fill-opacity:1;stroke:none"
-       d="M 116.26672,159.23167 L 50.198558,225.29984 C 46.214689,223.10799 44.367269,222.29941 40.908952,218.84109 C 37.450634,215.38278 36.642055,213.53536 34.450209,209.55149 L 100.51837,143.48333 C 105.58172,147.23135 112.63531,153.88125 116.26672,159.23167 z"
-       id="rect5757-8-7-2"
-       sodipodi:nodetypes="ccsccc" />
-    <path
-       style="fill:url(#linearGradient6244);fill-opacity:1;stroke:none"
-       d="M 105.77884,154.11797 C 109.23716,157.57629 113.21364,160.78433 114.29818,165.13731 L 50.198558,229.23692 C 43.682447,224.0819 35.643787,216.44629 30.513122,209.55149 L 94.61274,145.45187 C 98.104474,145.67517 102.27159,150.61074 105.72991,154.06905 L 105.77884,154.11797 z"
-       id="rect5757-8-6"
-       sodipodi:nodetypes="ccccccc" />
-    <path
-       style="opacity:0.59565214;fill:url(#linearGradient6279);fill-opacity:1;stroke:none"
-       d="M 105.53422,154.36259 C 108.99254,157.82091 113.21364,160.78433 114.29818,165.13731 L 50.198558,229.23692 C 42.321633,222.32946 38.401371,218.6125 30.513122,209.55149 L 94.61274,145.45187 C 98.104474,145.67517 102.02698,150.90428 105.4853,154.36259 L 105.53422,154.36259 z"
-       id="rect5757-8-6-3"
-       sodipodi:nodetypes="ccccccc" />
-    <path
-       style="opacity:0.6043478;fill:url(#linearGradient6595);fill-opacity:1;stroke:none"
-       d="M 131.1683,37.049946 C 171.82694,4.876587 209.3036,24.322024 208.95005,42.353247 C 208.5965,60.38447 152.38151,112.71037 132.58252,108.46773 C 112.78353,104.22509 107.12667,55.081169 131.1683,37.049946 z"
-       id="path6587" />
-    <text
-       xml:space="preserve"
-       style="font-size:19.79973221px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;opacity:0.46086958;fill:url(#radialGradient6482);fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-       x="99.83886"
-       y="69.184349"
-       id="text6302-7"
-       transform="matrix(0.9879609,-0.1547039,0.1547039,0.9879609,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan6304-0"
-         x="99.83886"
-         y="69.184349"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:url(#radialGradient6482);fill-opacity:1;font-family:Monospace;-inkscape-font-specification:Monospace Bold">01011001</tspan><tspan
-         sodipodi:role="line"
-         x="99.83886"
-         y="93.934013"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:url(#radialGradient6482);fill-opacity:1;font-family:Monospace;-inkscape-font-specification:Monospace Bold"
-         id="tspan6415-7">00110101</tspan><tspan
-         sodipodi:role="line"
-         x="99.83886"
-         y="118.68368"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:url(#radialGradient6482);fill-opacity:1;font-family:Monospace;-inkscape-font-specification:Monospace Bold"
-         id="tspan6417-1">10010011</tspan><tspan
-         sodipodi:role="line"
-         x="99.83886"
-         y="143.43335"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:url(#radialGradient6482);fill-opacity:1;font-family:Monospace;-inkscape-font-specification:Monospace Bold"
-         id="tspan6419-9" /></text>
-    <text
-       xml:space="preserve"
-       style="font-size:19.79973221px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:url(#radialGradient6427);fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-       x="99.410172"
-       y="67.898323"
-       id="text6302"
-       transform="matrix(0.9879609,-0.1547039,0.1547039,0.9879609,0,0)"><tspan
-         sodipodi:role="line"
-         id="tspan6304"
-         x="99.410172"
-         y="67.898323"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:url(#radialGradient6427);fill-opacity:1;font-family:Monospace;-inkscape-font-specification:Monospace Bold">01011001</tspan><tspan
-         sodipodi:role="line"
-         x="99.410172"
-         y="92.647987"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:url(#radialGradient6427);fill-opacity:1;font-family:Monospace;-inkscape-font-specification:Monospace Bold"
-         id="tspan6415">00110101</tspan><tspan
-         sodipodi:role="line"
-         x="99.410172"
-         y="117.39765"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:url(#radialGradient6427);fill-opacity:1;font-family:Monospace;-inkscape-font-specification:Monospace Bold"
-         id="tspan6417">10010011</tspan><tspan
-         sodipodi:role="line"
-         x="99.410172"
-         y="142.14732"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:url(#radialGradient6427);fill-opacity:1;font-family:Monospace;-inkscape-font-specification:Monospace Bold"
-         id="tspan6419" /></text>
-    <path
-       style="opacity:0.76521738;fill:url(#linearGradient6614);fill-opacity:1;stroke:none"
-       d="M 219.46318,129.09019 C 192.66917,151.07299 177.65484,150.09749 181.38844,142.22816 C 185.12205,134.35887 223.71429,100.57298 232.83561,98.47996 C 241.95691,96.38695 235.11079,116.52117 219.46318,129.09019 z"
-       id="path6587-7" />
+  <g>
+    <path fill="url(#aH)" d="M48.01 227.457l-4.807 4.558c-5.007-5.315-10.24-10.707-15.08-16.133l4.49-4.073c6.83 6.533 8.873 8.53 15.397 15.647z"/>
+    <path fill="#d0e9f2" fill-opacity=".476" d="M-95.5 225c28.72 0 52 23.28 52 52s-23.28 52-52 52-52-23.28-52-52 23.28-52 52-52z"/>
+    <path fill="#2d3335" d="M-82 136c-27.614 0-50-22.386-50-50s22.386-50 50-50 50 22.386 50 50-22.386 50-50 50zm0-3c26.51 0 48-20.49 48-47s-21.49-47-48-47-48 20.49-48 47 21.49 47 48 47z"/>
+    <path fill="#9eaaac" d="M-82 136c-27.614 0-50-22.386-50-50 0-.168-.002-.332 0-.5.27 27.382 22.554 49.5 50 49.5s49.73-22.118 50-49.5c.002.168 0 .332 0 .5 0 27.614-22.386 50-50 50zm-48-50.5c-.002-.167 0-.332 0-.5 0-26.51 21.49-47 48-47s48 20.49 48 47c0 .168.002.333 0 .5C-34.27 59.234-55.658 39-82 39s-47.73 20.234-48 46.5z"/>
+    <path fill="#d0e9f2" fill-opacity=".476" d="M-82 134c26.51 0 48-21.49 48-48s-21.49-48-48-48-48 21.49-48 48 21.49 48 48 48z"/>
+    <path fill="url(#aI)" d="M-82 134c26.51 0 48-21.49 48-48s-21.49-48-48-48-48 21.49-48 48 21.49 48 48 48z"/>
+    <path fill="url(#aJ)" d="M-96.438 130.72l-.843 5C-92.45 137.2-87.317 138-82 138c5.316 0 10.45-.8 15.28-2.28l-.843-5C-72.114 132.187-76.96 133-82 133c-5.04 0-9.885-.812-14.438-2.28z"/>
+    <path fill="url(#aK)" d="M-82 136.25c1.757 0 3.43.298 5 .813v26.625c-1.57.514-3.243.812-5 .812-1.757 0-3.43-.298-5-.813v-26.625c1.57-.514 3.243-.812 5-.812z"/>
+    <path fill="url(#aL)" d="M-82 150.5c3.514 0 5.613.653 8 2.438v67.124c-3.137.91-4.486 1.438-8 1.438-3.514 0-4.863-.528-8-1.438v-67.124c2.637-1.785 4.486-2.438 8-2.438z"/>
+    <path fill="url(#aM)" d="M-82 154.5c3.514 0 7.238.778 10 2.438v65.124c-2.012 1.785-6.486 2.438-10 2.438-3.514 0-7.863-.153-10-2.438v-65.124c1.887-1.66 6.486-2.438 10-2.438z"/>
+    <path fill="url(#aN)" d="M-82 217.5c3.514 0 5.863.778 8 2.438v5.124c-2.387 1.535-4.486 2.438-8 2.438-3.514 0-5.738-.903-8-2.438v-5.124c2.387-1.91 4.486-2.438 8-2.438z"/>
+    <path fill="#e0bb41" d="M-82 221.5c-3.514 0-5.613.277-8 2.438v1.125c2.262 1.535 4.486 2.437 8 2.437 3.514 0 5.613-.902 8-2.438v-1.125c-2.512-2.035-4.486-2.437-8-2.437z"/>
+    <path fill="#2d3335" d="M125.064 134.686c-27.18-27.18-27.18-71.247 0-98.427 27.18-27.18 71.247-27.18 98.427 0 27.18 27.18 27.18 71.246 0 98.426-27.18 27.18-71.246 27.18-98.426 0zm2.953-2.953c26.093 26.093 67.413 27.077 93.506.984 26.093-26.092 25.108-67.413-.984-93.506-26.094-26.09-67.415-27.076-93.507-.983-26.093 26.093-25.11 67.413.984 93.506z"/>
+    <path fill="#9eaaac" d="M125.064 134.686c-27.18-27.18-27.18-71.247 0-98.427.166-.167.325-.33.492-.494-26.685 27.218-26.522 70.92.492 97.936 27.015 27.014 70.718 27.177 97.935.492-.163.167-.326.326-.492.492-27.18 27.18-71.246 27.18-98.426 0zm2.46-96.95c.163-.168.328-.328.493-.493 26.093-26.093 67.413-25.11 93.506.984 26.092 26.093 27.077 67.413.984 93.506-.165.165-.326.33-.492.492 25.587-26.118 24.45-67.086-1.477-93.014-25.927-25.926-66.895-27.062-93.013-1.475z"/>
+    <path fill="#d0e9f2" fill-opacity=".476" d="M127.033 132.717c26.092 26.093 68.397 26.093 94.49 0 26.093-26.092 26.093-68.397 0-94.49-26.093-26.092-68.398-26.092-94.49 0-26.093 26.093-26.093 68.398 0 94.49z"/>
+    <path fill="url(#aO)" d="M127.033 132.717c26.092 26.093 68.397 26.093 94.49 0 26.093-26.092 26.093-68.397 0-94.49-26.093-26.092-68.398-26.093-94.49 0-26.093 26.093-26.093 68.398 0 94.49z"/>
+    <path fill="url(#aP)" d="M116.052 115.277l-5.752 4.09c3.295 6.214 7.563 12.055 12.796 17.287 5.232 5.233 11.073 9.5 17.286 12.796l4.09-5.752c-5.926-3.034-11.493-7.003-16.455-11.965-4.962-4.962-8.93-10.53-11.965-16.456z"/>
+    <path fill="url(#aQ)" d="M124.818 134.932c1.73 1.73 3.084 3.67 4.122 5.72l-26.206 26.207c-2.05-1.038-3.992-2.393-5.722-4.122-1.73-1.73-3.084-3.67-4.12-5.72l26.205-26.208c2.05 1.038 3.992 2.393 5.72 4.122z"/>
+    <path fill="url(#aR)" d="M116.267 159.232L50.2 225.3c-3.985-2.192-5.833-3-9.29-6.46-3.46-3.457-4.268-5.305-6.46-9.29l66.068-66.067c5.064 3.748 12.117 10.398 15.75 15.75z"/>
+    <path fill="url(#aS)" d="M105.78 154.118c3.457 3.458 7.434 6.666 8.518 11.02l-64.1 64.1c-6.516-5.156-14.554-12.792-19.685-19.687l64.1-64.098c3.49.223 7.66 5.16 11.117 8.617l.05.048z"/>
+    <path fill="url(#aT)" d="M105.534 154.363c3.46 3.458 7.68 6.42 8.764 10.774l-64.1 64.1c-7.876-6.908-11.797-10.624-19.685-19.686l64.1-64.098c3.49.223 7.414 5.452 10.872 8.91h.05z" opacity=".596"/>
+    <path fill="url(#aU)" d="M131.168 37.05c40.66-32.173 78.136-12.728 77.782 5.303-.353 18.03-56.568 70.357-76.367 66.115-19.8-4.243-25.456-53.387-1.415-71.418z" opacity=".604"/>
+    <text x="99.839" y="69.184" fill="url(#aV)" style="-inkscape-font-specification:Sans" transform="rotate(-8.9)" font-size="19.8" opacity=".461" font-family="Sans">
+      <tspan x="99.839" y="69.184" style="-inkscape-font-specification:Monospace Bold" font-weight="bold" font-family="Monospace">01011001</tspan><tspan x="99.839" y="93.934" style="-inkscape-font-specification:Monospace Bold" font-weight="bold" font-family="Monospace">00110101</tspan><tspan x="99.839" y="118.684" style="-inkscape-font-specification:Monospace Bold" font-weight="bold" font-family="Monospace">10010011</tspan>
+    </text>
+    <text x="99.41" y="67.898" fill="url(#aW)" style="-inkscape-font-specification:Sans" transform="rotate(-8.9)" font-size="19.8" font-family="Sans">
+      <tspan x="99.41" y="67.898" style="-inkscape-font-specification:Monospace Bold" font-weight="bold" font-family="Monospace">01011001</tspan><tspan x="99.41" y="92.648" style="-inkscape-font-specification:Monospace Bold" font-weight="bold" font-family="Monospace">00110101</tspan><tspan x="99.41" y="117.398" style="-inkscape-font-specification:Monospace Bold" font-weight="bold" font-family="Monospace">10010011</tspan>
+    </text>
+    <path fill="url(#aX)" d="M219.463 129.09c-26.794 21.983-41.808 21.007-38.075 13.138 3.734-7.87 42.326-41.655 51.448-43.748 9.12-2.093 2.275 18.04-13.373 30.61z" opacity=".765"/>
   </g>
 </svg>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,10 @@
 <header class="closed">
   <h1>
     <a href="<%= root_path %>" class="geolink">
-      <%= image_tag "osm_logo.png", :alt => t('layouts.logo.alt_text'), :class => 'logo' %>
+      <picture>
+        <source media="(-webkit-min-device-pixel-ratio: 2, min-resolution: 150dpi)" srcset="<%= image_path "osm_logo.svg" %>" type="image/svg+xml">
+        <%= image_tag "osm_logo.png", :alt => t('layouts.logo.alt_text'), :class => 'logo' %>
+      </picture>
       <%= t 'layouts.project_name.h1' %>
     </a>
   </h1>


### PR DESCRIPTION
modern browsers with high DPI screen will load svg which is a little bigger but retina enabled

partial fix for #850 