### PR TITLE
Use lazy translations where possible

### DIFF
--- a/app/views/browse/_containing_relation.html.erb
+++ b/app/views/browse/_containing_relation.html.erb
@@ -1,8 +1,8 @@
 <li><%=
   linked_name = link_to h(printable_name(containing_relation.relation)), :action => "relation", :id => containing_relation.relation.id.to_s
   if containing_relation.member_role.blank?
-    raw t 'browse.containing_relation.entry', :relation_name => linked_name
+    raw t '.entry', :relation_name => linked_name
   else
-    raw t 'browse.containing_relation.entry_role', :relation_name => linked_name, :relation_role => h(containing_relation.member_role)
+    raw t '.entry_role', :relation_name => linked_name, :relation_role => h(containing_relation.member_role)
   end
 %></li>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -16,7 +16,7 @@
     <% end %>
 
     <% unless relation.relation_members.empty? %>
-      <h4><%= t'browse.relation.members' %></h4>
+      <h4><%= t '.members' %></h4>
       <ul><%= render :partial => "relation_member", :collection => relation.relation_members %></ul>
     <% end %>
   </div>

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -1,12 +1,12 @@
 <%
   member_class = link_class(relation_member.member_type.downcase, relation_member.member)
   linked_name = link_to printable_name(relation_member.member), { :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, :title => link_title(relation_member.member), :rel => link_follow(relation_member.member)
-  type_str = t'browse.relation_member.type.' + relation_member.member_type.downcase
+  type_str = t '.type.' + relation_member.member_type.downcase
 %>
   <li class="<%= member_class %>"><%=
     if relation_member.member_role.blank?
-      raw t'browse.relation_member.entry', :type => type_str, :name => linked_name
+      raw t '.entry', :type => type_str, :name => linked_name
     else
-      raw t'browse.relation_member.entry_role', :type => type_str, :name => linked_name, :role => h(relation_member.member_role)
+      raw t '.entry_role', :type => type_str, :name => linked_name, :role => h(relation_member.member_role)
     end
   %></li>

--- a/app/views/browse/_tag_details.html.erb
+++ b/app/views/browse/_tag_details.html.erb
@@ -1,5 +1,5 @@
 <% unless tag_details.empty? %>
-  <h4><%= t 'browse.tag_details.tags' %></h4>
+  <h4><%= t '.tags' %></h4>
   <table class='browse-tag-list'>
     <%= render :partial => "tag", :collection => tag_details.sort %>
   </table>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -18,14 +18,14 @@
     <% end %>
 
     <% unless way.way_nodes.empty? %>
-      <h4><%= t'browse.way.nodes' %></h4>
+      <h4><%= t '.nodes' %></h4>
       <ul>
         <% way.way_nodes.each do |wn| %>
           <li>
             <%= link_to printable_name(wn.node), { :action => "node", :id => wn.node_id.to_s }, :class => link_class('node', wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) %>
             <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
             <% if related_ways.size > 0 then %>
-              (<%= raw t 'browse.way.also_part_of', :count => related_ways.size, :related_ways => related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, :class => link_class('way', w), :title => link_title(w) ) }.to_sentence %>)
+              (<%= raw t '.also_part_of', :count => related_ways.size, :related_ways => related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, :class => link_class('way', w), :title => link_title(w) ) }.to_sentence %>)
             <% end %>
           </li>
         <% end %>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -1,8 +1,8 @@
-<% set_title(t('browse.changeset.title', :id => @changeset.id)) %>
+<% set_title(t('.title', :id => @changeset.id)) %>
 
 <h2>
   <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-  <%= t('browse.changeset.title', :id => @changeset.id) %>
+  <%= t('.title', :id => @changeset.id) %>
 </h2>
 
 <div class="browse-section">
@@ -11,7 +11,7 @@
 
   <%= render :partial => "tag_details", :object => @changeset.tags.except('comment') %>
 
-  <h4 class="comments-header"><%= t('browse.changeset.discussion') %></h4>
+  <h4 class="comments-header"><%= t('.discussion') %></h4>
 
   <div class="buttons clearfix subscribe-buttons">
     <form action="#" class="hide_unless_logged_in">
@@ -33,7 +33,7 @@
             <% if comment.visible %>
               <li id="c<%= comment.id %>">
                 <small class='deemphasize'>
