### PR TITLE
Don't display a box at all if the note event doesn't include a comment

### DIFF
--- a/app/views/notifier/note_comment_notification.html.erb
+++ b/app/views/notifier/note_comment_notification.html.erb
@@ -6,8 +6,10 @@
   <p><%= raw t "notifier.note_comment_notification.#{@event}.commented_note", :commenter => link_to_user(@commenter), :place => @place %></p>
 <% end %>
 
-<%= message_body do %>
-  <%= @comment.to_html %>
+<% unless @comment.empty? %>
+  <%= message_body do %>
+    <%= @comment.to_html %>
+  <% end %>
 <% end %>
 
 <p><%= raw t 'notifier.note_comment_notification.details', :url => link_to(@noteurl, @noteurl) %></p>

--- a/app/views/notifier/note_comment_notification.text.erb
+++ b/app/views/notifier/note_comment_notification.text.erb
@@ -6,8 +6,10 @@
 <%= t "notifier.note_comment_notification.#{@event}.commented_note", :commenter => @commenter, :place => @place %>
 <% end %>
 
+<% unless @comment.empty? %>
 ==
 <%= @comment.to_text %>
 ==
 
+<% end %>
 <%= t 'notifier.note_comment_notification.details', :url => @noteurl %>


### PR DESCRIPTION
This fixes the bug reported in [this comment on PR #1401](https://github.com/openstreetmap/openstreetmap-website/pull/1401#issuecomment-278389580)