### PR TITLE
Reworded roundabout exit text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2377,11 +2377,11 @@ en:
         against_oneway_without_exit: Go against one-way on %{name}
         end_oneway_without_exit: End of one-way on %{name}
         roundabout_with_exit: At roundabout take exit %{exit} onto %{name}
-        turn_left_with_exit: At roundabout turn left onto %{name}
-        slight_left_with_exit: At roundabout slight left onto %{name}
-        turn_right_with_exit: At roundabout turn right onto %{name}
-        slight_right_with_exit: At roundabout slight right onto %{name}
-        continue_with_exit: At roundabout continue straight onto %{name}
+        turn_left_with_exit: Turn left onto %{name}
+        slight_left_with_exit: Make a slight left onto %{name}
+        turn_right_with_exit: Turn right onto %{name}
+        slight_right_with_exit: Make a slight right onto %{name}
+        continue_with_exit: Go straight onto %{name}
         unnamed: "unnamed road"
         courtesy: "Directions courtesy of %{link}"
       time: "Time"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2377,11 +2377,11 @@ en:
         against_oneway_without_exit: Go against one-way on %{name}
         end_oneway_without_exit: End of one-way on %{name}
         roundabout_with_exit: At roundabout take exit %{exit} onto %{name}
-        turn_left_with_exit: Turn left onto %{name}
-        slight_left_with_exit: Make a slight left onto %{name}
-        turn_right_with_exit: Turn right onto %{name}
-        slight_right_with_exit: Make a slight right onto %{name}
-        continue_with_exit: Go straight onto %{name}
+        turn_left_with_exit: Exit onto %{name}
+        slight_left_with_exit: Exit onto %{name}
+        turn_right_with_exit: Exit onto %{name}
+        slight_right_with_exit: Exit onto %{name}
+        continue_with_exit: Exit onto %{name}
         unnamed: "unnamed road"
         courtesy: "Directions courtesy of %{link}"
       time: "Time"


### PR DESCRIPTION
I've cut back all the complicated refactoring from the PR I've just closed, and just left in the roundabout wording changes.

Basically I've just reworded the instructions to be the same as whats used on OSRM..

See: https://www.openstreetmap.org/directions?engine=osrm_car&route=53.7320%2C-1.5165%3B53.7254%2C-1.5161

vs: http://map.project-osrm.org/?z=17&center=53.730483%2C-1.512321&loc=53.731819%2C-1.514997&loc=53.728976%2C-1.512133&hl=en&alt=0