-                  <%= t("browse.changeset.commented_by",
+                  <%= t(".commented_by",
                     :when => friendly_date(comment.created_at), :exact_time => l(comment.created_at),
                     :user => link_to(h(comment.author.display_name), user_path(comment.author))).html_safe %>
                   <% if current_user and current_user.moderator? %>
@@ -45,7 +45,7 @@
             <% elsif current_user and current_user.moderator? %>
               <li id="c<%= comment.id %>">
                 <small class='deemphasize'>
-                  <%= t("browse.changeset.hidden_commented_by",
+                  <%= t(".hidden_commented_by",
                     :when => friendly_date(comment.created_at), :exact_time => l(comment.created_at),
                     :user => link_to(h(comment.author.display_name), user_path(comment.author))).html_safe %>
                   — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_unhide_url(comment.id) %>"><%= t('javascripts.changesets.show.unhide_comment') %></span>
@@ -60,7 +60,7 @@
   <% end %>
 
   <div class="notice hide_if_logged_in">
-    <%= link_to(t("browse.changeset.join_discussion"), :controller => 'user', :action => 'login', :referer => request.fullpath) %>
+    <%= link_to(t(".join_discussion"), :controller => 'user', :action => 'login', :referer => request.fullpath) %>
   </div>
 
   <% unless @changeset.is_open? %>
@@ -72,7 +72,7 @@
     </form>
   <% else %>
     <div class="notice hide_unless_logged_in">
-    <%= t('browse.changeset.still_open') %>
+    <%= t('.still_open') %>
     </div>
   <% end %>
 
@@ -131,7 +131,7 @@
 <% end %>
 
 <div class='secondary-actions'>
-  <%= link_to(t('browse.changeset.changesetxml'), :controller => "changeset", :action => "read") %>
+  <%= link_to(t('.changesetxml'), :controller => "changeset", :action => "read") %>
   &middot;
-  <%= link_to(t('browse.changeset.osmchangexml'), :controller => "changeset", :action => "download") %>
+  <%= link_to(t('.osmchangexml'), :controller => "changeset", :action => "download") %>
 </div>

--- a/app/views/browse/not_found.html.erb
+++ b/app/views/browse/not_found.html.erb
@@ -1,12 +1,12 @@
 <%
   browse_not_found_type = {
-    'node' => I18n.t('browse.not_found.type.node'),
-    'way' => I18n.t('browse.not_found.type.way'),
-    'relation' => I18n.t('browse.not_found.type.relation'),
-    'changeset' => I18n.t('browse.not_found.type.changeset'),
+    'node' => I18n.t('.type.node'),
+    'way' => I18n.t('.type.way'),
+    'relation' => I18n.t('.type.relation'),
+    'changeset' => I18n.t('.type.changeset'),
   };
 %>
 
 <h2>
     <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-    <%= t'browse.not_found.sorry', :type=> browse_not_found_type[@type] , :id => params[:id] %></h2>
+    <%= t '.sorry', :type=> browse_not_found_type[@type] , :id => params[:id] %></h2>

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -1,12 +1,12 @@
-<% set_title(t('browse.note.title', :id => @note.id)) %>
+<% set_title(t('.title', :id => @note.id)) %>
 
 <h2>
   <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-  <%= t "browse.note.#{@note.status}_title", :note_name => @note.id %>
+  <%= t ".#{@note.status}_title", :note_name => @note.id %>
 </h2>
 
 <div class="browse-section">
-  <h4><%= t('browse.note.description') %></h4>
+  <h4><%= t('.description') %></h4>
   <div class="note-description">
     <%= h(@note_comments.first.body.to_html) %>
   </div>

--- a/app/views/browse/query.html.erb
+++ b/app/views/browse/query.html.erb
@@ -1,22 +1,22 @@
-<% set_title(t "browse.query.title") %>
+<% set_title(t ".title") %>
 
 <h2>
   <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-  <%= t "browse.query.title" %>
+  <%= t ".title" %>
 </h2>
 
 <div class="query-intro">
-  <p><%= t("browse.query.introduction") %></p>
+  <p><%= t(".introduction") %></p>
 </div>
 
 <div id="query-nearby" class="query-results">
-  <h3><%= t("browse.query.nearby") %></h3>
+  <h3><%= t(".nearby") %></h3>
   <%= image_tag "searching.gif", :class => "loader" %>
   <ul class="query-results-list"></ul>
 </div>
 
 <div id="query-isin" class="query-results">
-  <h3><%= t("browse.query.enclosing") %></h3>
+  <h3><%= t(".enclosing") %></h3>
   <%= image_tag "searching.gif", :class => "loader" %>
   <ul class="query-results-list"></ul>
 </div>

--- a/app/views/browse/timeout.html.erb
+++ b/app/views/browse/timeout.html.erb
@@ -1,12 +1,12 @@
 <%
   browse_timeout_type = {
-    'node' => I18n.t('browse.timeout.type.node'),
-    'way' => I18n.t('browse.timeout.type.way'),
-    'relation' => I18n.t('browse.timeout.type.relation'),
-    'changeset' => I18n.t('browse.timeout.type.changeset'),
+    'node' => I18n.t('.type.node'),
+    'way' => I18n.t('.type.way'),
+    'relation' => I18n.t('.type.relation'),
+    'changeset' => I18n.t('.type.changeset'),
   };
 %>
 <div class="browse-section">
   <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-  <%= t'browse.timeout.sorry', :type=> browse_timeout_type[@type] , :id => params[:id] %>
+  <%= t '.sorry', :type=> browse_timeout_type[@type] , :id => params[:id] %>
 </div>

--- a/app/views/changeset/list.html.erb
+++ b/app/views/changeset/list.html.erb
@@ -4,14 +4,14 @@
   </ol>
 <% if @edits.size == 20 -%>
   <div class="changeset_more">
-    <%= link_to t('changeset.list.load_more'), url_for(@params.merge(:max_id => @edits.last.id - 1)), :class => "button load_more" %>
+    <%= link_to t('.load_more'), url_for(@params.merge(:max_id => @edits.last.id - 1)), :class => "button load_more" %>
     <%= image_tag "searching.gif", :class => "loader", :style => "display: none;" %>
   </div>
 <% end -%>
 <% elsif params[:bbox] %>
-  <div class="inner22"><%= t(params[:max_id] ? 'changeset.list.no_more_area' : 'changeset.list.empty_area') %></div>
+  <div class="inner22"><%= t(params[:max_id] ? '.no_more_area' : '.empty_area') %></div>
 <% elsif params[:display_name] %>
-  <div class="inner22"><%= t(params[:max_id] ? 'changeset.list.no_more_user' : 'changeset.list.empty_user') %></div>
+  <div class="inner22"><%= t(params[:max_id] ? '.no_more_user' : '.empty_user') %></div>
 <% else %>
-  <div class="inner22"><%= t(params[:max_id] ? 'changeset.list.no_more' : 'changeset.list.empty') %></div>
+  <div class="inner22"><%= t(params[:max_id] ? '.no_more' : '.empty') %></div>
 <% end %>

--- a/app/views/changeset/timeout.atom.builder
+++ b/app/views/changeset/timeout.atom.builder
@@ -6,7 +6,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
 
   feed.subtitle :type => "xhtml" do |xhtml|
     xhtml.p do |p|
-      p << t("changeset.timeout.sorry")
+      p << t(".sorry")
     end
   end
 end

--- a/app/views/changeset/timeout.html.erb
+++ b/app/views/changeset/timeout.html.erb
@@ -1,1 +1,1 @@
-<p><%= t'changeset.timeout.sorry' %></p>
+<p><%= t '.sorry' %></p>

--- a/app/views/diary_entry/_diary_comment.html.erb
+++ b/app/views/diary_entry/_diary_comment.html.erb
@@ -1,8 +1,8 @@
 <div class="clearfix diary-comment">
   <%= user_thumbnail diary_comment.user %>
-  <p class="deemphasize comment-heading" id="comment<%= diary_comment.id %>"><%= raw(t('diary_entry.diary_comment.comment_from', :link_user => (link_to h(diary_comment.user.display_name), user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}"))) %></p>
+  <p class="deemphasize comment-heading" id="comment<%= diary_comment.id %>"><%= raw(t('.comment_from', :link_user => (link_to h(diary_comment.user.display_name), user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}"))) %></p>
   <div class="richtext"><%= diary_comment.body.to_html %></div>
   <%= if_administrator(:span) do %>
-    <%= link_to t('diary_entry.diary_comment.hide_link'), hide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data=> { :confirm => t('diary_entry.diary_comment.confirm') } %>
+    <%= link_to t('.hide_link'), hide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data=> { :confirm => t('.confirm') } %>
   <% end %>
 </div>

--- a/app/views/diary_entry/_diary_entry.html.erb
+++ b/app/views/diary_entry/_diary_entry.html.erb
@@ -7,7 +7,7 @@
     <h2><%= link_to h(diary_entry.title), :action => 'view', :display_name => diary_entry.user.display_name, :id => diary_entry.id %></h2>
 
     <small class='deemphasize'>
-      <%= raw(t 'diary_entry.diary_entry.posted_by', :link_user => (link_to h(diary_entry.user.display_name), user_path(diary_entry.user)), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to h(diary_entry.language.name), :controller => 'diary_entry', :action => 'list', :display_name => nil, :language => diary_entry.language_code)) %>
+      <%= raw(t '.posted_by', :link_user => (link_to h(diary_entry.user.display_name), user_path(diary_entry.user)), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to h(diary_entry.language.name), :controller => 'diary_entry', :action => 'list', :display_name => nil, :language => diary_entry.language_code)) %>
     </small>
 
   </div>
@@ -22,17 +22,17 @@
 
   <ul class='secondary-actions clearfix'>
     <% if params[:action] == 'list' %>
-      <li><%= link_to t('diary_entry.diary_entry.comment_link'), :action => 'view', :display_name => diary_entry.user.display_name, :id => diary_entry.id, :anchor => 'newcomment' %></li>
-      <li><%= link_to t('diary_entry.diary_entry.reply_link'), :controller => 'message', :action => 'new', :display_name => diary_entry.user.display_name, :message => { :title => "Re: #{diary_entry.title}" } %></li>
-      <li><%= link_to t('diary_entry.diary_entry.comment_count', :count => diary_entry.visible_comments.count), :action => 'view', :display_name => diary_entry.user.display_name, :id => diary_entry.id, :anchor => 'comments' %></li>
+      <li><%= link_to t('.comment_link'), :action => 'view', :display_name => diary_entry.user.display_name, :id => diary_entry.id, :anchor => 'newcomment' %></li>
+      <li><%= link_to t('.reply_link'), :controller => 'message', :action => 'new', :display_name => diary_entry.user.display_name, :message => { :title => "Re: #{diary_entry.title}" } %></li>
+      <li><%= link_to t('.comment_count', :count => diary_entry.visible_comments.count), :action => 'view', :display_name => diary_entry.user.display_name, :id => diary_entry.id, :anchor => 'comments' %></li>
     <% end %>
 
     <%= if_user(diary_entry.user, :li) do %>
-      <%= link_to t('diary_entry.diary_entry.edit_link'), :action => 'edit', :display_name => diary_entry.user.display_name, :id => diary_entry.id %>
+      <%= link_to t('.edit_link'), :action => 'edit', :display_name => diary_entry.user.display_name, :id => diary_entry.id %>
     <% end %>
 
     <%= if_administrator(:li) do %>
-      <%= link_to t('diary_entry.diary_entry.hide_link'), hide_diary_entry_path(:display_name => diary_entry.user.display_name, :id => diary_entry.id), :method => :post, :data => { :confirm => t('diary_entry.diary_entry.confirm') } %>
+      <%= link_to t('.hide_link'), hide_diary_entry_path(:display_name => diary_entry.user.display_name, :id => diary_entry.id), :method => :post, :data => { :confirm => t('.confirm') } %>
     <% end %>
   </ul>
 </div>

--- a/app/views/diary_entry/_location.html.erb
+++ b/app/views/diary_entry/_location.html.erb
@@ -1,4 +1,4 @@
-<%= t 'diary_entry.location.location' %>
+<%= t '.location' %>
 
 <a href="<%= url_for :controller => 'site', :action => 'index', :anchor => "map=14/#{location.latitude}/#{location.longitude}" %>">
 <abbr class="geo" title="<%= number_with_precision(location.latitude, :precision => 4) %>; <%= number_with_precision(location.longitude, :precision => 4) %>">

--- a/app/views/diary_entry/comments.html.erb
+++ b/app/views/diary_entry/comments.html.erb
@@ -1,24 +1,24 @@
 <% content_for :heading do %>
-  <h1><%= t('diary_entry.comments.has_commented_on', :display_name => @user.display_name) %></h1>
+  <h1><%= t('.has_commented_on', :display_name => @user.display_name) %></h1>
 <% end %>
 
 <table class="messages" width="100%">
   <tr>
-    <th width="25%"><%= t 'diary_entry.comments.post' %></th>
-    <th width="25%"><%= t 'diary_entry.comments.when' %></th>
-    <th width="50%"><%= t 'diary_entry.comments.comment' %></th>
+    <th width="25%"><%= t '.post' %></th>
+    <th width="25%"><%= t '.when' %></th>
+    <th width="50%"><%= t '.comment' %></th>
   </tr>
   <% @comments.each do |comment| -%>
   <% cl = cycle('table0', 'table1') %>
   <tr class="<%= cl %>">
     <td width="25%"><%= link_to comment.diary_entry.title, :action => :view, :display_name => comment.diary_entry.user.display_name, :id => comment.diary_entry.id %></td>
-    <td width="25%"><span title="<%= l comment.created_at, :format => :friendly %>"><%= t 'diary_entry.comments.ago', :ago => time_ago_in_words(comment.created_at) %></span></td>
+    <td width="25%"><span title="<%= l comment.created_at, :format => :friendly %>"><%= t '.ago', :ago => time_ago_in_words(comment.created_at) %></span></td>
     <td width="50%" class="richtext"><%= comment.body.to_html %></td>
   </tr>
   <% end -%>
 </table>
 
 <div class='secondary-actions clearfix'>
-  <span><%= link_to t('diary_entry.comments.older_comments') , { :page => @comment_pages.current.next} if @comment_pages.current.next %>
-  <%= link_to t('diary_entry.comments.newer_comments'), { :page => @comment_pages.current.previous } if @comment_pages.current.previous %></span>
+  <span><%= link_to t('.older_comments') , { :page => @comment_pages.current.next} if @comment_pages.current.next %>
+  <%= link_to t('.newer_comments'), { :page => @comment_pages.current.previous } if @comment_pages.current.previous %></span>
 </div>

--- a/app/views/diary_entry/edit.html.erb
+++ b/app/views/diary_entry/edit.html.erb
@@ -12,32 +12,32 @@
   <div class="diary_entry standard-form">
     <fieldset>
       <div class='form-row'>
-        <label class="standard-label"><%= t 'diary_entry.edit.subject' -%></label>
+        <label class="standard-label"><%= t '.subject' -%></label>
         <%= f.text_field :title, :class => "richtext_title" %>
       </div>
       <div class='form-row'>
-        <label class="standard-label"><%= t 'diary_entry.edit.body' -%></label>
+        <label class="standard-label"><%= t '.body' -%></label>
         <%= richtext_area :diary_entry, :body, :cols => 80, :rows => 20, :format => @diary_entry.body_format %>
       </div>
       <div class='form-row'>
-        <label class="standard-label"><%= t 'diary_entry.edit.language' -%></label>
+        <label class="standard-label"><%= t '.language' -%></label>
         <%= f.collection_select :language_code, Language.order(:english_name), :code, :name %>
     </div>
     </fieldset>
     <fieldset class='location'>
-      <label class="standard-label"><%= t 'diary_entry.edit.location' -%></label>
+      <label class="standard-label"><%= t '.location' -%></label>
       <%= content_tag "div", "", :id => "map", :data => {:lat => @lat, :lon => @lon, :zoom => @zoom} %>
       <div class='form-row clearfix'>
         <div class='form-column'>
-          <label class="secondary standard-label"><%= t 'diary_entry.edit.latitude' -%></label>
+          <label class="secondary standard-label"><%= t '.latitude' -%></label>
           <%= f.text_field :latitude, :size => 20, :id => "latitude" %>
         </div>
         <div class='form-column'>
-          <label class="secondary standard-label"><%= t 'diary_entry.edit.longitude' -%></label>
+          <label class="secondary standard-label"><%= t '.longitude' -%></label>
           <%= f.text_field :longitude, :size => 20, :id => "longitude" %>
         </div>
         <div class='form-column'>
-          <a href="#" id="usemap"><%= t 'diary_entry.edit.use_map_link' -%></a>
+          <a href="#" id="usemap"><%= t '.use_map_link' -%></a>
         </div>
       </div>
     </fieldset>
@@ -45,7 +45,7 @@
     <% if action_name == 'new' %>
       <%= submit_tag t('diary_entry.new.publish_button') %>
     <% else %>
-      <%= submit_tag t('diary_entry.edit.save_button') %>
+      <%= submit_tag t('.save_button') %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/diary_entry/list.html.erb
+++ b/app/views/diary_entry/list.html.erb
@@ -12,11 +12,11 @@
 
       <% if @user %>
         <%= if_user(@user) do %>
-          <li><%= link_to image_tag("new.png", :class => "small_icon", :border=>0) + t('diary_entry.list.new'), {:controller => 'diary_entry', :action => 'new'}, {:title => t('diary_entry.list.new_title')} %></li>
+          <li><%= link_to image_tag("new.png", :class => "small_icon", :border=>0) + t('.new'), {:controller => 'diary_entry', :action => 'new'}, {:title => t('.new_title')} %></li>
         <% end %>
       <% else %>
         <%= if_logged_in do %>
-          <li><%= link_to image_tag("new.png", :class => "small_icon", :border=>0) + t('diary_entry.list.new'), {:controller => 'diary_entry', :action => 'new'}, {:title => t('diary_entry.list.new_title')} %></li>
+          <li><%= link_to image_tag("new.png", :class => "small_icon", :border=>0) + t('.new'), {:controller => 'diary_entry', :action => 'new'}, {:title => t('.new_title')} %></li>
         <% end %>
       <% end %>
     </ul>
@@ -24,9 +24,9 @@
 <% end %>
 
 <% if @entries.empty? %>
-  <h4><%= t 'diary_entry.list.no_entries' %></h4>
+  <h4><%= t '.no_entries' %></h4>
 <% else %>
-  <h4><%= t 'diary_entry.list.recent_entries' %></h4>
+  <h4><%= t '.recent_entries' %></h4>
 
   <% if @user %>
     <%= render :partial => 'diary_entry', :collection => @entries %>
@@ -36,17 +36,17 @@
 
   <div class="pagination">
     <% if @entries.size < @page_size -%>
-      <%= t('diary_entry.list.older_entries') %>
+      <%= t('.older_entries') %>
     <% else -%>
-      <%= link_to t('diary_entry.list.older_entries'), @params.merge(:page => @page + 1 ) %>
+      <%= link_to t('.older_entries'), @params.merge(:page => @page + 1 ) %>
     <% end -%>
 
     |
 
     <% if @page > 1 -%>
-      <%= link_to t('diary_entry.list.newer_entries'), @params.merge(:page => @page - 1) %>
+      <%= link_to t('.newer_entries'), @params.merge(:page => @page - 1) %>
     <% else -%>
-      <%= t('diary_entry.list.newer_entries') %>
+      <%= t('.newer_entries') %>
     <% end -%>
   </div>
 <% end %>

--- a/app/views/diary_entry/no_such_entry.html.erb
+++ b/app/views/diary_entry/no_such_entry.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t 'diary_entry.no_such_entry.heading', :id => h(params[:id]) %></h2>
+  <h2><%= t '.heading', :id => h(params[:id]) %></h2>
 <% end %>
 
-<p><%= t 'diary_entry.no_such_entry.body', :id => h(params[:id]) %></p>
+<p><%= t '.body', :id => h(params[:id]) %></p>

--- a/app/views/diary_entry/view.html.erb
+++ b/app/views/diary_entry/view.html.erb
@@ -1,7 +1,7 @@
 <% content_for :heading do %>
   <div id="userinformation" >
     <%= user_image @entry.user %>
-    <h2><%= link_to t('diary_entry.view.user_title', :user => h(@entry.user.display_name)), :action => :list %></h2>
+    <h2><%= link_to t('.user_title', :user => h(@entry.user.display_name)), :action => :list %></h2>
     <p><%= rss_link_to :action => :rss, :display_name => @entry.user.display_name %></p>
   </div>
 <% end %>
@@ -13,13 +13,13 @@
 <%= render :partial => 'diary_comment', :collection => @entry.visible_comments %>
 </div>
 <%= if_logged_in(:div) do %>
-  <h3 id="newcomment"><%= t 'diary_entry.view.leave_a_comment' %></h3>
+  <h3 id="newcomment"><%= t '.leave_a_comment' %></h3>
 
   <%= error_messages_for 'diary_comment' %>
 
   <%= form_for :diary_comment, :url => { :action => 'comment' } do |f| %>
     <%= richtext_area :diary_comment, :body, :cols => 80, :rows => 15 %>
-    <%= submit_tag t('diary_entry.view.save_button') %>
+    <%= submit_tag t('.save_button') %>
   <% end %>
   <% if current_user and @entry.subscribers.exists?(current_user.id) %>
     <div class="diary-subscribe-buttons"><%= link_to t('javascripts.changesets.show.unsubscribe'), diary_entry_unsubscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => :button %></div>
@@ -29,7 +29,7 @@
 <% end %>
 
 <%= if_not_logged_in(:div) do %>
-  <h3 id="newcomment"><%= raw t("diary_entry.view.login_to_leave_a_comment", :login_link => link_to(t("diary_entry.view.login"), :controller => 'user', :action => 'login', :referer => request.fullpath)) %></h3>
+  <h3 id="newcomment"><%= raw t(".login_to_leave_a_comment", :login_link => link_to(t(".login"), :controller => 'user', :action => 'login', :referer => request.fullpath)) %></h3>
 <% end %>
 
 <% content_for :auto_discovery_link_tag do -%>

--- a/app/views/geocoder/results.html.erb
+++ b/app/views/geocoder/results.html.erb
@@ -1,5 +1,5 @@
 <% if @results.empty? %>
-  <p class="search_results_entry inner12"><%= t 'geocoder.results.no_results' %></p>
+  <p class="search_results_entry inner12"><%= t '.no_results' %></p>
 <% else %>
   <ul class='results-list'>
     <% @results.each do |result| %>
@@ -8,7 +8,7 @@
   </ul>
   <% if @more_params %>
     <div class="search_more">
-      <%= link_to t('geocoder.results.more_results'), url_for(@more_params), :class => "button load_more" %>
+      <%= link_to t('.more_results'), url_for(@more_params), :class => "button load_more" %>
       <%= image_tag "searching.gif", :class => "loader", :style => "display: none;" %>
     </div>
   <% end %>

--- a/app/views/geocoder/search.html.erb
+++ b/app/views/geocoder/search.html.erb
@@ -3,7 +3,7 @@
 	<%= t('site.sidebar.search_results') %>
 </h2>
 <% @sources.each do |source| %>
-  <h4 class="inner12"><%= raw(t "geocoder.search.title.#{source}") %></h4>
+  <h4 class="inner12"><%= raw(t ".title.#{source}") %></h4>
   <div class="search_results_entry" data-href="<%= url_for @params.merge(:action => "search_#{source}") %>">
     <%= image_tag "searching.gif", :class => "loader" %>
   </div>

--- a/app/views/message/_message_summary.html.erb
+++ b/app/views/message/_message_summary.html.erb
@@ -2,7 +2,7 @@
   <td class="inbox-sender"><%= link_to h(message_summary.sender.display_name), user_path(message_summary.sender) %></td>
   <td class="inbox-subject"><%= link_to h(message_summary.title), :controller => 'message', :action => 'read', :message_id => message_summary.id  %></td>
   <td class="inbox-sent"><%= l message_summary.sent_on, :format => :friendly %></td>
-  <td class="inbox-mark-unread"><%= button_to t('message.message_summary.unread_button'), {:controller => 'message', :action => 'mark', :message_id => message_summary.id, :mark => 'unread'}, { :remote => true } %></td>
-  <td class="inbox-mark-read"><%= button_to t('message.message_summary.read_button'), {:controller => 'message', :action => 'mark', :message_id => message_summary.id, :mark => 'read'}, { :remote => true } %></td>
-  <td class="inbox-delete"><%= button_to t('message.message_summary.delete_button'), {:controller => 'message', :action => 'delete', :message_id => message_summary.id, :referer => request.fullpath}, { :remote => true } %></td>
+  <td class="inbox-mark-unread"><%= button_to t('.unread_button'), {:controller => 'message', :action => 'mark', :message_id => message_summary.id, :mark => 'unread'}, { :remote => true } %></td>
+  <td class="inbox-mark-read"><%= button_to t('.read_button'), {:controller => 'message', :action => 'mark', :message_id => message_summary.id, :mark => 'read'}, { :remote => true } %></td>
+  <td class="inbox-delete"><%= button_to t('.delete_button'), {:controller => 'message', :action => 'delete', :message_id => message_summary.id, :referer => request.fullpath}, { :remote => true } %></td>
 </tr>

--- a/app/views/message/_sent_message_summary.html.erb
+++ b/app/views/message/_sent_message_summary.html.erb
@@ -2,5 +2,5 @@
   <td class="inbox-sender"><%= link_to h(sent_message_summary.recipient.display_name), user_path(sent_message_summary.recipient) %></td>
   <td class="inbox-subject"><%= link_to h(sent_message_summary.title), :controller => 'message', :action => 'read', :message_id => sent_message_summary.id  %></td>
   <td class="inbox-sent"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
-  <td class="inbox-delete"><%= button_to t('message.sent_message_summary.delete_button'), :controller => 'message', :action => 'delete', :message_id => sent_message_summary.id, :referer => request.fullpath %></td>
+  <td class="inbox-delete"><%= button_to t('.delete_button'), :controller => 'message', :action => 'delete', :message_id => sent_message_summary.id, :referer => request.fullpath %></td>
 </tr>

--- a/app/views/message/inbox.html.erb
+++ b/app/views/message/inbox.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t'message.inbox.my_inbox'%>/<%= link_to t('message.inbox.outbox'), outbox_path(current_user.display_name) %></h2>
+  <h2><%= t '.my_inbox'%>/<%= link_to t('.outbox'), outbox_path(current_user.display_name) %></h2>
 <% end %>
 
   <h4><%= render :partial => "message_count" %></h4>
@@ -8,9 +8,9 @@
   <table class="messages">
     <thead>
       <tr>
-        <th><%= t'message.inbox.from' %></th>
-        <th><%= t'message.inbox.subject' %></th>
-        <th><%= t'message.inbox.date' %></th>
+        <th><%= t '.from' %></th>
+        <th><%= t '.subject' %></th>
+        <th><%= t '.date' %></th>
         <th></th>
         <th></th>
       </tr>
@@ -20,5 +20,5 @@
     </tbody>
   </table>
 <% else %>
-  <div><%= raw(t'message.inbox.no_messages_yet', :people_mapping_nearby_link => link_to(t('message.inbox.people_mapping_nearby'), user_path(current_user))) %></div>
+  <div><%= raw(t '.no_messages_yet', :people_mapping_nearby_link => link_to(t('.people_mapping_nearby'), user_path(current_user))) %></div>
 <% end %>

--- a/app/views/message/new.html.erb
+++ b/app/views/message/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= raw(t'message.new.send_message_to', :name => link_to(h(@message.recipient.display_name), user_path(@message.recipient))) %></h2>
+  <h2><%= raw(t '.send_message_to', :name => link_to(h(@message.recipient.display_name), user_path(@message.recipient))) %></h2>
 <% end %>
 
 <%= error_messages_for 'message' %>
@@ -7,16 +7,16 @@
 <%= form_for :message, :html => { :class => 'standard-form' }, :url => { :action => "new", :display_name => @message.recipient.display_name } do |f| %>
   <fieldset>
     <div class='form-row'>
-      <label class="standard-label" for="message_title"><%= t'message.new.subject' %></label>
+      <label class="standard-label" for="message_title"><%= t '.subject' %></label>
       <%= f.text_field :title, :size => 60, :class => "richtext_title" %>
     </div>
     <div class='form-row'>
-      <label class="standard-label" for="message_body"><%= t'message.new.body' %></label>
+      <label class="standard-label" for="message_body"><%= t '.body' %></label>
       <%= richtext_area :message, :body, :cols => 80, :rows => 20 %>
     </div>
     <div class='buttons'>
-      <%= submit_tag t('message.new.send_button') %>
-      <%= link_to t('message.new.back_to_inbox'), { :controller => 'message', :action => 'inbox', :display_name => current_user.display_name }, :class => 'deemphasize button' %>
+      <%= submit_tag t('.send_button') %>
+      <%= link_to t('.back_to_inbox'), { :controller => 'message', :action => 'inbox', :display_name => current_user.display_name }, :class => 'deemphasize button' %>
     </div>
   </fieldset>
 <% end %>

--- a/app/views/message/no_such_message.html.erb
+++ b/app/views/message/no_such_message.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t'message.no_such_message.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
 <% end %>
 
-<p><%= t'message.no_such_message.body' %></p>
+<p><%= t '.body' %></p>

--- a/app/views/message/outbox.html.erb
+++ b/app/views/message/outbox.html.erb
@@ -1,16 +1,16 @@
 <% content_for :heading do %>
-  <h2><%= raw(t'message.outbox.my_inbox', :inbox_link => link_to(t('message.outbox.inbox'), inbox_path(current_user.display_name))) %>/<%= t'message.outbox.outbox' %></h2>
+  <h2><%= raw(t '.my_inbox', :inbox_link => link_to(t('.inbox'), inbox_path(current_user.display_name))) %>/<%= t'.outbox' %></h2>
 <% end %>
 
-<h4><%= t'message.outbox.messages', :count => current_user.sent_messages.size %></h4>
+<h4><%= t '.messages', :count => current_user.sent_messages.size %></h4>
 
 <% if current_user.sent_messages.size > 0 %>
   <table class="messages">
     <thead>
       <tr>
-        <th><%= t'message.outbox.to' %></th>
-        <th><%= t'message.outbox.subject' %></th>
-        <th><%= t'message.outbox.date' %></th>
+        <th><%= t '.to' %></th>
+        <th><%= t '.subject' %></th>
+        <th><%= t '.date' %></th>
         <th></th>
       </tr>
     </thead>
@@ -19,5 +19,5 @@
     </tbody>
   </table>
 <% else %>
-  <div class="messages"><%= raw(t'message.outbox.no_sent_messages', :people_mapping_nearby_link => link_to(t('message.outbox.people_mapping_nearby'), user_path(current_user))) %></div>
+  <div class="messages"><%= raw(t '.no_sent_messages', :people_mapping_nearby_link => link_to(t('.people_mapping_nearby'), user_path(current_user))) %></div>
 <% end %>

--- a/app/views/message/read.html.erb
+++ b/app/views/message/read.html.erb
@@ -14,9 +14,9 @@
   <div class="richtext"><%= @message.body.to_html %></div>
 
   <div class='message-buttons buttons'>
-    <%= button_to t('message.read.reply_button'), {:controller => 'message', :action => 'reply', :message_id => @message.id}, :class => 'reply-button' %>
-    <%= button_to t('message.read.unread_button'), {:controller => 'message', :action => 'mark', :message_id => @message.id, :mark => 'unread'}, :class => 'mark-unread-button' %>
-    <%= button_to t('message.read.delete_button'), {:controller => 'message', :action => 'delete', :message_id => @message.id}, :class => 'delete-button' %>
+    <%= button_to t('.reply_button'), {:controller => 'message', :action => 'reply', :message_id => @message.id}, :class => 'reply-button' %>
+    <%= button_to t('.unread_button'), {:controller => 'message', :action => 'mark', :message_id => @message.id, :mark => 'unread'}, :class => 'mark-unread-button' %>
+    <%= button_to t('.delete_button'), {:controller => 'message', :action => 'delete', :message_id => @message.id}, :class => 'delete-button' %>
 
 <% else %>
 
@@ -36,5 +36,5 @@
 
 <% end %>
 
-  <%= link_to t('message.read.back'), {:controller => 'message', :action => 'outbox', :display_name => current_user.display_name }, :class => "button deemphasize" %>
+  <%= link_to t('.back'), {:controller => 'message', :action => 'outbox', :display_name => current_user.display_name }, :class => "button deemphasize" %>
   </div>

--- a/app/views/notifier/changeset_comment_notification.html.erb
+++ b/app/views/notifier/changeset_comment_notification.html.erb
@@ -1,16 +1,16 @@
 <p>
-  <%= t 'notifier.changeset_comment_notification.hi', :to_user => @to_user %>
+  <%= t '.hi', :to_user => @to_user %>
 </p>
 <p>
   <% if @owner %>
-    <%= raw t "notifier.changeset_comment_notification.commented.your_changeset", :commenter => link_to_user(@commenter), :time => @time %>
+    <%= raw t ".commented.your_changeset", :commenter => link_to_user(@commenter), :time => @time %>
   <% else %>
-    <%= raw t "notifier.changeset_comment_notification.commented.commented_changeset", :commenter => link_to_user(@commenter), :time => @time, :changeset_author => @changeset_author %>
+    <%= raw t ".commented.commented_changeset", :commenter => link_to_user(@commenter), :time => @time, :changeset_author => @changeset_author %>
   <% end %>
   <% if @changeset_comment %>
-    <%= raw t "notifier.changeset_comment_notification.commented.partial_changeset_with_comment", :changeset_comment => content_tag("em", @changeset_comment) %>
+    <%= raw t ".commented.partial_changeset_with_comment", :changeset_comment => content_tag("em", @changeset_comment) %>
   <% else %>
-    <%= t "notifier.changeset_comment_notification.commented.partial_changeset_without_comment" %>
+    <%= t ".commented.partial_changeset_without_comment" %>
   <% end %>
 </p>
 
@@ -19,11 +19,11 @@
 <% end %>
 
 <p>
-  <%= raw t 'notifier.changeset_comment_notification.details', :url => link_to(@changeset_url, @changeset_url) %>
+  <%= raw t '.details', :url => link_to(@changeset_url, @changeset_url) %>
 </p>
 
 <% content_for :footer do %>
   <p>
-    <%= raw t 'notifier.changeset_comment_notification.unsubscribe', :url => link_to(@changeset_url, @changeset_url, :style => "color: #222") %>
+    <%= raw t '.unsubscribe', :url => link_to(@changeset_url, @changeset_url, :style => "color: #222") %>
   </p>
 <% end %>

--- a/app/views/notifier/changeset_comment_notification.text.erb
+++ b/app/views/notifier/changeset_comment_notification.text.erb
@@ -1,20 +1,20 @@
-<%= t 'notifier.changeset_comment_notification.hi', :to_user => @to_user %>
+<%= t '.hi', :to_user => @to_user %>
 
 <% if @owner %>
-<%= t "notifier.changeset_comment_notification.commented.your_changeset", :commenter => @commenter, :time => @time %>
+<%= t ".commented.your_changeset", :commenter => @commenter, :time => @time %>
 <% else %>
-<%= t "notifier.changeset_comment_notification.commented.commented_changeset", :commenter => @commenter, :time => @time, :changeset_author => @changeset_author %>
+<%= t ".commented.commented_changeset", :commenter => @commenter, :time => @time, :changeset_author => @changeset_author %>
 <% end %>
 <% if @changeset_comment %>
-<%= t "notifier.changeset_comment_notification.commented.partial_changeset_with_comment", :changeset_comment => @changeset_comment %>
+<%= t ".commented.partial_changeset_with_comment", :changeset_comment => @changeset_comment %>
 <% else %>
-<%= t "notifier.changeset_comment_notification.commented.partial_changeset_without_comment" %>
+<%= t ".commented.partial_changeset_without_comment" %>
 <% end %>
 
 ==
 <%= @comment.to_text %>
 ==
 
-<%= t 'notifier.changeset_comment_notification.details', :url => @changeset_url %>
+<%= t '.details', :url => @changeset_url %>
 
-<%= t 'notifier.changeset_comment_notification.unsubscribe', :url => @changeset_url %>
+<%= t '.unsubscribe', :url => @changeset_url %>

--- a/app/views/notifier/diary_comment_notification.html.erb
+++ b/app/views/notifier/diary_comment_notification.html.erb
@@ -1,8 +1,8 @@
 <p>
-  <%= t'notifier.diary_comment_notification.hi', :to_user => @to_user %>
+  <%= t '.hi', :to_user => @to_user %>
 </p>
 <p>
-  <%= raw t'notifier.diary_comment_notification.header', :from_user => link_to_user(@from_user), :subject => content_tag("em", @title) %>
+  <%= raw t '.header', :from_user => link_to_user(@from_user), :subject => content_tag("em", @title) %>
 </p>
 
 <%= message_body do %>
@@ -10,7 +10,7 @@
 <% end %>
 
 <% content_for :footer do %>
-  <p><%= raw t'notifier.diary_comment_notification.footer',
+  <p><%= raw t '.footer',
              :readurl => link_to(@readurl, @readurl) + tag(:br),
              :commenturl => link_to(@commenturl, @commenturl) + tag(:br),
              :replyurl => link_to(@replyurl, @replyurl)

--- a/app/views/notifier/diary_comment_notification.text.erb
+++ b/app/views/notifier/diary_comment_notification.text.erb
@@ -1,9 +1,9 @@
-<%= t'notifier.diary_comment_notification.hi', :to_user => @to_user %> 
+<%= t '.hi', :to_user => @to_user %>
 
-<%= t'notifier.diary_comment_notification.header', :from_user => @from_user, :subject => @title %>
+<%= t '.header', :from_user => @from_user, :subject => @title %>
 
 ==
 <%= raw @text.to_text %>
 ==
 
-<%= t'notifier.diary_comment_notification.footer', :readurl => @readurl, :commenturl => @commenturl, :replyurl => @replyurl %>
+<%= t '.footer', :readurl => @readurl, :commenturl => @commenturl, :replyurl => @replyurl %>

--- a/app/views/notifier/friend_notification.html.erb
+++ b/app/views/notifier/friend_notification.html.erb
@@ -1,9 +1,9 @@
-<p><%= t 'notifier.friend_notification.had_added_you', :user => @friend.befriender.display_name %></p>
+<p><%= t '.had_added_you', :user => @friend.befriender.display_name %></p>
 
 <%= message_body do %>
-  <p><%= raw t 'notifier.friend_notification.see_their_profile', :userurl => link_to(@viewurl, @viewurl) %></p>
+  <p><%= raw t '.see_their_profile', :userurl => link_to(@viewurl, @viewurl) %></p>
 
   <% unless @friend.befriendee.is_friends_with?(@friend.befriender) -%>
-  <p><%= raw t 'notifier.friend_notification.befriend_them', :befriendurl => link_to(@friendurl, @friendurl) %></p>
+  <p><%= raw t '.befriend_them', :befriendurl => link_to(@friendurl, @friendurl) %></p>
   <% end -%>
 <% end %>

--- a/app/views/notifier/friend_notification.text.erb
+++ b/app/views/notifier/friend_notification.text.erb
@@ -1,7 +1,7 @@
-<%= t 'notifier.friend_notification.had_added_you', :user => @friend.befriender.display_name %>
+<%= t '.had_added_you', :user => @friend.befriender.display_name %>
 
-<%= t 'notifier.friend_notification.see_their_profile', :userurl => @viewurl %>
+<%= t '.see_their_profile', :userurl => @viewurl %>
 
 <% unless @friend.befriendee.is_friends_with?(@friend.befriender) -%>
-<%= t 'notifier.friend_notification.befriend_them', :befriendurl => @friendurl %>
+<%= t '.befriend_them', :befriendurl => @friendurl %>
 <% end -%>

--- a/app/views/notifier/message_notification.html.erb
+++ b/app/views/notifier/message_notification.html.erb
@@ -1,8 +1,8 @@
 <p>
-  <%= t'notifier.message_notification.hi', :to_user => @to_user %>
+  <%= t '.hi', :to_user => @to_user %>
 </p>
 <p>
-  <%= raw t'notifier.message_notification.header',
+  <%= raw t '.header',
           :from_user => link_to_user(@from_user),
           :subject => content_tag("em", @title)
   %>
@@ -14,7 +14,7 @@
 
 <% content_for :footer do %>
   <p>
-    <%= t'notifier.message_notification.footer_html',
+    <%= t '.footer_html',
           :readurl => link_to(@readurl, @readurl) + tag(:br),
           :replyurl => link_to(@replyurl, @replyurl)
     %>

--- a/app/views/notifier/message_notification.text.erb
+++ b/app/views/notifier/message_notification.text.erb
@@ -1,9 +1,9 @@
-<%= raw t'notifier.message_notification.hi', :to_user => @to_user %> 
+<%= raw t '.hi', :to_user => @to_user %>
 
-<%= raw t'notifier.message_notification.header', :from_user => @from_user, :subject => @title %>
+<%= raw t '.header', :from_user => @from_user, :subject => @title %>
 
 ==
 <%= raw @text.to_text %>
 ==
 
-<%= word_wrap(t'notifier.message_notification.footer_html', :readurl => @readurl, :replyurl => @replyurl) %>
+<%= word_wrap(t '.footer_html', :readurl => @readurl, :replyurl => @replyurl) %>

--- a/app/views/notifier/note_comment_notification.html.erb
+++ b/app/views/notifier/note_comment_notification.html.erb
@@ -1,9 +1,9 @@
-<p><%= t 'notifier.note_comment_notification.greeting' %></p>
+<p><%= t '.greeting' %></p>
 
 <% if @owner %>
-  <p><%= raw t "notifier.note_comment_notification.#{@event}.your_note", :commenter => link_to_user(@commenter), :place => @place %></p>
+  <p><%= raw t ".#{@event}.your_note", :commenter => link_to_user(@commenter), :place => @place %></p>
 <% else %>
-  <p><%= raw t "notifier.note_comment_notification.#{@event}.commented_note", :commenter => link_to_user(@commenter), :place => @place %></p>
+  <p><%= raw t ".#{@event}.commented_note", :commenter => link_to_user(@commenter), :place => @place %></p>
 <% end %>
 
 <% unless @comment.empty? %>
@@ -12,4 +12,4 @@
   <% end %>
 <% end %>
 
-<p><%= raw t 'notifier.note_comment_notification.details', :url => link_to(@noteurl, @noteurl) %></p>
+<p><%= raw t '.details', :url => link_to(@noteurl, @noteurl) %></p>

--- a/app/views/notifier/note_comment_notification.text.erb
+++ b/app/views/notifier/note_comment_notification.text.erb
@@ -1,9 +1,9 @@
-<%= t 'notifier.note_comment_notification.greeting' %>
+<%= t '.greeting' %>
 
 <% if @owner %>
-<%= t "notifier.note_comment_notification.#{@event}.your_note", :commenter => @commenter, :place => @place %>
+<%= t ".#{@event}.your_note", :commenter => @commenter, :place => @place %>
 <% else %>
-<%= t "notifier.note_comment_notification.#{@event}.commented_note", :commenter => @commenter, :place => @place %>
+<%= t ".#{@event}.commented_note", :commenter => @commenter, :place => @place %>
 <% end %>
 
 <% unless @comment.empty? %>
@@ -12,4 +12,4 @@
 ==
 
 <% end %>
-<%= t 'notifier.note_comment_notification.details', :url => @noteurl %>
+<%= t '.details', :url => @noteurl %>

--- a/app/views/notifier/signup_confirm.html.erb
+++ b/app/views/notifier/signup_confirm.html.erb
@@ -1,9 +1,9 @@
-<p><%= t("notifier.signup_confirm.greeting") %></p>
+<p><%= t(".greeting") %></p>
 
-<p><%= t("notifier.signup_confirm.created", :site_url => SERVER_URL) %></p>
+<p><%= t(".created", :site_url => SERVER_URL) %></p>
 
-<p><%= t("notifier.signup_confirm.confirm") %></p>
+<p><%= t(".confirm") %></p>
 
 <p><%= link_to @url, @url %></p>
 
-<p><%= t("notifier.signup_confirm.welcome") %></p>
+<p><%= t(".welcome") %></p>

--- a/app/views/notifier/signup_confirm.text.erb
+++ b/app/views/notifier/signup_confirm.text.erb
@@ -1,9 +1,9 @@
-<%= fp(t("notifier.signup_confirm.greeting")) %>
+<%= fp(t(".greeting")) %>
 
-<%= fp(t("notifier.signup_confirm.created", :site_url => SERVER_URL)) %>
+<%= fp(t(".created", :site_url => SERVER_URL)) %>
 
-<%= fp(t("notifier.signup_confirm.confirm")) %>
+<%= fp(t(".confirm")) %>
 
   <%= @url %>
 
-<%= fp(t("notifier.signup_confirm.welcome")) %>
+<%= fp(t(".welcome")) %>

--- a/app/views/oauth_clients/_form.html.erb
+++ b/app/views/oauth_clients/_form.html.erb
@@ -1,28 +1,28 @@
 <div class='standard-form'>
   <fieldset>
     <div class="form-row">
-      <label class='standard-label' for="client_application_name"><%= t'oauth_clients.form.name' %> (<%= t'oauth_clients.form.required' %>)</label>
+      <label class='standard-label' for="client_application_name"><%= t '.name' %> (<%= t '.required' %>)</label>
       <%= f.text_field :name %>
     </div>
     <div class="form-row">
-      <label class='standard-label' for="client_application_url"><%= t'oauth_clients.form.url' %> (<%= t'oauth_clients.form.required' %>)</label>
+      <label class='standard-label' for="client_application_url"><%= t '.url' %> (<%= t '.required' %>)</label>
       <%= f.text_field :url %>
     </div>
     <div class="form-row">
-      <label class='standard-label' for="client_application_callback_url"><%= t'oauth_clients.form.callback_url' %></label>
+      <label class='standard-label' for="client_application_callback_url"><%= t '.callback_url' %></label>
       <%= f.text_field :callback_url %>
     </div>
     <div class="form-row">
-      <label class='standard-label' for="client_application_support_url"><%= t'oauth_clients.form.support_url' %></label>
+      <label class='standard-label' for="client_application_support_url"><%= t '.support_url' %></label>
       <%= f.text_field :support_url %>
     </div>
   </fieldset>
   <fieldset class='form-divider'>
-      <p><%= t'oauth_clients.form.requests' %></p>
+      <p><%= t '.requests' %></p>
       <% ClientApplication.all_permissions.each do |perm| %>
         <div class="form-row">
           <%= f.check_box perm %>
-          <label class='standard-label' for="client_application_<%= perm.to_s %>"><%= t('oauth_clients.form.' + perm.to_s) %></label>
+          <label class='standard-label' for="client_application_<%= perm.to_s %>"><%= t('.' + perm.to_s) %></label>
         </div>
       <% end %>
   </fieldset>

--- a/app/views/oauth_clients/edit.html.erb
+++ b/app/views/oauth_clients/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for :heading do %>
-  <h1><%= t'oauth_clients.edit.title' %></h1>
+  <h1><%= t '.title' %></h1>
 <% end %>
 
 <%= form_for @client_application, :url => oauth_client_path(@client_application.user.display_name, @client_application), :html => { :method => :put } do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
-  <%= submit_tag t'oauth_clients.edit.submit' %>
+  <%= submit_tag t '.submit' %>
 <% end %>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -1,13 +1,13 @@
 <% content_for :heading do %>
-  <h1><%= t'oauth_clients.index.title' %></h1>
+  <h1><%= t '.title' %></h1>
 <% end %>
 
 <% unless @tokens.empty? %>
-<h3><%= t'oauth_clients.index.my_tokens' %></h3>
-<p><%= t'oauth_clients.index.list_tokens' %></p>
+<h3><%= t '.my_tokens' %></h3>
+<p><%= t '.list_tokens' %></p>
 <table>
-  <tr><th><%= t'oauth_clients.index.application' %></th>
-    <th><%= t'oauth_clients.index.issued_at' %></th><th>&nbsp;</th></tr>
+  <tr><th><%= t '.application' %></th>
+    <th><%= t '.issued_at' %></th><th>&nbsp;</th></tr>
   <% @tokens.each do |token|%>
     <%= content_tag_for :tr, token do %>
       <td><%= link_to token.client_application.name, token.client_application.url %></td>
@@ -15,22 +15,22 @@
       <td>
 	<%= form_tag :controller => 'oauth', :action => 'revoke' do %>
 	<%= hidden_field_tag 'token', token.token %>
-	<%= submit_tag t('oauth_clients.index.revoke') %>
+	<%= submit_tag t('.revoke') %>
 	<% end %>
       </td>
     <% end %>
   <% end %>
 </table>
 <% end %>
-<h3><%= t'oauth_clients.index.my_apps' %></h3>
+<h3><%= t '.my_apps' %></h3>
 <% if @client_applications.empty? %>
-<p><%= raw(t('oauth_clients.index.no_apps', :oauth => "<a href=\"https://oauth.net\">OAuth</a>")) %></p>
+<p><%= raw(t('.no_apps', :oauth => "<a href=\"https://oauth.net\">OAuth</a>")) %></p>
 <% else %>
-<p><%= t'oauth_clients.index.registered_apps' %></p>
+<p><%= t '.registered_apps' %></p>
 <% @client_applications.each do |client|%>
   <%= div_for client do %>
     <%= link_to client.name, :action => :show, :id => client.id %>
   <% end %>
 <% end %>
 <% end %>
-<h3><%= link_to t('oauth_clients.index.register_new'), :action => :new %></h3>
+<h3><%= link_to t('.register_new'), :action => :new %></h3>

--- a/app/views/oauth_clients/new.html.erb
+++ b/app/views/oauth_clients/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for :heading do %>
-  <h1><%= t'oauth_clients.new.title' %></h1>
+  <h1><%= t '.title' %></h1>
 <% end %>
 
 <div class='standard-form'>
   <%= form_for :client_application, :url => { :action => :create } do |f| %>
     <%= render :partial => "form", :locals => { :f => f } %>
-    <%= submit_tag t('oauth_clients.new.submit') %>
+    <%= submit_tag t('.submit') %>
   <% end %>
 </div>

--- a/app/views/oauth_clients/not_found.erb
+++ b/app/views/oauth_clients/not_found.erb
@@ -1,1 +1,1 @@
-<p><%= t('oauth_clients.not_found.sorry', :type => @type) %></p>
+<p><%= t('.sorry', :type => @type) %></p>

--- a/app/views/oauth_clients/show.html.erb
+++ b/app/views/oauth_clients/show.html.erb
@@ -1,33 +1,33 @@
 <% content_for :heading do %>
-  <h1><%= t('oauth_clients.show.title', :app_name => @client_application.name) %></h1>
+  <h1><%= t('.title', :app_name => @client_application.name) %></h1>
 <% end %>
 <div class='prose'>
   <p>
-    <strong><%= t'oauth_clients.show.key' %></strong> <%=@client_application.key %>
+    <strong><%= t '.key' %></strong> <%=@client_application.key %>
   </p>
   <p>
-    <strong><%= t'oauth_clients.show.secret' %></strong> <%=@client_application.secret %>
+    <strong><%= t '.secret' %></strong> <%=@client_application.secret %>
   </p>
   <p>
-    <strong><%= t'oauth_clients.show.url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.request_token_path %>
+    <strong><%= t '.url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.request_token_path %>
   </p>
   <p>
-    <strong><%= t'oauth_clients.show.access_url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.access_token_path %>
+    <strong><%= t '.access_url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.access_token_path %>
   </p>
   <p>
-    <strong><%= t'oauth_clients.show.authorize_url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.authorize_path %>
+    <strong><%= t '.authorize_url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.authorize_path %>
   </p>
 
-  <p><%= t'oauth_clients.show.requests' %></p>
+  <p><%= t '.requests' %></p>
   <ul><% @client_application.permissions.each do |perm| %>
   <div class="field">
     <li><%= t('oauth_clients.form.' + perm.to_s) %></li>
   </div>
   <% end %></ul>
 
-  <p><%= t'oauth_clients.show.support_notice' %></p>
+  <p><%= t '.support_notice' %></p>
 </div>
 <div class="buttons">
-  <%= button_to t('oauth_clients.show.edit'), edit_oauth_client_path(@client_application.user.display_name, @client_application), :method => :get, :class=> "oauth-edit" %>
-  <%= button_to t('oauth_clients.show.delete'), oauth_client_path(@client_application.user.display_name, @client_application), :method => :delete, :data => { :confirm => t('oauth_clients.show.confirm') }, :class=> "oauth-delete deemphasize" %>
+  <%= button_to t('.edit'), edit_oauth_client_path(@client_application.user.display_name, @client_application), :method => :get, :class=> "oauth-edit" %>
+  <%= button_to t('.delete'), oauth_client_path(@client_application.user.display_name, @client_application), :method => :delete, :data => { :confirm => t('.confirm') }, :class=> "oauth-delete deemphasize" %>
 </div>

--- a/app/views/trace/_description.html.erb
+++ b/app/views/trace/_description.html.erb
@@ -1,6 +1,6 @@
 <%= image_tag(url_for(:controller => :trace, :action => :icon, :id => description.id, :display_name => description.user.display_name)) %>
 <% if description.size -%>
-<%= t "trace.description.description_with_count", :count => description.size, :user => description.user.display_name %>
+<%= t ".description_with_count", :count => description.size, :user => description.user.display_name %>
 <% else -%>
-<%= t "trace.description.description_without_count", :user => description.user.display_name %>
+<%= t ".description_without_count", :user => description.user.display_name %>
 <% end -%>

--- a/app/views/trace/_trace.html.erb
+++ b/app/views/trace/_trace.html.erb
@@ -5,25 +5,25 @@
       <% if trace.inserted %>
         <a href="<%= url_for :controller => 'trace', :action => 'view', :id => trace.id, :display_name => trace.user.display_name %>"><img src="<%= url_for :controller => 'trace', :action => 'icon', :id => trace.id, :display_name => trace.user.display_name %>" border="0" alt="" /></a>
       <% else %>
-        <span class="trace_pending"><%= t'trace.trace.pending' %></span>
+        <span class="trace_pending"><%= t '.pending' %></span>
       <% end %>
     <% end %>
   </td>
   <td class="<%= cl %>"><%= link_to trace.name, {:controller => 'trace', :action => 'view', :display_name => trace.user.display_name, :id => trace.id} %>
     <span class="trace_summary" title="<%= trace.timestamp %>"> ...
       <% if trace.inserted %>
-        (<%= t'trace.trace.count_points', :count => trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/,'\1,') %>)
+        (<%= t '.count_points', :count => trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/,'\1,') %>)
       <% end %>
-      ... <%= t'trace.trace.ago', :time_in_words_ago => time_ago_in_words(trace.timestamp) %></span>
-      <%= link_to_if trace.inserted?, t('trace.trace.map'), {:controller => 'site', :action => 'index', :mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}"}, {:title => t('trace.trace.view_map')} %> /
-      <%= link_to t('trace.trace.edit'), {:controller => 'site', :action => 'edit', :gpx => trace.id }, {:title => t('trace.trace.edit_map')} %>
-      <span class="trace_<%= trace.visibility %>"><%= t('trace.trace.' + trace.visibility) %></span>
+      ... <%= t '.ago', :time_in_words_ago => time_ago_in_words(trace.timestamp) %></span>
+      <%= link_to_if trace.inserted?, t('.map'), {:controller => 'site', :action => 'index', :mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}"}, {:title => t('.view_map')} %> /
+      <%= link_to t('.edit'), {:controller => 'site', :action => 'edit', :gpx => trace.id }, {:title => t('.edit_map')} %>
+      <span class="trace_<%= trace.visibility %>"><%= t('.' + trace.visibility) %></span>
       <br />
       <%= trace.description %>
     <br />
-    <%= t'trace.trace.by' %> <%=link_to h(trace.user.display_name), user_path(trace.user) %>
+    <%= t '.by' %> <%=link_to h(trace.user.display_name), user_path(trace.user) %>
     <% if !trace.tags.empty? %>
-      <%= t'trace.trace.in' %>
+      <%= t '.in' %>
       <%= raw(trace.tags.collect { |tag| link_to_tag tag.tag }.join(", ")) %>
     <% end %>
   </td>

--- a/app/views/trace/_trace_optionals.html.erb
+++ b/app/views/trace/_trace_optionals.html.erb
@@ -1,6 +1,6 @@
 <% content_for :optionals do %>
   <div class="optionalbox">
-    <h4><%= t'trace.trace_optionals.tags' %></h4>
+    <h4><%= t '.tags' %></h4>
     <% if @all_tags %>
       <% @all_tags.each do |tag| %>
         <%= link_to_tag tag %><br />

--- a/app/views/trace/_trace_paging_nav.html.erb
+++ b/app/views/trace/_trace_paging_nav.html.erb
@@ -2,17 +2,17 @@
 
 <% if @traces.size > 1 %>
 <% if @page > 1 %>
-<%= link_to t('trace.trace_paging_nav.newer'), @params.merge({ :page => @page - 1 }) %>
+<%= link_to t('.newer'), @params.merge({ :page => @page - 1 }) %>
 <% else %>
-<%= t('trace.trace_paging_nav.newer') %>
+<%= t('.newer') %>
 <% end %>
 
-| <%= t('trace.trace_paging_nav.showing_page', :page => @page) %> |
+| <%= t('.showing_page', :page => @page) %> |
 
 <% if @traces.size < @page_size %>
-<%= t('trace.trace_paging_nav.older') %>
+<%= t('.older') %>
 <% else %>
-<%= link_to t('trace.trace_paging_nav.older'), @params.merge({ :page => @page + 1 }) %>
+<%= link_to t('.older'), @params.merge({ :page => @page + 1 }) %>
 <% end %>
 <% end %>
 </p>

--- a/app/views/trace/create.html.erb
+++ b/app/views/trace/create.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t'trace.create.upload_trace' %></h1>
+  <h1><%= t '.upload_trace' %></h1>
 <% end %>
 
 <%= error_messages_for 'trace' %>

--- a/app/views/trace/edit.html.erb
+++ b/app/views/trace/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t 'trace.edit.heading', :name => h(@trace.name) %></h2>
+  <h2><%= t '.heading', :name => h(@trace.name) %></h2>
 <% end %>
 
 <img src="<%= url_for :controller => 'trace', :action => 'picture', :id => @trace.id, :display_name => @trace.user.display_name %>">
@@ -9,47 +9,47 @@
 <div id='edit-trace-form' class='standard-form'>
   <fieldset>
     <div class='form-row'>
-      <label class='standard-label'><%= t'trace.edit.filename' %></label>
-      <p class='deemphasize'><%= @trace.name %> (<%= link_to t('trace.edit.download'), trace_data_path(@trace) %>)</p>
+      <label class='standard-label'><%= t '.filename' %></label>
+      <p class='deemphasize'><%= @trace.name %> (<%= link_to t('.download'), trace_data_path(@trace) %>)</p>
     </div>
     <div class='form-row'>
-      <label class='standard-label'><%= t'trace.edit.uploaded_at' %></label>
+      <label class='standard-label'><%= t '.uploaded_at' %></label>
       <p class='deemphasize'><%= l @trace.timestamp, :format => :friendly %></p>
     </div>
   <% if @trace.inserted? %>
     <div class='form-row'>
-      <label class='standard-label'><%= t'trace.edit.points' %></label>
+      <label class='standard-label'><%= t '.points' %></label>
       <p class='deemphasize'><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/,'\1,') %></p>
     </div>
     <div class='form-row'>
-      <label class='standard-label'><%= t'trace.edit.start_coord' %></label>
+      <label class='standard-label'><%= t '.start_coord' %></label>
     </div>
     <div class="geo">
       <span class="latitude"><%= @trace.latitude %></span>;
       <span class="longitude"><%= @trace.longitude %></span>
     </div>
-    (<%=link_to t('trace.edit.map'), :controller => 'site', :action => 'index', :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%=link_to t('trace.edit.edit'), :controller => 'site', :action => 'edit', :gpx=> @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)
+    (<%=link_to t('.map'), :controller => 'site', :action => 'index', :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%=link_to t('.edit'), :controller => 'site', :action => 'edit', :gpx=> @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)
   <% end %>
     <div class='form-row'>
-      <label class='standard-label'><%= t'trace.edit.owner' %></label>
+      <label class='standard-label'><%= t '.owner' %></label>
       <p class='deemphasize'><%= link_to h(@trace.user.display_name), user_path(@trace.user) %></p>
     </div>
     <div class='form-row'>
-      <label class='standard-label'><%= t'trace.edit.description' %></label>
+      <label class='standard-label'><%= t '.description' %></label>
       <%= f.text_field :description %>
     </div>
     <div class='form-row'>
-      <label class='standard-label'><%= t'trace.edit.tags' %></label>
-      <%= f.text_field :tagstring %> (<%= t'trace.edit.tags_help' %>)
+      <label class='standard-label'><%= t '.tags' %></label>
+      <%= f.text_field :tagstring %> (<%= t '.tags_help' %>)
     </div>
     <div class='form-row'>
-      <label class='standard-label'><%= t'trace.edit.visibility' %></label>
-      <%= f.select :visibility, [[t('trace.visibility.private'),"private"],[t('trace.visibility.public'),"public"],[t('trace.visibility.trackable'),"trackable"],[t('trace.visibility.identifiable'),"identifiable"]] %> (<a href="<%= t'trace.edit.visibility_help_url' %>"><%= t'trace.edit.visibility_help' %></a>)
+      <label class='standard-label'><%= t '.visibility' %></label>
+      <%= f.select :visibility, [[t('trace.visibility.private'),"private"], [t('trace.visibility.public'),"public"], [t('trace.visibility.trackable'),"trackable"], [t('trace.visibility.identifiable'),"identifiable"]] %> (<a href="<%= t '.visibility_help_url' %>"><%= t '.visibility_help' %></a>)
     </div>
   </fieldset>
 
 </div>
 
-<%= submit_tag t'trace.edit.save_button' %>
+<%= submit_tag t '.save_button' %>
 
 <% end %>

--- a/app/views/trace/georss.rss.builder
+++ b/app/views/trace/georss.rss.builder
@@ -5,8 +5,8 @@ xml.rss("version" => "2.0",
         "xmlns:geo" => "http://www.w3.org/2003/01/geo/wgs84_pos#",
         "xmlns:georss" => "http://www.georss.org/georss") do
   xml.channel do
-    xml.title t("trace.georss.title")
-    xml.description t("trace.georss.title")
+    xml.title t(".title")
+    xml.description t(".title")
     xml.link url_for(:controller => :trace, :action => :list, :only_path => false)
 
     xml.image do

--- a/app/views/trace/list.html.erb
+++ b/app/views/trace/list.html.erb
@@ -1,7 +1,7 @@
 <% content_for :heading do %>
   <h1><%= h(@title) %></h1>
   <ul class='secondary-actions clearfix'>
-    <li><%= t('trace.list.description') %></li>
+    <li><%= t('.description') %></li>
     <li><%= rss_link_to :action => 'georss', :display_name => @display_name, :tag => @tag %></li>
     <li><%= link_to t('trace.trace_header.upload_trace'), :action => 'create' %></li>
     <% if @tag %>
@@ -39,7 +39,7 @@
 
   <%= render :partial => 'trace_paging_nav' %>
 <% else %>
-  <h4><%= t 'trace.list.empty_html', :upload_link => trace_create_path %></h4>
+  <h4><%= t '.empty_html', :upload_link => trace_create_path %></h4>
 <% end %>
 
 <%= render :partial => 'trace_optionals' %>

--- a/app/views/trace/offline.html.erb
+++ b/app/views/trace/offline.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-<h2><%= t 'trace.offline.heading' %></h2>
+<h2><%= t '.heading' %></h2>
 <% end %>
 
-<p><%= t 'trace.offline.message' %></p>
+<p><%= t '.message' %></p>

--- a/app/views/trace/view.html.erb
+++ b/app/views/trace/view.html.erb
@@ -1,54 +1,54 @@
 <% content_for :heading do %>
-  <h2><%= t 'trace.view.heading', :name => h(@trace.name) %></h2>
+  <h2><%= t '.heading', :name => h(@trace.name) %></h2>
 <% end %>
 
 <% if STATUS != :gpx_offline %>
   <% if @trace.inserted %>
     <img src="<%= url_for :controller => 'trace', :action => 'picture', :id => @trace.id, :display_name => @trace.user.display_name %>">
   <% else %>
-    <span class="trace_pending"><%= t'trace.view.pending' %></span>
+    <span class="trace_pending"><%= t '.pending' %></span>
   <% end %>
 <% end %>
 
 <table border="0">
   <tr>
-    <td><%= t'trace.view.filename' %></td>
-    <td><%= @trace.name %> (<%= link_to t('trace.view.download'), trace_data_path(@trace) %>)</td>
+    <td><%= t '.filename' %></td>
+    <td><%= @trace.name %> (<%= link_to t('.download'), trace_data_path(@trace) %>)</td>
   </tr>
   <tr>
-    <td><%= t'trace.view.uploaded' %></td>
+    <td><%= t '.uploaded' %></td>
     <td><%= l @trace.timestamp, :format => :friendly %></td>
   </tr>
   <% if @trace.inserted? %>
   <tr>
-    <td><%= t'trace.view.points' %></td>
+    <td><%= t '.points' %></td>
     <td><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/,'\1,') %></td></tr>
   <tr>
