### PR TITLE
Update New Zealand copyright based on current attribution instructions from LINZ

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1257,8 +1257,10 @@ en:
           <strong>Netherlands</strong>: Contains &copy; AND data, 2007
           (<a href="https://www.and.com">www.and.com</a>)
         contributors_nz_html: |
-          <strong>New Zealand</strong>: Contains data sourced from
-          Land Information New Zealand. Crown Copyright reserved.
+          <strong>New Zealand</strong>: Contains data sourced from the
+          <a href="https://data.linz.govt.nz/">LINZ Data Service</a> and
+          licensed for reuse under
+          <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
         contributors_si_html: |
           <strong>Slovenia</strong>: Contains data from the
           <a href="http://www.gu.gov.si/en/">Surveying and Mapping Authority</a> and


### PR DESCRIPTION
This updates the LINZ attribution at https://www.openstreetmap.org/copyright to be in line with the current recommendation for attribution provided in the LINZ data metadata:

> Following Attribution:
> If you publish, distribute or otherwise disseminate this work to the public without adapting it, the following attribution to Land Information New Zealand should be used:
> 'CC BY 4.0 Land Information New Zealand.
> 
> If you adapt this work in any way or include it in a collection, and publish, distribute or otherwise disseminate that adaptation or collection to the public, the following attribution to Land Information New Zealand should be used:
> 'Contains data sourced from the LINZ Data Service and licensed for reuse under CC BY 4.0'
> 
> If 'attribution stacking' problems exist then the requirement to display the above attribution statements is waived and in lieu the attribution statement is to be made in any terms or conditions associated with the work/ product/ application/ etc.

We have the CC BY 4.0 waiver template provided by the OSMF LWG (the version which points to /copyright) completed by LINZ at https://wiki.openstreetmap.org/wiki/File:LINZ_OSM-CC-4.0_waiver.pdf. Further details about which LINZ datasets are used is currently listed at https://wiki.openstreetmap.org/wiki/Contributors#LINZ

background for this PR at #1480