### PR TITLE
Close html <source> tags

### DIFF
--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,7 +1,7 @@
 <% if flash[:error] %>
   <div class="flash error">
     <picture>
-      <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml">
+      <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>
       <%= image_tag("notice.png", :srcset => image_path("notice.svg"), :class => "small_icon", :border => 0) %>
     </picture>
     <div class="message"><%= flash[:error] %></div>
@@ -11,7 +11,7 @@
 <% if flash[:warning] %>
   <div class="flash warning">
     <picture>
-      <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml">
+      <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>
       <%= image_tag("notice.png", :srcset => image_path("notice.svg"), :class => "small_icon", :border => 0) %>
     </picture>
     <div class="message"><%= flash[:warning] %></div>
@@ -21,7 +21,7 @@
 <% if flash[:notice] %>
   <div class="flash notice">
     <picture>
-      <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml">
+      <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>
       <%= image_tag("notice.png", :srcset => image_path("notice.svg"), :class => "small_icon", :border => 0) %>
     </picture>
     <div class="message"><%= flash[:notice] %></div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,7 +2,7 @@
   <h1>
     <a href="<%= root_path %>" class="geolink">
       <picture>
-        <source srcset="<%= image_path "osm_logo.svg" %>" type="image/svg+xml">
+        <source srcset="<%= image_path "osm_logo.svg" %>" type="image/svg+xml"></source>
         <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t('layouts.logo.alt_text'), :class => 'logo' %>
       </picture>
       <%= t 'layouts.project_name.h1' %>


### PR DESCRIPTION
Apparently this unclosed tag didn't break anything but judging from the
fact that this was the only unclosed tag and was introduced recently,
it probably wasn't intended.  The unit tests did expect the tag to be
closed.