-    <td><%= t'trace.view.start_coordinates' %></td>
-    <td><div class="geo"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%=link_to t('trace.view.map'), :controller => 'site', :action => 'index', :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%=link_to t('trace.view.edit'), :controller => 'site', :action => 'edit', :gpx=> @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
+    <td><%= t '.start_coordinates' %></td>
+    <td><div class="geo"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%=link_to t('.map'), :controller => 'site', :action => 'index', :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%=link_to t('.edit'), :controller => 'site', :action => 'edit', :gpx=> @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
   </tr>
   <% end %>
   <tr>
-    <td><%= t'trace.view.owner' %></td>
+    <td><%= t '.owner' %></td>
     <td><%= link_to h(@trace.user.display_name), user_path(@trace.user) %></td>
   </tr>
   <tr>
-    <td><%= t'trace.view.description' %></td>
+    <td><%= t '.description' %></td>
     <td><%= h(@trace.description) %></td>
   </tr>
   <tr>
-    <td><%= t'trace.view.tags' %></td>
+    <td><%= t '.tags' %></td>
     <td>
     <% unless @trace.tags.empty? %>
       <%= raw(@trace.tags.collect { |tag| link_to tag.tag, { :controller => 'trace', :action => 'list', :tag => tag.tag, :id => nil } }.join(", ")) %>
     <% else %>
