### PR TITLE
Add list views of changeset comments

### DIFF
--- a/app/controllers/changeset_comments_controller.rb
+++ b/app/controllers/changeset_comments_controller.rb
@@ -1,0 +1,70 @@
+class ChangesetCommentsController < ApplicationController
+  layout "site"
+
+  before_action :authorize_web
+  before_action :set_locale
+  before_action :require_user, :only => :subscribed
+  before_action :sanitize_params
+  before_action :set_target_user, :only => [:user, :received, :subscribed]
+  before_action :set_link_user
+  before_action :setup_pagination
+  before_action :setup_conditions_on_comments
+
+  def all
+    @comments = @comments.all
+    render :list
+  end
+
+  def user
+    @comments = @comments.where(:author => @target_user)
+    render :list
+  end
+
+  def received
+    @comments = @comments.joins(:changeset).where("changesets.user_id = ?", @target_user.id)
+    render :list
+  end
+
+  def subscribed
+    if @target_user == current_user
+      @comments = @comments.joins(:changeset)
+                           .joins("inner join changesets_subscribers on changesets.id = changesets_subscribers.changeset_id")
+                           .where("changesets_subscribers.subscriber_id = ?", @target_user.id)
+      render :list
+    else
+      # We know we have a logged in user thanks to before_action :require_user
+      redirect_to :action => "subscribed", :display_name => current_user.display_name
+    end
+  end
+
+  private
+
+  def sanitize_params
+    @params = params.permit(:display_name, :page)
+  end
+
+  # The user to target when fetching comments
+  def set_target_user
+    @target_user = User.active.where(:display_name => @params[:display_name]).first!
+  rescue ActiveRecord::RecordNotFound
+    render_unknown_user(display_name) && return
+  end
+
+  # The user, if any, which should be linked to in the view
+  def set_link_user
+    @link_user = @target_user || current_user
+  end
+
+  def setup_pagination
+    @page = (@params[:page] || 1).to_i
+    @page_size = 20
+  end
+
+  def setup_conditions_on_comments
+    @comments = ChangesetComment.visible
+                                .order("changeset_comments.created_at DESC")
+                                .offset((@page - 1) * @page_size)
+                                .limit(@page_size)
+                                .includes(:author, :changeset, :changeset => [:user, :changeset_tags])
+  end
+end

--- a/app/helpers/changeset_comments_helper.rb
+++ b/app/helpers/changeset_comments_helper.rb
@@ -1,0 +1,17 @@
+module ChangesetCommentsHelper
+  def user_comments_link_text(link_user)
+    if current_user == link_user
+      t "changeset_comments.list.heading_links.current_user_comments"
+    else
+      t "changeset_comments.list.heading_links.other_user_comments", :user => link_user.display_name
+    end
+  end
+
+  def user_received_comments_link_text(link_user)
+    if current_user == link_user
+      t "changeset_comments.list.heading_links.current_user_received_comments"
+    else
+      t "changeset_comments.list.heading_links.other_user_received_comments", :user => link_user.display_name
+    end
+  end
+end

--- a/app/models/changeset_comment.rb
+++ b/app/models/changeset_comment.rb
@@ -9,6 +9,8 @@ class ChangesetComment < ActiveRecord::Base
   validates :visible, :inclusion => [true, false]
   validates :body, :format => /\A[^\x00-\x08\x0b-\x0c\x0e-\x1f\x7f\ufffe\uffff]*\z/
 
+  scope :visible, -> { where(:visible => true) }
+
   # Return the comment text
   def body
     RichText.new("text", self[:body])

--- a/app/views/changeset_comments/_changeset_comment.html.erb
+++ b/app/views/changeset_comments/_changeset_comment.html.erb
@@ -1,0 +1,19 @@
+<li>
+  <h2>
+    <a href="<%= changeset_path(changeset_comment.changeset.id) %>">
+      <%= t "changeset_comments.list.comment_heading_link_text", :id => changeset_comment.changeset.id %>
+    </a> <%= changeset_comment.changeset.tags["comment"].to_s %>
+  </h2>
+  <small class="deemphasize">
+    <%= t("changeset_comments.list.comment_detail",
+              :when       => friendly_date(changeset_comment.created_at),
+              :exact_time => l(changeset_comment.created_at),
+              :user       => link_to(h(changeset_comment.author.display_name), {
+                                  :controller   => "user",
+                                  :action       => "view",
+                                  :display_name => changeset_comment.author.display_name }
+                              )
+         ).html_safe %>
+  </small>
+  <%= changeset_comment.body.to_html %>
+</li>

