### PR TITLE
Enable image compression utils for image_optim

### DIFF
--- a/config/image_optim.yml
+++ b/config/image_optim.yml
@@ -1,3 +1,4 @@
+skip_missing_workers: true
 pngout: false
 svgo:
   disable_plugins: ["cleanupIDs", "removeUnknownsAndDefaults"]

--- a/config/image_optim.yml
+++ b/config/image_optim.yml
@@ -1,12 +1,3 @@
-skip_missing_workers: true
 pngout: false
-pngcrush: true
-advpng: true
-optipng: true
-pngquant: true
-jhead: true
-jpegoptim: true
-gifsicle: true
-jpegtran: true
 svgo:
   disable_plugins: ["cleanupIDs", "removeUnknownsAndDefaults"]

--- a/config/image_optim.yml
+++ b/config/image_optim.yml
@@ -1,12 +1,12 @@
 skip_missing_workers: true
 pngout: false
-pngcrush: false
-advpng: false
-optipng: false
-pngquant: false
-jhead: false
-jpegoptim: false
-gifsicle: false
-jpegtran: false
+pngcrush: true
+advpng: true
+optipng: true
+pngquant: true
+jhead: true
+jpegoptim: true
+gifsicle: true
+jpegtran: true
 svgo:
   disable_plugins: ["cleanupIDs", "removeUnknownsAndDefaults"]


### PR DESCRIPTION
As discussed on https://github.com/openstreetmap/openstreetmap-website/pull/1691, enables png and jpeg utilities for image_optim.