### PR TITLE
Allow (un)subscribing discussions also when changeset still open

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -82,7 +82,7 @@ Metrics/BlockNesting:
 # Offense count: 63
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1796
+  Max: 1797
 
 # Offense count: 71
 Metrics/CyclomaticComplexity:

--- a/app/controllers/changeset_controller.rb
+++ b/app/controllers/changeset_controller.rb
@@ -357,7 +357,6 @@ class ChangesetController < ApplicationController
 
     # Find the changeset and check it is valid
     changeset = Changeset.find(id)
-    raise OSM::APIChangesetNotYetClosedError, changeset if changeset.is_open?
     raise OSM::APIChangesetAlreadySubscribedError, changeset if changeset.subscribers.exists?(current_user.id)
 
     # Add the subscriber
@@ -378,7 +377,6 @@ class ChangesetController < ApplicationController
 
     # Find the changeset and check it is valid
     changeset = Changeset.find(id)
-    raise OSM::APIChangesetNotYetClosedError, changeset if changeset.is_open?
     raise OSM::APIChangesetNotSubscribedError, changeset unless changeset.subscribers.exists?(current_user.id)
 
     # Remove the subscriber

--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -2248,6 +2248,13 @@ CHANGESET
       post :subscribe, :params => { :id => changeset.id }
     end
     assert_response :success
+
+    # not closed changeset
+    changeset = create(:changeset)
+    assert_difference "changeset.subscribers.count", 1 do
+      post :subscribe, :params => { :id => changeset.id }
+    end
+    assert_response :success
   end
 
   ##
@@ -2270,12 +2277,6 @@ CHANGESET
     end
     assert_response :not_found
 
-    # not closed changeset
-    changeset = create(:changeset)
-    assert_no_difference "changeset.subscribers.count" do
-      post :subscribe, :params => { :id => changeset.id }
-    end
-    assert_response :conflict
 
     # trying to subscribe when already subscribed
     changeset = create(:changeset, :closed)
@@ -2292,6 +2293,15 @@ CHANGESET
     user = create(:user)
     basic_authorization user.email, "test"
     changeset = create(:changeset, :closed)
+    changeset.subscribers.push(user)
+
+    assert_difference "changeset.subscribers.count", -1 do
+      post :unsubscribe, :params => { :id => changeset.id }
+    end
+    assert_response :success
+
+    # not closed changeset
+    changeset = create(:changeset)
     changeset.subscribers.push(user)
 
     assert_difference "changeset.subscribers.count", -1 do
@@ -2317,13 +2327,6 @@ CHANGESET
       post :unsubscribe, :params => { :id => 999111 }
     end
     assert_response :not_found
-
-    # not closed changeset
-    changeset = create(:changeset)
-    assert_no_difference "changeset.subscribers.count" do
-      post :unsubscribe, :params => { :id => changeset.id }
-    end
-    assert_response :conflict
 
     # trying to unsubscribe when not subscribed
     changeset = create(:changeset, :closed)

--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -2277,7 +2277,6 @@ CHANGESET
     end
     assert_response :not_found
 
-
     # trying to subscribe when already subscribed
     changeset = create(:changeset, :closed)
     changeset.subscribers.push(user)


### PR DESCRIPTION
Fixes #1627 

There’s one rubocop max class length message left in the Travis CI build, which i have no idea how to address properly. Supposedly, I need to run `rubocop --auto-gen-config`, but this creates a new file with many unrelated "fixes".