### PR TITLE
Avoid using jsonp for GraphHopper

### DIFF
--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -33,7 +33,7 @@ function GraphHopperEngine(id, vehicleType) {
           point: points.map(function (p) { return p.lat + "," + p.lng; })
         },
         traditional: true,
-        dataType: "jsonp",
+        dataType: "json",
         success: function (data) {
           if (!data.paths || data.paths.length === 0)
             return callback(true);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -411,9 +411,9 @@ class ApplicationController < ActionController::Base
     append_content_security_policy_directives(
       :child_src => %w[http://127.0.0.1:8111 https://127.0.0.1:8112],
       :frame_src => %w[http://127.0.0.1:8111 https://127.0.0.1:8112],
-      :connect_src => %w[nominatim.openstreetmap.org overpass-api.de router.project-osrm.org],
+      :connect_src => %w[nominatim.openstreetmap.org overpass-api.de router.project-osrm.org graphhopper.com],
       :form_action => %w[render.openstreetmap.org],
-      :script_src => %w[graphhopper.com open.mapquestapi.com],
+      :script_src => %w[open.mapquestapi.com],
       :img_src => %w[developer.mapquest.com]
     )
 


### PR DESCRIPTION
`jsonp` should be avoided as error reporting is not always possible. The necessary magic should be done from jquery automatically. (is there a possibility to test this on an openstreetmap.org domain before going production?)