### PR TITLE
fix for #1239 add public gps tiles layer for debugging purposes

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -157,6 +157,10 @@ $(document).ready(function () {
     if (params.layers.indexOf(map.dataLayer.options.code) >= 0) {
       map.addLayer(map.dataLayer);
     }
+
+    if (params.layers.indexOf(map.gpsLayer.options.code) >= 0) {
+      map.addLayer(map.gpsLayer);
+    }
   }
 
   var placement = $('html').attr('dir') === 'rtl' ? 'right' : 'left';

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -176,6 +176,7 @@ L.OSM.layers = function(options) {
 
       addOverlay(map.noteLayer, 'notes', OSM.MAX_NOTE_REQUEST_AREA);
       addOverlay(map.dataLayer, 'data', OSM.MAX_REQUEST_AREA);
+      addOverlay(map.gpsLayer, 'gps', OSM.MAX_REQUEST_AREA);
     }
 
     options.sidebar.addPane($ui);

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -176,7 +176,7 @@ L.OSM.layers = function(options) {
 
       addOverlay(map.noteLayer, 'notes', OSM.MAX_NOTE_REQUEST_AREA);
       addOverlay(map.dataLayer, 'data', OSM.MAX_REQUEST_AREA);
-      addOverlay(map.gpsLayer, 'gps', OSM.MAX_REQUEST_AREA);
+      addOverlay(map.gpsLayer, 'gps', Number.POSITIVE_INFINITY);
     }
 
     options.sidebar.addPane($ui);

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -57,9 +57,7 @@ L.OSM.Map = L.Map.extend({
     this.dataLayer.options.code = 'D';
     
     this.gpsLayer = new L.OSM.GPS({
-      attribution: copyright,
       code: "G",
-      keyid: "gps",
       name: I18n.t("javascripts.map.base.gps")
     });
   },

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -55,6 +55,13 @@ L.OSM.Map = L.Map.extend({
 
     this.dataLayer = new L.OSM.DataLayer(null);
     this.dataLayer.options.code = 'D';
+    
+    this.gpsLayer = new L.OSM.GPS({
+      attribution: copyright,
+      code: "G",
+      keyid: "gps",
+      name: I18n.t("javascripts.map.base.gps")
+    });
   },
 
   updateLayers: function(layerParam) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2211,7 +2211,7 @@ en:
         header: Map Layers
         notes: Map Notes
         data: Map Data
-        gps: GPS
+        gps: Public GPS Traces
         overlays: Enable overlays for troubleshooting the map
         title: "Layers"
       copyright: "© <a href='%{copyright_url}'>OpenStreetMap contributors</a>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2211,6 +2211,7 @@ en:
         header: Map Layers
         notes: Map Notes
         data: Map Data
+        gps: GPS
         overlays: Enable overlays for troubleshooting the map
         title: "Layers"
       copyright: "© <a href='%{copyright_url}'>OpenStreetMap contributors</a>"

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -64,6 +64,16 @@ L.OSM.HOT = L.OSM.TileLayer.extend({
   }
 });
 
+L.OSM.GPS = L.OSM.TileLayer.extend({
+  options: {
+    url: document.location.protocol === 'https:' ?
+      'https://{s}.gps-tile.openstreetmap.org/lines/{z}/{x}/{y}.png' :
+      'http://{s}.gps-tile.openstreetmap.org/lines/{z}/{x}/{y}.png',
+    maxZoom: 20,
+    subdomains: 'abc'
+  }
+});
+
 L.OSM.DataLayer = L.FeatureGroup.extend({
   options: {
     areaTags: ['area', 'building', 'leisure', 'tourism', 'ruins', 'historic', 'landuse', 'military', 'natural', 'sport'],


### PR DESCRIPTION
this pull request adds a checkbox in the debug area of the layers selection to show public GPS traces overlayed to the map. This comes in handy in sparsely mapped areas where GPS tracks might exist but no mapping has been done yet.
![screenshot](https://cloud.githubusercontent.com/assets/9305009/21642417/3c0cb3a8-d282-11e6-8b35-c22b83ea5968.png)
