### PR TITLE
Node factories 3

### DIFF
--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -241,7 +241,7 @@ class SiteControllerTest < ActionController::TestCase
   # Test editing a specific node
   def test_edit_with_node
     user = create(:user)
-    node = current_nodes(:visible_node)
+    node = create(:node, :lat => 1.0, :lon => 1.0)
 
     get :edit, { :node => node.id }, { :user => user }
     assert_response :success

--- a/test/factories/changesets.rb
+++ b/test/factories/changesets.rb
@@ -4,5 +4,10 @@ FactoryGirl.define do
     closed_at Time.now.utc + 1.day
 
     user
+
+    trait :closed do
+      created_at Time.now.utc - 5.hours
+      closed_at Time.now.utc - 4.hours
+    end
   end
 end

--- a/test/factories/relation.rb
+++ b/test/factories/relation.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :relation do
+    timestamp Time.now
+    visible true
+    version 1
+
+    changeset
+  end
+end

--- a/test/factories/relation_member.rb
+++ b/test/factories/relation_member.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :relation_member do
+    member_role ""
+
+    relation
+    # Default to creating nodes, but could be ways or relations as members
+    association :member, :factory => :node
+  end
+end

--- a/test/factories/way.rb
+++ b/test/factories/way.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :way do
+    timestamp Time.now
+    visible true
+    version 1
+
+    changeset
+  end
+end

--- a/test/factories/way_node.rb
+++ b/test/factories/way_node.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :way_node do
+    sequence_id 1
+
+    way
+    node
+  end
+end


### PR DESCRIPTION
This converts more tests to node factories. To replace the `:used_node_1` and `:node_used_by_relationship` fixtures, various new factories are introduced.

The test_delete section of node_controller_test alternated between using nodes() and current_nodes() fixtures, but I've stuck with using the Node factory consistently since it is testing other things.