### PR TITLE
Resolve redaction view from going off page with no text wrap.

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2304,6 +2304,11 @@ a.button {
     font-size: 13px;
     background: #e8e8e8;
     padding: 2px 3px;
+    white-space: pre-wrap;       /* css-3 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
 
     code {
       padding: 0;

--- a/app/views/redactions/show.html.erb
+++ b/app/views/redactions/show.html.erb
@@ -7,10 +7,10 @@
   <b><%= t '.user' %></b>
   <%= link_to(@redaction.user.display_name, user_path(@redaction.user)) %>
 </p>
-<p class="richtext">
+<div class="richtext">
   <b><%= t '.description' %></b>
   <%= @redaction.description.to_html %>
-</p>
+</div>
 
 <% if current_user and current_user.moderator? %>
 <div class="buttons">


### PR DESCRIPTION
This resolves issue #1845 

Added css to address \<pre\> tags and word wrap. Also noticed that
the output was surrounded by paragraph tags where the style should
have been applied to the \<div\> tag instead of a \<p\> tag, like the rest of the views.

Tested in development without any problems. Please see image below. I also check message view and all are OK and wrapped in a \<div\> tag.

![screen shot 2018-05-28 at 9 10 39 pm](https://user-images.githubusercontent.com/24664863/40637754-dcd9aa96-62bb-11e8-805b-007ac22febd9.png)
