### PR TITLE
modify HOT layer attribution

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -44,7 +44,7 @@ L.OSM.Map = L.Map.extend({
     }
 
     this.baseLayers.push(new L.OSM.HOT({
-      attribution: copyright + ". Tiles courtesy of <a href='https://www.hotosm.org/' target='_blank'>Humanitarian OpenStreetMap Team</a>",
+      attribution: copyright + ". Tiles style <a href='https://www.hotosm.org/' target='_blank'>Humanitarian OpenStreetMap Team</a>" + " hosted by <a href='https://openstreetmap.fr/' target='_blank'>OpenStreetMap France</a>",
       code: "H",
       keyid: "hot",
       name: I18n.t("javascripts.map.base.hot")


### PR DESCRIPTION
tiles style is HOT
tiles server is OSM-FR

Is the length OK?
> © [OpenStreetMap contributors](url). Tiles style [Humanitarian OpenStreetMap Team](url) hosted by [OpenStreetMap France](url)

Or you would you rather have
> © [OpenStreetMap contributors](url). Tiles style [Humanitarian OSM Team](url) hosted by [OSM-France](url)

Or
> © [OpenStreetMap contributors](url). Tiles style [HOT](url) hosted by [OSM-France](url)

cc @cquest @simonpoole 