### PR TITLE
Unlocateable place now highlighted in red and specified in error message

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -53,6 +53,10 @@ OSM.Directions = function (map) {
       }
     });
 
+    input.on("keydown", function() {
+      input.css("background-color", "#fff");
+    });
+
     input.on("change", function (e) {
       awaitingGeocode = true;
       
@@ -86,7 +90,8 @@ OSM.Directions = function (map) {
         endpoint.awaitingGeocode = false;
         endpoint.hasGeocode = true;
         if (json.length === 0) {
-          alert(I18n.t('javascripts.directions.errors.no_place'));
+          alert(I18n.t('javascripts.directions.errors.no_place_with_name', {place: endpoint.value}));
+          input.css("background-color", "rgba(255, 0, 0, 0.5)");
           return;
         }
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -90,7 +90,7 @@ OSM.Directions = function (map) {
         endpoint.awaitingGeocode = false;
         endpoint.hasGeocode = true;
         if (json.length === 0) {
-          alert(I18n.t('javascripts.directions.errors.no_place_with_name', {place: endpoint.value}));
+          alert(I18n.t('javascripts.directions.errors.no_place', {place: endpoint.value}));
           input.css("background-color", "rgba(255, 0, 0, 0.5)");
           return;
         }

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -54,7 +54,7 @@ OSM.Directions = function (map) {
     });
 
     input.on("keydown", function() {
-      input.css("background-color", "#fff");
+      input.removeClass("highlight_error");
     });
 
     input.on("change", function (e) {
@@ -91,7 +91,7 @@ OSM.Directions = function (map) {
         endpoint.hasGeocode = true;
         if (json.length === 0) {
           alert(I18n.t('javascripts.directions.errors.no_place', {place: endpoint.value}));
-          input.css("background-color", "rgba(255, 0, 0, 0.5)");
+          input.addClass("highlight_error");
           return;
         }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -938,6 +938,10 @@ header .search_forms,
     border-radius: 0 2px 2px 0;
   }
 
+  input.highlight_error {
+    background-color: rgba(255, 0, 0, 0.5);
+  }
+
   select {
     /* this next line is to polyfill the vertical alignment of text within a select element,
      * which is different between firefox and chrome. */

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2326,6 +2326,7 @@ en:
       errors:
         no_route: "Couldn't find a route between those two places."
         no_place: "Sorry - couldn't find that place."
+        no_place_with_name: "Sorry - couldn't locate '%{place}'."
       instructions:
         continue_without_exit: Continue on %{name}
         slight_right_without_exit: Slight right onto %{name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2325,8 +2325,7 @@ en:
       distance: "Distance"
       errors:
         no_route: "Couldn't find a route between those two places."
-        no_place: "Sorry - couldn't find that place."
-        no_place_with_name: "Sorry - couldn't locate '%{place}'."
+        no_place: "Sorry - couldn't locate '%{place}'."
       instructions:
         continue_without_exit: Continue on %{name}
         slight_right_without_exit: Slight right onto %{name}


### PR DESCRIPTION
Fixes #1790 
Added a new locale translation where you can specify a specific location in the 'not found' error message
Made it so that the textbox containing the error-ed value gets highlighted in red

![image](https://user-images.githubusercontent.com/4670502/38110505-d4fbc9b4-3393-11e8-91ba-274f4e61a819.png)