--- a/app/views/changeset_comments/list.html.erb
+++ b/app/views/changeset_comments/list.html.erb
@@ -1,0 +1,35 @@
+<% @title = t "changeset_comments.list.title.#{action_name}", :user => @target_user.try(:display_name) %>
+<% content_for :heading do %>
+  <h1><%= @title %></h1>
+  <ul class="secondary-actions clearfix">
+    <li><%= link_to t("changeset_comments.list.heading_links.all_comments"), :controller => "changeset_comments", :action => "all", :page => nil %></li>
+    <% if @link_user.present? %>
+    <li><%= link_to user_comments_link_text(@link_user), :controller => "changeset_comments", :action => "user", :page => nil, :display_name => @link_user.display_name %></li>
+    <li><%= link_to user_received_comments_link_text(@link_user), :controller => "changeset_comments", :action => "received", :page => nil, :display_name => @link_user.display_name %></li>
+      <% if current_user == @link_user %>
+    <li><%= link_to t("changeset_comments.list.heading_links.current_user_subscribed_comments"), :controller => "changeset_comments", :action => "subscribed", :page => nil, :display_name => @link_user.display_name %></li>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @comments.empty? %>
+  <h2><%= t "changeset_comments.list.empty" %></h2>
+<% else %>
+  <ul id="changeset-comments">
+    <%= render @comments %>
+  </ul>
+  <div class="pagination">
+    <% if @comments.size < @page_size -%>
+      <%= t("changeset_comments.list.older_records") %>
+    <% else -%>
+      <%= link_to t("changeset_comments.list.older_records"), @params.merge(:page => @page + 1 ) %>
+    <% end -%>
+    |
+    <% if @page > 1 -%>
+      <%= link_to t("changeset_comments.list.newer_records"), @params.merge(:page => @page - 1) %>
+    <% else -%>
+      <%= t("changeset_comments.list.newer_records") %>
+    <% end -%>
+  </div>
+<% end %>

--- a/app/views/user/view.html.erb
+++ b/app/views/user/view.html.erb
@@ -25,6 +25,10 @@
             <%= link_to t('user.view.my comments' ), :controller => 'diary_entry', :action => 'comments', :display_name => current_user.display_name %>
           </li>
           <li>
+            <%= link_to t('user.view.my_changeset_comments' ), :controller => 'changeset_comments', :action => 'user', :display_name => current_user.display_name %>
+            <span class='count-number'><%= number_with_delimiter(current_user.changeset_comments.size) %></span>
+          </li>
+          <li>
             <%= link_to t('user.view.my settings'), :controller => 'user', :action => 'account', :display_name => current_user.display_name %>
           </li>
 
@@ -71,6 +75,10 @@
           </li>
           <li>
             <%= link_to t('user.view.comments'), :controller => 'diary_entry', :action => 'comments', :display_name => @this_user.display_name %>
+          </li>
+          <li>
+            <%= link_to t('user.view.changeset_comments' ), :controller => 'changeset_comments', :action => 'user', :display_name => @this_user.display_name %>
+            <span class='count-number'><%= number_with_delimiter(@this_user.changeset_comments.size) %></span>
           </li>
           <li>
             <% if current_user and current_user.is_friends_with?(@this_user) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1512,6 +1512,25 @@ en:
       image: Image
       alt: Alt text
       url: URL
+  changeset_comments:
+    list:
+      empty: No comments to display
+      older_records: Older Comments
+      newer_records: Newer Comments
+      title:
+        all: "All Changeset Comments"
+        subscribed: "Comments On Your Subscribed Changesets"
+        received: "Comments On %{user}'s Changesets"
+        user: "Changeset Comments by %{user}"
+      heading_links:
+        all_comments: "All Comments"
+        current_user_comments: "Comments you've made"
+        current_user_received_comments: "Comments on your changesets"
+        current_user_subscribed_comments: "Comments on changesets you're subscribed to"
+        other_user_comments: "Comments by %{user}"
+        other_user_received_comments: "Comments on %{user}'s changesets"
+      comment_heading_link_text: "Changeset %{id}"
+      comment_detail: "Comment from %{user} <abbr title='%{exact_time}'>%{when} ago</abbr>"
   trace:
     visibility:
       private: "Private (only shared as anonymous, unordered points)"
@@ -1840,6 +1859,7 @@ en:
       my profile: My Profile
       my settings: My Settings
       my comments: My Comments
+      my_changeset_comments: My Changeset Comments
       oauth settings: oauth settings
       blocks on me: Blocks on Me
       blocks by me: Blocks by Me
@@ -1848,6 +1868,7 @@ en:
       edits: Edits
       traces: Traces
       notes: Map Notes
