### PR TITLE
Externalize message about missing OAuth capabilities/permissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,7 +61,8 @@ class ApplicationController < ActionController::Base
     # method, otherwise an OAuth token was used, which has to be checked.
     unless current_token.nil?
       unless current_token.read_attribute(cap)
-        report_error "OAuth token doesn't have that capability.", :forbidden
+        set_locale
+        report_error t("oauth.permissions.missing"), :forbidden
         false
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1651,6 +1651,8 @@ en:
       invalid: "The authorization token is not valid."
     revoke:
       flash: "You've revoked the token for %{application}"
+    permissions:
+      missing: "You have not permitted the application access to this facility"
   oauth_clients:
     new:
       title: "Register a new application"


### PR DESCRIPTION
I've tried to make the message slightly less technical, but betterwording suggestions are welcome.