### PR TITLE
Set default_url_options for action_mailer

### DIFF
--- a/app/models/notifier.rb
+++ b/app/models/notifier.rb
@@ -8,9 +8,7 @@ class Notifier < ActionMailer::Base
 
   def signup_confirm(user, token)
     with_recipient_locale user do
-      @url = url_for(:host => SERVER_URL,
-                     :protocol => SERVER_PROTOCOL,
-                     :controller => "user", :action => "confirm",
+      @url = url_for(:controller => "user", :action => "confirm",
                      :display_name => user.display_name,
                      :confirm_string => token.token)
 
@@ -22,9 +20,7 @@ class Notifier < ActionMailer::Base
   def email_confirm(user, token)
     with_recipient_locale user do
       @address = user.new_email
-      @url = url_for(:host => SERVER_URL,
-                     :protocol => SERVER_PROTOCOL,
-                     :controller => "user", :action => "confirm_email",
+      @url = url_for(:controller => "user", :action => "confirm_email",
                      :confirm_string => token.token)
 
       mail :to => user.new_email,
@@ -34,9 +30,7 @@ class Notifier < ActionMailer::Base
 
   def lost_password(user, token)
     with_recipient_locale user do
-      @url = url_for(:host => SERVER_URL,
-                     :protocol => SERVER_PROTOCOL,
-                     :controller => "user", :action => "reset_password",
+      @url = url_for(:controller => "user", :action => "reset_password",
                      :token => token.token)
 
       mail :to => user.email,
@@ -75,13 +69,9 @@ class Notifier < ActionMailer::Base
       @from_user = message.sender.display_name
       @text = message.body
       @title = message.title
-      @readurl = url_for(:host => SERVER_URL,
-                         :protocol => SERVER_PROTOCOL,
-                         :controller => "message", :action => "read",
+      @readurl = url_for(:controller => "message", :action => "read",
                          :message_id => message.id)
-      @replyurl = url_for(:host => SERVER_URL,
-                          :protocol => SERVER_PROTOCOL,
-                          :controller => "message", :action => "reply",
+      @replyurl = url_for(:controller => "message", :action => "reply",
                           :message_id => message.id)
       @author = @from_user
 
@@ -99,26 +89,21 @@ class Notifier < ActionMailer::Base
       @from_user = comment.user.display_name
       @text = comment.body
       @title = comment.diary_entry.title
-      @readurl = url_for(:host => SERVER_URL,
-                         :protocol => SERVER_PROTOCOL,
-                         :controller => "diary_entry",
+      @readurl = url_for(:controller => "diary_entry",
                          :action => "view",
                          :display_name => comment.diary_entry.user.display_name,
                          :id => comment.diary_entry.id,
                          :anchor => "comment#{comment.id}")
-      @commenturl = url_for(:host => SERVER_URL,
-                            :protocol => SERVER_PROTOCOL,
-                            :controller => "diary_entry",
+      @commenturl = url_for(:controller => "diary_entry",
                             :action => "view",
                             :display_name => comment.diary_entry.user.display_name,
                             :id => comment.diary_entry.id,
                             :anchor => "newcomment")
-      @replyurl = url_for(:host => SERVER_URL,
-                          :protocol => SERVER_PROTOCOL,
-                          :controller => "message",
+      @replyurl = url_for(:controller => "message",
                           :action => "new",
                           :display_name => comment.user.display_name,
                           :title => "Re: #{comment.diary_entry.title}")
+
       @author = @from_user
 
       attach_user_avatar(comment.user)
@@ -132,13 +117,9 @@ class Notifier < ActionMailer::Base
   def friend_notification(friend)
     with_recipient_locale friend.befriendee do
       @friend = friend
-      @viewurl = url_for(:host => SERVER_URL,
-                         :protocol => SERVER_PROTOCOL,
-                         :controller => "user", :action => "view",
+      @viewurl = url_for(:controller => "user", :action => "view",
                          :display_name => @friend.befriender.display_name)
-      @friendurl = url_for(:host => SERVER_URL,
-                           :protocol => SERVER_PROTOCOL,
-                           :controller => "user", :action => "make_friend",
+      @friendurl = url_for(:controller => "user", :action => "make_friend",
                            :display_name => @friend.befriender.display_name)
       @author = @friend.befriender.display_name
 
@@ -150,7 +131,7 @@ class Notifier < ActionMailer::Base
 
   def note_comment_notification(comment, recipient)
     with_recipient_locale recipient do
-      @noteurl = browse_note_url(comment.note, :host => SERVER_URL)
+      @noteurl = browse_note_url(comment.note)
       @place = Nominatim.describe_location(comment.note.lat, comment.note.lon, 14, I18n.locale)
       @comment = comment.body
       @owner = recipient == comment.note.author
@@ -178,7 +159,7 @@ class Notifier < ActionMailer::Base
   def changeset_comment_notification(comment, recipient)
     with_recipient_locale recipient do
       @to_user = recipient.display_name
-      @changeset_url = changeset_url(comment.changeset, :host => SERVER_URL)
+      @changeset_url = changeset_url(comment.changeset)
       @comment = comment.body
       @owner = recipient == comment.changeset.user
       @commenter = comment.author.display_name
@@ -202,7 +183,7 @@ class Notifier < ActionMailer::Base
   private
 
   def set_shared_template_vars
-    @root_url = root_url(:host => SERVER_URL)
+    @root_url = root_url
   end
 
   def attach_project_logo

--- a/app/views/notifier/_message_body.html.erb
+++ b/app/views/notifier/_message_body.html.erb
@@ -10,7 +10,7 @@
             height: 50,
             border: 0
           ),
-          user_url(@author, :host => SERVER_URL),
+          user_url(@author),
           :target => "_blank"
       ) %>
     </td>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,8 +43,5 @@ module OpenStreetMap
       config.logstasher.logger_path = LOGSTASH_PATH
       config.logstasher.log_controller_parameters = true
     end
-
-    # Set the host and protocol for all action mailer urls
-    config.action_mailer.default_url_options = { :host => SERVER_URL, :protocol => SERVER_PROTOCOL }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,8 @@ module OpenStreetMap
       config.logstasher.logger_path = LOGSTASH_PATH
       config.logstasher.log_controller_parameters = true
     end
+
+    # Set the host and protocol for all action mailer urls
+    config.action_mailer.default_url_options = { :host => SERVER_URL, :protocol => SERVER_PROTOCOL }
   end
 end

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -5,3 +5,6 @@ ActionMailer::Base.smtp_settings = {
   :domain => "localhost",
   :enable_starttls_auto => false
 }
+
+# Set the host and protocol for all action mailer urls
+ActionMailer::Base.default_url_options = { :host => SERVER_URL, :protocol => SERVER_PROTOCOL }


### PR DESCRIPTION
This saves having to repeat the same host and protocol options throughout the notifiers.