### PR TITLE
Remove link to wiki legal FAQ as confusing and unmaintained

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1005,9 +1005,7 @@ en:
       more_title_html: Finding out more
       more_1_html: |
         Read more about using our data, and how to credit us, at the <a
-        href="http://osmfoundation.org/Licence">OSMF Licence page</a> and the community <a
-        href="http://wiki.openstreetmap.org/wiki/Legal_FAQ">Legal
-        FAQ</a>.
+        href="http://osmfoundation.org/Licence">OSMF Licence page</a>.
       more_2_html: |
         Although OpenStreetMap is open data, we cannot provide a
         free-of-charge map API for third-parties.


### PR DESCRIPTION
In particular translations of the web site point to translated version of the wiki page that are even worse.