### PR TITLE
Api timeout rollbacks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -343,17 +343,15 @@ class ApplicationController < ActionController::Base
   ##
   # wrap an api call in a timeout
   def api_call_timeout
-    OSM::Timer.timeout(API_TIMEOUT) do
+    OSM::Timer.timeout(API_TIMEOUT, OSM::APITimeoutError) do
       yield
     end
-  rescue Timeout::Error
-    raise OSM::APITimeoutError
   end
 
   ##
   # wrap a web page in a timeout
   def web_timeout
-    OSM::Timer.timeout(WEB_TIMEOUT) do
+    OSM::Timer.timeout(WEB_TIMEOUT, OSM::APITimeoutError) do
       yield
     end
   rescue ActionView::Template::Error => ex
@@ -369,6 +367,8 @@ class ApplicationController < ActionController::Base
       raise
     end
   rescue Timeout::Error
+    render :action => "timeout"
+  rescue OSM::APITimeoutError
     render :action => "timeout"
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -363,6 +363,8 @@ class ApplicationController < ActionController::Base
 
     if ex.is_a?(Timeout::Error)
       render :action => "timeout"
+    elsif ex.is_a?(OSM::APITimeoutError)
+      render :action => "timeout"
     else
       raise
     end


### PR DESCRIPTION
This seems like it would be the default behaviour, but because the exception that [Timeout::timeout raises on the other thread](https://github.com/ruby/ruby/blob/v2_3_1/lib/timeout.rb#L106) [doesn't appear to be rescue-able](https://gist.github.com/zerebubuth/8211e07e9f592e5b8146dea2344906b7), [Rails doesn't detect it](https://github.com/rails/rails/blob/v4.2.7.1/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L185). However, it still runs the ensure block, which [attempts to commit](https://github.com/rails/rails/blob/v4.2.7.1/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L193-L198) the transaction.

The result of this is that a long-running transaction can potentially be interrupted while partially complete and will commit the partial result rather than rolling back.

I've tried to fix this by using `Timeout.timeout`'s second argument, which allows a custom exception to be thrown. On the API side, we were doing this anyway, so hopefully the behaviour is unchanged. On the web side, I've added in some extra logic to treat the API error as if it were a `Timeout::Error`.

Thanks to @Zverik for pointing this out.
