### PR TITLE
Fix route path 'hovering' when marker positions are changed

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -54,6 +54,8 @@ OSM.Directions = function (map) {
     });
 
     input.on("change", function (e) {
+      awaitingGeocode = true;
+      
       // make text the same in both text boxes
       var value = e.target.value;
       endpoint.setValue(value);
@@ -88,12 +90,9 @@ OSM.Directions = function (map) {
           return;
         }
 
-        input.val(json[0].display_name);
+        endpoint.setLatLng(L.latLng(json[0]));
 
-        endpoint.latlng = L.latLng(json[0]);
-        endpoint.marker
-          .setLatLng(endpoint.latlng)
-          .addTo(map);
+        input.val(json[0].display_name);
 
         if (awaitingGeocode) {
           awaitingGeocode = false;


### PR DESCRIPTION
If you have a route already on screen, and then type in a new location in either the start or end destinations and click anywhere except for basically the Go button, then the marker position moves, but the route remains going to the old position.

Likewise, if you then type in a new destination for the other marker and click anywhere except the Go button, then you end up with 2 markers in their respective positions and a route path just gliding across the screen unconnected from everything!

I propose that getRoute() is called everytime the input text is changed because chances are, the marker will move and a new route will need to be calculated.

I do this by simply setting `awaitingGeocode = true` when the input text changes.

___
I also included in some refactoring which should probably be in another PR.