### PR TITLE
Use lazy lookups for user_blocks translations

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -45,7 +45,7 @@ class UserBlocksController < ApplicationController
       )
 
       if @user_block.save
-        flash[:notice] = t("user_block.create.flash", :name => @user.display_name)
+        flash[:notice] = t(".flash", :name => @user.display_name)
         redirect_to @user_block
       else
         render :action => "new"
@@ -58,14 +58,14 @@ class UserBlocksController < ApplicationController
   def update
     if @valid_params
       if @user_block.creator != current_user
-        flash[:error] = t("user_block.update.only_creator_can_edit")
+        flash[:error] = t(".only_creator_can_edit")
         redirect_to :action => "edit"
       elsif @user_block.update(
         :ends_at => Time.now.getutc + @block_period.hours,
         :reason => params[:user_block][:reason],
         :needs_view => params[:user_block][:needs_view]
       )
-        flash[:notice] = t("user_block.update.success")
+        flash[:notice] = t(".success")
         redirect_to(@user_block)
       else
         render :action => "edit"
@@ -80,7 +80,7 @@ class UserBlocksController < ApplicationController
   def revoke
     if params[:confirm]
       if @user_block.revoke! current_user
-        flash[:notice] = t "user_block.revoke.flash"
+        flash[:notice] = t ".flash"
         redirect_to(@user_block)
       end
     end
@@ -128,10 +128,10 @@ class UserBlocksController < ApplicationController
     @valid_params = false
 
     if !UserBlock::PERIODS.include?(@block_period)
-      flash[:error] = t("user_block.filter.block_period")
+      flash[:error] = t("user_blocks.filter.block_period")
 
     elsif @user_block && !@user_block.active?
-      flash[:error] = t("user_block.filter.block_expired")
+      flash[:error] = t("user_blocks.filter.block_expired")
 
     else
       @valid_params = true

--- a/app/helpers/user_blocks_helper.rb
+++ b/app/helpers/user_blocks_helper.rb
@@ -7,19 +7,19 @@ module UserBlocksHelper
       # if the block hasn't expired yet show the date, if the user just needs to login show that
       if block.needs_view?
         if block.ends_at > Time.now.getutc
-          I18n.t("user_block.helper.time_future_and_until_login", :time => friendly_date(block.ends_at)).html_safe
+          I18n.t("user_blocks.helper.time_future_and_until_login", :time => friendly_date(block.ends_at)).html_safe
         else
-          I18n.t("user_block.helper.until_login")
+          I18n.t("user_blocks.helper.until_login")
         end
       else
-        I18n.t("user_block.helper.time_future", :time => friendly_date(block.ends_at)).html_safe
+        I18n.t("user_blocks.helper.time_future", :time => friendly_date(block.ends_at)).html_safe
       end
     else
       # the max of the last update time or the ends_at time is when this block finished
       # either because the user viewed the block (updated_at) or it expired or was
       # revoked (ends_at)
       last_time = [block.ends_at, block.updated_at].max
-      I18n.t("user_block.helper.time_past", :time => friendly_date(last_time)).html_safe
+      I18n.t("user_blocks.helper.time_past", :time => friendly_date(last_time)).html_safe
     end
   end
 end

--- a/app/views/user_blocks/blocks_by.html.erb
+++ b/app/views/user_blocks/blocks_by.html.erb
@@ -1,10 +1,10 @@
-<% @title = t('user_block.blocks_by.title', :name => h(@user.display_name)) %>
+<% @title = t('.title', :name => h(@user.display_name)) %>
 <% content_for :heading do %>
-  <h1><%= raw(t('user_block.blocks_by.heading', :name => link_to(h(@user.display_name), user_path(@user)))) %></h1>
+  <h1><%= raw(t('.heading', :name => link_to(h(@user.display_name), user_path(@user)))) %></h1>
 <% end %>
 
 <% unless @user_blocks.empty? %>
 <%= render :partial => 'blocks', :locals => { :show_revoke_link => (current_user and current_user.moderator?), :show_user_name => true, :show_creator_name => false } %>
 <% else %>
