### PR TITLE
Avoid using or comparing explicit model ids

### DIFF
--- a/app/controllers/changeset_controller.rb
+++ b/app/controllers/changeset_controller.rb
@@ -28,7 +28,7 @@ class ChangesetController < ApplicationController
     cs = Changeset.from_xml(request.raw_post, true)
 
     # Assume that Changeset.from_xml has thrown an exception if there is an error parsing the xml
-    cs.user_id = current_user.id
+    cs.user = current_user
     cs.save_with_tags!
 
     # Subscribe user to changeset comments
@@ -496,7 +496,7 @@ class ChangesetController < ApplicationController
         # changesets if they're non-public
         setup_user_auth
 
-        raise OSM::APINotFoundError if current_user.nil? || current_user.id != u.id
+        raise OSM::APINotFoundError if current_user.nil? || current_user != u
       end
 
       changesets.where(:user_id => u.id)

--- a/app/controllers/message_controller.rb
+++ b/app/controllers/message_controller.rb
@@ -18,8 +18,8 @@ class MessageController < ApplicationController
         flash[:error] = t "message.new.limit_exceeded"
       else
         @message = Message.new(message_params)
-        @message.to_user_id = @this_user.id
-        @message.from_user_id = current_user.id
+        @message.recipient = @this_user
+        @message.sender = current_user
         @message.sent_on = Time.now.getutc
 
         if @message.save
@@ -38,7 +38,7 @@ class MessageController < ApplicationController
   def reply
     message = Message.find(params[:message_id])
 
-    if message.to_user_id == current_user.id
+    if message.recipient == current_user
       message.update(:message_read => true)
 
       @message = Message.new(
@@ -64,8 +64,8 @@ class MessageController < ApplicationController
     @title = t "message.read.title"
     @message = Message.find(params[:message_id])
 
-    if @message.to_user_id == current_user.id || @message.from_user_id == current_user.id
-      @message.message_read = true if @message.to_user_id == current_user.id
+    if @message.recipient == current_user || @message.sender == current_user
+      @message.message_read = true if @message.recipient == current_user
       @message.save
     else
       flash[:notice] = t "message.read.wrong_user", :user => current_user.display_name

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -20,7 +20,7 @@ class UserBlocksController < ApplicationController
   end
 
   def show
-    if current_user && current_user.id == @user_block.user_id
+    if current_user && current_user == @user_block.user
       @user_block.needs_view = false
       @user_block.save!
     end
@@ -37,8 +37,8 @@ class UserBlocksController < ApplicationController
   def create
     if @valid_params
       @user_block = UserBlock.new(
-        :user_id => @this_user.id,
-        :creator_id => current_user.id,
+        :user => @this_user,
+        :creator => current_user,
         :reason => params[:user_block][:reason],
         :ends_at => Time.now.getutc + @block_period.hours,
         :needs_view => params[:user_block][:needs_view]
@@ -57,7 +57,7 @@ class UserBlocksController < ApplicationController
 
   def update
     if @valid_params
-      if @user_block.creator_id != current_user.id
+      if @user_block.creator != current_user
         flash[:error] = t("user_block.update.only_creator_can_edit")
         redirect_to :action => "edit"
       elsif @user_block.update_attributes(

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -411,8 +411,8 @@ class UserController < ApplicationController
     if @new_friend
       if request.post?
         friend = Friend.new
-        friend.user_id = current_user.id
-        friend.friend_user_id = @new_friend.id
+        friend.befriender = current_user
+        friend.befriendee = @new_friend
         if current_user.is_friends_with?(@new_friend)
           flash[:warning] = t "user.make_friend.already_a_friend", :name => @new_friend.display_name
         elsif friend.save

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -10,7 +10,7 @@ class UserRolesController < ApplicationController
   before_action :in_role, :only => [:revoke]
 
   def grant
-    @this_user.roles.create(:role => @role, :granter_id => current_user.id)
+    @this_user.roles.create(:role => @role, :granter => current_user)
     redirect_to :controller => "user", :action => "view", :display_name => @this_user.display_name
   end
 


### PR DESCRIPTION
The code is easier to read using higher-level concepts. This PR isn't comprehensive but it fixes a few obvious cases in the controllers.