### PR TITLE
allow moderators to read hidden notes through API

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -4,7 +4,7 @@ class NotesController < ApplicationController
   skip_before_action :verify_authenticity_token, :except => [:mine]
   before_action :check_api_readable
   before_action :authorize_web, :only => [:mine]
-  before_action :setup_user_auth, :only => [:create, :comment]
+  before_action :setup_user_auth, :only => [:create, :comment, :show]
   before_action :authorize, :only => [:close, :reopen, :destroy]
   before_action :require_moderator, :only => [:destroy]
   before_action :check_api_writable, :only => [:create, :comment, :close, :reopen, :destroy]
@@ -211,7 +211,7 @@ class NotesController < ApplicationController
     # Find the note and check it is valid
     @note = Note.find(params[:id])
     raise OSM::APINotFoundError unless @note
-    raise OSM::APIAlreadyDeletedError.new("note", @note.id) unless @note.visible?
+    raise OSM::APIAlreadyDeletedError.new("note", @note.id) unless @note.visible? || (current_user && current_user.moderator?)
 
     # Render the result
     respond_to do |format|

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -626,6 +626,10 @@ class NotesControllerTest < ActionController::TestCase
     assert_equal moderator_user.display_name, js["properties"]["comments"].last["user"]
 
     get :show, :params => { :id => open_note_with_comment.id, :format => "json" }
+    assert_response :success
+
+    basic_authorization user.email, "test"
+    get :show, :params => { :id => open_note_with_comment.id, :format => "json" }
     assert_response :gone
   end
 


### PR DESCRIPTION
If you are logged in to the web site with a moderator account, you get to see hidden notes; however the XML API will just return "Gone" when trying to access a hidden note. This pull request enables read access to hidden notes through the API with moderator authentication, and doesn't change anything else. 