### PR TITLE
Standardise on basic_authorization without the parentheses

### DIFF
--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -406,7 +406,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   def test_permissions_basic_auth
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     get :permissions
     assert_response :success
     assert_select "osm > permissions", :count => 1 do

--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -1321,7 +1321,7 @@ EOF
     node = create(:node)
 
     ## First try with a non-public user, which should get a forbidden
-    basic_authorization(create(:user, :data_public => false).email, "test")
+    basic_authorization create(:user, :data_public => false).email, "test"
 
     # create a temporary changeset
     content "<osm><changeset>" +
@@ -1331,7 +1331,7 @@ EOF
     assert_response :forbidden
 
     ## Now try with a normal user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # create a temporary changeset
     content "<osm><changeset>" +
@@ -1377,7 +1377,7 @@ EOF
   #
   # NOTE: the error turned out to be something else completely!
   def test_josm_upload
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # create a temporary changeset
     content "<osm><changeset>" +
@@ -1439,7 +1439,7 @@ OSMFILE
     node = create(:node)
     node2 = create(:node)
     way = create(:way)
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # create a temporary changeset
     content "<osm><changeset>" +
@@ -2147,7 +2147,7 @@ EOF
     deleted_user = create(:user, :deleted)
     private_user_closed_changeset = create(:changeset, :closed, :user => private_user)
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     assert_difference "ChangesetComment.count", 1 do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
@@ -2176,7 +2176,7 @@ EOF
 
     ActionMailer::Base.deliveries.clear
 
-    basic_authorization(user2.email, "test")
+    basic_authorization user2.email, "test"
 
     assert_difference "ChangesetComment.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 2 do
@@ -2205,7 +2205,7 @@ EOF
     post :comment, :params => { :id => create(:changeset, :closed).id, :text => "This is a comment" }
     assert_response :unauthorized
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # bad changeset id
     assert_no_difference "ChangesetComment.count" do
@@ -2235,7 +2235,7 @@ EOF
   ##
   # test subscribe success
   def test_subscribe_success
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     changeset = create(:changeset, :closed)
 
     assert_difference "changeset.subscribers.count", 1 do
@@ -2256,7 +2256,7 @@ EOF
     end
     assert_response :unauthorized
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # bad changeset id
     assert_no_difference "changeset.subscribers.count" do
@@ -2284,7 +2284,7 @@ EOF
   # test unsubscribe success
   def test_unsubscribe_success
     user = create(:user)
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
     changeset = create(:changeset, :closed)
     changeset.subscribers.push(user)
 
@@ -2304,7 +2304,7 @@ EOF
     end
     assert_response :unauthorized
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # bad changeset id
     assert_no_difference "changeset.subscribers.count" do
@@ -2338,14 +2338,14 @@ EOF
     assert_response :unauthorized
     assert_equal true, comment.reload.visible
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # not a moderator
     post :hide_comment, :params => { :id => comment.id }
     assert_response :forbidden
     assert_equal true, comment.reload.visible
 
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     # bad comment id
     post :hide_comment, :params => { :id => 999111 }
@@ -2359,7 +2359,7 @@ EOF
     comment = create(:changeset_comment)
     assert_equal true, comment.visible
 
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     post :hide_comment, :params => { :id => comment.id }
     assert_response :success
@@ -2377,14 +2377,14 @@ EOF
     assert_response :unauthorized
     assert_equal false, comment.reload.visible
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # not a moderator
     post :unhide_comment, :params => { :id => comment.id }
     assert_response :forbidden
     assert_equal false, comment.reload.visible
 
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     # bad comment id
     post :unhide_comment, :params => { :id => 999111 }
@@ -2398,7 +2398,7 @@ EOF
     comment = create(:changeset_comment, :visible => false)
     assert_equal false, comment.visible
 
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     post :unhide_comment, :params => { :id => comment.id }
     assert_response :success

--- a/test/controllers/node_controller_test.rb
+++ b/test/controllers/node_controller_test.rb
@@ -46,7 +46,7 @@ class NodeControllerTest < ActionController::TestCase
     assert_response :unauthorized, "node upload did not return unauthorized status"
 
     ## Now try with the user which doesn't have their data public
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # create a minimal xml file
     content("<osm><node lat='#{lat}' lon='#{lon}' changeset='#{private_changeset.id}'/></osm>")
