### PR TITLE
Add "Set home location to here" button on context menu

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -229,14 +229,19 @@ $(document).ready(function () {
     L.marker([params.mlat, params.mlon]).addTo(map);
   }
 
+  var homemarker;
   $("#homeanchor").on("click", function(e) {
     e.preventDefault();
 
     var data = $(this).data(),
       center = L.latLng(data.lat, data.lon);
 
+    if (homemarker) {
+      map.removeLayer(homemarker);
+    }
+
     map.setView(center, data.zoom);
-    L.marker(center, {icon: OSM.getUserIcon()}).addTo(map);
+    homemarker = L.marker(center, {icon: OSM.getUserIcon()}).addTo(map);
   });
 
   function remoteEditHandler(bbox, object) {

--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -72,6 +72,21 @@ OSM.initializeContextMenu = function (map) {
     }
   });
 
+  map.contextmenu.addItem({
+    text: I18n.t("javascripts.context.set_home_location"),
+    callback: function setHomeLocation(e) {
+      var precision = OSM.zoomPrecision(map.getZoom()),
+          latlng = e.latlng.wrap(),
+          lat = latlng.lat.toFixed(precision),
+          lng = latlng.lng.toFixed(precision);
+console.log(lng);
+$.ajax({url: "/api/0.6/set_home_loc?lat=" + lat + "&lon=" + lng, success: function(result){
+        console.log("TREST");
+    }});
+      //OSM.router.route("/set_home_loc?lat=" + lat + "&lon=" + lng);
+    }
+  });
+
   map.on("mousedown", function (e) {
     if (e.originalEvent.shiftKey) map.contextmenu.disable();
     else map.contextmenu.enable();

--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -79,11 +79,12 @@ OSM.initializeContextMenu = function (map) {
           latlng = e.latlng.wrap(),
           lat = latlng.lat.toFixed(precision),
           lng = latlng.lng.toFixed(precision);
-console.log(lng);
-$.ajax({url: "/api/0.6/set_home_loc?lat=" + lat + "&lon=" + lng, success: function(result){
-        console.log("TREST");
-    }});
-      //OSM.router.route("/set_home_loc?lat=" + lat + "&lon=" + lng);
+      
+      $.ajax({url: "/set_home_loc?lat=" + lat + "&lon=" + lng, success: function(result){
+        $('#homeanchor').data("lat", lat);
+        $('#homeanchor').data("lon", lng);
+        $('#homeanchor').click();
+      }});
     }
   });
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -568,6 +568,12 @@ class UserController < ApplicationController
     redirect_to params[:origin] || login_url
   end
 
+  ##
+  # Update a user's home location
+  def set_home_location
+    current_user.update({home_lat: params[:lat], home_lon: params[:lon]});
+  end
+
   private
 
   ##
@@ -733,20 +739,6 @@ class UserController < ApplicationController
         end
 
         user.restore_email!
-      end
-    end
-  end
-
-  ##
-  # Update a user's home location
-  def set_home_location
-    puts "TEST"
-    current_user.home_lat = params[:lat]
-    current_user.home_lon = params[:lon]
-
-    if current_user.save
-      if current_user.valid?
-        flash.now[:notice] = t "flash home location update success"
       end
     end
   end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -738,6 +738,20 @@ class UserController < ApplicationController
   end
 
   ##
+  # Update a user's home location
+  def set_home_location
+    puts "TEST"
+    current_user.home_lat = params[:lat]
+    current_user.home_lon = params[:lon]
+
+    if current_user.save
+      if current_user.valid?
+        flash.now[:notice] = t "flash home location update success"
+      end
+    end
+  end
+
+  ##
   # require that the user is a administrator, or fill out a helpful error message
   # and return them to the user page.
   def require_administrator

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2010,6 +2010,7 @@ en:
       return to profile: Return to profile
       flash update success confirm needed: "User information updated successfully. Check your email for a note to confirm your new email address."
       flash update success: "User information updated successfully."
+      flash home location update success: "Home location updated successfully."
     confirm:
       heading: Check your email!
       introduction_1: |
@@ -2407,6 +2408,7 @@ en:
       show_address: Show address
       query_features: Query features
       centre_map: Centre map here
+      set_home_location: Set home location to here
   redactions:
     edit:
       description: "Description"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2010,7 +2010,6 @@ en:
       return to profile: Return to profile
       flash update success confirm needed: "User information updated successfully. Check your email for a note to confirm your new email address."
       flash update success: "User information updated successfully."
-      flash home location update success: "Home location updated successfully."
     confirm:
       heading: Check your email!
       introduction_1: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,9 @@ OpenStreetMap::Application.routes.draw do
   # directions
   get "/directions" => "directions#search"
 
+  # set home location
+  match "/set_home_loc" => "user#set_home_location", :via => [:get, :post]
+
   # export
   post "/export/finish" => "export#finish"
   get "/export/embed" => "export#embed"


### PR DESCRIPTION
I thought it would be helpful to make setting the user's home location much easier, and save having to use the slightly clunky Settings page interface.

Now the user can just right-click anywhere on the map and select "Set home location", and their home location will be updated (provided they are logged in)

The backend process might need reworking a bit (not sure how happy you'll be using an Ajax call - However creating a new valid OSM.Router.route path seemed like a bit of an overkill!)