### PR TITLE
Return maximum size of bounding box for note retrieval

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -263,6 +263,9 @@ class ApiController < ApplicationController
     area = XML::Node.new "area"
     area["maximum"] = MAX_REQUEST_AREA.to_s
     api << area
+    notearea = XML::Node.new "note_area"
+    notearea["maximum"] = MAX_NOTE_REQUEST_AREA.to_s
+    api << notearea
     tracepoints = XML::Node.new "tracepoints"
     tracepoints["per_page"] = TRACEPOINTS_PER_PAGE.to_s
     api << tracepoints

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -364,6 +364,7 @@ class ApiControllerTest < ActionController::TestCase
       assert_select "api", :count => 1 do
         assert_select "version[minimum='#{API_VERSION}'][maximum='#{API_VERSION}']", :count => 1
         assert_select "area[maximum='#{MAX_REQUEST_AREA}']", :count => 1
+        assert_select "note_area[maximum='#{MAX_NOTE_REQUEST_AREA}']", :count => 1
         assert_select "tracepoints[per_page='#{TRACEPOINTS_PER_PAGE}']", :count => 1
         assert_select "changesets[maximum_elements='#{Changeset::MAX_ELEMENTS}']", :count => 1
         assert_select "status[database='online']", :count => 1


### PR DESCRIPTION
Trivial patch so that we return the maximum bounding box size for notes retrieval in the capabilities.