### PR TITLE
Correctly sort the Copyright item in the compact menu

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -48,9 +48,9 @@
         <ul class="dropdown-menu">
           <li class="<%= current_page_class(traces_path) %>"><%= link_to t('layouts.gps_traces'), traces_path %></li>
           <li class="<%= current_page_class(diary_path) %>"><%= link_to t('layouts.user_diaries'), diary_path %></li>
+          <li class="<%= current_page_class(copyright_path) %>"><%= link_to t('layouts.copyright'), copyright_path %></li>
           <li class="<%= current_page_class(help_path) %>"><%= link_to t('layouts.help'), help_path %></li>
           <li class="<%= current_page_class(about_path) %>"><%= link_to t('layouts.about'), about_path %></li>
-          <li class="<%= current_page_class(copyright_path) %>"><%= link_to t('layouts.copyright'), copyright_path %></li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
In the default menu it had been moved left on commit bfd11bf79
(2013-11-30), but the compact drop-down menu had not been adapted
accordingly.