### PR TITLE
Use Webmock to intercept http requests in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ group :test do
   gem "rubocop"
   gem "timecop"
   gem "minitest", "~> 5.1", :platforms => [:ruby_19, :ruby_20]
+  gem "webmock"
 end
 
 # Needed in development as well so rake can see konacha tasks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (>= 1.6.0, < 2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.2)
     dalli (2.7.6)
     deadlock_retry (1.2.0)
@@ -94,6 +96,7 @@ GEM
     geoip (1.6.2)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    hashdiff (0.3.0)
     hashie (3.4.6)
     htmlentities (4.3.4)
     http_accept_language (2.0.5)
@@ -257,6 +260,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-openid (2.7.0)
     ruby-progressbar (1.8.1)
+    safe_yaml (1.0.4)
     sanitize (4.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
@@ -298,6 +302,10 @@ GEM
     validates_email_format_of (1.6.3)
       i18n
     vendorer (0.1.16)
+    webmock (1.24.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -359,6 +367,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   validates_email_format_of (>= 1.5.1)
   vendorer
+  webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -569,11 +569,6 @@ module OSM
     @http_client ||= Faraday.new
   end
 
-  # Set the HTTP client to use
-  def self.http_client=(client)
-    @http_client = client
-  end
-
   # Return the GeoIP database handle
   def self.geoip_database
     @geoip_database ||= GeoIP.new(GEOIP_DATABASE) if defined?(GEOIP_DATABASE)

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -8,6 +8,8 @@ class SiteControllerTest < ActionController::TestCase
   def setup
     Object.const_set("ID_KEY", client_applications(:oauth_web_app).key)
     Object.const_set("POTLATCH2_KEY", client_applications(:oauth_web_app).key)
+
+    stub_request(:get, "http://api.hostip.info/country.php?ip=0.0.0.0")
   end
 
   ##

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -9,7 +9,7 @@ class SiteControllerTest < ActionController::TestCase
     Object.const_set("ID_KEY", client_applications(:oauth_web_app).key)
     Object.const_set("POTLATCH2_KEY", client_applications(:oauth_web_app).key)
 
-    stub_request(:get, "http://api.hostip.info/country.php?ip=0.0.0.0")
+    stub_signup_requests
   end
 
   ##

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -5,6 +5,7 @@ class UserControllerTest < ActionController::TestCase
 
   setup do
     stub_request(:get, "http://api.hostip.info/country.php?ip=0.0.0.0")
+    stub_request(:get, /.*gravatar.com.*d=404/).to_return(:status => 404)
   end
 
   ##

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class UserControllerTest < ActionController::TestCase
   api_fixtures
 
-  setup do
+  def setup
     stub_signup_requests
   end
 

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -4,7 +4,7 @@ class UserControllerTest < ActionController::TestCase
   api_fixtures
 
   setup do
-    stub_request(:get, "http://api.hostip.info/country.php?ip=0.0.0.0")
+    stub_signup_requests
   end
 
   ##

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -3,6 +3,10 @@ require "test_helper"
 class UserControllerTest < ActionController::TestCase
   api_fixtures
 
+  setup do
+    stub_request(:get, "http://api.hostip.info/country.php?ip=0.0.0.0")
+  end
+
   ##
   # test all routes which lead to this controller
   def test_routes

--- a/test/http/geocoder_ca.yml
+++ b/test/http/geocoder_ca.yml
@@ -1,5 +1,5 @@
-/?geoit=XML&postal=A1B+2C3: 
-  code: 200 
+/?geoit=XML&postal=A1B%202C3:
+  code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8"?>
     <geodata>
@@ -15,8 +15,8 @@
       </standard>
     </geodata>
 
-/?geoit=XML&postal=k1a+0b1:
-  code: 200 
+/?geoit=XML&postal=k1a%200b1:
+  code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8"?>
     <geodata>
@@ -31,9 +31,9 @@
         <confidence>0.9</confidence>
       </standard>
     </geodata>
-  
-/?geoit=XML&postal=Q0Q+0Q0:
-  code: 200 
+
+/?geoit=XML&postal=Q0Q%200Q0:
+  code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8"?>
     <geodata>

--- a/test/http/gravatar.yml
+++ b/test/http/gravatar.yml
@@ -1,7 +1,0 @@
-/avatar/842bc90353fac655450e62223e4e105d?d=404 :
-  code: 404
-  body: Ignored, test for new_g2@openstreetmap.org
-
-/avatar/d2e95ef0ac6933916bf42ff1ee4eca4b?d=404 :
-  code: 200
-  body: Ignored, test for new_g1@openstreetmap.org

--- a/test/http/nominatim.yml
+++ b/test/http/nominatim.yml
@@ -1,12 +1,12 @@
-/search?accept-language=&format=xml&q=Hoddesdon&viewbox=-0.559%2C51.766%2C0.836%2C51.217:
+/search?accept-language=&extratags=1&format=xml&q=Hoddesdon&viewbox=-0.559,51.766,0.836,51.217:
   code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8" ?>
     <searchresults timestamp='Sun, 01 Mar 15 20:02:29 +0000' attribution='Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright' querystring='Hoddesdon' viewbox='-0.559,51.766,0.836,51.217' polygon='false' exclude_place_ids='110741' more_url='http://nominatim.openstreetmap.org/search?format=xml&amp;exclude_place_ids=110741&amp;viewbox=-0.559%2C51.766%2C0.836%2C51.217&amp;q=Hoddesdon'>
       <place place_id='110741' osm_type='node' osm_id='18007599' place_rank='18' boundingbox="51.7216709,51.8016709,-0.0512898,0.0287102" lat='51.7616709' lon='-0.0112898' display_name='Hoddesdon, Hertfordshire, East of England, England, United Kingdom' class='place' type='town' importance='0.50547792382382' icon='http://nominatim.openstreetmap.org/images/mapicons/poi_place_town.p.20.png'/>
     </searchresults>
-  
-/search?accept-language=&format=xml&extratags=1&q=Broxbourne&viewbox=-0.559%2C51.766%2C0.836%2C51.217:
+
+/search?accept-language=&extratags=1&format=xml&q=Broxbourne&viewbox=-0.559,51.766,0.836,51.217:
   code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8" ?>
@@ -15,7 +15,7 @@
       <place place_id='127984131' osm_type='relation' osm_id='2677978' place_rank='16' boundingbox="51.6808751,51.7806237,-0.114204,0.0145267" lat='51.73083995' lon='-0.0579457295222991' display_name='Broxbourne, Hertfordshire, East of England, England, United Kingdom' class='boundary' type='administrative' importance='0.46' icon='http://nominatim.openstreetmap.org/images/mapicons/poi_boundary_administrative.p.20.png'><extratags><tag key="place" value="village"/></extratags></place>
       <place place_id='109724' osm_type='node' osm_id='17044599' place_rank='30' boundingbox="51.7418469,51.7518469,-0.0156773,-0.0056773" lat='51.7468469' lon='-0.0106773' display_name='Broxbourne, Stafford Drive, Broxbourne, Hertfordshire, East of England, England, United Kingdom' class='railway' type='station' importance='0.111' icon='http://nominatim.openstreetmap.org/images/mapicons/transport_train_station2.p.20.png'><extratags></extratags></place>
     </searchresults>
-  
+
 /reverse?accept-language=&lat=51.7632&lon=-0.0076&zoom=15:
   code: 200
   body: |
@@ -32,7 +32,7 @@
         <country_code>gb</country_code>
       </addressparts>
     </reversegeocode>
-  
+
 /reverse?accept-language=&lat=51.7632&lon=-0.0076&zoom=17:
   code: 200
   body: |

--- a/test/http/npemap.yml
+++ b/test/http/npemap.yml
@@ -1,10 +1,10 @@
-/cgi/geocoder.fcgi?format=text&postcode=CV4+7AL:
+/cgi/geocoder.fcgi?format=text&postcode=CV4%207AL:
   code: 200
   body: |
     # Easting,Northing,Matched Postcode,Latitude,Longitude
     429926,276058,'CV4 7AL',52.381748701968,-1.56176420939232
 
-/cgi/geocoder.fcgi?format=text&postcode=XX9+9XX:
+/cgi/geocoder.fcgi?format=text&postcode=XX9%209XX:
   code: 200
   body: |
     Error: Postcode area 'XX' not found, postcode probably invalid

--- a/test/integration/oauth_test.rb
+++ b/test/integration/oauth_test.rb
@@ -6,6 +6,10 @@ class OAuthTest < ActionDispatch::IntegrationTest
 
   include OAuth::Helper
 
+  setup do
+    stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
+  end
+
   def test_oauth10_web_app
     client = client_applications(:oauth_web_app)
 

--- a/test/integration/oauth_test.rb
+++ b/test/integration/oauth_test.rb
@@ -7,7 +7,7 @@ class OAuthTest < ActionDispatch::IntegrationTest
   include OAuth::Helper
 
   setup do
-    stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
+    stub_signup_requests
   end
 
   def test_oauth10_web_app

--- a/test/integration/page_locale_test.rb
+++ b/test/integration/page_locale_test.rb
@@ -5,7 +5,7 @@ class PageLocaleTest < ActionDispatch::IntegrationTest
 
   def setup
     I18n.locale = "en"
-    stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
+    stub_signup_requests
   end
 
   def teardown

--- a/test/integration/page_locale_test.rb
+++ b/test/integration/page_locale_test.rb
@@ -5,6 +5,7 @@ class PageLocaleTest < ActionDispatch::IntegrationTest
 
   def setup
     I18n.locale = "en"
+    stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
   end
 
   def teardown

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -7,6 +7,8 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     I18n.locale = "en"
 
     OmniAuth.config.test_mode = true
+
+    stub_request(:get, /.*gravatar.com.*d=404/).to_return(:status => 404)
   end
 
   def teardown

--- a/test/integration/user_roles_test.rb
+++ b/test/integration/user_roles_test.rb
@@ -3,6 +3,10 @@ require "test_helper"
 class UserRolesTest < ActionDispatch::IntegrationTest
   fixtures :users, :user_roles
 
+  setup do
+    stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
+  end
+
   test "grant" do
     check_fail(:grant, :public_user, :moderator)
     check_fail(:grant, :moderator_user, :moderator)

--- a/test/integration/user_roles_test.rb
+++ b/test/integration/user_roles_test.rb
@@ -4,7 +4,7 @@ class UserRolesTest < ActionDispatch::IntegrationTest
   fixtures :users, :user_roles
 
   setup do
-    stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
+    stub_signup_requests
   end
 
   test "grant" do

--- a/test/integration/user_terms_seen_test.rb
+++ b/test/integration/user_terms_seen_test.rb
@@ -3,6 +3,10 @@ require "test_helper"
 class UserTermsSeenTest < ActionDispatch::IntegrationTest
   fixtures :users
 
+  setup do
+    stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
+  end
+
   def test_api_blocked
     with_terms_seen(true) do
       user = users(:terms_not_seen_user)

--- a/test/integration/user_terms_seen_test.rb
+++ b/test/integration/user_terms_seen_test.rb
@@ -4,7 +4,7 @@ class UserTermsSeenTest < ActionDispatch::IntegrationTest
   fixtures :users
 
   setup do
-    stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
+    stub_signup_requests
   end
 
   def test_api_blocked

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ Coveralls.wear!("rails")
 ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
+require "webmock/minitest"
 load "composite_primary_keys/fixtures.rb"
 
 module ActiveSupport

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -174,5 +174,11 @@ module ActiveSupport
       url = "https://www.gravatar.com/avatar/#{hash}?d=404"
       stub_request(:get, url).and_return(:status => status, :body => body)
     end
+
+    def stub_signup_requests
+      # Controller tests and integration tests use different IPs
+      stub_request(:get, "http://api.hostip.info/country.php?ip=0.0.0.0")
+      stub_request(:get, "http://api.hostip.info/country.php?ip=127.0.0.1")
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -161,23 +161,12 @@ module ActiveSupport
     ##
     # execute a block with a given set of HTTP responses stubbed
     def with_http_stubs(stubs_file)
-      http_client_save = OSM.http_client
-
-      begin
-        stubs = YAML.load_file(File.expand_path("../http/#{stubs_file}.yml", __FILE__))
-
-        OSM.http_client = Faraday.new do |builder|
-          builder.adapter :test do |stub|
-            stubs.each do |url, response|
-              stub.get(url) { |_env| [response["code"], {}, response["body"]] }
-            end
-          end
-        end
-
-        yield
-      ensure
-        OSM.http_client = http_client_save
+      stubs = YAML.load_file(File.expand_path("../http/#{stubs_file}.yml", __FILE__))
+      stubs.each do |url, response|
+        stub_request(:get, Regexp.new(Regexp.quote(url))).to_return(:status => response["code"], :body => response["body"])
       end
+
+      yield
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -168,5 +168,11 @@ module ActiveSupport
 
       yield
     end
+
+    def stub_gravatar_request(email, status = 200, body = nil)
+      hash = Digest::MD5.hexdigest(email.downcase)
+      url = "https://www.gravatar.com/avatar/#{hash}?d=404"
+      stub_request(:get, url).and_return(:status => status, :body => body)
+    end
   end
 end


### PR DESCRIPTION
I found while offline that many of the tests make real http requests. Using [webmock](https://github.com/bblimke/webmock) means these are disabled by default, and need to be explicitly stubbed - this ensures that http requests aren't accidentally overlooked when they are written while online.

Later I found that some http requests were being mocked out using the stub_http_requests method, so I've refactored that to use webmock too. I also refactored some gravatar tests to improve their clarity, and removed their http fixture since it was just dummy responses anyway.
