### PR TITLE
Further refactoring to avoid @user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
   end
 
   def require_oauth
-    @oauth = @user.access_token(OAUTH_KEY) if current_user && defined? OAUTH_KEY
+    @oauth = current_user.access_token(OAUTH_KEY) if current_user && defined? OAUTH_KEY
   end
 
   ##

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
 
   before_action :fetch_body
 
+  helper_method :current_user
+
   def authorize_web
     if session[:user]
       self.current_user = User.where(:id => session[:user]).where("status IN ('active', 'confirmed', 'suspended')").first

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -28,10 +28,10 @@ class UserController < ApplicationController
     else
       @title = t "user.terms.title"
 
-      if @user && @user.terms_agreed?
+      if current_user && current_user.terms_agreed?
         # Already agreed to terms, so just show settings
-        redirect_to :action => :account, :display_name => @user.display_name
-      elsif @user.nil? && session[:new_user].nil?
+        redirect_to :action => :account, :display_name => current_user.display_name
+      elsif current_user.nil? && session[:new_user].nil?
         redirect_to :action => :login, :referer => request.fullpath
       end
     end
@@ -41,52 +41,52 @@ class UserController < ApplicationController
     @title = t "user.new.title"
 
     if params[:decline]
-      if @user
-        @user.terms_seen = true
+      if current_user
+        current_user.terms_seen = true
 
-        if @user.save
+        if current_user.save
           flash[:notice] = t("user.new.terms declined", :url => t("user.new.terms declined url")).html_safe
         end
 
         if params[:referer]
           redirect_to params[:referer]
         else
-          redirect_to :action => :account, :display_name => @user.display_name
+          redirect_to :action => :account, :display_name => current_user.display_name
         end
       else
         redirect_to t("user.terms.declined")
       end
-    elsif @user
-      unless @user.terms_agreed?
-        @user.consider_pd = params[:user][:consider_pd]
-        @user.terms_agreed = Time.now.getutc
-        @user.terms_seen = true
+    elsif current_user
+      unless current_user.terms_agreed?
+        current_user.consider_pd = params[:user][:consider_pd]
+        current_user.terms_agreed = Time.now.getutc
+        current_user.terms_seen = true
 
-        flash[:notice] = t "user.new.terms accepted" if @user.save
+        flash[:notice] = t "user.new.terms accepted" if current_user.save
       end
 
       if params[:referer]
         redirect_to params[:referer]
       else
-        redirect_to :action => :account, :display_name => @user.display_name
+        redirect_to :action => :account, :display_name => current_user.display_name
       end
     else
-      @user = session.delete(:new_user)
+      self.current_user = session.delete(:new_user)
 
-      if check_signup_allowed(@user.email)
-        @user.data_public = true
-        @user.description = "" if @user.description.nil?
-        @user.creation_ip = request.remote_ip
-        @user.languages = http_accept_language.user_preferred_languages
-        @user.terms_agreed = Time.now.getutc
-        @user.terms_seen = true
+      if check_signup_allowed(current_user.email)
+        current_user.data_public = true
+        current_user.description = "" if current_user.description.nil?
+        current_user.creation_ip = request.remote_ip
+        current_user.languages = http_accept_language.user_preferred_languages
+        current_user.terms_agreed = Time.now.getutc
+        current_user.terms_seen = true
 
-        if @user.auth_uid.blank?
-          @user.auth_provider = nil
-          @user.auth_uid = nil
+        if current_user.auth_uid.blank?
+          current_user.auth_provider = nil
+          current_user.auth_uid = nil
         end
 
-        if @user.save
+        if current_user.save
           flash[:piwik_goal] = PIWIK["goals"]["signup"] if defined?(PIWIK)
 
           referer = welcome_path
@@ -103,13 +103,13 @@ class UserController < ApplicationController
             # Use default
           end
 
-          if @user.status == "active"
+          if current_user.status == "active"
             session[:referer] = referer
-            successful_login(@user)
+            successful_login(current_user)
           else
-            session[:token] = @user.tokens.create.token
-            Notifier.signup_confirm(@user, @user.tokens.create(:referer => referer)).deliver_now
-            redirect_to :action => "confirm", :display_name => @user.display_name
+            session[:token] = current_user.tokens.create.token
+            Notifier.signup_confirm(current_user, current_user.tokens.create(:referer => referer)).deliver_now
+            redirect_to :action => "confirm", :display_name => current_user.display_name
           end
         else
           render :action => "new", :referer => params[:referer]
@@ -120,29 +120,29 @@ class UserController < ApplicationController
 
   def account
     @title = t "user.account.title"
-    @tokens = @user.oauth_tokens.authorized
+    @tokens = current_user.oauth_tokens.authorized
 
     if params[:user] && params[:user][:display_name] && params[:user][:description]
       if params[:user][:auth_provider].blank? ||
-         (params[:user][:auth_provider] == @user.auth_provider &&
-          params[:user][:auth_uid] == @user.auth_uid)
-        update_user(@user, params)
+         (params[:user][:auth_provider] == current_user.auth_provider &&
+          params[:user][:auth_uid] == current_user.auth_uid)
+        update_user(current_user, params)
       else
         session[:new_user_settings] = params
         redirect_to auth_url(params[:user][:auth_provider], params[:user][:auth_uid])
       end
     elsif errors = session.delete(:user_errors)
       errors.each do |attribute, error|
-        @user.errors.add(attribute, error)
+        current_user.errors.add(attribute, error)
       end
     end
   end
 
   def go_public
-    @user.data_public = true
-    @user.save
+    current_user.data_public = true
+    current_user.save
     flash[:notice] = t "user.go_public.flash success"
-    redirect_to :action => "account", :display_name => @user.display_name
+    redirect_to :action => "account", :display_name => current_user.display_name
   end
 
   def lost_password
@@ -175,18 +175,18 @@ class UserController < ApplicationController
       token = UserToken.find_by(:token => params[:token])
 
       if token
-        @user = token.user
+        self.current_user = token.user
 
         if params[:user]
-          @user.pass_crypt = params[:user][:pass_crypt]
-          @user.pass_crypt_confirmation = params[:user][:pass_crypt_confirmation]
-          @user.status = "active" if @user.status == "pending"
-          @user.email_valid = true
+          current_user.pass_crypt = params[:user][:pass_crypt]
+          current_user.pass_crypt_confirmation = params[:user][:pass_crypt_confirmation]
+          current_user.status = "active" if current_user.status == "pending"
+          current_user.email_valid = true
 
