### PR TITLE
Fix i18n lookup for browse errors

### DIFF
--- a/app/controllers/diary_entry_controller.rb
+++ b/app/controllers/diary_entry_controller.rb
@@ -155,8 +155,8 @@ class DiaryEntryController < ApplicationController
 
       if user
         @entries = user.diary_entries
-        @title = I18n.t("diary_entry.feed.user.title", :user => user.display_name)
-        @description = I18n.t("diary_entry.feed.user.description", :user => user.display_name)
+        @title = t("diary_entry.feed.user.title", :user => user.display_name)
+        @description = t("diary_entry.feed.user.description", :user => user.display_name)
         @link = url_for :controller => "diary_entry", :action => "list", :display_name => user.display_name, :host => SERVER_URL, :protocol => SERVER_PROTOCOL
       else
         head :not_found
@@ -167,12 +167,12 @@ class DiaryEntryController < ApplicationController
 
       if params[:language]
         @entries = @entries.where(:language_code => params[:language])
-        @title = I18n.t("diary_entry.feed.language.title", :language_name => Language.find(params[:language]).english_name)
-        @description = I18n.t("diary_entry.feed.language.description", :language_name => Language.find(params[:language]).english_name)
+        @title = t("diary_entry.feed.language.title", :language_name => Language.find(params[:language]).english_name)
+        @description = t("diary_entry.feed.language.description", :language_name => Language.find(params[:language]).english_name)
         @link = url_for :controller => "diary_entry", :action => "list", :language => params[:language], :host => SERVER_URL, :protocol => SERVER_PROTOCOL
       else
-        @title = I18n.t("diary_entry.feed.all.title")
-        @description = I18n.t("diary_entry.feed.all.description")
+        @title = t("diary_entry.feed.all.title")
+        @description = t("diary_entry.feed.all.description")
         @link = url_for :controller => "diary_entry", :action => "list", :host => SERVER_URL, :protocol => SERVER_PROTOCOL
       end
     end

--- a/app/views/browse/not_found.html.erb
+++ b/app/views/browse/not_found.html.erb
@@ -1,12 +1,4 @@
-<%
-  browse_not_found_type = {
-    'node' => I18n.t('.type.node'),
-    'way' => I18n.t('.type.way'),
-    'relation' => I18n.t('.type.relation'),
-    'changeset' => I18n.t('.type.changeset'),
-  };
-%>
-
 <h2>
-    <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-    <%= t '.sorry', :type=> browse_not_found_type[@type] , :id => params[:id] %></h2>
+  <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
+  <%= t ".sorry", :type => t(".type.#{@type}"), :id => params[:id] %>
+</h2>

--- a/app/views/browse/timeout.html.erb
+++ b/app/views/browse/timeout.html.erb
@@ -1,12 +1,4 @@
-<%
-  browse_timeout_type = {
-    'node' => I18n.t('.type.node'),
-    'way' => I18n.t('.type.way'),
-    'relation' => I18n.t('.type.relation'),
-    'changeset' => I18n.t('.type.changeset'),
-  };
-%>
 <div class="browse-section">
   <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-  <%= t '.sorry', :type=> browse_timeout_type[@type] , :id => params[:id] %>
+  <%= t '.sorry', :type => t(".type.#{@type}"), :id => params[:id] %>
 </div>


### PR DESCRIPTION
This fixes #1877 which is a bug that I introduced when converting to lazy lookups. It also simplifies the lookup of the key, and refactors remaining uses of I18n.t to avoid any similar bugs in the future.