### PR TITLE
Redaction factory

### DIFF
--- a/test/controllers/old_node_controller_test.rb
+++ b/test/controllers/old_node_controller_test.rb
@@ -196,11 +196,10 @@ class OldNodeControllerTest < ActionController::TestCase
   # test the redaction of an old version of a node, while being
   # authorised as a normal user.
   def test_redact_node_normal_user
-    user = create(:user)
-    basic_authorization(user.email, "test")
+    basic_authorization(create(:user).email, "test")
 
     do_redact_node(nodes(:node_with_versions_v3),
-                   create(:redaction, :user => user))
+                   create(:redaction))
     assert_response :forbidden, "should need to be moderator to redact."
   end
 
@@ -208,11 +207,10 @@ class OldNodeControllerTest < ActionController::TestCase
   # test that, even as moderator, the current version of a node
   # can't be redacted.
   def test_redact_node_current_version
-    moderator_user = create(:moderator_user)
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
     do_redact_node(nodes(:node_with_versions_v4),
-                   create(:redaction, :user => moderator_user))
+                   create(:redaction))
     assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
   end
 
@@ -251,11 +249,10 @@ class OldNodeControllerTest < ActionController::TestCase
   # test the redaction of an old version of a node, while being
   # authorised as a moderator.
   def test_redact_node_moderator
-    moderator_user = create(:moderator_user)
     node = nodes(:node_with_versions_v3)
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
-    do_redact_node(node, create(:redaction, :user => moderator_user))
+    do_redact_node(node, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # check moderator can still see the redacted data, when passing
@@ -277,11 +274,10 @@ class OldNodeControllerTest < ActionController::TestCase
   # testing that if the moderator drops auth, he can't see the
   # redacted stuff any more.
   def test_redact_node_is_redacted
-    moderator_user = create(:moderator_user)
     node = nodes(:node_with_versions_v3)
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
-    do_redact_node(node, create(:redaction, :user => moderator_user))
+    do_redact_node(node, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # re-auth as non-moderator

--- a/test/controllers/old_relation_controller_test.rb
+++ b/test/controllers/old_relation_controller_test.rb
@@ -39,7 +39,7 @@ class OldRelationControllerTest < ActionController::TestCase
   # authorised.
   def test_redact_relation_unauthorised
     do_redact_relation(relations(:relation_with_versions_v3),
-                       redactions(:example))
+                       create(:redaction))
     assert_response :unauthorized, "should need to be authenticated to redact."
   end
 
@@ -47,10 +47,11 @@ class OldRelationControllerTest < ActionController::TestCase
   # test the redaction of an old version of a relation, while being
   # authorised as a normal user.
   def test_redact_relation_normal_user
-    basic_authorization(users(:public_user).email, "test")
+    user = create(:user)
+    basic_authorization(user.email, "test")
 
     do_redact_relation(relations(:relation_with_versions_v3),
-                       redactions(:example))
+                       create(:redaction, :user => user))
     assert_response :forbidden, "should need to be moderator to redact."
   end
 
@@ -58,10 +59,11 @@ class OldRelationControllerTest < ActionController::TestCase
   # test that, even as moderator, the current version of a relation
   # can't be redacted.
   def test_redact_relation_current_version
-    basic_authorization(users(:moderator_user).email, "test")
+    moderator_user = create(:moderator_user)
+    basic_authorization(moderator_user.email, "test")
 
     do_redact_relation(relations(:relation_with_versions_v4),
-                       redactions(:example))
+                       create(:redaction, :user => moderator_user))
     assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
   end
 
@@ -101,10 +103,11 @@ class OldRelationControllerTest < ActionController::TestCase
   # test the redaction of an old version of a relation, while being
   # authorised as a moderator.
   def test_redact_relation_moderator
+    moderator_user = create(:moderator_user)
     relation = relations(:relation_with_versions_v3)
