### PR TITLE
Fix destinations and roundabouts locale

### DIFF
--- a/app/assets/javascripts/index/directions/osrm.js
+++ b/app/assets/javascripts/index/directions/osrm.js
@@ -119,14 +119,17 @@ function OSRMEngine() {
         } else if (step.maneuver.type.match(/on ramp|off ramp/)) {
           var params = {};
           if (step.exits && step.maneuver.type.match(/off ramp/)) params.exit = step.exits;
-          if (step.destinations) params.directions = destinations;
-          if (namedRoad) params.directions = name;
+          if (namedRoad) params.name = name;
           if (Object.keys(params).length > 0) {
             template = template + "_with_" + Object.keys(params).join("_");
           }
           instText += I18n.t(template, params);
         } else {
           instText += I18n.t(template + '_without_exit', { name: name });
+        }
+
+        if (step.destinations) {
+          instText += I18n.t('javascripts.directions.instructions.towards_destination', { destination: destinations });
         }
         return [[step.maneuver.location[1], step.maneuver.location[0]], ICON_MAP[maneuver_id], instText, step.distance, step_geometry];
       });

--- a/app/assets/javascripts/index/directions/osrm.js
+++ b/app/assets/javascripts/index/directions/osrm.js
@@ -110,26 +110,28 @@ function OSRMEngine() {
           namedRoad = false;
         }
 
+        var params = {};
         if (step.maneuver.type.match(/rotary|roundabout/)) {
-          if (step.maneuver.exit) {
-            instText += I18n.t(template + '_with_exit', { exit: step.maneuver.exit, name: name } );
-          } else {
-            instText += I18n.t(template + '_without_exit', { name: name } );
+          if (step.maneuver.exit) params.exit = step.maneuver.exit;
+          if (step.maneuver.type.match(/exit/)) {
+            template = template.substr(0, template.lastIndexOf(".")) + ".exit_roundabout_" + template.substr(template.lastIndexOf(".")+1);
+            params.name = name;
+            delete params.exit;
           }
         } else if (step.maneuver.type.match(/on ramp|off ramp/)) {
-          var params = {};
           if (step.exits && step.maneuver.type.match(/off ramp/)) params.exit = step.exits;
-          if (namedRoad) params.name = name;
-          if (Object.keys(params).length > 0) {
-            template = template + "_with_" + Object.keys(params).join("_");
-          }
-          instText += I18n.t(template, params);
         } else {
-          instText += I18n.t(template + '_without_exit', { name: name });
+          params.name = name;
         }
 
+        if (namedRoad) params.name = name;
+        if (Object.keys(params).length > 0) {
+          template = template + "_with_" + Object.keys(params).join("_");
+        }
+        instText += I18n.t(template, params);
+
         if (step.destinations) {
-          instText += I18n.t('javascripts.directions.instructions.towards_destination', { destination: destinations });
+          instText += ", " + I18n.t('javascripts.directions.instructions.towards_destination', { destination: destinations });
         }
         return [[step.maneuver.location[1], step.maneuver.location[0]], ICON_MAP[maneuver_id], instText, step.distance, step_geometry];
       });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2327,48 +2327,49 @@ en:
         no_route: "Couldn't find a route between those two places."
         no_place: "Sorry - couldn't find that place."
       instructions:
-        towards_destination: ", towards %{destination}"
-        continue_without_exit: Continue on %{name}
-        slight_right_without_exit: Slight right onto %{name}
+        towards_destination: "towards %{destination}"
+        continue_with_name: Continue on %{name}
+        slight_right_with_name: Slight right onto %{name}
         offramp_right: Take the ramp on the right
         offramp_right_with_exit: Take exit %{exit} on the right
         offramp_right_with_exit_name: Take exit %{exit} on the right onto %{name}
         offramp_right_with_name: Take the ramp on the right onto %{name}
         onramp_right: Turn right onto the ramp
         onramp_right_with_name: Turn right on the ramp onto %{name}
