### PR TITLE
Collapse all tokens for an app into a single line

### DIFF
--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -7,7 +7,7 @@ class OauthClientsController < ApplicationController
 
   def index
     @client_applications = @user.client_applications
-    @tokens = @user.oauth_tokens.authorized
+    @tokens_by_app = @user.oauth_tokens.authorized.group_by(&:client_application)
   end
 
   def new

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -27,12 +27,12 @@ class OauthController < ApplicationController
   end
 
   def revoke
-    @token = current_user.oauth_tokens.find_by :token => params[:token]
-    if @token
-      @token.invalidate!
-      flash[:notice] = t("oauth.revoke.flash", :application => @token.client_application.name)
+    @tokens = current_user.oauth_tokens.where :client_application => params[:app]
+    if @tokens
+      @tokens.each { |token| token.invalidate! }
+      flash[:notice] = t("oauth.revoke.flash", :application => @tokens.take.client_application.name)
     end
-    redirect_to oauth_clients_url(:display_name => @token.user.display_name)
+    redirect_to oauth_clients_url(:display_name => current_user.display_name)
   end
 
   protected

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -2,19 +2,19 @@
   <h1><%= t'oauth_clients.index.title' %></h1>
 <% end %>
 
-<% unless @tokens.empty? %>
+<% unless @tokens_by_app.empty? %>
 <h3><%= t'oauth_clients.index.my_tokens' %></h3>
 <p><%= t'oauth_clients.index.list_tokens' %></p>
 <table>
   <tr><th><%= t'oauth_clients.index.application' %></th>
     <th><%= t'oauth_clients.index.issued_at' %></th><th>&nbsp;</th></tr>
-  <% @tokens.each do |token|%>
-    <%= content_tag_for :tr, token do %>
-      <td><%= link_to token.client_application.name, token.client_application.url %></td>
-      <td><%= token.authorized_at %></td>
+  <% @tokens_by_app.each do |client_application, tokens|%>
+    <%= content_tag_for :tr, tokens[0] do %>
+      <td><%= link_to client_application.name, client_application.url %></td>
+      <td><%= tokens[0].authorized_at %></td>
       <td>
 	<%= form_tag :controller => 'oauth', :action => 'revoke' do %>
-	<%= hidden_field_tag 'token', token.token %>
+	<%= hidden_field_tag 'app', client_application.id %>
 	<%= submit_tag t('oauth_clients.index.revoke') %>
 	<% end %>
       </td>


### PR DESCRIPTION
The first step for #1455.

This request removes duplicate lines in the list of tokens granted to client applications. When a user clicks "Revoke", all tokens for the app are removed.

Pros: users won't be puzzled by duplicated and cleaning up the list is much simpler
Cons: the actual number of tokens will be hidden. Not that it is of any importance or affects anything.