### PR TITLE
Use lazy lookups and rename keys for site pages

### DIFF
--- a/app/views/site/_markdown_help.html.erb
+++ b/app/views/site/_markdown_help.html.erb
@@ -1,26 +1,26 @@
-<h4 class='heading'><%= t "site.markdown_help.title_html" %></h4>
+<h4 class='heading'><%= t ".title_html" %></h4>
 <ul>
   <li>
-    <h4><%= t "site.markdown_help.headings" %></h4>
-    <p># <%= t "site.markdown_help.heading" %><br>
-       ## <%= t "site.markdown_help.subheading" %></p>
+    <h4><%= t ".headings" %></h4>
+    <p># <%= t ".heading" %><br>
+       ## <%= t ".subheading" %></p>
   </li>
   <li>
-    <h4><%= t "site.markdown_help.unordered" %></h4>
-    <p>* <%= t "site.markdown_help.first" %><br>
-       * <%= t "site.markdown_help.second" %></p>
+    <h4><%= t ".unordered" %></h4>
+    <p>* <%= t ".first" %><br>
+       * <%= t ".second" %></p>
   </li>
   <li>
-    <h4><%= t "site.markdown_help.ordered" %></h4>
-    <p>1. <%= t "site.markdown_help.first" %><br>
-       2. <%= t "site.markdown_help.second" %></p>
+    <h4><%= t ".ordered" %></h4>
+    <p>1. <%= t ".first" %><br>
+       2. <%= t ".second" %></p>
   </li>
   <li>
-    <h4><%= t "site.markdown_help.link" %></h4>
-    <span>[<%= t "site.markdown_help.text" %>](<%= t "site.markdown_help.url" %>)</span>
+    <h4><%= t ".link" %></h4>
+    <span>[<%= t ".text" %>](<%= t ".url" %>)</span>
   </li>
   <li>
-    <h4><%= t "site.markdown_help.image" %></h4>
-    <span>![<%= t "site.markdown_help.alt" %>](<%= t "site.markdown_help.url" %>)</span>
+    <h4><%= t ".image" %></h4>
+    <span>![<%= t ".alt" %>](<%= t ".url" %>)</span>
   </li>
 </ul>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -1,37 +1,37 @@
 <div class='attr'>
   <div class='byosm'>
-    <%= t "about_page.copyright_html" %>
+    <%= t ".copyright_html" %>
   </div>
 
   <div class='user-image'></div>
 
-  <h1><%= raw t "about_page.used_by", :name => "<span class='user-name'>OpenStreetMap</span>" %></h1>
+  <h1><%= raw t ".used_by", :name => "<span class='user-name'>OpenStreetMap</span>" %></h1>
 </div>
 
 <div class='text'>
   <div class='section'>
-    <p><strong><%= t "about_page.lede_text" %></strong></p>
-    <h2><div class='icon local'></div><%= t "about_page.local_knowledge_title" %></h2>
-    <p><%= t "about_page.local_knowledge_html" %></p>
+    <p><strong><%= t ".lede_text" %></strong></p>
+    <h2><div class='icon local'></div><%= t ".local_knowledge_title" %></h2>
+    <p><%= t ".local_knowledge_html" %></p>
   </div>
 
   <div class='section'>
-    <h2><div class='icon community'></div><%= t "about_page.community_driven_title" %></h2>
-    <p><%= t "about_page.community_driven_html", :diary_path => diary_path %></p>
+    <h2><div class='icon community'></div><%= t ".community_driven_title" %></h2>
+    <p><%= t ".community_driven_html", :diary_path => diary_path %></p>
   </div>
 
   <div class='section' id='open-data'>
-    <h2><div class='icon open'></div><%= t "about_page.open_data_title" %></h2>
-    <p><%= t "about_page.open_data_html", :copyright_path => copyright_path %></p>
+    <h2><div class='icon open'></div><%= t ".open_data_title" %></h2>
+    <p><%= t ".open_data_html", :copyright_path => copyright_path %></p>
   </div>
 
   <div class='section' id='legal'>
-    <h2><div class='icon legal'></div><%= t "about_page.legal_title" %></h2>
-    <p><%= t "about_page.legal_html" %></p>
+    <h2><div class='icon legal'></div><%= t ".legal_title" %></h2>
+    <p><%= t ".legal_html" %></p>
   </div>
 
   <div class='section' id='partners'>
-    <h2><div class='icon partners'></div><%= t "about_page.partners_title" %></h2>
+    <h2><div class='icon partners'></div><%= t ".partners_title" %></h2>
     <p><%= t 'layouts.partners_html',
              :ucl => link_to(t('layouts.partners_ucl'), "https://www.ucl.ac.uk"),
              :ic => link_to(t('layouts.partners_ic'), "https://www.imperial.ac.uk/"),

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -2,15 +2,15 @@
 <% if @locale == 'en' %>
   <!-- Maybe ease foreigners back to their native page -->
 
-    <% if t('license_page.legal_babble', :locale => I18n.locale) != t('license_page.legal_babble', :locale => :en) %>
-      <h1><%= t 'license_page.native.title' %></h1>
+    <% if t('.legal_babble', :locale => I18n.locale) != t('.legal_babble', :locale => :en) %>
+      <h1><%= t '.native.title' %></h1>
       <p>
