### PR TITLE
Make all factory-generated users 'normal'

### DIFF
--- a/test/controllers/amf_controller_test.rb
+++ b/test/controllers/amf_controller_test.rb
@@ -19,8 +19,8 @@ class AmfControllerTest < ActionController::TestCase
   end
 
   def test_getpresets
-    user_en_de = create(:normal_user, :languages => %w(en de))
-    user_de = create(:normal_user, :languages => %w(de))
+    user_en_de = create(:user, :languages => %w(en de))
+    user_de = create(:user, :languages => %w(de))
     [user_en_de, user_de].each do |user|
       amf_content "getpresets", "/1", ["#{user.email}:test", ""]
       post :amf_read
@@ -460,7 +460,7 @@ class AmfControllerTest < ActionController::TestCase
     assert_equal -1, result[0]
     assert_match /must be logged in/, result[1]
 
-    blocked_user = create(:normal_user)
+    blocked_user = create(:user)
     create(:user_block, :user => blocked_user)
     amf_content "findgpx", "/1", [1, "#{blocked_user.email}:test"]
     post :amf_read
@@ -474,7 +474,7 @@ class AmfControllerTest < ActionController::TestCase
   end
 
   def test_findgpx_by_id
-    user = create(:normal_user)
+    user = create(:user)
     trace = create(:trace, :visibility => "private", :user => user)
 
     amf_content "findgpx", "/1", [trace.id, "#{user.email}:test"]

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -382,7 +382,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   def test_permissions_basic_auth
-    basic_authorization(create(:normal_user).email, "test")
+    basic_authorization(create(:user).email, "test")
     get :permissions
     assert_response :success
     assert_select "osm > permissions", :count => 1 do

--- a/test/controllers/diary_entry_controller_test.rb
+++ b/test/controllers/diary_entry_controller_test.rb
@@ -109,7 +109,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
 
   def test_new_form
     # Now try again when logged in
-    get :new, {}, { :user => create(:normal_user) }
+    get :new, {}, { :user => create(:user) }
     assert_response :success
     assert_select "title", :text => /New Diary Entry/, :count => 1
     assert_select "div.content-heading", :count => 1 do
@@ -136,7 +136,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
       get :new, { :commit => "save",
                   :diary_entry => { :title => "New Title", :body => "This is a new body for the diary entry", :latitude => "1.1",
                                     :longitude => "2.2", :language_code => "en" } },
-          { :user => create(:normal_user).id }
+          { :user => create(:user).id }
     end
     assert_response :success
     assert_template :edit
@@ -144,7 +144,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
 
   def test_new_no_body
     # Now try creating a invalid diary entry with an empty body