-      <i><%= t'trace.view.none' %></i>
+      <i><%= t '.none' %></i>
     <% end %>
     </td>
   </tr>
   <tr>
-    <td><%= t'trace.view.visibility' %></td>
-    <td><%= t"trace.visibility.#{@trace.visibility}" %></td>
+    <td><%= t '.visibility' %></td>
+    <td><%= t "trace.visibility.#{@trace.visibility}" %></td>
   </tr>
 </table>
 
@@ -57,8 +57,8 @@
 <% if current_user && (current_user==@trace.user || current_user.administrator? || current_user.moderator?)%>
   <div class="buttons">
     <%= if_user(@trace.user) do %>
-      <%= button_to t('trace.view.edit_track'), trace_edit_path(@trace) %>
+      <%= button_to t('.edit_track'), trace_edit_path(@trace) %>
     <% end %>
-    <%= button_to t('trace.view.delete_track'), { :controller => 'trace', :action => 'delete', :id => @trace.id }, :data => { :confirm => t('trace.view.confirm_delete') } %>
+    <%= button_to t('.delete_track'), { :controller => 'trace', :action => 'delete', :id => @trace.id }, :data => { :confirm => t('.confirm_delete') } %>
   </div>
 <% end %>

--- a/app/views/user/_auth_association.html.erb
+++ b/app/views/user/_auth_association.html.erb
@@ -1,3 +1,3 @@
-<p><%= t "user.auth_association.heading" %></p>
-<p><%= t "user.auth_association.option_1" %></p>
-<p><%= t "user.auth_association.option_2" %></p>
+<p><%= t ".heading" %></p>
+<p><%= t ".option_1" %></p>
+<p><%= t ".option_2" %></p>

