### PR TITLE
Allow closing the sidebar when a timeout occured

### DIFF
--- a/app/views/browse/timeout.html.erb
+++ b/app/views/browse/timeout.html.erb
@@ -6,4 +6,7 @@
     'changeset' => I18n.t('browse.timeout.type.changeset'),
   };
 %>
-<p><%= t'browse.timeout.sorry', :type=> browse_timeout_type[@type] , :id => params[:id] %></p>
+<div class="browse-section">
+  <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
+  <%= t'browse.timeout.sorry', :type=> browse_timeout_type[@type] , :id => params[:id] %>
+</div>


### PR DESCRIPTION
This adds an `X` to the sidebar, in order to allow the user to close the sidebar after a timeout occured (happens e.g. for objects with long history).

Before/after-comparison:
![timeout-close](https://cloud.githubusercontent.com/assets/3904348/11610239/d312d386-9b9c-11e5-95c8-359c2bfb153c.gif)

