### PR TITLE
Revoking administrator role on current user should fail

### DIFF
--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -8,6 +8,7 @@ class UserRolesController < ApplicationController
   before_action :require_valid_role
   before_action :not_in_role, :only => [:grant]
   before_action :in_role, :only => [:revoke]
+  before_action :not_revoke_admin_current_user
 
   def grant
     @this_user.roles.create(:role => @role, :granter => current_user)
@@ -56,6 +57,16 @@ class UserRolesController < ApplicationController
   def in_role
     unless @this_user.has_role? @role
       flash[:error] = t("user_role.filter.doesnt_have_role", :role => @role)
+      redirect_to :controller => "user", :action => "view", :display_name => @this_user.display_name
+    end
+  end
+
+  ##
+  # checks that administrator role is not revoked from current user
+  def not_revoke_admin_current_user
+    @role = params[:role]
+    if current_user == @this_user && @role == "administrator"
+      flash[:error] = t("user_role.filter.not_revoke_admin_current_user")
       redirect_to :controller => "user", :action => "view", :display_name => @this_user.display_name
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2035,6 +2035,7 @@ en:
       not_a_role: "The string `%{role}' is not a valid role."
       already_has_role: "The user already has role %{role}."
       doesnt_have_role: "The user does not have role %{role}."
+      not_revoke_admin_current_user: "Cannot revoke administrator role from current user."
     grant:
       title: Confirm role granting
       heading: Confirm role granting

--- a/test/controllers/user_roles_controller_test.rb
+++ b/test/controllers/user_roles_controller_test.rb
@@ -134,5 +134,9 @@ class UserRolesControllerTest < ActionController::TestCase
     end
     assert_redirected_to user_path(target_user.display_name)
     assert_equal "The string `no_such_role' is not a valid role.", flash[:error]
+
+    # Revoking administrator role from current user should fail
+    post :revoke, :params => { :display_name => administrator_user.display_name, :role => "administrator" }
+    assert_redirected_to user_path(administrator_user.display_name)
   end
 end

--- a/test/controllers/user_roles_controller_test.rb
+++ b/test/controllers/user_roles_controller_test.rb
@@ -138,5 +138,6 @@ class UserRolesControllerTest < ActionController::TestCase
     # Revoking administrator role from current user should fail
     post :revoke, :params => { :display_name => administrator_user.display_name, :role => "administrator" }
     assert_redirected_to user_path(administrator_user.display_name)
+    assert_equal "Cannot revoke administrator role from current user.", flash[:error]
   end
 end


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/issues/1697 for further discussion:

> maybe stop them removing their own administrator role

That's exactly what I wanted to accomplish. As there's no additional confirmation popup, I accidentally locked myself out of being local admin, and had to head for the rails console.

Second attempt is now restricted to the *administrator* role. Code style and naming conventions may not be ideal - will happily apply suggestions for improvement.

Change introduced in this pull request:

![grafik](https://user-images.githubusercontent.com/5842757/33777419-09ecb2e2-dc45-11e7-85f3-28b85637dccc.png)

Hit orange star (revoke administrator role):

![grafik](https://user-images.githubusercontent.com/5842757/33777427-13e8436a-dc45-11e7-8041-8dede4fd6a1f.png)

Action rejected, user is still admin
