### PR TITLE
Friendly error msg for missing iD key in application.yml

### DIFF
--- a/app/views/site/_id.html.erb
+++ b/app/views/site/_id.html.erb
@@ -1,7 +1,7 @@
 <%= javascript_include_tag "edit/id" %>
 
 <div id="map">
-  <% data = { :key => ID_KEY } -%>
+  <% data = { :key => defined?(ID_KEY) ? ID_KEY : "" } -%>
   <% data[:lat] = @lat if @lat -%>
   <% data[:lon] = @lon if @lon -%>
   <% data[:gpx] = trace_data_url(params[:gpx], :format => :xml) if params[:gpx] -%>


### PR DESCRIPTION
Fall back to an empty iD key in case it hasn't been maintained in application.yml yet.

This way, a user will see an _"iD has not been configured"_ popup when starting iD, instead of a stack trace with "uninitialized constant ActionView::CompiledTemplates::ID_KEY" on it.

Fixes #1830