### PR TITLE
Beautify 404 page

### DIFF
--- a/app/assets/stylesheets/errors.scss
+++ b/app/assets/stylesheets/errors.scss
@@ -1,8 +1,6 @@
-.logo {
-  float: left;
-  margin: 10px;
-}
-
-.details {
-  float: left;
+.error {
+  max-width: 100%;
+  width: 500px;
+  margin: 20px auto;
+  text-align: center;
 }

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,3 +1,3 @@
-<h1>Forbidden</h1>  
+<h1>Forbidden</h1>
 <p>The operation you requested on the OpenStreetMap server is only available to administrators (HTTP 403)</p>
-<p>Feel free to <a href="http://wiki.openstreetmap.org/wiki/Contact" title="Various contact channels explained">contact</a> the OpenStreetMap community if you have found a broken link / bug. Make a note of the exact URL of your request.</p>
+<p>Feel free to <a href="https://wiki.openstreetmap.org/wiki/Contact" title="Various contact channels explained">contact</a> the OpenStreetMap community if you have found a broken link / bug. Make a note of the exact URL of your request.</p>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,4 +1,4 @@
 <h1>Application error</h1>
 <p>The OpenStreetMap server encountered an unexpected condition that prevented it from fulfilling the request (HTTP 500)</p>
-<p>Feel free to <a href="http://wiki.openstreetmap.org/wiki/Contact" title="Various contact channels explained">contact</a> the OpenStreetMap community if your problem persists. Make a note of the exact URL / post data of your request.</p>
+<p>Feel free to <a href="https://wiki.openstreetmap.org/wiki/Contact" title="Various contact channels explained">contact</a> the OpenStreetMap community if your problem persists. Make a note of the exact URL / post data of your request.</p>
 <p>This may be a problem in our Ruby On Rails code. 500 occurs with exceptions thrown outside of an action (like in Dispatcher setups or broken Ruby code)</p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,3 +1,3 @@
-<h1>File not found</h1>  
-<p>Couldn't find a file/directory/API operation by that name on the OpenStreetMap server (HTTP 404)</p>
-<p>Feel free to <a href="http://wiki.openstreetmap.org/wiki/Contact" title="Various contact channels explained">contact</a> the OpenStreetMap community if you have found a broken link / bug. Make a note of the exact URL of your request.</p>
+<h1>Page does not exist :(</h1>
+<p>Head back to <a href="https://www.openstreetmap.org/">OpenStreetMap</a>.</p>
+<p>Feel free to <a href="https://wiki.openstreetmap.org/wiki/Contact" title="Various contact channels explained">contact</a> the OpenStreetMap community if you have found a broken link / bug. Make a note of the exact URL of your request.</p>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -6,9 +6,11 @@
     <%= stylesheet_link_tag "errors", :media=> "screen" %>
   </head>
   <body>
-    <%= image_tag "osm_logo.png", :class => "logo" %>
-    <div class="details">
-      <%= yield %>
+    <div class="error">
+      <%= image_tag "osm_logo.png", :class => "logo" %>
+      <div class="details">
+        <%= yield %>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
I stumbled upon the 404 page today and I thought I should give it some love.

I guess inline style and no external css on that page is intentional, so I kept this pattern.

![404](https://cloud.githubusercontent.com/assets/939357/26530613/e1199c9c-43e0-11e7-8755-0e1b5344f1e0.jpg)
