### PR TITLE
Fix changeset comment notification plain text indentation

### DIFF
--- a/app/views/notifier/changeset_comment_notification.text.erb
+++ b/app/views/notifier/changeset_comment_notification.text.erb
@@ -1,14 +1,14 @@
 <%= t 'notifier.changeset_comment_notification.hi', :to_user => @to_user %>
 
 <% if @owner %>
-  <%= t "notifier.changeset_comment_notification.commented.your_changeset", :commenter => @commenter, :time => @time %>
+<%= t "notifier.changeset_comment_notification.commented.your_changeset", :commenter => @commenter, :time => @time %>
 <% else %>
-  <%= t "notifier.changeset_comment_notification.commented.commented_changeset", :commenter => @commenter, :time => @time, :changeset_author => @changeset_author %>
+<%= t "notifier.changeset_comment_notification.commented.commented_changeset", :commenter => @commenter, :time => @time, :changeset_author => @changeset_author %>
 <% end %>
 <% if @changeset_comment %>
-  <%= t "notifier.changeset_comment_notification.commented.partial_changeset_with_comment", :changeset_comment => @changeset_comment %>
+<%= t "notifier.changeset_comment_notification.commented.partial_changeset_with_comment", :changeset_comment => @changeset_comment %>
 <% else %>
-  <%= t "notifier.changeset_comment_notification.commented.partial_changeset_without_comment" %>
+<%= t "notifier.changeset_comment_notification.commented.partial_changeset_without_comment" %>
 <% end %>
 
 ==


### PR DESCRIPTION
This plain text templates had nice indentation in the source, however that got reflected in the output, which was visibly and needlessly indented.