### PR TITLE
Update gem, fix icons on RTL/Arabic pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "jquery-rails"
 gem "jsonify-rails"
 
 # Use R2 for RTL conversion
-gem "r2"
+gem "r2", "~> 0.2.7"
 
 # Use autoprefixer to generate CSS prefixes
 gem "autoprefixer-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
     progress (3.3.1)
     psych (2.2.4)
     public_suffix (2.0.5)
-    r2 (0.2.6)
+    r2 (0.2.7)
     rack (2.0.3)
     rack-cors (0.4.1)
     rack-openid (1.3.1)
@@ -382,7 +382,7 @@ DEPENDENCIES
   pg
   poltergeist
   psych
-  r2
+  r2 (~> 0.2.7)
   rack-cors
   rack-uri_sanitizer
   rails (= 5.0.4)

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2776,12 +2776,30 @@ input.richtext_title[type="text"] {
     vertical-align: middle;
     background: 40px 40px image-url('about/sprite.png') no-repeat;
 
-    &.local        { background-position: 0px    0px; }
-    &.community    { background-position: 0px  -40px; }
-    &.open         { background-position: 0px  -80px; }
-    &.partners     { background-position: 0px -120px; }
-    &.infringement { background-position: 0px -160px; }
-    &.legal        { background-position: -45px -160px; }
+    &.local {
+      /* no-r2 */
+      background-position: 0px 0px;
+    }
+    &.community {
+      /* no-r2 */
+      background-position: 0px -40px;
+    }
+    &.open {
+      /* no-r2 */
+      background-position: 0px -80px;
+    }
+    &.partners {
+      /* no-r2 */
+      background-position: 0px -120px;
+    }
+    &.infringement {
+      /* no-r2 */
+      background-position: 0px -160px;
+    }
+    &.legal {
+      /* no-r2 */
+      background-position: -45px -160px;
+    }
   }
 }
 


### PR DESCRIPTION
OSM uses the R2 gem to "flip" CSS for right-to-left languages.  In #1585 I explained how this is causing all but one icon to go missing on these languages' pages on OpenStreetMap.

![image](https://user-images.githubusercontent.com/643918/28294715-985565f2-6af7-11e7-80bd-6f79cdb6825a.png)

The issue got back to the R2 gem developer and he released a new version of the gem (0.2.7) where you can place a ```/* no-r2 */``` comment inside a CSS block and have sprites and other items not be modified. Due to how we use SASS, I believe that the comment needs to be inside each block.