-          if @user.save
+          if current_user.save
             token.destroy
             flash[:notice] = t "user.reset_password.flash changed"
-            successful_login(@user)
+            successful_login(current_user)
           end
         end
       else
@@ -202,7 +202,7 @@ class UserController < ApplicationController
     @title = t "user.new.title"
     @referer = params[:referer] || session[:referer]
 
-    if @user
+    if current_user
       # The user is logged in already, so don't show them the signup
       # page, instead send them to the home page
       if @referer
@@ -211,11 +211,11 @@ class UserController < ApplicationController
         redirect_to :controller => "site", :action => "index"
       end
     elsif params.key?(:auth_provider) && params.key?(:auth_uid)
-      @user = User.new(:email => params[:email],
-                       :email_confirmation => params[:email],
-                       :display_name => params[:nickname],
-                       :auth_provider => params[:auth_provider],
-                       :auth_uid => params[:auth_uid])
+      self.current_user = User.new(:email => params[:email],
+                                   :email_confirmation => params[:email],
+                                   :display_name => params[:nickname],
+                                   :auth_provider => params[:auth_provider],
+                                   :auth_uid => params[:auth_uid])
 
       flash.now[:notice] = render_to_string :partial => "auth_association"
     else
@@ -224,30 +224,30 @@ class UserController < ApplicationController
   end
 
   def create
-    @user = User.new(user_params)
+    self.current_user = User.new(user_params)
 
-    if check_signup_allowed(@user.email)
+    if check_signup_allowed(current_user.email)
       session[:referer] = params[:referer]
 
-      @user.status = "pending"
+      current_user.status = "pending"
 
-      if @user.auth_provider.present? && @user.pass_crypt.empty?
+      if current_user.auth_provider.present? && current_user.pass_crypt.empty?
         # We are creating an account with external authentication and
         # no password was specified so create a random one
-        @user.pass_crypt = SecureRandom.base64(16)
-        @user.pass_crypt_confirmation = @user.pass_crypt
+        current_user.pass_crypt = SecureRandom.base64(16)
+        current_user.pass_crypt_confirmation = current_user.pass_crypt
       end
 
-      if @user.invalid?
+      if current_user.invalid?
         # Something is wrong with a new user, so rerender the form
         render :action => "new"
-      elsif @user.auth_provider.present?
+      elsif current_user.auth_provider.present?
         # Verify external authenticator before moving on
-        session[:new_user] = @user
-        redirect_to auth_url(@user.auth_provider, @user.auth_uid)
+        session[:new_user] = current_user
+        redirect_to auth_url(current_user.auth_provider, current_user.auth_uid)
       else
         # Save the user record
-        session[:new_user] = @user
+        session[:new_user] = current_user
         redirect_to :action => :terms
       end
     end
@@ -345,23 +345,23 @@ class UserController < ApplicationController
     if request.post?
       token = UserToken.find_by(:token => params[:confirm_string])
       if token && token.user.new_email?
-        @user = token.user
-        @user.email = @user.new_email
-        @user.new_email = nil
-        @user.email_valid = true
-        gravatar_enabled = gravatar_enable(@user)
-        if @user.save
+        self.current_user = token.user
+        current_user.email = current_user.new_email
+        current_user.new_email = nil
+        current_user.email_valid = true
+        gravatar_enabled = gravatar_enable(current_user)
+        if current_user.save
           flash[:notice] = if gravatar_enabled
-                             t("user.confirm_email.success") + " " + gravatar_status_message(@user)
+                             t("user.confirm_email.success") + " " + gravatar_status_message(current_user)
                            else
                              t("user.confirm_email.success")
                            end
         else
-          flash[:errors] = @user.errors
+          flash[:errors] = current_user.errors
         end
         token.destroy
-        session[:user] = @user.id
-        redirect_to :action => "account", :display_name => @user.display_name
+        session[:user] = current_user.id
+        redirect_to :action => "account", :display_name => current_user.display_name
       elsif token
         flash[:error] = t "user.confirm_email.failure"
         redirect_to :action => "account", :display_name => token.user.display_name
@@ -380,13 +380,13 @@ class UserController < ApplicationController
   end
 
   def api_details
-    @this_user = @user
+    @this_user = current_user
     render :action => :api_read, :content_type => "text/xml"
   end
 
   def api_gpx_files
     doc = OSM::API.new.get_xml_doc
-    @user.traces.reload.each do |trace|
+    current_user.traces.reload.each do |trace|
       doc.root << trace.to_xml_node
     end
     render :xml => doc.to_s
@@ -396,7 +396,7 @@ class UserController < ApplicationController
     @this_user = User.find_by(:display_name => params[:display_name])
 
     if @this_user &&
-       (@this_user.visible? || (@user && @user.administrator?))
+       (@this_user.visible? || (current_user && current_user.administrator?))
       @title = @this_user.display_name
     else
       render_unknown_user params[:display_name]
@@ -409,9 +409,9 @@ class UserController < ApplicationController
     if @new_friend
       if request.post?
         friend = Friend.new
-        friend.user_id = @user.id
+        friend.user_id = current_user.id
         friend.friend_user_id = @new_friend.id
-        if @user.is_friends_with?(@new_friend)
+        if current_user.is_friends_with?(@new_friend)
           flash[:warning] = t "user.make_friend.already_a_friend", :name => @new_friend.display_name
         elsif friend.save
           flash[:notice] = t "user.make_friend.success", :name => @new_friend.display_name
@@ -436,8 +436,8 @@ class UserController < ApplicationController
 
     if @friend
       if request.post?
-        if @user.is_friends_with?(@friend)
-          Friend.where(:user_id => @user.id, :friend_user_id => @friend.id).delete_all
+        if current_user.is_friends_with?(@friend)
+          Friend.where(:user_id => current_user.id, :friend_user_id => @friend.id).delete_all
           flash[:notice] = t "user.remove_friend.success", :name => @friend.display_name
         else
           flash[:error] = t "user.remove_friend.not_a_friend", :name => @friend.display_name
