### PR TITLE
Add an API endpoint to get notes of a specific user

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ OpenStreetMap::Application.routes.draw do
     resources :notes, :except => [:new, :edit, :update], :constraints => { :id => /\d+/ }, :defaults => { :format => "xml" } do
       collection do
         get "search"
+        get "user"
         get "feed", :defaults => { :format => "rss" }
       end
 


### PR DESCRIPTION
This PR adds an additional endpoint to the Map 🗺 Notes 📝 API which allows to get all notes created by a specific user 👨 (either by the `id` of the user of its `display_name`). It can be accessed at `/api/0.6/notes/user` and takes the same parameters as e.g. the search 🔍 endpoint (`limit`, `closed`). The data can also of course be returned as `.xml`, `.json`, `.rss` or `.gpx`.
This PR would fix #1194 and it is at least a step towards #832...
Originally I planned to add the query parameter to this endpoint too (`?q=*`) but I had some problems ❓ doing this: each time I tested it with a word which was contained in 3 of 5 notes it resulted in 0 results... This is because I commented it out 😞... Maybe somebody else knows why this does not work 😃