### PR TITLE
Responsive HTML mails

### DIFF
--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -20,6 +20,9 @@ module NotifierHelper
   end
 
   def style_message(html)
-    html.gsub /<p>/, '<p style="color: black; margin: 0.75em 0">'
+    # Because we can't use stylesheets in HTML emails, we need to inline the
+    # styles. Rather than copy-paste the same string of CSS into every message,
+    # we apply it once here, after the message has been composed.
+    html.gsub /<p>/, '<p style="color: black; margin: 0.75em 0; font-family: \'Helvetica Neue\', Arial, Sans-Serif">'
   end
 end

--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -6,7 +6,7 @@ module NotifierHelper
   def link_to_user(display_name)
     link_to(
       content_tag(
-        'strong',
+        "strong",
         display_name,
         # NB we need "text-decoration: none" twice: GMail only honours it on
         # the <a> but Outlook only on the <strong>

--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -5,10 +5,16 @@ module NotifierHelper
 
   def link_to_user(display_name)
     link_to(
-      display_name,
+      content_tag(
+        'strong',
+        display_name,
+        # NB we need "text-decoration: none" twice: GMail only honours it on
+        # the <a> but Outlook only on the <strong>
+        :style => "text-decoration: none"
+      ),
       user_url(display_name, :host => SERVER_URL),
       :target => "_blank",
-      :style => "text-decoration: none; color: #222; font-weight: bold"
+      :style => "text-decoration: none; color: #222"
     )
   end
 

--- a/app/views/layouts/notifier.html.erb
+++ b/app/views/layouts/notifier.html.erb
@@ -5,7 +5,7 @@
   <body style="padding: 0; margin: 0; font-size: 14px; font-family: 'Helvetica Neue', Arial, sans-serif; color: #222">
     <table style="background-color: #eee; width: 100%">
       <tr>
-        <td style="text-align: center">
+        <td style="text-align: center; padding: 0px 7px">
           <table style="width: 600px; color: #222; margin-left: auto; margin-right: auto">
             <tr>
               <td style="width: 30px; padding: 10px 10px 10px 0px">

--- a/app/views/layouts/notifier.html.erb
+++ b/app/views/layouts/notifier.html.erb
@@ -10,7 +10,7 @@
             <tr>
               <td style="width: 30px; padding: 10px 10px 10px 0px">
                 <a href="<%= @root_url %>" target="_blank">
-                  <%= image_tag attachments["logo.png"].url, alt: "OpenStreetMap logo", title: "OpenStreetMap", height: "30", width: "30", border: "0" %>
+                  <%= image_tag attachments["logo.png"].url, alt: "OpenStreetMap", title: "OpenStreetMap", height: "30", width: "30", border: "0" %>
                 </a>
               </td>
               <td style="width: 550px; padding: 0px; text-align: left">

--- a/app/views/layouts/notifier.html.erb
+++ b/app/views/layouts/notifier.html.erb
@@ -13,7 +13,7 @@
                   <%= image_tag attachments["logo.png"].url, alt: "OpenStreetMap logo", title: "OpenStreetMap", height: "30", width: "30", border: "0" %>
                 </a>
               </td>
-              <td style="padding: 10px 0px">
+              <td style="width: 550px; padding: 0px; text-align: left">
                 <a href="<%= @root_url %>" target="_blank" style="text-decoration: none; color: #000">
                   <h1 style="font-size: 18px; font-weight: 600; margin: 0; text-align: left">OpenStreetMap</h1>
                 </a>

--- a/app/views/layouts/notifier.html.erb
+++ b/app/views/layouts/notifier.html.erb
@@ -5,8 +5,10 @@
   <body style="padding: 0; margin: 0; font-size: 14px; font-family: 'Helvetica Neue', Arial, sans-serif; color: #222">
     <table style="background-color: #eee; width: 100%">
       <tr>
-        <td style="text-align: center; padding: 0px 7px">
-          <table style="max-width: 600px; color: #222; margin-left: auto; margin-right: auto">
+        <%# having width=100% on the table and then only a fixed width on the middle cell gives us a max-width that works in Outlook %>
+        <td rowspan="2"></td>
+        <td width="600" style="text-align: center; padding: 0px 7px">
+          <table style="width: 100%; color: #222; margin-left: auto; margin-right: auto">
             <tr>
               <td style="width: 30px; padding: 10px 10px 10px 0px">
                 <a href="<%= @root_url %>" target="_blank">
@@ -34,6 +36,7 @@
             </tr>
           </table>
         </td>
+        <td rowspan="2"></td>
       </tr>
       <tr>
         <td style="text-align: center; font-size: 11px; font-family: 'Helvetica Neue', Arial, sans-serif">

--- a/app/views/layouts/notifier.html.erb
+++ b/app/views/layouts/notifier.html.erb
@@ -13,9 +13,10 @@
                   <%= image_tag attachments["logo.png"].url, alt: "OpenStreetMap", title: "OpenStreetMap", height: "30", width: "30", border: "0" %>
                 </a>
               </td>
-              <td style="width: 550px; padding: 0px; text-align: left">
+              <td style="width: 570px; padding: 0px; text-align: left">
+                <%# NB we need "text-decoration: none" twice: GMail only honours it on the <a> but Outlook only on the <strong> %>
                 <a href="<%= @root_url %>" target="_blank" style="text-decoration: none; color: #000">
-                  <h1 style="font-size: 18px; font-weight: 600; margin: 0; text-align: left">OpenStreetMap</h1>
+                  <strong style="text-decoration: none; font-size: 18px; font-weight: 600; margin: 0; text-align: left">OpenStreetMap</strong>
                 </a>
               </td>
             </tr>

--- a/app/views/layouts/notifier.html.erb
+++ b/app/views/layouts/notifier.html.erb
@@ -17,7 +17,7 @@
               <td style="width: 100%; padding: 0px; text-align: left">
                 <%# NB we need "text-decoration: none" twice: GMail only honours it on the <a> but Outlook only on the <strong> %>
                 <a href="<%= @root_url %>" target="_blank" style="text-decoration: none; color: #000">
-                  <strong style="text-decoration: none; font-size: 18px; font-weight: 600; margin: 0; text-align: left">OpenStreetMap</strong>
+                  <strong style="text-decoration: none; font-size: 18px; font-weight: 600; margin: 0; text-align: left; font-family: 'Helvetica Neue', Arial, sans-serif">OpenStreetMap</strong>
                 </a>
               </td>
             </tr>

--- a/app/views/layouts/notifier.html.erb
+++ b/app/views/layouts/notifier.html.erb
@@ -34,7 +34,7 @@
         </td>
       </tr>
       <tr>
-        <td style="text-align: center; font-size: 11px">
+        <td style="text-align: center; font-size: 11px; font-family: 'Helvetica Neue', Arial, sans-serif">
           <%= yield :footer %>
           <p style="margin-bottom: 10px">
             <a href="<%= @root_url %>" target="_blank" style="color: #222">OpenStreetMap</a>

--- a/app/views/layouts/notifier.html.erb
+++ b/app/views/layouts/notifier.html.erb
@@ -6,14 +6,15 @@
     <table style="background-color: #eee; width: 100%">
       <tr>
         <td style="text-align: center; padding: 0px 7px">
-          <table style="width: 600px; color: #222; margin-left: auto; margin-right: auto">
+          <table style="max-width: 600px; color: #222; margin-left: auto; margin-right: auto">
             <tr>
               <td style="width: 30px; padding: 10px 10px 10px 0px">
                 <a href="<%= @root_url %>" target="_blank">
                   <%= image_tag attachments["logo.png"].url, alt: "OpenStreetMap", title: "OpenStreetMap", height: "30", width: "30", border: "0" %>
                 </a>
               </td>
-              <td style="width: 570px; padding: 0px; text-align: left">
+              <%# the "width: 100%" here looks wrong, but I couldn't find a better way of making Outlook give this cell full width %>
+              <td style="width: 100%; padding: 0px; text-align: left">
                 <%# NB we need "text-decoration: none" twice: GMail only honours it on the <a> but Outlook only on the <strong> %>
                 <a href="<%= @root_url %>" target="_blank" style="text-decoration: none; color: #000">
                   <strong style="text-decoration: none; font-size: 18px; font-weight: 600; margin: 0; text-align: left">OpenStreetMap</strong>

--- a/app/views/notifier/_message_body.html.erb
+++ b/app/views/notifier/_message_body.html.erb
@@ -1,4 +1,4 @@
-<table style="font-size: 15px; margin: 15px 0px; background-color: #eee; width: 565px">
+<table style="font-size: 15px; margin: 15px 0px; background-color: #eee; max-width: 565px">
   <tr>
     <td style="width: 50px; vertical-align: top; padding: 15px">
       <%= link_to(
@@ -14,7 +14,7 @@
           :target => "_blank"
       ) %>
     </td>
-    <td style="text-align: left; vertical-align: top; padding-right: 10px">
+    <td style="text-align: left; vertical-align: top; padding-right: 10px; max-width: 550px">
       <%= body %>
     </td>
   </tr>

--- a/app/views/notifier/_message_body.html.erb
+++ b/app/views/notifier/_message_body.html.erb
@@ -1,4 +1,4 @@
-<table style="font-size: 15px; margin: 15px 0px; background-color: #eee; width: 550px">
+<table style="font-size: 15px; margin: 15px 0px; background-color: #eee; width: 565px">
   <tr>
     <td style="width: 50px; vertical-align: top; padding: 15px">
       <%= link_to(

--- a/app/views/notifier/_message_body.html.erb
+++ b/app/views/notifier/_message_body.html.erb
@@ -1,6 +1,6 @@
-<table style="font-size: 15px; margin: 15px 0px; background-color: #eee; max-width: 565px">
+<table style="font-size: 15px; margin: 15px 0px; background-color: #eee; width: 100%">
   <tr>
-    <td style="width: 50px; vertical-align: top; padding: 15px">
+    <td style="width: 50px; min-width: 50px; vertical-align: top; padding: 15px">
       <%= link_to(
           image_tag(
             attachments["avatar.png"].url,
@@ -14,7 +14,7 @@
           :target => "_blank"
       ) %>
     </td>
-    <td style="text-align: left; vertical-align: top; padding-right: 10px; max-width: 550px">
+    <td style="text-align: left; vertical-align: top; padding-right: 10px; width: 100%">
       <%= body %>
     </td>
   </tr>

--- a/app/views/notifier/_message_body.html.erb
+++ b/app/views/notifier/_message_body.html.erb
@@ -1,4 +1,4 @@
-<table style="font-size: 15px; font-style: italic; margin: 15px 0px; background-color: #eee; width: 520px">
+<table style="font-size: 15px; font-style: italic; margin: 15px 0px; background-color: #eee; width: 550px">
   <tr>
     <td style="width: 50px; vertical-align: top; padding: 15px">
       <%= link_to(

--- a/app/views/notifier/_message_body.html.erb
+++ b/app/views/notifier/_message_body.html.erb
@@ -1,4 +1,4 @@
-<table style="font-size: 15px; font-style: italic; margin: 15px 0px; background-color: #eee; width: 550px">
+<table style="font-size: 15px; margin: 15px 0px; background-color: #eee; width: 550px">
   <tr>
     <td style="width: 50px; vertical-align: top; padding: 15px">
       <%= link_to(

--- a/app/views/notifier/changeset_comment_notification.html.erb
+++ b/app/views/notifier/changeset_comment_notification.html.erb
@@ -16,11 +16,11 @@
 <% end %>
 
 <p>
-  <%= raw t 'notifier.changeset_comment_notification.details', :url => link_to(@changeset_url, @changeset_url, :style => "white-space: nowrap") %>
+  <%= raw t 'notifier.changeset_comment_notification.details', :url => link_to(@changeset_url, @changeset_url) %>
 </p>
 
 <% content_for :footer do %>
   <p>
-    <%= raw t 'notifier.changeset_comment_notification.unsubscribe', :url => link_to(@changeset_url, @changeset_url, :style => "color: #222; white-space: nowrap") %>
+    <%= raw t 'notifier.changeset_comment_notification.unsubscribe', :url => link_to(@changeset_url, @changeset_url, :style => "color: #222") %>
   </p>
 <% end %>

--- a/app/views/notifier/email_confirm.html.erb
+++ b/app/views/notifier/email_confirm.html.erb
@@ -4,4 +4,4 @@
 
 <p><%= t 'notifier.email_confirm_html.click_the_link' %></p>
 
-<p><a href="<%= @url %>" style="white-space: nowrap"><%= @url %></a></p>
+<p><a href="<%= @url %>"><%= @url %></a></p>

--- a/app/views/notifier/signup_confirm.html.erb
+++ b/app/views/notifier/signup_confirm.html.erb
@@ -4,6 +4,6 @@
 
 <p><%= t("notifier.signup_confirm.confirm") %></p>
 
-<p><%= link_to @url, @url, :style => "white-space: nowrap" %></p>
+<p><%= link_to @url, @url %></p>
 
 <p><%= t("notifier.signup_confirm.welcome") %></p>


### PR DESCRIPTION
A few tweaks to the HTML/CSS code of the email notifications to make messages more responsive on narrow displays, which should improve the viewing experience on mobile. Also a handful of minor tweaks to fonts.

There are no changes to content, only implementation.

https://wiki.openstreetmap.org/wiki/Dressed-up_Notification_Mails is up to date with screenshots of what this PR produces.