### PR TITLE
Add Host: to robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -17,3 +17,5 @@ Disallow: /*lat=
 Disallow: /*node=
 Disallow: /*way=
 Disallow: /*relation=
+
+Host: www.openstreetmap.org


### PR DESCRIPTION
Add a Host: which is an extension to the robots.txt standard. https://en.wikipedia.org/wiki/Robots_exclusion_standard#Host

Googlebot particularly seems to be incorrectly indexing the spike-0x host urls.