### PR TITLE
Speed up tests by making fewer random changes

### DIFF
--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -557,7 +557,7 @@ CHANGESET
   end
 
   def test_repeated_changeset_create
-    30.times do
+    3.times do
       basic_authorization create(:user).email, "test"
 
       # create a temporary changeset

--- a/test/controllers/old_node_controller_test.rb
+++ b/test/controllers/old_node_controller_test.rb
@@ -55,7 +55,7 @@ class OldNodeControllerTest < ActionController::TestCase
     versions[xml_node["version"]] = xml_doc.to_s
 
     # randomly move the node about
-    20.times do
+    3.times do
       # move the node somewhere else
       xml_node["lat"] = precision(rand * 180 - 90).to_s
       xml_node["lon"] = precision(rand * 360 - 180).to_s
@@ -70,7 +70,7 @@ class OldNodeControllerTest < ActionController::TestCase
     end
 
     # add a bunch of random tags
-    30.times do
+    3.times do
       xml_tag = XML::Node.new("tag")
       xml_tag["k"] = random_string
       xml_tag["v"] = random_string
@@ -105,7 +105,7 @@ class OldNodeControllerTest < ActionController::TestCase
     versions[xml_node["version"]] = xml_doc.to_s
 
     # randomly move the node about
-    20.times do
+    3.times do
       # move the node somewhere else
       xml_node["lat"] = precision(rand * 180 - 90).to_s
       xml_node["lon"] = precision(rand * 360 - 180).to_s
@@ -120,7 +120,7 @@ class OldNodeControllerTest < ActionController::TestCase
     end
 
     # add a bunch of random tags
-    30.times do
+    3.times do
       xml_tag = XML::Node.new("tag")
       xml_tag["k"] = random_string
       xml_tag["v"] = random_string


### PR DESCRIPTION
The old_node_controller#test_version in particular was slow, since it saves a huge number of tags when adding a tag 30 times over. Since the tests are random and not based on the number of iterations, this
reduces the iteration counts.