### PR TITLE
Support version for /nodes, /ways, /relations

### DIFF
--- a/app/controllers/old_node_controller.rb
+++ b/app/controllers/old_node_controller.rb
@@ -8,4 +8,9 @@ class OldNodeController < OldController
   def lookup_old_element_versions
     @elements = OldNode.where(:node_id => params[:id]).order(:version)
   end
+
+  def lookup_old_elements
+    ids = parse_old_elements("nodes")
+    @elements = OldNode.find(ids)
+  end
 end

--- a/app/controllers/old_relation_controller.rb
+++ b/app/controllers/old_relation_controller.rb
@@ -8,4 +8,9 @@ class OldRelationController < OldController
   def lookup_old_element_versions
     @elements = OldRelation.where(:relation_id => params[:id]).order(:version)
   end
+
+  def lookup_old_elements
+    ids = parse_old_elements("relations")
+    @elements = OldNode.find(ids)
+  end
 end

--- a/app/controllers/old_way_controller.rb
+++ b/app/controllers/old_way_controller.rb
@@ -8,4 +8,9 @@ class OldWayController < OldController
   def lookup_old_element_versions
     @elements = OldWay.where(:way_id => params[:id]).order(:version)
   end
+
+  def lookup_old_elements
+    ids = parse_old_elements("ways")
+    @elements = OldNode.find(ids)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ OpenStreetMap::Application.routes.draw do
   match "api/0.6/node/:id" => "node#update", :via => :put, :id => /\d+/
   match "api/0.6/node/:id" => "node#delete", :via => :delete, :id => /\d+/
   match "api/0.6/nodes" => "node#nodes", :via => :get
+  match "api/0.6/nodes/versions" => "old_node#elements", :via => :get
 
   match "api/0.6/way/create" => "way#create", :via => :put
   match "api/0.6/way/:id/history" => "old_way#history", :via => :get, :id => /\d+/
@@ -39,6 +40,7 @@ OpenStreetMap::Application.routes.draw do
   match "api/0.6/way/:id" => "way#update", :via => :put, :id => /\d+/
   match "api/0.6/way/:id" => "way#delete", :via => :delete, :id => /\d+/
   match "api/0.6/ways" => "way#ways", :via => :get
+  match "api/0.6/ways/versions" => "old_way#elements", :via => :get
 
   match "api/0.6/relation/create" => "relation#create", :via => :put
   match "api/0.6/relation/:id/relations" => "relation#relations_for_relation", :via => :get, :id => /\d+/
@@ -50,6 +52,7 @@ OpenStreetMap::Application.routes.draw do
   match "api/0.6/relation/:id" => "relation#update", :via => :put, :id => /\d+/
   match "api/0.6/relation/:id" => "relation#delete", :via => :delete, :id => /\d+/
   match "api/0.6/relations" => "relation#relations", :via => :get
+  match "api/0.6/relations/versions" => "old_relation#elements", :via => :get
 
   match "api/0.6/map" => "api#map", :via => :get
 

--- a/test/controllers/old_relation_controller_test.rb
+++ b/test/controllers/old_relation_controller_test.rb
@@ -19,6 +19,10 @@ class OldRelationControllerTest < ActionController::TestCase
       { :path => "/api/0.6/relation/1/2/redact", :method => :post },
       { :controller => "old_relation", :action => "redact", :id => "1", :version => "2" }
     )
+    assert_routing(
+      { :path => "/api/0.6/relations/versions", :method => :get },
+      { :controller => "old_relation", :action => "elements" }
+    )
   end
 
   # -------------------------------------
@@ -32,6 +36,15 @@ class OldRelationControllerTest < ActionController::TestCase
     # check chat a non-existent relations is not returned
     get :history, :id => 0
     assert_response :not_found
+  end
+
+  def test_elements
+    relation = relations(:relation_with_versions_v2)
+    ids = relation.id.join("v")
+    get :elements, :relations => ids
+    assert_response :success
+    assert_select "osm relation", 1
+    assert_select "osm relation[id='#{relation.relation_id}'][version='#{relation.version}']", 1, "relation #{relation.relation_id} version #{relation.version} should be present."
   end
 
   ##

--- a/test/controllers/old_way_controller_test.rb
+++ b/test/controllers/old_way_controller_test.rb
@@ -19,6 +19,10 @@ class OldWayControllerTest < ActionController::TestCase
       { :path => "/api/0.6/way/1/2/redact", :method => :post },
       { :controller => "old_way", :action => "redact", :id => "1", :version => "2" }
     )
+    assert_routing(
+      { :path => "/api/0.6/ways/versions", :method => :get },
+      { :controller => "old_way", :action => "elements" }
+    )
   end
 
   # -------------------------------------
@@ -49,6 +53,15 @@ class OldWayControllerTest < ActionController::TestCase
     check_current_version(current_ways(:visible_way).id)
     check_current_version(current_ways(:used_way).id)
     check_current_version(current_ways(:way_with_versions).id)
+  end
+
+  def test_elements
+    way = ways(:way_with_versions_v2)
+    ids = way.id.join("v")
+    get :elements, :ways => ids
+    assert_response :success
+    assert_select "osm way", 1
+    assert_select "osm way[id='#{way.way_id}'][version='#{way.version}']", 1, "way #{way.way_id} version #{way.version} should be present."
   end
 
   ##


### PR DESCRIPTION
Fixes #1067.

Adds the following API methods:
- `/api/0.6/nodes/versions?nodes=123v4,56v7`
- `/api/0.6/ways/versions?ways=123v4,56v7`
- `/api/0.6/relations/versions?relations=123v4,56v7`
