### PR TITLE
Refactor some messages urls

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -67,7 +67,7 @@ Metrics/AbcSize:
 # Offense count: 41
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 240
+  Max: 245
 
 # Offense count: 12
 # Configuration parameters: CountBlocks.

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -63,7 +63,7 @@ class MessagesController < ApplicationController
   # Show a message
   def show
     @title = t ".title"
-    @message = Message.find(params[:message_id])
+    @message = Message.find(params[:id])
 
     if @message.recipient == current_user || @message.sender == current_user
       @message.message_read = true if @message.recipient == current_user

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -56,7 +56,7 @@ class MessagesController < ApplicationController
       redirect_to :controller => "user", :action => "login", :referer => request.fullpath
     end
   rescue ActiveRecord::RecordNotFound
-    @title = t "message.no_such_message.title"
+    @title = t "messages.no_such_message.title"
     render :action => "no_such_message", :status => :not_found
   end
 
@@ -73,7 +73,7 @@ class MessagesController < ApplicationController
       redirect_to :controller => "user", :action => "login", :referer => request.fullpath
     end
   rescue ActiveRecord::RecordNotFound
-    @title = t "message.no_such_message.title"
+    @title = t "messages.no_such_message.title"
     render :action => "no_such_message", :status => :not_found
   end
 
@@ -103,7 +103,7 @@ class MessagesController < ApplicationController
       redirect_to :action => :inbox
     end
   rescue ActiveRecord::RecordNotFound
-    @title = t "message.no_such_message.title"
+    @title = t "messages.no_such_message.title"
     render :action => "no_such_message", :status => :not_found
   end
 
@@ -122,7 +122,7 @@ class MessagesController < ApplicationController
       end
     end
   rescue ActiveRecord::RecordNotFound
-    @title = t "message.no_such_message.title"
+    @title = t "messages.no_such_message.title"
     render :action => "no_such_message", :status => :not_found
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -26,7 +26,7 @@ class MessagesController < ApplicationController
         if @message.save
           flash[:notice] = t ".message_sent"
           Notifier.message_notification(@message).deliver_now
-          redirect_to :action => "inbox", :display_name => current_user.display_name
+          redirect_to :action => :inbox
         end
       end
     end
@@ -80,19 +80,11 @@ class MessagesController < ApplicationController
   # Display the list of messages that have been sent to the user.
   def inbox
     @title = t ".title"
-    if current_user && params[:display_name] == current_user.display_name
-    else
-      redirect_to :action => "inbox", :display_name => current_user.display_name
-    end
   end
 
   # Display the list of messages that the user has sent to other users.
   def outbox
     @title = t ".title"
-    if current_user && params[:display_name] == current_user.display_name
-    else
-      redirect_to :action => "outbox", :display_name => current_user.display_name
-    end
   end
 
   # Set the message as being read or unread.
@@ -108,7 +100,7 @@ class MessagesController < ApplicationController
     @message.message_read = message_read
     if @message.save && !request.xhr?
       flash[:notice] = notice
-      redirect_to :action => "inbox", :display_name => current_user.display_name
+      redirect_to :action => :inbox
     end
   rescue ActiveRecord::RecordNotFound
     @title = t "message.no_such_message.title"
@@ -126,7 +118,7 @@ class MessagesController < ApplicationController
       if params[:referer]
         redirect_to params[:referer]
       else
-        redirect_to :action => "inbox", :display_name => current_user.display_name
+        redirect_to :action => :inbox
       end
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -64,7 +64,7 @@
         </a>
         <ul class='dropdown-menu'>
           <li>
-            <%= link_to inbox_path(:display_name => current_user.display_name) do %>
+            <%= link_to inbox_messages_path do %>
               <span class='count-number'><%= number_with_delimiter(current_user.new_messages.size) %></span>
               <%= t('user.view.my messages') %>
             <% end %>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h2><%= t '.my_inbox'%>/<%= link_to t('.outbox'), outbox_path(current_user.display_name) %></h2>
+  <h2><%= t '.my_inbox'%>/<%= link_to t('.outbox'), outbox_messages_path %></h2>
 <% end %>
 
   <h4><%= render :partial => "message_count" %></h4>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class='buttons'>
       <%= submit_tag t('.send_button') %>
