### PR TITLE
Fix misleading wording

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1013,7 +1013,7 @@ en:
         FAQ</a>.
       more_2_html: |
         Although OpenStreetMap is open data, we cannot provide a
-        free-of-charge map API for third-party developers.
+        free-of-charge map API for third-parties.
         See our <a href="http://wiki.openstreetmap.org/wiki/API_usage_policy">API Usage Policy</a>,
         <a href="http://wiki.openstreetmap.org/wiki/Tile_usage_policy">Tile Usage Policy</a>
         and <a href="http://wiki.openstreetmap.org/wiki/Nominatim#Usage_Policy">Nominatim Usage Policy</a>.


### PR DESCRIPTION
We can't provide a free unlimited API for any third-party, not just developers. The change should further make translations less bumpy.