### PR TITLE
Allow the hiding of changeset tags

### DIFF
--- a/app/controllers/changeset_controller.rb
+++ b/app/controllers/changeset_controller.rb
@@ -389,7 +389,7 @@ class ChangesetController < ApplicationController
     # Extract the arguments
     id = params[:id].to_i
 
-    # Find the changeset
+    # Find the comment
     comment = ChangesetComment.find(id)
 
     # Hide the comment
@@ -408,7 +408,7 @@ class ChangesetController < ApplicationController
     # Extract the arguments
     id = params[:id].to_i
 
-    # Find the changeset
+    # Find the comment
     comment = ChangesetComment.find(id)
 
     # Unhide the comment
@@ -416,6 +416,44 @@ class ChangesetController < ApplicationController
 
     # Return a copy of the updated changeset
     render :text => comment.changeset.to_xml.to_s, :content_type => "text/xml"
+  end
+
+  ##
+  # Hide tags
+  def hide_tags
+    # Check the arguments are sane
+    raise OSM::APIBadUserInput.new("No id was given") unless params[:id]
+
+    # Extract the arguments
+    id = params[:id].to_i
+
+    # Find the changeset
+    changeset = Changeset.find(id)
+
+    # Hide the tags
+    changeset.update(:tags_hidden => true)
+
+    # Return a copy of the updated changeset
+    render :text => changeset.to_xml.to_s, :content_type => "text/xml"
+  end
+
+  ##
+  # Un-Hide tags
+  def unhide_tags
+    # Check the arguments are sane
+    raise OSM::APIBadUserInput.new("No id was given") unless params[:id]
+
+    # Extract the arguments
+    id = params[:id].to_i
+
+    # Find the changeset
+    changeset = Changeset.find(id)
+
+    # Unhide the tags
+    changeset.update(:tags_hidden => false)
+
+    # Return a copy of the updated changeset
+    render :text => changeset.to_xml.to_s, :content_type => "text/xml"
   end
 
   ##
@@ -442,6 +480,7 @@ class ChangesetController < ApplicationController
   rescue OSM::APIBadUserInput
     render :text => "", :status => :bad_request
   end
+
 
   private
 

--- a/app/helpers/changeset_helper.rb
+++ b/app/helpers/changeset_helper.rb
@@ -31,4 +31,14 @@ module ChangesetHelper
         :user => changeset_user_link(changeset)
     end
   end
+
+  def changeset_comment_or_nocomment(changeset)
+    if !changeset.tags['comment'].present
+      t("browse.no_comment")
+    elsif changeset.tags_hidden
+      t("browse.tags_hidden")
+    else
+      changeset.tags['comment']
+    end
+  end
 end

--- a/app/helpers/changeset_helper.rb
+++ b/app/helpers/changeset_helper.rb
@@ -33,7 +33,7 @@ module ChangesetHelper
   end
 
   def changeset_comment_or_nocomment(changeset)
-    if !changeset.tags['comment'].present
+    if !changeset.tags['comment'].present?
       t("browse.no_comment")
     elsif changeset.tags_hidden
       t("browse.tags_hidden")

--- a/app/helpers/changeset_helper.rb
+++ b/app/helpers/changeset_helper.rb
@@ -32,10 +32,10 @@ module ChangesetHelper
     end
   end
 
-  def changeset_comment_or_nocomment(changeset)
+  def changeset_comment_or_nocomment(changeset, moderator = false)
     if !changeset.tags['comment'].present?
       t("browse.no_comment")
-    elsif changeset.tags_hidden
+    elsif changeset.tags_hidden and !moderator
       t("browse.tags_hidden")
     else
       changeset.tags['comment']

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,9 +1,5 @@
 <h4>
-  <% if common_details.changeset.tags['comment'].present? %>
-    <%= linkify(h(common_details.changeset.tags['comment'])) %>
-  <% else %>
-    <%= t 'browse.no_comment' %>
-  <% end %>
+  <%= linkify(h(changeset_comment_or_nocomment(common_details.changeset))) %>
 </h4>
 
 <div class="details">

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -6,11 +6,14 @@
 </h2>
 
 <div class="browse-section">
-  <h4><%= linkify(h(changeset_comment_or_nocomment(@changeset))) %></h4>
+  <h4><%= linkify(h(changeset_comment_or_nocomment(@changeset, @user && @user.moderator?))) %></h4>
   <div class="details"><%= changeset_details(@changeset) %></div>
 
   <% if (@user and @user.moderator?) or !@changeset.tags_hidden %>
-  <%= render :partial => "tag_details", :object => @changeset.tags_hidden ? @changeset.tags : @changeset.tags.except('comment') %>
+    <% if @changeset.tags_hidden %>
+      <%= t('browse.tags_hidden') %>
+    <% end %>
+    <%= render :partial => "tag_details", :object => @changeset.tags.except('comment') %>
   <% end %>
 
   <% if @user and @user.moderator? %>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -6,10 +6,12 @@
 </h2>
 
 <div class="browse-section">
-  <h4><%= linkify(h(@changeset.tags['comment'].to_s.presence || t('browse.no_comment'))) %></h4>
+  <h4><%= linkify(h(changeset_comment_or_nocomment(@changeset))) %></h4>
   <div class="details"><%= changeset_details(@changeset) %></div>
 
+  <% unless @changeset.tags_hidden %>
   <%= render :partial => "tag_details", :object => @changeset.tags.except('comment') %>
+  <% end %>
 
   <h4 class="comments-header"><%= t('browse.changeset.discussion') %></h4>
   

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -9,8 +9,16 @@
   <h4><%= linkify(h(changeset_comment_or_nocomment(@changeset))) %></h4>
   <div class="details"><%= changeset_details(@changeset) %></div>
 