@@ -57,7 +57,7 @@ class NodeControllerTest < ActionController::TestCase
     assert_require_public_data "node create did not return forbidden status"
 
     ## Now try with the user that has the public data
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # create a minimal xml file
     content("<osm><node lat='#{lat}' lon='#{lon}' changeset='#{changeset.id}'/></osm>")
@@ -83,7 +83,7 @@ class NodeControllerTest < ActionController::TestCase
     user = create(:user)
     changeset = create(:changeset, :user => user)
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
     lat = 3.434
     lon = 3.23
 
@@ -160,7 +160,7 @@ class NodeControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     ## now set auth for the non-data public user
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # try to delete with an invalid (closed) changeset
     content update_changeset(private_node.to_xml, private_user_closed_changeset.id)
@@ -208,7 +208,7 @@ class NodeControllerTest < ActionController::TestCase
     changeset = create(:changeset, :user => user)
     closed_changeset = create(:changeset, :closed, :user => user)
     node = create(:node, :changeset => changeset)
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # try to delete with an invalid (closed) changeset
     content update_changeset(node.to_xml, closed_changeset.id)
@@ -295,7 +295,7 @@ class NodeControllerTest < ActionController::TestCase
     ## Second test with the private user
 
     # setup auth
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     ## trying to break changesets
 
@@ -347,7 +347,7 @@ class NodeControllerTest < ActionController::TestCase
     assert_response :forbidden
 
     # setup auth
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     ## trying to break changesets
 
@@ -465,7 +465,7 @@ class NodeControllerTest < ActionController::TestCase
     existing_tag = create(:node_tag)
     assert_equal true, existing_tag.node.changeset.user.data_public
     # setup auth
-    basic_authorization(existing_tag.node.changeset.user.email, "test")
+    basic_authorization existing_tag.node.changeset.user.email, "test"
 
     # add an identical tag to the node
     tag_xml = XML::Node.new("tag")
@@ -492,7 +492,7 @@ class NodeControllerTest < ActionController::TestCase
     changeset = create(:changeset, :user => user)
 
     ## First try with the non-data public user
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # try and put something into a string that the API might
     # use unquoted and therefore allow code injection...
@@ -503,7 +503,7 @@ class NodeControllerTest < ActionController::TestCase
     assert_require_public_data "Shouldn't be able to create with non-public user"
 
     ## Then try with the public data user
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # try and put something into a string that the API might
     # use unquoted and therefore allow code injection...

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -303,7 +303,7 @@ class NotesControllerTest < ActionController::TestCase
 
     ActionMailer::Base.deliveries.clear
 
-    basic_authorization(third_user.email, "test")
+    basic_authorization third_user.email, "test"
 
     assert_difference "NoteComment.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 2 do
@@ -397,7 +397,7 @@ class NotesControllerTest < ActionController::TestCase
     post :close, :params => { :id => open_note_with_comment.id, :text => "This is a close comment", :format => "json" }
     assert_response :unauthorized
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     post :close, :params => { :id => open_note_with_comment.id, :text => "This is a close comment", :format => "json" }
     assert_response :success
@@ -428,7 +428,7 @@ class NotesControllerTest < ActionController::TestCase
     post :close
     assert_response :unauthorized
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     post :close
     assert_response :bad_request
@@ -454,7 +454,7 @@ class NotesControllerTest < ActionController::TestCase
     post :reopen, :params => { :id => closed_note_with_comment.id, :text => "This is a reopen comment", :format => "json" }
     assert_response :unauthorized
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     post :reopen, :params => { :id => closed_note_with_comment.id, :text => "This is a reopen comment", :format => "json" }
     assert_response :success
@@ -487,7 +487,7 @@ class NotesControllerTest < ActionController::TestCase
     post :reopen, :params => { :id => hidden_note_with_comment.id }
     assert_response :unauthorized
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     post :reopen, :params => { :id => 12345 }
     assert_response :not_found
@@ -606,12 +606,12 @@ class NotesControllerTest < ActionController::TestCase
     delete :destroy, :params => { :id => open_note_with_comment.id, :text => "This is a hide comment", :format => "json" }
     assert_response :unauthorized
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     delete :destroy, :params => { :id => open_note_with_comment.id, :text => "This is a hide comment", :format => "json" }
     assert_response :forbidden
 
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization moderator_user.email, "test"
 
     delete :destroy, :params => { :id => open_note_with_comment.id, :text => "This is a hide comment", :format => "json" }
     assert_response :success
