### PR TITLE
Use https:// for server_url

### DIFF
--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   # The server URL
-  server_url: "www.openstreetmap.org"
+  server_url: "https://www.openstreetmap.org"
   # The generator
   generator: "OpenStreetMap server"
   copyright_owner: "OpenStreetMap and contributors"


### PR DESCRIPTION
The server URL is used to generate links in password recovery e-mails.
This should happen via HTTPS not plain HTTP to prevent
man-in-the-middle attacks.

There are a lot of other places that hardcode http:// instead of https:// for several URLs. If you do not mind changing the links to https, I can create a follow-up patch to address the other instances. Also I guess that the actual config file in production needs to be adjusted to actually use this change.