@@ -514,14 +514,14 @@ class UserController < ApplicationController
     end
 
     if settings = session.delete(:new_user_settings)
-      @user.auth_provider = provider
-      @user.auth_uid = uid
+      current_user.auth_provider = provider
+      current_user.auth_uid = uid
 
-      update_user(@user, settings)
+      update_user(current_user, settings)
 
-      session[:user_errors] = @user.errors.as_json
+      session[:user_errors] = current_user.errors.as_json
 
-      redirect_to :action => "account", :display_name => @user.display_name
+      redirect_to :action => "account", :display_name => current_user.display_name
     elsif session[:new_user]
       session[:new_user].auth_provider = provider
       session[:new_user].auth_uid = uid
@@ -725,8 +725,8 @@ class UserController < ApplicationController
             # Ignore errors sending email
           end
         else
-          @user.errors.add(:new_email, @user.errors[:email])
-          @user.errors.add(:email, [])
+          current_user.errors.add(:new_email, current_user.errors[:email])
+          current_user.errors.add(:email, [])
         end
 
         user.restore_email!
@@ -738,7 +738,7 @@ class UserController < ApplicationController
   # require that the user is a administrator, or fill out a helpful error message
   # and return them to the user page.
   def require_administrator
-    if @user && !@user.administrator?
+    if current_user && !current_user.administrator?
       flash[:error] = t("user.filter.not_an_administrator")
 
       if params[:display_name]
@@ -746,7 +746,7 @@ class UserController < ApplicationController
       else
         redirect_to :action => "login", :referer => request.fullpath
       end
-    elsif !@user
+    elsif !current_user
       redirect_to :action => "login", :referer => request.fullpath
     end
   end
@@ -754,7 +754,7 @@ class UserController < ApplicationController
   ##
   # require that the user in the URL is the logged in user
   def require_self
-    head :forbidden if params[:display_name] != @user.display_name
+    head :forbidden if params[:display_name] != current_user.display_name
   end
 
   ##

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -12,10 +12,10 @@
   <%= render :partial => "tag_details", :object => @changeset.tags.except('comment') %>
 
   <h4 class="comments-header"><%= t('browse.changeset.discussion') %></h4>
-  
+
   <div class="buttons clearfix subscribe-buttons">
     <form action="#" class="hide_unless_logged_in">
-      <% if @user and @changeset.subscribers.exists?(@user.id) %>
+      <% if current_user and @changeset.subscribers.exists?(current_user.id) %>
         <input class="action-button" type="submit" name="unsubscribe" value="<%= t('javascripts.changesets.show.unsubscribe') %>" data-method="POST" data-url="<%= changeset_unsubscribe_url(@changeset) %>" />
       <% else %>
         <input class="action-button" type="submit" name="subscribe" value="<%= t('javascripts.changesets.show.subscribe') %>" data-method="POST" data-url="<%= changeset_subscribe_url(@changeset) %>" />
@@ -37,13 +37,13 @@
                     :when => friendly_date(comment.created_at), :exact_time => l(comment.created_at),
                     :user => link_to(h(comment.author.display_name), {:controller => "user", :action => "view",
                     :display_name => comment.author.display_name})).html_safe %>
-                  <% if @user and @user.moderator? %>
+                  <% if current_user and current_user.moderator? %>
                     — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_hide_url(comment.id) %>"><%= t('javascripts.changesets.show.hide_comment') %></span>
                   <% end %>
                 </small>
                 <%= comment.body.to_html %>
               </li>
-            <% elsif @user and @user.moderator? %>
+            <% elsif current_user and current_user.moderator? %>
               <li id="c<%= comment.id %>">
                 <small class='deemphasize'>
                   <%= t("browse.changeset.hidden_commented_by",

--- a/app/views/changeset/history.html.erb
+++ b/app/views/changeset/history.html.erb
@@ -5,7 +5,7 @@
 <% end -%>
 
 <%
-   set_title(changeset_list_title(params, @user))
+   set_title(changeset_list_title(params, current_user))
    if params[:display_name]
      @heading = t('changeset.list.title_user', :user => link_to(params[:display_name], :controller => "user", :action => "view", :display_name => params[:display_name])).html_safe
    else

--- a/app/views/changeset/list.atom.builder
+++ b/app/views/changeset/list.atom.builder
@@ -2,7 +2,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
           :id => url_for(@params.merge(:only_path => false)),
           :root_url => url_for(@params.merge(:action => :list, :format => nil, :only_path => false)),
           "xmlns:georss" => "http://www.georss.org/georss") do |feed|
-  feed.title changeset_list_title(params, @user)
+  feed.title changeset_list_title(params, current_user)
 
   feed.updated @edits.map { |e| [e.created_at, e.closed_at].max }.max
   feed.icon image_url("favicon.ico")

--- a/app/views/diary_entry/view.html.erb
+++ b/app/views/diary_entry/view.html.erb
@@ -21,9 +21,9 @@
     <%= richtext_area :diary_comment, :body, :cols => 80, :rows => 15 %>
     <%= submit_tag t('diary_entry.view.save_button') %>
   <% end %>
-  <% if @user and @entry.subscribers.exists?(@user.id) %>
+  <% if current_user and @entry.subscribers.exists?(current_user.id) %>
     <div class="diary-subscribe-buttons"><%= link_to t('javascripts.changesets.show.unsubscribe'), diary_entry_unsubscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => :button %></div>
-  <% elsif @user %>
+  <% elsif current_user %>
     <div class="diary-subscribe-buttons"><%= link_to t('javascripts.changesets.show.subscribe'), diary_entry_subscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => :button %></div>
   <% end %>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -54,26 +54,26 @@
         </ul>
       </li>
     </ul>
-    <% if @user && @user.id %>
+    <% if current_user && current_user.id %>
       <div class='dropdown user-menu logged-in'>
         <a class='dropdown-toggle' data-toggle='dropdown' href="#">
-          <%= user_thumbnail_tiny(@user, :width => 25, :height => 25)
+          <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25)
           %><%= render :partial => 'layouts/inbox'
-        %><span class="user-button"><span class='username'><%= @user.display_name %></span>
+        %><span class="user-button"><span class='username'><%= current_user.display_name %></span>
           <b class="caret"></b></span>
         </a>
         <ul class='dropdown-menu'>
           <li>
