### PR TITLE
Change language immediately after updating settings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -295,7 +295,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def preferred_languages
+  def preferred_languages(reset = false)
+    @preferred_languages = nil if reset
     @preferred_languages ||= if params[:locale]
                                Locale.list(params[:locale])
                              elsif current_user
@@ -313,7 +314,7 @@ class ApplicationController < ActionController::Base
       current_user.save
     end
 
-    I18n.locale = Locale.available.preferred(preferred_languages)
+    I18n.locale = Locale.available.preferred(preferred_languages(true))
 
     response.headers["Vary"] = "Accept-Language"
     response.headers["Content-Language"] = I18n.locale.to_s

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -308,13 +308,13 @@ class ApplicationController < ActionController::Base
 
   helper_method :preferred_languages
 
-  def set_locale
+  def set_locale(reset = false)
     if current_user && current_user.languages.empty? && !http_accept_language.user_preferred_languages.empty?
       current_user.languages = http_accept_language.user_preferred_languages
       current_user.save
     end
 
-    I18n.locale = Locale.available.preferred(preferred_languages(true))
+    I18n.locale = Locale.available.preferred(preferred_languages(reset))
 
     response.headers["Vary"] = "Accept-Language"
     response.headers["Content-Language"] = I18n.locale.to_s

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -712,7 +712,7 @@ class UserController < ApplicationController
     end
 
     if user.save
-      set_locale
+      set_locale(true)
 
       if user.new_email.blank? || user.new_email == user.email
         flash.now[:notice] = t "user.account.flash update success"

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -118,7 +118,6 @@ class UserController < ApplicationController
   end
 
   def account
-    @title = t "user.account.title"
     @tokens = current_user.oauth_tokens.authorized
 
     if params[:user] && params[:user][:display_name] && params[:user][:description]
@@ -126,7 +125,6 @@ class UserController < ApplicationController
          (params[:user][:auth_provider] == current_user.auth_provider &&
           params[:user][:auth_uid] == current_user.auth_uid)
         update_user(current_user, params)
-        @title = t "user.account.title"
       else
         session[:new_user_settings] = params
         redirect_to auth_url(params[:user][:auth_provider], params[:user][:auth_uid])
@@ -136,6 +134,7 @@ class UserController < ApplicationController
         current_user.errors.add(attribute, error)
       end
     end
+    @title = t "user.account.title"
   end
 
   def go_public
@@ -713,7 +712,6 @@ class UserController < ApplicationController
     end
 
     if user.save
-      @preferred_languages = current_user.preferred_languages
       set_locale
 
       if user.new_email.blank? || user.new_email == user.email

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -126,6 +126,7 @@ class UserController < ApplicationController
          (params[:user][:auth_provider] == current_user.auth_provider &&
           params[:user][:auth_uid] == current_user.auth_uid)
         update_user(current_user, params)
+        @title = t "user.account.title"
       else
         session[:new_user_settings] = params
         redirect_to auth_url(params[:user][:auth_provider], params[:user][:auth_uid])
@@ -712,6 +713,7 @@ class UserController < ApplicationController
     end
 
     if user.save
+      @preferred_languages = current_user.preferred_languages
       set_locale
 
       if user.new_email.blank? || user.new_email == user.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -189,7 +189,7 @@ class User < ActiveRecord::Base
   end
 
   def preferred_languages
-    @preferred_languages ||= Locale.list(languages)
+    Locale.list(languages)
   end
 
   def nearby(radius = NEARBY_RADIUS, num = NEARBY_USERS)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,6 +112,7 @@ class User < ActiveRecord::Base
   before_save :encrypt_password
   before_save :update_tile
   after_save :spam_check
+  after_save :reset_preferred_languages
 
   def to_param
     display_name
@@ -189,7 +190,11 @@ class User < ActiveRecord::Base
   end
 
   def preferred_languages
-    Locale.list(languages)
+    @preferred_languages ||= Locale.list(languages)
+  end
+
+  def reset_preferred_languages
+    @preferred_languages = nil
   end
 
   def nearby(radius = NEARBY_RADIUS, num = NEARBY_USERS)


### PR DESCRIPTION
Makes sure that the correct locale is used immediately after updating settings.

At the moment, changing the user's preferred language on the settings page doesn't take effect immediately, and the old locale language is used on the "Your settings have been successfully updated" page.