### PR TITLE
Silence puma startup messages when running tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,6 +4,8 @@ require "capybara/poltergeist"
 WebMock.disable_net_connect!(:allow_localhost => true)
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  ActionDispatch::SystemTesting::Server.silence_puma = true
+
   driven_by :poltergeist, :screen_size => [1400, 1400]
 
   def initialize(*args)


### PR DESCRIPTION
This comes via https://github.com/rails/rails/pull/29561