### PR TITLE
Add functionality to return a specific message for zero hour blocks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,10 +152,14 @@ class ApplicationController < ActionController::Base
     # have we identified the user?
     if @user
       # check if the user has been banned
-      if @user.blocks.active.exists?
-        # NOTE: need slightly more helpful message than this.
+      user_block =  @user.blocks.active.take
+      unless user_block.nil? 
         set_locale
-        report_error t("application.setup_user_auth.blocked"), :forbidden
+        if  @user.blocks.active.take.zero_hour?
+          report_error  t("application.setup_user_auth.blocked_zero_hour"), :forbidden
+        else
+          report_error t("application.setup_user_auth.blocked"), :forbidden
+        end
       end
 
       # if the user hasn't seen the contributor terms then don't

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -155,7 +155,7 @@ class ApplicationController < ActionController::Base
       user_block =  @user.blocks.active.take
       unless user_block.nil? 
         set_locale
-        if  @user.blocks.active.take.zero_hour?
+        if  user_block.zero_hour?
           report_error  t("application.setup_user_auth.blocked_zero_hour"), :forbidden
         else
           report_error t("application.setup_user_auth.blocked"), :forbidden

--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -29,7 +29,8 @@ class UserBlock < ActiveRecord::Base
   ##
   # returns true if the block is a "zero hour" block
   def zero_hour?
-    needs_view && (ends_at.to_i == updated_at.to_i)
+    # if the times differ more than 1 minute we probably have more important issues
+    needs_view && (ends_at.to_i - updated_at.to_i) < 60
   end
 
   ##

--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -27,6 +27,12 @@ class UserBlock < ActiveRecord::Base
   end
 
   ##
+  # returns true if the block is a "zero hour" block
+  def zero_hour?
+    needs_view && (ends_at.to_i == updated_at.to_i)
+  end
+
+  ##
   # revokes the block, allowing the user to use the API again. the argument
   # is the user object who is revoking the ban.
   def revoke!(revoker)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1625,6 +1625,7 @@ en:
     require_moderator:
       not_a_moderator: "You need to be a moderator to perform that action."
     setup_user_auth:
+      blocked_zero_hour: "You have an urgent message on the OpenStreetMap web site. You need to read the message before you will be able to save your edits."
       blocked: "Your access to the API has been blocked. Please log-in to the web interface to find out more."
       need_to_see_terms: "Your access to the API is temporarily suspended. Please log-in to the web interface to view the Contributor Terms. You do not need to agree, but you must view them."
   oauth:


### PR DESCRIPTION
This PR adds a specific message for zero hour blocks that is a bit friendlier than the rather technical default message.

While this improves the messaging special support at least in iD would be good as the user is asked to login to the OSM website and it may not be clear to the user how to do this without losing their edits.

Tests to come.