--- a/app/views/user/_popup.html.erb
+++ b/app/views/user/_popup.html.erb
@@ -1,5 +1,5 @@
 <div class="user_popup">
   <%= user_thumbnail popup %>
-  <p><%= t('user.popup.' + type) %></p>
+  <p><%= t('.' + type) %></p>
   <p><%= link_to popup.display_name, user_path(popup) %></p>
 </div>

--- a/app/views/user/account.html.erb
+++ b/app/views/user/account.html.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h1><%= t 'user.account.my settings' %></h1>
+  <h1><%= t '.my settings' %></h1>
   <ul class='secondary-actions clearfix'>
-    <li><%= link_to t('user.account.return to profile'), user_path(current_user) %></li>
+    <li><%= link_to t('.return to profile'), user_path(current_user) %></li>
     <li><%= link_to t('user.view.oauth settings'), :controller => 'oauth_clients', :action => 'index' %></li>
   </ul>
 <% end %>
@@ -21,15 +21,15 @@
 
   <fieldset>
     <div class="form-row">
-      <label class="standard-label"><%= t 'user.account.current email address' %></label>
+      <label class="standard-label"><%= t '.current email address' %></label>
       <input type="email" disabled value="<%= current_user.email %>" />
-      <span class="form-help deemphasize"><%= t 'user.account.email never displayed publicly' %></span>
+      <span class="form-help deemphasize"><%= t '.email never displayed publicly' %></span>
     </div>
 
     <div class="form-row">
