### PR TITLE
Silence image_optim missing worker warnings during tests

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -43,8 +43,5 @@ module OpenStreetMap
       config.logstasher.logger_path = LOGSTASH_PATH
       config.logstasher.log_controller_parameters = true
     end
-
-    # Configure image optimisation
-    config.assets.image_optim = YAML.load_file(Rails.root.join("config", "image_optim.yml"))
   end
 end

--- a/config/image_optim/test.yml
+++ b/config/image_optim/test.yml
@@ -1,0 +1,11 @@
+skip_missing_workers: true
+advpng: false
+gifsicle: false
+jhead: false
+jpegoptim: false
+jpegtran: false
+optipng: false
+pngquant: false
+pngout: false
+pngcrush: false
+svgo: false


### PR DESCRIPTION
There's two parts to this - firstly, removing the forced loading of the config file, and letting image_optim load the config itself. Secondly, this then enables per-environment image_optim config files, and so we can disable the various workers in the test environment.