### PR TITLE
Update about text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1195,7 +1195,7 @@ en:
   about_page:
     next: Next
     copyright_html: <span>&copy;</span>OpenStreetMap<br>contributors
-    used_by: "%{name} powers map data on thousands of web sites, mobile apps, and hardware devices"
+    used_by: "%{name} provides geographic data for thousands of maps, routers and other services."
     lede_text: |
       OpenStreetMap is built by a community of mappers that contribute and maintain data
       about roads, trails, cafés, railway stations, and much more, all over the world.


### PR DESCRIPTION
Change
OpenStreetMap powers map data on thousands of web sites, mobile apps, and hardware devices
to
OpenStreetMap provides geographic data for thousands of maps, routers and other services.

as this is more universal and better fits the today's situation. OpenStreetMap is a base not only for maps but also for routers and other people evaluating the data in any way, e.g. creating statistics etc.

https://wiki.openstreetmap.org/wiki/Main_Page also uses the wording geographic data.

The current wording is used as reference to map for maps only as other use cases are not mentioned at the about page (see discussion at http://www.openstreetmap.org/changeset/51405110).

This PR also fixes two grammar typos.