### PR TITLE
add a step to vagrant setup to migrate the test db

### DIFF
--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -53,4 +53,5 @@ if [ ! -f config/application.yml ]; then
 fi
 # migrate the database to the latest version
 sudo -u vagrant rake db:migrate
+sudo -u vagrant rake db:migrate RAILS_ENV=test
 popd


### PR DESCRIPTION
Following the VAGRANT.md instructions we get a 'pending migrations' error. We could add another manual step to the instructions, but this way it's set up automatically.