### PR TITLE
Add allow_read_email oauth permission

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -381,7 +381,8 @@ class UserController < ApplicationController
 
   def api_details
     @this_user = @user
-    render :action => :api_read, :content_type => "text/xml"
+    allow_read_email = !current_token.nil? && current_token.read_attribute(:allow_read_email)
+    render :action => :api_read, :content_type => "text/xml", :locals => { :allow_read_email => allow_read_email }
   end
 
   def api_gpx_files

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -381,7 +381,7 @@ class UserController < ApplicationController
 
   def api_details
     @this_user = @user
-    allow_read_email = !current_token.nil? && current_token.read_attribute(:allow_read_email)
+    allow_read_email = current_token && current_token.read_attribute(:allow_read_email)
     render :action => :api_read, :content_type => "text/xml", :locals => { :allow_read_email => allow_read_email }
   end
 

--- a/app/models/client_application.rb
+++ b/app/models/client_application.rb
@@ -75,9 +75,9 @@ class ClientApplication < ActiveRecord::Base
   # this is the set of permissions that the client can ask for. clients
   # have to say up-front what permissions they want and when users sign up they
   # can agree or not agree to each of them.
-  PERMISSIONS = [:allow_read_prefs, :allow_write_prefs, :allow_write_diary,
-                 :allow_write_api, :allow_read_gpx, :allow_write_gpx,
-                 :allow_write_notes].freeze
+  PERMISSIONS = [:allow_read_prefs, :allow_read_email, :allow_write_prefs,
+                 :allow_write_diary, :allow_write_api, :allow_read_gpx,
+                 :allow_write_gpx, :allow_write_notes].freeze
 
   def generate_keys
     self.key = OAuth::Helper.generate_key(40)[0, 40]

--- a/app/views/user/api_read.builder
+++ b/app/views/user/api_read.builder
@@ -29,6 +29,7 @@ xml.osm("version" => API_VERSION, "generator" => GENERATOR) do
       end
     end
     if @user && @user == @this_user
+      xml.tag! "email", @this_user.email if allow_read_email
       if @this_user.home_lat && @this_user.home_lon
         xml.tag! "home", :lat => @this_user.home_lat,
                          :lon => @this_user.home_lon,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1639,6 +1639,7 @@ en:
       allow_read_gpx:    "read your private GPS traces."
       allow_write_gpx:   "upload GPS traces."
       allow_write_notes: "modify notes."
+      allow_read_email:  "see your e-mail address."
       grant_access: "Grant Access"
     oauthorize_success:
       title: "Authorization request allowed"
@@ -1676,6 +1677,7 @@ en:
       allow_read_gpx:    "read their private GPS traces."
       allow_write_gpx:   "upload GPS traces."
       allow_write_notes: "modify notes."
+      allow_read_email:  "see your e-mail address."
     index:
       title: "My OAuth Details"
       my_tokens: "My Authorised Applications"
@@ -1701,6 +1703,7 @@ en:
       allow_read_gpx:    "read their private GPS traces."
       allow_write_gpx:   "upload GPS traces."
       allow_write_notes: "modify notes."
+      allow_read_email:  "see your e-mail address."
     not_found:
       sorry: "Sorry, that %{type} could not be found."
     create:

--- a/db/migrate/20170127002700_add_read_email_permission.rb
+++ b/db/migrate/20170127002700_add_read_email_permission.rb
@@ -1,11 +1,6 @@
 class AddReadEmailPermission < ActiveRecord::Migration
-  def up
+  def change
     add_column :oauth_tokens, :allow_read_email, :boolean, :null => false, :default => false
     add_column :client_applications, :allow_read_email, :boolean, :null => false, :default => false
-  end
-
-  def down
-    remove_column :client_applications, :allow_read_email
-    remove_column :oauth_tokens, :allow_read_email
   end
 end

--- a/db/migrate/20170127002700_add_read_email_permission.rb
+++ b/db/migrate/20170127002700_add_read_email_permission.rb
@@ -1,0 +1,11 @@
+class AddReadEmailPermission < ActiveRecord::Migration
+  def up
+    add_column :oauth_tokens, :allow_read_email, :boolean, :null => false, :default => false
+    add_column :client_applications, :allow_read_email, :boolean, :null => false, :default => false
+  end
+
+  def down
+    remove_column :client_applications, :allow_read_email
+    remove_column :oauth_tokens, :allow_read_email
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -298,7 +298,8 @@ CREATE TABLE client_applications (
     allow_write_api boolean DEFAULT false NOT NULL,
     allow_read_gpx boolean DEFAULT false NOT NULL,
     allow_write_gpx boolean DEFAULT false NOT NULL,
-    allow_write_notes boolean DEFAULT false NOT NULL
+    allow_write_notes boolean DEFAULT false NOT NULL,
+    allow_read_email boolean DEFAULT false NOT NULL
 );
 
 
@@ -877,7 +878,8 @@ CREATE TABLE oauth_tokens (
     verifier character varying(20),
     scope character varying(255),
     valid_to timestamp without time zone,
-    allow_write_notes boolean DEFAULT false NOT NULL
+    allow_write_notes boolean DEFAULT false NOT NULL,
+    allow_read_email boolean DEFAULT false NOT NULL
 );
 
 
@@ -2598,6 +2600,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150818224516');
 INSERT INTO schema_migrations (version) VALUES ('20161002153425');
 
 INSERT INTO schema_migrations (version) VALUES ('20161011010929');
+
+INSERT INTO schema_migrations (version) VALUES ('20170127002700');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
Most social networks and other OAuth providers allow users to opt in to providing their email addresses to third-party services. This PR adds an `allow_read_email` OAuth permission, which adds a `<email>what@ever.com</email>` into the `/user/details` API output.