-      <%= link_to t('.back_to_inbox'), inbox_path(current_user), :class => 'deemphasize button' %>
+      <%= link_to t('.back_to_inbox'), inbox_messages_path, :class => 'deemphasize button' %>
     </div>
   </fieldset>
 <% end %>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h2><%= raw(t '.my_inbox', :inbox_link => link_to(t('.inbox'), inbox_path(current_user.display_name))) %>/<%= t'.outbox' %></h2>
+  <h2><%= raw(t '.my_inbox', :inbox_link => link_to(t('.inbox'), inbox_messages_path)) %>/<%= t'.outbox' %></h2>
 <% end %>
 
 <h4><%= t '.messages', :count => current_user.sent_messages.size %></h4>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -36,5 +36,5 @@
 
 <% end %>
 
-  <%= link_to t('.back'), outbox_path(current_user), :class => "button deemphasize" %>
+  <%= link_to t('.back'), outbox_messages_path, :class => "button deemphasize" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,8 +261,14 @@ OpenStreetMap::Application.routes.draw do
   get "/export/embed" => "export#embed"
 
   # messages
-  get "/user/:display_name/inbox" => "messages#inbox", :as => "inbox"
-  get "/user/:display_name/outbox" => "messages#outbox", :as => "outbox"
+  resources :messages, :only => [] do
+    collection do
+      get :inbox
+      get :outbox
+    end
+  end
+  get "/user/:display_name/inbox", :to => redirect(:path => "/messages/inbox")
+  get "/user/:display_name/outbox", :to => redirect(:path => "/messages/outbox")
   match "/message/new/:display_name" => "messages#new", :via => [:get, :post], :as => "new_message"
   get "/message/read/:message_id" => "messages#show", :as => "message"
   post "/message/mark/:message_id" => "messages#mark", :as => "mark_message"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,7 +261,7 @@ OpenStreetMap::Application.routes.draw do
   get "/export/embed" => "export#embed"
 
   # messages
-  resources :messages, :only => [] do
+  resources :messages, :only => [:show] do
     collection do
       get :inbox
       get :outbox
@@ -270,7 +270,7 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/inbox", :to => redirect(:path => "/messages/inbox")
   get "/user/:display_name/outbox", :to => redirect(:path => "/messages/outbox")
   match "/message/new/:display_name" => "messages#new", :via => [:get, :post], :as => "new_message"
-  get "/message/read/:message_id" => "messages#show", :as => "message"
+  get "/message/read/:message_id", :to => redirect(:path => "/messages/%{message_id}")
   post "/message/mark/:message_id" => "messages#mark", :as => "mark_message"
   match "/message/reply/:message_id" => "messages#reply", :via => [:get, :post], :as => "reply_message"
   post "/message/delete/:message_id" => "messages#destroy", :as => "destroy_message"

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -5,12 +5,12 @@ class MessagesControllerTest < ActionController::TestCase
   # test all routes which lead to this controller
   def test_routes
     assert_routing(
-      { :path => "/user/username/inbox", :method => :get },
-      { :controller => "messages", :action => "inbox", :display_name => "username" }
+      { :path => "/messages/inbox", :method => :get },
+      { :controller => "messages", :action => "inbox" }
     )
     assert_routing(
-      { :path => "/user/username/outbox", :method => :get },
-      { :controller => "messages", :action => "outbox", :display_name => "username" }
+      { :path => "/messages/outbox", :method => :get },
+      { :controller => "messages", :action => "outbox" }
     )
     assert_routing(
       { :path => "/message/new/username", :method => :get },
@@ -171,7 +171,7 @@ class MessagesControllerTest < ActionController::TestCase
                           :message => { :title => "Test Message", :body => "Test message body" } }
       end
     end
-    assert_redirected_to inbox_path(:display_name => user.display_name)
+    assert_redirected_to inbox_messages_path
     assert_equal "Message sent", flash[:notice]
     e = ActionMailer::Base.deliveries.first
     assert_equal [recipient_user.email], e.to
