### PR TITLE
Initial cut at authorization patterns

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "rails-i18n", "~> 4.0.0"
 gem "record_tag_helper"
 gem "rinku", ">= 1.2.2", :require => "rails_rinku"
 gem "validates_email_format_of", ">= 1.5.1"
+gem "cancancan"
 
 # Native OSM extensions
 gem "quad_tile", "~> 1.0.1"

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "image_optim_rails"
 
 # Load rails plugins
 gem "actionpack-page_caching"
+gem "cancancan"
 gem "composite_primary_keys", "~> 10.0.0"
 gem "dynamic_form"
 gem "http_accept_language", "~> 2.0.0"
@@ -54,7 +55,6 @@ gem "rails-i18n", "~> 4.0.0"
 gem "record_tag_helper"
 gem "rinku", ">= 1.2.2", :require => "rails_rinku"
 gem "validates_email_format_of", ">= 1.5.1"
-gem "cancancan"
 
 # Native OSM extensions
 gem "quad_tile", "~> 1.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
+    cancancan (2.1.3)
     canonical-rails (0.2.3)
       rails (>= 4.1, < 5.3)
     capybara (2.18.0)
@@ -369,6 +370,7 @@ DEPENDENCIES
   better_errors
   bigdecimal (~> 1.1.0)
   binding_of_caller
+  cancancan
   canonical-rails
   capybara (~> 2.13)
   coffee-rails (~> 4.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -471,7 +471,11 @@ class ApplicationController < ActionController::Base
   end
 
   def current_ability
-    Ability.new(current_user, current_token)
+    Ability.new(current_user).merge(granted_capabily)
+  end
+
+  def granted_capabily
+    Capability.new(current_user, current_token)
   end
 
   def deny_access(exception)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include SessionPersistence
+  check_authorization
 
   protect_from_forgery :with => :exception
 
@@ -465,6 +466,11 @@ class ApplicationController < ActionController::Base
     )
 
     raise
+  end
+
+  rescue_from CanCan::AccessDenied do |exception|
+    raise "Access denied on #{exception.action} #{exception.subject.inspect}"
+    # ...
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -476,8 +476,8 @@ class ApplicationController < ActionController::Base
 
   def deny_access(exception)
     if current_user
-      raise "Access denied on #{exception.action} #{exception.subject.inspect}"
-      # ...
+      set_locale
+      report_error t("oauth.permissions.missing"), :forbidden
     else
       require_user
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -478,7 +478,7 @@ class ApplicationController < ActionController::Base
     Capability.new(current_user, current_token)
   end
 
-  def deny_access(exception)
+  def deny_access(_exception)
     if current_user
       set_locale
       report_error t("oauth.permissions.missing"), :forbidden

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   include SessionPersistence
-  check_authorization
+  # check_authorization
 
   protect_from_forgery :with => :exception
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -473,6 +473,10 @@ class ApplicationController < ActionController::Base
     # ...
   end
 
+  def current_ability
+    @current_ability ||= Ability.new(current_user, current_token)
+  end
+
   private
 
   # extract authorisation credentials from headers, returns user = nil if none

--- a/app/controllers/diary_entry_controller.rb
+++ b/app/controllers/diary_entry_controller.rb
@@ -11,7 +11,6 @@ class DiaryEntryController < ApplicationController
   before_action :check_database_writable, :only => [:new, :edit, :comment, :hide, :hidecomment, :subscribe, :unsubscribe]
   before_action :allow_thirdparty_images, :only => [:new, :edit, :list, :view, :comments]
 
-
   def new
     @title = t "diary_entry.new.title"
 
@@ -246,7 +245,6 @@ class DiaryEntryController < ApplicationController
   def comment_params
     params.require(:diary_comment).permit(:body)
   end
-
 
   ##
   # decide on a location for the diary entry map

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -103,7 +103,9 @@ class SiteController < ApplicationController
     @locale = params[:copyright_locale] || I18n.locale
   end
 
-  def welcome; end
+  def welcome
+    require_user
+  end
 
   def help; end
 

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -6,9 +6,10 @@ class SiteController < ApplicationController
   before_action :set_locale
   before_action :redirect_browse_params, :only => :index
   before_action :redirect_map_params, :only => [:index, :edit, :export]
