### PR TITLE
Fix shift key handling in contextmenu

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -71,7 +71,7 @@ OSM.initializeContextMenu = function (map) {
   });
 
   map.on("mousedown", function (e) {
-    if (e.shiftKey) map.contextmenu.disable();
+    if (e.originalEvent.shiftKey) map.contextmenu.disable();
   }).on("mouseup", function () {
     map.contextmenu.enable();
   });


### PR DESCRIPTION
At least in Google Chrome `e.shiftKey` is not defined in `mousedown` event here, so the desired effect (skipping contextmenu) is not working. Using `e.originalEvent.shiftKey` now.

I really love TypeScript :-)