### PR TITLE
Add links to new approved OSMF privacy policy and some rewording.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1226,7 +1226,9 @@ en:
     legal_html: |
       This site and many other related services are formally operated by the  
       <a href='http://osmfoundation.org/'>OpenStreetMap Foundation</a> (OSMF) 
-      on behalf of the community.
+      on behalf of the community. Use of all OSMF operated services is subject 
+      to our <a href="http://wiki.openstreetmap.org/wiki/Acceptable_Use_Policy">
+      Acceptable Use Policies</a> and our <a href="http://wiki.osmfoundation.org/wiki/Privacy_Policy">Privacy Policy</a>
       <br> 
       Please <a href='http://osmfoundation.org/Contact'>contact the OSMF</a> 
       if you have licensing, copyright or other legal questions and issues.
@@ -1786,7 +1788,7 @@ en:
       license_agreement: 'When you confirm your account you will need to agree to the <a href="http://www.osmfoundation.org/wiki/License/Contributor_Terms">contributor terms</a>.'
       email address: "Email Address:"
       confirm email address: "Confirm Email Address:"
-      not displayed publicly: 'Not displayed publicly (see <a href="http://wiki.openstreetmap.org/wiki/Privacy_Policy" title="wiki privacy policy including section on email addresses">privacy policy</a>)'
+      not displayed publicly: 'Your address is not displayed publicly, see our <a href="http://wiki.osmfoundation.org/wiki/Privacy_Policy" title="OSMF privacy policy including section on email addresses">privacy policy</a> for more information'
       display name: "Display Name:"
       display name description: "Your publicly displayed username. You can change this later in the preferences."
       external auth: "Third Party Authentication:"


### PR DESCRIPTION
Pro memoria: while we only have one (old) translation of the privacy policy, it is conceivable that down the road we would want more and then we would potentially need to revisit where we actually store the policy.