-    basic_authorization(users(:moderator_user).email, "test")
+    basic_authorization(moderator_user.email, "test")
 
-    do_redact_relation(relation, redactions(:example))
+    do_redact_relation(relation, create(:redaction, :user => moderator_user))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # check moderator can still see the redacted data, when passing
@@ -126,10 +129,11 @@ class OldRelationControllerTest < ActionController::TestCase
   # testing that if the moderator drops auth, he can't see the
   # redacted stuff any more.
   def test_redact_relation_is_redacted
+    moderator_user = create(:moderator_user)
     relation = relations(:relation_with_versions_v3)
-    basic_authorization(users(:moderator_user).email, "test")
+    basic_authorization(moderator_user.email, "test")
 
-    do_redact_relation(relation, redactions(:example))
+    do_redact_relation(relation, create(:redaction, :user => moderator_user))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # re-auth as non-moderator

--- a/test/controllers/old_relation_controller_test.rb
+++ b/test/controllers/old_relation_controller_test.rb
@@ -245,7 +245,7 @@ class OldRelationControllerTest < ActionController::TestCase
 
   def do_redact_relation(relation, redaction)
     get :version, :id => relation.relation_id, :version => relation.version
-    assert_response :success, "should be able to get version #{relation.version} of node #{relation.relation_id}."
+    assert_response :success, "should be able to get version #{relation.version} of relation #{relation.relation_id}."
 
     # now redact it
     post :redact, :id => relation.relation_id, :version => relation.version, :redaction => redaction.id

--- a/test/controllers/old_relation_controller_test.rb
+++ b/test/controllers/old_relation_controller_test.rb
@@ -47,11 +47,10 @@ class OldRelationControllerTest < ActionController::TestCase
   # test the redaction of an old version of a relation, while being
   # authorised as a normal user.
   def test_redact_relation_normal_user
-    user = create(:user)
-    basic_authorization(user.email, "test")
+    basic_authorization(create(:user).email, "test")
 
     do_redact_relation(relations(:relation_with_versions_v3),
-                       create(:redaction, :user => user))
+                       create(:redaction))
     assert_response :forbidden, "should need to be moderator to redact."
   end
 
@@ -59,11 +58,10 @@ class OldRelationControllerTest < ActionController::TestCase
   # test that, even as moderator, the current version of a relation
   # can't be redacted.
   def test_redact_relation_current_version
-    moderator_user = create(:moderator_user)
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
     do_redact_relation(relations(:relation_with_versions_v4),
-                       create(:redaction, :user => moderator_user))
+                       create(:redaction))
     assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
   end
 
@@ -103,11 +101,10 @@ class OldRelationControllerTest < ActionController::TestCase
   # test the redaction of an old version of a relation, while being
   # authorised as a moderator.
   def test_redact_relation_moderator