@@ -636,12 +636,12 @@ class NotesControllerTest < ActionController::TestCase
     delete :destroy, :params => { :id => 12345, :format => "json" }
     assert_response :unauthorized
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     delete :destroy, :params => { :id => 12345, :format => "json" }
     assert_response :forbidden
 
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization moderator_user.email, "test"
 
     delete :destroy, :params => { :id => 12345, :format => "json" }
     assert_response :not_found

--- a/test/controllers/old_node_controller_test.rb
+++ b/test/controllers/old_node_controller_test.rb
@@ -40,7 +40,7 @@ class OldNodeControllerTest < ActionController::TestCase
     propagate_tags(node, node.old_nodes.last)
 
     ## First try this with a non-public user
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # setup a simple XML node
     xml_doc = private_node.to_xml
@@ -89,7 +89,7 @@ class OldNodeControllerTest < ActionController::TestCase
     # probably should check that they didn't get written to the database
 
     ## Now do it with the public user
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # setup a simple XML node
 
@@ -206,7 +206,7 @@ class OldNodeControllerTest < ActionController::TestCase
   # test the redaction of an old version of a node, while being
   # authorised as a normal user.
   def test_redact_node_normal_user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     node = create(:node, :with_history, :version => 4)
     node_v3 = node.old_nodes.find_by(:version => 3)
@@ -220,7 +220,7 @@ class OldNodeControllerTest < ActionController::TestCase
   # test that, even as moderator, the current version of a node
   # can't be redacted.
   def test_redact_node_current_version
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     node = create(:node, :with_history, :version => 4)
     node_v4 = node.old_nodes.find_by(:version => 4)
@@ -242,7 +242,7 @@ class OldNodeControllerTest < ActionController::TestCase
     assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
 
     # not even to a logged-in user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }
     assert_response :forbidden, "Redacted node shouldn't be visible via the version API, even when logged in."
   end
@@ -259,7 +259,7 @@ class OldNodeControllerTest < ActionController::TestCase
     assert_select "osm node[id='#{node_v1.node_id}'][version='#{node_v1.version}']", 0, "redacted node #{node_v1.node_id} version #{node_v1.version} shouldn't be present in the history."
 
     # not even to a logged-in user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     get :history, :params => { :id => node_v1.node_id }
     assert_response :success, "Redaction shouldn't have stopped history working."
     assert_select "osm node[id='#{node_v1.node_id}'][version='#{node_v1.version}']", 0, "redacted node #{node_v1.node_id} version #{node_v1.version} shouldn't be present in the history, even when logged in."
