### PR TITLE
Reduce maximum changeset size to 10k changes

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -32,7 +32,7 @@ class Changeset < ActiveRecord::Base
   EXPAND = 0.1
 
   # maximum number of elements allowed in a changeset
-  MAX_ELEMENTS = 50000
+  MAX_ELEMENTS = 10000
 
   # maximum time a changeset is allowed to be open for.
   MAX_TIME_OPEN = 1.day


### PR DESCRIPTION
10k changes ought to be enough for any normal mapping activity. Automatic edits and imports are controlled by scripts anyway so it doesn't make a difference to them (they just have to adapt the limit). Reason for my suggestion is that large changesets are increasingly difficult to handle (frequent timeouts when trying to load and process). The changeset size limit is returned by the API in the "capabilities" request (http://api.openstreetmap.org/api/capabilities) i.e. client software that honours that information will automatically pick up the new limit.
