### PR TITLE
Fixed motorway directions when using OSRM directions

### DIFF
--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -47,7 +47,14 @@ function GraphHopperEngine(id, vehicleType) {
             var instr = path.instructions[i];
             var instrCode = (i === len - 1) ? 14 : GH_INSTR_MAP[instr.sign];
             var instrText = "<b>" + (i + 1) + ".</b> ";
-            instrText += instr.text;
+
+            var directionText = instr.text;
+            if (directionText.includes(" onto ")) {
+              var directions = directionText.split(" onto ");
+              directionText = directions[0] + " onto <b>" + directions[1] + "</b>";
+            }
+
+            instrText += directionText;
             var latLng = line[instr.interval[0]];
             var distInMeter = instr.distance;
             var lineseg = [];

--- a/app/assets/javascripts/index/directions/osrm.js
+++ b/app/assets/javascripts/index/directions/osrm.js
@@ -95,14 +95,18 @@ function OSRMEngine() {
         Array.prototype.push.apply(line, step_geometry);
 
         var instText = "<b>" + (idx + 1) + ".</b> ";
-        var name;
+        var name, ref;
+
+        if (step.ref) {
+          ref = step.ref.replace(/ \$\w+/g, "");
+        }
 
         if (step.name && step.ref) {
-          name = "<b>" + step.name + " (" + step.ref + ")</b>";
+          name = "<b>" + step.name + " (" + ref + ")</b>";
         } else if (step.name) {
           name = "<b>" + step.name + "</b>";
         } else if (step.ref) {
-          name = "<b>" + step.ref + "</b>";
+          name = "<b>" + ref + "</b>";
         } else {
           name = I18n.t('javascripts.directions.instructions.unnamed');
         }

--- a/app/assets/javascripts/index/directions/osrm.js
+++ b/app/assets/javascripts/index/directions/osrm.js
@@ -95,7 +95,18 @@ function OSRMEngine() {
         Array.prototype.push.apply(line, step_geometry);
 
         var instText = "<b>" + (idx + 1) + ".</b> ";
-        var name = step.name ? "<b>" + step.name + "</b>" : I18n.t('javascripts.directions.instructions.unnamed');
+        var name;
+
+        if (step.name && step.ref) {
+          name = "<b>" + step.name + " (" + step.ref + ")</b>";
+        } else if (step.name) {
+          name = "<b>" + step.name + "</b>";
+        } else if (step.ref) {
+          name = "<b>" + step.ref + "</b>";
+        } else {
+          name = I18n.t('javascripts.directions.instructions.unnamed');
+        }
+
         if (step.maneuver.type.match(/rotary|roundabout/)) {
           instText += I18n.t(template + '_with_exit', { exit: step.maneuver.exit, name: name } );
         } else {


### PR DESCRIPTION
 - OSRM directions now have named motorways instead of naming them all as unnamed roads.
 - GraphHopper roads are now written in bold, to bring them in alignment with OSRM styling