### PR TITLE
Pluralise user_preferences_controller

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,7 +35,7 @@ Lint/AssignmentInCondition:
     - 'app/controllers/notes_controller.rb'
     - 'app/controllers/trace_controller.rb'
     - 'app/controllers/user_controller.rb'
-    - 'app/controllers/user_preference_controller.rb'
+    - 'app/controllers/user_preferences_controller.rb'
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/browse_helper.rb'
     - 'app/models/client_application.rb'

--- a/app/controllers/user_preferences_controller.rb
+++ b/app/controllers/user_preferences_controller.rb
@@ -1,5 +1,5 @@
 # Update and read user preferences, which are arbitrayr key/val pairs
-class UserPreferenceController < ApplicationController
+class UserPreferencesController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :authorize
   before_action :require_allow_read_prefs, :only => [:read_one, :read]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,11 +68,11 @@ OpenStreetMap::Application.routes.draw do
     get "user/details" => "user#api_details"
     get "user/gpx_files" => "user#api_gpx_files"
 
-    get "user/preferences" => "user_preference#read"
-    get "user/preferences/:preference_key" => "user_preference#read_one"
-    put "user/preferences" => "user_preference#update"
-    put "user/preferences/:preference_key" => "user_preference#update_one"
-    delete "user/preferences/:preference_key" => "user_preference#delete_one"
+    get "user/preferences" => "user_preferences#read"
+    get "user/preferences/:preference_key" => "user_preferences#read_one"
+    put "user/preferences" => "user_preferences#update"
+    put "user/preferences/:preference_key" => "user_preferences#update_one"
+    delete "user/preferences/:preference_key" => "user_preferences#delete_one"
 
     post "gpx/create" => "trace#api_create"
     get "gpx/:id" => "trace#api_read", :id => /\d+/

--- a/test/controllers/user_preferences_controller_test.rb
+++ b/test/controllers/user_preferences_controller_test.rb
@@ -1,28 +1,28 @@
 require "test_helper"
 
-class UserPreferenceControllerTest < ActionController::TestCase
+class UserPreferencesControllerTest < ActionController::TestCase
   ##
   # test all routes which lead to this controller
   def test_routes
     assert_routing(
       { :path => "/api/0.6/user/preferences", :method => :get },
-      { :controller => "user_preference", :action => "read" }
+      { :controller => "user_preferences", :action => "read" }
     )
     assert_routing(
       { :path => "/api/0.6/user/preferences", :method => :put },
-      { :controller => "user_preference", :action => "update" }
+      { :controller => "user_preferences", :action => "update" }
     )
     assert_routing(
       { :path => "/api/0.6/user/preferences/key", :method => :get },
-      { :controller => "user_preference", :action => "read_one", :preference_key => "key" }
+      { :controller => "user_preferences", :action => "read_one", :preference_key => "key" }
     )
     assert_routing(
       { :path => "/api/0.6/user/preferences/key", :method => :put },
-      { :controller => "user_preference", :action => "update_one", :preference_key => "key" }
+      { :controller => "user_preferences", :action => "update_one", :preference_key => "key" }
     )
     assert_routing(
       { :path => "/api/0.6/user/preferences/key", :method => :delete },
-      { :controller => "user_preference", :action => "delete_one", :preference_key => "key" }
+      { :controller => "user_preferences", :action => "delete_one", :preference_key => "key" }
     )
   end
 


### PR DESCRIPTION
This is the rails convention for controllers and can make route generation easier.

http://guides.rubyonrails.org/action_controller_overview.html#controller-naming-convention

There's plenty more renaming that can be done, but most need some refactoring around named paths. This one is completely stand-alone!