### PR TITLE
adding srcset for osm logo img

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
     <a href="<%= root_path %>" class="geolink">
       <picture>
         <source srcset="<%= image_path "osm_logo.svg" %>" type="image/svg+xml">
-        <%= image_tag "osm_logo.png", :alt => t('layouts.logo.alt_text'), :class => 'logo' %>
+        <img src="<%= image_path "osm_logo.png" %>" srcset="<%= image_path "osm_logo.svg" %>" alt="<%= t('layouts.logo.alt_text') %>" class="logo">
       </picture>
       <%= t 'layouts.project_name.h1' %>
     </a>


### PR DESCRIPTION
This way we can support Safari and Internet Explorer, which does not support `picture` element, but `srcset` on the `img` tag.

related to #850 