-<p><%= t "user_block.blocks_by.empty", :name => h(@user.display_name) %></p>
+<p><%= t ".empty", :name => h(@user.display_name) %></p>
 <% end %>

--- a/app/views/user_blocks/blocks_on.html.erb
+++ b/app/views/user_blocks/blocks_on.html.erb
@@ -1,9 +1,9 @@
-<% @title = t('user_block.blocks_on.title', :name => h(@user.display_name)) %>
+<% @title = t('.title', :name => h(@user.display_name)) %>
 <% content_for :heading do %>
-  <h1><%= raw(t('user_block.blocks_on.heading', :name => link_to(h(@user.display_name), user_path(@user)))) %></h1>
+  <h1><%= raw(t('.heading', :name => link_to(h(@user.display_name), user_path(@user)))) %></h1>
 <% end %>
 <% unless @user_blocks.empty? %>
 <%= render :partial => 'blocks', :locals => { :show_revoke_link => (current_user and current_user.moderator?), :show_user_name => false, :show_creator_name => true } %>
 <% else %>
-<p><%= t "user_block.blocks_on.empty", :name => h(@user.display_name) %></p>
+<p><%= t ".empty", :name => h(@user.display_name) %></p>
 <% end %>

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -1,11 +1,11 @@
-<% @title = t 'user_block.edit.title', :name => h(@user_block.user.display_name) %>
+<% @title = t '.title', :name => h(@user_block.user.display_name) %>
 <% content_for :heading do %>
