### PR TITLE
Add links to the trademark policy

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1079,7 +1079,7 @@ en:
         <a href="http://dmca.openstreetmap.org/">on-line filing page</a>.
       trademarks_title_html: <span id="trademarks"></span>Trademarks
       trademarks_1_html: |
-        OpenStreetMap, the magnifying glass logo and State of the Map are registered trademarks of the OpenStreetMap Foundation. If you have questions about your use of the marks, please send your questions to the <a href="https://wiki.osmfoundation.org/wiki/Licensing_Working_Group">Licence Working Group</a>.
+        OpenStreetMap, the magnifying glass logo and State of the Map are registered trademarks of the OpenStreetMap Foundation. If you have questions about your use of the marks, please see our <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">Trademark Policy</a>.
   welcome_page:
     title: Welcome!
     introduction_html: |
@@ -1229,7 +1229,9 @@ en:
       Acceptable Use Policies</a> and our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy">Privacy Policy</a>
       <br> 
       Please <a href='https://osmfoundation.org/Contact'>contact the OSMF</a> 
-      if you have licensing, copyright or other legal questions and issues.
+      if you have licensing, copyright or other legal questions.
+      <br>
+      OpenStreetMap, the magnifiying glass logo and State of the Map are <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">registered trademarks of the OSMF</a>.
     partners_title: Partners
   notifier:
     diary_comment_notification:


### PR DESCRIPTION
The trademark policy has now been approved by the OSMF board, link to it 

- point to the TM policy instead of the LWG on the Copyright page
- add short text on TMs to the About page