### PR TITLE
Update xid_to_int4.c

### DIFF
--- a/db/functions/xid_to_int4.c
+++ b/db/functions/xid_to_int4.c
@@ -1,10 +1,13 @@
 #include <postgres.h>
 #include <fmgr.h>
 
-int xid_to_int4(TransactionId xid)
+Datum
+xid_to_int4(PG_FUNCTION_ARGS)
 {
-   return xid;
+   PG_RETURN_INT32(DatumGetTransactionId(0));
 }
+
+PG_FUNCTION_INFO_V1(xid_to_int4);
 
 /*
  * To bind this into PGSQL, try something like:


### PR DESCRIPTION
Made changes to avoid error when executing "CREATE FUNCTION xid_to_int4(xid) RETURNS int4 AS '`pwd`/db/functions/libpgosm', 'xid_to_int4' LANGUAGE C STRICT".