@@ -271,7 +271,7 @@ class OldNodeControllerTest < ActionController::TestCase
   def test_redact_node_moderator
     node = create(:node, :with_history, :version => 4)
     node_v3 = node.old_nodes.find_by(:version => 3)
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     do_redact_node(node_v3, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
@@ -297,13 +297,13 @@ class OldNodeControllerTest < ActionController::TestCase
   def test_redact_node_is_redacted
     node = create(:node, :with_history, :version => 4)
     node_v3 = node.old_nodes.find_by(:version => 3)
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     do_redact_node(node_v3, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # re-auth as non-moderator
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # check can't see the redacted data
     get :version, :params => { :id => node_v3.node_id, :version => node_v3.version }
@@ -336,7 +336,7 @@ class OldNodeControllerTest < ActionController::TestCase
     node_v1 = node.old_nodes.find_by(:version => 1)
     node_v1.redact!(create(:redaction))
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     post :redact, :params => { :id => node_v1.node_id, :version => node_v1.version }
     assert_response :forbidden, "should need to be moderator to unredact."
@@ -351,7 +351,7 @@ class OldNodeControllerTest < ActionController::TestCase
     node_v1 = node.old_nodes.find_by(:version => 1)
     node_v1.redact!(create(:redaction))
 
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization moderator_user.email, "test"
 
     post :redact, :params => { :id => node_v1.node_id, :version => node_v1.version }
     assert_response :success, "should be OK to unredact old version as moderator."
@@ -366,7 +366,7 @@ class OldNodeControllerTest < ActionController::TestCase
     assert_response :success, "Unredaction shouldn't have stopped history working."
     assert_select "osm node[id='#{node_v1.node_id}'][version='#{node_v1.version}']", 1, "node #{node_v1.node_id} version #{node_v1.version} should now be present in the history for moderators without passing flag."
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # check normal user can now see the redacted data
     get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }

--- a/test/controllers/old_relation_controller_test.rb
+++ b/test/controllers/old_relation_controller_test.rb
@@ -50,7 +50,7 @@ class OldRelationControllerTest < ActionController::TestCase
     relation = create(:relation, :with_history, :version => 4)
     relation_v3 = relation.old_relations.find_by(:version => 3)
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     do_redact_relation(relation_v3, create(:redaction))
     assert_response :forbidden, "should need to be moderator to redact."
@@ -63,7 +63,7 @@ class OldRelationControllerTest < ActionController::TestCase
     relation = create(:relation, :with_history, :version => 4)
     relation_latest = relation.old_relations.last
 
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     do_redact_relation(relation_latest, create(:redaction))
     assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
@@ -81,7 +81,7 @@ class OldRelationControllerTest < ActionController::TestCase
     assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
 
     # not even to a logged-in user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
     assert_response :forbidden, "Redacted relation shouldn't be visible via the version API, even when logged in."
   end
@@ -98,7 +98,7 @@ class OldRelationControllerTest < ActionController::TestCase
     assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 0, "redacted relation #{relation_v1.relation_id} version #{relation_v1.version} shouldn't be present in the history."
 
     # not even to a logged-in user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
     get :history, :params => { :id => relation_v1.relation_id }
     assert_response :success, "Redaction shouldn't have stopped history working."
@@ -112,7 +112,7 @@ class OldRelationControllerTest < ActionController::TestCase
     relation = create(:relation, :with_history, :version => 4)
     relation_v3 = relation.old_relations.find_by(:version => 3)
 
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     do_redact_relation(relation_v3, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
@@ -139,13 +139,13 @@ class OldRelationControllerTest < ActionController::TestCase
     relation = create(:relation, :with_history, :version => 4)
     relation_v3 = relation.old_relations.find_by(:version => 3)
 
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     do_redact_relation(relation_v3, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # re-auth as non-moderator
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # check can't see the redacted data
     get :version, :params => { :id => relation_v3.relation_id, :version => relation_v3.version }
@@ -177,7 +177,7 @@ class OldRelationControllerTest < ActionController::TestCase
     relation_v1 = relation.old_relations.find_by(:version => 1)
     relation_v1.redact!(create(:redaction))
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     post :redact, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
     assert_response :forbidden, "should need to be moderator to unredact."
@@ -191,7 +191,7 @@ class OldRelationControllerTest < ActionController::TestCase
     relation_v1 = relation.old_relations.find_by(:version => 1)
     relation_v1.redact!(create(:redaction))
 
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     post :redact, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
     assert_response :success, "should be OK to unredact old version as moderator."
@@ -206,7 +206,7 @@ class OldRelationControllerTest < ActionController::TestCase
     assert_response :success, "Redaction shouldn't have stopped history working."
     assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 1, "relation #{relation_v1.relation_id} version #{relation_v1.version} should still be present in the history for moderators."
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # check normal user can now see the redacted data
     get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }

--- a/test/controllers/old_way_controller_test.rb
+++ b/test/controllers/old_way_controller_test.rb
@@ -90,7 +90,7 @@ class OldWayControllerTest < ActionController::TestCase
   # test the redaction of an old version of a way, while being
   # authorised as a normal user.
   def test_redact_way_normal_user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     way = create(:way, :with_history, :version => 4)
     way_v3 = way.old_ways.find_by(:version => 3)
 
@@ -102,7 +102,7 @@ class OldWayControllerTest < ActionController::TestCase
   # test that, even as moderator, the current version of a way
   # can't be redacted.
   def test_redact_way_current_version
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
     way = create(:way, :with_history, :version => 4)
     way_latest = way.old_ways.last
 
@@ -122,7 +122,7 @@ class OldWayControllerTest < ActionController::TestCase
     assert_response :forbidden, "Redacted way shouldn't be visible via the version API."
 
     # not even to a logged-in user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }
     assert_response :forbidden, "Redacted way shouldn't be visible via the version API, even when logged in."
   end
@@ -139,7 +139,7 @@ class OldWayControllerTest < ActionController::TestCase
     assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 0, "redacted way #{way_v1.way_id} version #{way_v1.version} shouldn't be present in the history."
 
     # not even to a logged-in user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
     get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }
     get :history, :params => { :id => way_v1.way_id }
     assert_response :success, "Redaction shouldn't have stopped history working."
@@ -152,7 +152,7 @@ class OldWayControllerTest < ActionController::TestCase
   def test_redact_way_moderator
     way = create(:way, :with_history, :version => 4)
     way_v3 = way.old_ways.find_by(:version => 3)
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     do_redact_way(way_v3, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
@@ -178,13 +178,13 @@ class OldWayControllerTest < ActionController::TestCase
   def test_redact_way_is_redacted
     way = create(:way, :with_history, :version => 4)
     way_v3 = way.old_ways.find_by(:version => 3)
-    basic_authorization(create(:moderator_user).email, "test")
+    basic_authorization create(:moderator_user).email, "test"
 
     do_redact_way(way_v3, create(:redaction))
     assert_response :success, "should be OK to redact old version as moderator."
 
     # re-auth as non-moderator
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # check can't see the redacted data
     get :version, :params => { :id => way_v3.way_id, :version => way_v3.version }
@@ -216,7 +216,7 @@ class OldWayControllerTest < ActionController::TestCase
     way_v1 = way.old_ways.find_by(:version => 1)
     way_v1.redact!(create(:redaction))
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     post :redact, :params => { :id => way_v1.way_id, :version => way_v1.version }
     assert_response :forbidden, "should need to be moderator to unredact."
@@ -231,7 +231,7 @@ class OldWayControllerTest < ActionController::TestCase
     way_v1 = way.old_ways.find_by(:version => 1)
     way_v1.redact!(create(:redaction))
 
-    basic_authorization(moderator_user.email, "test")
+    basic_authorization moderator_user.email, "test"
 
     post :redact, :params => { :id => way_v1.way_id, :version => way_v1.version }
     assert_response :success, "should be OK to unredact old version as moderator."
@@ -246,7 +246,7 @@ class OldWayControllerTest < ActionController::TestCase
     assert_response :success, "Unredaction shouldn't have stopped history working."
     assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 1, "way #{way_v1.way_id} version #{way_v1.version} should still be present in the history for moderators."
 
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # check normal user can now see the unredacted data
     get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }

--- a/test/controllers/relation_controller_test.rb
+++ b/test/controllers/relation_controller_test.rb
@@ -514,7 +514,7 @@ class RelationControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     ## Then try with the private user, to make sure that you get a forbidden
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # this shouldn't work, as we should need the payload...
     delete :delete, :params => { :id => relation.id }
@@ -556,7 +556,7 @@ class RelationControllerTest < ActionController::TestCase
     assert_response :forbidden
 
     ## now set auth for the public user
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # this shouldn't work, as we should need the payload...
     delete :delete, :params => { :id => relation.id }
@@ -739,7 +739,7 @@ class RelationControllerTest < ActionController::TestCase
     way1 = create(:way_with_nodes, :nodes_count => 2)
     way2 = create(:way_with_nodes, :nodes_count => 2)
 
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     doc_str = <<OSM.strip_heredoc
       <osm>
@@ -814,14 +814,14 @@ OSM
     doc = XML::Parser.string(doc_str).parse
 
     ## First try with the private user
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     content doc
     put :create
     assert_response :forbidden
 
     ## Now try with the public user
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     content doc
     put :create
@@ -855,7 +855,7 @@ OSM
       </osm>
 OSM
     doc = XML::Parser.string(doc_str).parse
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     content doc
     put :create
@@ -936,7 +936,7 @@ OSM
   # that the changeset bounding box is +bbox+.
   def check_changeset_modify(bbox)
     ## First test with the private user to check that you get a forbidden
-    basic_authorization(create(:user, :data_public => false).email, "test")
+    basic_authorization create(:user, :data_public => false).email, "test"
 
     # create a new changeset for this operation, so we are assured
     # that the bounding box will be newly-generated.
@@ -947,7 +947,7 @@ OSM
     end
 
     ## Now do the whole thing with the public user
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # create a new changeset for this operation, so we are assured
     # that the bounding box will be newly-generated.

--- a/test/controllers/trace_controller_test.rb
+++ b/test/controllers/trace_controller_test.rb
@@ -692,12 +692,12 @@ class TraceControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # Now with some other user, which should work since the trace is public
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     get :api_read, :params => { :id => public_trace_file.id }
     assert_response :success
 
     # And finally we should be able to do it with the owner of the trace
-    basic_authorization(public_trace_file.user.display_name, "test")
+    basic_authorization public_trace_file.user.display_name, "test"
     get :api_read, :params => { :id => public_trace_file.id }
     assert_response :success
   end
@@ -711,12 +711,12 @@ class TraceControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # Now try with another user, which shouldn't work since the trace is anon
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     get :api_read, :params => { :id => anon_trace_file.id }
     assert_response :forbidden
 
     # And finally we should be able to get the trace details with the trace owner
-    basic_authorization(anon_trace_file.user.display_name, "test")
+    basic_authorization anon_trace_file.user.display_name, "test"
     get :api_read, :params => { :id => anon_trace_file.id }
     assert_response :success
   end
@@ -730,12 +730,12 @@ class TraceControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # Login, and try again
-    basic_authorization(deleted_trace_file.user.display_name, "test")
+    basic_authorization deleted_trace_file.user.display_name, "test"
     get :api_read, :params => { :id => 0 }
     assert_response :not_found
 
     # Now try a trace which did exist but has been deleted
-    basic_authorization(deleted_trace_file.user.display_name, "test")
+    basic_authorization deleted_trace_file.user.display_name, "test"
     get :api_read, :params => { :id => deleted_trace_file.id }
     assert_response :not_found
   end
@@ -749,12 +749,12 @@ class TraceControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # Now with some other user, which should work since the trace is public
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     get :api_data, :params => { :id => public_trace_file.id }
     check_trace_data public_trace_file
 
     # And finally we should be able to do it with the owner of the trace
-    basic_authorization(public_trace_file.user.display_name, "test")
+    basic_authorization public_trace_file.user.display_name, "test"
     get :api_data, :params => { :id => public_trace_file.id }
     check_trace_data public_trace_file
   end
@@ -764,7 +764,7 @@ class TraceControllerTest < ActionController::TestCase
     identifiable_trace_file = create(:trace, :visibility => "identifiable", :fixture => "d")
 
     # Authenticate as the owner of the trace we will be using
-    basic_authorization(identifiable_trace_file.user.display_name, "test")
+    basic_authorization identifiable_trace_file.user.display_name, "test"
 
     # First get the data as is
     get :api_data, :params => { :id => identifiable_trace_file.id }
@@ -788,12 +788,12 @@ class TraceControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # Now with some other user, which shouldn't work since the trace is anon
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     get :api_data, :params => { :id => anon_trace_file.id }
     assert_response :forbidden
 
     # And finally we should be able to do it with the owner of the trace
-    basic_authorization(anon_trace_file.user.display_name, "test")
+    basic_authorization anon_trace_file.user.display_name, "test"
     get :api_data, :params => { :id => anon_trace_file.id }
     check_trace_data anon_trace_file
   end
@@ -807,12 +807,12 @@ class TraceControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # Login, and try again
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     get :api_data, :params => { :id => 0 }
     assert_response :not_found
 
     # Now try a trace which did exist but has been deleted
-    basic_authorization(deleted_trace_file.user.display_name, "test")
+    basic_authorization deleted_trace_file.user.display_name, "test"
     get :api_data, :params => { :id => deleted_trace_file.id }
     assert_response :not_found
   end
@@ -831,7 +831,7 @@ class TraceControllerTest < ActionController::TestCase
     # Now authenticated
     create(:user_preference, :user => user, :k => "gps.trace.visibility", :v => "identifiable")
     assert_not_equal "trackable", user.preferences.where(:k => "gps.trace.visibility").first.v
-    basic_authorization(user.display_name, "test")
+    basic_authorization user.display_name, "test"
     post :api_create, :params => { :file => file, :description => "New Trace", :tags => "new,trace", :visibility => "trackable" }
     assert_response :success
     trace = Trace.find(response.body.to_i)
@@ -849,7 +849,7 @@ class TraceControllerTest < ActionController::TestCase
 
     # Now authenticated, with the legacy public flag
     assert_not_equal "public", user.preferences.where(:k => "gps.trace.visibility").first.v
-    basic_authorization(user.display_name, "test")
+    basic_authorization user.display_name, "test"
     post :api_create, :params => { :file => file, :description => "New Trace", :tags => "new,trace", :public => 1 }
     assert_response :success
     trace = Trace.find(response.body.to_i)
@@ -868,7 +868,7 @@ class TraceControllerTest < ActionController::TestCase
     # Now authenticated, with the legacy private flag
     second_user = create(:user)
     assert_nil second_user.preferences.where(:k => "gps.trace.visibility").first
-    basic_authorization(second_user.display_name, "test")
+    basic_authorization second_user.display_name, "test"
     post :api_create, :params => { :file => file, :description => "New Trace", :tags => "new,trace", :public => 0 }
     assert_response :success
     trace = Trace.find(response.body.to_i)
@@ -894,32 +894,32 @@ class TraceControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # Now with some other user, which should fail
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     content public_trace_file.to_xml
     put :api_update, :params => { :id => public_trace_file.id }
     assert_response :forbidden
 
     # Now with a trace which doesn't exist
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     content public_trace_file.to_xml
     put :api_update, :params => { :id => 0 }
     assert_response :not_found
 
     # Now with a trace which did exist but has been deleted
-    basic_authorization(deleted_trace_file.user.display_name, "test")
+    basic_authorization deleted_trace_file.user.display_name, "test"
     content deleted_trace_file.to_xml
     put :api_update, :params => { :id => deleted_trace_file.id }
     assert_response :not_found
 
     # Now try an update with the wrong ID
-    basic_authorization(public_trace_file.user.display_name, "test")
+    basic_authorization public_trace_file.user.display_name, "test"
     content anon_trace_file.to_xml
     put :api_update, :params => { :id => public_trace_file.id }
     assert_response :bad_request,
                     "should not be able to update a trace with a different ID from the XML"
 
     # And finally try an update that should work
-    basic_authorization(public_trace_file.user.display_name, "test")
+    basic_authorization public_trace_file.user.display_name, "test"
     t = public_trace_file
     t.description = "Changed description"
     t.visibility = "private"
@@ -940,22 +940,22 @@ class TraceControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # Now with some other user, which should fail
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     delete :api_delete, :params => { :id => public_trace_file.id }
     assert_response :forbidden
 
     # Now with a trace which doesn't exist
-    basic_authorization(create(:user).display_name, "test")
+    basic_authorization create(:user).display_name, "test"
     delete :api_delete, :params => { :id => 0 }
     assert_response :not_found
 
     # And finally we should be able to do it with the owner of the trace
-    basic_authorization(public_trace_file.user.display_name, "test")
+    basic_authorization public_trace_file.user.display_name, "test"
     delete :api_delete, :params => { :id => public_trace_file.id }
     assert_response :success
 
     # Try it a second time, which should fail
-    basic_authorization(public_trace_file.user.display_name, "test")
+    basic_authorization public_trace_file.user.display_name, "test"
     delete :api_delete, :params => { :id => public_trace_file.id }
     assert_response :not_found
   end

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -1093,7 +1093,7 @@ class UserControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # check that we get a response when logged in
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
     get :api_details
     assert_response :success
     assert_equal "text/xml", response.content_type
@@ -1148,7 +1148,7 @@ class UserControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # check that we get a response when logged in
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
     get :api_gpx_files
     assert_response :success
     assert_equal "application/xml", response.content_type

--- a/test/controllers/user_preference_controller_test.rb
+++ b/test/controllers/user_preference_controller_test.rb
@@ -34,7 +34,7 @@ class UserPreferenceControllerTest < ActionController::TestCase
     assert_response :unauthorized, "should be authenticated"
 
     # authenticate as a user with no preferences
-    basic_authorization(create(:user).email, "test")
+    basic_authorization create(:user).email, "test"
 
     # try the read again
     get :read
@@ -48,7 +48,7 @@ class UserPreferenceControllerTest < ActionController::TestCase
     user = create(:user)
     user_preference = create(:user_preference, :user => user)
     user_preference2 = create(:user_preference, :user => user)
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # try the read again
     get :read
@@ -74,7 +74,7 @@ class UserPreferenceControllerTest < ActionController::TestCase
     assert_response :unauthorized, "should be authenticated"
 
     # authenticate as a user with preferences
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # try the read again
     get :read_one, :params => { :preference_key => "key" }
@@ -107,7 +107,7 @@ class UserPreferenceControllerTest < ActionController::TestCase
     end
 
     # authenticate as a user with preferences
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # try the put again
     assert_no_difference "UserPreference.count" do
@@ -158,7 +158,7 @@ class UserPreferenceControllerTest < ActionController::TestCase
     end
 
     # authenticate as a user with preferences
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # try adding a new preference
     assert_difference "UserPreference.count", 1 do
@@ -195,7 +195,7 @@ class UserPreferenceControllerTest < ActionController::TestCase
     assert_equal "value", UserPreference.find([user.id, "key"]).v
 
     # authenticate as a user with preferences
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # try the delete again
     assert_difference "UserPreference.count", -1 do

--- a/test/controllers/way_controller_test.rb
+++ b/test/controllers/way_controller_test.rb
@@ -278,7 +278,7 @@ class WayControllerTest < ActionController::TestCase
     assert_response :unauthorized
 
     # now set auth using the private user
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # this shouldn't work as with the 0.6 api we need pay load to delete
     delete :delete, :params => { :id => private_way.id }
@@ -327,7 +327,7 @@ class WayControllerTest < ActionController::TestCase
 
     ### Now check with a public user
     # now set auth
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # this shouldn't work as with the 0.6 api we need pay load to delete
     delete :delete, :params => { :id => way.id }
@@ -397,7 +397,7 @@ class WayControllerTest < ActionController::TestCase
     ## Second test with the private user
 
     # setup auth
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     ## trying to break changesets
 
@@ -435,7 +435,7 @@ class WayControllerTest < ActionController::TestCase
     ## Finally test with the public user
 
     # setup auth
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     ## trying to break changesets
 
@@ -519,7 +519,7 @@ class WayControllerTest < ActionController::TestCase
 
     ## Try with the non-public user
     # setup auth
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # add an identical tag to the way
     tag_xml = XML::Node.new("tag")
@@ -538,7 +538,7 @@ class WayControllerTest < ActionController::TestCase
 
     ## Now try with the public user
     # setup auth
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # add an identical tag to the way
     tag_xml = XML::Node.new("tag")
@@ -569,7 +569,7 @@ class WayControllerTest < ActionController::TestCase
 
     ## Try with the non-public user
     # setup auth
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # add an identical tag to the way
     tag_xml = XML::Node.new("tag")
@@ -588,7 +588,7 @@ class WayControllerTest < ActionController::TestCase
 
     ## Now try with the public user
     # setup auth
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # add an identical tag to the way
     tag_xml = XML::Node.new("tag")
@@ -617,7 +617,7 @@ class WayControllerTest < ActionController::TestCase
 
     ## First test with the non-public user so should be rejected
     # setup auth
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # create duplicate tag
     tag_xml = XML::Node.new("tag")
@@ -638,7 +638,7 @@ class WayControllerTest < ActionController::TestCase
 
     ## Now test with the public user
     # setup auth
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # create duplicate tag
     tag_xml = XML::Node.new("tag")
@@ -671,7 +671,7 @@ class WayControllerTest < ActionController::TestCase
 
     ## First make sure that you can't with a non-public user
     # setup auth
-    basic_authorization(private_user.email, "test")
+    basic_authorization private_user.email, "test"
 
     # add the tag into the existing xml
     way_str = "<osm><way changeset='#{private_changeset.id}'>"
@@ -687,7 +687,7 @@ class WayControllerTest < ActionController::TestCase
 
     ## Now do it with a public user
     # setup auth
-    basic_authorization(user.email, "test")
+    basic_authorization user.email, "test"
 
     # add the tag into the existing xml
     way_str = "<osm><way changeset='#{changeset.id}'>"


### PR DESCRIPTION
This is just a cleanup for consistency