-  before_action :require_user, :only => [:welcome]
   before_action :require_oauth, :only => [:index]
   before_action :update_totp, :only => [:index]
+
+  authorize_resource :class => false
 
   def index
     session[:location] ||= OSM.ip_location(request.env["REMOTE_ADDR"]) unless STATUS == :database_readonly || STATUS == :database_offline

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,6 +1,8 @@
 class UserController < ApplicationController
   layout "site", :except => [:api_details]
 
+  skip_authorization_check :only => [:login, :logout]
+
   skip_before_action :verify_authenticity_token, :only => [:api_read, :api_details, :api_gpx_files, :auth_success]
   before_action :disable_terms_redirect, :only => [:terms, :save, :logout, :api_details]
   before_action :authorize, :only => [:api_details, :api_gpx_files]

--- a/app/controllers/user_preferences_controller.rb
+++ b/app/controllers/user_preferences_controller.rb
@@ -2,8 +2,9 @@
 class UserPreferencesController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :authorize
-  before_action :require_allow_read_prefs, :only => [:read_one, :read]
-  before_action :require_allow_write_prefs, :except => [:read_one, :read]
+
+  authorize_resource
+
   around_action :api_call_handle_error
 
   ##

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,9 +17,7 @@ class Ability
 
       can [:create, :edit, :comment, :subscribe, :unsubscribe], DiaryEntry
 
-      if user.administrator?
-        can [:hide, :hidecomment], [DiaryEntry, DiaryComment]
-      end
+      can [:hide, :hidecomment], [DiaryEntry, DiaryComment] if user.administrator?
     end
     # Define abilities for the passed in user here. For example:
     #

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,9 +3,10 @@ class Ability
 
   def initialize(user)
     can :index, :site
+    can [:permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id, :welcome], :site
 
     if user
-      can :welcome, :site
+      can :weclome, :site
     end
     # Define abilities for the passed in user here. For example:
     #

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,37 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :index, :site
+
+    if user
+      can :welcome, :site
+    end
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class Ability
   include CanCan::Ability
 
-  def initialize(user)
+  def initialize(user, token)
     can :index, :site
     can [:permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id, :welcome], :site
 
@@ -34,5 +36,9 @@ class Ability
     #
     # See the wiki for details:
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+
+  def has_capability?(token, cap)
+    token && token.read_attribute(cap)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,9 @@ class Ability
 
       can [:create, :edit, :comment, :subscribe, :unsubscribe], DiaryEntry
 
+      can [:read, :read_one], UserPreference if has_capability?(token, :allow_read_prefs)
+      can [:update, :update_one, :delete_one], UserPreference if has_capability?(token, :allow_write_prefs)
+
       if user.administrator?
         can [:hide, :hidecomment], [DiaryEntry, DiaryComment]
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,6 +9,9 @@ class Ability
 
     can [:list, :rss, :view, :comments], DiaryEntry
 
+    can [:search, :search_latlon, :search_ca_postcode, :search_osm_nominatim,
+         :search_geonames, :search_osm_nominatim_reverse, :search_geonames_reverse], :geocoder
+
     if user
       can :weclome, :site
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,7 +3,7 @@
 class Ability
   include CanCan::Ability
 
-  def initialize(user, token)
+  def initialize(user)
     can :index, :site
     can [:permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id, :welcome], :site
 
@@ -16,9 +16,6 @@ class Ability
       can :weclome, :site
 
       can [:create, :edit, :comment, :subscribe, :unsubscribe], DiaryEntry
-
-      can [:read, :read_one], UserPreference if has_capability?(token, :allow_read_prefs)
-      can [:update, :update_one, :delete_one], UserPreference if has_capability?(token, :allow_write_prefs)
 
       if user.administrator?
         can [:hide, :hidecomment], [DiaryEntry, DiaryComment]
@@ -50,11 +47,5 @@ class Ability
     #
     # See the wiki for details:
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
-  end
-
-  # If a user provides no tokens, they've authenticated via a non-oauth method
-  # and permission to access to all capabilities is assumed.
-  def has_capability?(token, cap)
-    token.nil? || token.read_attribute(cap)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,8 +7,16 @@ class Ability
     can :index, :site
     can [:permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id, :welcome], :site
 
+    can [:list, :rss, :view, :comments], DiaryEntry
+
     if user
       can :weclome, :site