-        endofroad_right_without_exit: At the end of the road turn right onto %{name}
-        merge_right_without_exit: Merge right onto %{name}
-        fork_right_without_exit: At the fork bear right onto %{name}
-        turn_right_without_exit: Turn right onto %{name}
-        sharp_right_without_exit: Sharp right onto %{name}
-        uturn_without_exit: U-turn along %{name}
-        sharp_left_without_exit: Sharp left onto %{name}
-        turn_left_without_exit: Turn left onto %{name}
+        endofroad_right_with_name: At the end of the road turn right onto %{name}
+        merge_right_with_name: Merge right onto %{name}
+        fork_right_with_name: At the fork bear right onto %{name}
+        turn_right_with_name: Turn right onto %{name}
+        sharp_right_with_name: Sharp right onto %{name}
+        uturn_with_name: U-turn along %{name}
+        sharp_left_with_name: Sharp left onto %{name}
+        turn_left_with_name: Turn left onto %{name}
         offramp_left: Take the ramp on the left
         offramp_left_with_exit: Take exit %{exit} on the left
         offramp_left_with_exit_name: Take exit %{exit} on the left onto %{name}
         offramp_left_with_name: Take the ramp on the left onto %{name}
         onramp_left: Turn left onto the ramp
         onramp_left_with_name: Turn left on the ramp onto %{name}
-        endofroad_left_without_exit: At the end of the road turn left onto %{name}
-        merge_left_without_exit: Merge left onto %{name}
-        fork_left_without_exit: At the fork bear left onto %{name}
-        slight_left_without_exit: Slight left onto %{name}
-        via_point_without_exit: (via point)
-        follow_without_exit: Follow %{name}
-        roundabout_without_exit: At roundabout take exit onto %{name}
-        leave_roundabout_without_exit: Leave roundabout - %{name}
-        stay_roundabout_without_exit: Stay on roundabout - %{name}
-        start_without_exit: Start on %{name}
-        destination_without_exit: Reach destination
-        against_oneway_without_exit: Go against one-way on %{name}
-        end_oneway_without_exit: End of one-way on %{name}
-        roundabout_with_exit: At roundabout take exit %{exit} onto %{name}
-        turn_left_with_exit: At roundabout turn left onto %{name}
-        slight_left_with_exit: At roundabout slight left onto %{name}
-        turn_right_with_exit: At roundabout turn right onto %{name}
-        slight_right_with_exit: At roundabout slight right onto %{name}
-        continue_with_exit: At roundabout continue straight onto %{name}
+        endofroad_left_with_name: At the end of the road turn left onto %{name}
+        merge_left_with_name: Merge left onto %{name}
+        fork_left_with_name: At the fork bear left onto %{name}
+        slight_left_with_name: Slight left onto %{name}
+        via_point_with_name: (via point)
+        follow_with_name: Follow %{name}
+        start_with_name: Start on %{name}
+        destination_with_name: Reach destination
+        against_oneway_with_name: Go against one-way on %{name}
+        end_oneway_with_name: End of one-way on %{name}
+        roundabout_with_name: At roundabout take exit onto %{name}
+        roundabout_with_exit: At roundabout take exit %{exit}
+        roundabout_with_exit_name: At roundabout take exit %{exit} onto %{name}
+        leave_roundabout_with_name: Leave roundabout - %{name}
+        stay_roundabout_with_name: Stay on roundabout - %{name}
+        exit_roundabout_turn_left_with_name: Exit left onto %{name}
+        exit_roundabout_slight_left_with_name: Exit slight left onto %{name}
+        exit_roundabout_turn_right_with_name: Exit right onto %{name}
+        exit_roundabout_slight_right_with_name: Exit slight right onto %{name}
+        exit_roundabout_continue_with_name: Exit straight onto %{name}
         unnamed: "unnamed road"
         courtesy: "Directions courtesy of %{link}"
       time: "Time"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2360,9 +2360,9 @@ en:
         destination_with_name: Reach destination
         against_oneway_with_name: Go against one-way on %{name}
         end_oneway_with_name: End of one-way on %{name}