+      changeset_comments: Changeset Comments
       remove as friend: Unfriend
       add as friend: Add Friend
       mapper since: "Mapper since:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -231,6 +231,16 @@ OpenStreetMap::Application.routes.draw do
   match "/user/:display_name/diary/:id/subscribe" => "diary_entry#subscribe", :via => :post, :as => :diary_entry_subscribe, :id => /\d+/
   match "/user/:display_name/diary/:id/unsubscribe" => "diary_entry#unsubscribe", :via => :post, :as => :diary_entry_unsubscribe, :id => /\d+/
 
+  # changeset comments pages
+  match "/changesets/comments" => "changeset_comments#all", :via => :get
+  match "/changesets/comments/page/:page" => "changeset_comments#all", :via => :get
+  match "/user/:display_name/changesets/comments" => "changeset_comments#user", :via => :get
+  match "/user/:display_name/changesets/comments/page/:page" => "changeset_comments#user", :via => :get
+  match "/user/:display_name/changesets/comments/received" => "changeset_comments#received", :via => :get
+  match "/user/:display_name/changesets/comments/received/page/:page" => "changeset_comments#received", :via => :get
+  match "/user/:display_name/changesets/comments/subscribed" => "changeset_comments#subscribed", :via => :get
+  match "/user/:display_name/changesets/comments/subscribed/page/:page" => "changeset_comments#subscribed", :via => :get
+
   # user pages
   match "/user/:display_name" => "user#view", :via => :get, :as => "user"
   match "/user/:display_name/make_friend" => "user#make_friend", :via => [:get, :post], :as => "make_friend"

