### PR TITLE
Add the OpenStreetMap Blog to the list of community links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1207,7 +1207,9 @@ en:
       Our contributors include enthusiast mappers, GIS professionals, engineers
       running the OSM servers, humanitarians mapping disaster-affected areas,
       and many more.
-      To learn more about the community, see the <a href='%{diary_path}'>user diaries</a>,
+      To learn more about the community, see the
+      <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>,
+      <a href='%{diary_path}'>user diaries</a>,
       <a href='http://blogs.openstreetmap.org/'>community blogs</a>, and
       the <a href='http://www.osmfoundation.org/'>OSM Foundation</a> website.
     open_data_title: Open Data


### PR DESCRIPTION
Although the content is currently duplicated into the blog aggregator, it's still worth having an explicit link, and making it the first one, since it contains entries of more significant interest to the community.

Refs #260 and #1042 and I think is a reasonable compromise.