### PR TITLE
User factory associations for all factories

### DIFF
--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -1045,6 +1045,7 @@ class UserControllerTest < ActionController::TestCase
 
   def test_api_details
     create(:message, :read, :recipient => users(:normal_user))
+    create(:message, :sender => users(:normal_user))
 
     # check that nothing is returned when not logged in
     get :api_details

--- a/test/factories/changeset_comments.rb
+++ b/test/factories/changeset_comments.rb
@@ -6,7 +6,6 @@ FactoryGirl.define do
     # FIXME: needs changeset factory
     changeset_id 3
 
-    # FIXME: needs user factory
-    author_id 1
+    association :author, :factory => :user
   end
 end

--- a/test/factories/diary_comments.rb
+++ b/test/factories/diary_comments.rb
@@ -3,8 +3,6 @@ FactoryGirl.define do
     sequence(:body) { |n| "This is diary comment #{n}" }
 
     diary_entry
-
-    # Fixme requires User Factory
-    user_id 1
+    user
   end
 end

--- a/test/factories/diary_entries.rb
+++ b/test/factories/diary_entries.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
     sequence(:title) { |n| "Diary entry #{n}" }
     sequence(:body) { |n| "This is diary entry #{n}" }
 
-    # Fixme requires User Factory
-    user_id 1
+    user
   end
 end

--- a/test/factories/friends.rb
+++ b/test/factories/friends.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :friend do
-    # Fixme requires User Factory
-    user_id 1
-    friend_user_id 2
+    association :befriender, :factory => :user
+    association :befriendee, :factory => :user
   end
 end

--- a/test/factories/messages.rb
+++ b/test/factories/messages.rb
@@ -4,11 +4,8 @@ FactoryGirl.define do
     sequence(:body) { |n| "Body text for message #{n}" }
     sent_on Time.now
 
-    # FIXME: needs user factory
-    from_user_id 1
-
-    # FIXME: needs user factory
-    to_user_id 2
+    association :sender, :factory => :user
+    association :recipient, :factory => :user
 
     trait :unread do
       message_read false

--- a/test/factories/traces.rb
+++ b/test/factories/traces.rb
@@ -3,8 +3,7 @@ FactoryGirl.define do
     sequence(:name) { |n| "Trace #{n}.gpx" }
     sequence(:description) { |n| "This is trace #{n}" }
 
-    # Fixme requires User Factory
-    user_id 1
+    user
 
     timestamp Time.now
     inserted true

--- a/test/factories/user_blocks.rb
+++ b/test/factories/user_blocks.rb
@@ -3,11 +3,8 @@ FactoryGirl.define do
     sequence(:reason) { |n| "User Block #{n}" }
     ends_at Time.now + 1.day
 
-    # FIXME: requires User factory
-    user_id 13
-
-    # FIXME: requires User factory
-    creator_id 15
+    user
+    association :creator, :factory => :moderator_user
 
     trait :needs_view do
       needs_view true

--- a/test/factories/user_preferences.rb
+++ b/test/factories/user_preferences.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
     sequence(:k) { |n| "Key #{n}" }
     sequence(:v) { |n| "Value #{n}" }
 
-    # FIXME: needs user factory
-    user_id 1
+    user
   end
 end

--- a/test/models/user_preference_test.rb
+++ b/test/models/user_preference_test.rb
@@ -7,7 +7,7 @@ class UserPreferenceTest < ActiveSupport::TestCase
   def test_add_duplicate_preference
     up = create(:user_preference)
     new_up = UserPreference.new
-    new_up.user = users(:normal_user)
+    new_up.user = up.user
     new_up.k = up.k
     new_up.v = "some other value"
     assert_not_equal new_up.v, up.v


### PR DESCRIPTION
We have a User factory now, might as well use it!

There were two tests that made assumptions about the user_id of objects generated by factories. For the `test_api_details` the assumption was that the message was sender was also user_id 1. I think the test is clearer by having two messages, since having a message sent to yourself is a bit curious.