### PR TITLE
Added "Get tile image" context menu item

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -64,6 +64,26 @@ OSM.initializeContextMenu = function (map) {
   });
 
   map.contextmenu.addItem({
+    text: I18n.t("javascripts.context.open_tile_image"),
+    callback: function openTileImage(e) {
+      for (var i = 0; i < map.baseLayers.length; i++) {
+        if (map.hasLayer(map.baseLayers[i])) {
+          var latlng = e.latlng.wrap(),
+              pixel = map.project(latlng, map.getZoom()).floor(),
+              tileSize = map.baseLayers[i].getTileSize(),
+              coords = pixel.unscaleBy(tileSize).floor(),
+              url = map.baseLayers[i].getTileUrl(coords);
+
+          if (url)
+            window.open(url);
+
+          break;
+        }
+      }
+    }
+  });
+
+  map.contextmenu.addItem({
     text: I18n.t("javascripts.context.centre_map"),
     callback: function centreMap(e) {
       map.panTo(e.latlng);

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2311,6 +2311,7 @@ en:
       add_note: Add a note here
       show_address: Show address
       query_features: Query features
+      open_tile_image: Open tile image
       centre_map: Centre map here
   redaction:
     edit:


### PR DESCRIPTION
Resolves #1446. Adds a popup menu item that opens a tile under cursor in a new tab. Just so there is a working solution to the issue: I am getting more and more complaints about not being able to view distinct tiles from mappers all over Russia.