### PR TITLE
Display coordinates on notes pages

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1214,8 +1214,9 @@ tr.turn:hover {
   }
 
   .warning {
-    margin: 0 0 $lineheight/2 0;
-    padding: 0 $lineheight/2;
+    margin: 0 10px;
+    padding: 10px;
+    background-color: #ffe0cc;
   }
 
   .note-comments li, .changeset-comments li {

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -19,6 +19,11 @@
     <% end %>
   </div>
 
+  <div class="details geo">
+  <%= t 'browse.note.location' %>
+  <%= link_to(content_tag(:span, number_with_delimiter(@note.lat), :class => "latitude") + ", " + content_tag(:span, number_with_delimiter(@note.lon), :class => "longitude"), {:controller => 'site', :action => 'index', :anchor => "map=18/#{@note.lat}/#{@note.lon}"}) %>
+  </div>
+
   <% if @note_comments.find { |comment| comment.author.nil? } -%>
     <p class='warning'><%= t "javascripts.notes.show.anonymous_warning" %></p>
   <% end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,7 @@ en:
       title: "Note: %{id}"
       new_note: "New Note"
       description: "Description"
+      location: "Location:"
       open_title: "Unresolved note #%{note_name}"
       closed_title: "Resolved note #%{note_name}"
       hidden_title: "Hidden note #%{note_name}"


### PR DESCRIPTION
<img width="693" alt="untitled" src="https://user-images.githubusercontent.com/58878/36753650-9ff68a00-1bbb-11e8-957d-6f20aff2382e.png">*before and after*

Fixes #1355.

Clicking note coordinates simply zooms to the area at Z18, just like node pages behave. I also cleaned up the warning, which impacted export and note creation pages. Here they are now.

<img width="351" alt="screen shot 2018-02-27 at 12 43 52 pm" src="https://user-images.githubusercontent.com/58878/36753803-2b81672a-1bbc-11e8-9393-94e28af848ec.png">
<img width="346" alt="screen shot 2018-02-27 at 12 44 13 pm" src="https://user-images.githubusercontent.com/58878/36753812-2e782fc2-1bbc-11e8-8b21-90943de00c6c.png">
