### PR TITLE
More lazy translation lookups for traces

### DIFF
--- a/app/controllers/trace_controller.rb
+++ b/app/controllers/trace_controller.rb
@@ -31,14 +31,14 @@ class TraceController < ApplicationController
 
     # set title
     @title = if target_user.nil?
-               t "trace.list.public_traces"
+               t ".public_traces"
              elsif current_user && current_user == target_user
-               t "trace.list.my_traces"
+               t ".my_traces"
              else
-               t "trace.list.public_traces_from", :user => target_user.display_name
+               t ".public_traces_from", :user => target_user.display_name
              end
 
-    @title += t "trace.list.tagged_with", :tags => params[:tag] if params[:tag]
+    @title += t ".tagged_with", :tags => params[:tag] if params[:tag]
 
     # four main cases:
     # 1 - all traces, logged in = all public traces + all user's (i.e + all mine)
@@ -94,13 +94,13 @@ class TraceController < ApplicationController
 
     if @trace && @trace.visible? &&
        (@trace.public? || @trace.user == current_user)
-      @title = t "trace.view.title", :name => @trace.name
+      @title = t ".title", :name => @trace.name
     else
-      flash[:error] = t "trace.view.trace_not_found"
+      flash[:error] = t ".trace_not_found"
       redirect_to :action => "list"
     end
   rescue ActiveRecord::RecordNotFound
-    flash[:error] = t "trace.view.trace_not_found"
+    flash[:error] = t ".trace_not_found"
     redirect_to :action => "list"
   end
 
@@ -117,9 +117,8 @@ class TraceController < ApplicationController
         end
 
         if @trace.id
-          flash[:notice] = t "trace.create.trace_uploaded"
-
-          flash[:warning] = t "trace.trace_header.traces_waiting", :count => current_user.traces.where(:inserted => false).count if current_user.traces.where(:inserted => false).count > 4
+          flash[:notice] = t ".trace_uploaded"
+          flash[:warning] = t ".traces_waiting", :count => current_user.traces.where(:inserted => false).count if current_user.traces.where(:inserted => false).count > 4
 
           redirect_to :action => :list, :display_name => current_user.display_name
         end
@@ -137,7 +136,7 @@ class TraceController < ApplicationController
       @trace = Trace.new(:visibility => default_visibility)
     end
 
-    @title = t "trace.create.upload_trace"
+    @title = t ".upload_trace"
   end
 
   def data
@@ -191,7 +190,7 @@ class TraceController < ApplicationController
     else
       trace.visible = false
       trace.save
-      flash[:notice] = t "trace.delete.scheduled_for_deletion"
+      flash[:notice] = t ".scheduled_for_deletion"
       redirect_to :action => :list, :display_name => trace.user.display_name
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/views/trace/create.html.erb
+++ b/app/views/trace/create.html.erb
@@ -8,26 +8,26 @@
   <div class="standard-form">
     <fieldset>
       <div class='form-row'>
-        <label for="trace_gpx_file" class="standard-label"><%= t'trace.trace_form.upload_gpx' %></label>
+        <label for="trace_gpx_file" class="standard-label"><%= t '.upload_gpx' %></label>
         <%= f.file_field :gpx_file %>
       </div>
       <div class='form-row'>
-        <label class="standard-label"><%= t'trace.trace_form.description' %></label>
+        <label class="standard-label"><%= t '.description' %></label>
         <%= f.text_field :description %>
       </div>
       <div class='form-row'>
-        <label class="standard-label"><%= t'trace.trace_form.tags' %></label>
+        <label class="standard-label"><%= t '.tags' %></label>
         <%= f.text_field :tagstring %>
-        <span class="form-help deemphasize">(<%= t'trace.trace_form.tags_help' %>)</span>
+        <span class="form-help deemphasize">(<%= t '.tags_help' %>)</span>
       </div>
       <div class='form-row'>
-        <label class="standard-label"><%= t'trace.trace_form.visibility' %></label>
+        <label class="standard-label"><%= t '.visibility' %></label>
         <%= f.select :visibility, [[t('trace.visibility.private'),"private"],[t('trace.visibility.public'),"public"],[t('trace.visibility.trackable'),"trackable"],[t('trace.visibility.identifiable'),"identifiable"]] %>
-        <span class="form-help deemphasize">(<a href="<%= t'trace.trace_form.visibility_help_url' %>"><%= t'trace.trace_form.visibility_help' %></a>)</span>
+        <span class="form-help deemphasize">(<a href="<%= t '.visibility_help_url' %>"><%= t '.visibility_help' %></a>)</span>
       </div>
     </fieldset>
 
-    <%= submit_tag t('trace.trace_form.upload_button') %>
-    <span class="form-help deemphasize"><a href="<%= t'trace.trace_form.help_url' %>"><%= t'trace.trace_form.help' %></a></span>
+    <%= submit_tag t('.upload_button') %>
+    <span class="form-help deemphasize"><a href="<%= t '.help_url' %>"><%= t '.help' %></a></span>
   </div>
 <% end %>

