### PR TITLE
Facebook emails are verified

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -497,7 +497,7 @@ class UserController < ApplicationController
     when "openid"
       email_verified = uid.match(%r{https://www.google.com/accounts/o8/id?(.*)}) ||
                        uid.match(%r{https://me.yahoo.com/(.*)})
-    when "google"
+    when "google", "facebook"
       email_verified = true
     else
       email_verified = false


### PR DESCRIPTION
E-mail addresses aquired bia Facebook Graph API (that is, OAuth) are always verified. If not, they are not returned at all. See [this stackoverflow explanation](http://stackoverflow.com/questions/14280535/is-it-possible-to-check-if-an-email-is-confirmed-on-facebook).

This PR enables confirm-less registration workflow for users registering via Facebook.