### PR TITLE
sprite.svg: converted inkscape font info to font-family

### DIFF
--- a/app/assets/images/sprite.svg
+++ b/app/assets/images/sprite.svg
@@ -271,7 +271,7 @@
        inkscape:export-ydpi="90" />
     <text
        xml:space="preserve"
-       style="font-size:20px;font-style:normal;font-weight:bold;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans Bold"
+       style="font-size:20px;font-style:normal;font-weight:bold;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:'DejaVu Sans', Sans, sans-serif"
        x="264.8125"
        y="869.62622"
        id="text3021"


### PR DESCRIPTION
With this change the visual style is similar to the PNG. 
Right now we have a Times question mark on windows.
`'DejaVu Sans', Sans, sans-serif` is rendered with Arial on windows which looks the same as DejaVu.

BTW travis does not have svgo installed :)

relates to #1055