### PR TITLE
Fix handling of title when replying to diary entries

### DIFF
--- a/app/views/diary_entry/_diary_entry.html.erb
+++ b/app/views/diary_entry/_diary_entry.html.erb
@@ -23,7 +23,7 @@
   <ul class='secondary-actions clearfix'>
     <% if params[:action] == 'list' %>
       <li><%= link_to t('diary_entry.diary_entry.comment_link'), :action => 'view', :display_name => diary_entry.user.display_name, :id => diary_entry.id, :anchor => 'newcomment' %></li>
-      <li><%= link_to t('diary_entry.diary_entry.reply_link'), :controller => 'message', :action => 'new', :display_name => diary_entry.user.display_name, :title => "Re: #{diary_entry.title}" %></li>
+      <li><%= link_to t('diary_entry.diary_entry.reply_link'), :controller => 'message', :action => 'new', :display_name => diary_entry.user.display_name, :message => { :title => "Re: #{diary_entry.title}" } %></li>
       <li><%= link_to t('diary_entry.diary_entry.comment_count', :count => diary_entry.visible_comments.count), :action => 'view', :display_name => diary_entry.user.display_name, :id => diary_entry.id, :anchor => 'comments' %></li>
     <% end %>
 

--- a/app/views/message/new.html.erb
+++ b/app/views/message/new.html.erb
@@ -7,11 +7,11 @@
 <%= form_for :message, :html => { :class => 'standard-form' }, :url => { :action => "new", :display_name => @message.recipient.display_name } do |f| %>
   <fieldset>
     <div class='form-row'>
-      <label class="standard-label"><%= t'message.new.subject' %></label>
+      <label class="standard-label" for="message_title"><%= t'message.new.subject' %></label>
       <%= f.text_field :title, :size => 60, :class => "richtext_title" %>
     </div>
     <div class='form-row'>
-      <label class="standard-label"><%= t'message.new.body' %></label>
+      <label class="standard-label" for="message_body"><%= t'message.new.body' %></label>
       <%= richtext_area :message, :body, :cols => 80, :rows => 20 %>
     </div>
     <div class='buttons'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,7 +224,7 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/diary" => "diary_entry#list"
   get "/diary/:language" => "diary_entry#list"
   get "/diary" => "diary_entry#list"
-  get "/user/:display_name/diary/:id" => "diary_entry#view", :id => /\d+/
+  get "/user/:display_name/diary/:id" => "diary_entry#view", :id => /\d+/, :as => :diary_entry
   post "/user/:display_name/diary/:id/newcomment" => "diary_entry#comment", :id => /\d+/
   match "/user/:display_name/diary/:id/edit" => "diary_entry#edit", :via => [:get, :post], :id => /\d+/
   post "/user/:display_name/diary/:id/hide" => "diary_entry#hide", :id => /\d+/, :as => :hide_diary_entry

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -1,0 +1,18 @@
+require "application_system_test_case"
+
+class DiaryEntryTest < ApplicationSystemTestCase
+  def setup
+    create(:language, :code => "en")
+    @diary_entry = create(:diary_entry)
+  end
+
+  test "reply to diary entry should prefill the message subject" do
+    sign_in_as(create(:user))
+    visit diary_path
+
+    click_on "Reply to this entry"
+
+    assert page.has_content? "Send a new message"
+    assert_equal "Re: #{@diary_entry.title}", page.find_field("Subject").value
+  end
+end

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -1,6 +1,6 @@
 require "application_system_test_case"
 
-class DiaryEntryTest < ApplicationSystemTestCase
+class DiaryEntrySystemTest < ApplicationSystemTestCase
   def setup
     create(:language, :code => "en")
     @diary_entry = create(:diary_entry)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -150,5 +150,13 @@ module ActiveSupport
         end
       end
     end
+
+    def sign_in_as(user)
+      stub_hostip_requests
+      visit login_path
+      fill_in "username", :with => user.email
+      fill_in "password", :with => "test"
+      click_on "Login", :match => :first
+    end
   end
 end


### PR DESCRIPTION
I noticed that the link "Reply to this entry" includes the title for the message, but this wasn't being shown in the new message form. This PR includes a test to ensure that the form field is filled in correctly, and includes some extras to make the tests easier to write (taken from the moderation branch).