### PR TITLE
Use lazy translation lookups for the user_blocks partials

### DIFF
--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -11,14 +11,14 @@
   <td class="<%= c1 %>"><%=h block_status(block) %></td>
   <td class="<%= c1 %>">
     <% if block.revoker_id.nil? %>
-      <%= t('user_block.partial.not_revoked') %>
+      <%= t('.not_revoked') %>
     <% else %>
       <%= link_to h(block.revoker.display_name), user_path(block.revoker) %>
     <% end %>
   </td>
-  <td class="<%= c1 %>"><%= link_to t('user_block.partial.show'), block %></td>
-  <td class="<%= c1 %>"><% if current_user and current_user.id == block.creator_id and block.active? %><%= link_to t('user_block.partial.edit'), edit_user_block_path(block) %><% end %></td>
+  <td class="<%= c1 %>"><%= link_to t('.show'), block %></td>
+  <td class="<%= c1 %>"><% if current_user and current_user.id == block.creator_id and block.active? %><%= link_to t('.edit'), edit_user_block_path(block) %><% end %></td>
   <% if show_revoke_link %>
-  <td class="<%= c1 %>"><% if block.active? %><%= link_to t('user_block.partial.revoke'), :controller => 'user_blocks', :action => 'revoke', :id => block.id %><% end %></td>
+  <td class="<%= c1 %>"><% if block.active? %><%= link_to t('.revoke'), :controller => 'user_blocks', :action => 'revoke', :id => block.id %><% end %></td>
   <% end %>
 </tr>

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -1,14 +1,14 @@
 <table id="block_list" cellpadding="3">
   <tr>
     <% if show_user_name %>
-    <th><%= t'user_block.partial.display_name' %></th>
+    <th><%= t '.display_name' %></th>
     <% end %>
     <% if show_creator_name %>
-    <th><%= t'user_block.partial.creator_name' %></th>
+    <th><%= t '.creator_name' %></th>
     <% end %>
-    <th><%= t'user_block.partial.reason' %></th>
-    <th><%= t'user_block.partial.status' %></th>
-    <th><%= t'user_block.partial.revoker_name' %></th>
+    <th><%= t '.reason' %></th>
+    <th><%= t '.status' %></th>
+    <th><%= t '.revoker_name' %></th>
     <th></th>
     <th></th>
     <% if show_revoke_link %>
@@ -20,16 +20,16 @@
 
 <ul class='secondary-actions'>
   <% if @user_blocks_pages.current_page.number > 1 -%>
-    <li><%= link_to t('user_block.partial.previous'), @params.merge({ :page => @user_blocks_pages.current_page.number - 1 }) %></li>
+    <li><%= link_to t('.previous'), @params.merge({ :page => @user_blocks_pages.current_page.number - 1 }) %></li>
   <% else -%>
-    <li><%= t('user_block.partial.previous') %></li>
+    <li><%= t('.previous') %></li>
   <% end -%>
 
-  <li><%= t('user_block.partial.showing_page', :page => @user_blocks_pages.current_page.number) %></li>
+  <li><%= t('.showing_page', :page => @user_blocks_pages.current_page.number) %></li>
 
   <% if @user_blocks_pages.current_page.number < @user_blocks_pages.page_count -%>
-    <li><%= link_to t('user_block.partial.next'), @params.merge({ :page => @user_blocks_pages.current_page.number + 1 }) %></li>
+    <li><%= link_to t('.next'), @params.merge({ :page => @user_blocks_pages.current_page.number + 1 }) %></li>
   <% else -%>
-    <li><%= t('user_block.partial.next') %></li>
+    <li><%= t('.next') %></li>
   <% end -%>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2159,20 +2159,6 @@ en:
     period:
       one: "1 hour"
       other: "%{count} hours"
-    partial:
-      show: "Show"
-      edit: "Edit"
-      revoke: "Revoke!"
-      confirm: "Are you sure?"
-      display_name: "Blocked User"
-      creator_name: "Creator"
-      reason: "Reason for block"
-      status: "Status"
-      revoker_name: "Revoked by"
-      not_revoked: "(not revoked)"
-      showing_page: "Page %{page}"
-      next: "Next »"
-      previous: "« Previous"
     helper:
       time_future: "Ends in %{time}."
       until_login: "Active until the user logs in."
@@ -2202,6 +2188,21 @@ en:
       back: "View all blocks"
       revoker: "Revoker:"
       needs_view: "The user needs to log in before this block will be cleared."
+  user_blocks:
+    block:
+      not_revoked: "(not revoked)"
+      show: "Show"
+      edit: "Edit"
+      revoke: "Revoke!"
+    blocks:
+      display_name: "Blocked User"
+      creator_name: "Creator"
+      reason: "Reason for block"
+      status: "Status"
+      revoker_name: "Revoked by"
+      showing_page: "Page %{page}"
+      next: "Next »"
+      previous: "« Previous"
   note:
     description:
       opened_at_html: "Created %{when} ago"


### PR DESCRIPTION
Lazy translations are easier to read, to write, and easier to deal with when refactoring things like partial names, controller methods and controller names. 

This is just a first gentle step in a wider project.

@Nikerabbit as per https://github.com/openstreetmap/openstreetmap-website/issues/1289 this PR will involve changing translation keys on Translatewiki, if it is merged.

