### PR TITLE
fix misspelling (lon -> lng)

### DIFF
--- a/app/views/site/_id.html.erb
+++ b/app/views/site/_id.html.erb
@@ -10,7 +10,7 @@
       params.id = mapParams.object.type[0] + mapParams.object.id;
       mapParams = OSM.parseHash(location.hash);
       if (mapParams.center) {
-        params.map = mapParams.zoom + '/' + mapParams.center.lat + '/' + mapParams.center.lon;
+        params.map = mapParams.zoom + '/' + mapParams.center.lat + '/' + mapParams.center.lng;
       }
     } else {
 <% if @lat && @lon -%>


### PR DESCRIPTION
fixes https://github.com/openstreetmap/iD/issues/3588

The typo slipped in through the iDv2.0.0 upgrade (#1373, see https://github.com/openstreetmap/openstreetmap-website/commit/6c3a31d06c8b8dab8b141c5ae54aaad55614b721#diff-dcb803599f773af7085d12ddacacea22L13)