### PR TITLE
Add marker at trace start coordinate

### DIFF
--- a/app/views/trace/_trace.html.erb
+++ b/app/views/trace/_trace.html.erb
@@ -16,7 +16,7 @@
       <% end %>
       ... <%= t'trace.trace.ago', :time_in_words_ago => time_ago_in_words(trace.timestamp) %></span>
       <%= link_to t('trace.trace.more'), {:controller => 'trace', :action => 'view', :display_name => trace.user.display_name, :id => trace.id}, {:title => t('trace.trace.trace_details')} %> /
-      <%= link_to_if trace.inserted?, t('trace.trace.map'), {:controller => 'site', :action => 'index', :anchor => "map=14/#{trace.latitude}/#{trace.longitude}"}, {:title => t('trace.trace.view_map')} %> /
+      <%= link_to_if trace.inserted?, t('trace.trace.map'), {:controller => 'site', :action => 'index', :mlat => "#{trace.latitude}", :mlon => "#{trace.longitude}", :anchor => "map=14/#{trace.latitude}/#{trace.longitude}"}, {:title => t('trace.trace.view_map')} %> /
       <%= link_to t('trace.trace.edit'), {:controller => 'site', :action => 'edit', :gpx => trace.id }, {:title => t('trace.trace.edit_map')} %>
       <span class="trace_<%= trace.visibility %>"><%= t('trace.trace.' + trace.visibility) %></span>
       <br />

--- a/app/views/trace/view.html.erb
+++ b/app/views/trace/view.html.erb
@@ -25,7 +25,7 @@
     <td><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/,'\1,') %></td></tr>
   <tr>
     <td><%= t'trace.view.start_coordinates' %></td>
-    <td><div class="geo"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%=link_to t('trace.view.map'), :controller => 'site', :action => 'index', :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%=link_to t('trace.view.edit'), :controller => 'site', :action => 'edit', :gpx=> @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
+    <td><div class="geo"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%=link_to t('trace.view.map'), :controller => 'site', :action => 'index', :mlat => "#{@trace.latitude}", :mlon => "#{@trace.longitude}", :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%=link_to t('trace.view.edit'), :controller => 'site', :action => 'edit', :gpx=> @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
   </tr>
   <% end %>
   <tr>


### PR DESCRIPTION
Fixes #1676 

I have added mlat and mlon parameters in map link of trace. It now marks the starting coordinate of the trace.