### PR TITLE
Add missing href=# in location button

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -114,6 +114,7 @@ $(document).ready(function () {
     .removeClass('leaflet-control-locate leaflet-bar')
     .addClass('control-locate')
     .children("a")
+    .attr('href', '#')
     .removeClass('leaflet-bar-part leaflet-bar-part-single')
     .addClass('control-button');
 

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -28,6 +28,7 @@ $(document).ready(function () {
       .removeClass('leaflet-control-locate leaflet-bar')
       .addClass('control-locate')
       .children("a")
+      .attr('href', '#')
       .removeClass('leaflet-bar-part leaflet-bar-part-single')
       .addClass('control-button');
 


### PR DESCRIPTION
With this the cursor should render identical to the other buttons. 
It is a proper `a` element where the browser default style is a pointer.

closes #1653

