### PR TITLE
fix clang build error

### DIFF
--- a/lib/quad_tile/quad_tile.h
+++ b/lib/quad_tile/quad_tile.h
@@ -1,6 +1,6 @@
 #include <math.h>
 
-inline unsigned int xy2tile(unsigned int x, unsigned int y)
+static inline unsigned int xy2tile(unsigned int x, unsigned int y)
 {
    unsigned int tile = 0;
    int          i;
@@ -14,12 +14,12 @@ inline unsigned int xy2tile(unsigned int x, unsigned int y)
    return tile;
 }
 
-inline unsigned int lon2x(double lon)
+static inline unsigned int lon2x(double lon)
 {
    return round((lon + 180.0) * 65535.0 / 360.0);
 }
 
-inline unsigned int lat2y(double lat)
+static inline unsigned int lat2y(double lat)
 {
    return round((lat + 90.0) * 65535.0 / 180.0);
 }


### PR DESCRIPTION
```
hanchaodeMacBook-Pro:functions hanchao$ make libpgosm.so
cc -I `pg_config --includedir` -I `pg_config --includedir-server` -I../../lib/quad_tile -fPIC -O3 -DUSE_PGSQL -c -o quadtile.o quadtile.c
cc -I `pg_config --includedir` -I `pg_config --includedir-server` -I../../lib/quad_tile -fPIC -O3 -DUSE_PGSQL -c -o maptile.o maptile.c
cc -I `pg_config --includedir` -I `pg_config --includedir-server` -I../../lib/quad_tile -fPIC -O3 -DUSE_PGSQL -c -o xid_to_int4.o xid_to_int4.c
cc -bundle -o libpgosm.so quadtile.o maptile.o xid_to_int4.o
Undefined symbols for architecture x86_64:
  "_xy2tile", referenced from:
      _tile_for_point in quadtile.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [libpgosm.so] Error 1

```

```
hanchaodeMacBook-Pro:functions hanchao$ cc -v
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
By default, Clang builds C code in GNU C11 mode, so it uses standard C99 semantics for the inline keyword.
http://clang.llvm.org/compatibility.html#inline