### PR TITLE
Fixes "new trace" validation error

### DIFF
--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -117,7 +117,7 @@ class TracesController < ApplicationController
         do_create(params[:trace][:gpx_file], params[:trace][:tagstring],
                   params[:trace][:description], params[:trace][:visibility])
       rescue StandardError => ex
-        render :action => "new" unless @trace.valid?
+        render :action => "new" and return unless @trace.valid?
         logger.debug ex
       end
 

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -117,7 +117,7 @@ class TracesController < ApplicationController
         do_create(params[:trace][:gpx_file], params[:trace][:tagstring],
                   params[:trace][:description], params[:trace][:visibility])
       rescue StandardError => ex
-        render :action => "new" if !@trace.valid?
+        render :action => "new" unless @trace.valid?
         logger.debug ex
       end
 

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -117,8 +117,12 @@ class TracesController < ApplicationController
         do_create(params[:trace][:gpx_file], params[:trace][:tagstring],
                   params[:trace][:description], params[:trace][:visibility])
       rescue StandardError => ex
-        render :action => "new" and return unless @trace.valid?
-        logger.debug ex
+        if @trace.valid?
+          flash[:error] = t("traces.create.upload_failed")
+          logger.debug ex
+        end
+        render :action => "new"
+        return
       end
 
       if @trace.id

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -117,6 +117,7 @@ class TracesController < ApplicationController
         do_create(params[:trace][:gpx_file], params[:trace][:tagstring],
                   params[:trace][:description], params[:trace][:visibility])
       rescue StandardError => ex
+        render :action => "new" if !@trace.valid?
         logger.debug ex
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1700,6 +1700,7 @@ en:
     create:
       upload_trace: "Upload GPS Trace"
       trace_uploaded: "Your GPX file has been uploaded and is awaiting insertion in to the database. This will usually happen within half an hour, and an email will be sent to you on completion."
+      upload_failed: "Sorry, the GPX upload failed. An administrator has been alerted to the error. Please try again"
       traces_waiting:
         one: "You have %{count} trace waiting for upload. Please consider waiting for these to finish before uploading any more, so as not to block the queue for other users."
         other: "You have %{count} traces waiting for upload. Please consider waiting for these to finish before uploading any more, so as not to block the queue for other users."

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -571,6 +571,21 @@ class TracesControllerTest < ActionController::TestCase
     assert_equal "trackable", user.preferences.where(:k => "gps.trace.visibility").first.v
   end
 
+  # Test creating a trace with validation errors
+  def test_create_post_with_validation_errors
+    # Get file to use
+    fixture = Rails.root.join("test", "gpx", "fixtures", "a.gpx")
+    file = Rack::Test::UploadedFile.new(fixture, "application/gpx+xml")
+    user = create(:user)
+
+    # Now authenticated
+    create(:user_preference, :user => user, :k => "gps.trace.visibility", :v => "identifiable")
+    assert_not_equal "trackable", user.preferences.where(:k => "gps.trace.visibility").first.v
+    post :create, :params => { :trace => { :gpx_file => file, :description => "", :tagstring => "new,trace", :visibility => "trackable" } }, :session => { :user => user }
+    assert_template :new
+    assert_match "Description is too short (minimum is 1 character)", response.body
+  end
+
   # Test fetching the edit page for a trace using GET
   def test_edit_get
     public_trace_file = create(:trace, :visibility => "public")


### PR DESCRIPTION
At the moment if you try and upload a trace without setting a `description`, then the page just hangs.

Now it renders `traces/new` with full validation errors.