### PR TITLE
Vagrant fix provision script + fix locale errors

### DIFF
--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # set locale to UTF-8 compatible. apologies to non-english speakers...
+locale-gen en_GB.utf8
 update-locale LANG=en_GB.utf8 LC_ALL=en_GB.utf8
-locale-gen
 export LANG=en_GB.utf8
 export LC_ALL=en_GB.utf8
 

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -13,12 +13,12 @@ apt-get update
 apt-get upgrade -y
 
 # install packages as explained in INSTALL.md
-apt-get install -y ruby1.9.1 libruby1.9.1 ruby1.9.1-dev ri1.9.1 \
-    libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
-    apache2 apache2-threaded-dev build-essential git-core \
-    postgresql postgresql-contrib libpq-dev postgresql-server-dev-all \
-    libsasl2-dev
-gem1.9.1 install bundle
+apt-get install -y ruby2.0 libruby2.0 ruby2.0-dev \
+                     libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
+                     apache2 apache2-threaded-dev build-essential git-core \
+                     postgresql postgresql-contrib libpq-dev postgresql-server-dev-all \
+                     libsasl2-dev imagemagick
+gem2.0 install bundler
 
 ## install the bundle necessary for openstreetmap-website
 pushd /srv/openstreetmap-website


### PR DESCRIPTION
`bundle install` was failing because of missing ruby2.0.
And `rake db:migrate` was also failing subsequently.

The only locale related error remaining is:
```
==> default: Generating locales...
==> default:   en_GB.UTF-8... 
==> default: done
==> default: Generation complete.
==> default: /tmp/vagrant-shell: line 7: warning: setlocale: LC_ALL: cannot change locale (en_GB.utf8)
```
It seems to be `update-locale LANG=en_GB.utf8 LC_ALL=en_GB.utf8`