### PR TITLE
Fix the upcoming issue with EasyList blocking

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -198,9 +198,9 @@ $(document).ready(function () {
   var bannerExpiry = new Date();
   bannerExpiry.setYear(bannerExpiry.getFullYear() + 1);
 
-  $('#banner .close-wrap').on('click', function(e) {
+  $('#event .close-wrap').on('click', function(e) {
     var cookieId = e.target.id;
-    $('#banner').hide();
+    $('#event').hide();
     e.preventDefault();
     if (cookieId) {
       $.cookie(cookieId, 'hide', { expires: bannerExpiry, path: '/' });

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -611,7 +611,7 @@ body.compact {
     height: auto;
     overflow: hidden;
 
-    #banner,
+    #event,
     .welcome {
       display: block;
     }
@@ -645,7 +645,7 @@ body.compact {
     }
   }
 
-  #banner {
+  #event {
     display: none;
 
     img {

--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -127,7 +127,7 @@ body.small {
   }
 
   #sidebar .welcome,
-  #sidebar #banner {
+  #sidebar #event {
     display: none !important;
   }
 

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -54,7 +54,7 @@
       </div>
     <% end %>
 
-    <div id="banner">
+    <div id="event">
       <%= render :partial => "layouts/banner" %>
     </div>
   </div>


### PR DESCRIPTION
Changing `<div id="banner">` to `<div id="event">` to better reflect the contents of banners and to circumvent ad blockers that use EasyList.