### PR TITLE
Concept URIs for Wikidata entities

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -163,7 +163,7 @@ module BrowseHelper
     # The simple wikidata-tag (this is limited to only one value)
     if key == "wikidata" && value =~ /^[Qq][1-9][0-9]*$/
       return [{
-        :url => "//www.wikidata.org/wiki/#{value}?uselang=#{I18n.locale}",
+        :url => "//www.wikidata.org/entity/#{value}?uselang=#{I18n.locale}",
         :title => value
       }]
     # Key has to be one of the accepted wikidata-tags
@@ -172,7 +172,7 @@ module BrowseHelper
           value =~ /^[Qq][1-9][0-9]*(\s*;\s*[Qq][1-9][0-9]*)*$/
       # Splitting at every semicolon to get a separate hash for each wikidata-ID
       return value.split(";").map do |id|
-        { :title => id, :url => "//www.wikidata.org/wiki/#{id.strip}?uselang=#{I18n.locale}" }
+        { :title => id, :url => "//www.wikidata.org/entity/#{id.strip}?uselang=#{I18n.locale}" }
       end
     end
     nil


### PR DESCRIPTION
Wikidata entities should be linked using concept URIs, which are permanent. This is the correct way of linking web resources according to the Linked Data principles.

Example: http://www.wikidata.org/entity/Q42