### PR TITLE
Remove support for soon discontinued josm remote https endpoint

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -241,9 +241,7 @@ $(document).ready(function () {
 
   function remoteEditHandler(bbox, object) {
     var loaded = false,
-        url = document.location.protocol === "https:" ?
-        "https://127.0.0.1:8112/load_and_zoom?" :
-        "http://127.0.0.1:8111/load_and_zoom?",
+        url = "http://127.0.0.1:8111/load_and_zoom?",
         query = {
           left: bbox.getWest() - 0.0001,
           top: bbox.getNorth() + 0.0001,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -413,7 +413,7 @@ class ApplicationController < ActionController::Base
 
   def map_layout
     append_content_security_policy_directives(
-      :child_src => %w[127.0.0.1:8111 127.0.0.1:8112],
+      :child_src => %w[127.0.0.1:8111],
       :connect_src => %w[nominatim.openstreetmap.org overpass-api.de router.project-osrm.org valhalla.mapzen.com],
       :form_action => %w[render.openstreetmap.org],
       :script_src => %w[graphhopper.com open.mapquestapi.com],


### PR DESCRIPTION
Fixes #1703.

This should actually be merged as soon as we're happy with browser support. It makes setting up the JOSM remote a lot easier, and supports calling merkaator from https (how many people still use merkaator?)

[Chrome 53+ works](https://chromium.googlesource.com/chromium/src.git/+/130ee686fa00b617bfc001ceb3bb49782da2cb4e).

[Firefox 55+ works](https://bugzilla.mozilla.org/show_bug.cgi?id=903966) but not ESR.

[Safari wontfix](https://bugs.webkit.org/show_bug.cgi?id=171934).

[MS Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11963735/) is fixed, release coming.

[No plans for IE 11](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11963735/#comment-0) ?