### PR TITLE
Change wording for hosting partners

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -932,7 +932,7 @@ en:
     intro_header: Welcome to OpenStreetMap!
     intro_text: OpenStreetMap is a map of the world, created by people like you and free to use under an open license.
     intro_2_create_account: "Create a user account"
-    partners_html: "Hosting is supported by %{ucl}, %{bytemark} and %{ic}, and other %{partners}."
+    partners_html: "Hosting is supported by %{ucl}, %{bytemark}, %{ic}, and other %{partners}."
     partners_ucl: "UCL"
     partners_ic: "Imperial College London"
     partners_bytemark: "Bytemark Hosting"


### PR DESCRIPTION
This removes the repeated `add` 
`Hosting is supported by UCL, Bytemark Hosting and Imperial College London, and other partners.` to 
`Hosting is supported by UCL, Bytemark Hosting, Imperial College London, and other partners.`