### PR TITLE
Stop setValue() always changing input text to coords

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -62,11 +62,12 @@ OSM.Directions = function (map) {
     endpoint.setValue = function(value, latlng) {
       endpoint.value = value;
       delete endpoint.latlng;
-      input.val(value);
 
       if (latlng) {
         endpoint.setLatLng(latlng);
+        input.val(value);
       } else {
+        input.val(value);
         endpoint.getGeocode();
       }
     };


### PR DESCRIPTION
Stops the input text always getting set to coords.

Was unsure to use `endpoints[0].value` or `$("#route_from").val()`. Went with the jQuery because the first time you hit Go, `endpoint.value` is still the non-geocoded text (despite the input box text being geocoded)

Also not sure of positioning of `input.val(value)` in the `setValue()` method, and whether it needs to be copied into the else statement too (or whether it needs some different refactoring), but the general idea works.

Geocoded values are now saved in the url and stay as geocoded string values when reversing directions and pressing Go etc.