### PR TITLE
Update Austrian copyright statement (EN).

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1024,8 +1024,11 @@ en:
         <strong>Austria</strong>: Contains data from
         <a href="http://data.wien.gv.at/">Stadt Wien</a> (under
         <a href="http://creativecommons.org/licenses/by/3.0/at/deed.de">CC BY</a>),
-        <a href="http://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Land Vorarlberg</a> and
-        Land Tirol (under <a href="http://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC BY AT with amendments</a>).
+        <a href="http://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Land Vorarlberg</a>,
+        Land Tirol (under <a href="http://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC BY AT with amendments</a>)
+        and
+        <a href="http://www.bev.gv.at/portal/page?_pageid=713,2168079&_dad=portal&_schema=PORTAL" target="_blank">the address data set released by the Austrian Federal Office for Calibration and Measurement</a>
+        (<a href="https://wiki.openstreetmap.org/w/images/c/c7/I4-006-2017_Open_Street_Map_Nutzungsgenehmigung_Adressregister.pdf" target="_blank">explicit usage permission for OpenStreetMap</a>).
       contributors_ca_html: |
         <strong>Canada</strong>: Contains data from
         GeoBase&reg;, GeoGratis (&copy; Department of Natural


### PR DESCRIPTION
I added a link to the address dataset released by the Austrian Federal Office for Calibration and Measurement to the German and English copyright statements. OpenStreetMap has [explicit permission to use the data without restrictions](https://wiki.openstreetmap.org/wiki/WikiProject_Austria/%C3%96sterreichisches_Adressregister), but only if we mention the address dataset on the [copyright page](https://www.openstreetmap.org/copyright) (see [the permission written in German](https://wiki.openstreetmap.org/w/images/c/c7/I4-006-2017_Open_Street_Map_Nutzungsgenehmigung_Adressregister.pdf) for details).

This replaces https://github.com/openstreetmap/openstreetmap-website/pull/1479 (German translation will be added through the translation Wiki).