-            <%= link_to inbox_path(:display_name => @user.display_name) do %>
-              <span class='count-number'><%= number_with_delimiter(@user.new_messages.size) %></span>
+            <%= link_to inbox_path(:display_name => current_user.display_name) do %>
+              <span class='count-number'><%= number_with_delimiter(current_user.new_messages.size) %></span>
               <%= t('user.view.my messages') %>
             <% end %>
           </li>
           <li>
-            <%= link_to t('user.view.my profile'), user_path(:display_name => @user.display_name) %>
+            <%= link_to t('user.view.my profile'), user_path(:display_name => current_user.display_name) %>
           </li>
           <li>
-            <%= link_to t('user.view.my settings'), :controller => 'user', :action => 'account', :display_name => @user.display_name %>
+            <%= link_to t('user.view.my settings'), :controller => 'user', :action => 'account', :display_name => current_user.display_name %>
           </li>
           <li class="divider"></li>
           <li>

--- a/app/views/layouts/_inbox.html.erb
+++ b/app/views/layouts/_inbox.html.erb
@@ -1,3 +1,3 @@
-<% if @user.new_messages.size > 0 %>
-<span id="inboxanchor" class="count-number"><%= @user.new_messages.size %></span>
+<% if current_user.new_messages.size > 0 %>
+<span id="inboxanchor" class="count-number"><%= current_user.new_messages.size %></span>
 <% end %>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -4,14 +4,14 @@
 
 <% content_for(:body_class) { "map-layout" } %>
 
-<% if @user and !@user.home_lon.nil? and !@user.home_lat.nil? %>
+<% if current_user and !current_user.home_lon.nil? and !current_user.home_lat.nil? %>
   <% content_for :greeting do %>
     <%= link_to t("layouts.home"),
                 "#",
                 :id => "homeanchor",
                 :class => "set_position",
