### PR TITLE
Blacklist all Google imagery with one regex

### DIFF
--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -87,9 +87,9 @@ defaults: &defaults
   require_terms_agreed: false
   # Imagery to return in capabilities as blacklisted
   imagery_blacklist:
-    - ".*\\.googleapis\\.com/.*"
-    - ".*\\.google\\.com/.*"
-    - ".*\\.google\\.ru/.*"
+    # Current Google imagery URLs have google or googleapis in the domain
+    # a vt or kh endpoint, and x, y and z query paramters
+    - '.*\.google(apis)?\..*/(vt|kh)[\?/].*([xyz]=.*){3}.*'
   # URL of Overpass instance to use for feature queries
   overpass_url: "//overpass-api.de/api/interpreter"
   # Routing endpoints


### PR DESCRIPTION
This expression catches 100% of Google imagery seen in `imagery_used` with no false positives.

It won't stop someone who tries to load "https://www.google.com/maps" as imagery, but that will fail to get imagery.

Tested with JOSM, and it blocks some of the recent problems we've seen.

@pnorman
For the Data Working Group