-    user = create(:normal_user)
+    user = create(:user)
     assert_no_difference "DiaryEntry.count" do
       post :new, { :commit => "save",
                    :diary_entry => { :title => "New Title", :body => "", :latitude => "1.1",
@@ -159,7 +159,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
 
   def test_new_post
     # Now try creating a diary entry
-    user = create(:normal_user)
+    user = create(:user)
     assert_difference "DiaryEntry.count", 1 do
       post :new, { :commit => "save",
                    :diary_entry => { :title => "New Title", :body => "This is a new body for the diary entry", :latitude => "1.1",
@@ -184,7 +184,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
 
   def test_new_german
     create(:language, :code => "de")
-    user = create(:normal_user)
+    user = create(:user)
 
     # Now try creating a diary entry in a different language
     assert_difference "DiaryEntry.count", 1 do
@@ -210,7 +210,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_new_spammy
-    user = create(:normal_user)
+    user = create(:user)
     # Generate some spammy content
     spammy_title = "Spam Spam Spam Spam Spam"
     spammy_body = 1.upto(50).map { |n| "http://example.com/spam#{n}" }.join(" ")
@@ -237,8 +237,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_edit
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
 
     entry = create(:diary_entry, :user => user)
 
@@ -337,7 +337,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_edit_i18n
-    user = create(:normal_user)
+    user = create(:user)
     diary_entry = create(:diary_entry, :language_code => "en", :user => user)
     get :edit, { :display_name => user.display_name, :id => diary_entry.id }, { :user => user }
     assert_response :success
@@ -345,8 +345,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_comment
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
     entry = create(:diary_entry, :user => user)
 
     # Make sure that you are denied when you are not logged in
@@ -406,8 +406,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_comment_spammy
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
 
     # Find the entry to comment on
     entry = create(:diary_entry, :user => user)
@@ -450,7 +450,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
   def test_list_all
     diary_entry = create(:diary_entry)
     geo_entry = create(:diary_entry, :latitude => 51.50763, :longitude => -0.10781)
-    public_entry = create(:diary_entry, :user => create(:normal_user))
+    public_entry = create(:diary_entry, :user => create(:user))
 
     # Try a list of all diary entries
     get :list
@@ -458,8 +458,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_list_user
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
 
     diary_entry = create(:diary_entry, :user => user)
     geo_entry = create(:diary_entry, :user => user, :latitude => 51.50763, :longitude => -0.10781)
@@ -476,8 +476,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_list_friends
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
     friend = create(:friend, :befriender => user)
     diary_entry = create(:diary_entry, :user => friend.befriendee)
     _other_entry = create(:diary_entry, :user => other_user)
@@ -495,8 +495,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_list_nearby
-    user = create(:normal_user, :home_lat => 12, :home_lon => 12)
-    nearby_user = create(:normal_user, :home_lat => 11.9, :home_lon => 12.1)
+    user = create(:user, :home_lat => 12, :home_lon => 12)
+    nearby_user = create(:user, :home_lat => 11.9, :home_lon => 12.1)
 
     diary_entry = create(:diary_entry, :user => user)
 
@@ -575,8 +575,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_rss_user
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
     create(:diary_entry, :user => user)
     create(:diary_entry, :user => user)
     create(:diary_entry, :user => other_user)
@@ -608,7 +608,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_view
-    user = create(:normal_user)
+    user = create(:user)
     suspended_user = create(:user, :suspended)
     deleted_user = create(:user, :deleted)
 
@@ -636,7 +636,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
 
   def test_view_hidden_comments
     # Get a diary entry that has hidden comments
-    user = create(:normal_user)
+    user = create(:user)
     diary_entry = create(:diary_entry, :user => user)
     visible_comment = create(:diary_comment, :diary_entry => diary_entry)
     suspended_user_comment = create(:diary_comment, :diary_entry => diary_entry, :user => create(:user, :suspended))
@@ -655,7 +655,7 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_hide
-    user = create(:normal_user)
+    user = create(:user)
 
     # Try without logging in
     diary_entry = create(:diary_entry, :user => user)
@@ -670,15 +670,15 @@ class DiaryEntryControllerTest < ActionController::TestCase
     assert_equal true, DiaryEntry.find(diary_entry.id).visible
 
     # Finally try as an administrator
-    post :hide, { :display_name => user.display_name, :id => diary_entry.id }, { :user => create(:administrator_user, :status => "confirmed", :terms_seen => true) }
+    post :hide, { :display_name => user.display_name, :id => diary_entry.id }, { :user => create(:administrator_user) }
     assert_response :redirect
     assert_redirected_to :action => :list, :display_name => user.display_name
     assert_equal false, DiaryEntry.find(diary_entry.id).visible
   end
 
   def test_hidecomment
-    user = create(:normal_user)
-    administrator_user = create(:administrator_user, :status => "active", :terms_seen => true)
+    user = create(:user)
+    administrator_user = create(:administrator_user)
     diary_entry = create(:diary_entry, :user => user)
     diary_comment = create(:diary_comment, :diary_entry => diary_entry)
     # Try without logging in
@@ -700,10 +700,10 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_comments
-    user = create(:normal_user)
-    other_user = create(:normal_user)
-    suspended_user = create(:normal_user, :suspended)
-    deleted_user = create(:normal_user, :deleted)
+    user = create(:user)
+    other_user = create(:user)
+    suspended_user = create(:user, :suspended)
+    deleted_user = create(:user, :deleted)
     # Test a user with no comments
     get :comments, :display_name => user.display_name
     assert_response :success
@@ -732,8 +732,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_subscribe_success
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
     diary_entry = create(:diary_entry, :user => user)
 
     assert_difference "diary_entry.subscribers.count", 1 do
@@ -743,8 +743,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_subscribe_fail
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
 
     diary_entry = create(:diary_entry, :user => user)
 
@@ -766,8 +766,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_unsubscribe_success
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
 
     diary_entry = create(:diary_entry, :user => user)
 
@@ -779,8 +779,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
   end
 
   def test_unsubscribe_fail
-    user = create(:normal_user)
-    other_user = create(:normal_user)
+    user = create(:user)
+    other_user = create(:user)
 
     diary_entry = create(:diary_entry, :user => user)
 

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -248,9 +248,9 @@ class NotesControllerTest < ActionController::TestCase
     assert_nil js["properties"]["comments"].last["user"]
 
     # Ensure that emails are sent to users
-    first_user = create(:normal_user)
-    second_user = create(:normal_user)
-    third_user = create(:normal_user)
+    first_user = create(:user)
+    second_user = create(:user)
+    third_user = create(:user)
 
     note_with_comments_by_users = create(:note) do |note|
       create(:note_comment, :note => note, :author => first_user)
@@ -380,7 +380,7 @@ class NotesControllerTest < ActionController::TestCase
 
   def test_close_success
     open_note_with_comment = create(:note_with_comments)
-    user = create(:normal_user)
+    user = create(:user)
 
     post :close, :id => open_note_with_comment.id, :text => "This is a close comment", :format => "json"
     assert_response :unauthorized
@@ -416,7 +416,7 @@ class NotesControllerTest < ActionController::TestCase
     post :close
     assert_response :unauthorized
 
-    basic_authorization(create(:normal_user).email, "test")
+    basic_authorization(create(:user).email, "test")
 
     post :close
     assert_response :bad_request
@@ -437,7 +437,7 @@ class NotesControllerTest < ActionController::TestCase
 
   def test_reopen_success
     closed_note_with_comment = create(:note_with_comments, :status => "closed", :closed_at => Time.now)
-    user = create(:normal_user)
+    user = create(:user)
 
     post :reopen, :id => closed_note_with_comment.id, :text => "This is a reopen comment", :format => "json"
     assert_response :unauthorized
@@ -475,7 +475,7 @@ class NotesControllerTest < ActionController::TestCase
     post :reopen, :id => hidden_note_with_comment.id
     assert_response :unauthorized
 
-    basic_authorization(create(:normal_user).email, "test")
+    basic_authorization(create(:user).email, "test")
 
     post :reopen, :id => 12345
     assert_response :not_found
@@ -588,7 +588,7 @@ class NotesControllerTest < ActionController::TestCase
 
   def test_destroy_success
     open_note_with_comment = create(:note_with_comments)
-    user = create(:normal_user)
+    user = create(:user)
     moderator_user = create(:moderator_user, :status => "active")
 
     delete :destroy, :id => open_note_with_comment.id, :text => "This is a hide comment", :format => "json"
@@ -618,7 +618,7 @@ class NotesControllerTest < ActionController::TestCase
   end
 
   def test_destroy_fail
-    user = create(:normal_user)
+    user = create(:user)
     moderator_user = create(:moderator_user, :status => "active")
 
     delete :destroy, :id => 12345, :format => "json"
@@ -948,8 +948,8 @@ class NotesControllerTest < ActionController::TestCase
   end
 
   def test_mine_success
-    first_user = create(:normal_user)
-    second_user = create(:normal_user)
+    first_user = create(:user)
+    second_user = create(:user)
     moderator_user = create(:moderator_user, :status => "active", :terms_seen => true)
 
     create(:note) do |note|

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -4,6 +4,12 @@ FactoryGirl.define do
     sequence(:display_name) { |n| "User #{n}" }
     pass_crypt Digest::MD5.hexdigest("test")
 
+    # These attributes are not the defaults, but in most tests we want
+    # a 'normal' user who can log in without being redirected etc.
+    status "active"
+    terms_seen true
+    data_public true
+
     trait :with_home_location do
       home_lat { rand(-90.0...90.0) }
       home_lon { rand(-180.0...180.0) }
@@ -39,13 +45,6 @@ FactoryGirl.define do
       after(:create) do |user, _evaluator|
         create(:user_role, :role => "administrator", :user => user)
       end
-    end
-
-    # A commonly needed user is one who can log in an isn't redirected anywhere
-    factory :normal_user do
-      status "active"
-      terms_seen true
-      data_public true
     end
   end
 end


### PR DESCRIPTION
The use of create(:normal_user) makes the tests needlessly harder to understand and reason about, particularly when we start using associations in the factories.