### PR TITLE
Update mapzen directions credit link

### DIFF
--- a/app/assets/javascripts/index/directions/mapzen.js
+++ b/app/assets/javascripts/index/directions/mapzen.js
@@ -34,7 +34,7 @@ function MapzenEngine(id, costing) {
 
   return {
     id: id,
-    creditline: "<a href='https://mapzen.com/projects/valhalla' target='_blank'>Mapzen</a>",
+    creditline: "<a href='https://mapzen.com/products/turn-by-turn/' target='_blank'>Mapzen</a>",
     draggable: false,
 
     getRoute: function (points, callback) {


### PR DESCRIPTION
Rather than pointing at a redirect, point at the target of the redirect. Refs #1388