### PR TITLE
Fixed motorways being referred to as unnamed roads

### DIFF
--- a/app/assets/javascripts/index/directions/osrm.js
+++ b/app/assets/javascripts/index/directions/osrm.js
@@ -95,7 +95,18 @@ function OSRMEngine() {
         Array.prototype.push.apply(line, step_geometry);
 
         var instText = "<b>" + (idx + 1) + ".</b> ";
-        var name = step.name ? "<b>" + step.name + "</b>" : I18n.t('javascripts.directions.instructions.unnamed');
+        
+        var name;
+        if (step.name && step.ref) {
+          name = "<b>" + step.name + " (" + step.ref + ")</b>";
+        } else if (step.name) {
+          name = "<b>" + step.name + "</b>";
+        } else if (step.ref) {
+          name = "<b>" + step.ref + "</b>";
+        } else {
+          name = I18n.t('javascripts.directions.instructions.unnamed');
+        }
+        
         if (step.maneuver.type.match(/rotary|roundabout/)) {
           instText += I18n.t(template + '_with_exit', { exit: step.maneuver.exit, name: name } );
         } else {


### PR DESCRIPTION
At the moment, most motorways are listed as unnamed roads.

This is because, for some reason, the OSRM API returns normal road names (i.e. Savile Street) in the `step.name` attribute in the JSON response, however, includes motorway/freeway names (i.e. M1) in the `step.ref` attribute.
Sometimes motorways are named (i.e.  _L'Autoroute du Nord_ heading north out of Paris), however, it would still be useful to have the numeric reference too (in this case, _A1_)

At the moment, the _L'Autoroute du Nord_ out of Paris is referenced just by name (i.e. _"Turn left onto **L'Autoroute du Nord**"_, however, it would be very beneficial when planning routes if the route number is indicated too (i.e. _"Turn left onto **L'Autoroute du Nord (A1)**"_), which this pull request does.

Likewise, the M1 in Britain is an unnamed road, so at the moment directions are in the form of _Turn left onto unnamed road (110km)_, which seems like a massive oversight when referencing a national highway system!
My changes change this so it now says _Turn left onto **M1**_.

In addition, main trunk roads are also referenced by road number too, so "Turn left onto **Tottenham Court Road**" becomes "Turn left onto **Tottenham Court Road (A400)**", which again is very useful for route planning.


_____


I have tested the changes across the USA, Africa, Europe, Japan, China etc, and in all cases times where you are directed along 1000s of kms of unnamed road, it now directs you along 750km of E1 or 300km of N23 for example.