### PR TITLE
Hide contributor terms details, unless the user hasn't agreed

### DIFF
--- a/app/views/user/view.html.erb
+++ b/app/views/user/view.html.erb
@@ -141,14 +141,14 @@
       <p class='deemphasize'>
         <small>
           <%= t 'user.view.mapper since' %> <%= l @this_user.creation_time.to_date, :format => :long %>
-          |
-          <%= t 'user.view.ct status' %>
-          <% if not @this_user.terms_agreed.nil? -%>
-          <%= t 'user.view.ct accepted', :ago =>time_ago_in_words(@this_user.terms_agreed)  %>
-          <% elsif not @this_user.terms_seen? -%>
-          <%= t 'user.view.ct undecided' %>
-          <% else -%>
-          <%= t 'user.view.ct declined' %>
+          <% unless @this_user.terms_agreed %>
+            |
+            <%= t 'user.view.ct status' %>
+            <% if @this_user.terms_seen? -%>
+              <%= t 'user.view.ct declined' %>
+            <% else -%>
+              <%= t 'user.view.ct undecided' %>
+            <% end -%>
           <% end -%>
         </small>
       </p>

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -1007,6 +1007,34 @@ class UserControllerTest < ActionController::TestCase
     end
   end
 
+  # Test whether information about contributor terms is shown for users who haven't agreed
+  def test_terms_not_agreed
+    agreed_user = create(:user, :terms_agreed => 3.days.ago)
+    seen_user = create(:user, :terms_seen => true)
+    not_seen_user = create(:user, :terms_seen => false)
+
+    get :view, :params => { :display_name => agreed_user.display_name }
+    assert_response :success
+    assert_select "div#userinformation" do
+      assert_select "p", :count => 0, :text => /Contributor terms/
+    end
+
+    get :view, :params => { :display_name => seen_user.display_name }
+    assert_response :success
+    # put @response.body
+    assert_select "div#userinformation" do
+      assert_select "p", :count => 1, :text => /Contributor terms/
+      assert_select "p", /Declined/
+    end
+
+    get :view, :params => { :display_name => not_seen_user.display_name }
+    assert_response :success
+    assert_select "div#userinformation" do
+      assert_select "p", :count => 1, :text => /Contributor terms/
+      assert_select "p", /Undecided/
+    end
+  end
+
   def test_api_read
     user = create(:user, :description => "test", :terms_agreed => Date.yesterday)
     # check that a visible user is returned properly


### PR DESCRIPTION
It's no longer important to show when users agreed to the contributor terms.
For users that haven't agreed, we still show their status on their profile.

Logic was also re-written to avoid lots of `if not` things, and tests added.

Replaces #97 