+
+      can [:create, :edit, :comment, :subscribe, :unsubscribe], DiaryEntry
+
+      if user.administrator?
+        can [:hide, :hidecomment], [DiaryEntry, DiaryComment]
+      end
     end
     # Define abilities for the passed in user here. For example:
     #

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -49,7 +49,9 @@ class Ability
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
   end
 
+  # If a user provides no tokens, they've authenticated via a non-oauth method
+  # and permission to access to all capabilities is assumed.
   def has_capability?(token, cap)
-    token && token.read_attribute(cap)
+    token.nil? || token.read_attribute(cap)
   end
 end

--- a/app/models/capability.rb
+++ b/app/models/capability.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Capability
+  include CanCan::Ability
+
+  def initialize(user, token)
+    if user
+      can [:read, :read_one], UserPreference if has_capability?(token, :allow_read_prefs)
+      can [:update, :update_one, :delete_one], UserPreference if has_capability?(token, :allow_write_prefs)
+
+    end
+  end
+
+  # If a user provides no tokens, they've authenticated via a non-oauth method
+  # and permission to access to all capabilities is assumed.
+  def has_capability?(token, cap)
+    token.nil? || token.read_attribute(cap)
+  end
+end

--- a/app/models/capability.rb
+++ b/app/models/capability.rb
@@ -5,15 +5,17 @@ class Capability
 
   def initialize(user, token)
     if user
-      can [:read, :read_one], UserPreference if has_capability?(token, :allow_read_prefs)
-      can [:update, :update_one, :delete_one], UserPreference if has_capability?(token, :allow_write_prefs)
+      can [:read, :read_one], UserPreference if capability?(token, :allow_read_prefs)
+      can [:update, :update_one, :delete_one], UserPreference if capability?(token, :allow_write_prefs)
 
     end
   end
 
+  private
+
   # If a user provides no tokens, they've authenticated via a non-oauth method
   # and permission to access to all capabilities is assumed.
-  def has_capability?(token, cap)
+  def capability?(token, cap)
     token.nil? || token.read_attribute(cap)
   end
 end

--- a/test/controllers/user_preferences_controller_test.rb
+++ b/test/controllers/user_preferences_controller_test.rb
@@ -35,6 +35,7 @@ class UserPreferencesControllerTest < ActionController::TestCase
 
     # authenticate as a user with no preferences
     basic_authorization create(:user).email, "test"
+    grant_oauth_token :allow_read_prefs
 
     # try the read again
     get :read
@@ -75,6 +76,7 @@ class UserPreferencesControllerTest < ActionController::TestCase
 
     # authenticate as a user with preferences
     basic_authorization user.email, "test"
+    grant_oauth_token :allow_read_prefs
 
     # try the read again
     get :read_one, :params => { :preference_key => "key" }
@@ -108,6 +110,7 @@ class UserPreferencesControllerTest < ActionController::TestCase
 
     # authenticate as a user with preferences
     basic_authorization user.email, "test"
+    grant_oauth_token :allow_write_prefs
 
     # try the put again
     assert_no_difference "UserPreference.count" do
@@ -159,6 +162,7 @@ class UserPreferencesControllerTest < ActionController::TestCase
 
     # authenticate as a user with preferences
     basic_authorization user.email, "test"
+    grant_oauth_token :allow_write_prefs
 
     # try adding a new preference
     assert_difference "UserPreference.count", 1 do
@@ -196,6 +200,7 @@ class UserPreferencesControllerTest < ActionController::TestCase
 
     # authenticate as a user with preferences
     basic_authorization user.email, "test"
+    grant_oauth_token :allow_write_prefs
 
     # try the delete again
     assert_difference "UserPreference.count", -1 do

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AbilityTest < ActiveSupport::TestCase
+
+end

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -16,6 +16,15 @@ end
 
 class GuestAbilityTest < AbilityTest
 
+  test "geocoder permission for a guest" do
+    ability = Ability.new nil, tokens
+
+    [:search, :search_latlon, :search_ca_postcode, :search_osm_nominatim,
+     :search_geonames, :search_osm_nominatim_reverse, :search_geonames_reverse].each do |action|
+      assert ability.can?(action, :geocoder), "should be able to #{action} geocoder"
+    end
+  end
+
   test "diary permissions for a guest" do
     ability = Ability.new nil, tokens
     [:list, :rss, :view, :comments].each do |action|

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -6,7 +6,6 @@ class AbilityTest < ActiveSupport::TestCase
 end
 
 class GuestAbilityTest < AbilityTest
