### PR TITLE
Fix icons on RTL/Arabic About page

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2776,11 +2776,11 @@ input.richtext_title[type="text"] {
     vertical-align: middle;
     background: 40px 40px image-url('about/sprite.png') no-repeat;
 
-    &.local        { background-position: 0px    0px; }
-    &.community    { background-position: 0px  -40px; }
-    &.open         { background-position: 0px  -80px; }
-    &.partners     { background-position: 0px -120px; }
-    &.infringement { background-position: 0px -160px; }
+    &.local        { background-position: 0    0px; }
+    &.community    { background-position: 0  -40px; }
+    &.open         { background-position: 0  -80px; }
+    &.partners     { background-position: 0 -120px; }
+    &.infringement { background-position: 0 -160px; }
     &.legal        { background-position: -45px -160px; }
   }
 }


### PR DESCRIPTION
OSM uses the R2 gem to "flip" CSS for right-to-left languages. I have filed [this bug](https://github.com/mzsanford/R2rb/issues/17) in their repo as well.

On the about page (screenshot attached) only one of the icons is visible for Arabic or other rtl languages. This is happening because R2 "flips" the background-position of the icons to an invalid value. One icon escapes because its background-position does not match the RegEx used by the gem.  Even if this were valid CSS, we would not want to change/flip our sprite coordinates.

My recommendation is to use 0 or possibly ```-0px``` instead of ```0px``` as the x-coordinate here until R2 has some change to avoid sprites.

OSM is already using this syntax (intentionally or not, I don't know) on icon.search which has ```background-position: 0 0;```

![screen shot 2017-07-13 at 3 58 57 pm](https://user-images.githubusercontent.com/643918/28195348-55c28e64-67e5-11e7-8d2e-18dae72c350d.png)