### PR TITLE
Point at new OSRM demo server

### DIFF
--- a/app/assets/javascripts/index/directions/osrm.js
+++ b/app/assets/javascripts/index/directions/osrm.js
@@ -1,12 +1,10 @@
 // OSRM car engine
-// Doesn't yet support hints
 
 function OSRMEngine() {
-  var cachedHints = [];
 
   return {
     id: "osrm_car",
-    creditline: '<a href="http://project-osrm.org/" target="_blank">OSRM</a>',
+    creditline: '<a href="https://www.mapbox.com/navigation/" target="_blank">Mapbox</a>',
     draggable: true,
 
     _transformSteps: function(input_steps, line) {
@@ -110,18 +108,11 @@ function OSRMEngine() {
     getRoute: function (points, callback) {
 
       var params = [
+        { name: "access_token": value: "pk.eyJ1Ijoib3NybSIsImEiOiJjajdiOHNna28wcGVhMnFvOTVkOWlpNWUzIn0.7V3lSL-vVZ_RSf8_Pc1Ebw" },
         { name: "overview", value: "false" },
         { name: "geometries", value: "polyline" },
         { name: "steps", value: true }
       ];
-
-
-      if (cachedHints.length === points.length) {
-        params.push({name: "hints", value: cachedHints.join(";")});
-      } else {
-        // invalidate cache
-        cachedHints = [];
-      }
 
       var encoded_coords = points.map(function(p) {
         return p.lng + ',' + p.lat;
@@ -132,10 +123,6 @@ function OSRMEngine() {
       var onResponse = function (data) {
         if (data.code !== 'Ok')
           return callback(true);
-
-        cachedHints = data.waypoints.map(function(wp) {
-          return wp.hint;
-        });
 
         var line = [];
         var transformLeg = function (leg) {

--- a/app/assets/javascripts/index/directions/osrm.js
+++ b/app/assets/javascripts/index/directions/osrm.js
@@ -108,7 +108,7 @@ function OSRMEngine() {
     getRoute: function (points, callback) {
 
       var params = [
-        { name: "access_token": value: "pk.eyJ1Ijoib3NybSIsImEiOiJjajdiOHNna28wcGVhMnFvOTVkOWlpNWUzIn0.7V3lSL-vVZ_RSf8_Pc1Ebw" },
+        { name: "access_token", value: "pk.eyJ1Ijoib3NybSIsImEiOiJjajdiOHNna28wcGVhMnFvOTVkOWlpNWUzIn0.7V3lSL-vVZ_RSf8_Pc1Ebw" },
         { name: "overview", value: "false" },
         { name: "geometries", value: "polyline" },
         { name: "steps", value: true }

--- a/config/example.application.yml
+++ b/config/example.application.yml
@@ -102,7 +102,7 @@ defaults: &defaults
   graphhopper_url: "//graphhopper.com/api/1/route"
   mapquest_directions_url: "//open.mapquestapi.com/directions/v2/route"
   mapzen_valhalla_url: "//valhalla.mapzen.com/route"
-  osrm_url: "//router.project-osrm.org/route/v1/driving/"
+  osrm_url: "//api.mapbox.com/directions/v5/mapbox/driving/"
   # External authentication credentials
   #google_auth_id: ""
   #google_auth_secret: ""


### PR DESCRIPTION
The OSRM Demo Server is down and we're now using the Mapbox API as the official OSRM demo. This PR switches to point at the Mapbox Directions API, which has nearly an identical API. The only thing we don't support right now is the `hints` parameter, so I removed that in this PR. The access token included here should give plenty of headroom to avoid interruptions in the future.