-                :data => { :lat => @user.home_lat,
-                           :lon => @user.home_lon,
+                :data => { :lat => current_user.home_lat,
+                           :lon => current_user.home_lon,
                            :zoom => 15 } %>
   <% end %>
 <% end %>
@@ -38,7 +38,7 @@
       <%= yield %>
     </div>
 
-    <% unless @user %>
+    <% unless current_user %>
       <div class="welcome">
         <h2><%= t 'layouts.intro_header' %></h2>
         <div class="close-wrap"><span class="icon close"></span></div>

--- a/app/views/message/_message_count.html.erb
+++ b/app/views/message/_message_count.html.erb
@@ -1,8 +1,8 @@
 <p id="inbox-count">
 <%= t "message.inbox.messages",
-      :new_messages => t("message.inbox.new_messages", 
-                         :count => @user.new_messages.size),
-      :old_messages => t("message.inbox.old_messages", 
-                         :count => @user.messages.size - @user.new_messages.size)
+      :new_messages => t("message.inbox.new_messages",
+                         :count => current_user.new_messages.size),
+      :old_messages => t("message.inbox.old_messages",
+                         :count => current_user.messages.size - current_user.new_messages.size)
 %>
-</p> 
+</p>

--- a/app/views/message/inbox.html.erb
+++ b/app/views/message/inbox.html.erb
@@ -1,10 +1,10 @@
 <% content_for :heading do %>
-  <h2><%= t'message.inbox.my_inbox'%>/<%= link_to t('message.inbox.outbox'), outbox_path(@user.display_name) %></h2>
+  <h2><%= t'message.inbox.my_inbox'%>/<%= link_to t('message.inbox.outbox'), outbox_path(current_user.display_name) %></h2>
 <% end %>
 
   <h4><%= render :partial => "message_count" %></h4>
 
-<% if @user.messages.size > 0 %>
+<% if current_user.messages.size > 0 %>
   <table class="messages">
     <thead>
       <tr>
@@ -16,9 +16,9 @@
       </tr>
     </thead>
     <tbody>
-        <%= render :partial => "message_summary", :collection => @user.messages %>
+        <%= render :partial => "message_summary", :collection => current_user.messages %>
     </tbody>
   </table>
 <% else %>
-  <div><%= raw(t'message.inbox.no_messages_yet', :people_mapping_nearby_link => link_to(t('message.inbox.people_mapping_nearby'), :controller => 'user', :action => 'view', :display_name => @user.display_name)) %></div>
+  <div><%= raw(t'message.inbox.no_messages_yet', :people_mapping_nearby_link => link_to(t('message.inbox.people_mapping_nearby'), :controller => 'user', :action => 'view', :display_name => current_user.display_name)) %></div>
 <% end %>

--- a/app/views/message/new.html.erb
+++ b/app/views/message/new.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class='buttons'>
       <%= submit_tag t('message.new.send_button') %>
-      <%= link_to t('message.new.back_to_inbox'), { :controller => 'message', :action => 'inbox', :display_name => @user.display_name }, :class => 'deemphasize button' %>
+      <%= link_to t('message.new.back_to_inbox'), { :controller => 'message', :action => 'inbox', :display_name => current_user.display_name }, :class => 'deemphasize button' %>
     </div>
   </fieldset>
 <% end %>

--- a/app/views/message/outbox.html.erb
+++ b/app/views/message/outbox.html.erb
@@ -1,10 +1,10 @@
 <% content_for :heading do %>
-  <h2><%= raw(t'message.outbox.my_inbox', :inbox_link => link_to(t('message.outbox.inbox'), inbox_path(@user.display_name))) %>/<%= t'message.outbox.outbox' %></h2>
+  <h2><%= raw(t'message.outbox.my_inbox', :inbox_link => link_to(t('message.outbox.inbox'), inbox_path(current_user.display_name))) %>/<%= t'message.outbox.outbox' %></h2>
 <% end %>
 
-<h4><%= t'message.outbox.messages', :count => @user.sent_messages.size %></h4>
+<h4><%= t'message.outbox.messages', :count => current_user.sent_messages.size %></h4>
 
-<% if @user.sent_messages.size > 0 %>
+<% if current_user.sent_messages.size > 0 %>
   <table class="messages">
     <thead>
       <tr>
@@ -15,9 +15,9 @@
       </tr>
     </thead>
     <tbody>
-      <%= render :partial => "sent_message_summary", :collection => @user.sent_messages %>
+      <%= render :partial => "sent_message_summary", :collection => current_user.sent_messages %>
     </tbody>
   </table>
 <% else %>
-  <div class="messages"><%= raw(t'message.outbox.no_sent_messages', :people_mapping_nearby_link => link_to(t('message.outbox.people_mapping_nearby'), :controller => 'user', :action => 'view', :display_name => @user.display_name)) %></div>
+  <div class="messages"><%= raw(t'message.outbox.no_sent_messages', :people_mapping_nearby_link => link_to(t('message.outbox.people_mapping_nearby'), :controller => 'user', :action => 'view', :display_name => current_user.display_name)) %></div>
 <% end %>

--- a/app/views/message/read.html.erb
+++ b/app/views/message/read.html.erb
@@ -1,4 +1,4 @@
-<% if @user == @message.recipient %>
+<% if current_user == @message.recipient %>
   <% content_for :heading do %>
     <h2><%= h(@message.title) %></h2>
   <% end %>
@@ -36,5 +36,5 @@
 
 <% end %>
 
-  <%= link_to t('message.read.back'), {:controller => 'message', :action => 'outbox', :display_name => @user.display_name }, :class => "button deemphasize" %>
+  <%= link_to t('message.read.back'), {:controller => 'message', :action => 'outbox', :display_name => current_user.display_name }, :class => "button deemphasize" %>
   </div>

--- a/app/views/oauth/authorize.html.erb
+++ b/app/views/oauth/authorize.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t "oauth.oauthorize.title" %></h1>
 <% end %>
 
-<p><%= raw t("oauth.oauthorize.request_access", :app_name => link_to(@token.client_application.name, @token.client_application.url), :user => link_to(@user.display_name, :controller => :user, :action => :view, :display_name => @user.display_name)) %></p>
+<p><%= raw t("oauth.oauthorize.request_access", :app_name => link_to(@token.client_application.name, @token.client_application.url), :user => link_to(current_user.display_name, :controller => :user, :action => :view, :display_name => current_user.display_name)) %></p>
 
 <%= form_tag authorize_url do %>
   <%= hidden_field_tag "oauth_token", @token.token %>

--- a/app/views/redactions/show.html.erb
+++ b/app/views/redactions/show.html.erb
@@ -12,8 +12,8 @@
   <%= @redaction.description.to_html %>
 </p>
 
-<% if @user and @user.moderator? %>
-<div class="buttons">  
+<% if current_user and current_user.moderator? %>
+<div class="buttons">
   <%= button_to t('redaction.show.edit'), edit_redaction_path(@redaction), :method => :get %></td>
   <%= button_to t('redaction.show.destroy'), @redaction, :method => "delete", :remote => true, :data => { :confirm => t('redaction.show.confirm') } %>
 </div>

--- a/app/views/site/_potlatch.html.erb
+++ b/app/views/site/_potlatch.html.erb
@@ -1,7 +1,7 @@
 <%= javascript_include_tag "edit/potlatch" %>
 
 <div id="map">
-  <% session[:token] = @user.tokens.create.token unless session[:token] and UserToken.find_by_token(session[:token]) -%>
+  <% session[:token] = current_user.tokens.create.token unless session[:token] and UserToken.find_by_token(session[:token]) -%>
   <% data = { :token => session[:token] } -%>
   <% data[:lat] = @lat if @lat -%>
   <% data[:lon] = @lon if @lon -%>

--- a/app/views/site/_potlatch2.html.erb
+++ b/app/views/site/_potlatch2.html.erb
@@ -1,13 +1,13 @@
 <%= javascript_include_tag "edit/potlatch2" %>
 
 <div id="map">
-  <% session[:token] = @user.tokens.create.token unless session[:token] and UserToken.find_by_token(session[:token]) -%>
+  <% session[:token] = current_user.tokens.create.token unless session[:token] and UserToken.find_by_token(session[:token]) -%>
   <% data = { :token => session[:token] } -%>
   <% data[:lat] = @lat if @lat -%>
   <% data[:lon] = @lon if @lon -%>
   <% data[:zoom] = @zoom if @zoom -%>
   <% if defined? POTLATCH2_KEY %>
-  <% token = @user.access_token(POTLATCH2_KEY) %>
+  <% token = current_user.access_token(POTLATCH2_KEY) %>
   <% data[:token] = token.token -%>
   <% data[:token_secret] = token.secret -%>
   <% data[:consumer_key] = token.client_application.key -%>

--- a/app/views/site/edit.html.erb
+++ b/app/views/site/edit.html.erb
@@ -3,9 +3,9 @@
     <p><%= t 'layouts.osm_offline' %></p>
   <% elsif STATUS == :database_readonly or STATUS == :api_readonly %>
     <p><%= t 'layouts.osm_read_only' %></p>
-  <% elsif !@user.data_public? %>
+  <% elsif !current_user.data_public? %>
     <p><%= t 'site.edit.not_public' %></p>
-    <p><%= raw t 'site.edit.not_public_description', :user_page => (link_to t('site.edit.user_page_link'), {:controller => 'user', :action => 'account', :display_name => @user.display_name, :anchor => 'public'}) %></p>
+    <p><%= raw t 'site.edit.not_public_description', :user_page => (link_to t('site.edit.user_page_link'), {:controller => 'user', :action => 'account', :display_name => current_user.display_name, :anchor => 'public'}) %></p>
     <p><%= raw t 'site.edit.anon_edits', :link => link_to(t('site.edit.anon_edits_link_text'), t('site.edit.anon_edits_link')) %></p>
   <% else %>
     <%= render :partial => preferred_editor %>

--- a/app/views/site/help.html.erb
+++ b/app/views/site/help.html.erb
@@ -5,7 +5,7 @@
 <p class='introduction'><%= t "help_page.introduction" %></p>
 
 <% ['welcome', 'beginners_guide', 'help', 'mailing_lists', 'forums', 'irc', 'switch2osm', 'wiki'].each do |site| %>
-  <% unless site == 'welcome' && !@user %>
+  <% unless site == 'welcome' && !current_user %>
   <div class='<%= site %> help-item'>
   <h3>
     <a href='<%= t "help_page.#{site}.url" %>'>

--- a/app/views/site/id.html.erb
+++ b/app/views/site/id.html.erb
@@ -10,7 +10,7 @@
 <body>
 <% data = {} -%>
 <% if defined? ID_KEY %>
-<% token = @user.access_token(ID_KEY) %>
+<% token = current_user.access_token(ID_KEY) %>
 <% data[:token] = token.token -%>
 <% data[:token_secret] = token.secret -%>
 <% data[:consumer_key] = token.client_application.key -%>

--- a/app/views/user/_contact.html.erb
+++ b/app/views/user/_contact.html.erb
@@ -37,7 +37,7 @@
     <ul class='secondary-actions clearfix deemphasize'>
       <li><%= link_to t('user.view.send message'), :controller => 'message', :action => 'new', :display_name => contact.display_name %></li>
       <li>
-        <% if @user.is_friends_with?(contact) %>
+        <% if current_user.is_friends_with?(contact) %>
           <%= link_to t('user.view.remove as friend'), remove_friend_path(:display_name => contact.display_name, :referer => request.fullpath), :method => :post %>
         <% else %>
           <%= link_to t('user.view.add as friend'), make_friend_path(:display_name => contact.display_name, :referer => request.fullpath), :method => :post %>

--- a/app/views/user/account.html.erb
+++ b/app/views/user/account.html.erb
@@ -5,7 +5,7 @@
 <% content_for :heading do %>
   <h1><%= t 'user.account.my settings' %></h1>
   <ul class='secondary-actions clearfix'>
-    <li><%= link_to t('user.account.return to profile'), :controller => 'user', :action => 'view', :display_name => @user.display_name %></li>
+    <li><%= link_to t('user.account.return to profile'), :controller => 'user', :action => 'view', :display_name => current_user.display_name %></li>
     <li><%= link_to t('user.view.oauth settings'), :controller => 'oauth_clients', :action => 'index' %></li>
   </ul>
 <% end %>
@@ -22,7 +22,7 @@
   <fieldset>
     <div class="form-row">
       <label class="standard-label"><%= t 'user.account.current email address' %></label>
-      <input type="email" disabled value="<%= @user.email %>" />
+      <input type="email" disabled value="<%= current_user.email %>" />
       <span class="form-help deemphasize"><%= t 'user.account.email never displayed publicly' %></span>
     </div>
 
@@ -58,7 +58,7 @@
     <div class="form-row">
       <label class="standard-label"><%= t 'user.account.public editing.heading' %></label>
       <span class="form-help deemphasize">
-        <% if @user.data_public? %>
+        <% if current_user.data_public? %>
           <%= t 'user.account.public editing.enabled' %>
           (<a href="<%= t 'user.account.public editing.enabled link' %>" target="_new"><%= t 'user.account.public editing.enabled link text' %></a>)
         <% else %>
@@ -71,10 +71,10 @@
     <div class="form-row">
       <label class="standard-label"><%= t 'user.account.contributor terms.heading' %></label>
       <span class="form-help deemphasize">
-        <% if @user.terms_agreed? %>
+        <% if current_user.terms_agreed? %>
           <%= t 'user.account.contributor terms.agreed' %>
           (<a href="<%= t 'user.account.contributor terms.link' %>" target="_new"><%= t 'user.account.contributor terms.link text' %></a>)
-          <% if @user.consider_pd? %>
+          <% if current_user.consider_pd? %>
             <%= t 'user.account.contributor terms.agreed_with_pd' %>
           <% end %>
         <% else %>
@@ -102,21 +102,21 @@
 
     <div class='form-row accountImage'>
       <label class="standard-label"><%= t 'user.account.image' %></label>
-        <%= user_image @user %>
+        <%= user_image current_user %>
         <ul class='form-list accountImage-options'>
-        <% if @user.image.file? %>
+        <% if current_user.image.file? %>
         <li>
-          <%= radio_button_tag "image_action", "keep", !@user.image_use_gravatar %>
+          <%= radio_button_tag "image_action", "keep", !current_user.image_use_gravatar %>
           <label class='standard-label' for='image_action_keep'><%= t 'user.account.keep image' %></label>
         </li>
         <% end %>
-        <% if @user.image.file? || @user.image_use_gravatar? %>
+        <% if current_user.image.file? || current_user.image_use_gravatar? %>
         <li>
           <%= radio_button_tag "image_action", "delete" %>
           <label class='standard-label' for='image_action_delete'><%= t 'user.account.delete image' %></label>
         </li>
         <% end %>
-        <% if @user.image.file? %>
+        <% if current_user.image.file? %>
           <li>
             <%= radio_button_tag "image_action", "new" %>
             <label class='standard-label' for='image_action_new'>
@@ -136,7 +136,7 @@
         </li>
         <% end %>
         <li>
-          <%= radio_button_tag "image_action", "gravatar", @user.image_use_gravatar %>
+          <%= radio_button_tag "image_action", "gravatar", current_user.image_use_gravatar %>
           <label class='standard-label' for='image_action_gravatar'>
             <%= t 'user.account.gravatar.gravatar' %>
             <span class='form-help deemphasize'> (<a href="<%= t 'user.account.gravatar.link' %>" target="_new"><%= t 'user.account.gravatar.link text' %></a>)</span>
@@ -149,7 +149,7 @@
   <fieldset class="form-divider">
     <div class='form-row location clearfix'>
     <label class="standard-label"><%= t 'user.account.home location' %></label>
-    <div id="homerow" <% unless @user.home_lat and @user.home_lon %>class="nohome"<%end%> >
+    <div id="homerow" <% unless current_user.home_lat and current_user.home_lon %>class="nohome"<%end%> >
       <p class="message form-help deemphasize"><%= t 'user.account.no home location' %></p>
         <div class='form-column'>
           <label class="standard-label secondary"><%= t 'user.account.latitude' %></label>
@@ -163,7 +163,7 @@
     </div>
 
     <div class="form-row">
-      <input type="checkbox" name="updatehome" value="1" <% unless @user.home_lat and @user.home_lon %> checked="checked" <% end %> id="updatehome" />
+      <input type="checkbox" name="updatehome" value="1" <% unless current_user.home_lat and current_user.home_lon %> checked="checked" <% end %> id="updatehome" />
       <label class="standard-label" for="updatehome"><%= t 'user.account.update home location on click' %></label>
     </div>
     <%= content_tag "div", "", :id => "map", :class => "content_map settings_map set_location" %>
@@ -172,7 +172,7 @@
   <%= submit_tag t('user.account.save changes button') %>
 <% end %>
 
-<% unless @user.data_public? %>
+<% unless current_user.data_public? %>
 <a name="public"></a>
 <h2><%= t 'user.account.public editing note.heading' %></h2>
 <%= raw t 'user.account.public editing note.text' %>

--- a/app/views/user/api_read.builder
+++ b/app/views/user/api_read.builder
@@ -4,7 +4,7 @@ xml.osm("version" => API_VERSION, "generator" => GENERATOR) do
                    :display_name => @this_user.display_name,
                    :account_created => @this_user.creation_time.xmlschema do
     xml.tag! "description", @this_user.description if @this_user.description
-    if @user && @user == @this_user
+    if current_user && current_user == @this_user
       xml.tag! "contributor-terms", :agreed => @this_user.terms_agreed.present?,
                                     :pd => @this_user.consider_pd
     else
@@ -28,7 +28,7 @@ xml.osm("version" => API_VERSION, "generator" => GENERATOR) do
                            :active => @this_user.blocks_created.active.size
       end
     end
-    if @user && @user == @this_user
+    if current_user && current_user == @this_user
       if @this_user.home_lat && @this_user.home_lon
         xml.tag! "home", :lat => @this_user.home_lat,
                          :lon => @this_user.home_lon,

--- a/app/views/user/reset_password.html.erb
+++ b/app/views/user/reset_password.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t 'user.reset_password.heading', :user => @user.display_name %></h1>
+  <h1><%= t 'user.reset_password.heading', :user => current_user.display_name %></h1>
 <% end %>
 
 <%= error_messages_for :user %>

--- a/app/views/user/save.html.erb
+++ b/app/views/user/save.html.erb
@@ -1,1 +1,1 @@
-<%= @user.email %>
+<%= current_user.email %>

--- a/app/views/user/view.html.erb
+++ b/app/views/user/view.html.erb
@@ -3,42 +3,42 @@
     <%= user_image @this_user %>
     <div class='userinformation-inner'>
       <h1><%= @this_user.display_name %><%= role_icons(@this_user) %></h1>
-      <% if @user and @this_user.id == @user.id %>
+      <% if current_user and @this_user.id == current_user.id %>
         <!-- Displaying user's own profile page to themself -->
         <ul class='secondary-actions clearfix'>
           <li>
-            <%= link_to t('user.view.my edits'), :controller => 'changeset', :action => 'list', :display_name => @user.display_name %>
-            <span class='count-number'><%= number_with_delimiter(@user.changesets.size) %></span>
+            <%= link_to t('user.view.my edits'), :controller => 'changeset', :action => 'list', :display_name => current_user.display_name %>
+            <span class='count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
           </li>
           <li>
             <%= link_to t('user.view.my notes'), :controller => 'notes', :action=> 'mine' %>
           </li>
           <li>
             <%= link_to t('user.view.my traces'), :controller => 'trace', :action=>'mine' %>
-            <span class='count-number'><%= number_with_delimiter(@user.traces.size) %></span>
+            <span class='count-number'><%= number_with_delimiter(current_user.traces.size) %></span>
           </li>
           <li>
-            <%= link_to t('user.view.my diary'), :controller => 'diary_entry', :action => 'list', :display_name => @user.display_name %>
-            <span class='count-number'><%= number_with_delimiter(@user.diary_entries.size) %></span>
+            <%= link_to t('user.view.my diary'), :controller => 'diary_entry', :action => 'list', :display_name => current_user.display_name %>
+            <span class='count-number'><%= number_with_delimiter(current_user.diary_entries.size) %></span>
           </li>
           <li>
-            <%= link_to t('user.view.my comments' ), :controller => 'diary_entry', :action => 'comments', :display_name => @user.display_name %>
+            <%= link_to t('user.view.my comments' ), :controller => 'diary_entry', :action => 'comments', :display_name => current_user.display_name %>
           </li>
           <li>
-            <%= link_to t('user.view.my settings'), :controller => 'user', :action => 'account', :display_name => @user.display_name %>
+            <%= link_to t('user.view.my settings'), :controller => 'user', :action => 'account', :display_name => current_user.display_name %>
           </li>
 
-          <% if @user.blocks.exists? %>
+          <% if current_user.blocks.exists? %>
             <li>
-              <%= link_to t('user.view.blocks on me'), :controller => 'user_blocks', :action => 'blocks_on', :display_name => @user.display_name %>
-              <span class='count-number'><%= number_with_delimiter(@user.blocks.active.size) %></span>
+              <%= link_to t('user.view.blocks on me'), :controller => 'user_blocks', :action => 'blocks_on', :display_name => current_user.display_name %>
+              <span class='count-number'><%= number_with_delimiter(current_user.blocks.active.size) %></span>
             </li>
           <% end %>
 
-          <% if @user and @user.moderator? and @user.blocks_created.exists? %>
+          <% if current_user and current_user.moderator? and current_user.blocks_created.exists? %>
             <li>
-              <%= link_to t('user.view.blocks by me'), :controller => 'user_blocks', :action => 'blocks_by', :display_name => @user.display_name %>
-              <span class='count-number'><%= number_with_delimiter(@user.blocks_created.active.size) %></span>
+              <%= link_to t('user.view.blocks by me'), :controller => 'user_blocks', :action => 'blocks_by', :display_name => current_user.display_name %>
+              <span class='count-number'><%= number_with_delimiter(current_user.blocks_created.active.size) %></span>
             </li>
           <% end %>
 
@@ -73,9 +73,9 @@
             <%= link_to t('user.view.comments'), :controller => 'diary_entry', :action => 'comments', :display_name => @this_user.display_name %>
           </li>
           <li>
-            <% if @user and @user.is_friends_with?(@this_user) %>
+            <% if current_user and current_user.is_friends_with?(@this_user) %>
               <%= link_to t('user.view.remove as friend'), remove_friend_path(:display_name => @this_user.display_name), :method => :post %>
-            <% elsif @user %>
+            <% elsif current_user %>
               <%= link_to t('user.view.add as friend'), make_friend_path(:display_name => @this_user.display_name), :method => :post %>
             <% else %>
               <%= link_to t('user.view.add as friend'), make_friend_path(:display_name => @this_user.display_name) %>
@@ -96,7 +96,7 @@
             </li>
           <% end %>
 
-          <% if @user and @user.moderator? %>
+          <% if current_user and current_user.moderator? %>
             <li>
             <%= link_to t('user.view.create_block'), :controller => 'user_blocks', :action => 'new', :display_name => @this_user.display_name %>
             </li>
@@ -106,7 +106,7 @@
 
       <% end %>
 
-      <% if @user and @user.administrator? %>
+      <% if current_user and current_user.administrator? %>
 
         <ul class='secondary-actions clearfix'>
           <% if ["active", "confirmed"].include? @this_user.status %>
@@ -158,7 +158,7 @@
 
   </div>
 
-  <% if @user and @user.administrator? -%>
+  <% if current_user and current_user.administrator? -%>
     <div class='admin-user-info deemphasize'>
       <small><b><%= t 'user.view.email address' %></b> <%= @this_user.email %></small>
       <% unless @this_user.creation_ip.nil? -%>
@@ -171,10 +171,10 @@
 
 <% end %>
 
-  <% if @user and @this_user.id == @user.id %>
+  <% if current_user and @this_user.id == current_user.id %>
     <% if @this_user.home_lat.nil? or @this_user.home_lon.nil? %>
       <div id="map" class="content_map">
-        <p id="no_home_location"><%= raw(t 'user.view.if set location', :settings_link => (link_to t('user.view.settings_link_text'), :controller => 'user', :action => 'account', :display_name => @user.display_name)) %></p>
+        <p id="no_home_location"><%= raw(t 'user.view.if set location', :settings_link => (link_to t('user.view.settings_link_text'), :controller => 'user', :action => 'account', :display_name => current_user.display_name)) %></p>
       </div>
     <% else %>
       <% content_for :head do %>
@@ -182,10 +182,10 @@
       <% end %>
       <%
         user_data = {
-          :lon => @user.home_lon,
-          :lat => @user.home_lat,
+          :lon => current_user.home_lon,
+          :lat => current_user.home_lat,
           :icon => image_path("marker-red.png"),
-          :description => render(:partial => "popup", :object => @user, :locals => {:type => "your location"})
+          :description => render(:partial => "popup", :object => current_user, :locals => {:type => "your location"})
         }
       %>
       <%= content_tag "div", "", :id => "map", :class => "content_map", :data => {:user => user_data} %>

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   </td>
   <td class="<%= c1 %>"><%= link_to t('user_block.partial.show'), block %></td>
-  <td class="<%= c1 %>"><% if @user and @user.id == block.creator_id and block.active? %><%= link_to t('user_block.partial.edit'), edit_user_block_path(block) %><% end %></td>
+  <td class="<%= c1 %>"><% if current_user and current_user.id == block.creator_id and block.active? %><%= link_to t('user_block.partial.edit'), edit_user_block_path(block) %><% end %></td>
   <% if show_revoke_link %>
   <td class="<%= c1 %>"><% if block.active? %><%= link_to t('user_block.partial.revoke'), :controller => 'user_blocks', :action => 'revoke', :id => block.id %><% end %></td>
   <% end %>

--- a/app/views/user_blocks/blocks_by.html.erb
+++ b/app/views/user_blocks/blocks_by.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <% unless @user_blocks.empty? %>
-<%= render :partial => 'blocks', :locals => { :show_revoke_link => (@user and @user.moderator?), :show_user_name => true, :show_creator_name => false } %>
+<%= render :partial => 'blocks', :locals => { :show_revoke_link => (current_user and current_user.moderator?), :show_user_name => true, :show_creator_name => false } %>
 <% else %>
 <p><%= t "user_block.blocks_by.empty", :name => h(@this_user.display_name) %></p>
 <% end %>

--- a/app/views/user_blocks/blocks_on.html.erb
+++ b/app/views/user_blocks/blocks_on.html.erb
@@ -3,7 +3,7 @@
   <h1><%= raw(t('user_block.blocks_on.heading', :name => link_to(h(@this_user.display_name), {:controller => 'user', :action => 'view', :display_name => @this_user.display_name}))) %></h1>
 <% end %>
 <% unless @user_blocks.empty? %>
-<%= render :partial => 'blocks', :locals => { :show_revoke_link => (@user and @user.moderator?), :show_user_name => false, :show_creator_name => true } %>
+<%= render :partial => 'blocks', :locals => { :show_revoke_link => (current_user and current_user.moderator?), :show_user_name => false, :show_creator_name => true } %>
 <% else %>
 <p><%= t "user_block.blocks_on.empty", :name => h(@this_user.display_name) %></p>
 <% end %>

--- a/app/views/user_blocks/index.html.erb
+++ b/app/views/user_blocks/index.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <% unless @user_blocks.empty? %>
-<%= render :partial => 'blocks', :locals => { :show_revoke_link => (@user and @user.moderator?), :show_user_name => true, :show_creator_name => true } %>
+<%= render :partial => 'blocks', :locals => { :show_revoke_link => (current_user and current_user.moderator?), :show_user_name => true, :show_creator_name => true } %>
 <% else %>
 <p><%= t "user_block.index.empty" %></p>
 <% end %>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -12,10 +12,10 @@
                                      {:controller => 'user', :action => 'view', :display_name => @user_block.creator.display_name})) %></h1>
 <ul class='secondary-actions clearfix'>
   <% if @user_block.ends_at > Time.now.getutc %>
-    <% if @user and @user.id == @user_block.creator_id %>
+    <% if current_user and current_user.id == @user_block.creator_id %>
       <li><%= link_to t('user_block.show.edit'), edit_user_block_path(@user_block) %></li>
     <% end %>
-    <% if @user and @user.moderator? %>
+    <% if current_user and current_user.moderator? %>
       <li><%= link_to(t('user_block.show.revoke'),{:controller => 'user_blocks', :action => 'revoke', :id => @user_block.id}) %></li>
     <% end %>
   <% end %>


### PR DESCRIPTION
This follows on from #1583 and refactors the remaining controller code, and all of the views, to use the `current_user` approach for accessing the currently logged in user.

The `self.current_user =` feels a bit clumsy, but it's necessary to avoid creating local variables with the same name as the controller method. I'm sure those will disappear when we eventually migrate to a devise or similar.