### PR TITLE
Fix "Report a problem" link in embedded map

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -51,7 +51,7 @@ window.onload = function () {
 L.Control.OSMReportAProblem = L.Control.Attribution.extend({
   options: {
     position: 'bottomright',
-    prefix: '<a href="http://www.openstreetmap.org/fixthemap?lat={x}&lon={y}&zoom={z}">Report a problem</a>'
+    prefix: '<a href="http://www.openstreetmap.org/fixthemap?lat={x}&lon={y}&zoom={z}" target="_blank">Report a problem</a>'
   },
 
   onAdd: function (map) {

--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -51,7 +51,7 @@ window.onload = function () {
 L.Control.OSMReportAProblem = L.Control.Attribution.extend({
   options: {
     position: 'bottomright',
-    prefix: '<a href="http://www.openstreetmap.org/fixthemap?lat={x}&lon={y}&zoom={z}" target="_blank">Report a problem</a>'
+    prefix: '<a href="http://www.openstreetmap.org/fixthemap?lat={x}&lon={y}&zoom={z}" target="_blank">'+I18n.t('javascripts.embed.report_problem')+'</a>'
   },
 
   onAdd: function (map) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2171,6 +2171,8 @@ en:
       center_marker: "Center map on marker"
       paste_html: "Paste HTML to embed in website"
       view_larger_map: "View Larger Map"
+    embed:
+      report_problem: "Report a problem"
     key:
       title: "Map Key"
       tooltip: "Map Key"


### PR DESCRIPTION
You can find a demo of the problem here: http://floscher.github.io/openstreetmap-website/demo.html
The first map is the current `embed.html`, the second map incorporates my proposed change.

Previously when you embedded a map with the HTML from the share-menu on http://osm.org, the link "Report a problem" was broken, because some browsers (at least Firefox 43 and Chromium 47) denied to open that link.

In Firefox the map is turning invisible and I get the following error message in the developer console:
```
Load denied by X-Frame-Options: http://www.openstreetmap.org/fixthemap?lat=0&lon=1.40625&zoom=0 does not permit cross-origin framing.
```

In Chromium simply nothing happens and the developer console shows:
```
Refused to display 'http://www.openstreetmap.org/fixthemap?lat=-1.1449996853268662e-13&lon=0&zoom=0' in a frame because it set 'X-Frame-Options' to 'SAMEORIGIN'.
```

I fixed that problem by setting the attribute `target="_blank"` for that link, so it now opens in a new tab.

I also added the text of this link to the translatable strings.