--- a/test/controllers/changeset_comments_controller_test.rb
+++ b/test/controllers/changeset_comments_controller_test.rb
@@ -1,0 +1,173 @@
+require "test_helper"
+
+class ChangesetCommentsControllerTest < ActionController::TestCase
+  ##
+  # test all routes which lead to this controller
+  def test_routes
+    assert_routing(
+      { :path => "/changesets/comments", :method => :get },
+      { :controller => "changeset_comments", :action => "all" }
+    )
+    assert_routing(
+      { :path => "/changesets/comments/page/1", :method => :get },
+      { :controller => "changeset_comments", :action => "all", :page => "1" }
+    )
+    assert_routing(
+      { :path => "/user/username/changesets/comments", :method => :get },
+      { :controller => "changeset_comments", :action => "user", :display_name => "username" }
+    )
+    assert_routing(
+      { :path => "/user/username/changesets/comments/page/1", :method => :get },
+      { :controller => "changeset_comments", :action => "user", :display_name => "username", :page => "1" }
+    )
+    assert_routing(
+      { :path => "/user/username/changesets/comments/subscribed", :method => :get },
+      { :controller => "changeset_comments", :action => "subscribed", :display_name => "username" }
+    )
+    assert_routing(
+      { :path => "/user/username/changesets/comments/subscribed/page/1", :method => :get },
+      { :controller => "changeset_comments", :action => "subscribed", :display_name => "username", :page => "1" }
+    )
+    assert_routing(
+      { :path => "/user/username/changesets/comments/received", :method => :get },
+      { :controller => "changeset_comments", :action => "received", :display_name => "username" }
+    )
+    assert_routing(
+      { :path => "/user/username/changesets/comments/received/page/1", :method => :get },
+      { :controller => "changeset_comments", :action => "received", :display_name => "username", :page => "1" }
+    )
+  end
+
+  # Records should be displayed in created_at descending order
+  def test_list_changeset_comments_sort_order
+    10.times do |count|
+      # Create records with created_at values alternately before and after the current time
+      create(:changeset_comment, :visible, :created_at => Time.now + ((-1)**count * count.minutes))
+    end
+
+    get :all
+    check_changeset_comments_list ChangesetComment.all
+  end
+
+  # Only visible records should be displayed
+  def test_list_only_displays_visible_comments
+    create(:changeset_comment, :visible)
+    create(:changeset_comment, :hidden)
+
+    get :all
+    check_changeset_comments_list ChangesetComment.visible
+  end
+
+  # List all changeset comments on all changesets
+  def test_all_changeset_comments
+    create_test_data
+
+    get :all
+    assert_select "title", Regexp.new(I18n.t("changeset_comments.list.title.all"))
+    check_changeset_comments_list ChangesetComment.all
+  end
+
+  # List changeset comments created by the specified user
+  def test_list_user_with_changeset_comments
+    create_test_data
+
+    # When no relevant changeset comments exist
+    get :user,
+        :params => { :display_name => create(:user).display_name }
+    check_changeset_comments_list
+
+    # When relevant changeset comments exist
+    get :user,
+        :params => { :display_name => @target_user.display_name }
+    assert_select "title", Regexp.new(I18n.t("changeset_comments.list.title.user", :user => @target_user.display_name))
+    check_changeset_comments_list @target_user.changeset_comments
+  end
+
+  # Case: Changeset comments for all changesets created by the target user
+  def test_list_received_changeset_comments
+    create_test_data
+
+    # When no relevant changeset comments exist
+    get :received,
+        :params => { :display_name => create(:user).display_name }
+    check_changeset_comments_list
+
+    # When relevant changeset comments exist
+    get :received,
+        :params => { :display_name => @target_user.display_name }
+    assert_select "title", Regexp.new(I18n.t("changeset_comments.list.title.received", :user => @target_user.display_name))
+    check_changeset_comments_list ChangesetComment.where(:changeset => @target_user.changesets)
+  end
+
+  # Case: Changeset comments for all changesets which the target user has subscribed to
+  def test_list_subscribed_changeset_comments
+    create_test_data
+
+    # Not logged in
+    get :subscribed,
+        :params => { :display_name => @target_user.display_name }
+    assert_response :redirect
+    assert_redirected_to :controller => :user, :action => :login, :referer => "/user/#{URI.encode(@target_user.display_name)}/changesets/comments/subscribed"
+
+    # Logged in as another user
+    another_user = create(:user)
+
+    get :subscribed,
+        :params => { :display_name => @target_user.display_name },
+        :session => { :user => another_user }
+    assert_response :redirect
+    assert_redirected_to :controller => :changeset_comments, :action => :subscribed, :display_name => another_user.display_name
+
+    # Logged in as target user but no relevant changeset comments exist
+    user = create(:user)
+
+    get :subscribed,
+        :params => { :display_name => user.display_name },
+        :session => { :user => user }
+    check_changeset_comments_list
+
+    # Logged in as target user and relevant changeset comments exist
+    get :subscribed,
+        :params => { :display_name => @target_user.display_name },
+        :session => { :user => @target_user }
+    assert_select "title", Regexp.new(I18n.t("changeset_comments.list.title.subscribed"))
+    check_changeset_comments_list ChangesetComment.where(:changeset => @target_user.changeset_subscriptions)
+  end
+
+  private
+
+  def create_test_data
+    @target_user = create(:user)
+
+    # Two changesets belonging to other users, each with three comments, two made by target_user
+    create_list(:changeset, 2).each do |changeset|
+      [@target_user, create(:user), @target_user].each do |user|
+        create(:changeset_comment, :author => user, :changeset => changeset)
+      end
+    end
+
+    # Two changesets belonging to target_user, each with three comments from other users
+    create_list(:changeset_with_comments, 2, :comment_count => 3, :user => @target_user)
+
+    # Two changesets belonging to other users, subscribed to by target_user and each with three comments
+    create_list(:changeset_with_comments, 2, :comment_count => 3, :subscribers => [@target_user])
+  end
+
+  def check_changeset_comments_list(changeset_comments = [])
+    assert_response :success
+    assert_template "list"
+
+    if changeset_comments.count.positive?
+      assert_select "ul#changeset-comments", :count => 1 do
+        assert_select "li", :count => changeset_comments.count do |list_items|
+          changeset_comments.order("created_at DESC").zip(list_items).each do |changeset_comment, list_item|
+            assert_select list_item, "h2", Regexp.new(I18n.t("changeset_comments.list.comment_heading_link_text", :id => changeset_comment.changeset.id))
+            assert_select list_item, "p", Regexp.new(changeset_comment.body)
+          end
+        end
+      end
+    else
+      assert_select "h2", I18n.t("changeset_comments.list.empty")
+    end
+  end
+end

--- a/test/factories/changeset_comments.rb
+++ b/test/factories/changeset_comments.rb
@@ -6,5 +6,13 @@ FactoryGirl.define do
     changeset
 
     association :author, :factory => :user
+
+    trait :visible do
+      visible true
+    end
+
+    trait :hidden do
+      visible false
+    end
   end
 end

--- a/test/factories/changesets.rb
+++ b/test/factories/changesets.rb
@@ -9,5 +9,15 @@ FactoryGirl.define do
       created_at Time.now.utc - 5.hours
       closed_at Time.now.utc - 4.hours
     end
+
+    factory :changeset_with_comments do
+      transient do
+        comment_count 1
+      end
+
+      after(:create) do |changeset, evaluator|
+        create_list(:changeset_comment, evaluator.comment_count, :changeset => changeset)
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds the following:
  * View of all changeset comments made on all changesets
  * View of all changeset comments made by a given user
  * View of all changeset comments made on a changeset created by a given user
  * View of all changeset comments made on a changeset subscribed to by logged in user

This commit builds on initial work by:
  Łukasz Gurdek <git@ukasiu.pl>
with additional work by:
  Éric Gillet <eric.gillet+gh@linuxw.info>
  Victor Grousset <victor@tuxayo.net>