### PR TITLE
Additional command for postgres headers installation and possible errors

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -170,7 +170,7 @@ Also run "sudo apt-get install postgresql-server-dev-headers" separately if comm
 
 ```
 cd db/functions
-make libpgosm.so 
+make libpgosm.so
 cd ../..
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -165,10 +165,12 @@ psql -d openstreetmap -c "CREATE EXTENSION btree_gist"
 ### PostgreSQL Functions
 
 We need to install special functions into the PostgreSQL databases, and these are provided by a library that needs compiling first.
+Error like "#include <postgres.h> not found" may show up if latest version of PostgreSQL is not installed. Header files in PostgreSQL 9 and below have different names.
+Also run "sudo apt-get install postgresql-server-dev-headers" separately if command at line #34 did not install completely.
 
 ```
 cd db/functions
-make libpgosm.so
+make libpgosm.so 
 cd ../..
 ```
 


### PR DESCRIPTION
Postgresql-server-dev-all sometimes does not install all the dependencies. Error for missing header file like "postgres.h" may show up. Suggested additional command for installation and reason for PostgresSQL 9.1+ requirement.