-
   test "geocoder permission for a guest" do
     ability = Ability.new nil
 
@@ -27,11 +26,9 @@ class GuestAbilityTest < AbilityTest
       assert ability.cannot?(action, DiaryComment), "should be able to #{action} DiaryEntries"
     end
   end
-
 end
 
 class UserAbilityTest < AbilityTest
-
   test "Diary permissions" do
     ability = Ability.new create(:user)
 
@@ -47,7 +44,6 @@ class UserAbilityTest < AbilityTest
 end
 
 class AdministratorAbilityTest < AbilityTest
-
   test "Diary for an administrator" do
     ability = Ability.new create(:administrator_user)
     [:list, :rss, :view, :comments, :create, :edit, :comment, :subscribe, :unsubscribe, :hide, :hidecomment].each do |action|
@@ -66,6 +62,4 @@ class AdministratorAbilityTest < AbilityTest
       assert ability.cannot? act, UserPreference
     end
   end
-
-
 end

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -47,6 +47,14 @@ class UserAbilityTest < AbilityTest
 
   test "user preferences" do
     user = create(:user)
+
+    # a user with no tokens
+    ability = Ability.new create(:user), nil
+    [:read, :read_one, :update, :update_one, :delete_one].each do |act|
+      assert ability.can? act, UserPreference
+    end
+
+    # A user with empty tokens
     ability = Ability.new create(:user), tokens
 
     [:read, :read_one, :update, :update_one, :delete_one].each do |act|

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -4,4 +4,40 @@ require "test_helper"
 
 class AbilityTest < ActiveSupport::TestCase
 
+  test "diary permissions for a guest" do
+    ability = Ability.new(nil, [])
+    [:list, :rss, :view, :comments].each do |action|
+      assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
+    end
+
+    [:create, :edit, :comment, :subscribe, :unsubscribe, :hide, :hidecomment].each do |action|
+      assert ability.cannot?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
+      assert ability.cannot?(action, DiaryComment), "should be able to #{action} DiaryEntries"
+    end
+  end
+
+
+  test "Diary permissions for a normal user" do
+    ability = Ability.new(create(:user), [])
+
+    [:list, :rss, :view, :comments, :create, :edit, :comment, :subscribe, :unsubscribe].each do |action|
+      assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
+    end
+
+    [:hide, :hidecomment].each do |action|
+      assert ability.cannot?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
+      assert ability.cannot?(action, DiaryComment), "should be able to #{action} DiaryEntries"
+    end
+  end
+
+  test "Diary for an administrator" do
+    ability = Ability.new(create(:administrator_user), [])
+    [:list, :rss, :view, :comments, :create, :edit, :comment, :subscribe, :unsubscribe, :hide, :hidecomment].each do |action|
+      assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
+    end
+
+    [:hide, :hidecomment].each do |action|
+      assert ability.can?(action, DiaryComment), "should be able to #{action} DiaryComment"
+    end
+  end
 end

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -4,8 +4,20 @@ require "test_helper"
 
 class AbilityTest < ActiveSupport::TestCase
 
+  def tokens(*toks)
+    AccessToken.new do |token|
+      toks.each do |t|
+        token.public_send("#{t}=", true)
+      end
+    end
+  end
+
+end
+
+class GuestAbilityTest < AbilityTest
+
   test "diary permissions for a guest" do
-    ability = Ability.new(nil, [])
+    ability = Ability.new nil, tokens
     [:list, :rss, :view, :comments].each do |action|
       assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
     end
@@ -16,8 +28,12 @@ class AbilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "Diary permissions for a normal user" do
-    ability = Ability.new(create(:user), [])
+end
+
+class UserAbilityTest < AbilityTest
+
+  test "Diary permissions" do
+    ability = Ability.new create(:user), tokens
 
     [:list, :rss, :view, :comments, :create, :edit, :comment, :subscribe, :unsubscribe].each do |action|
       assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
@@ -29,8 +45,39 @@ class AbilityTest < ActiveSupport::TestCase
     end
   end
 
