### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,6 +160,7 @@ We need to load the btree-gist extension, which is needed for showing changesets
 
 ```
 psql -d openstreetmap -c "CREATE EXTENSION btree_gist"
+psql -d osm_test -c "CREATE EXTENSION btree_gist"
 ```
 
 ### PostgreSQL Functions


### PR DESCRIPTION
Adds an extra line to load btree-gist extension for database osm_test as well (and not only for database openstreetmap). Gets rid of an migration error with `bundle exec rake test` at the end of the installation.