### PR TITLE
Fixed roundabout without exit

### DIFF
--- a/app/assets/javascripts/index/directions/osrm.js
+++ b/app/assets/javascripts/index/directions/osrm.js
@@ -111,7 +111,11 @@ function OSRMEngine() {
         }
 
         if (step.maneuver.type.match(/rotary|roundabout/)) {
-          instText += I18n.t(template + '_with_exit', { exit: step.maneuver.exit, name: name } );
+          if (step.maneuver.exit) {
+            instText += I18n.t(template + '_with_exit', { exit: step.maneuver.exit, name: name } );
+          } else {
+            instText += I18n.t(template + '_without_exit', { name: name } );
+          }
         } else if (step.maneuver.type.match(/on ramp|off ramp/)) {
           if (step.destinations) {
             if (namedRoad) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2360,7 +2360,7 @@ en:
         slight_left_without_exit: Slight left onto %{name}
         via_point_without_exit: (via point)
         follow_without_exit: Follow %{name}
-        roundabout_without_exit: At roundabout take %{name}
+        roundabout_without_exit: At roundabout take exit onto %{name}
         leave_roundabout_without_exit: Leave roundabout - %{name}
         stay_roundabout_without_exit: Stay on roundabout - %{name}
         start_without_exit: Start on %{name}


### PR DESCRIPTION
Very niche, but text is broken when roundabout has no exit.

(e.g. Search from anywhere to `london`) and it breaks. Destination geolocates toTrafalgar square in the centre of the roundabout, no exit..