### PR TITLE
Remove inline property of secondary links on diary page

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1588,10 +1588,6 @@ tr.turn:hover {
     float: left;
     display: block;
   }
-
-  ul.secondary-actions {
-    display: inline-block;
-  }
 }
 
 .content-heading .hide_unless_logged_in { // hacky selector, better to just add a new class to this div


### PR DESCRIPTION
Is there any particular reason for secondary links being inline? They are on next line if location is long enough anyway. This PR changes this:
![screenshot from 2015-10-26 12 06 40](https://cloud.githubusercontent.com/assets/7680662/10723183/3f619024-7bde-11e5-850c-a9578e68eac4.png)
to this:
![screenshot from 2015-10-26 12 37 43](https://cloud.githubusercontent.com/assets/7680662/10723228/b35984d2-7bde-11e5-8c4c-4db7f9d8f4e9.png)