-        <%= raw t 'license_page.native.text',
-                    :native_link => link_to(t('license_page.native.native_link'),
+        <%= raw t '.native.text',
+                    :native_link => link_to(t('.native.native_link'),
                                                 :controller => 'site',
                                                 :action => 'copyright',
                                                 :copyright_locale => nil),
-                    :mapping_link => link_to(t('license_page.native.mapping_link'),
+                    :mapping_link => link_to(t('.native.mapping_link'),
                                                 :controller => 'site',
                                                 :action => 'index') %>
       </p>
@@ -18,11 +18,11 @@
     <% end %>
   <% else %>
     <!-- Maybe note that this page has been translated -->
-    <% if t('license_page.legal_babble', :locale => @locale) != t('license_page.legal_babble', :locale => :en) %>
-      <h1><%= t 'license_page.foreign.title' %></h1>
+    <% if t('.legal_babble', :locale => @locale) != t('.legal_babble', :locale => :en) %>
+      <h1><%= t '.foreign.title' %></h1>
       <p>
-        <%= raw t 'license_page.foreign.text',
-                    :english_original_link => link_to(t('license_page.foreign.english_link'),
+        <%= raw t '.foreign.text',
+                    :english_original_link => link_to(t('.foreign.english_link'),
                                                           :controller => 'site',
                                                           :action => 'copyright',
                                                           :copyright_locale => 'en') %>
@@ -31,46 +31,46 @@
     <% end %>
   <% end %>
 
-  <h1><%= t "license_page.legal_babble.title_html", :locale => @locale %></h1>
+  <h1><%= t ".legal_babble.title_html", :locale => @locale %></h1>
 
 <% end %>
 
-<p><%= t "license_page.legal_babble.intro_1_html", :locale => @locale %></p>
-<p><%= t "license_page.legal_babble.intro_2_html", :locale => @locale %></p>
-<p><%= t "license_page.legal_babble.intro_3_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.intro_1_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.intro_2_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.intro_3_html", :locale => @locale %></p>
 
-<h3><%= t "license_page.legal_babble.credit_title_html", :locale => @locale %></h3>
-<p><%= t "license_page.legal_babble.credit_1_html", :locale => @locale %></p>
-<p><%= t "license_page.legal_babble.credit_2_html", :locale => @locale %></p>
-<p><%= t "license_page.legal_babble.credit_3_html", :locale => @locale %></p>
+<h3><%= t ".legal_babble.credit_title_html", :locale => @locale %></h3>
+<p><%= t ".legal_babble.credit_1_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.credit_2_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.credit_3_html", :locale => @locale %></p>
 <p><%= image_tag("attribution_example.png",
-              :alt => t('license_page.legal_babble.attribution_example.alt'),
+              :alt => t('.legal_babble.attribution_example.alt'),
               :border => 0,
-              :title => t('license_page.legal_babble.attribution_example.title')) %>
+              :title => t('.legal_babble.attribution_example.title')) %>
 
-<h3><%= t "license_page.legal_babble.more_title_html", :locale => @locale %></h3>
-<p><%= t "license_page.legal_babble.more_1_html", :locale => @locale %></p>
-<p><%= t "license_page.legal_babble.more_2_html", :locale => @locale %></p>
+<h3><%= t ".legal_babble.more_title_html", :locale => @locale %></h3>
+<p><%= t ".legal_babble.more_1_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.more_2_html", :locale => @locale %></p>
 
-<h3><%= t "license_page.legal_babble.contributors_title_html", :locale => @locale %></h3>
-<p><%= t "license_page.legal_babble.contributors_intro_html", :locale => @locale %></p>
+<h3><%= t ".legal_babble.contributors_title_html", :locale => @locale %></h3>
+<p><%= t ".legal_babble.contributors_intro_html", :locale => @locale %></p>
 <ul id="contributors">
-  <li><%= t "license_page.legal_babble.contributors_at_html", :locale => @locale %></li>
-  <li><%= t "license_page.legal_babble.contributors_ca_html", :locale => @locale %></li>
-  <li><%= t "license_page.legal_babble.contributors_fi_html", :locale => @locale %></li>
-  <li><%= t "license_page.legal_babble.contributors_fr_html", :locale => @locale %></li>
-  <li><%= t "license_page.legal_babble.contributors_nl_html", :locale => @locale %></li>
-  <li><%= t "license_page.legal_babble.contributors_nz_html", :locale => @locale %></li>
-  <li><%= t "license_page.legal_babble.contributors_si_html", :locale => @locale %></li>
-  <li><%= t "license_page.legal_babble.contributors_za_html", :locale => @locale %></li>
-  <li><%= t "license_page.legal_babble.contributors_gb_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_at_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_ca_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_fi_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_fr_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_nl_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_nz_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_si_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_za_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_gb_html", :locale => @locale %></li>
 </ul>
-<p><%= t "license_page.legal_babble.contributors_footer_1_html", :locale => @locale %></p>
-<p><%= t "license_page.legal_babble.contributors_footer_2_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.contributors_footer_1_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.contributors_footer_2_html", :locale => @locale %></p>
 
-<h3><%= t "license_page.legal_babble.infringement_title_html", :locale => @locale %></h3>
-<p><%= t "license_page.legal_babble.infringement_1_html", :locale => @locale %></p>
-<p><%= t "license_page.legal_babble.infringement_2_html", :locale => @locale %></p>
+<h3><%= t ".legal_babble.infringement_title_html", :locale => @locale %></h3>
+<p><%= t ".legal_babble.infringement_1_html", :locale => @locale %></p>
+<p><%= t ".legal_babble.infringement_2_html", :locale => @locale %></p>
 
-<h3><%= t "license_page.legal_babble.trademarks_title_html", :locale => @locale %></h3>
-<p><%= t "license_page.legal_babble.trademarks_1_html", :locale => @locale %></p>
+<h3><%= t ".legal_babble.trademarks_title_html", :locale => @locale %></h3>
+<p><%= t ".legal_babble.trademarks_1_html", :locale => @locale %></p>

--- a/app/views/site/edit.html.erb
+++ b/app/views/site/edit.html.erb
@@ -4,9 +4,9 @@
   <% elsif STATUS == :database_readonly or STATUS == :api_readonly %>
     <p><%= t 'layouts.osm_read_only' %></p>
   <% elsif !current_user.data_public? %>
-    <p><%= t 'site.edit.not_public' %></p>
-    <p><%= raw t 'site.edit.not_public_description', :user_page => (link_to t('site.edit.user_page_link'), {:controller => 'user', :action => 'account', :display_name => current_user.display_name, :anchor => 'public'}) %></p>
-    <p><%= raw t 'site.edit.anon_edits', :link => link_to(t('site.edit.anon_edits_link_text'), t('site.edit.anon_edits_link')) %></p>
+    <p><%= t '.not_public' %></p>
+    <p><%= raw t '.not_public_description', :user_page => (link_to t('.user_page_link'), {:controller => 'user', :action => 'account', :display_name => current_user.display_name, :anchor => 'public'}) %></p>
+    <p><%= raw t 'site.edit.anon_edits', :link => link_to(t('.anon_edits_link_text'), t('.anon_edits_link')) %></p>
   <% else %>
     <%= render :partial => preferred_editor %>
   <% end %>

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -1,8 +1,8 @@
-<% set_title(t('export.title')) %>
+<% set_title(t('.title')) %>
 
 <h2>
   <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-  <%= t 'export.title' %>
+  <%= t '.title' %>
 </h2>
 
 <%= form_tag({:controller => "export", :action => "finish"}, :class => "export_form") do %>
@@ -17,37 +17,37 @@
       <br/><br/>
       <%= text_field_tag('minlat', nil, :size => 10, :class => "export_bound") %>
       </div>
-    <a id='drag_box' href="#"><%= t'export.start.manually_select' %></a>
+    <a id='drag_box' href="#"><%= t '.manually_select' %></a>
   </div>
 
-  <h4><%= t'export.start.licence' %></h4>
-  <p><%= raw t 'export.start.export_details' %></p>
+  <h4><%= t '.licence' %></h4>
+  <p><%= raw t '.export_details' %></p>
 
   <div id="export_osm_too_large">
     <p class="warning">
-      <%= t'export.start.too_large.body' %>
+      <%= t '.too_large.body' %>
     </p>
   </div>
 
   <div id="export_commit">
     <div class="export_button">
-      <%= submit_tag t('export.start.export_button') %>
+      <%= submit_tag t('.export_button') %>
     </div>
 
-    <p><%= t'export.start.too_large.advice' %></p>
+    <p><%= t '.too_large.advice' %></p>
   </div>
 
-  <dl class="inner12">  
-    <dt><a id="export_overpass" href="https://overpass-api.de/api/map?bbox="><%= t'export.start.too_large.overpass.title' %></a></dt>
-    <dd><%= t'export.start.too_large.overpass.description' %></dd>
-    
-    <dt><a href="https://planet.openstreetmap.org/"><%= t'export.start.too_large.planet.title' %></a></dt>
-    <dd><%= t'export.start.too_large.planet.description' %></dd>
+  <dl class="inner12">
+    <dt><a id="export_overpass" href="https://overpass-api.de/api/map?bbox="><%= t '.too_large.overpass.title' %></a></dt>
+    <dd><%= t '.too_large.overpass.description' %></dd>
 
-    <dt><a href="https://download.geofabrik.de/"><%= t'export.start.too_large.geofabrik.title' %></a></dt>
-    <dd><%= t'export.start.too_large.geofabrik.description' %></dd>
+    <dt><a href="https://planet.openstreetmap.org/"><%= t '.too_large.planet.title' %></a></dt>
+    <dd><%= t '.too_large.planet.description' %></dd>
 
-    <dt><a href="https://wiki.openstreetmap.org/wiki/Download"><%= t'export.start.too_large.other.title' %></a></dt>
-    <dd><%= t'export.start.too_large.other.description' %></dd>
+    <dt><a href="https://download.geofabrik.de/"><%= t '.too_large.geofabrik.title' %></a></dt>
+    <dd><%= t '.too_large.geofabrik.description' %></dd>
+
+    <dt><a href="https://wiki.openstreetmap.org/wiki/Download"><%= t '.too_large.other.title' %></a></dt>
+    <dd><%= t '.too_large.other.description' %></dd>
   </dl>
 <% end %>

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -21,8 +21,8 @@
     </div>
   </div>
   <div class='col6 inner11'>
-    <h3><%= t "welcome_page.add_a_note.title" %></h3>
-    <p><%= t "welcome_page.add_a_note.paragraph_1_html" %></p>
+    <h3><%= t "site.welcome.add_a_note.title" %></h3>
+    <p><%= t "site.welcome.add_a_note.paragraph_1_html" %></p>
     <p><%= t "fixthemap.how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
   </div>
 </div>
@@ -31,7 +31,7 @@
 <p><%= t "fixthemap.other_concerns.explanation_html" %></p>
 
 <div class='col12 clearfix icon-list'>
-  <h3><%= t "welcome_page.questions.title" %></h3>
+  <h3><%= t "site.welcome.questions.title" %></h3>
   <span class='sprite small term question'></span>
-  <p><%= t "welcome_page.questions.paragraph_1_html", :help_url => help_path %></p>
+  <p><%= t "site.welcome.questions.paragraph_1_html", :help_url => help_path %></p>
 </div>

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -3,19 +3,19 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h1><%= t "fixthemap.title" %></h1>
+  <h1><%= t ".title" %></h1>
 <% end %>
 
 <h3><%= t "layouts.intro_header" %></h3>
 
 <p><%= t "layouts.intro_text" %></p>
 
-<h3><%= t "fixthemap.how_to_help.title" %></h3>
+<h3><%= t ".how_to_help.title" %></h3>
 
 <div class='clearfix'>
   <div class='col6 inner11'>
-    <h3><%= t "fixthemap.how_to_help.join_the_community.title" %></h3>
-    <%= t "fixthemap.how_to_help.join_the_community.explanation_html" %>
+    <h3><%= t ".how_to_help.join_the_community.title" %></h3>
+    <%= t ".how_to_help.join_the_community.explanation_html" %>
     <div class='clearfix center'>
       <a class="button sign-up" href="<%= user_new_path %>"><%= t('layouts.start_mapping') %></a>
     </div>
@@ -23,12 +23,12 @@
   <div class='col6 inner11'>
     <h3><%= t "site.welcome.add_a_note.title" %></h3>
     <p><%= t "site.welcome.add_a_note.paragraph_1_html" %></p>
-    <p><%= t "fixthemap.how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
+    <p><%= t ".how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
   </div>
 </div>
 
-<h3><%= t "fixthemap.other_concerns.title" %></h3>
-<p><%= t "fixthemap.other_concerns.explanation_html" %></p>
+<h3><%= t ".other_concerns.title" %></h3>
+<p><%= t ".other_concerns.explanation_html" %></p>
 
 <div class='col12 clearfix icon-list'>
   <h3><%= t "site.welcome.questions.title" %></h3>

--- a/app/views/site/help.html.erb
+++ b/app/views/site/help.html.erb
@@ -1,18 +1,18 @@
 <% content_for :heading do %>
-  <h1><%= t "help_page.title" %></h1>
+  <h1><%= t ".title" %></h1>
 <% end %>
 
-<p class='introduction'><%= t "help_page.introduction" %></p>
+<p class='introduction'><%= t ".introduction" %></p>
 
 <% ['welcome', 'beginners_guide', 'help', 'mailing_lists', 'forums', 'irc', 'switch2osm', 'wiki'].each do |site| %>
   <% unless site == 'welcome' && !current_user %>
   <div class='<%= site %> help-item'>
   <h3>
-    <a href='<%= t "help_page.#{site}.url" %>'>
-      <%= t "help_page.#{site}.title" %>
+    <a href='<%= t ".#{site}.url" %>'>
+      <%= t ".#{site}.title" %>
     </a>
   </h3>
-  <p><%= t "help_page.#{site}.description" %></p>
+  <p><%= t ".#{site}.description" %></p>
   </div>
   <% end %>
 <% end %>

--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -7,7 +7,7 @@
             <%= image_tag "key/#{name}/#{entry['image']}" %>
           </td>
           <td class="mapkey-table-value">
-            <%= [*t("site.key.table.entry.#{entry['name']}")].to_sentence %>
+            <%= [*t(".table.entry.#{entry['name']}")].to_sentence %>
           </td>
         </tr>
       <% end %>

--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -3,71 +3,71 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h1><%= t "welcome_page.title" %></h1>
+  <h1><%= t ".title" %></h1>
 <% end %>
 
-<p><%= t "welcome_page.introduction_html" %></p>
+<p><%= t ".introduction_html" %></p>
 
-<h3><%= t "welcome_page.whats_on_the_map.title" %></h3>
+<h3><%= t ".whats_on_the_map.title" %></h3>
 
 <div class=' clearfix'>
   <div class='col6 inner11'>
     <div class='center clearfix inner11'>
       <span class='sprite small check'></span>
     </div>
-    <p><%= t "welcome_page.whats_on_the_map.on_html" %></p>
+    <p><%= t ".whats_on_the_map.on_html" %></p>
   </div>
   <div class='col6 inner11'>
     <div class='center clearfix inner11'>
       <span class='sprite small x'></span>
     </div>
-    <p><%= t "welcome_page.whats_on_the_map.off_html" %></p>
+    <p><%= t ".whats_on_the_map.off_html" %></p>
   </div>
 </div>
 
-<h3><%= t "welcome_page.basic_terms.title" %></h3>
+<h3><%= t ".basic_terms.title" %></h3>
 
-<p><%= t "welcome_page.basic_terms.paragraph_1_html" %></p>
+<p><%= t ".basic_terms.paragraph_1_html" %></p>
 
 <div class='col12 clearfix icon-list'>
   <div class='clearfix'>
     <span class='sprite small term editor'></span>
-    <p><%= t "welcome_page.basic_terms.editor_html" %></p>
+    <p><%= t ".basic_terms.editor_html" %></p>
   </div>
   <div class='clearfix'>
     <span class='sprite small term node'></span>
-    <p><%= t "welcome_page.basic_terms.node_html" %></p>
+    <p><%= t ".basic_terms.node_html" %></p>
   </div>
   <div class='clearfix'>
     <span class='sprite small term way'></span>
-    <p><%= t "welcome_page.basic_terms.way_html" %></p>
+    <p><%= t ".basic_terms.way_html" %></p>
   </div>
   <div class='clearfix'>
     <span class='sprite small term tag'></span>
-    <p><%= t "welcome_page.basic_terms.tag_html" %></p>
+    <p><%= t ".basic_terms.tag_html" %></p>
   </div>
 </div>
 
 <div class='col12 clearfix icon-list'>
-  <h3><%= t "welcome_page.rules.title" %></h3>
+  <h3><%= t ".rules.title" %></h3>
   <span class='sprite small term rules'></span>
-  <p><%= t "welcome_page.rules.paragraph_1_html" %></p>
+  <p><%= t ".rules.paragraph_1_html" %></p>
 </div>
 
 <div class='col12 clearfix icon-list'>
-  <h3><%= t "welcome_page.questions.title" %></h3>
+  <h3><%= t ".questions.title" %></h3>
   <span class='sprite small term question'></span>
-  <p><%= t "welcome_page.questions.paragraph_1_html", :help_url => help_path %></p>
+  <p><%= t ".questions.paragraph_1_html", :help_url => help_path %></p>
 </div>
 
 <div class='clearfix center'>
-  <a href="<%= edit_path %>" class="button start-mapping"><%= t "welcome_page.start_mapping" %></a>
+  <a href="<%= edit_path %>" class="button start-mapping"><%= t ".start_mapping" %></a>
 </div>
 
 <div class='note-box'>
   <div class='inner22'>
-    <h3><%= t "welcome_page.add_a_note.title" %></h3>
-    <p><%= t "welcome_page.add_a_note.paragraph_1_html" %></p>
-    <p><%= t "welcome_page.add_a_note.paragraph_2_html", :map_url => root_path %></p>
+    <h3><%= t ".add_a_note.title" %></h3>
+    <p><%= t ".add_a_note.paragraph_1_html" %></p>
+    <p><%= t ".add_a_note.paragraph_2_html", :map_url => root_path %></p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -968,26 +968,6 @@ en:
       text: Make a Donation
     learn_more: "Learn More"
     more: More
-  fixthemap:
-    title: Report a problem / Fix the map
-    how_to_help:
-      title: How to Help
-      join_the_community:
-        title: Join the community
-        explanation_html: |
-          If you have noticed a problem with our map data, for example a road is missing or your address, the best way to
-          proceed is to join the OpenStreetMap community and add or repair the data yourself.
-      add_a_note:
-        instructions_html: |
-          Just click <a class='icon note'></a> or the same icon on the map display.
-          This will add a marker to the map, which you can move
-          by dragging. Add your message, then click save, and other mappers will investigate.
-    other_concerns:
-      title: Other concerns
-      explanation_html: |
-        If you have concerns about how our data is being used or about the contents please consult our
-        <a href='/copyright'>copyright page</a> for more legal information, or contact the appropriate
-        <a href='https://wiki.osmfoundation.org/wiki/Working_Groups'>OSMF working group</a>.
   help_page:
     title: Getting Help
     introduction: |
@@ -1416,6 +1396,26 @@ en:
       output: "Output"
       paste_html: "Paste HTML to embed in website"
       export_button: "Export"
+    fixthemap:
+      title: Report a problem / Fix the map
+      how_to_help:
+        title: How to Help
+        join_the_community:
+          title: Join the community
+          explanation_html: |
+            If you have noticed a problem with our map data, for example a road is missing or your address, the best way to
+            proceed is to join the OpenStreetMap community and add or repair the data yourself.
+        add_a_note:
+          instructions_html: |
+            Just click <a class='icon note'></a> or the same icon on the map display.
+            This will add a marker to the map, which you can move
+            by dragging. Add your message, then click save, and other mappers will investigate.
+      other_concerns:
+        title: Other concerns
+        explanation_html: |
+          If you have concerns about how our data is being used or about the contents please consult our
+          <a href='/copyright'>copyright page</a> for more legal information, or contact the appropriate
+          <a href='https://wiki.osmfoundation.org/wiki/Working_Groups'>OSMF working group</a>.
     sidebar:
       search_results: Search Results
       close: Close

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1135,59 +1135,6 @@ en:
       trademarks_title_html: <span id="trademarks"></span>Trademarks
       trademarks_1_html: |
         OpenStreetMap, the magnifying glass logo and State of the Map are registered trademarks of the OpenStreetMap Foundation. If you have questions about your use of the marks, please see our <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">Trademark Policy</a>.
-  welcome_page:
-    title: Welcome!
-    introduction_html: |
-      Welcome to OpenStreetMap, the free and editable map of the world. Now that you're signed
-      up, you're all set to get started mapping. Here's a quick guide with the most important
-      things you need to know.
-    whats_on_the_map:
-      title: What's on the Map
-      on_html: |
-        OpenStreetMap is a place for mapping things that are both <em>real and current</em> -
-        it includes millions of buildings, roads, and other details about places. You can map
-        whatever real-world features are interesting to you.
-      off_html: |
-        What it <em>doesn't</em> include is opinionated data like ratings, historical or
-        hypothetical features, and data from copyrighted sources. Unless you have special
-        permission, don't copy from online or paper maps.
-    basic_terms:
-      title: Basic Terms For Mapping
-      paragraph_1_html: |
-        OpenStreetMap has some of its own lingo. Here are a few key words that'll come in handy.
-      editor_html: |
-        An <strong>editor</strong> is a program or website you can use to edit the map.
-      node_html: |
-        A <strong>node</strong> is a point on the map, like a single restaurant or a tree.
-      way_html: |
-        A <strong>way</strong> is a line or area, like a road, stream, lake or building.
-      tag_html: |
-        A <strong>tag</strong> is a bit of data about a node or way, like a
-        restaurant's name or a road's speed limit.
-    rules:
-      title: Rules!
-      paragraph_1_html: |
-        OpenStreetMap has few formal rules but we expect all participants to collaborate
-        with, and communicate with, the community. If you are considering
-        any activities other than editing by hand, please read and follow the guidelines on
-        <a href='https://wiki.openstreetmap.org/wiki/Import/Guidelines'>Imports</a> and
-        <a href='https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct'>Automated Edits</a>.
-    questions:
-      title: Any questions?
-      paragraph_1_html: |
-        OpenStreetMap has several resources for learning about the project, asking and answering
-        questions, and collaboratively discussing and documenting mapping topics.
-        <a href='%{help_url}'>Get help here</a>.
-    start_mapping: Start Mapping
-    add_a_note:
-      title: No Time To Edit? Add a Note!
-      paragraph_1_html: |
-        If you just want something small fixed and don't have the time to sign up and learn how to edit, it's
-        easy to add a note.
-      paragraph_2_html: |
-        Just go to <a href='%{map_url}'>the map</a> and click the note icon:
-        <span class='icon note'></span>. This will add a marker to the map, which you can move
-        by dragging. Add your message, then click save, and other mappers will investigate.
   fixthemap:
     title: Report a problem / Fix the map
     how_to_help:
@@ -1570,6 +1517,59 @@ en:
       image: Image
       alt: Alt text
       url: URL
+    welcome:
+      title: Welcome!
+      introduction_html: |
+        Welcome to OpenStreetMap, the free and editable map of the world. Now that you're signed
+        up, you're all set to get started mapping. Here's a quick guide with the most important
+        things you need to know.
+      whats_on_the_map:
+        title: What's on the Map
+        on_html: |
+          OpenStreetMap is a place for mapping things that are both <em>real and current</em> -
+          it includes millions of buildings, roads, and other details about places. You can map
+          whatever real-world features are interesting to you.
+        off_html: |
+          What it <em>doesn't</em> include is opinionated data like ratings, historical or
+          hypothetical features, and data from copyrighted sources. Unless you have special
+          permission, don't copy from online or paper maps.
+      basic_terms:
+        title: Basic Terms For Mapping
+        paragraph_1_html: |
+          OpenStreetMap has some of its own lingo. Here are a few key words that'll come in handy.
+        editor_html: |
+          An <strong>editor</strong> is a program or website you can use to edit the map.
+        node_html: |
+          A <strong>node</strong> is a point on the map, like a single restaurant or a tree.
+        way_html: |
+          A <strong>way</strong> is a line or area, like a road, stream, lake or building.
+        tag_html: |
+          A <strong>tag</strong> is a bit of data about a node or way, like a
+          restaurant's name or a road's speed limit.
+      rules:
+        title: Rules!
+        paragraph_1_html: |
+          OpenStreetMap has few formal rules but we expect all participants to collaborate
+          with, and communicate with, the community. If you are considering
+          any activities other than editing by hand, please read and follow the guidelines on
+          <a href='https://wiki.openstreetmap.org/wiki/Import/Guidelines'>Imports</a> and
+          <a href='https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct'>Automated Edits</a>.
+      questions:
+        title: Any questions?
+        paragraph_1_html: |
+          OpenStreetMap has several resources for learning about the project, asking and answering
+          questions, and collaboratively discussing and documenting mapping topics.
+          <a href='%{help_url}'>Get help here</a>.
+      start_mapping: Start Mapping
+      add_a_note:
+        title: No Time To Edit? Add a Note!
+        paragraph_1_html: |
+          If you just want something small fixed and don't have the time to sign up and learn how to edit, it's
+          easy to add a note.
+        paragraph_2_html: |
+          Just go to <a href='%{map_url}'>the map</a> and click the note icon:
+          <span class='icon note'></span>. This will add a marker to the map, which you can move
+          by dragging. Add your message, then click save, and other mappers will investigate.
   trace:
     visibility:
       private: "Private (only shared as anonymous, unordered points)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -968,43 +968,6 @@ en:
       text: Make a Donation
     learn_more: "Learn More"
     more: More
-  help_page:
-    title: Getting Help
-    introduction: |
-      OpenStreetMap has several resources for learning about the project, asking and answering questions,
-      and collaboratively discussing and documenting mapping topics.
-    welcome:
-      url: /welcome
-      title: Welcome to OSM
-      description: Start with this quick guide covering the OpenStreetMap basics.
-    beginners_guide:
-      url: https://wiki.openstreetmap.org/wiki/Beginners%27_guide
-      title: Beginners' Guide
-      description: Community maintained guide for beginners.
-    help:
-      url: https://help.openstreetmap.org/
-      title: help.openstreetmap.org
-      description: Ask a question or look up answers on OSM's question-and-answer site.
-    mailing_lists:
-      url: https://lists.openstreetmap.org/
-      title: Mailing Lists
-      description: Ask a question or discuss interesting matters on a wide range of topical or regional mailing lists.
-    forums:
-      url: https://forum.openstreetmap.org/
-      title: Forums
-      description: Questions and discussions for those that prefer a bulletin board style interface.
-    irc:
-      url: https://irc.openstreetmap.org/
-      title: IRC
-      description: Interactive chat in many different languages and on many topics.
-    switch2osm:
-      url: https://switch2osm.org/
-      title: switch2osm
-      description: Help for companies and organisations switching to OpenStreetMap based maps and other services.
-    wiki:
-      url: https://wiki.openstreetmap.org/
-      title: wiki.openstreetmap.org
-      description: Browse the wiki for in-depth OSM documentation.
   notifier:
     diary_comment_notification:
       subject: "[OpenStreetMap] %{user} commented on a diary entry"
@@ -1416,6 +1379,43 @@ en:
           If you have concerns about how our data is being used or about the contents please consult our
           <a href='/copyright'>copyright page</a> for more legal information, or contact the appropriate
           <a href='https://wiki.osmfoundation.org/wiki/Working_Groups'>OSMF working group</a>.
+    help:
+      title: Getting Help
+      introduction: |
+        OpenStreetMap has several resources for learning about the project, asking and answering questions,
+        and collaboratively discussing and documenting mapping topics.
+      welcome:
+        url: /welcome
+        title: Welcome to OSM
+        description: Start with this quick guide covering the OpenStreetMap basics.
+      beginners_guide:
+        url: https://wiki.openstreetmap.org/wiki/Beginners%27_guide
+        title: Beginners' Guide
+        description: Community maintained guide for beginners.
+      help:
+        url: https://help.openstreetmap.org/
+        title: help.openstreetmap.org
+        description: Ask a question or look up answers on OSM's question-and-answer site.
+      mailing_lists:
+        url: https://lists.openstreetmap.org/
+        title: Mailing Lists
+        description: Ask a question or discuss interesting matters on a wide range of topical or regional mailing lists.
+      forums:
+        url: https://forum.openstreetmap.org/
+        title: Forums
+        description: Questions and discussions for those that prefer a bulletin board style interface.
+      irc:
+        url: https://irc.openstreetmap.org/
+        title: IRC
+        description: Interactive chat in many different languages and on many topics.
+      switch2osm:
+        url: https://switch2osm.org/
+        title: switch2osm
+        description: Help for companies and organisations switching to OpenStreetMap based maps and other services.
+      wiki:
+        url: https://wiki.openstreetmap.org/
+        title: wiki.openstreetmap.org
+        description: Browse the wiki for in-depth OSM documentation.
     sidebar:
       search_results: Search Results
       close: Close

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,47 +323,6 @@ en:
       ago: "%{ago} ago"
       newer_comments: "Newer Comments"
       older_comments: "Older Comments"
-  export:
-    title: "Export"
-    start:
-      area_to_export: "Area to Export"
-      manually_select: "Manually select a different area"
-      format_to_export: "Format to Export"
-      osm_xml_data: "OpenStreetMap XML Data"
-      map_image: "Map Image (shows standard layer)"
-      embeddable_html: "Embeddable HTML"
-      licence: "Licence"
-      export_details: 'OpenStreetMap data is licensed under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Data Commons Open Database License</a> (ODbL).'
-      too_large:
-        advice: "If the above export fails, please consider using one of the sources listed below:"
-        body: "This area is too large to be exported as OpenStreetMap XML Data. Please zoom in or select a smaller area, or use one of the sources listed below for bulk data downloads."
-        planet:
-          title: "Planet OSM"
-          description: "Regularly-updated copies of the complete OpenStreetMap database"
-        overpass:
-          title: "Overpass API"
-          description: "Download this bounding box from a mirror of the OpenStreetMap database"
-        geofabrik:
-          title: "Geofabrik Downloads"
-          description: "Regularly-updated extracts of continents, countries, and selected cities"
-        metro:
-          title: "Metro Extracts"
-          description: "Extracts for major world cities and their surrounding areas"
-        other:
-          title: "Other Sources"
-          description: "Additional sources listed on the OpenStreetMap wiki"
-      options: "Options"
-      format: "Format"
-      scale: "Scale"
-      max: "max"
-      image_size: "Image Size"
-      zoom: "Zoom"
-      add_marker: "Add a marker to the map"
-      latitude: "Lat:"
-      longitude: "Lon:"
-      output: "Output"
-      paste_html: "Paste HTML to embed in website"
-      export_button: "Export"
   geocoder:
     search:
       title:
@@ -1417,6 +1376,46 @@ en:
       potlatch2_unsaved_changes: "You have unsaved changes. (To save in Potlatch 2, you should click save.)"
       id_not_configured: "iD has not been configured"
       no_iframe_support: "Your browser doesn't support HTML iframes, which are necessary for this feature."
+    export:
+      title: "Export"
+      area_to_export: "Area to Export"
+      manually_select: "Manually select a different area"
+      format_to_export: "Format to Export"
+      osm_xml_data: "OpenStreetMap XML Data"
+      map_image: "Map Image (shows standard layer)"
+      embeddable_html: "Embeddable HTML"
+      licence: "Licence"
+      export_details: 'OpenStreetMap data is licensed under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Data Commons Open Database License</a> (ODbL).'
+      too_large:
+        advice: "If the above export fails, please consider using one of the sources listed below:"
+        body: "This area is too large to be exported as OpenStreetMap XML Data. Please zoom in or select a smaller area, or use one of the sources listed below for bulk data downloads."
+        planet:
+          title: "Planet OSM"
+          description: "Regularly-updated copies of the complete OpenStreetMap database"
+        overpass:
+          title: "Overpass API"
+          description: "Download this bounding box from a mirror of the OpenStreetMap database"
+        geofabrik:
+          title: "Geofabrik Downloads"
+          description: "Regularly-updated extracts of continents, countries, and selected cities"
+        metro:
+          title: "Metro Extracts"
+          description: "Extracts for major world cities and their surrounding areas"
+        other:
+          title: "Other Sources"
+          description: "Additional sources listed on the OpenStreetMap wiki"
+      options: "Options"
+      format: "Format"
+      scale: "Scale"
+      max: "max"
+      image_size: "Image Size"
+      zoom: "Zoom"
+      add_marker: "Add a marker to the map"
+      latitude: "Lat:"
+      longitude: "Lon:"
+      output: "Output"
+      paste_html: "Paste HTML to embed in website"
+      export_button: "Export"
     sidebar:
       search_results: Search Results
       close: Close

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1009,132 +1009,6 @@ en:
       text: Make a Donation
     learn_more: "Learn More"
     more: More
-  license_page:
-    foreign:
-      title: About this translation
-      text: In the event of a conflict between this translated page and %{english_original_link}, the English page shall take precedence
-      english_link: the English original
-    native:
-      title: About this page
-      text: You are viewing the English version of the copyright page. You can go back to the %{native_link} of this page or you can stop reading about copyright and %{mapping_link}.
-      native_link: THIS_LANGUAGE_NAME_HERE version
-      mapping_link: start mapping
-    legal_babble:
-      title_html: Copyright and License
-      intro_1_html: |
-        OpenStreetMap<sup><a href="#trademarks">&reg;</a></sup> is <i>open data</i>, licensed under the <a
-        href="https://opendatacommons.org/licenses/odbl/">Open Data
-        Commons Open Database License</a> (ODbL) by the  <a
-        href="https://osmfoundation.org/">OpenStreetMap Foundation</a> (OSMF).
-      intro_2_html: |
-        You are free to copy, distribute, transmit and adapt our data,
-        as long as you credit OpenStreetMap and its
-        contributors. If you alter or build upon our data, you
-        may distribute the result only under the same licence. The
-        full <a href="https://opendatacommons.org/licenses/odbl/1.0/">legal
-        code</a> explains your rights and responsibilities.
-      intro_3_html: |
-        The cartography in our map tiles, and our documentation, are
-        licensed under the <a href="https://creativecommons.org/licenses/by-sa/2.0/">Creative
-        Commons Attribution-ShareAlike 2.0</a> license (CC BY-SA).
-      credit_title_html: How to credit OpenStreetMap
-      credit_1_html: |
-        We require that you use the credit &ldquo;&copy; OpenStreetMap
-        contributors&rdquo;.
-      credit_2_html: |
-        You must also make it clear that the data is available under the Open
-        Database License, and if using our map tiles, that the cartography is
-        licensed as CC BY-SA. You may do this by linking to
-        <a href="https://www.openstreetmap.org/copyright">this copyright page</a>.
-        Alternatively, and as a requirement if you are distributing OSM in a
-        data form, you can name and link directly to the license(s). In media
-        where links are not possible (e.g. printed works), we suggest you
-        direct your readers to openstreetmap.org (perhaps by expanding
-        'OpenStreetMap' to this full address), to opendatacommons.org, and
-        if relevant, to creativecommons.org.
-      credit_3_html: |
-        For a browsable electronic map, the credit should appear in the corner of the map.
-        For example:
-      attribution_example:
-        alt: Example of how to attribute OpenStreetMap on a webpage
-        title: Attribution example
-      more_title_html: Finding out more
-      more_1_html: |
-        Read more about using our data, and how to credit us, at the <a
-        href="https://osmfoundation.org/Licence">OSMF Licence page</a>.
-      more_2_html: |
-        Although OpenStreetMap is open data, we cannot provide a
-        free-of-charge map API for third-parties.
-        See our <a href="https://operations.osmfoundation.org/policies/api/">API Usage Policy</a>,
-        <a href="https://operations.osmfoundation.org/policies/tiles/">Tile Usage Policy</a>
-        and <a href="https://operations.osmfoundation.org/policies/nominatim/">Nominatim Usage Policy</a>.
-      contributors_title_html: Our contributors
-      contributors_intro_html: |
-        Our contributors are thousands of individuals. We also include
-        openly-licensed data from national mapping agencies
-        and other sources, among them:
-      contributors_at_html: |
-        <strong>Austria</strong>: Contains data from
-        <a href="https://data.wien.gv.at/">Stadt Wien</a> (under
-        <a href="https://creativecommons.org/licenses/by/3.0/at/deed.de">CC BY</a>),
-        <a href="https://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Land Vorarlberg</a> and
-        Land Tirol (under <a href="https://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC BY AT with amendments</a>).
-      contributors_ca_html: |
-        <strong>Canada</strong>: Contains data from
-        GeoBase&reg;, GeoGratis (&copy; Department of Natural
-        Resources Canada), CanVec (&copy; Department of Natural
-        Resources Canada), and StatCan (Geography Division,
-        Statistics Canada).
-      contributors_fi_html: |
-        <strong>Finland</strong>: Contains data from the
-        National Land Survey of Finland's Topographic Database
-        and other datasets, under the
-        <a href="https://www.maanmittauslaitos.fi/en/opendata-licence-version1">NLSFI License</a>.
-      contributors_fr_html: |
-        <strong>France</strong>: Contains data sourced from
-        Direction Générale des Impôts.
-      contributors_nl_html: |
-        <strong>Netherlands</strong>: Contains &copy; AND data, 2007
-        (<a href="https://www.and.com">www.and.com</a>)
-      contributors_nz_html: |
-        <strong>New Zealand</strong>: Contains data sourced from
-        Land Information New Zealand. Crown Copyright reserved.
-      contributors_si_html: |
-        <strong>Slovenia</strong>: Contains data from the
-        <a href="http://www.gu.gov.si/en/">Surveying and Mapping Authority</a> and
-        <a href="http://www.mkgp.gov.si/en/">Ministry of Agriculture, Forestry and Food</a>
-        (public information of Slovenia).
-      contributors_za_html: |
-        <strong>South Africa</strong>: Contains data sourced from
-        <a href="http://www.ngi.gov.za/">Chief Directorate:
-        National Geo-Spatial Information</a>, State copyright reserved.
-      contributors_gb_html: |
-        <strong>United Kingdom</strong>: Contains Ordnance
-        Survey data &copy; Crown copyright and database right
-        2010-12.
-      contributors_footer_1_html: |
-        For further details of these, and other sources that have been used
-        to help improve OpenStreetMap, please see the <a
-        href="https://wiki.openstreetmap.org/wiki/Contributors">Contributors
-        page</a> on the OpenStreetMap Wiki.
-      contributors_footer_2_html: |
-        Inclusion of data in OpenStreetMap does not imply that the original
-        data provider endorses OpenStreetMap, provides any warranty, or
-        accepts any liability.
-      infringement_title_html: Copyright infringement
-      infringement_1_html: |
-        OSM contributors are reminded never to add data from any
-        copyrighted sources (e.g. Google Maps or printed maps) without
-        explicit permission from the copyright holders.
-      infringement_2_html: |
-        If you believe that copyrighted material has been inappropriately
-        added to the OpenStreetMap database or this site, please refer
-        to our <a href="https://www.osmfoundation.org/wiki/License/Takedown_procedure">takedown
-        procedure</a> or file directly at our
-        <a href="http://dmca.openstreetmap.org/">on-line filing page</a>.
-      trademarks_title_html: <span id="trademarks"></span>Trademarks
-      trademarks_1_html: |
-        OpenStreetMap, the magnifying glass logo and State of the Map are registered trademarks of the OpenStreetMap Foundation. If you have questions about your use of the marks, please see our <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">Trademark Policy</a>.
   fixthemap:
     title: Report a problem / Fix the map
     how_to_help:
@@ -1393,6 +1267,132 @@ en:
         <br>
         OpenStreetMap, the magnifying glass logo and State of the Map are <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">registered trademarks of the OSMF</a>.
       partners_title: Partners
+    copyright:
+      foreign:
+        title: About this translation
+        text: In the event of a conflict between this translated page and %{english_original_link}, the English page shall take precedence
+        english_link: the English original
+      native:
+        title: About this page
+        text: You are viewing the English version of the copyright page. You can go back to the %{native_link} of this page or you can stop reading about copyright and %{mapping_link}.
+        native_link: THIS_LANGUAGE_NAME_HERE version
+        mapping_link: start mapping
+      legal_babble:
+        title_html: Copyright and License
+        intro_1_html: |
+          OpenStreetMap<sup><a href="#trademarks">&reg;</a></sup> is <i>open data</i>, licensed under the <a
+          href="https://opendatacommons.org/licenses/odbl/">Open Data
+          Commons Open Database License</a> (ODbL) by the  <a
+          href="https://osmfoundation.org/">OpenStreetMap Foundation</a> (OSMF).
+        intro_2_html: |
+          You are free to copy, distribute, transmit and adapt our data,
+          as long as you credit OpenStreetMap and its
+          contributors. If you alter or build upon our data, you
+          may distribute the result only under the same licence. The
+          full <a href="https://opendatacommons.org/licenses/odbl/1.0/">legal
+          code</a> explains your rights and responsibilities.
+        intro_3_html: |
+          The cartography in our map tiles, and our documentation, are
+          licensed under the <a href="https://creativecommons.org/licenses/by-sa/2.0/">Creative
+          Commons Attribution-ShareAlike 2.0</a> license (CC BY-SA).
+        credit_title_html: How to credit OpenStreetMap
+        credit_1_html: |
+          We require that you use the credit &ldquo;&copy; OpenStreetMap
+          contributors&rdquo;.
+        credit_2_html: |
+          You must also make it clear that the data is available under the Open
+          Database License, and if using our map tiles, that the cartography is
+          licensed as CC BY-SA. You may do this by linking to
+          <a href="https://www.openstreetmap.org/copyright">this copyright page</a>.
+          Alternatively, and as a requirement if you are distributing OSM in a
+          data form, you can name and link directly to the license(s). In media
+          where links are not possible (e.g. printed works), we suggest you
+          direct your readers to openstreetmap.org (perhaps by expanding
+          'OpenStreetMap' to this full address), to opendatacommons.org, and
+          if relevant, to creativecommons.org.
+        credit_3_html: |
+          For a browsable electronic map, the credit should appear in the corner of the map.
+          For example:
+        attribution_example:
+          alt: Example of how to attribute OpenStreetMap on a webpage
+          title: Attribution example
+        more_title_html: Finding out more
+        more_1_html: |
+          Read more about using our data, and how to credit us, at the <a
+          href="https://osmfoundation.org/Licence">OSMF Licence page</a>.
+        more_2_html: |
+          Although OpenStreetMap is open data, we cannot provide a
+          free-of-charge map API for third-parties.
+          See our <a href="https://operations.osmfoundation.org/policies/api/">API Usage Policy</a>,
+          <a href="https://operations.osmfoundation.org/policies/tiles/">Tile Usage Policy</a>
+          and <a href="https://operations.osmfoundation.org/policies/nominatim/">Nominatim Usage Policy</a>.
+        contributors_title_html: Our contributors
+        contributors_intro_html: |
+          Our contributors are thousands of individuals. We also include
+          openly-licensed data from national mapping agencies
+          and other sources, among them:
+        contributors_at_html: |
+          <strong>Austria</strong>: Contains data from
+          <a href="https://data.wien.gv.at/">Stadt Wien</a> (under
+          <a href="https://creativecommons.org/licenses/by/3.0/at/deed.de">CC BY</a>),
+          <a href="https://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Land Vorarlberg</a> and
+          Land Tirol (under <a href="https://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC BY AT with amendments</a>).
+        contributors_ca_html: |
+          <strong>Canada</strong>: Contains data from
+          GeoBase&reg;, GeoGratis (&copy; Department of Natural
+          Resources Canada), CanVec (&copy; Department of Natural
+          Resources Canada), and StatCan (Geography Division,
+          Statistics Canada).
+        contributors_fi_html: |
+          <strong>Finland</strong>: Contains data from the
+          National Land Survey of Finland's Topographic Database
+          and other datasets, under the
+          <a href="https://www.maanmittauslaitos.fi/en/opendata-licence-version1">NLSFI License</a>.
+        contributors_fr_html: |
+          <strong>France</strong>: Contains data sourced from
+          Direction Générale des Impôts.
+        contributors_nl_html: |
+          <strong>Netherlands</strong>: Contains &copy; AND data, 2007
+          (<a href="https://www.and.com">www.and.com</a>)
+        contributors_nz_html: |
+          <strong>New Zealand</strong>: Contains data sourced from
+          Land Information New Zealand. Crown Copyright reserved.
+        contributors_si_html: |
+          <strong>Slovenia</strong>: Contains data from the
+          <a href="http://www.gu.gov.si/en/">Surveying and Mapping Authority</a> and
+          <a href="http://www.mkgp.gov.si/en/">Ministry of Agriculture, Forestry and Food</a>
+          (public information of Slovenia).
+        contributors_za_html: |
+          <strong>South Africa</strong>: Contains data sourced from
+          <a href="http://www.ngi.gov.za/">Chief Directorate:
+          National Geo-Spatial Information</a>, State copyright reserved.
+        contributors_gb_html: |
+          <strong>United Kingdom</strong>: Contains Ordnance
+          Survey data &copy; Crown copyright and database right
+          2010-12.
+        contributors_footer_1_html: |
+          For further details of these, and other sources that have been used
+          to help improve OpenStreetMap, please see the <a
+          href="https://wiki.openstreetmap.org/wiki/Contributors">Contributors
+          page</a> on the OpenStreetMap Wiki.
+        contributors_footer_2_html: |
+          Inclusion of data in OpenStreetMap does not imply that the original
+          data provider endorses OpenStreetMap, provides any warranty, or
+          accepts any liability.
+        infringement_title_html: Copyright infringement
+        infringement_1_html: |
+          OSM contributors are reminded never to add data from any
+          copyrighted sources (e.g. Google Maps or printed maps) without
+          explicit permission from the copyright holders.
+        infringement_2_html: |
+          If you believe that copyrighted material has been inappropriately
+          added to the OpenStreetMap database or this site, please refer
+          to our <a href="https://www.osmfoundation.org/wiki/License/Takedown_procedure">takedown
+          procedure</a> or file directly at our
+          <a href="http://dmca.openstreetmap.org/">on-line filing page</a>.
+        trademarks_title_html: <span id="trademarks"></span>Trademarks
+        trademarks_1_html: |
+          OpenStreetMap, the magnifying glass logo and State of the Map are registered trademarks of the OpenStreetMap Foundation. If you have questions about your use of the marks, please see our <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">Trademark Policy</a>.
     index:
       js_1: "You are either using a browser that does not support JavaScript, or you have disabled JavaScript."
       js_2: "OpenStreetMap uses JavaScript for its slippy map."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1245,49 +1245,6 @@ en:
       url: https://wiki.openstreetmap.org/
       title: wiki.openstreetmap.org
       description: Browse the wiki for in-depth OSM documentation.
-  about_page:
-    next: Next
-    copyright_html: <span>&copy;</span>OpenStreetMap<br>contributors
-    used_by: "%{name} powers map data on thousands of web sites, mobile apps, and hardware devices"
-    lede_text: |
-      OpenStreetMap is built by a community of mappers that contribute and maintain data
-      about roads, trails, cafés, railway stations, and much more, all over the world.
-    local_knowledge_title: Local Knowledge
-    local_knowledge_html: |
-      OpenStreetMap emphasizes local knowledge. Contributors use
-      aerial imagery, GPS devices, and low-tech field maps to verify that OSM
-      is accurate and up to date.
-    community_driven_title: Community Driven
-    community_driven_html: |
-      OpenStreetMap's community is diverse, passionate, and growing every day.
-      Our contributors include enthusiast mappers, GIS professionals, engineers
-      running the OSM servers, humanitarians mapping disaster-affected areas,
-      and many more.
-      To learn more about the community, see the
-      <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>,
-      <a href='%{diary_path}'>user diaries</a>,
-      <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and
-      the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.
-    open_data_title: Open Data
-    open_data_html: |
-      OpenStreetMap is <i>open data</i>: you are free to use it for any purpose
-      as long as you credit OpenStreetMap and its contributors. If you alter or
-      build upon the data in certain ways, you may distribute the result only
-      under the same licence. See the <a href='%{copyright_path}'>Copyright and
-      License page</a> for details.
-    legal_title: Legal
-    legal_html: |
-      This site and many other related services are formally operated by the
-      <a href='https://osmfoundation.org/'>OpenStreetMap Foundation</a> (OSMF)
-      on behalf of the community. Use of all OSMF operated services is subject
-      to our <a href="https://wiki.openstreetmap.org/wiki/Acceptable_Use_Policy">
-      Acceptable Use Policies</a> and our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy">Privacy Policy</a>
-      <br>
-      Please <a href='https://osmfoundation.org/Contact'>contact the OSMF</a>
-      if you have licensing, copyright or other legal questions.
-      <br>
-      OpenStreetMap, the magnifying glass logo and State of the Map are <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">registered trademarks of the OSMF</a>.
-    partners_title: Partners
   notifier:
     diary_comment_notification:
       subject: "[OpenStreetMap] %{user} commented on a diary entry"
@@ -1446,6 +1403,49 @@ en:
     delete:
       deleted: "Message deleted"
   site:
+    about:
+      next: Next
+      copyright_html: <span>&copy;</span>OpenStreetMap<br>contributors
+      used_by: "%{name} powers map data on thousands of web sites, mobile apps, and hardware devices"
+      lede_text: |
+        OpenStreetMap is built by a community of mappers that contribute and maintain data
+        about roads, trails, cafés, railway stations, and much more, all over the world.
+      local_knowledge_title: Local Knowledge
+      local_knowledge_html: |
+        OpenStreetMap emphasizes local knowledge. Contributors use
+        aerial imagery, GPS devices, and low-tech field maps to verify that OSM
+        is accurate and up to date.
+      community_driven_title: Community Driven
+      community_driven_html: |
+        OpenStreetMap's community is diverse, passionate, and growing every day.
+        Our contributors include enthusiast mappers, GIS professionals, engineers
+        running the OSM servers, humanitarians mapping disaster-affected areas,
+        and many more.
+        To learn more about the community, see the
+        <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>,
+        <a href='%{diary_path}'>user diaries</a>,
+        <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and
+        the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.
+      open_data_title: Open Data
+      open_data_html: |
+        OpenStreetMap is <i>open data</i>: you are free to use it for any purpose
+        as long as you credit OpenStreetMap and its contributors. If you alter or
+        build upon the data in certain ways, you may distribute the result only
+        under the same licence. See the <a href='%{copyright_path}'>Copyright and
+        License page</a> for details.
+      legal_title: Legal
+      legal_html: |
+        This site and many other related services are formally operated by the
+        <a href='https://osmfoundation.org/'>OpenStreetMap Foundation</a> (OSMF)
+        on behalf of the community. Use of all OSMF operated services is subject
+        to our <a href="https://wiki.openstreetmap.org/wiki/Acceptable_Use_Policy">
+        Acceptable Use Policies</a> and our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy">Privacy Policy</a>
+        <br>
+        Please <a href='https://osmfoundation.org/Contact'>contact the OSMF</a>
+        if you have licensing, copyright or other legal questions.
+        <br>
+        OpenStreetMap, the magnifying glass logo and State of the Map are <a href="https://wiki.osmfoundation.org/wiki/Trademark_Policy">registered trademarks of the OSMF</a>.
+      partners_title: Partners
     index:
       js_1: "You are either using a browser that does not support JavaScript, or you have disabled JavaScript."
       js_2: "OpenStreetMap uses JavaScript for its slippy map."


### PR DESCRIPTION
Some of the site pages had their own top-level i18n keys, so I've renamed them to fit with their view names. In addition, I've removed the 'start' prefix from the export keys since there was no other prefix and it seems unnecessary.

cc @Nikerabbit the following keys have been renamed in this PR:

* `export.title` to `site.export.title`
* `export.start.*` to `site.export.*`
* `license_page.*` to `site.copyright.*`
* `welcome_page.*` to `site.welcome.*`
* `fixthemap.*` to `site.fixthemap.*`
* `help_page.*` to `site.help.*`
* `about_page.*` to `site.about.*`
