### PR TITLE
Add facebook access token authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem "omniauth"
 gem "omniauth-openid"
 gem "omniauth-google-oauth2", ">= 0.2.7"
 gem "omniauth-facebook"
+gem "omniauth-facebook-access-token"
 gem "omniauth-windowslive"
 gem "omniauth-github"
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -33,6 +33,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :openid, openid_options
   provider :google_oauth2, GOOGLE_AUTH_ID, GOOGLE_AUTH_SECRET, google_options if defined?(GOOGLE_AUTH_ID)
   provider :facebook, FACEBOOK_AUTH_ID, FACEBOOK_AUTH_SECRET, facebook_options if defined?(FACEBOOK_AUTH_ID)
+  provider :facebook_access_token, FACEBOOK_AUTH_ID, FACEBOOK_AUTH_SECRET if defined?(FACEBOOK_AUTH_ID)
   provider :windowslive, WINDOWSLIVE_AUTH_ID, WINDOWSLIVE_AUTH_SECRET, windowslive_options if defined?(WINDOWSLIVE_AUTH_ID)
   provider :github, GITHUB_AUTH_ID, GITHUB_AUTH_SECRET, github_options if defined?(GITHUB_AUTH_ID)
 end


### PR DESCRIPTION
This adds a long-term facebook access token authentication, in addition to short-term tokens used by `omniauth-facebook`. It allows for native mobile Facebook SDKs. Well, for now ony for a hypothetical app that OSM itself would publish, but after a discussion on OWG mailing list, maybe for other external apps too.
