### PR TITLE
Feed validation

### DIFF
--- a/app/views/changeset/list.atom.builder
+++ b/app/views/changeset/list.atom.builder
@@ -5,12 +5,12 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
   feed.title changeset_list_title(params, @user)
 
   feed.updated @edits.map { |e| [e.created_at, e.closed_at].max }.max
-  feed.icon "http://#{SERVER_URL}/favicon.ico"
-  feed.logo "http://#{SERVER_URL}/images/mag_map-rss2.0.png"
+  feed.icon image_path("favicon.ico", :host => SERVER_URL)
+  feed.logo image_path("mag_map-rss2.0.png", :host => SERVER_URL)
 
   feed.rights :type => "xhtml" do |xhtml|
     xhtml.a :href => "http://creativecommons.org/licenses/by-sa/2.0/" do |a|
-      a.img :src => "http://#{SERVER_URL}/images/cc_button.png", :alt => "CC by-sa 2.0"
+      a.img :src => image_path("cc_button.png", :host => SERVER_URL), :alt => "CC by-sa 2.0"
     end
   end
 

--- a/app/views/diary_entry/rss.rss.builder
+++ b/app/views/diary_entry/rss.rss.builder
@@ -9,7 +9,7 @@ xml.rss("version" => "2.0",
     xml.description @description
     xml.link url_for(:action => "list", :host => SERVER_URL)
     xml.image do
-      xml.url image_path("mag_map-rss2.0.png")
+      xml.url image_path("mag_map-rss2.0.png", :host => SERVER_URL)
       xml.title @title
       xml.width "100"
       xml.height "100"

--- a/app/views/diary_entry/rss.rss.builder
+++ b/app/views/diary_entry/rss.rss.builder
@@ -1,6 +1,7 @@
 xml.instruct!
 
 xml.rss("version" => "2.0",
+        "xmlns:dc" => "http://purl.org/dc/elements/1.1/",
         "xmlns:geo" => "http://www.w3.org/2003/01/geo/wgs84_pos#",
         "xmlns:georss" => "http://www.georss.org/georss") do
   xml.channel do

--- a/app/views/notes/index.rss.builder
+++ b/app/views/notes/index.rss.builder
@@ -1,6 +1,7 @@
 xml.instruct!
 
 xml.rss("version" => "2.0",
+        "xmlns:dc" => "http://purl.org/dc/elements/1.1/",
         "xmlns:geo" => "http://www.w3.org/2003/01/geo/wgs84_pos#",
         "xmlns:georss" => "http://www.georss.org/georss") do
   xml.channel do


### PR DESCRIPTION
This PR fixes a couple of missing xmlns declarations, and makes the remaining feeds use the assets path for their images.