### PR TITLE
Add the Wikimedia tiles as a layer

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -36,6 +36,8 @@ window.onload = function () {
     new L.OSM.TransportMap(thunderforestOptions).addTo(map);
   } else if (args.layer === "hot") {
     new L.OSM.HOT().addTo(map);
+  } else if (args.layer === "wikimedia") {
+    new L.OSM.Wikimedia().addTo(map);
   }
 
   if (args.marker) {

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -50,6 +50,13 @@ L.OSM.Map = L.Map.extend({
       name: I18n.t("javascripts.map.base.hot")
     }));
 
+    this.baseLayers.push(new L.OSM.Wikimedia({
+      attribution: copyright + ". Tiles courtesy of <a href='https://www.wikimedia.org/' target='_blank'>Wikimedia</a>",
+      code: "W",
+      keyid: "wikimedia",
+      name: I18n.t("javascripts.map.base.wikimedia")
+    }));
+
     this.noteLayer = new L.FeatureGroup();
     this.noteLayer.options = {code: 'N'};
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2202,6 +2202,7 @@ en:
         cycle_map: Cycle Map
         transport_map: Transport Map
         hot: Humanitarian
+        wikimedia: Wikimedia
       layers:
         header: Map Layers
         notes: Map Notes

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -64,6 +64,13 @@ L.OSM.HOT = L.OSM.TileLayer.extend({
   }
 });
 
+L.OSM.Wikimedia = L.OSM.TileLayer.extend({
+  options: {
+    url: 'https://https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png',
+    attribution: '© <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors. Tiles courtesy of <a href="https://www.wikimedia.org/" target="_blank">Wikimedia</a>'
+  }
+});
+
 L.OSM.DataLayer = L.FeatureGroup.extend({
   options: {
     areaTags: ['area', 'building', 'leisure', 'tourism', 'ruins', 'historic', 'landuse', 'military', 'natural', 'sport'],


### PR DESCRIPTION
I was asked if this could be added to openstreetmap.org as a featured layer. I have no idea what is needed from the OSM side for this, so I'm going by https://wiki.openstreetmap.org/wiki/Featured_tile_layers/Guidelines_for_new_tile_layers .
This is a tile set generated with only free software including the style that can be contributed to, with the intent on being embeddable on Wikimedia projects.

* Internally supported: Yes.
* Global scope and coverage: Yes
* Capable of meeting traffic demands: By a quick estimate, yes. This was started with the goal of supporting the demand of being used on all Wikimedia projects. Which is probably more traffic than we are talking about here. Though it is not serving at that scale yet. The documentation links to details of the setup, including traffic graphs of the caching cluster for this service. Are there more specific demands?
* Reliable service: It is a production service. Though it is new so there are not yet any long term statistics.
* Up-to-date data: TBD

Documentation for this tile set:
https://www.mediawiki.org/wiki/Maps#Production_maps_cluster
Web slippy map useable at: https://maps.wikimedia.org/
Example usages: https://www.mediawiki.org/wiki/Help:Extension:Kartographer 