-      <label class="standard-label"><%= t 'user.account.new email address' %></label>
+      <label class="standard-label"><%= t '.new email address' %></label>
       <%= f.email_field :new_email, :autocomplete => :off %>
-      <span class="form-help deemphasize"><%= t 'user.account.email never displayed publicly' %></span>
+      <span class="form-help deemphasize"><%= t '.email never displayed publicly' %></span>
     </div>
   </fieldset>
 
@@ -47,81 +47,81 @@
 
   <fieldset>
     <div class="form-row">
-      <label class="standard-label"><%= t 'user.account.external auth' %></label>
+      <label class="standard-label"><%= t '.external auth' %></label>
       <%= f.select :auth_provider, Auth::PROVIDERS %>
       <%= f.text_field :auth_uid %>
-      <span class="form-help deemphasize">(<a href="<%= t 'user.account.openid.link' %>" target="_new"><%= t 'user.account.openid.link text' %></a>)</span>
+      <span class="form-help deemphasize">(<a href="<%= t '.openid.link' %>" target="_new"><%= t '.openid.link text' %></a>)</span>
     </diV>
   </fieldset>
 
   <fieldset class="form-divider">
     <div class="form-row">
-      <label class="standard-label"><%= t 'user.account.public editing.heading' %></label>
+      <label class="standard-label"><%= t '.public editing.heading' %></label>
       <span class="form-help deemphasize">
         <% if current_user.data_public? %>
-          <%= t 'user.account.public editing.enabled' %>
-          (<a href="<%= t 'user.account.public editing.enabled link' %>" target="_new"><%= t 'user.account.public editing.enabled link text' %></a>)
+          <%= t '.public editing.enabled' %>
+          (<a href="<%= t '.public editing.enabled link' %>" target="_new"><%= t '.public editing.enabled link text' %></a>)
         <% else %>
-          <%= t 'user.account.public editing.disabled' %>
-          (<a href="#public"><%= t 'user.account.public editing.disabled link text' %></a>)
+          <%= t '.public editing.disabled' %>
+          (<a href="#public"><%= t '.public editing.disabled link text' %></a>)
         <% end %>
       </span>
     </div>
 
     <div class="form-row">
-      <label class="standard-label"><%= t 'user.account.contributor terms.heading' %></label>
+      <label class="standard-label"><%= t '.contributor terms.heading' %></label>
       <span class="form-help deemphasize">
         <% if current_user.terms_agreed? %>
-          <%= t 'user.account.contributor terms.agreed' %>
-          (<a href="<%= t 'user.account.contributor terms.link' %>" target="_new"><%= t 'user.account.contributor terms.link text' %></a>)
+          <%= t '.contributor terms.agreed' %>
+          (<a href="<%= t '.contributor terms.link' %>" target="_new"><%= t '.contributor terms.link text' %></a>)
           <% if current_user.consider_pd? %>
-            <%= t 'user.account.contributor terms.agreed_with_pd' %>
+            <%= t '.contributor terms.agreed_with_pd' %>
           <% end %>
         <% else %>
-          <%= t 'user.account.contributor terms.not yet agreed' %>
-          <%= link_to t('user.account.contributor terms.review link text'), :controller => 'user', :action => 'terms' %>
+          <%= t '.contributor terms.not yet agreed' %>
+          <%= link_to t('.contributor terms.review link text'), :controller => 'user', :action => 'terms' %>
         <% end %>
       </span>
     </div>
     <div class="form-row">
-      <label class="standard-label"><%= t 'user.account.preferred editor' %></label>
+      <label class="standard-label"><%= t '.preferred editor' %></label>
       <%= f.select :preferred_editor, [[t("editor.default", :name => t("editor.#{DEFAULT_EDITOR}.name")), 'default']] + Editors::ALL_EDITORS.collect { |e| [t("editor.#{e}.description"), e] } %>
     </div>
   </fieldset>
 
   <fieldset class="form-divider">
     <div class='form-row'>
-      <label class="standard-label"><%= t 'user.account.profile description' %></label>
+      <label class="standard-label"><%= t '.profile description' %></label>
       <%= richtext_area :user, :description, :object => current_user, :cols => 80, :rows => 20 %>
     </div>
 
     <div class="form-row">
-      <label class="standard-label"><%= t 'user.account.preferred languages' %></label>
+      <label class="standard-label"><%= t '.preferred languages' %></label>
       <%= f.text_field :languages %>
     </div>
 
     <div class='form-row accountImage'>
-      <label class="standard-label"><%= t 'user.account.image' %></label>
+      <label class="standard-label"><%= t '.image' %></label>
         <%= user_image current_user %>
         <ul class='form-list accountImage-options'>
         <% if current_user.image.file? %>
         <li>
           <%= radio_button_tag "image_action", "keep", !current_user.image_use_gravatar %>
-          <label class='standard-label' for='image_action_keep'><%= t 'user.account.keep image' %></label>
+          <label class='standard-label' for='image_action_keep'><%= t '.keep image' %></label>
         </li>
         <% end %>
         <% if current_user.image.file? || current_user.image_use_gravatar? %>
         <li>
           <%= radio_button_tag "image_action", "delete" %>
-          <label class='standard-label' for='image_action_delete'><%= t 'user.account.delete image' %></label>
+          <label class='standard-label' for='image_action_delete'><%= t '.delete image' %></label>
         </li>
         <% end %>
         <% if current_user.image.file? %>
           <li>
             <%= radio_button_tag "image_action", "new" %>
             <label class='standard-label' for='image_action_new'>
-                <%= t 'user.account.replace image' %>
-                <span class="form-help deemphasize"><%= t 'user.account.image size hint' %></span>
+                <%= t '.replace image' %>
+                <span class="form-help deemphasize"><%= t '.image size hint' %></span>
             </label>
             <%= f.file_field :image %>
           </li>
@@ -129,8 +129,8 @@
         <li>
           <%= radio_button_tag "image_action", "new" %>
           <label class='standard-label' for='image_action_new'>
-            <%= t 'user.account.new image' %>
-            <span class="form-help deemphasize"><%= t 'user.account.image size hint' %></span>
+            <%= t '.new image' %>
+            <span class="form-help deemphasize"><%= t '.image size hint' %></span>
           </label>
           <%= f.file_field :image %>
         </li>
@@ -138,8 +138,8 @@
         <li>
           <%= radio_button_tag "image_action", "gravatar", current_user.image_use_gravatar %>
           <label class='standard-label' for='image_action_gravatar'>
-            <%= t 'user.account.gravatar.gravatar' %>
-            <span class='form-help deemphasize'> (<a href="<%= t 'user.account.gravatar.link' %>" target="_new"><%= t 'user.account.gravatar.link text' %></a>)</span>
+            <%= t '.gravatar.gravatar' %>
+            <span class='form-help deemphasize'> (<a href="<%= t '.gravatar.link' %>" target="_new"><%= t '.gravatar.link text' %></a>)</span>
           </label>
         </li>
       </ul>
@@ -148,15 +148,15 @@
 
   <fieldset class="form-divider">
     <div class='form-row location clearfix'>
-    <label class="standard-label"><%= t 'user.account.home location' %></label>
+    <label class="standard-label"><%= t '.home location' %></label>
     <div id="homerow" <% unless current_user.home_lat and current_user.home_lon %>class="nohome"<%end%> >
-      <p class="message form-help deemphasize"><%= t 'user.account.no home location' %></p>
+      <p class="message form-help deemphasize"><%= t '.no home location' %></p>
         <div class='form-column'>
-          <label class="standard-label secondary"><%= t 'user.account.latitude' %></label>
+          <label class="standard-label secondary"><%= t '.latitude' %></label>
           <%= f.text_field :home_lat, :id => "home_lat" %>
         </div>
         <div class='form-column'>
-          <label class="standard-label secondary"><%= t 'user.account.longitude' %></label>
+          <label class="standard-label secondary"><%= t '.longitude' %></label>
           <%= f.text_field :home_lon, :id => "home_lon" %>
         </div>
       </div>
@@ -164,17 +164,17 @@
 
     <div class="form-row">
       <input type="checkbox" name="updatehome" value="1" <% unless current_user.home_lat and current_user.home_lon %> checked="checked" <% end %> id="updatehome" />
-      <label class="standard-label" for="updatehome"><%= t 'user.account.update home location on click' %></label>
+      <label class="standard-label" for="updatehome"><%= t '.update home location on click' %></label>
     </div>
     <%= content_tag "div", "", :id => "map", :class => "content_map settings_map set_location" %>
   </fieldset>
 
-  <%= submit_tag t('user.account.save changes button') %>
+  <%= submit_tag t('.save changes button') %>
 <% end %>
 
 <% unless current_user.data_public? %>
 <a name="public"></a>
-<h2><%= t 'user.account.public editing note.heading' %></h2>
-<%= raw t 'user.account.public editing note.text' %>
-  <%= button_to t('user.account.make edits public button'), :action => :go_public %>
+<h2><%= t '.public editing note.heading' %></h2>
+<%= raw t '.public editing note.text' %>
+  <%= button_to t('.make edits public button'), :action => :go_public %>
 <% end %>

--- a/app/views/user/confirm.html.erb
+++ b/app/views/user/confirm.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t 'user.confirm.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
   <div class='header-illustration confirm-main'></div>
 <% end %>
 
@@ -8,23 +8,23 @@
     <%= javascript_include_tag "user" %>
   <% end %>
 
-  <% content_for(:content_class) { "user_confirm" } %>  
+  <% content_for(:content_class) { "user_confirm" } %>
 
-  <p><%= t 'user.confirm.press confirm button' %></p>
+  <p><%= t '.press confirm button' %></p>
 
   <%= form_tag({}, { :id => "confirm" }) do %>
     <input type="display_name" name="confirm_string" value="<%= params[:display_name] %>">
     <input type="hidden" name="confirm_string" value="<%= params[:confirm_string] %>">
-    <input type="submit" name="confirm_action" value="<%= t 'user.confirm.button' %>">
+    <input type="submit" name="confirm_action" value="<%= t '.button' %>">
   <% end %>
 <% else %>
   <h1>
-    <%= t "user.confirm.introduction_1" %>
+    <%= t ".introduction_1" %>
     <span class="deemphasize">
-      <%= t "user.confirm.introduction_2" %>
+      <%= t ".introduction_2" %>
     </span>
   </h1>
 
-  <p class='deemphasize'><%= t "user.confirm.reconfirm_html",
+  <p class='deemphasize'><%= t ".reconfirm_html",
                                :reconfirm => url_for(:action => 'confirm_resend')%></p>
 <% end %>

--- a/app/views/user/confirm_email.html.erb
+++ b/app/views/user/confirm_email.html.erb
@@ -2,15 +2,15 @@
   <%= javascript_include_tag "user" %>
 <% end %>
 
-<% content_for(:content_class) { "user_confirm" } %>  
+<% content_for(:content_class) { "user_confirm" } %>
 
 <% content_for :heading do %>
-  <h1><%= t 'user.confirm_email.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
 <% end %>
 
-<p><%= t 'user.confirm_email.press confirm button' %></p>
+<p><%= t '.press confirm button' %></p>
 
 <%= form_tag({}, { :id => "confirm" }) do %>
   <input type="hidden" name="confirm_string" value="<%= params[:confirm_string] %>">
-  <input type="submit" name="confirm_action" value="<%= t 'user.confirm_email.button' %>">
+  <input type="submit" name="confirm_action" value="<%= t '.button' %>">
 <% end %>

--- a/app/views/user/list.html.erb
+++ b/app/views/user/list.html.erb
@@ -1,11 +1,11 @@
-<% @title = t('user.list.title') %>
+<% @title = t('.title') %>
 
 <% content_for :head do %>
   <%= javascript_include_tag "user" %>
 <% end %>
 
 <% content_for :heading do %>
-  <h1><%= t('user.list.heading') %></h1>
+  <h1><%= t('.heading') %></h1>
 <% end %>
 
 <% unless @users.empty? %>
@@ -16,7 +16,7 @@
     <table id="user_list">
       <tr>
         <td colspan="2">
-          <%= t 'user.list.showing',
+          <%= t '.showing',
               :page => @user_pages.current_page.number,
               :first_item => @user_pages.current_page.first_item,
               :last_item => @user_pages.current_page.last_item,
@@ -35,10 +35,10 @@
     </table>
 
     <div id="user_list_actions buttons">
-      <%= submit_tag t('user.list.confirm'), :name => "confirm" %>
-      <%= submit_tag t('user.list.hide'), :name => "hide" %>
+      <%= submit_tag t('.confirm'), :name => "confirm" %>
+      <%= submit_tag t('.hide'), :name => "hide" %>
     </div>
   <% end %>
 <% else %>
