### PR TITLE
Remove HTML entities from user.auth association

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1785,16 +1785,7 @@ en:
       confirm password: "Confirm Password:"
       use external auth: "Alternatively, use a third party to login"
       auth no password: "With third party authentication a password is not required, but some extra tools or server may still need one."
-      auth association: |
-        <p>Your ID is not associated with a OpenStreetMap account yet.</p>
-        <ul>
-          <li>If you are new to OpenStreetMap, please create a new account using the form below.</li>
-          <li>
-            If you already have an account, you can login to your account
-            using your username and password and then associate the account
-            with your ID in your user settings.
-          </li>
-        </ul>
+      auth association: "Your ID is not associated with a OpenStreetMap account yet. If you are new to OpenStreetMap, please create a new account using the form below. Otherwise, you can login to your account using your username and password and then associate the account with your ID in your user settings."
       continue: Sign Up
       terms accepted: "Thanks for accepting the new contributor terms!"
       terms declined: "We are sorry that you have decided to not accept the new Contributor Terms. For more information, please see <a href=\"%{url}\">this wiki page</a>."


### PR DESCRIPTION
Flashes do not support raw HTML, and if they did, this HTML code would look bad (I've checked). So In this PR I remove all HTML formatting from the message that appears when a user logs in via omniauth, but has no osm account tied to it.

Obviously, it would require redoing all the translations. Not sure if there is an easy way.