### PR TITLE
fix locate control cursor

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -524,6 +524,7 @@ body.compact {
 .control-locate .control-button,
 .control-share .control-button {
   border-radius: 0 0 0 4px;
+  cursor: pointer;
 }
 
 /* Rules for the sidebar and main map area */


### PR DESCRIPTION
in chrome 61 the cursor for the locate button for some reason was not the hand, but simple mouse