@@ -317,55 +317,45 @@ class MessagesControllerTest < ActionController::TestCase
   # test the inbox action
   def test_inbox
     user = create(:user)
-    other_user = create(:user)
     read_message = create(:message, :read, :recipient => user)
     # Check that the inbox page requires us to login
-    get :inbox, :params => { :display_name => user.display_name }
-    assert_redirected_to login_path(:referer => inbox_path(:display_name => user.display_name))
+    get :inbox
+    assert_redirected_to login_path(:referer => inbox_messages_path)
 
     # Login
     session[:user] = user.id
 
     # Check that we can view our inbox when logged in
-    get :inbox, :params => { :display_name => user.display_name }
+    get :inbox
     assert_response :success
     assert_template "inbox"
     assert_select "table.messages", :count => 1 do
       assert_select "tr", :count => 2
       assert_select "tr#inbox-#{read_message.id}.inbox-row", :count => 1
     end
-
-    # Check that we can't view somebody else's inbox when logged in
-    get :inbox, :params => { :display_name => other_user.display_name }
-    assert_redirected_to inbox_path(:display_name => user.display_name)
   end
 
   ##
   # test the outbox action
   def test_outbox
     user = create(:user)
-    other_user = create(:user)
     create(:message, :sender => user)
 
     # Check that the outbox page requires us to login
-    get :outbox, :params => { :display_name => user.display_name }
-    assert_redirected_to login_path(:referer => outbox_path(:display_name => user.display_name))
+    get :outbox
+    assert_redirected_to login_path(:referer => outbox_messages_path)
 
     # Login
     session[:user] = user.id
 
     # Check that we can view our outbox when logged in
-    get :outbox, :params => { :display_name => user.display_name }
+    get :outbox
     assert_response :success
     assert_template "outbox"
     assert_select "table.messages", :count => 1 do
       assert_select "tr", :count => 2
       assert_select "tr.inbox-row", :count => 1
     end
-
-    # Check that we can't view somebody else's outbox when logged in
-    get :outbox, :params => { :display_name => other_user.display_name }
-    assert_redirected_to outbox_path(:display_name => user.display_name)
   end
 
   ##
@@ -393,12 +383,12 @@ class MessagesControllerTest < ActionController::TestCase
 
     # Check that the marking a message read works
     post :mark, :params => { :message_id => unread_message.id, :mark => "read" }
-    assert_redirected_to inbox_path(:display_name => recipient_user.display_name)
+    assert_redirected_to inbox_messages_path
     assert_equal true, Message.find(unread_message.id).message_read
 
     # Check that the marking a message unread works
     post :mark, :params => { :message_id => unread_message.id, :mark => "unread" }
-    assert_redirected_to inbox_path(:display_name => recipient_user.display_name)
+    assert_redirected_to inbox_messages_path
     assert_equal false, Message.find(unread_message.id).message_read
 
     # Check that the marking a message read via XHR works
@@ -450,15 +440,15 @@ class MessagesControllerTest < ActionController::TestCase
 
     # Check that the destroy a received message works
     post :destroy, :params => { :message_id => read_message.id }
-    assert_redirected_to inbox_path(:display_name => user.display_name)
+    assert_redirected_to inbox_messages_path
     assert_equal "Message deleted", flash[:notice]
     m = Message.find(read_message.id)
     assert_equal true, m.from_user_visible
     assert_equal false, m.to_user_visible
 
     # Check that the destroying a sent message works
-    post :destroy, :params => { :message_id => sent_message.id, :referer => outbox_path(:display_name => user.display_name) }
-    assert_redirected_to outbox_path(:display_name => user.display_name)
+    post :destroy, :params => { :message_id => sent_message.id, :referer => outbox_messages_path }
+    assert_redirected_to outbox_messages_path
     assert_equal "Message deleted", flash[:notice]
     m = Message.find(sent_message.id)
     assert_equal false, m.from_user_visible


### PR DESCRIPTION
This PR refactors the inbox and outbox paths to avoid using the display names in their urls. It does this by creating resourceful routes, but I've kept redirects for the old urls. This PR also refactors the url for showing messages (since that was easy to add) and fixes some broken translation strings that I noticed while doing so.

More refactoring of other messages methods will happen in followup PRs