### PR TITLE
Delete <tt> tag in French translation, obsolete in HTML5

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1894,7 +1894,7 @@ fr:
       help_text: Entrez l’adresse de courriel que vous avez utilisée à votre inscription,
         nous enverrons à cette adresse un lien que vous pourrez utiliser pour réinitialiser
         votre mot de passe.
-      notice email on way: Désolé que vous ayez perdu votre mot de passe <tt>:-(</tt>
+      notice email on way: Désolé que vous ayez perdu votre mot de passe :-(
         Un courriel vous a été envoyé pour que vous puissiez vite le réinitialiser.
       notice email cannot find: Cette adresse de courriel est introuvable, désolé.
     reset_password:


### PR DESCRIPTION
The HTML tag <tt> is not suported anymore in HTML5, source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt