### PR TITLE
Add maintainers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ We're always keen to have more developers! Pull requests are very welcome.
 * IRC - there is the #osm-dev channel on irc.oftc.net.
 
 More details on contributing to the code are in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+
+# Maintainers
+
+* Tom Hughes [@tomhughes](https://github.com/tomhughes/)
+* Andy Allan [@gravitystorm](https://github.com/gravitystorm/)


### PR DESCRIPTION
It's nice to be explicit, so that new contributers know who is who.

While github shows "owner" and "member" labels these are for the openstreetmap organisation as a whole, and can be misleading.