-  <p><%= t "user.list.empty" %></p>
+  <p><%= t ".empty" %></p>
 <% end %>

--- a/app/views/user/login.html.erb
+++ b/app/views/user/login.html.erb
@@ -3,49 +3,49 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h1><%= t 'user.login.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
 <% end %>
 
 <div id="login_login">
   <%= form_tag({ :action => "login" }, { :id => "login_form" }) do %>
     <%= hidden_field_tag('referer', h(params[:referer])) %>
 
-    <p class='deemphasize'><%= t 'user.login.no account' %> <%= link_to t('user.login.register now'), :action => :new, :referer => params[:referer] %></p>
+    <p class='deemphasize'><%= t '.no account' %> <%= link_to t('.register now'), :action => :new, :referer => params[:referer] %></p>
 
     <div id="loginForm" class="standard-form">
 
       <fieldset>
         <div class="form-row">
           <label for="username" class="standard-label">
-            <%= t 'user.login.email or username' %>
+            <%= t '.email or username' %>
           </label>
           <%= text_field_tag "username", params[:username], :tabindex => 1 %>
         </div>
         <div class="form-row">
           <label for="password" class="standard-label">
-            <%= t 'user.login.password' %>
+            <%= t '.password' %>
           </label>
           <%= password_field_tag "password", "", :tabindex => 2 %>
         </div>
         <span class="form-help deemphasize">
-          <%= link_to t('user.login.lost password link'), :controller => 'user', :action => 'lost_password' %>
+          <%= link_to t('.lost password link'), :controller => 'user', :action => 'lost_password' %>
         </span>
       </fieldset>
 
       <fieldset>
         <%= check_box_tag "remember_me", "yes", params[:remember_me] == "yes", :tabindex => 3 %>
         <label for="remember_me" class="standard-label">
-          <%= t 'user.login.remember' %>
+          <%= t '.remember' %>
         </label>
-        <%= submit_tag t('user.login.login_button'), :tabindex => 4 %>
+        <%= submit_tag t('.login_button'), :tabindex => 4 %>
       </fieldset>
 
       <fieldset class='form-divider'>
 
-        <p class='standard-label'><%= t 'user.login.with external' %></p>
+        <p class='standard-label'><%= t '.with external' %></p>
 
         <ul class='clearfix' id="login_auth_buttons">
-          <li><%= link_to image_tag("openid.png", :alt => t("user.login.auth_providers.openid.title")), "#", :id => "openid_open_url", :title => t("user.login.auth_providers.openid.title") %></li>
+          <li><%= link_to image_tag("openid.png", :alt => t(".auth_providers.openid.title")), "#", :id => "openid_open_url", :title => t(".auth_providers.openid.title") %></li>
           <% if defined?(GOOGLE_AUTH_ID) -%>
           <li><%= auth_button "google", "google" %></li>
           <% end -%>
@@ -67,17 +67,17 @@
         </ul>
 
         <div id='login_openid_url' class='form-row'>
-          <label for='openid_url' class="standard-label"><%= raw t 'user.login.openid', :logo => openid_logo %></label>
+          <label for='openid_url' class="standard-label"><%= raw t '.openid', :logo => openid_logo %></label>
           <%= text_field_tag("openid_url", "", { :tabindex => 3, :class => "openid_url" }) %>
           <span class="minorNote">(<a href="<%= t 'user.account.openid.link' %>" target="_new"><%= t 'user.account.openid.link text' %></a>)</span>
         </div>
 
         <div class='form-row'>
           <%= check_box_tag "remember_me_openid", "yes", false, :tabindex => 5 %>
-          <label class="standard-label" for="remember_me_openid"><%= t 'user.login.remember' %></label>
+          <label class="standard-label" for="remember_me_openid"><%= t '.remember' %></label>
         </div>
 
-        <%= submit_tag t('user.login.login_button'), :tabindex => 6, :id => "login_openid_submit" %>
+        <%= submit_tag t('.login_button'), :tabindex => 6, :id => "login_openid_submit" %>
 
       </fieldset>
 

--- a/app/views/user/logout.html.erb
+++ b/app/views/user/logout.html.erb
@@ -1,9 +1,9 @@
 <% content_for :heading do %>
-  <h1><%= t 'user.logout.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
 <% end %>
 
 <%= form_tag :action => "logout" do %>
   <%= hidden_field_tag("referer", h(params[:referer])) %>
   <%= hidden_field_tag("session", session.id) %>
-  <%= submit_tag t('user.logout.logout_button') %>
+  <%= submit_tag t('.logout_button') %>
 <% end %>

--- a/app/views/user/lost_password.html.erb
+++ b/app/views/user/lost_password.html.erb
@@ -1,13 +1,13 @@
 <% content_for :heading do %>
-  <h1><%= t 'user.lost_password.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
 <% end %>
 
-<p><%= t 'user.lost_password.help_text' %></p>
+<p><%= t '.help_text' %></p>
 
 <%= form_tag :action => 'lost_password' do %>
   <div class="standard-form">
-    <label class="standard-label"><%= t 'user.lost_password.email address' %></label>
+    <label class="standard-label"><%= t '.email address' %></label>
     <%= text_field('user', 'email', { :tabindex => 1} ) %>
-    <%= submit_tag t('user.lost_password.new password button'), :tabindex => 2 %>
+    <%= submit_tag t('.new password button'), :tabindex => 2 %>
   </div>
 <% end %>

--- a/app/views/user/make_friend.html.erb
+++ b/app/views/user/make_friend.html.erb
@@ -1,10 +1,10 @@
 <% content_for :heading do %>
-  <h1><%= t "user.make_friend.heading", :user => @new_friend.display_name %></h1>
+  <h1><%= t ".heading", :user => @new_friend.display_name %></h1>
 <% end %>
 
 <%= form_tag do %>
   <% if params[:referer] -%>
   <%= hidden_field_tag("referer", params[:referer]) %>
   <% end -%>
-  <%= submit_tag t("user.make_friend.button") %>
+  <%= submit_tag t(".button") %>
 <% end %>

--- a/app/views/user/new.html.erb
+++ b/app/views/user/new.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h1><%= t 'user.new.title' %></h1>
+  <h1><%= t '.title' %></h1>
   <div class='header-illustration new-user-main'></div>
   <div class='header-illustration new-user-arm'></div>
 <% end %>
@@ -14,55 +14,55 @@
   <fieldset>
     <div class="form-row">
       <label for="email" class="standard-label">
-        <%= t 'user.new.email address' %>
+        <%= t '.email address' %>
       </label>
       <%= f.email_field(:email, { :tabindex => 1 }) %>
       <%= f.error_message_on(:email) %>
     </div>
     <div class="form-row">
       <label for="email_confirmation" class="standard-label">
-        <%= t 'user.new.confirm email address' %>
+        <%= t '.confirm email address' %>
       </label>
       <%= f.email_field(:email_confirmation, { :tabindex => 2 }) %>
       <%= f.error_message_on(:email_confirmation) %>
     </div>
-    <span class="form-help deemphasize"><%= raw(t 'user.new.not displayed publicly') %></span>
+    <span class="form-help deemphasize"><%= raw(t '.not displayed publicly') %></span>
   </fieldset>
 
   <fieldset>
     <div class="form-row">
       <label for="display_name" class="standard-label">
-        <%= t 'user.new.display name' %>
+        <%= t '.display name' %>
       </label>
       <%= f.text_field(:display_name, { :tabindex => 3 }) %>
       <%= f.error_message_on(:display_name) %>
     </div>
-    <span class="form-help deemphasize"><%= t 'user.new.display name description' %></span>
+    <span class="form-help deemphasize"><%= t '.display name description' %></span>
   </fieldset>
 
   <fieldset class="form-divider" id="auth_field">
     <div class="form-row">
       <label for="openid_url" class="standard-label">
-        <%= raw t 'user.new.external auth' %>
+        <%= raw t '.external auth' %>
       </label>
       <%= f.select(:auth_provider, Auth::PROVIDERS, { :default => "", :tabindex => 4 }) %>
       <%= f.text_field(:auth_uid, { :tabindex => 5 }) %>
       <%= f.error_message_on(:auth_uid) %>
     </div>
-    <span class="form-help deemphasize"><%= t 'user.new.auth no password' %></span>
+    <span class="form-help deemphasize"><%= t '.auth no password' %></span>
   </fieldset>
 
   <fieldset>
     <div class="form-row">
       <label for='user[pass_crypt]' class="standard-label">
-        <%= t 'user.new.password' %>
+        <%= t '.password' %>
       </label>
       <%= f.password_field(:pass_crypt, { :tabindex => 6 }) %>
       <%= f.error_message_on(:pass_crypt) %>
     </div>
     <div class="form-row">
       <label class="standard-label">
-        <%= t 'user.new.confirm password' %>
+        <%= t '.confirm password' %>
       </label>
       <%= f.password_field(:pass_crypt_confirmation, { :tabindex => 7 }) %>
       <%= f.error_message_on(:pass_crypt_confirmation) %>
@@ -70,13 +70,13 @@
   </fieldset>
 
   <div id="auth_prompt" class="form-row">
-    <%= link_to raw(t("user.new.use external auth")), "#", :id => "auth_enable" %>
+    <%= link_to raw(t(".use external auth")), "#", :id => "auth_enable" %>
   </div>
 
-  <%= submit_tag t('user.new.continue'), :tabindex => 8 %>
+  <%= submit_tag t('.continue'), :tabindex => 8 %>
 <% end %>
 
 <div class='aside col6 deemphasize inner22'>
-  <h4><%= t 'user.new.about.header' %></h4>
-  <%= t 'user.new.about.html' %>
+  <h4><%= t '.about.header' %></h4>
+  <%= t '.about.html' %>
 </div>

--- a/app/views/user/no_such_user.html.erb
+++ b/app/views/user/no_such_user.html.erb
@@ -1,4 +1,4 @@
 <% content_for :heading do %>
-  <h1><%= t 'user.no_such_user.heading', :user => h(@not_found_user) %></h1>
+  <h1><%= t '.heading', :user => h(@not_found_user) %></h1>
 <% end %>
-<p><%= t 'user.no_such_user.body', :user => h(@not_found_user) %></p>
+<p><%= t '.body', :user => h(@not_found_user) %></p>

--- a/app/views/user/remove_friend.html.erb
+++ b/app/views/user/remove_friend.html.erb
@@ -1,10 +1,10 @@
 <% content_for :heading do %>
-  <h1><%= t "user.remove_friend.heading", :user => @friend.display_name %></h1>
+  <h1><%= t ".heading", :user => @friend.display_name %></h1>
 <% end %>
 
 <%= form_tag do %>
   <% if params[:referer] -%>
   <%= hidden_field_tag("referer", params[:referer]) %>
   <% end -%>
-  <%= submit_tag t("user.remove_friend.button") %>
+  <%= submit_tag t(".button") %>
 <% end %>

--- a/app/views/user/reset_password.html.erb
+++ b/app/views/user/reset_password.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t 'user.reset_password.heading', :user => current_user.display_name %></h1>
+  <h1><%= t '.heading', :user => current_user.display_name %></h1>
 <% end %>
 
 <%= error_messages_for current_user %>
@@ -8,13 +8,13 @@
 <%= hidden_field_tag(:token, params[:token]) %>
   <div class="standard-form">
     <fieldset>
-      <label class="standard-label"><%= t 'user.reset_password.password' %></label>
+      <label class="standard-label"><%= t '.password' %></label>
       <%= password_field(:user, :pass_crypt, {:value => '', :tabindex => 4}) %>
     </fieldset>
     <fieldset>
-      <label class="standard-label"><%= t 'user.reset_password.confirm password' %></label>
+      <label class="standard-label"><%= t '.confirm password' %></label>
       <%= password_field(:user, :pass_crypt_confirmation, {:value => '', :tabindex => 5}) %>
     </fieldset>
-    <%= submit_tag t('user.reset_password.reset'), :tabindex => 6 %>
+    <%= submit_tag t('.reset'), :tabindex => 6 %>
   </div>
 <% end %>

--- a/app/views/user/suspended.html.erb
+++ b/app/views/user/suspended.html.erb
@@ -1,7 +1,7 @@
-<% @title = t "user.suspended.title" %>
+<% @title = t ".title" %>
 
 <% content_for :heading do %>
-  <h1><%= t "user.suspended.heading" %></h1>
+  <h1><%= t ".heading" %></h1>
 <% end %>
 
-<%= raw t "user.suspended.body", :webmaster => link_to(t("user.suspended.webmaster"), "mailto:#{SUPPORT_EMAIL}") %>
+<%= raw t ".body", :webmaster => link_to(t(".webmaster"), "mailto:#{SUPPORT_EMAIL}") %>

--- a/app/views/user/terms.html.erb
+++ b/app/views/user/terms.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h1><%= t 'user.terms.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
   <div class='header-illustration new-user-terms'></div>
 <% end %>
 
@@ -11,14 +11,14 @@
   <!-- legale is <%= @legale %> -->
   <div class='form-row horizontal-list'>
     <label class="standard-label">
-      <%= t 'user.terms.legale_select' %>
+      <%= t '.legale_select' %>
     </label>
 
     <% [['france', 'FR'], ['italy', 'IT'], ['rest_of_world', 'GB']].each do |name, legale| %>
       <div class="form-row">
         <label for="legale_<%= legale %>">
           <%= radio_button_tag 'legale', legale, @legale == legale, :data => { :url => url_for(:legale => legale) } %>
-          <%= t('user.terms.legale_names.' + name) %>
+          <%= t('.legale_names.' + name) %>
         </label>
       </div>
     <% end %>
@@ -31,21 +31,21 @@
   <div class="form-row">
     <label for="user_consider_pd">
       <%= check_box('user', 'consider_pd') %>
-      <%= t 'user.terms.consider_pd' %>
+      <%= t '.consider_pd' %>
     </label>
-    <span class="minorNote">(<%= link_to(t('user.terms.consider_pd_why'), t('user.terms.consider_pd_why_url'), :target => :new)%>)</span>
+    <span class="minorNote">(<%= link_to(t('.consider_pd_why'), t('.consider_pd_why_url'), :target => :new)%>)</span>
 
     <%= hidden_field_tag('referer', h(params[:referer])) unless params[:referer].nil? %>
 
     <div class="buttons form-row inner20 clearfix">
