### PR TITLE
Remove unnecessary controller references from the redirect hashes.

### DIFF
--- a/app/controllers/diary_entry_controller.rb
+++ b/app/controllers/diary_entry_controller.rb
@@ -24,7 +24,7 @@ class DiaryEntryController < ApplicationController
         else
           @user.preferences.create(:k => "diary.default_language", :v => @diary_entry.language_code)
         end
-        redirect_to :controller => "diary_entry", :action => "list", :display_name => @user.display_name
+        redirect_to :action => "list", :display_name => @user.display_name
       else
         render :action => "edit"
       end
@@ -42,9 +42,9 @@ class DiaryEntryController < ApplicationController
     @diary_entry = DiaryEntry.find(params[:id])
 
     if @user != @diary_entry.user
-      redirect_to :controller => "diary_entry", :action => "view", :id => params[:id]
+      redirect_to :action => "view", :id => params[:id]
     elsif params[:diary_entry] && @diary_entry.update_attributes(entry_params)
-      redirect_to :controller => "diary_entry", :action => "view", :id => params[:id]
+      redirect_to :action => "view", :id => params[:id]
     end
 
     set_map_location
@@ -61,7 +61,7 @@ class DiaryEntryController < ApplicationController
         Notifier.diary_comment_notification(@diary_comment).deliver_now
       end
 
-      redirect_to :controller => "diary_entry", :action => "view", :display_name => @entry.user.display_name, :id => @entry.id
+      redirect_to :action => "view", :display_name => @entry.user.display_name, :id => @entry.id
     else
       render :action => "view"
     end
@@ -201,7 +201,7 @@ class DiaryEntryController < ApplicationController
   def require_administrator
     unless @user.administrator?
       flash[:error] = t("user.filter.not_an_administrator")
-      redirect_to :controller => "diary_entry", :action => "view"
+      redirect_to :action => "view"
     end
   end
 

--- a/app/controllers/message_controller.rb
+++ b/app/controllers/message_controller.rb
@@ -25,7 +25,7 @@ class MessageController < ApplicationController
         if @message.save
           flash[:notice] = t "message.new.message_sent"
           Notifier.message_notification(@message).deliver_now
-          redirect_to :controller => "message", :action => "inbox", :display_name => @user.display_name
+          redirect_to :action => "inbox", :display_name => @user.display_name
         end
       end
     end
@@ -81,7 +81,7 @@ class MessageController < ApplicationController
     @title = t "message.inbox.title"
     if @user && params[:display_name] == @user.display_name
     else
-      redirect_to :controller => "message", :action => "inbox", :display_name => @user.display_name
+      redirect_to :action => "inbox", :display_name => @user.display_name
     end
   end
 
@@ -90,7 +90,7 @@ class MessageController < ApplicationController
     @title = t "message.outbox.title"
     if @user && params[:display_name] == @user.display_name
     else
-      redirect_to :controller => "message", :action => "outbox", :display_name => @user.display_name
+      redirect_to :action => "outbox", :display_name => @user.display_name
     end
   end
 
@@ -107,7 +107,7 @@ class MessageController < ApplicationController
     @message.message_read = message_read
     if @message.save && !request.xhr?
       flash[:notice] = notice
-      redirect_to :controller => "message", :action => "inbox", :display_name => @user.display_name
+      redirect_to :action => "inbox", :display_name => @user.display_name
     end
   rescue ActiveRecord::RecordNotFound
     @title = t "message.no_such_message.title"
@@ -125,7 +125,7 @@ class MessageController < ApplicationController
       if params[:referer]
         redirect_to params[:referer]
       else
-        redirect_to :controller => "message", :action => "inbox", :display_name => @user.display_name
+        redirect_to :action => "inbox", :display_name => @user.display_name
       end
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/trace_controller.rb
+++ b/app/controllers/trace_controller.rb
@@ -95,11 +95,11 @@ class TraceController < ApplicationController
       @title = t "trace.view.title", :name => @trace.name
     else
       flash[:error] = t "trace.view.trace_not_found"
-      redirect_to :controller => "trace", :action => "list"
+      redirect_to :action => "list"
     end
   rescue ActiveRecord::RecordNotFound
     flash[:error] = t "trace.view.trace_not_found"
-    redirect_to :controller => "trace", :action => "list"
+    redirect_to :action => "list"
   end
 
   def create

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -142,7 +142,7 @@ class UserController < ApplicationController
     @user.data_public = true
     @user.save
     flash[:notice] = t "user.go_public.flash success"
-    redirect_to :controller => "user", :action => "account", :display_name => @user.display_name
+    redirect_to :action => "account", :display_name => @user.display_name
   end
 
   def lost_password
@@ -423,7 +423,7 @@ class UserController < ApplicationController
         if params[:referer]
           redirect_to params[:referer]
         else
-          redirect_to :controller => "user", :action => "view"
+          redirect_to :action => "view"
         end
       end
     else
@@ -446,7 +446,7 @@ class UserController < ApplicationController
         if params[:referer]
           redirect_to params[:referer]
         else
-          redirect_to :controller => "user", :action => "view"
+          redirect_to :action => "view"
         end
       end
     else
@@ -459,14 +459,14 @@ class UserController < ApplicationController
   def set_status
     @this_user.status = params[:status]
     @this_user.save
-    redirect_to :controller => "user", :action => "view", :display_name => params[:display_name]
+    redirect_to :action => "view", :display_name => params[:display_name]
   end
 
   ##
   # delete a user, marking them as deleted and removing personal data
   def delete
     @this_user.delete
-    redirect_to :controller => "user", :action => "view", :display_name => params[:display_name]
+    redirect_to :action => "view", :display_name => params[:display_name]
   end
 
   ##
@@ -628,7 +628,7 @@ class UserController < ApplicationController
     # - If they were referred to the login, send them back there.
     # - Otherwise, send them to the home page.
     if REQUIRE_TERMS_SEEN && !user.terms_seen
-      redirect_to :controller => :user, :action => :terms, :referer => target
+      redirect_to :action => :terms, :referer => target
     elsif user.blocked_on_view
       redirect_to user.blocked_on_view, :referer => target
     else
@@ -740,12 +740,12 @@ class UserController < ApplicationController
       flash[:error] = t("user.filter.not_an_administrator")
 
       if params[:display_name]
-        redirect_to :controller => "user", :action => "view", :display_name => params[:display_name]
+        redirect_to :action => "view", :display_name => params[:display_name]
       else
-        redirect_to :controller => "user", :action => "login", :referer => request.fullpath
+        redirect_to :action => "login", :referer => request.fullpath
       end
     elsif !@user
-      redirect_to :controller => "user", :action => "login", :referer => request.fullpath
+      redirect_to :action => "login", :referer => request.fullpath
     end
   end
 
@@ -768,7 +768,7 @@ class UserController < ApplicationController
   def lookup_user_by_name
     @this_user = User.find_by_display_name(params[:display_name])
   rescue ActiveRecord::RecordNotFound
-    redirect_to :controller => "user", :action => "view", :display_name => params[:display_name] unless @this_user
+    redirect_to :action => "view", :display_name => params[:display_name] unless @this_user
   end
 
   ##


### PR DESCRIPTION
Rails redirect_to uses the current controller by default, so there
is no need to re-iterate this in the code when the redirect targets
the current controller.

The short-form is already used elsewhere, this just tidies up those
which were still using the long-form.