-  <h1><%= raw t('user_block.edit.title',
+  <h1><%= raw t('.title',
                 :name => link_to(h(@user_block.user.display_name),
                                  user_path(@user_block.user))) %></h1>
   <ul class='secondary-actions clearfix'>
-    <li><%= link_to t('user_block.edit.show'), @user_block %></li>
-    <li><%= link_to t('user_block.edit.back'), user_blocks_path %></li>
+    <li><%= link_to t('.show'), @user_block %></li>
+    <li><%= link_to t('.back'), user_blocks_path %></li>
   </ul>
 <% end %>
 
@@ -13,18 +13,18 @@
   <%= f.error_messages %>
 
   <p>
-    <%= f.label :reason, t('user_block.edit.reason', :name => h(@user_block.user.display_name)) %><br />
+    <%= f.label :reason, t('.reason', :name => h(@user_block.user.display_name)) %><br />
     <%= richtext_area :user_block, :reason, :cols => 80, :rows => 20, :format => @user_block.reason_format %>
   </p>
   <p>
-    <%= label_tag 'user_block_period', t('user_block.edit.period') %><br />
-    <%= select_tag('user_block_period', options_for_select(UserBlock::PERIODS.collect { |h| [t('user_block.period', :count => h), h.to_s] }, params[:user_block_period])) %>
+    <%= label_tag 'user_block_period', t('.period') %><br />
+    <%= select_tag('user_block_period', options_for_select(UserBlock::PERIODS.collect { |h| [t('user_blocks.period', :count => h), h.to_s] }, params[:user_block_period])) %>
   </p>
   <p>
     <%= f.check_box :needs_view %>
-    <%= f.label :needs_view, t('user_block.edit.needs_view') %>
+    <%= f.label :needs_view, t('.needs_view') %>
   </p>
   <p>
-    <%= f.submit t('user_block.edit.submit') %>
+    <%= f.submit t('.submit') %>
   </p>
 <% end %>

--- a/app/views/user_blocks/index.html.erb
+++ b/app/views/user_blocks/index.html.erb
@@ -1,10 +1,10 @@
-<% @title = t('user_block.index.title') %>
+<% @title = t('.title') %>
 <% content_for :heading do %>
-  <h1><%= t('user_block.index.heading') %></h1>
+  <h1><%= t('.heading') %></h1>
 <% end %>
 
 <% unless @user_blocks.empty? %>
 <%= render :partial => 'blocks', :locals => { :show_revoke_link => (current_user and current_user.moderator?), :show_user_name => true, :show_creator_name => true } %>
 <% else %>
-<p><%= t "user_block.index.empty" %></p>
+<p><%= t ".empty" %></p>
 <% end %>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -1,6 +1,6 @@
-<% @title = t 'user_block.new.title', :name => h(@user.display_name) %>
+<% @title = t '.title', :name => h(@user.display_name) %>
 <% content_for :heading do %>
-  <h1><%= raw t('user_block.new.heading',
+  <h1><%= raw t('.heading',
                 :name => link_to(
                                  h(@user.display_name),
                                  user_path(@user))) %></h1>
@@ -9,21 +9,21 @@
   <%= f.error_messages %>
 
   <p>
-    <%= f.label :reason, t('user_block.new.reason', :name => @user.display_name) %><br />
+    <%= f.label :reason, t('.reason', :name => @user.display_name) %><br />
     <%= richtext_area :user_block, :reason, :cols => 80, :rows => 20 %>
   </p>
   <p>
-    <%= label_tag 'user_block_period', t('user_block.new.period') %><br />
-    <%= select_tag('user_block_period', options_for_select(UserBlock::PERIODS.collect { |h| [t('user_block.period', :count => h), h.to_s] }, params[:user_block_period] )) %>
+    <%= label_tag 'user_block_period', t('.period') %><br />
+    <%= select_tag('user_block_period', options_for_select(UserBlock::PERIODS.collect { |h| [t('user_blocks.period', :count => h), h.to_s] }, params[:user_block_period] )) %>
   </p>
   <p>
     <%= f.check_box :needs_view %>
-    <%= f.label :needs_view, t('user_block.new.needs_view') %>
+    <%= f.label :needs_view, t('.needs_view') %>
   </p>
   <p>
     <%= hidden_field_tag 'display_name', @user.display_name %>
-    <%= f.submit t('user_block.new.submit') %>
+    <%= f.submit t('.submit') %>
   </p>
 <% end %>
 
-<%= link_to t('user_block.new.back'), user_blocks_path %>
+<%= link_to t('.back'), user_blocks_path %>

--- a/app/views/user_blocks/not_found.html.erb
+++ b/app/views/user_blocks/not_found.html.erb
@@ -1,3 +1,3 @@
-<p><%= t'user_block.not_found.sorry', :id => params[:id] %></p>
+<p><%= t'.sorry', :id => params[:id] %></p>
 
-<%= link_to t('user_block.not_found.back'), user_blocks_path %>
+<%= link_to t('.back'), user_blocks_path %>

--- a/app/views/user_blocks/revoke.html.erb
+++ b/app/views/user_blocks/revoke.html.erb
@@ -1,9 +1,9 @@
-<% @title = t('user_block.revoke.title',
+<% @title = t('.title',
               :block_on => h(@user_block.user.display_name),
               :block_by => h(@user_block.creator.display_name)) %>
 
 <% content_for :heading do %>
-  <h1><%= raw t('user_block.revoke.heading',
+  <h1><%= raw t('.heading',
                 :block_on => link_to(
                                      h(@user_block.user.display_name),
                                      user_path(@user_block.user)),
@@ -14,22 +14,22 @@
 
 <% if @user_block.ends_at > Time.now %>
 <p><b>
-  <%= t('user_block.revoke.time_future', :time => distance_of_time_in_words_to_now(@user_block.ends_at)) %>
+  <%= t('.time_future', :time => distance_of_time_in_words_to_now(@user_block.ends_at)) %>
 </b></p>
 
 <%= form_for :revoke, :url => { :action => "revoke" } do |f| %>
   <%= f.error_messages %>
 <p>
   <%= check_box_tag 'confirm', 'yes' %>
-  <%= label_tag 'confirm', t('user_block.revoke.confirm') %>
+  <%= label_tag 'confirm', t('.confirm') %>
 </p>
 <p>
-  <%= submit_tag t('user_block.revoke.revoke') %>
+  <%= submit_tag t('.revoke') %>
 </p>
 <% end %>
 
 <% else %>
 <p>
-  <%= t('user_block.revoke.past', :time => distance_of_time_in_words_to_now(@user_block.ends_at)) %>
+  <%= t('.past', :time => distance_of_time_in_words_to_now(@user_block.ends_at)) %>
 </p>
 <% end %>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -1,9 +1,9 @@
-<% @title = t('user_block.show.title',
+<% @title = t('.title',
               :block_on => @user_block.user.display_name,
               :block_by => @user_block.creator.display_name) %>
 
 <% content_for :heading do %>
-  <h1><%= raw t('user_block.show.heading',
+  <h1><%= raw t('.heading',
                 :block_on => link_to(
                                      h(@user_block.user.display_name),
                                      user_path(@user_block.user)),
@@ -13,26 +13,26 @@
 <ul class='secondary-actions clearfix'>
   <% if @user_block.ends_at > Time.now.getutc %>
     <% if current_user and current_user.id == @user_block.creator_id %>
-      <li><%= link_to t('user_block.show.edit'), edit_user_block_path(@user_block) %></li>
+      <li><%= link_to t('.edit'), edit_user_block_path(@user_block) %></li>
     <% end %>
     <% if current_user and current_user.moderator? %>
-      <li><%= link_to(t('user_block.show.revoke'),{:controller => 'user_blocks', :action => 'revoke', :id => @user_block.id}) %></li>
+      <li><%= link_to(t('.revoke'),{:controller => 'user_blocks', :action => 'revoke', :id => @user_block.id}) %></li>
     <% end %>
   <% end %>
-  <li><%= link_to t('user_block.show.back'), user_blocks_path %></li>
+  <li><%= link_to t('.back'), user_blocks_path %></li>
 </ul>
 <% end %>
 
 <% if @user_block.revoker %>
 <p>
-  <b><%= t'user_block.show.revoker' %></b>
+  <b><%= t'.revoker' %></b>
   <%= link_to h(@user_block.revoker.display_name), user_path(@user_block.revoker) %>
 </p>
 <% end %>
 
-<p><b><%= t'user_block.show.created' %></b>: <%= raw t'user_block.show.ago', :time => friendly_date(@user_block.created_at) %></p>
+<p><b><%= t'.created' %></b>: <%= raw t'.ago', :time => friendly_date(@user_block.created_at) %></p>
 
-<p><b><%= t'user_block.show.status' %></b>: <%= block_status(@user_block) %></p>
+<p><b><%= t'.status' %></b>: <%= block_status(@user_block) %></p>
 
-<p><b><%= t'user_block.show.reason' %></b></p>
+<p><b><%= t'.reason' %></b></p>
 <div class="richtext"><%= @user_block.reason.to_html %></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2108,7 +2108,7 @@ en:
       are_you_sure: "Are you sure you want to revoke the role `%{role}' from the user `%{name}'?"
       confirm: "Confirm"
       fail: "Could not revoke role `%{role}' from user `%{name}'. Please check that the user and role are both valid."
-  user_block:
+  user_blocks:
     model:
       non_moderator_update: "Must be a moderator to create or update a block."
       non_moderator_revoke: "Must be a moderator to revoke a block."
@@ -2188,7 +2188,6 @@ en:
       back: "View all blocks"
       revoker: "Revoker:"
       needs_view: "The user needs to log in before this block will be cleared."
-  user_blocks:
     block:
       not_revoked: "(not revoked)"
       show: "Show"


### PR DESCRIPTION
This PR converts the user_blocks views to use lazy translation lookups, and involves renaming all the remaining `user_block.*` i18n keys to `user_blocks.*`.

cc @Nikerabbit 