### PR TITLE
Do not hyperlink profiles of deleted users

### DIFF
--- a/app/helpers/changeset_helper.rb
+++ b/app/helpers/changeset_helper.rb
@@ -1,6 +1,6 @@
 module ChangesetHelper
   def changeset_user_link(changeset)
-    if changeset.user.data_public?
+    if changeset.user.status != "deleted" && changeset.user.data_public?
       link_to(changeset.user.display_name, user_path(changeset.user.display_name))
     else
       t("browse.anonymous")

--- a/app/helpers/changeset_helper.rb
+++ b/app/helpers/changeset_helper.rb
@@ -1,6 +1,8 @@
 module ChangesetHelper
   def changeset_user_link(changeset)
-    if changeset.user.status != "deleted" && changeset.user.data_public?
+    if changeset.user.status == "deleted"
+      t("user.no_such_user.deleted")
+    elsif changeset.user.data_public?
       link_to(changeset.user.display_name, user_path(changeset.user.display_name))
     else
       t("browse.anonymous")

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -17,6 +17,8 @@ module NoteHelper
   def note_author(author, link_options = {})
     if author.nil?
       ""
+    elsif author.status == "deleted"
+      t("browse.anonymous")
     else
       link_to h(author.display_name), link_options.merge(:controller => "user", :action => "view", :display_name => author.display_name)
     end

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -18,7 +18,7 @@ module NoteHelper
     if author.nil?
       ""
     elsif author.status == "deleted"
-      t("browse.anonymous")
+      t("user.no_such_user.deleted")
     else
       link_to h(author.display_name), link_options.merge(:controller => "user", :action => "view", :display_name => author.display_name)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1810,6 +1810,7 @@ en:
       title: "No such user"
       heading: "The user %{user} does not exist"
       body: "Sorry, there is no user with the name %{user}. Please check your spelling, or maybe the link you clicked is wrong."
+      deleted: "deleted"
     view:
       my diary: My Diary
       new diary entry: new diary entry

--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -1574,7 +1574,7 @@ EOF
 
     get :query, :closed => "true"
     assert_response :success, "can't get changesets by closed-ness"
-    assert_changesets [3, 5, 6, 7, 8]
+    assert_changesets [3, 5, 6, 7, 8, 9]
 
     get :query, :closed => "true", :user => users(:normal_user).id
     assert_response :success, "can't get changesets by closed-ness and user"

--- a/test/fixtures/changesets.yml
+++ b/test/fixtures/changesets.yml
@@ -21,6 +21,13 @@ public_user_first_change:
   closed_at: <%= Time.now.utc + 86400 %>
   num_changes: 0
 
+deleted_user_first_change:
+  id: 9
+  user_id: 11
+  created_at: "2007-01-01 00:00:00"
+  closed_at: "2007-01-02 00:00:00"
+  num_changes: 0
+
 normal_user_closed_change:
   id: 3
   user_id: 1

--- a/test/helpers/changeset_helper_test.rb
+++ b/test/helpers/changeset_helper_test.rb
@@ -6,7 +6,7 @@ class ChangesetHelperTest < ActionView::TestCase
   def test_changeset_user_link
     assert_equal "<a href=\"/user/test2\">test2</a>", changeset_user_link(changesets(:public_user_first_change))
     assert_equal "anonymous", changeset_user_link(changesets(:normal_user_first_change))
-    assert_equal "anonymous", changeset_user_link(changesets(:deleted_user_first_change))
+    assert_equal "deleted", changeset_user_link(changesets(:deleted_user_first_change))
   end
 
   def test_changeset_details

--- a/test/helpers/changeset_helper_test.rb
+++ b/test/helpers/changeset_helper_test.rb
@@ -6,6 +6,7 @@ class ChangesetHelperTest < ActionView::TestCase
   def test_changeset_user_link
     assert_equal "<a href=\"/user/test2\">test2</a>", changeset_user_link(changesets(:public_user_first_change))
     assert_equal "anonymous", changeset_user_link(changesets(:normal_user_first_change))
+    assert_equal "anonymous", changeset_user_link(changesets(:deleted_user_first_change))
   end
 
   def test_changeset_details

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -15,6 +15,7 @@ class NoteHelperTest < ActionView::TestCase
 
   def test_note_author
     assert_equal "", note_author(nil)
+    assert_equal "anonymous", note_author(users(:deleted_user))
     assert_equal "<a href=\"/user/test2\">test2</a>", note_author(users(:public_user))
     assert_equal "<a href=\"http://test.host/user/test2\">test2</a>", note_author(users(:public_user), :only_path => false)
   end

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -15,7 +15,7 @@ class NoteHelperTest < ActionView::TestCase
 
   def test_note_author
     assert_equal "", note_author(nil)
-    assert_equal "anonymous", note_author(users(:deleted_user))
+    assert_equal "deleted", note_author(users(:deleted_user))
     assert_equal "<a href=\"/user/test2\">test2</a>", note_author(users(:public_user))
     assert_equal "<a href=\"http://test.host/user/test2\">test2</a>", note_author(users(:public_user), :only_path => false)
   end

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -4,7 +4,7 @@ class ChangesetTest < ActiveSupport::TestCase
   api_fixtures
 
   def test_changeset_count
-    assert_equal 8, Changeset.count
+    assert_equal 9, Changeset.count
   end
 
   def test_from_xml_no_text


### PR DESCRIPTION
`anonymous` is closest thing I could find in yml files for internationalization, should I create a new tag named 'DELETED' like #579 suggests?

Related: #1069 