### PR TITLE
Add better_errors gem for easier debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,8 @@ gem "logstasher"
 # Gems useful for development
 group :development do
   gem "annotate"
+  gem "better_errors"
+  gem "binding_of_caller"
   gem "listen"
   gem "vendorer"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,13 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (8.2.0)
       execjs
+    better_errors (2.4.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bigdecimal (1.1.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     builder (3.2.3)
     canonical-rails (0.2.2)
       rails (>= 4.1, < 5.2)
@@ -63,6 +69,7 @@ GEM
       xpath (>= 2.0, < 4.0)
     climate_control (0.2.0)
     cliver (0.3.2)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -83,6 +90,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
     dalli (2.7.6)
+    debug_inspector (0.0.2)
     docile (1.1.5)
     dynamic_form (1.1.4)
     erubi (1.7.1)
@@ -357,7 +365,9 @@ DEPENDENCIES
   actionpack-page_caching
   annotate
   autoprefixer-rails
+  better_errors
   bigdecimal (~> 1.1.0)
+  binding_of_caller
   canonical-rails
   capybara (~> 2.13)
   coffee-rails (~> 4.2)


### PR DESCRIPTION
This PR adds one of my favourite gems - [better_errors](https://github.com/charliesome/better_errors)

In particular, I like the REPL that allows you to interact with the current state of the app. I often use it when debugging controllers, figuring out what's going wrong with params and form submissions and the like.