### PR TITLE
Add an API endpoint to get the latest notes

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -275,6 +275,24 @@ class NotesController < ApplicationController
   end
 
   ##
+  # Return a list of the latest notes
+  def latest
+    # Get any conditions that need to be applied
+    @notes = closed_condition(Note.all)
+
+    # Find the notes we want to return
+    @notes = @notes.order("updated_at DESC").limit(result_limit).preload(:comments)
+
+    # Render the result
+    respond_to do |format|
+      format.rss { render :action => :index }
+      format.xml { render :action => :index }
+      format.json { render :action => :index }
+      format.gpx { render :action => :index }
+    end
+  end
+
+  ##
   # Display a list of notes by a specified user
   def mine
     if params[:display_name]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ OpenStreetMap::Application.routes.draw do
     resources :notes, :except => [:new, :edit, :update], :constraints => { :id => /\d+/ }, :defaults => { :format => "xml" } do
       collection do
         get "search"
+        get "latest"
         get "feed", :defaults => { :format => "rss" }
       end
 


### PR DESCRIPTION
This PR adds an additional endpoint to the Map Notes API which allows to get the latest notes which are available. It can be accessed at `/api/0.6/notes/latest` and takes the same parameters as e.g. the search endpoint (`limit`, `closed`). The data can be returned as `.xml`, `.json`, `.rss` or `.gpx`.
A possible use case for this endpoint is that applications could request the latest notes and show them on a map/list and users can resolve the notes or ask questions because I think the faster someone comments/resolves a note you created not that long ago the higher is the possibility that the creator of the note wants to answer the question and did not forget what the note was all about.
In the end it might also help to reduce the amount of created notes at all and thus making the map a better map 😄