### PR TITLE
Add missing onramp instructions to locale file

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2341,6 +2341,7 @@ en:
         onramp_right_with_directions: Turn right onto the ramp towards %{directions}
         onramp_right_with_name_directions: Turn right on the ramp onto %{name}, towards %{directions}
         onramp_right_without_directions: Turn right onto the ramp
+        onramp_right: Turn right onto the ramp
         endofroad_right_without_exit: At the end of the road turn right onto %{name}
         merge_right_without_exit: Merge right onto %{name}
         fork_right_without_exit: At the fork turn right onto %{name}
@@ -2361,6 +2362,7 @@ en:
         onramp_left_with_directions: Turn left onto the ramp towards %{directions}
         onramp_left_with_name_directions: Turn left on the ramp onto %{name}, towards %{directions}
         onramp_left_without_directions: Turn left onto the ramp
+        onramp_left: Turn left onto the ramp
         endofroad_left_without_exit: At the end of the road turn left onto %{name}
         merge_left_without_exit: Merge left onto %{name}
         fork_left_without_exit: At the fork turn left onto %{name}


### PR DESCRIPTION
If you go to https://www.openstreetmap.org/directions?engine=osrm_car&route=52.4680%2C-1.7135%3B52.4601%2C-1.7042#map=15/52.4612/-1.7058 you'll notice that there is a missing locale instruction in the directions list, which this PR fixes