### PR TITLE
Implement the OWG credit policy for hosting partners.

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -49,6 +49,12 @@
         <h2><%= t 'layouts.intro_header' %></h2>
         <div class="close-wrap"><span class="icon close"></span></div>
         <p><%= t 'layouts.intro_text' %></p>
+        <p><%= t 'layouts.partners_html',
+               :ucl => link_to(t('layouts.partners_ucl'), "http://www.bartlett.ucl.ac.uk"),
+               :ic => link_to(t('layouts.partners_ic'), "http://www.imperial.ac.uk/"),
+               :bytemark => link_to(t('layouts.partners_bytemark'), "http://www.bytemark.co.uk"),
+               :partners => link_to(t('layouts.partners_partners'), "https://hardware.openstreetmap.org/thanks/") %>
+        </p>
         <a class="button learn-more" href="<%= about_path %>"><%= t('layouts.learn_more') %></a>
         <a class="button sign-up" href="<%= user_new_path %>"><%= t('layouts.start_mapping') %></a>
       </div>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -36,7 +36,7 @@
              :ucl => link_to(t('layouts.partners_ucl'), "http://www.bartlett.ucl.ac.uk"),
              :ic => link_to(t('layouts.partners_ic'), "http://www.imperial.ac.uk/"),
              :bytemark => link_to(t('layouts.partners_bytemark'), "http://www.bytemark.co.uk"),
-             :partners => link_to(t('layouts.partners_partners'), t('layouts.partners_url')) %>
+             :partners => link_to(t('layouts.partners_partners'), "https://hardware.openstreetmap.org/thanks/") %>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -933,12 +933,11 @@ en:
     intro_header: Welcome to OpenStreetMap!
     intro_text: OpenStreetMap is a map of the world, created by people like you and free to use under an open license.
     intro_2_create_account: "Create a user account"
-    partners_html: "Hosting is supported by %{ucl}, %{ic} and %{bytemark}, and other %{partners}."
+    partners_html: "Hosting is supported by %{ucl}, %{bytemark} and %{ic}, and other %{partners}."
     partners_ucl: "the UCL VR Centre"
     partners_ic: "Imperial College London"
     partners_bytemark: "Bytemark Hosting"
     partners_partners: "partners"
-    partners_url: "http://wiki.openstreetmap.org/wiki/Partners"
     osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."
     osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential database maintenance work is carried out."
     donate: "Support OpenStreetMap by %{link} to the Hardware Upgrade Fund."


### PR DESCRIPTION
See [the policy](https://operations.osmfoundation.org/policies/hosting/) for the details, but basically means a swap in the order that we list credits (which might take some time to percolate through translations), plus a paragraph in the welcome box. It looks like this (until dismissed as usual):

![image](https://cloud.githubusercontent.com/assets/271360/23064464/247d9e34-f508-11e6-9e3c-577f25493190.png)

Note that, since I'm using `en_GB`, the order hasn't changed - I'll have to wait for translatewiki for that.