### PR TITLE
when no cache store is set, use cookies for sessions

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,6 +2,8 @@
 
 if defined?(MEMCACHE_SERVERS)
   Rails.application.config.session_store :mem_cache_store, :memcache_server => MEMCACHE_SERVERS, :namespace => "rails:session", :key => "_osm_session"
-else
+elsif Rails.application.config.cache_store != :null_store
   Rails.application.config.session_store :cache_store, :key => "_osm_session"
+else
+  Rails.application.config.session_store :cookie_store, :key => "_osm_session"
 end


### PR DESCRIPTION
This will help provide "training wheels" to keep new users from situations as reported in https://github.com/openstreetmap/openstreetmap-website/issues/1662

I've tested all three conditions and found them to work -- at least locally in the Rails `development` environment on a Mac.