### PR TITLE
Only use language part of locale for Wikidata link

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -161,7 +161,7 @@ module BrowseHelper
   def wikidata_link(key, value)
     if key == "wikidata" && value =~ /^[Qq][1-9][0-9]*$/
       return {
-        :url => "//www.wikidata.org/wiki/#{value}?uselang=#{I18n.locale}",
+        :url => "//www.wikidata.org/wiki/#{value}?uselang=#{I18n.locale.split("-")[0]}",
         :title => value
       }
     end


### PR DESCRIPTION
The Wikidata link includes the locale in a parameter on the end of the URL. In my case this is "en-GB", so Wikidata shows me the interface in British English, which is useful. It also tries to show item labels in British English, but most items don't have a label in British English, instead it says "No label defined", this is less useful.

The best solution would be for Wikidata to use the English label if there is a no British English label. This is a simpler change that we can implement on the OSM side to use just the language part of the locale. In my case the locale passed to Wikidata will be "en", and I'll see labels in English.