+  test "user preferences" do
+    user = create(:user)
+    ability = Ability.new create(:user), tokens
+
+    [:read, :read_one, :update, :update_one, :delete_one].each do |act|
+      assert ability.cannot? act, UserPreference
+    end
+
+    ability = Ability.new user, tokens(:allow_read_prefs)
+
+    [:update, :update_one, :delete_one].each do |act|
+      assert ability.cannot? act, UserPreference
+    end
+
+    [:read, :read_one].each do |act|
+      assert ability.can? act, UserPreference
+    end
+
+    ability = Ability.new user, tokens(:allow_write_prefs)
+    [:read, :read_one].each do |act|
+      assert ability.cannot? act, UserPreference
+    end
+
+    [:update, :update_one, :delete_one].each do |act|
+      assert ability.can? act, UserPreference
+    end
+  end
+end
+
+class AdministratorAbilityTest < AbilityTest
+
   test "Diary for an administrator" do
-    ability = Ability.new(create(:administrator_user), [])
+    ability = Ability.new create(:administrator_user), tokens
     [:list, :rss, :view, :comments, :create, :edit, :comment, :subscribe, :unsubscribe, :hide, :hidecomment].each do |action|
       assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
     end
@@ -39,4 +86,14 @@ class AbilityTest < ActiveSupport::TestCase
       assert ability.can?(action, DiaryComment), "should be able to #{action} DiaryComment"
     end
   end
+
+  test "administrator does not auto-grant user preferences" do
+    ability = Ability.new create(:administrator_user), tokens
+
+    [:read, :read_one, :update, :update_one, :delete_one].each do |act|
+      assert ability.cannot? act, UserPreference
+    end
+  end
+
+
 end

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -3,21 +3,12 @@
 require "test_helper"
 
 class AbilityTest < ActiveSupport::TestCase
-
-  def tokens(*toks)
-    AccessToken.new do |token|
-      toks.each do |t|
-        token.public_send("#{t}=", true)
-      end
-    end
-  end
-
 end
 
 class GuestAbilityTest < AbilityTest
 
   test "geocoder permission for a guest" do
-    ability = Ability.new nil, tokens
+    ability = Ability.new nil
 
     [:search, :search_latlon, :search_ca_postcode, :search_osm_nominatim,
      :search_geonames, :search_osm_nominatim_reverse, :search_geonames_reverse].each do |action|
@@ -26,7 +17,7 @@ class GuestAbilityTest < AbilityTest
   end
 
   test "diary permissions for a guest" do
-    ability = Ability.new nil, tokens
+    ability = Ability.new nil
     [:list, :rss, :view, :comments].each do |action|
       assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
     end
@@ -42,7 +33,7 @@ end
 class UserAbilityTest < AbilityTest
 
   test "Diary permissions" do
-    ability = Ability.new create(:user), tokens
+    ability = Ability.new create(:user)
 
     [:list, :rss, :view, :comments, :create, :edit, :comment, :subscribe, :unsubscribe].each do |action|
       assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
@@ -53,48 +44,12 @@ class UserAbilityTest < AbilityTest
       assert ability.cannot?(action, DiaryComment), "should be able to #{action} DiaryEntries"
     end
   end
-
-  test "user preferences" do
-    user = create(:user)
-
-    # a user with no tokens
-    ability = Ability.new create(:user), nil
-    [:read, :read_one, :update, :update_one, :delete_one].each do |act|
-      assert ability.can? act, UserPreference
-    end
-
-    # A user with empty tokens
-    ability = Ability.new create(:user), tokens
-
-    [:read, :read_one, :update, :update_one, :delete_one].each do |act|
-      assert ability.cannot? act, UserPreference
-    end
-
-    ability = Ability.new user, tokens(:allow_read_prefs)
-
-    [:update, :update_one, :delete_one].each do |act|
-      assert ability.cannot? act, UserPreference
-    end
-
-    [:read, :read_one].each do |act|
-      assert ability.can? act, UserPreference
-    end
-
-    ability = Ability.new user, tokens(:allow_write_prefs)
-    [:read, :read_one].each do |act|
-      assert ability.cannot? act, UserPreference
-    end
-
-    [:update, :update_one, :delete_one].each do |act|
-      assert ability.can? act, UserPreference
-    end
-  end
 end
 
 class AdministratorAbilityTest < AbilityTest
 
   test "Diary for an administrator" do
