### PR TITLE
Update Austrian copyright statement (DE and EN)

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1091,8 +1091,11 @@ de:
       contributors_at_html: '<strong>Österreich</strong>: Enthält Daten der <a href="http://data.wien.gv.at/">Stadt
         Wien</a> (lizenziert gemäß <a href="http://creativecommons.org/licenses/by/3.0/at/deed.de">CC
         BY AT</a>), des <a href="http://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Landes
-        Vorarlberg</a> und des Landes Tirol (<a href="http://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">lizenziert
-        gemäß CC BY AT samt Erweiterungen zur Lizenz</a>).'
+        Vorarlberg</a>, des Landes Tirol (<a href="http://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">lizenziert
+        gemäß CC BY AT samt Erweiterungen zur Lizenz</a>) und
+        <a href="http://www.bev.gv.at/portal/page?_pageid=713,2168079&_dad=portal&_schema=PORTAL">Daten des Österreichischen Adressregisters des Österreichischen
+        Bundesamtes für Eich- und Vermessungswesen</a>
+        (<a href="https://wiki.openstreetmap.org/w/images/c/c7/I4-006-2017_Open_Street_Map_Nutzungsgenehmigung_Adressregister.pdf">ausdrückliche Genehmigung durch das BEV</a>).'
       contributors_ca_html: '<strong>Kanada</strong>: Enthält Daten von GeoBase&reg;,
         GeoGratis (&copy; <i>Department of Natural Resources Canada</i>), CanVec (&copy;
         <i>Department of Natural Resources Canada</i>) und StatCan (<i>Geography Division,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1024,8 +1024,12 @@ en:
         <strong>Austria</strong>: Contains data from
         <a href="http://data.wien.gv.at/">Stadt Wien</a> (under
         <a href="http://creativecommons.org/licenses/by/3.0/at/deed.de">CC BY</a>),
-        <a href="http://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Land Vorarlberg</a> and
-        Land Tirol (under <a href="http://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC BY AT with amendments</a>).
+        <a href="http://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Land Vorarlberg</a>,
+        Land Tirol (under <a href="http://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC BY AT with amendments</a>)
+        and
+        <a href="http://www.bev.gv.at/portal/page?_pageid=713,2168079&_dad=portal&_schema=PORTAL">the address dataset released by the Austrian Federal Office for
+        Calibration and Measurement</a>(<a href="https://wiki.openstreetmap.org/w/images/c/c7/I4-006-2017_Open_Street_Map_Nutzungsgenehmigung_Adressregister.pdf">
+        explicit permission by the federal office for OpenStreetMap</a>).
       contributors_ca_html: |
         <strong>Canada</strong>: Contains data from
         GeoBase&reg;, GeoGratis (&copy; Department of Natural


### PR DESCRIPTION
I added a link to the address dataset released by the Austrian Federal Office for Calibration and Measurement to the German and English copyright statements. OpenStreetMap has [explicit permission to use the data without restrictions](https://wiki.openstreetmap.org/wiki/WikiProject_Austria/%C3%96sterreichisches_Adressregister), but only if we mention the address dataset on the [copyright page](https://www.openstreetmap.org/copyright) (see [the permission written in German](https://wiki.openstreetmap.org/w/images/c/c7/I4-006-2017_Open_Street_Map_Nutzungsgenehmigung_Adressregister.pdf) for details).