-        roundabout_with_name: At roundabout take exit onto %{name}
-        roundabout_with_exit: At roundabout take exit %{exit}
-        roundabout_with_exit_name: At roundabout take exit %{exit} onto %{name}
+        roundabout_with_name: At the roundabout take exit onto %{name}
+        roundabout_with_exit: At the roundabout take exit %{exit}
+        roundabout_with_exit_name: At the roundabout take exit %{exit} onto %{name}
         leave_roundabout_with_name: Leave roundabout - %{name}
         stay_roundabout_with_name: Stay on roundabout - %{name}
         exit_roundabout_turn_left_with_name: Exit left onto %{name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2327,23 +2327,18 @@ en:
         no_route: "Couldn't find a route between those two places."
         no_place: "Sorry - couldn't find that place."
       instructions:
+        towards_destination: ", towards %{destination}"
         continue_without_exit: Continue on %{name}
         slight_right_without_exit: Slight right onto %{name}
         offramp_right: Take the ramp on the right
         offramp_right_with_exit: Take exit %{exit} on the right
         offramp_right_with_exit_name: Take exit %{exit} on the right onto %{name}
-        offramp_right_with_exit_directions: Take exit %{exit} on the right towards %{directions}
-        offramp_right_with_exit_name_directions: Take exit %{exit} on the right onto %{name}, towards %{directions}
         offramp_right_with_name: Take the ramp on the right onto %{name}
-        offramp_right_with_directions: Take the ramp on the right towards %{directions}
-        offramp_right_with_name_directions: Take the ramp on the right onto %{name}, towards %{directions}
-        onramp_right_without_exit: Turn right on the ramp onto %{name}
-        onramp_right_with_directions: Turn right onto the ramp towards %{directions}
-        onramp_right_with_name_directions: Turn right on the ramp onto %{name}, towards %{directions}
-        onramp_right_without_directions: Turn right onto the ramp
+        onramp_right: Turn right onto the ramp
+        onramp_right_with_name: Turn right on the ramp onto %{name}
         endofroad_right_without_exit: At the end of the road turn right onto %{name}
         merge_right_without_exit: Merge right onto %{name}
-        fork_right_without_exit: At the fork turn right onto %{name}
+        fork_right_without_exit: At the fork bear right onto %{name}
         turn_right_without_exit: Turn right onto %{name}
         sharp_right_without_exit: Sharp right onto %{name}
         uturn_without_exit: U-turn along %{name}
@@ -2352,18 +2347,12 @@ en:
         offramp_left: Take the ramp on the left
         offramp_left_with_exit: Take exit %{exit} on the left
         offramp_left_with_exit_name: Take exit %{exit} on the left onto %{name}
-        offramp_left_with_exit_directions: Take exit %{exit} on the left towards %{directions}
-        offramp_left_with_exit_name_directions: Take exit %{exit} on the left onto %{name}, towards %{directions}
         offramp_left_with_name: Take the ramp on the left onto %{name}
-        offramp_left_with_directions: Take the ramp on the left towards %{directions}
-        offramp_left_with_name_directions: Take the ramp on the left onto %{name}, towards %{directions}
-        onramp_left_without_exit: Turn left on the ramp onto %{name}
-        onramp_left_with_directions: Turn left onto the ramp towards %{directions}
-        onramp_left_with_name_directions: Turn left on the ramp onto %{name}, towards %{directions}
-        onramp_left_without_directions: Turn left onto the ramp
+        onramp_left: Turn left onto the ramp
+        onramp_left_with_name: Turn left on the ramp onto %{name}
         endofroad_left_without_exit: At the end of the road turn left onto %{name}
         merge_left_without_exit: Merge left onto %{name}
-        fork_left_without_exit: At the fork turn left onto %{name}
+        fork_left_without_exit: At the fork bear left onto %{name}
         slight_left_without_exit: Slight left onto %{name}
         via_point_without_exit: (via point)
         follow_without_exit: Follow %{name}


### PR DESCRIPTION
Done a few changes here.

I refactored the with_destination locale so its just a string that one can append onto the end of an instruction. Hopefully it will still work with different grammar structures in different languages!

I also fixed some ambiguous roundabout instructions..
i.e. https://www.openstreetmap.org/directions?engine=osrm_car&route=53.7338%2C-1.5258%3B53.6832%2C-1.4999#map=13/53.7086/-1.5171

Instructions 7-16 are a bit weird - so I've fixed it to specify `"Exit straight/slight right/right from roundabout"` when exiting roundabouts