-    moderator_user = create(:moderator_user)
     relation = relations(:relation_with_versions_v3)
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
-    do_redact_relation(relation, create(:redaction, :user => moderator_user))
+    do_redact_relation(relation, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # check moderator can still see the redacted data, when passing
@@ -129,11 +126,10 @@ class OldRelationControllerTest < ActionController::TestCase
   # testing that if the moderator drops auth, he can't see the
   # redacted stuff any more.
   def test_redact_relation_is_redacted
-    moderator_user = create(:moderator_user)
     relation = relations(:relation_with_versions_v3)
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
-    do_redact_relation(relation, create(:redaction, :user => moderator_user))
+    do_redact_relation(relation, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # re-auth as non-moderator

--- a/test/controllers/old_way_controller_test.rb
+++ b/test/controllers/old_way_controller_test.rb
@@ -278,7 +278,7 @@ class OldWayControllerTest < ActionController::TestCase
 
   def do_redact_way(way, redaction)
     get :version, :id => way.way_id, :version => way.version
-    assert_response :success, "should be able to get version #{way.version} of node #{way.way_id}."
+    assert_response :success, "should be able to get version #{way.version} of way #{way.way_id}."
 
     # now redact it
     post :redact, :id => way.way_id, :version => way.version, :redaction => redaction.id

--- a/test/controllers/old_way_controller_test.rb
+++ b/test/controllers/old_way_controller_test.rb
@@ -80,11 +80,10 @@ class OldWayControllerTest < ActionController::TestCase
   # test the redaction of an old version of a way, while being
   # authorised as a normal user.
   def test_redact_way_normal_user
-    user = create(:user)
-    basic_authorization(user.email, "test")
+    basic_authorization(create(:user).email, "test")
 
     do_redact_way(ways(:way_with_versions_v3),
-                  create(:redaction, :user => user))
+                  create(:redaction))
     assert_response :forbidden, "should need to be moderator to redact."
   end
 
@@ -92,11 +91,10 @@ class OldWayControllerTest < ActionController::TestCase
   # test that, even as moderator, the current version of a way
   # can't be redacted.
   def test_redact_way_current_version
-    moderator_user = create(:moderator_user)
-    basic_authorization(users(:moderator_user).email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
     do_redact_way(ways(:way_with_versions_v4),
-                  create(:redaction, :user => moderator_user))
+                  create(:redaction))
     assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
   end
 
@@ -136,11 +134,10 @@ class OldWayControllerTest < ActionController::TestCase
   # test the redaction of an old version of a way, while being
   # authorised as a moderator.
   def test_redact_way_moderator
-    moderator_user = create(:moderator_user)
     way = ways(:way_with_versions_v3)
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
-    do_redact_way(way, create(:redaction, :user => moderator_user))
+    do_redact_way(way, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # check moderator can still see the redacted data, when passing
@@ -162,11 +159,10 @@ class OldWayControllerTest < ActionController::TestCase
   # testing that if the moderator drops auth, he can't see the
   # redacted stuff any more.
   def test_redact_way_is_redacted
-    moderator_user = create(:moderator_user)
     way = ways(:way_with_versions_v3)
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization(create(:moderator_user).email, "test")
 
-    do_redact_way(way, create(:redaction, :user => moderator_user))
+    do_redact_way(way, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # re-auth as non-moderator

--- a/test/controllers/redactions_controller_test.rb
+++ b/test/controllers/redactions_controller_test.rb
@@ -94,11 +94,8 @@ class RedactionsControllerTest < ActionController::TestCase
   def test_destroy_moderator_empty
     session[:user] = create(:moderator_user).id
 
-    # remove all elements from the redaction
-    redaction = redactions(:example)
-    redaction.old_nodes.each     { |n| n.update!(:redaction => nil) }
-    redaction.old_ways.each      { |w| w.update!(:redaction => nil) }
-    redaction.old_relations.each { |r| r.update!(:redaction => nil) }
+    # create an empty redaction
+    redaction = create(:redaction)
 
     delete :destroy, :id => redaction.id
     assert_response :redirect
@@ -108,8 +105,9 @@ class RedactionsControllerTest < ActionController::TestCase
   def test_destroy_moderator_non_empty
     session[:user] = create(:moderator_user).id
 
-    # leave elements in the redaction
-    redaction = redactions(:example)
+    # create elements in the redaction
+    redaction = create(:redaction)
+    create(:old_node, :redaction => redaction)
 
     delete :destroy, :id => redaction.id
     assert_response :redirect
@@ -120,27 +118,29 @@ class RedactionsControllerTest < ActionController::TestCase
   def test_delete_non_moderator
     session[:user] = create(:user).id
 
-    delete :destroy, :id => redactions(:example).id
+    delete :destroy, :id => create(:redaction).id
     assert_response :forbidden
   end
 
   def test_edit
-    get :edit, :id => redactions(:example).id
+    redaction = create(:redaction)
+
+    get :edit, :id => redaction.id
     assert_response :redirect
-    assert_redirected_to login_path(:referer => edit_redaction_path(redactions(:example)))
+    assert_redirected_to login_path(:referer => edit_redaction_path(redaction))
   end
 
   def test_edit_moderator
     session[:user] = create(:moderator_user).id
 
-    get :edit, :id => redactions(:example).id
+    get :edit, :id => create(:redaction).id
     assert_response :success
   end
 
   def test_edit_non_moderator
     session[:user] = create(:user).id
 
-    get :edit, :id => redactions(:example).id
+    get :edit, :id => create(:redaction).id
     assert_response :redirect
     assert_redirected_to(redactions_path)
   end
@@ -148,7 +148,7 @@ class RedactionsControllerTest < ActionController::TestCase
   def test_update_moderator
     session[:user] = create(:moderator_user).id
 
-    redaction = redactions(:example)
+    redaction = create(:redaction)
 
     put :update, :id => redaction.id, :redaction => { :title => "Foo", :description => "Description here." }
     assert_response :redirect
@@ -158,7 +158,7 @@ class RedactionsControllerTest < ActionController::TestCase
   def test_update_moderator_invalid
     session[:user] = create(:moderator_user).id
 
-    redaction = redactions(:example)
+    redaction = create(:redaction)
 
     put :update, :id => redaction.id, :redaction => { :title => "Foo", :description => "" }
     assert_response :success
@@ -168,7 +168,7 @@ class RedactionsControllerTest < ActionController::TestCase
   def test_updated_non_moderator
     session[:user] = create(:user).id
 
-    redaction = redactions(:example)
+    redaction = create(:redaction)
 
     put :update, :id => redaction.id, :redaction => { :title => "Foo", :description => "Description here." }
     assert_response :forbidden

--- a/test/factories/old_node.rb
+++ b/test/factories/old_node.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :old_node do
+    latitude 1 * GeoRecord::SCALE
+    longitude 1 * GeoRecord::SCALE
+
+    # FIXME: needs changeset factory
+    changeset_id 1
+
+    # FIXME: needs node factory
+    node_id 1000
+
+    visible true
+    timestamp Time.now
+    version 1
+  end
+end

--- a/test/factories/redaction.rb
+++ b/test/factories/redaction.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :redaction do
+    sequence(:title) { |n| "Redaction #{n}" }
+    sequence(:description) { |n| "Description of redaction #{n}" }
+
+    user
+  end
+end

--- a/test/models/redaction_test.rb
+++ b/test/models/redaction_test.rb
@@ -3,11 +3,10 @@ require "osm"
 
 class RedactionTest < ActiveSupport::TestCase
   api_fixtures
-  fixtures :redactions
 
   def test_cannot_redact_current
     n = current_nodes(:node_with_versions)
-    r = redactions(:example)
+    r = create(:redaction)
     assert_equal(false, n.redacted?, "Expected node to not be redacted already.")
     assert_raise(OSM::APICannotRedactError) do
       n.redact!(r)
@@ -16,7 +15,7 @@ class RedactionTest < ActiveSupport::TestCase
 
   def test_cannot_redact_current_via_old
     n = nodes(:node_with_versions_v4)
-    r = redactions(:example)
+    r = create(:redaction)
     assert_equal(false, n.redacted?, "Expected node to not be redacted already.")
     assert_raise(OSM::APICannotRedactError) do
       n.redact!(r)
@@ -25,7 +24,7 @@ class RedactionTest < ActiveSupport::TestCase
 
   def test_can_redact_old
     n = nodes(:node_with_versions_v3)
-    r = redactions(:example)
+    r = create(:redaction)
     assert_equal(false, n.redacted?, "Expected node to not be redacted already.")
     assert_nothing_raised(OSM::APICannotRedactError) do
       n.redact!(r)


### PR DESCRIPTION
This PR creates a redaction factory and uses it wherever the redactions fixtures were used explicitly. The redactions fixture is still used indirectly by various other fixtures so needs to wait for them to be refactored before it can be removed.