### PR TITLE
Remove unused user_tokens fixture and pointless test

### DIFF
--- a/test/models/user_token_test.rb
+++ b/test/models/user_token_test.rb
@@ -1,10 +1,4 @@
 require "test_helper"
 
 class UserTokenTest < ActiveSupport::TestCase
-  api_fixtures
-  fixtures :user_tokens
-
-  def test_user_token_count
-    assert_equal 0, UserToken.count
-  end
 end


### PR DESCRIPTION
The fixture is a 0-byte file, and the test is only checking that no fixtures have been loaded from that 0-byte file.