### PR TITLE
Avoid double-escaping diary entry titles

### DIFF
--- a/app/views/diary_entry/rss.rss.builder
+++ b/app/views/diary_entry/rss.rss.builder
@@ -17,7 +17,7 @@ xml.rss("version" => "2.0",
 
     @entries.each do |entry|
       xml.item do
-        xml.title h(entry.title)
+        xml.title entry.title
         xml.link url_for(:action => "view", :id => entry.id, :display_name => entry.user.display_name, :host => SERVER_URL)
         xml.guid url_for(:action => "view", :id => entry.id, :display_name => entry.user.display_name, :host => SERVER_URL)
         xml.description entry.body.to_html

--- a/test/controllers/diary_entry_controller_test.rb
+++ b/test/controllers/diary_entry_controller_test.rb
@@ -563,6 +563,13 @@ class DiaryEntryControllerTest < ActionController::TestCase
     assert_response :not_found, "Should not be able to get a deleted users diary RSS"
   end
 
+  def test_rss_character_escaping
+    create(:diary_entry, :title => "<script>")
+    get :rss, :format => :rss
+
+    assert_match "<title>&lt;script&gt;</title>", response.body
+  end
+
   def test_view
     # Try a normal entry that should work
     diary_entry = create(:diary_entry, :user => users(:normal_user))


### PR DESCRIPTION
The XML builder takes care of the escaping, and adding h() lead to
double-escaped titles in the RSS feed.