-  <% unless @changeset.tags_hidden %>
-  <%= render :partial => "tag_details", :object => @changeset.tags.except('comment') %>
+  <% if (@user and @user.moderator?) or !@changeset.tags_hidden %>
+  <%= render :partial => "tag_details", :object => @changeset.tags_hidden ? @changeset.tags : @changeset.tags.except('comment') %>
+  <% end %>
+
+  <% if @user and @user.moderator? %>
+    <%if @changeset.tags_hidden %>
+    — <span class="action-button deemphasize" data-id="<%= @changeset.id %>" data-method="POST" data-url="<%= changeset_tags_unhide_url(@changeset.id) %>"><%= t('javascripts.changesets.show.unhide_tags') %></span>
+    <% else %>
+    — <span class="action-button deemphasize" data-id="<%= @changeset.id %>" data-method="POST" data-url="<%= changeset_tags_hide_url(@changeset.id) %>"><%= t('javascripts.changesets.show.hide_tags') %></span>
+    <% end %>
   <% end %>
 
   <h4 class="comments-header"><%= t('browse.changeset.discussion') %></h4>

--- a/app/views/changeset/_changeset.html.erb
+++ b/app/views/changeset/_changeset.html.erb
@@ -15,7 +15,7 @@
 <%= content_tag "li", :id => "changeset_#{changeset.id}", :data => {:changeset => changeset_data} do %>
   <h4>
     <a class="changeset_id" href="<%= changeset_path(changeset.id) %>">
-      <%= changeset.tags['comment'].to_s.presence || t('browse.no_comment') %>
+      <%= changeset_comment_or_nocomment(changeset) %>
     </a>
   </h4>
   <div class="comments comments-<%= changeset.comments.length %>">

--- a/app/views/changeset/list.atom.builder
+++ b/app/views/changeset/list.atom.builder
@@ -23,7 +23,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
                  :href => changeset_download_url(changeset, :only_path => false),
                  :type => "application/osmChange+xml"
 
-      if !changeset.tags.empty? and changeset.tags.has_key? "comment"
+      if !changeset.tags_hidden and !changeset.tags.empty? and changeset.tags.has_key? "comment"
         entry.title t('browse.changeset.feed.title_comment', :id => h(changeset.id), :comment => h(changeset.tags['comment'])), :type => "html"
       else
         entry.title t('browse.changeset.feed.title', :id => h(changeset.id))

--- a/app/views/user/_contact.html.erb
+++ b/app/views/user/_contact.html.erb
@@ -24,8 +24,7 @@
       <% changeset = contact.changesets.first %>
       <% if changeset %>
         <%= t('user.view.latest edit', :ago => t('user.view.ago', :time_in_words_ago => time_ago_in_words(changeset.created_at))) %>
-        <% comment = changeset.tags['comment'].to_s != '' ? changeset.tags['comment'] : t('browse.no_comment') %>
-        "<%= link_to(comment,
+        "<%= link_to(changeset_comment_or_nocomment(changeset),
                             {:controller => 'browse', :action => 'changeset', :id => changeset.id},
                             {:title => t('changeset.changeset.view_changeset_details')})
         %>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
     in_changeset: "Changeset"
     anonymous: "anonymous"
     no_comment: "(no comment)"
+    tags_hidden: "(tags of this changeset have been hidden)"
     part_of: "Part of"
     download_xml: "Download XML"
     view_history: "View History"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2214,6 +2214,8 @@ en:
         unsubscribe: "Unsubscribe"
         hide_comment: "hide"
         unhide_comment: "unhide"
+        hide_tags: "hide tags"
+        unhide_tags: "unhide tags"
     notes:
       new:
         intro: "Spotted a mistake or something missing? Let other mappers know so we can fix it. Move the marker to the correct position and type a note to explain the problem. (Please don't enter personal information or information from copyrighted maps or directory listings.)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ OpenStreetMap::Application.routes.draw do
   match "api/0.6/changeset/:id/close" => "changeset#close", :via => :put, :id => /\d+/
   match "api/0.6/changesets" => "changeset#query", :via => :get
   post "api/0.6/changeset/:id/comment" => "changeset#comment", :as => :changeset_comment, :id => /\d+/
+  post "api/0.6/changeset/:id/hide_tags" => "changeset#hide_tags", :as => :changeset_tags_hide, :id => /\d+/
+  post "api/0.6/changeset/:id/unhide_tags" => "changeset#unhide_tags", :as => :changeset_tags_unhide, :id => /\d+/
   post "api/0.6/changeset/comment/:id/hide" => "changeset#hide_comment", :as => :changeset_comment_hide, :id => /\d+/
   post "api/0.6/changeset/comment/:id/unhide" => "changeset#unhide_comment", :as => :changeset_comment_unhide, :id => /\d+/
 

--- a/db/migrate/20160228105610_add_changeset_tag_hide.rb
+++ b/db/migrate/20160228105610_add_changeset_tag_hide.rb
@@ -1,0 +1,5 @@
+class AddChangesetTagHide < ActiveRecord::Migration
+  def change
+    add_column :changesets, :tags_hidden, :boolean, :default => false
+  end
+end


### PR DESCRIPTION
This pull request establishes a simple mechanism for moderators to hide/unhide changset tags. All tags of a changeset are hidden, or none are hidden; there is no per-tag granularity. Tags are only hidden from the web interface, and not from the API. 
This is meant to be used in cases where people upload data with offensive changeset comments, or where advertising is placed in the changeset comment. 
