### PR TITLE
Remove Potlatch 1 note from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository consists of:
 
 * The web site, including user accounts, diary entries, user-to-user messaging
 * The XML-based editing [API](http://wiki.openstreetmap.org/wiki/API_v0.6)
-* The integrated versions of the [Potlatch](http://wiki.openstreetmap.org/wiki/Potlatch_1), [Potlatch 2](http://wiki.openstreetmap.org/wiki/Potlatch_2) and [iD](http://wiki.openstreetmap.org/wiki/ID) editors
+* The integrated versions of the [Potlatch 2](http://wiki.openstreetmap.org/wiki/Potlatch_2) and [iD](http://wiki.openstreetmap.org/wiki/ID) editors
 * The Browse pages - a web front-end to the OpenStreetMap data
 * The GPX uploads, browsing and API.
 


### PR DESCRIPTION
Just a small fix - Potlatch 1 editor is not available on website now.