### PR TITLE
Strip trailing whitespace from multiline html translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1169,8 +1169,8 @@ en:
       paragraph_1_html: |
         OpenStreetMap has few formal rules but we expect all participants to collaborate
         with, and communicate with, the community. If you are considering
-        any activities other than editing by hand, please read and follow the guidelines on 
-        <a href='https://wiki.openstreetmap.org/wiki/Import/Guidelines'>Imports</a> and 
+        any activities other than editing by hand, please read and follow the guidelines on
+        <a href='https://wiki.openstreetmap.org/wiki/Import/Guidelines'>Imports</a> and
         <a href='https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct'>Automated Edits</a>.
     questions:
       title: Any questions?
@@ -1196,7 +1196,7 @@ en:
         title: Join the community
         explanation_html: |
           If you have noticed a problem with our map data, for example a road is missing or your address, the best way to
-          proceed is to join the OpenStreetMap community and add or repair the data yourself. 
+          proceed is to join the OpenStreetMap community and add or repair the data yourself.
       add_a_note:
         instructions_html: |
           Just click <a class='icon note'></a> or the same icon on the map display.
@@ -1206,8 +1206,8 @@ en:
       title: Other concerns
       explanation_html: |
         If you have concerns about how our data is being used or about the contents please consult our
-        <a href='/copyright'>copyright page</a> for more legal information, or contact the appropriate 
-        <a href='https://wiki.osmfoundation.org/wiki/Working_Groups'>OSMF working group</a>.  
+        <a href='/copyright'>copyright page</a> for more legal information, or contact the appropriate
+        <a href='https://wiki.osmfoundation.org/wiki/Working_Groups'>OSMF working group</a>.
   help_page:
     title: Getting Help
     introduction: |
@@ -1277,13 +1277,13 @@ en:
       License page</a> for details.
     legal_title: Legal
     legal_html: |
-      This site and many other related services are formally operated by the  
-      <a href='https://osmfoundation.org/'>OpenStreetMap Foundation</a> (OSMF) 
-      on behalf of the community. Use of all OSMF operated services is subject 
+      This site and many other related services are formally operated by the
+      <a href='https://osmfoundation.org/'>OpenStreetMap Foundation</a> (OSMF)
+      on behalf of the community. Use of all OSMF operated services is subject
       to our <a href="https://wiki.openstreetmap.org/wiki/Acceptable_Use_Policy">
       Acceptable Use Policies</a> and our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy">Privacy Policy</a>
-      <br> 
-      Please <a href='https://osmfoundation.org/Contact'>contact the OSMF</a> 
+      <br>
+      Please <a href='https://osmfoundation.org/Contact'>contact the OSMF</a>
       if you have licensing, copyright or other legal questions.
       <br>
       OpenStreetMap, the magnifying glass logo and State of the Map are <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">registered trademarks of the OSMF</a>.


### PR DESCRIPTION
This keeps bugging me when doing work in the translations file, since my editor strips the trailing white space automatically on save.