-      <p class="deemphasize"><%= t 'user.terms.read and accept' %></p>
-      <%= submit_tag(t('user.terms.agree'), :name => "agree", :id => "agree") %>
-      <%= submit_tag(t('user.terms.decline'), :name => "decline", :id => "decline") %>
+      <p class="deemphasize"><%= t '.read and accept' %></p>
+      <%= submit_tag(t('.agree'), :name => "agree", :id => "agree") %>
+      <%= submit_tag(t('.decline'), :name => "decline", :id => "decline") %>
     </div>
 
     <div class="deemphasize">
       <p id="contributorGuidance">
-        <%= raw t 'user.terms.guidance',
+        <%= raw t '.guidance',
                   :summary => 'https://www.osmfoundation.org/wiki/License/Contributor_Terms_Summary',
                   :translations => 'https://www.osmfoundation.org/wiki/License/Contributor_Terms/Informal_Translations' %>
       </p>

--- a/app/views/user/view.html.erb
+++ b/app/views/user/view.html.erb
@@ -7,37 +7,37 @@
         <!-- Displaying user's own profile page to themself -->
         <ul class='secondary-actions clearfix'>
           <li>
-            <%= link_to t('user.view.my edits'), :controller => 'changeset', :action => 'list', :display_name => current_user.display_name %>
+            <%= link_to t('.my edits'), :controller => 'changeset', :action => 'list', :display_name => current_user.display_name %>
             <span class='count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
           </li>
           <li>
-            <%= link_to t('user.view.my notes'), :controller => 'notes', :action=> 'mine' %>
+            <%= link_to t('.my notes'), :controller => 'notes', :action=> 'mine' %>
           </li>
           <li>
-            <%= link_to t('user.view.my traces'), :controller => 'trace', :action=>'mine' %>
+            <%= link_to t('.my traces'), :controller => 'trace', :action=>'mine' %>
             <span class='count-number'><%= number_with_delimiter(current_user.traces.size) %></span>
           </li>
           <li>
-            <%= link_to t('user.view.my diary'), :controller => 'diary_entry', :action => 'list', :display_name => current_user.display_name %>
+            <%= link_to t('.my diary'), :controller => 'diary_entry', :action => 'list', :display_name => current_user.display_name %>
             <span class='count-number'><%= number_with_delimiter(current_user.diary_entries.size) %></span>
           </li>
           <li>
-            <%= link_to t('user.view.my comments' ), :controller => 'diary_entry', :action => 'comments', :display_name => current_user.display_name %>
+            <%= link_to t('.my comments' ), :controller => 'diary_entry', :action => 'comments', :display_name => current_user.display_name %>
           </li>
           <li>
-            <%= link_to t('user.view.my settings'), :controller => 'user', :action => 'account', :display_name => current_user.display_name %>
+            <%= link_to t('.my settings'), :controller => 'user', :action => 'account', :display_name => current_user.display_name %>
           </li>
 
           <% if current_user.blocks.exists? %>
             <li>
-              <%= link_to t('user.view.blocks on me'), :controller => 'user_blocks', :action => 'blocks_on', :display_name => current_user.display_name %>
+              <%= link_to t('.blocks on me'), :controller => 'user_blocks', :action => 'blocks_on', :display_name => current_user.display_name %>
               <span class='count-number'><%= number_with_delimiter(current_user.blocks.active.size) %></span>
             </li>
           <% end %>
 
           <% if current_user and current_user.moderator? and current_user.blocks_created.exists? %>
             <li>
-              <%= link_to t('user.view.blocks by me'), :controller => 'user_blocks', :action => 'blocks_by', :display_name => current_user.display_name %>
+              <%= link_to t('.blocks by me'), :controller => 'user_blocks', :action => 'blocks_by', :display_name => current_user.display_name %>
               <span class='count-number'><%= number_with_delimiter(current_user.blocks_created.active.size) %></span>
             </li>
           <% end %>
@@ -49,56 +49,56 @@
         <ul class='secondary-actions clearfix'>
 
           <li>
-            <%= link_to t('user.view.edits'), :controller => 'changeset', :action => 'list', :display_name => @user.display_name %>
+            <%= link_to t('.edits'), :controller => 'changeset', :action => 'list', :display_name => @user.display_name %>
             <span class='count-number'><%= number_with_delimiter(@user.changesets.size) %></span>
           </li>
           <li>
-            <%= link_to t('user.view.notes'), :controller => 'notes', :action=> 'mine' %>
+            <%= link_to t('.notes'), :controller => 'notes', :action=> 'mine' %>
           </li>
           <li>
-            <%= link_to t('user.view.traces'), :controller => 'trace', :action => 'list', :display_name => @user.display_name %>
+            <%= link_to t('.traces'), :controller => 'trace', :action => 'list', :display_name => @user.display_name %>
             <span class='count-number'><%= number_with_delimiter(@user.traces.size) %></span>
           </li>
 
           <!-- Displaying another user's profile page -->
 
           <li>
-            <%= link_to t('user.view.send message'), :controller => 'message', :action => 'new', :display_name => @user.display_name %>
+            <%= link_to t('.send message'), :controller => 'message', :action => 'new', :display_name => @user.display_name %>
           </li>
           <li>
-            <%= link_to t('user.view.diary'), :controller => 'diary_entry', :action => 'list', :display_name => @user.display_name %>
+            <%= link_to t('.diary'), :controller => 'diary_entry', :action => 'list', :display_name => @user.display_name %>
             <span class='count-number'><%= number_with_delimiter(@user.diary_entries.size) %></span>
           </li>
           <li>
-            <%= link_to t('user.view.comments'), :controller => 'diary_entry', :action => 'comments', :display_name => @user.display_name %>
+            <%= link_to t('.comments'), :controller => 'diary_entry', :action => 'comments', :display_name => @user.display_name %>
           </li>
           <li>
             <% if current_user and current_user.is_friends_with?(@user) %>
-              <%= link_to t('user.view.remove as friend'), remove_friend_path(:display_name => @user.display_name), :method => :post %>
+              <%= link_to t('.remove as friend'), remove_friend_path(:display_name => @user.display_name), :method => :post %>
             <% elsif current_user %>
-              <%= link_to t('user.view.add as friend'), make_friend_path(:display_name => @user.display_name), :method => :post %>
+              <%= link_to t('.add as friend'), make_friend_path(:display_name => @user.display_name), :method => :post %>
             <% else %>
-              <%= link_to t('user.view.add as friend'), make_friend_path(:display_name => @user.display_name) %>
+              <%= link_to t('.add as friend'), make_friend_path(:display_name => @user.display_name) %>
             <% end %>
           </li>
 
           <% if @user.blocks.exists? %>
             <li>
-              <%= link_to t('user.view.block_history'), :controller => 'user_blocks', :action => 'blocks_on', :display_name => @user.display_name %>
+              <%= link_to t('.block_history'), :controller => 'user_blocks', :action => 'blocks_on', :display_name => @user.display_name %>
               <span class='count-number'><%= number_with_delimiter(@user.blocks.active.size) %></span>
             </li>
           <% end %>
 
           <% if @user.moderator? and @user.blocks_created.exists? %>
             <li>
-              <%= link_to t('user.view.moderator_history'), :controller => 'user_blocks', :action => 'blocks_by', :display_name => @user.display_name %>
+              <%= link_to t('.moderator_history'), :controller => 'user_blocks', :action => 'blocks_by', :display_name => @user.display_name %>
               <span class='count-number'><%= number_with_delimiter(@user.blocks_created.active.size) %></span>
             </li>
           <% end %>
 
           <% if current_user and current_user.moderator? %>
             <li>
-            <%= link_to t('user.view.create_block'), :controller => 'user_blocks', :action => 'new', :display_name => @user.display_name %>
+            <%= link_to t('.create_block'), :controller => 'user_blocks', :action => 'new', :display_name => @user.display_name %>
             </li>
           <% end %>
 
@@ -111,28 +111,28 @@
         <ul class='secondary-actions clearfix'>
           <% if ["active", "confirmed"].include? @user.status %>
             <li>
-              <%= link_to t('user.view.deactivate_user'), set_status_user_path(:status => 'pending', :display_name => @user.display_name), :data => { :confirm => t('user.view.confirm') } %>
+              <%= link_to t('.deactivate_user'), set_status_user_path(:status => 'pending', :display_name => @user.display_name), :data => { :confirm => t('.confirm') } %>
             </li>
           <% elsif ["pending"].include? @user.status %>
             <li>
-              <%= link_to t('user.view.activate_user'), set_status_user_path(:status => 'active', :display_name => @user.display_name), :data => { :confirm => t('user.view.confirm') } %>
+              <%= link_to t('.activate_user'), set_status_user_path(:status => 'active', :display_name => @user.display_name), :data => { :confirm => t('.confirm') } %>
             </li>
           <% end %>
 
           <% if ["active", "suspended"].include? @user.status %>
             <li>
-              <%= link_to t('user.view.confirm_user'), set_status_user_path(:status => 'confirmed', :display_name => @user.display_name), :data => { :confirm => t('user.view.confirm') } %>
+              <%= link_to t('.confirm_user'), set_status_user_path(:status => 'confirmed', :display_name => @user.display_name), :data => { :confirm => t('.confirm') } %>
             </li>
           <% end %>
             <li>
               <% if ["pending", "active", "confirmed", "suspended"].include? @user.status %>
-                <%= link_to t('user.view.hide_user'), set_status_user_path(:status => 'deleted', :display_name => @user.display_name), :data => { :confirm => t('user.view.confirm') } %>
+                <%= link_to t('.hide_user'), set_status_user_path(:status => 'deleted', :display_name => @user.display_name), :data => { :confirm => t('.confirm') } %>
             <% else %>
-              <%= link_to t('user.view.unhide_user'), set_status_user_path(:status => 'active', :display_name => @user.display_name), :data => { :confirm => t('user.view.confirm') } %>
+              <%= link_to t('.unhide_user'), set_status_user_path(:status => 'active', :display_name => @user.display_name), :data => { :confirm => t('.confirm') } %>
             </li>
           <% end %>
           <li>
-            <%= link_to t('user.view.delete_user'), delete_user_path(:display_name => @user.display_name), :data => { :confirm => t('user.view.confirm') } %>
+            <%= link_to t('.delete_user'), delete_user_path(:display_name => @user.display_name), :data => { :confirm => t('.confirm') } %>
           </li>
         </ul>
 
@@ -140,14 +140,14 @@
 
       <p class='deemphasize'>
         <small>
-          <%= t 'user.view.mapper since' %> <%= l @user.creation_time.to_date, :format => :long %>
+          <%= t '.mapper since' %> <%= l @user.creation_time.to_date, :format => :long %>
           <% unless @user.terms_agreed %>
             |
-            <%= t 'user.view.ct status' %>
+            <%= t '.ct status' %>
             <% if @user.terms_seen? -%>
-              <%= t 'user.view.ct declined' %>
+              <%= t '.ct declined' %>
             <% else -%>
-              <%= t 'user.view.ct undecided' %>
+              <%= t '.ct undecided' %>
             <% end -%>
           <% end -%>
         </small>
@@ -160,12 +160,12 @@
 
   <% if current_user and current_user.administrator? -%>
     <div class='admin-user-info deemphasize'>
-      <small><b><%= t 'user.view.email address' %></b> <%= @user.email %></small>
+      <small><b><%= t '.email address' %></b> <%= @user.email %></small>
       <% unless @user.creation_ip.nil? -%>
-        <small><b><%= t 'user.view.created from' %></b> <%= @user.creation_ip %></small>
+        <small><b><%= t '.created from' %></b> <%= @user.creation_ip %></small>
       <% end -%>
-      <small><b><%= t 'user.view.status' %></b> <%= @user.status.capitalize %></small>
-      <small><b><%= t 'user.view.spam score' %></b> <%= @user.spam_score %></small>
+      <small><b><%= t '.status' %></b> <%= @user.status.capitalize %></small>
+      <small><b><%= t '.spam score' %></b> <%= @user.spam_score %></small>
     </div>
   <% end -%>
 
@@ -174,7 +174,7 @@
   <% if current_user and @user.id == current_user.id %>
     <% if @user.home_lat.nil? or @user.home_lon.nil? %>
       <div id="map" class="content_map">
-        <p id="no_home_location"><%= raw(t 'user.view.if set location', :settings_link => (link_to t('user.view.settings_link_text'), :controller => 'user', :action => 'account', :display_name => current_user.display_name)) %></p>
+        <p id="no_home_location"><%= raw(t '.if set location', :settings_link => (link_to t('.settings_link_text'), :controller => 'user', :action => 'account', :display_name => current_user.display_name)) %></p>
       </div>
     <% else %>
       <% content_for :head do %>
@@ -195,14 +195,14 @@
     <% nearby = @user.nearby - friends %>
 
   <div class="activity-block column-1">
-    <h3><%= t 'user.view.my friends' %></h3>
+    <h3><%= t '.my friends' %></h3>
 
     <% if friends.empty? %>
-      <%= t 'user.view.no friends' %>
+      <%= t '.no friends' %>
     <% else %>
       <ul class='secondary-actions clearfix'>
-        <li><%= link_to t('user.view.friends_changesets'), friend_changesets_path %></li>
-        <li><%= link_to t('user.view.friends_diaries'), friend_diaries_path %></li>
+        <li><%= link_to t('.friends_changesets'), friend_changesets_path %></li>
+        <li><%= link_to t('.friends_diaries'), friend_diaries_path %></li>
       </ul>
       <div id="friends-container">
         <%= render :partial => "contact", :collection => friends, :locals => {:type => "friend"} %>
@@ -211,14 +211,14 @@
   </div>
 
   <div class="activity-block column-1">
-    <h3><%= t 'user.view.nearby users' %></h3>
+    <h3><%= t '.nearby users' %></h3>
 
     <% if nearby.empty? %>
-      <%= t 'user.view.no nearby users' %>
+      <%= t '.no nearby users' %>
     <% else %>
       <ul class='secondary-actions clearfix'>
-        <li><%= link_to t('user.view.nearby_changesets'), nearby_changesets_path %></li>
-        <li><%= link_to t('user.view.nearby_diaries'), nearby_diaries_path %></li>
+        <li><%= link_to t('.nearby_changesets'), nearby_changesets_path %></li>
+        <li><%= link_to t('.nearby_diaries'), nearby_diaries_path %></li>
       </ul>
       <div id="nearbyusers">
         <%= render :partial => "contact", :collection => nearby, :locals => {:type => "nearby mapper"} %>


### PR DESCRIPTION
This changes the majority of translations to use lazy lookups, where it was possible to do so without renaming keys. So in effect, this removes the prefix of the key where it was just the name of the controller plus the name of the view.

Further (smaller) PRs will be required to deal with the non-standard and the more complex situations.
