### PR TITLE
Rename note to notes in i18n lookups

### DIFF
--- a/app/views/notes/_comment.html.erb
+++ b/app/views/notes/_comment.html.erb
@@ -1,8 +1,8 @@
 <div class="note-comment" style="margin-top: 5px">
   <% if comment.author.nil? -%>
-  <div class="note-comment-description" style="font-size: smaller; color: #999999"><%= t "note.description.#{comment.event}_at_html", :when => friendly_date(comment.created_at) %></div>
+  <div class="note-comment-description" style="font-size: smaller; color: #999999"><%= t ".#{comment.event}_at_html", :when => friendly_date(comment.created_at) %></div>
   <% else -%>
-  <div class="note-comment-description" style="font-size: smaller; color: #999999"><%= t "note.description.#{comment.event}_at_by_html", :when => friendly_date(comment.created_at), :user => note_author(comment.author, :only_path => false) %></div>
+  <div class="note-comment-description" style="font-size: smaller; color: #999999"><%= t ".#{comment.event}_at_by_html", :when => friendly_date(comment.created_at), :user => note_author(comment.author, :only_path => false) %></div>
   <% end -%>
   <div class="note-comment-text"><%= comment.body %></div>
 </div>

--- a/app/views/notes/_entry.html.erb
+++ b/app/views/notes/_entry.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t "note.entry.comment" %></h2>
+<h2><%= t ".comment" %></h2>
 <%= render :partial => "comment", :object => entry %>
-<h2><%= t "note.entry.full" %></h2>
+<h2><%= t ".full" %></h2>
 <%= render :partial => "description", :object => entry.note %>

--- a/app/views/notes/_note.rss.builder
+++ b/app/views/notes/_note.rss.builder
@@ -2,11 +2,11 @@ xml.item do
   location = describe_location(note.lat, note.lon, 14, locale)
 
   if note.closed?
-    xml.title t("note.rss.closed", :place => location)
+    xml.title t("notes.rss.closed", :place => location)
   elsif note.comments.length > 1
-    xml.title t("note.rss.commented", :place => location)
+    xml.title t("notes.rss.commented", :place => location)
   else
-    xml.title t("note.rss.opened", :place => location)
+    xml.title t("notes.rss.opened", :place => location)
   end
 
   xml.link browse_note_url(note)

--- a/app/views/notes/feed.rss.builder
+++ b/app/views/notes/feed.rss.builder
@@ -5,15 +5,15 @@ xml.rss("version" => "2.0",
         "xmlns:geo" => "http://www.w3.org/2003/01/geo/wgs84_pos#",
         "xmlns:georss" => "http://www.georss.org/georss") do
   xml.channel do
-    xml.title t("note.rss.title")
-    xml.description t("note.rss.description_area", :min_lat => @min_lat, :min_lon => @min_lon, :max_lat => @max_lat, :max_lon => @max_lon)
+    xml.title t("notes.rss.title")
+    xml.description t("notes.rss.description_area", :min_lat => @min_lat, :min_lon => @min_lon, :max_lat => @max_lat, :max_lon => @max_lon)
     xml.link url_for(:controller => "site", :action => "index", :only_path => false)
 
     @comments.each do |comment|
       location = describe_location(comment.note.lat, comment.note.lon, 14, locale)
 
       xml.item do
-        xml.title t("note.rss.#{comment.event}", :place => location)
+        xml.title t("notes.rss.#{comment.event}", :place => location)
 
         xml.link url_for(:controller => "browse", :action => "note", :id => comment.note.id, :anchor => "c#{comment.id}", :only_path => false)
         xml.guid url_for(:controller => "browse", :action => "note", :id => comment.note.id, :anchor => "c#{comment.id}", :only_path => false)

--- a/app/views/notes/index.rss.builder
+++ b/app/views/notes/index.rss.builder
@@ -5,8 +5,8 @@ xml.rss("version" => "2.0",
         "xmlns:geo" => "http://www.w3.org/2003/01/geo/wgs84_pos#",
         "xmlns:georss" => "http://www.georss.org/georss") do
   xml.channel do
-    xml.title t("note.rss.title")
-    xml.description t("note.rss.description_area", :min_lat => @min_lat, :min_lon => @min_lon, :max_lat => @max_lat, :max_lon => @max_lon)
+    xml.title t("notes.rss.title")
+    xml.description t("notes.rss.description_area", :min_lat => @min_lat, :min_lon => @min_lon, :max_lat => @max_lat, :max_lon => @max_lon)
     xml.link url_for(:controller => "site", :action => "index", :only_path => false)
 
     xml << (render(:partial => "note", :collection => @notes) || "")

--- a/app/views/notes/mine.html.erb
+++ b/app/views/notes/mine.html.erb
@@ -8,11 +8,11 @@
 <table class="note_list">
   <tr>
     <th></th>
-    <th><%= t'note.mine.id' %></th>
-    <th><%= t'note.mine.creator' %></th>
-    <th><%= t'note.mine.description' %></th>
-    <th><%= t'note.mine.created_at' %></th>
-    <th><%= t'note.mine.last_changed' %></th>
+    <th><%= t '.id' %></th>
+    <th><%= t '.creator' %></th>
+    <th><%= t '.description' %></th>
+    <th><%= t '.created_at' %></th>
+    <th><%= t '.last_changed' %></th>
   </tr>
 <% @notes.each do |note| -%>
   <tr<% if note.author != @user2 %> class="creator"<% end %>>
@@ -25,9 +25,9 @@
     </td>
     <td><%= link_to note.id.to_s, :controller => "browse", :action => "note", :id => note.id %></td>
     <td><%= note_author(note.author) %></td>
-    <td><%= note.comments.first.body.to_html %></td>	
-    <td><%= t 'note.mine.ago_html', :when => friendly_date(note.created_at) %></td>
-    <td><%= t 'note.mine.ago_html', :when => friendly_date(note.updated_at) %></td>
+    <td><%= note.comments.first.body.to_html %></td>
+    <td><%= t '.ago_html', :when => friendly_date(note.created_at) %></td>
+    <td><%= t '.ago_html', :when => friendly_date(note.updated_at) %></td>
   </tr>
 <% end -%>
 </table>

--- a/app/views/notes/show.rss.builder
+++ b/app/views/notes/show.rss.builder
@@ -4,8 +4,8 @@ xml.rss("version" => "2.0",
         "xmlns:geo" => "http://www.w3.org/2003/01/geo/wgs84_pos#",
         "xmlns:georss" => "http://www.georss.org/georss") do
   xml.channel do
-    xml.title t("note.rss.title")
-    xml.description t("note.rss.description_item", :id => @note.id)
+    xml.title t("notes.rss.title")
+    xml.description t("notes.rss.description_item", :id => @note.id)
     xml.link url_for(:controller => "site", :action => "index", :only_path => false)
 
     xml << render(:partial => "note", :object => @note)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2203,8 +2203,8 @@ en:
       showing_page: "Page %{page}"
       next: "Next »"
       previous: "« Previous"
-  note:
-    description:
+  notes:
+    comment:
       opened_at_html: "Created %{when} ago"
       opened_at_by_html: "Created %{when} ago by %{user}"
       commented_at_html: "Updated %{when} ago"


### PR DESCRIPTION
Enables lazy translation lookups for most cases. 

cc @Nikerabbit this PR contains the following renames:

* `note.*` to `notes.*`
* then in addition, `notes.description.*` to `notes.comment.*`