### PR TITLE
Allow searching via UK GSS code.

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -404,6 +404,7 @@ en-GB:
         osm_nominatim: Results from <a href="http://nominatim.openstreetmap.org/">OpenStreetMap
           Nominatim</a>
         geonames: Results from <a href="http://www.geonames.org/">GeoNames</a>
+        overpass_gss: Results from <a href="https://en.wikipedia.org/wiki/ONS_coding_system">UK GSS code</a>
         osm_nominatim_reverse: Results from <a href="http://nominatim.openstreetmap.org/">OpenStreetMap
           Nominatim</a>
         geonames_reverse: Results from <a href="http://www.geonames.org/">GeoNames</a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,6 +371,7 @@ en:
         ca_postcode: 'Results from <a href="https://geocoder.ca/">Geocoder.CA</a>'
         osm_nominatim: 'Results from <a href="https://nominatim.openstreetmap.org/">OpenStreetMap Nominatim</a>'
         geonames: 'Results from <a href="http://www.geonames.org/">GeoNames</a>'
+        overpass_gss: 'Results from <a href="https://en.wikipedia.org/wiki/ONS_coding_system">UK GSS code</a>'
         osm_nominatim_reverse: 'Results from <a href="https://nominatim.openstreetmap.org/">OpenStreetMap Nominatim</a>'
         geonames_reverse: 'Results from <a href="http://www.geonames.org/">GeoNames</a>'
     search_osm_nominatim:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,6 +248,7 @@ OpenStreetMap::Application.routes.draw do
   get "/search" => "geocoder#search"
   get "/geocoder/search_latlon" => "geocoder#search_latlon"
   get "/geocoder/search_ca_postcode" => "geocoder#search_ca_postcode"
+  get "/geocoder/search_overpass_gss" => "geocoder#search_overpass_gss"
   get "/geocoder/search_osm_nominatim" => "geocoder#search_osm_nominatim"
   get "/geocoder/search_geonames" => "geocoder#search_geonames"
   get "/geocoder/search_osm_nominatim_reverse" => "geocoder#search_osm_nominatim_reverse"


### PR DESCRIPTION
The UK Office for National Statistics maintains a series of codes to
represent geographical areas of the UK. These codes follow a standard
format and are recorded in OpenStreetMap using the ref:gss tag.

This change lets map users search the map by UK GSS code. It uses the
Overpass API to look for a relation with the code provided by the user.

Example search: E06000001 will return Hartlepool (unitary authority).