### PR TITLE
Map pans to improved position when clicking on directions

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -7,7 +7,7 @@ OSM.Directions = function (map) {
   var dragging;        // true if the user is dragging a start/end point
   var chosenEngine;
 
-  var popup = L.popup();
+  var popup = L.popup({autoPanPadding: [100, 100]});
 
   var polyline = L.polyline([], {
     color: '#03f',


### PR DESCRIPTION
Selected direction & popup now pan to the center of the screen, whereas before sometimes it would have the highlighted junction & popup tucked away right in the corner..

As an example, go to https://www.openstreetmap.org/directions?engine=osrm_car&route=55.9496%2C-3.1915%3B52.2033%2C0.1249
- Zoom in close to street level at a location far away from the route (i.e. zoom into central Paris)
- Then click on of the direction instructions on the left, and the map will pan to the selected direction point, but it will be right in the corner of the screen most likely.