--- a/app/views/trace/list.html.erb
+++ b/app/views/trace/list.html.erb
@@ -3,16 +3,16 @@
   <ul class='secondary-actions clearfix'>
     <li><%= t('.description') %></li>
     <li><%= rss_link_to :action => 'georss', :display_name => @display_name, :tag => @tag %></li>
-    <li><%= link_to t('trace.trace_header.upload_trace'), :action => 'create' %></li>
+    <li><%= link_to t('.upload_trace'), :action => 'create' %></li>
     <% if @tag %>
-      <li><%= link_to t('trace.trace_header.see_all_traces'), :controller => 'trace', :action => 'list', :display_name => nil, :tag => nil, :page => nil %></li>
-      <li><%= link_to t('trace.trace_header.see_my_traces'), :action => 'mine', :tag => nil, :page => nil %></li>
+      <li><%= link_to t('.see_all_traces'), :controller => 'trace', :action => 'list', :display_name => nil, :tag => nil, :page => nil %></li>
+      <li><%= link_to t('.see_my_traces'), :action => 'mine', :tag => nil, :page => nil %></li>
     <% else %>
       <% if @display_name %>
-        <li><%= link_to t('trace.trace_header.see_all_traces'), :controller => 'trace', :action => 'list', :display_name => nil, :tag => nil, :page => nil %></li>
+        <li><%= link_to t('.see_all_traces'), :controller => 'trace', :action => 'list', :display_name => nil, :tag => nil, :page => nil %></li>
       <% end %>
       <%= unless_user(@target_user, :li) do %>
-        <%= link_to t('trace.trace_header.see_my_traces'), :action => 'mine', :tag => nil, :page => nil %>
+        <%= link_to t('.see_my_traces'), :action => 'mine', :tag => nil, :page => nil %>
       <% end %>
     <% end %>
   </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1578,6 +1578,19 @@ en:
     create:
       upload_trace: "Upload GPS Trace"
       trace_uploaded: "Your GPX file has been uploaded and is awaiting insertion in to the database. This will usually happen within half an hour, and an email will be sent to you on completion."
+      traces_waiting:
+        one: "You have %{count} trace waiting for upload. Please consider waiting for these to finish before uploading any more, so as not to block the queue for other users."
+        other: "You have %{count} traces waiting for upload. Please consider waiting for these to finish before uploading any more, so as not to block the queue for other users."
+      upload_gpx: "Upload GPX File:"
+      description: "Description:"
+      tags: "Tags:"
+      tags_help: "comma delimited"
+      visibility: "Visibility:"
+      visibility_help: "what does this mean?"
+      visibility_help_url: "https://wiki.openstreetmap.org/wiki/Visibility_of_GPS_traces"
+      upload_button: "Upload"
+      help: "Help"
+      help_url: "https://wiki.openstreetmap.org/wiki/Upload"
     edit:
       title: "Editing trace %{name}"
       heading: "Editing trace %{name}"
@@ -1596,24 +1609,6 @@ en:
       visibility: "Visibility:"
       visibility_help: "what does this mean?"
       visibility_help_url: "https://wiki.openstreetmap.org/wiki/Visibility_of_GPS_traces"
-    trace_form:
-      upload_gpx: "Upload GPX File:"
-      description: "Description:"
-      tags: "Tags:"
-      tags_help: "comma delimited"
-      visibility: "Visibility:"
-      visibility_help: "what does this mean?"
-      visibility_help_url: "https://wiki.openstreetmap.org/wiki/Visibility_of_GPS_traces"
-      upload_button: "Upload"
-      help: "Help"
-      help_url: "https://wiki.openstreetmap.org/wiki/Upload"
-    trace_header:
-      upload_trace: "Upload a trace"
-      see_all_traces: "See all traces"
-      see_my_traces: "See my traces"
-      traces_waiting:
-        one: "You have %{count} trace waiting for upload. Please consider waiting for these to finish before uploading any more, so as not to block the queue for other users."
-        other: "You have %{count} traces waiting for upload. Please consider waiting for these to finish before uploading any more, so as not to block the queue for other users."
     trace_optionals:
       tags: "Tags"
     view:
@@ -1663,6 +1658,9 @@ en:
       description: "Browse recent GPS trace uploads"
       tagged_with: " tagged with %{tags}"
       empty_html: "Nothing here yet. <a href='%{upload_link}'>Upload a new trace</a> or learn more about GPS tracing on the <a href='https://wiki.openstreetmap.org/wiki/Beginners_Guide_1.2'>wiki page</a>."
+      upload_trace: "Upload a trace"
+      see_all_traces: "See all traces"
+      see_my_traces: "See my traces"
     delete:
       scheduled_for_deletion: "Trace scheduled for deletion"
     make_public:


### PR DESCRIPTION
A few more lazy translations, to make future refactoring easier.

@Nikerabbit  This PR contains translation key renaming as follows:

* `trace.trace_form.*` is combined into the existing `trace.create.*`
* `trace.trace_header.traces_waiting.*` becomes `trace.create.traces_waiting.*`
* Other `trace.trace_header.*` is combined into the existing `trace.list.*`