### PR TITLE
Transform the web site into a fullscreen web app

### DIFF
--- a/app/assets/favicons/manifest.json.erb
+++ b/app/assets/favicons/manifest.json.erb
@@ -37,5 +37,7 @@
 			"type": "image\/png",
 			"density": "4.0"
 		}
-	]
+	],
+	"start_url": "index.html",
+	"display": "standalone"
 }

--- a/app/assets/favicons/manifest.json.erb
+++ b/app/assets/favicons/manifest.json.erb
@@ -38,6 +38,6 @@
 			"density": "4.0"
 		}
 	],
-	"start_url": "index.html",
-	"display": "standalone"
+	"start_url": "/",
+	"display": "minimal-ui"
 }


### PR DESCRIPTION
I made the necessary changes to turn OSM.org into fullscreen web app on iOS and android

Sources : 

https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html
https://developer.chrome.com/multidevice/android/installtohomescreen

Issue from https://trac.openstreetmap.org/ticket/5218