### PR TITLE
Update site to use jQuery 3

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,4 @@
-//= require jquery
+//= require jquery3
 //= require jquery_ujs
 //= require jquery.timers
 //= require jquery.cookie


### PR DESCRIPTION
I did't realise that jquery-rails offers all three major versions of jQuery and you have to choose which one you want, so we've been sat on 1.x for a long time...

I've tried to test as much as I can but it wouldn't hurt if other people played with it before we merge it - there's a test site deploying now at https://tomh.apis.dev.openstreetmap.org/.