### PR TITLE
Use lazy translation lookups for redactions

### DIFF
--- a/app/controllers/redactions_controller.rb
+++ b/app/controllers/redactions_controller.rb
@@ -25,7 +25,7 @@ class RedactionsController < ApplicationController
     # note that the description format will default to 'markdown'
 
     if @redaction.save
-      flash[:notice] = t("redaction.create.flash")
+      flash[:notice] = t(".flash")
       redirect_to @redaction
     else
       render :action => "new"
@@ -42,7 +42,7 @@ class RedactionsController < ApplicationController
     @redaction.description = params[:redaction][:description]
 
     if @redaction.save
-      flash[:notice] = t("redaction.update.flash")
+      flash[:notice] = t(".flash")
       redirect_to @redaction
     else
       render :action => "edit"
@@ -54,14 +54,14 @@ class RedactionsController < ApplicationController
        @redaction.old_ways.empty? &&
        @redaction.old_relations.empty?
       if @redaction.destroy
-        flash[:notice] = t("redaction.destroy.flash")
+        flash[:notice] = t(".flash")
         redirect_to :redactions
       else
-        flash[:error] = t("redaction.destroy.error")
+        flash[:error] = t(".error")
         redirect_to @redaction
       end
     else
-      flash[:error] = t("redaction.destroy.not_empty")
+      flash[:error] = t(".not_empty")
       redirect_to @redaction
     end
   end

--- a/app/views/redactions/edit.html.erb
+++ b/app/views/redactions/edit.html.erb
@@ -1,22 +1,21 @@
-<% @title = t 'redaction.edit.title' %>
+<% @title = t '.title' %>
 
 <% content_for :heading do %>
-  <h1><%= t 'redaction.edit.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
 <% end %>
 
 <%= form_for(@redaction) do |f| %>
   <%= f.error_messages %>
 
   <p>
-    <%= f.label :title, t('redaction.edit.title') %><br />
+    <%= f.label :title, t('.title') %><br />
     <%= f.text_field :title %>
   </p>
   <p>
-    <%= f.label :description, t('redaction.edit.description') %><br />
+    <%= f.label :description, t('.description') %><br />
     <%= richtext_area :redaction, :description, :cols => 80, :rows => 20, :format => @redaction.description_format %>
   </p>
   <p>
-    <%= f.submit t('redaction.edit.submit') %>
+    <%= f.submit t('.submit') %>
   </p>
 <% end %>
-

--- a/app/views/redactions/index.html.erb
+++ b/app/views/redactions/index.html.erb
@@ -1,10 +1,10 @@
-<% @title = t('redaction.index.title') %>
+<% @title = t('.title') %>
 <% content_for :heading do %>
-  <h1><%= t('redaction.index.heading') %></h1>
+  <h1><%= t('.heading') %></h1>
 <% end %>
 
 <% unless @redactions.empty? %>
   <%= render :partial => 'redactions' %>
 <% else %>
-  <p><%= t 'redaction.index.empty' %></p>
+  <p><%= t '.empty' %></p>
 <% end %>

--- a/app/views/redactions/new.html.erb
+++ b/app/views/redactions/new.html.erb
@@ -1,22 +1,20 @@
-<% @title = t 'redaction.new.title' %>
+<% @title = t '.title' %>
 <% content_for :heading do %>
-  <h1><%= t 'redaction.new.heading' %></h1>
+  <h1><%= t '.heading' %></h1>
 <% end %>
 
 <%= form_for(@redaction) do |f| %>
   <%= f.error_messages %>
 
   <p>
-    <%= f.label :title, t('redaction.new.title') %><br />
+    <%= f.label :title, t('.title') %><br />
     <%= f.text_field :title %>
   </p>
   <p>
-    <%= f.label :description, t('redaction.new.description') %><br />
+    <%= f.label :description, t('.description') %><br />
     <%= richtext_area :redaction, :description, :cols => 80, :rows => 20, :format => @redaction.description_format %>
   </p>
   <p>
-    <%= f.submit t('redaction.new.submit') %>
+    <%= f.submit t('.submit') %>
   </p>
 <% end %>
-
-

--- a/app/views/redactions/show.html.erb
+++ b/app/views/redactions/show.html.erb
@@ -1,20 +1,20 @@
-<% @title = t('redaction.show.title') %>
+<% @title = t('.title') %>
 <% content_for :heading do %>
-  <h1><%= t('redaction.show.heading', :title => @redaction.title) %></h1>
+  <h1><%= t('.heading', :title => @redaction.title) %></h1>
 <% end %>
 
 <p>
-  <b><%= t 'redaction.show.user' %></b>
+  <b><%= t '.user' %></b>
   <%= link_to(@redaction.user.display_name, user_path(@redaction.user)) %>
 </p>
 <p class="richtext">
-  <b><%= t 'redaction.show.description' %></b>
+  <b><%= t '.description' %></b>
   <%= @redaction.description.to_html %>
 </p>
 
 <% if current_user and current_user.moderator? %>
 <div class="buttons">
-  <%= button_to t('redaction.show.edit'), edit_redaction_path(@redaction), :method => :get %></td>
-  <%= button_to t('redaction.show.destroy'), @redaction, :method => "delete", :remote => true, :data => { :confirm => t('redaction.show.confirm') } %>
+  <%= button_to t('.edit'), edit_redaction_path(@redaction), :method => :get %></td>
+  <%= button_to t('.destroy'), @redaction, :method => "delete", :remote => true, :data => { :confirm => t('.confirm') } %>
 </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2401,7 +2401,7 @@ en:
       show_address: Show address
       query_features: Query features
       centre_map: Centre map here
-  redaction:
+  redactions:
     edit:
       description: "Description"
       heading: "Edit redaction"


### PR DESCRIPTION
cc @Nikerabbit 

The following translations are renamed in this PR

* `redation.*` to `redactions.*`