### PR TITLE
Update OWG policy links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1014,9 +1014,9 @@ en:
       more_2_html: |
         Although OpenStreetMap is open data, we cannot provide a
         free-of-charge map API for third-party developers.
-        See our <a href="http://wiki.openstreetmap.org/wiki/API_usage_policy">API Usage Policy</a>,
-        <a href="http://wiki.openstreetmap.org/wiki/Tile_usage_policy">Tile Usage Policy</a>
-        and <a href="http://wiki.openstreetmap.org/wiki/Nominatim#Usage_Policy">Nominatim Usage Policy</a>.
+        See our <a href="https://operations.osmfoundation.org/policies/api/">API Usage Policy</a>,
+        <a href="https://operations.osmfoundation.org/policies/tiles/">Tile Usage Policy</a>
+        and <a href="https://operations.osmfoundation.org/policies/nominatim/">Nominatim Usage Policy</a>.
       contributors_title_html: Our contributors
       contributors_intro_html: |
         Our contributors are thousands of individuals. We also include


### PR DESCRIPTION
This updates the OWG policy links to point at the operations.osmfoundation.org website.