### PR TITLE
Add a note_with_comments factory

### DIFF
--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -85,15 +85,13 @@ class BrowseControllerTest < ActionController::TestCase
   end
 
   def test_read_note
-    open_note = create(:note)
-    create(:note_comment, :note => open_note)
+    open_note = create(:note_with_comments)
 
     browse_check "note", open_note.id, "browse/note"
   end
 
   def test_read_hidden_note
-    hidden_note_with_comment = create(:note, :status => "hidden")
-    create(:note_comment, :note => hidden_note_with_comment)
+    hidden_note_with_comment = create(:note_with_comments, :status => "hidden")
 
     get :note, :id => hidden_note_with_comment.id
     assert_response :not_found
@@ -111,10 +109,9 @@ class BrowseControllerTest < ActionController::TestCase
   end
 
   def test_read_note_hidden_comments
-    note_with_hidden_comment = create(:note)
-    create(:note_comment, :note => note_with_hidden_comment)
-    create(:note_comment, :note => note_with_hidden_comment)
-    create(:note_comment, :note => note_with_hidden_comment, :visible => false)
+    note_with_hidden_comment = create(:note_with_comments, :comments_count => 2) do |note|
+      create(:note_comment, :note => note, :visible => false)
+    end
 
     browse_check "note", note_with_hidden_comment.id, "browse/note"
     assert_select "div.note-comments ul li", :count => 1

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -265,8 +265,9 @@ class SiteControllerTest < ActionController::TestCase
   # Test editing a specific note
   def test_edit_with_note
     user = users(:public_user)
-    note = create(:note)
-    create(:note_comment, :author_id => user.id)
+    note = create(:note) do |n|
+      n.comments.create(:author_id => user.id)
+    end
 
     get :edit, { :note => note.id }, { :user => user.id }
     assert_response :success

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -3,5 +3,15 @@ FactoryGirl.define do
     latitude 1 * GeoRecord::SCALE
     longitude 1 * GeoRecord::SCALE
     # tile QuadTile.tile_for_point(1,1)
+
+    factory :note_with_comments do
+      transient do
+        comments_count 1
+      end
+
+      after(:create) do |note, evaluator|
+        create_list(:note_comment, evaluator.comments_count, :note => note)
+      end
+    end
   end
 end


### PR DESCRIPTION
Add a note_with_comments factory and migrate tests to use it, and blocks, to create notes and their associated comments in one action.

Partly I was playing with factory girl, but I also think I prefer creating the object in one go rather than creating it and then adding things to it. Maybe @gravitystorm will have some thoughts on whether we should merge this?