### PR TITLE
Add Factorygirl as an alternative to fixtures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,5 +109,6 @@ group :development, :test do
   gem "jshint"
   gem "konacha"
   gem "poltergeist"
+  gem "factory_girl_rails"
   gem "coveralls", :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,11 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     exifr (1.2.4)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fspath (2.1.1)
@@ -316,6 +321,7 @@ DEPENDENCIES
   dalli
   deadlock_retry (>= 1.2.0)
   dynamic_form
+  factory_girl_rails
   faraday
   htmlentities
   http_accept_language (~> 2.0.0)

--- a/test/factories/diary_comments.rb
+++ b/test/factories/diary_comments.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :diary_comment do
+    sequence(:body) { |n| "This is diary comment #{n}" }
+
+    diary_entry
+
+    # Fixme requires User Factory
+    user_id 1
+  end
+end

--- a/test/factories/diary_entries.rb
+++ b/test/factories/diary_entries.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :diary_entry do
+    sequence(:title) { |n| "Diary entry #{n}" }
+    sequence(:body) { |n| "This is diary entry #{n}" }
+
+    # Fixme requires User Factory
+    user_id 1
+  end
+end

--- a/test/models/diary_comment_test.rb
+++ b/test/models/diary_comment_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class DiaryCommentTest < ActiveSupport::TestCase
-  def test_diary_comment_count
+  def test_diary_comment_exists
     comment = create(:diary_comment)
     assert_includes DiaryComment.all, comment
   end

--- a/test/models/diary_comment_test.rb
+++ b/test/models/diary_comment_test.rb
@@ -1,10 +1,8 @@
 require "test_helper"
 
 class DiaryCommentTest < ActiveSupport::TestCase
-  api_fixtures
-  fixtures :diary_comments
-
   def test_diary_comment_count
-    assert_equal 4, DiaryComment.count
+    comment = create(:diary_comment)
+    assert_includes DiaryComment.all, comment
   end
 end

--- a/test/models/diary_entry_test.rb
+++ b/test/models/diary_entry_test.rb
@@ -44,8 +44,7 @@ class DiaryEntryTest < ActiveSupport::TestCase
   private
 
   def diary_entry_valid(attrs, result = true)
-    entry = DiaryEntry.new(attributes_for(:diary_entry))
-    entry.assign_attributes(attrs)
+    entry = build(:diary_entry, attrs)
     assert_equal result, entry.valid?, "Expected #{attrs.inspect} to be #{result}"
   end
 end

--- a/test/models/diary_entry_test.rb
+++ b/test/models/diary_entry_test.rb
@@ -28,6 +28,7 @@ class DiaryEntryTest < ActiveSupport::TestCase
 
   def test_diary_entry_comments
     diary = create(:diary_entry)
+    assert_equal(0, diary.comments.count)
     create(:diary_comment, :diary_entry => diary)
     assert_equal(1, diary.comments.count)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ load "composite_primary_keys/fixtures.rb"
 
 module ActiveSupport
   class TestCase
+    include FactoryGirl::Syntax::Methods
+
     # Load standard fixtures needed to test API methods
     def self.api_fixtures
       # print "setting up the api_fixtures"


### PR DESCRIPTION
FactoryGirl is a widely used alternative to fixtures in tests. The fixtures are annoying since every time you want to test something slightly different (for example, a diary entry with an apostrophe in its title), you need to add a whole new fixture and rework the tests. Fixtures are also a pain when the model attributes change.

This PR adds FactoryGirl, and reworks two model tests (DiaryEntry and DiaryComment) to use them.