### PR TITLE
Small improvement to block status display

### DIFF
--- a/app/helpers/user_blocks_helper.rb
+++ b/app/helpers/user_blocks_helper.rb
@@ -4,8 +4,13 @@ module UserBlocksHelper
   # user block (i.e: whether it's active, what the expiry time is)
   def block_status(block)
     if block.active?
+      # if the block hasn't expired yet show the date, if the user just needs to login show that
       if block.needs_view?
-        I18n.t("user_block.helper.until_login")
+        if block.ends_at > Time.now.getutc
+          I18n.t("user_block.helper.time_future_and_until_login", :time => friendly_date(block.ends_at)).html_safe
+        else
+          I18n.t("user_block.helper.until_login")
+        end
       else
         I18n.t("user_block.helper.time_future", :time => friendly_date(block.ends_at)).html_safe
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2112,7 +2112,7 @@ en:
     helper:
       time_future: "Ends in %{time}."
       until_login: "Active until the user logs in."
-      time_future_and_until_login: "Expires in %{time} and requires the user to login."
+      time_future_and_until_login: "Ends in %{time} and after the user has logged in."
       time_past: "Ended %{time} ago."
     blocks_on:
       title: "Blocks on %{name}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2112,6 +2112,7 @@ en:
     helper:
       time_future: "Ends in %{time}."
       until_login: "Active until the user logs in."
+      time_future_and_until_login: "Expires in %{time} and requires the user to login."
       time_past: "Ended %{time} ago."
     blocks_on:
       title: "Blocks on %{name}"

--- a/test/helpers/user_blocks_helper_test.rb
+++ b/test/helpers/user_blocks_helper_test.rb
@@ -1,9 +1,8 @@
 # coding: utf-8
 require "test_helper"
-include ApplicationHelper
 
 class UserBlocksHelperTest < ActionView::TestCase
-
+  include ApplicationHelper
   def setup
     I18n.locale = "en"
   end
@@ -29,7 +28,7 @@ class UserBlocksHelperTest < ActionView::TestCase
       :needs_view => true,
       :ends_at => Time.now.getutc + 60.minutes
     )
-    assert_equal I18n.t("user_block.helper.time_future_and_until_login", :time => friendly_date(block_end)).html_safe, block_status(block)
+    assert_equal I18n.t("user_block.helper.time_future_and_until_login", :time => friendly_date(block_end)), block_status(block)
     block_end = Time.now.getutc + 60.minutes
     block = UserBlock.create(
       :user_id => 1,
@@ -38,6 +37,6 @@ class UserBlocksHelperTest < ActionView::TestCase
       :needs_view => false,
       :ends_at => Time.now.getutc + 60.minutes
     )
-    assert_equal I18n.t("user_block.helper.time_future", :time => friendly_date(block_end)).html_safe, block_status(block)
+    assert_equal I18n.t("user_block.helper.time_future", :time => friendly_date(block_end)), block_status(block)
   end
 end

--- a/test/helpers/user_blocks_helper_test.rb
+++ b/test/helpers/user_blocks_helper_test.rb
@@ -1,0 +1,43 @@
+# coding: utf-8
+require "test_helper"
+include ApplicationHelper
+
+class UserBlocksHelperTest < ActionView::TestCase
+
+  def setup
+    I18n.locale = "en"
+  end
+
+  def teardown
+    I18n.locale = "en"
+  end
+
+  def test_block_status
+    block = UserBlock.create(
+      :user_id => 1,
+      :creator_id => 2,
+      :reason => "testing",
+      :needs_view => true,
+      :ends_at => Time.now.getutc
+    )
+    assert_equal I18n.t("user_block.helper.until_login"), block_status(block)
+    block_end = Time.now.getutc + 60.minutes
+    block = UserBlock.create(
+      :user_id => 1,
+      :creator_id => 2,
+      :reason => "testing",
+      :needs_view => true,
+      :ends_at => Time.now.getutc + 60.minutes
+    )
+    assert_equal I18n.t("user_block.helper.time_future_and_until_login", :time => friendly_date(block_end)).html_safe, block_status(block)
+    block_end = Time.now.getutc + 60.minutes
+    block = UserBlock.create(
+      :user_id => 1,
+      :creator_id => 2,
+      :reason => "testing",
+      :needs_view => false,
+      :ends_at => Time.now.getutc + 60.minutes
+    )
+    assert_equal I18n.t("user_block.helper.time_future", :time => friendly_date(block_end)).html_safe, block_status(block)
+  end
+end


### PR DESCRIPTION
This fixes a tiny issue with the block display: previously if the need_view flag was set, the status only displayed that the user has to login even if the block hadn't expired yet, this PR makes the remaining block time visible too.