### PR TITLE
Suppress XML parsing errors.

### DIFF
--- a/app/controllers/changeset_controller.rb
+++ b/app/controllers/changeset_controller.rb
@@ -83,7 +83,7 @@ class ChangesetController < ApplicationController
 
     # the request is in pseudo-osm format... this is kind-of an
     # abuse, maybe should change to some other format?
-    doc = XML::Parser.string(request.raw_post).parse
+    doc = XML::Parser.string(request.raw_post, :options => XML::Parser::Options::NOERROR).parse
     doc.find("//osm/node").each do |n|
       lon << n["lon"].to_f * GeoRecord::SCALE
       lat << n["lat"].to_f * GeoRecord::SCALE

--- a/app/controllers/user_preference_controller.rb
+++ b/app/controllers/user_preference_controller.rb
@@ -39,7 +39,7 @@ class UserPreferenceController < ApplicationController
 
     new_preferences = {}
 
-    doc = XML::Parser.string(request.raw_post).parse
+    doc = XML::Parser.string(request.raw_post, :options => XML::Parser::Options::NOERROR).parse
 
     doc.find("//preferences/preference").each do |pt|
       if preference = old_preferences.delete(pt["k"])

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -49,7 +49,7 @@ class Node < ActiveRecord::Base
 
   # Read in xml as text and return it's Node object representation
   def self.from_xml(xml, create = false)
-    p = XML::Parser.string(xml)
+    p = XML::Parser.string(xml, :options => XML::Parser::Options::NOERROR)
     doc = p.parse
 
     doc.find("//osm/node").each do |pt|

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -36,7 +36,7 @@ class Relation < ActiveRecord::Base
   TYPES = %w(node way relation).freeze
 
   def self.from_xml(xml, create = false)
-    p = XML::Parser.string(xml)
+    p = XML::Parser.string(xml, :options => XML::Parser::Options::NOERROR)
     doc = p.parse
 
     doc.find("//osm/relation").each do |pt|

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -174,7 +174,7 @@ class Trace < ActiveRecord::Base
 
   # Read in xml as text and return it's Node object representation
   def self.from_xml(xml, create = false)
-    p = XML::Parser.string(xml)
+    p = XML::Parser.string(xml, :options => XML::Parser::Options::NOERROR)
     doc = p.parse
 
     doc.find("//osm/gpx_file").each do |pt|

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -34,7 +34,7 @@ class Way < ActiveRecord::Base
 
   # Read in xml as text and return it's Way object representation
   def self.from_xml(xml, create = false)
-    p = XML::Parser.string(xml)
+    p = XML::Parser.string(xml, :options => XML::Parser::Options::NOERROR)
     doc = p.parse
 
     doc.find("//osm/way").each do |pt|


### PR DESCRIPTION
This technique was already used in app/models/changeset.rb

This suppresses the error messages when parsing invalid XML, but
the exceptions are still raised, as tested in test_from_xml_double_lat
in test/models/node_test.rb