### PR TITLE
change described dependancies ruby2.0->ruby 2.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,17 +18,17 @@ of packages required before you can get the various gems installed.
 
 ## Minimum requirements
 
-* Ruby 2.0
+* Ruby 2.3
 * RubyGems 1.3.1+
 * PostgreSQL 9.1+
 * ImageMagick
 * Bundler
 * Javascript Runtime
 
-These can be installed on Ubuntu 14.04 or later with:
+These can be installed on Ubuntu 16.04 or later with:
 
 ```
-sudo apt-get install ruby2.0 libruby2.0 ruby2.0-dev \
+sudo apt-get install ruby2.3 libruby2.3 ruby2.3-dev \
                      libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
                      apache2 apache2-threaded-dev build-essential git-core \
                      postgresql postgresql-contrib libpq-dev postgresql-server-dev-all \


### PR DESCRIPTION
change dependancies. nokogiri requires a later ruby now as pointed out here: https://github.com/openstreetmap/openstreetmap-website/issues/1402 ruby2.0->ruby 2.3 ...which then entails a later ubuntu if we're installing from packages.