### PR TITLE
Refactor diary entry tests to use User factory

### DIFF
--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -40,5 +40,12 @@ FactoryGirl.define do
         create(:user_role, :role => "administrator", :user => user)
       end
     end
+
+    # A commonly needed user is one who can log in an isn't redirected anywhere
+    factory :normal_user do
+      status "active"
+      terms_seen true
+      data_public true
+    end
   end
 end

--- a/test/models/diary_comment_test.rb
+++ b/test/models/diary_comment_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class DiaryCommentTest < ActiveSupport::TestCase
-  fixtures :users
-
   def setup
     # Create the default language for diary entries
     create(:language, :code => "en")

--- a/test/models/diary_entry_test.rb
+++ b/test/models/diary_entry_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class DiaryEntryTest < ActiveSupport::TestCase
-  fixtures :users
-
   def setup
     # Create the default language for diary entries
     create(:language, :code => "en")


### PR DESCRIPTION
This PR refactors the diary_entry tests to use the User factory instead of the fixtures. To simplify them I've created a "normal user" factory, which can log in without being redirected to view contributor terms etc.

I've tried to keep consistent naming for the tests, in most cases there are 'user' and 'other_user' objects replacing the 'normal_user' and 'public_user' fixtures.