### PR TITLE
Fix latLng from GraphHopper engine

### DIFF
--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -50,7 +50,7 @@ function GraphHopperEngine(id, vehicleType) {
             var latLng = line[instr.interval[0]];
             var distInMeter = instr.distance;
             steps.push([
-              {lat: latLng.lat, lng: latLng.lng},
+              {lat: latLng[0], lng: latLng[1]},
               instrCode,
               instrText,
               distInMeter,


### PR DESCRIPTION
latLng is an array and not a latLng object

Here is a minor fix for GraphHopper engine