### PR TITLE
Add greeting to changeset comment notification

### DIFF
--- a/app/models/notifier.rb
+++ b/app/models/notifier.rb
@@ -167,6 +167,7 @@ class Notifier < ActionMailer::Base
 
   def changeset_comment_notification(comment, recipient)
     with_recipient_locale recipient do
+      @to_user = recipient.display_name
       @changeset_url = changeset_url(comment.changeset, :host => SERVER_URL)
       @comment = comment.body
       @owner = recipient == comment.changeset.user

--- a/app/views/notifier/changeset_comment_notification.html.erb
+++ b/app/views/notifier/changeset_comment_notification.html.erb
@@ -1,4 +1,7 @@
 <p>
+  <%= t 'notifier.changeset_comment_notification.hi', :to_user => @to_user %>
+</p>
+<p>
   <% if @owner %>
     <%= raw t "notifier.changeset_comment_notification.commented.your_changeset", :commenter => link_to_user(@commenter), :time => @time %>
   <% else %>

--- a/app/views/notifier/changeset_comment_notification.text.erb
+++ b/app/views/notifier/changeset_comment_notification.text.erb
@@ -1,4 +1,4 @@
-<%= t 'notifier.changeset_comment_notification.greeting' %>
+<%= t 'notifier.changeset_comment_notification.hi', :to_user => @to_user %>
 
 <% if @owner %>
   <%= t "notifier.changeset_comment_notification.commented.your_changeset", :commenter => @commenter, :time => @time %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1243,6 +1243,7 @@ en:
       header: "%{from_user} has sent you a message through OpenStreetMap with the subject %{subject}:"
       footer_html: "You can also read the message at %{readurl} and you can reply at %{replyurl}"
     friend_notification:
+      hi: "Hi %{to_user},"
       subject: "[OpenStreetMap] %{user} added you as a friend"
       had_added_you: "%{user} has added you as a friend on OpenStreetMap."
       see_their_profile: "You can see their profile at %{userurl}."


### PR DESCRIPTION
In PR #1401 we added a new I18N string, `notifier.changeset_comment_notification.hi`, whose value is `"Hi %{to_user},"`. It's now been translated to 32 languages (if I'm grepping right).

The only other email that doesn't already open with a greeting is `friend_notification`.

This PR does two things:

1. start using the new string in the changeset comment notification template
2. add a a new string, `notifier.friend_notification.hi`, which is a copy of the `changeset_comment_notification.hi` (IIUC there's no way around the translatewiki pipeline, even for strings that are identical to previous ones?) Once translated this can be added to the friend_notification templates.