### PR TITLE
Clone objects before saving in case of a retry

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -232,10 +232,14 @@ class Node < ActiveRecord::Base
 
   def save_with_history!
     t = Time.now.getutc
+
+    self.version += 1
+    self.timestamp = t
+
     Node.transaction do
-      self.version += 1
-      self.timestamp = t
-      save!
+      # clone the object before saving it so that the original is
+      # still marked as dirty if we retry the transaction
+      clone.save!
 
       # Create a NodeTag
       tags = self.tags

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -281,15 +281,19 @@ class Relation < ActiveRecord::Base
   private
 
   def save_with_history!
+    t = Time.now.getutc
+
+    self.version += 1
+    self.timestamp = t
+
     Relation.transaction do
       # have to be a little bit clever here - to detect if any tags
       # changed then we have to monitor their before and after state.
       tags_changed = false
 
-      t = Time.now.getutc
-      self.version += 1
-      self.timestamp = t
-      save!
+      # clone the object before saving it so that the original is
+      # still marked as dirty if we retry the transaction
+      clone.save!
 
       tags = self.tags.clone
       relation_tags.each do |old_tag|


### PR DESCRIPTION
If a deadlock occurs then the transaction will be retried so we need to make sure that the object will still be dirty so that it will be saved again during the retry but that the version won't be incremented a second time.