### PR TITLE
Remove invalid YML from EN locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -782,7 +782,6 @@ en:
           car_parts: "Car Parts"
           car_repair: "Car Repair"
           carpet: "Carpet Shop"
-          car_repair: "Car Repair"
           charity: "Charity Shop"
           chemist: "Chemist"
           clothes: "Clothes Shop"


### PR DESCRIPTION
Nothing crazy here, was just getting an invalid YML error due to a duplicate entry when analyzing and comparing the locale files.

cc/ @tomhughes 

I'm assuming this doesn't need to be done through the translation wiki but if it does lmk.