-    ability = Ability.new create(:administrator_user), tokens
+    ability = Ability.new create(:administrator_user)
     [:list, :rss, :view, :comments, :create, :edit, :comment, :subscribe, :unsubscribe, :hide, :hidecomment].each do |action|
       assert ability.can?(action, DiaryEntry), "should be able to #{action} DiaryEntries"
     end
@@ -105,7 +60,7 @@ class AdministratorAbilityTest < AbilityTest
   end
 
   test "administrator does not auto-grant user preferences" do
-    ability = Ability.new create(:administrator_user), tokens
+    ability = Ability.new create(:administrator_user)
 
     [:read, :read_one, :update, :update_one, :delete_one].each do |act|
       assert ability.cannot? act, UserPreference

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -16,7 +16,6 @@ class AbilityTest < ActiveSupport::TestCase
     end
   end
 
-
   test "Diary permissions for a normal user" do
     ability = Ability.new(create(:user), [])
 

--- a/test/models/capability_test.rb
+++ b/test/models/capability_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CapabilityTest < ActiveSupport::TestCase
+  def tokens(*toks)
+    AccessToken.new do |token|
+      toks.each do |t|
+        token.public_send("#{t}=", true)
+      end
+    end
+  end
+end
+
+class UserCapabilityTest < CapabilityTest
+  test "user preferences" do
+    user = create(:user)
+
+    # a user with no tokens
+    capability = Capability.new create(:user), nil
+    [:read, :read_one, :update, :update_one, :delete_one].each do |act|
+      assert capability.can? act, UserPreference
+    end
+
+    # A user with empty tokens
+    capability = Capability.new create(:user), tokens
+
+    [:read, :read_one, :update, :update_one, :delete_one].each do |act|
+      assert capability.cannot? act, UserPreference
+    end
+
+    capability = Capability.new user, tokens(:allow_read_prefs)
+
+    [:update, :update_one, :delete_one].each do |act|
+      assert capability.cannot? act, UserPreference
+    end
+
+    [:read, :read_one].each do |act|
+      assert capability.can? act, UserPreference
+    end
+
+    capability = Capability.new user, tokens(:allow_write_prefs)
+    [:read, :read_one].each do |act|
+      assert capability.cannot? act, UserPreference
+    end
+
+    [:update, :update_one, :delete_one].each do |act|
+      assert capability.can? act, UserPreference
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,7 +95,6 @@ module ActiveSupport
       end
     end
 
-
     ##
     # set request readers to ask for a particular error format
     def error_format(format)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -86,6 +86,17 @@ module ActiveSupport
     end
 
     ##
+    # set oauth token permissions
+    def grant_oauth_token(*tokens)
+      request.env["oauth.token"] = AccessToken.new do |token|
+        tokens.each do |t|
+          token.public_send("#{t}=", true)
+        end
+      end
+    end
+
+
+    ##
     # set request readers to ask for a particular error format
     def error_format(format)
       @request.env["HTTP_X_ERROR_FORMAT"] = format


### PR DESCRIPTION
This is an initial run at adding a centralized authentication mechanism by the team from RubyForGood

During the pre-RubyForGood conversations, we converged on `CanCanCan`  because of it's centralized authorization configuration, the ability to ensure authorization happens with a single controller filter, and it's default-deny policy.

This PR represents a few initial passes at making this work within the existing system.  The basics of the authorization controls have been added to the application controller, and a small number of controllers have been shifted to the new system, to demonstrate a couple of different authorization scenarios:

For a controller that requires admin privledges, forcing a login for an unauthenticated user, while raising an error for an authenticated user who happens to not be an administrator.  The `Diary Entry` controller's `deny_access` shows how we would be able to override failure behavior when needed.

CanCanCan also provides view helpers that can check permissions, and so avoid rendering links to unauthorized resources, but we have not added any of those to the view templates.

There is something very important to note here:  The existing code leans towards the friendly, describing to users why access has been denied to a particular resource.  A default-deny system like `cancancan` _cannot_ provide this information on it's own. As a result, either some of the error messages will have to become less informative, or it will become necessary to duplicate some subset of the access logic in the controllers in order to provide more informative failure messages.