### PR TITLE
Use lazy translation lookups for the oauth controller

### DIFF
--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -30,7 +30,7 @@ class OauthController < ApplicationController
     @token = current_user.oauth_tokens.find_by :token => params[:token]
     if @token
       @token.invalidate!
-      flash[:notice] = t("oauth.revoke.flash", :application => @token.client_application.name)
+      flash[:notice] = t(".flash", :application => @token.client_application.name)
     end
     redirect_to oauth_clients_url(:display_name => @token.user.display_name)
   end
@@ -41,7 +41,7 @@ class OauthController < ApplicationController
     append_content_security_policy_directives(:form_action => %w[*])
 
     if @token.invalidated?
-      @message = t "oauth.oauthorize_failure.invalid"
+      @message = t "oauth.authorize_failure.invalid"
       render :action => "authorize_failure"
     elsif request.post?
       if user_authorizes_token?
@@ -69,7 +69,7 @@ class OauthController < ApplicationController
         end
       else
         @token.invalidate!
-        @message = t("oauth.oauthorize_failure.denied", :app_name => @token.client_application.name)
+        @message = t("oauth.authorize_failure.denied", :app_name => @token.client_application.name)
         render :action => "authorize_failure"
       end
     end

--- a/app/views/oauth/authorize.html.erb
+++ b/app/views/oauth/authorize.html.erb
@@ -1,19 +1,19 @@
 <% content_for :heading do %>
-  <h1><%= t "oauth.oauthorize.title" %></h1>
+  <h1><%= t ".title" %></h1>
 <% end %>
 
-<p><%= raw t("oauth.oauthorize.request_access", :app_name => link_to(@token.client_application.name, @token.client_application.url), :user => link_to(current_user.display_name, :controller => :user, :action => :view, :display_name => current_user.display_name)) %></p>
+<p><%= raw t(".request_access", :app_name => link_to(@token.client_application.name, @token.client_application.url), :user => link_to(current_user.display_name, :controller => :user, :action => :view, :display_name => current_user.display_name)) %></p>
 
 <%= form_tag authorize_url do %>
   <%= hidden_field_tag "oauth_token", @token.token %>
   <%- if params[:oauth_callback] -%>
     <%= hidden_field_tag "oauth_callback", params[:oauth_callback] %>
   <%- end -%>
-  <p><%= t 'oauth.oauthorize.allow_to' %></p>
+  <p><%= t '.allow_to' %></p>
   <ul>
   <% @token.client_application.permissions.each do |perm| %>
-    <li><%= check_box_tag perm.to_s, "yes", @token.read_attribute(perm) %><%= t "oauth.oauthorize.#{perm}" %></li>
+    <li><%= check_box_tag perm.to_s, "yes", @token.read_attribute(perm) %><%= t ".#{perm}" %></li>
   <% end %>
   </ul>
-  <p><%= submit_tag t("oauth.oauthorize.grant_access") %></p>
+  <p><%= submit_tag t(".grant_access") %></p>
 <% end %>

--- a/app/views/oauth/authorize_failure.html.erb
+++ b/app/views/oauth/authorize_failure.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t "oauth.oauthorize_failure.title" %></h1>
+  <h1><%= t ".title" %></h1>
 <% end %>
 
 <p><%= @message %></p>

--- a/app/views/oauth/authorize_success.html.erb
+++ b/app/views/oauth/authorize_success.html.erb
@@ -1,9 +1,9 @@
 <% content_for :heading do %>
-  <h1><%= t "oauth.oauthorize_success.title" %></h1>
+  <h1><%= t ".title" %></h1>
 <% end %>
 
-<p><%= raw t("oauth.oauthorize_success.allowed", :app_name => link_to(@token.client_application.name, @token.client_application.url)) %></p>
+<p><%= raw t(".allowed", :app_name => link_to(@token.client_application.name, @token.client_application.url)) %></p>
 
 <% if @token.oob? and not @token.oauth10? %>
-<p><%= t "oauth.oauthorize_success.verification", :code => @token.verifier %></p>
+<p><%= t ".verification", :code => @token.verifier %></p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1690,7 +1690,7 @@ en:
       blocked: "Your access to the API has been blocked. Please log-in to the web interface to find out more."
       need_to_see_terms: "Your access to the API is temporarily suspended. Please log-in to the web interface to view the Contributor Terms. You do not need to agree, but you must view them."
   oauth:
-    oauthorize:
+    authorize:
       title: "Authorize access to your account"
       request_access: "The application %{app_name} is requesting access to your account, %{user}. Please check whether you would like the application to have the following capabilities. You may choose as many or as few as you like."
       allow_to: "Allow the client application to:"
@@ -1702,11 +1702,11 @@ en:
       allow_write_gpx:   "upload GPS traces."
       allow_write_notes: "modify notes."
       grant_access: "Grant Access"
-    oauthorize_success:
+    authorize_success:
       title: "Authorization request allowed"
       allowed: "You have granted application %{app_name} access to your account."
       verification: "The verification code is %{code}."
-    oauthorize_failure:
+    authorize_failure:
       title: "Authorization request failed"
       denied: "You have denied application %{app_name} access to your account."
       invalid: "The authorization token is not valid."


### PR DESCRIPTION
cc @Nikerabbit 

This PR renames the following keys:
* `oauth.oauthorize.*` to `oauth.authorize.*`
* `oauth.oauthorize_success.*` to `oauth.authorize_success.*`
* `oauth.oauthorize_failure.*` to `oauth.authorize_failure.*`