### PR TITLE
make cpanp command help working without requiring changes from user

### DIFF
--- a/script/misc/update-wiki-pages
+++ b/script/misc/update-wiki-pages
@@ -9,7 +9,7 @@ use Getopt::Long ();
 BEGIN {
     eval "require MediaWiki::API; require YAML::XS;" or do {
         print "You have to install some modules via CPAN to run this:\n";
-        print "   sudo cpanp MediaWiki::API YAML::XS\n";
+        print "   sudo cpanp i MediaWiki::API YAML::XS\n";
         exit 1;
     };
 }


### PR DESCRIPTION
https://raw.githubusercontent.com/mmd-osm/openstreetmap-website/master/script/misc/update-wiki-pages has

>         print "   sudo cpanp MediaWiki::API YAML::XS\n";

From my own experience and reading http://search.cpan.org/~bingos/CPANPLUS-0.9172/bin/cpanp it seems that it should be 

> sudo cpanp i MediaWiki::API YAML::XS