### PR TITLE
Make list items highlighting visible

### DIFF
--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -15,5 +15,5 @@ $headerHeight: 55px;
 $sidebarWidth: 350px;
 $keyline: 1px solid $lightgrey;
 $border-radius: 3px;
-$list-highlight: #FFFFE6;
+$list-highlight: #FFFFC0;
 $border: 1px solid $grey;


### PR DESCRIPTION
For instance on page `http://www.openstreetmap.org/user/%username%/history` when mouse hovers over changeset rectangle on the map, corresspoding changeset is highlighted in sidebar. This should make it easy to spot desired changeset in whole list, but current highlighting too close to white background, it's not visible at all!