### PR TITLE
Don't allow characters which aren't valid in XML 1.0.

### DIFF
--- a/app/models/changeset_comment.rb
+++ b/app/models/changeset_comment.rb
@@ -7,6 +7,8 @@ class ChangesetComment < ActiveRecord::Base
   validates :changeset, :presence => true, :associated => true
   validates :author, :presence => true, :associated => true
   validates :visible, :inclusion => [true, false]
+  # don't allow characters not valid in XML 1.0
+  validates :body, :format => /\A[^\x00-\x08\x0b-\x0c\x0e-\x1f\x7f\ufffe\uffff]*\z/
 
   # Return the comment text
   def body


### PR DESCRIPTION
The "real fix" for https://github.com/openstreetmap/chef/pull/51.
