### PR TITLE
User factories for user_roles_helper tests

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,7 +74,7 @@ Metrics/CyclomaticComplexity:
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives.
 # URISchemes: http, https
 Metrics/LineLength:
-  Max: 962
+  Max: 1072
 
 # Offense count: 612
 # Configuration parameters: CountComments.

--- a/test/controllers/user_roles_controller_test.rb
+++ b/test/controllers/user_roles_controller_test.rb
@@ -20,11 +20,7 @@ class UserRolesControllerTest < ActionController::TestCase
     target_user = create(:user)
     normal_user = create(:user)
     administrator_user = create(:administrator_user)
-    # Create a super user which has all known roles
-    super_user = create(:user)
-    UserRole::ALL_ROLES.each do |role|
-      create(:user_role, :user => super_user, :granter => administrator_user, :role => role)
-    end
+    super_user = create(:super_user)
 
     # Granting should fail when not logged in
     post :grant, :display_name => target_user.display_name, :role => "moderator"
@@ -85,11 +81,7 @@ class UserRolesControllerTest < ActionController::TestCase
     target_user = create(:user)
     normal_user = create(:user)
     administrator_user = create(:administrator_user)
-    # Create a super user which has all known roles
-    super_user = create(:user)
-    UserRole::ALL_ROLES.each do |role|
-      create(:user_role, :user => super_user, :granter => administrator_user, :role => role)
-    end
+    super_user = create(:super_user)
 
     # Revoking should fail when not logged in
     post :revoke, :display_name => target_user.display_name, :role => "moderator"

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -46,5 +46,13 @@ FactoryGirl.define do
         create(:user_role, :role => "administrator", :user => user)
       end
     end
+
+    factory :super_user do
+      after(:create) do |user, _evaluator|
+        UserRole::ALL_ROLES.each do |role|
+          create(:user_role, :role => role, :user => user)
+        end
+      end
+    end
   end
 end

--- a/test/helpers/user_roles_helper_test.rb
+++ b/test/helpers/user_roles_helper_test.rb
@@ -1,51 +1,56 @@
 require "test_helper"
 
 class UserRolesHelperTest < ActionView::TestCase
-  fixtures :users, :user_roles
-
   def test_role_icon_normal
-    @user = users(:normal_user)
+    user = create(:user)
+    @user = user
 
-    icon = role_icon(users(:normal_user), "moderator")
+    icon = role_icon(user, "moderator")
     assert_dom_equal "", icon
 
-    icon = role_icon(users(:moderator_user), "moderator")
+    icon = role_icon(create(:moderator_user), "moderator")
     assert_dom_equal '<picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="This user is a moderator" title="This user is a moderator" src="/images/roles/moderator.png" width="20" height="20" /></picture>', icon
   end
 
   def test_role_icon_administrator
-    @user = users(:administrator_user)
+    @user = create(:administrator_user)
 
-    icon = role_icon(users(:normal_user), "moderator")
-    assert_dom_equal '<a confirm="Are you sure you want to grant the role `moderator&#39; to the user `test&#39;?" rel="nofollow" data-method="post" href="/user/test/role/moderator/grant"><picture><source srcset="/images/roles/blank_moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/blank_moderator.svg" border="0" alt="Grant moderator access" title="Grant moderator access" src="/images/roles/blank_moderator.png" width="20" height="20" /></picture></a>', icon
+    user = create(:user)
+    icon = role_icon(user, "moderator")
+    assert_dom_equal %(<a confirm="Are you sure you want to grant the role `moderator&#39; to the user `#{user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{URI.encode(user.display_name)}/role/moderator/grant"><picture><source srcset="/images/roles/blank_moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/blank_moderator.svg" border="0" alt="Grant moderator access" title="Grant moderator access" src="/images/roles/blank_moderator.png" width="20" height="20" /></picture></a>), icon
 
