### PR TITLE
Vagrant: Virtualbox: increase RAM and put 2 CPUs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,9 +3,11 @@
 
 Vagrant.configure("2") do |config|
   # use official ubuntu image for virtualbox
-  config.vm.provider "virtualbox" do |_, override|
+  config.vm.provider "virtualbox" do |vb, override|
     override.vm.box = "ubuntu/trusty64"
     override.vm.synced_folder ".", "/srv/openstreetmap-website"
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--cpus", "2"]
   end
 
   # use third party image and NFS sharing for lxc


### PR DESCRIPTION
Because some tests were crashing by lack to RAM.
Once, even a part of the provisioning failed with an out of memory error.

And a second core speeds up the provisioning and the tests.

I can't test for lxc and libvirt so I only edited virtualbox config.