### PR TITLE
Adding lxml2 related hint to MacOS installation section

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,11 +83,10 @@ Installing other dependencies:
 * Install Homebrew from http://mxcl.github.io/homebrew/
 * Install the latest version of Ruby: `brew install ruby`
 * Install ImageMagick: `brew install imagemagick`
+* Install libxml2: `brew install libxml2 --with-xml2-config`
 * Install Bundler: `gem install bundler`
 
 Note that OS X does not have a /home directory by default, so if you are using the GPX functions, you will need to change the directories specified in config/application.yml.
-
-If you run into trouble installing the `libxml-ruby` gem, follow [these steps](https://gist.github.com/unixcharles/1226596#gistcomment-2217297).
 
 ## Cloning the repository
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,6 +87,8 @@ Installing other dependencies:
 
 Note that OS X does not have a /home directory by default, so if you are using the GPX functions, you will need to change the directories specified in config/application.yml.
 
+If you run into trouble installing the `libxml-ruby` gem, follow [these steps](https://gist.github.com/unixcharles/1226596#gistcomment-2217297).
+
 ## Cloning the repository
 
 The repository is reasonably large (~150MB) and it's unlikely that you need the full history. If you are happy to wait for it all to download, run:


### PR DESCRIPTION
On High Sierra, `libxml-ruby` has trouble finding `lxml2` headers when `lxml2` was installed using homebrew without the config binary. The internet has some steps to redo the installation so that everything works OK.