-    icon = role_icon(users(:moderator_user), "moderator")
-    assert_dom_equal '<a confirm="Are you sure you want to revoke the role `moderator&#39; from the user `moderator&#39;?" rel="nofollow" data-method="post" href="/user/moderator/role/moderator/revoke"><picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" /></picture></a>', icon
+    moderator_user = create(:moderator_user)
+    icon = role_icon(moderator_user, "moderator")
+    assert_dom_equal %(<a confirm="Are you sure you want to revoke the role `moderator&#39; from the user `#{moderator_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{URI.encode(moderator_user.display_name)}/role/moderator/revoke"><picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" /></picture></a>), icon
   end
 
   def test_role_icons_normal
-    @user = users(:normal_user)
+    user = create(:user)
+    @user = user
 
-    icons = role_icons(users(:normal_user))
+    icons = role_icons(user)
     assert_dom_equal "  ", icons
 
-    icons = role_icons(users(:moderator_user))
+    icons = role_icons(create(:moderator_user))
     assert_dom_equal '  <picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="This user is a moderator" title="This user is a moderator" src="/images/roles/moderator.png" width="20" height="20" /></picture>', icons
 
-    icons = role_icons(users(:super_user))
+    icons = role_icons(create(:super_user))
     assert_dom_equal ' <picture><source srcset="/images/roles/administrator.svg" type="image/svg+xml" /><img srcset="/images/roles/administrator.svg" border="0" alt="This user is an administrator" title="This user is an administrator" src="/images/roles/administrator.png" width="20" height="20" /></picture> <picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="This user is a moderator" title="This user is a moderator" src="/images/roles/moderator.png" width="20" height="20" /></picture>', icons
   end
 
   def test_role_icons_administrator
-    @user = users(:administrator_user)
+    @user = create(:administrator_user)
 
-    icons = role_icons(users(:normal_user))
-    assert_dom_equal ' <a confirm="Are you sure you want to grant the role `administrator&#39; to the user `test&#39;?" rel="nofollow" data-method="post" href="/user/test/role/administrator/grant"><picture><source srcset="/images/roles/blank_administrator.svg" type="image/svg+xml" /><img srcset="/images/roles/blank_administrator.svg" border="0" alt="Grant administrator access" title="Grant administrator access" src="/images/roles/blank_administrator.png" width="20" height="20" /></picture></a> <a confirm="Are you sure you want to grant the role `moderator&#39; to the user `test&#39;?" rel="nofollow" data-method="post" href="/user/test/role/moderator/grant"><picture><source srcset="/images/roles/blank_moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/blank_moderator.svg" border="0" alt="Grant moderator access" title="Grant moderator access" src="/images/roles/blank_moderator.png" width="20" height="20" /></picture></a>', icons
+    user = create(:user)
+    icons = role_icons(user)
+    assert_dom_equal %( <a confirm="Are you sure you want to grant the role `administrator&#39; to the user `#{user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{URI.encode(user.display_name)}/role/administrator/grant"><picture><source srcset="/images/roles/blank_administrator.svg" type="image/svg+xml" /><img srcset="/images/roles/blank_administrator.svg" border="0" alt="Grant administrator access" title="Grant administrator access" src="/images/roles/blank_administrator.png" width="20" height="20" /></picture></a> <a confirm="Are you sure you want to grant the role `moderator&#39; to the user `#{user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{URI.encode(user.display_name)}/role/moderator/grant"><picture><source srcset="/images/roles/blank_moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/blank_moderator.svg" border="0" alt="Grant moderator access" title="Grant moderator access" src="/images/roles/blank_moderator.png" width="20" height="20" /></picture></a>), icons
 
-    icons = role_icons(users(:moderator_user))
-    assert_dom_equal ' <a confirm="Are you sure you want to grant the role `administrator&#39; to the user `moderator&#39;?" rel="nofollow" data-method="post" href="/user/moderator/role/administrator/grant"><picture><source srcset="/images/roles/blank_administrator.svg" type="image/svg+xml" /><img srcset="/images/roles/blank_administrator.svg" border="0" alt="Grant administrator access" title="Grant administrator access" src="/images/roles/blank_administrator.png" width="20" height="20" /></picture></a> <a confirm="Are you sure you want to revoke the role `moderator&#39; from the user `moderator&#39;?" rel="nofollow" data-method="post" href="/user/moderator/role/moderator/revoke"><picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" /></picture></a>', icons
+    moderator_user = create(:moderator_user)
+    icons = role_icons(moderator_user)
+    assert_dom_equal %( <a confirm="Are you sure you want to grant the role `administrator&#39; to the user `#{moderator_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{URI.encode(moderator_user.display_name)}/role/administrator/grant"><picture><source srcset="/images/roles/blank_administrator.svg" type="image/svg+xml" /><img srcset="/images/roles/blank_administrator.svg" border="0" alt="Grant administrator access" title="Grant administrator access" src="/images/roles/blank_administrator.png" width="20" height="20" /></picture></a> <a confirm="Are you sure you want to revoke the role `moderator&#39; from the user `#{moderator_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{URI.encode(moderator_user.display_name)}/role/moderator/revoke"><picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" /></picture></a>), icons
 
-    icons = role_icons(users(:super_user))
-    assert_dom_equal ' <a confirm="Are you sure you want to revoke the role `administrator&#39; from the user `super&#39;?" rel="nofollow" data-method="post" href="/user/super/role/administrator/revoke"><picture><source srcset="/images/roles/administrator.svg" type="image/svg+xml" /><img srcset="/images/roles/administrator.svg" border="0" alt="Revoke administrator access" title="Revoke administrator access" src="/images/roles/administrator.png" width="20" height="20" /></picture></a> <a confirm="Are you sure you want to revoke the role `moderator&#39; from the user `super&#39;?" rel="nofollow" data-method="post" href="/user/super/role/moderator/revoke"><picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" /></picture></a>', icons
+    super_user = create(:super_user)
+    icons = role_icons(super_user)
+    assert_dom_equal %( <a confirm="Are you sure you want to revoke the role `administrator&#39; from the user `#{super_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{URI.encode(super_user.display_name)}/role/administrator/revoke"><picture><source srcset="/images/roles/administrator.svg" type="image/svg+xml" /><img srcset="/images/roles/administrator.svg" border="0" alt="Revoke administrator access" title="Revoke administrator access" src="/images/roles/administrator.png" width="20" height="20" /></picture></a> <a confirm="Are you sure you want to revoke the role `moderator&#39; from the user `#{super_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{URI.encode(super_user.display_name)}/role/moderator/revoke"><picture><source srcset="/images/roles/moderator.svg" type="image/svg+xml" /><img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" /></picture></a>), icons
   end
 end


### PR DESCRIPTION
I couldn't figure out a neat way to shorten these monster lines. The %() notation is a useful way to avoid the nested double-quotes, but the ruby parser then had problems splitting that over multiple lines, e.g.

```
expected = %(<a href=....)\
           %(<picture><....)
             ^ruby got confused by the left bracket here
```
If anyone has a suggestion for breaking these lines then I'm all ears, otherwise I just extended the rubocop limit to the largest of the new strings.