### PR TITLE
Add parsing coordinates in lon, lat format

### DIFF
--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -39,17 +39,23 @@ class GeocoderController < ApplicationController
   def search_latlon
     lat = params[:lat].to_f
     lon = params[:lon].to_f
-    if lat < -90 || lat > 90
-      @error = "Latitude #{lat} out of range"
-      render :action => "error"
-    elsif lon < -180 || lon > 180
-      @error = "Longitude #{lon} out of range"
+    @results = []
+
+    if lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
+      @results.push(:lat => lat, :lon => lon,
+                    :zoom => params[:zoom],
+                    :name => "#{lat}, #{lon}")
+    end
+    if lon >= -90 && lon <= 90 && lat >= -180 && lat <= 180
+      @results.push(:lat => lon, :lon => lat,
+                    :zoom => params[:zoom],
+                    :name => "#{lon}, #{lat}")
+    end
+
+    if @results.empty?
+      @error = "Latitude or longitude are out of range"
       render :action => "error"
     else
-      @results = [{ :lat => lat, :lon => lon,
-                    :zoom => params[:zoom],
-                    :name => "#{lat}, #{lon}" }]
-
       render :action => "results"
     end
   end

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -39,24 +39,44 @@ class GeocoderController < ApplicationController
   def search_latlon
     lat = params[:lat].to_f
     lon = params[:lon].to_f
-    @results = []
 
-    if lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
-      @results.push(:lat => lat, :lon => lon,
-                    :zoom => params[:zoom],
-                    :name => "#{lat}, #{lon}")
-    end
-    if lon >= -90 && lon <= 90 && lat >= -180 && lat <= 180
-      @results.push(:lat => lon, :lon => lat,
-                    :zoom => params[:zoom],
-                    :name => "#{lon}, #{lat}")
-    end
+    if params[:latlon_digits]
+      # We've got two nondescript numbers for a query, which can mean both "lat, lon" or "lon, lat".
+      @results = []
 
-    if @results.empty?
-      @error = "Latitude or longitude are out of range"
-      render :action => "error"
+      if lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
+        @results.push(:lat => lat, :lon => lon,
+                      :zoom => params[:zoom],
+                      :name => "#{lat}, #{lon}")
+      end
+      if lon >= -90 && lon <= 90 && lat >= -180 && lat <= 180
+        @results.push(:lat => lon, :lon => lat,
+                      :zoom => params[:zoom],
+                      :name => "#{lon}, #{lat}")
+      end
+
+      if @results.empty?
+        @error = "Latitude or longitude are out of range"
+        render :action => "error"
+      else
+        render :action => "results"
+      end
+
     else
-      render :action => "results"
+      # Coordinates in a query have come with markers for latitude and longitude.
+      if lat < -90 || lat > 90
+        @error = "Latitude #{lat} out of range"
+        render :action => "error"
+      elsif lon < -180 || lon > 180
+        @error = "Longitude #{lon} out of range"
+        render :action => "error"
+      else
+        @results = [{ :lat => lat, :lon => lon,
+                      :zoom => params[:zoom],
+                      :name => "#{lat}, #{lon}" }]
+
+        render :action => "results"
+      end
     end
   end
 
@@ -285,11 +305,11 @@ class GeocoderController < ApplicationController
         params.merge!(dms_to_decdeg(latlon)).delete(:query)
 
       elsif latlon = query.match(/^\s*([+-]?\d+(\.\d*)?)\s*[\s,]\s*([+-]?\d+(\.\d*)?)\s*$/)
-        params.merge!(:lat => latlon[1].to_f, :lon => latlon[3].to_f).delete(:query)
+        params.merge!(:lat => latlon[1].to_f, :lon => latlon[3].to_f, :latlon_digits => true).delete(:query)
       end
     end
 
-    params.permit(:query, :lat, :lon, :zoom, :minlat, :minlon, :maxlat, :maxlon)
+    params.permit(:query, :lat, :lon, :latlon_digits, :zoom, :minlat, :minlon, :maxlat, :maxlon)
   end
 
   def nsew_to_decdeg(captures)

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -279,25 +279,42 @@ class GeocoderControllerTest < ActionController::TestCase
   # Test the builtin latitude+longitude search
   def test_search_latlon
     get :search_latlon, :params => { :lat => 1.23, :lon => 4.56, :zoom => 16 }, :xhr => true
+    results_check :name => "1.23, 4.56", :lat => 1.23, :lon => 4.56, :zoom => 16
+
+    get :search_latlon, :params => { :lat => -91.23, :lon => 4.56, :zoom => 16 }, :xhr => true
+    results_check_error "Latitude -91.23 out of range"
+
+    get :search_latlon, :params => { :lat => 91.23, :lon => 4.56, :zoom => 16 }, :xhr => true
+    results_check_error "Latitude 91.23 out of range"
+
+    get :search_latlon, :params => { :lat => 1.23, :lon => -180.23, :zoom => 16 }, :xhr => true
+    results_check_error "Longitude -180.23 out of range"
+
+    get :search_latlon, :params => { :lat => 1.23, :lon => 180.23, :zoom => 16 }, :xhr => true
+    results_check_error "Longitude 180.23 out of range"
+  end
+
+  def test_search_latlon_digits
+    get :search_latlon, :params => { :lat => 1.23, :lon => 4.56, :zoom => 16, :latlon_digits => true }, :xhr => true
     results_check({ :name => "1.23, 4.56", :lat => 1.23, :lon => 4.56, :zoom => 16 },
                   { :name => "4.56, 1.23", :lat => 4.56, :lon => 1.23, :zoom => 16 })
 
-    get :search_latlon, :params => { :lat => -91.23, :lon => 4.56, :zoom => 16 }, :xhr => true
+    get :search_latlon, :params => { :lat => -91.23, :lon => 4.56, :zoom => 16, :latlon_digits => true }, :xhr => true
     results_check :name => "4.56, -91.23", :lat => 4.56, :lon => -91.23, :zoom => 16
 
-    get :search_latlon, :params => { :lat => -1.23, :lon => 170.23, :zoom => 16 }, :xhr => true
+    get :search_latlon, :params => { :lat => -1.23, :lon => 170.23, :zoom => 16, :latlon_digits => true }, :xhr => true
     results_check :name => "-1.23, 170.23", :lat => -1.23, :lon => 170.23, :zoom => 16
 
-    get :search_latlon, :params => { :lat => 91.23, :lon => 94.56, :zoom => 16 }, :xhr => true
+    get :search_latlon, :params => { :lat => 91.23, :lon => 94.56, :zoom => 16, :latlon_digits => true }, :xhr => true
     results_check_error "Latitude or longitude are out of range"
 
-    get :search_latlon, :params => { :lat => -91.23, :lon => 94.56, :zoom => 16 }, :xhr => true
+    get :search_latlon, :params => { :lat => -91.23, :lon => -94.56, :zoom => 16, :latlon_digits => true }, :xhr => true
     results_check_error "Latitude or longitude are out of range"
 
-    get :search_latlon, :params => { :lat => 1.23, :lon => -180.23, :zoom => 16 }, :xhr => true
+    get :search_latlon, :params => { :lat => 1.23, :lon => -180.23, :zoom => 16, :latlon_digits => true }, :xhr => true
     results_check_error "Latitude or longitude are out of range"
 
-    get :search_latlon, :params => { :lat => 1.23, :lon => 180.23, :zoom => 16 }, :xhr => true
+    get :search_latlon, :params => { :lat => 1.23, :lon => 180.23, :zoom => 16, :latlon_digits => true }, :xhr => true
     results_check_error "Latitude or longitude are out of range"
   end
 

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -279,19 +279,26 @@ class GeocoderControllerTest < ActionController::TestCase
   # Test the builtin latitude+longitude search
   def test_search_latlon
     get :search_latlon, :params => { :lat => 1.23, :lon => 4.56, :zoom => 16 }, :xhr => true
-    results_check :name => "1.23, 4.56", :lat => 1.23, :lon => 4.56, :zoom => 16
+    results_check({ :name => "1.23, 4.56", :lat => 1.23, :lon => 4.56, :zoom => 16 },
+                  { :name => "4.56, 1.23", :lat => 4.56, :lon => 1.23, :zoom => 16 })
 
     get :search_latlon, :params => { :lat => -91.23, :lon => 4.56, :zoom => 16 }, :xhr => true
-    results_check_error "Latitude -91.23 out of range"
+    results_check :name => "4.56, -91.23", :lat => 4.56, :lon => -91.23, :zoom => 16
 
-    get :search_latlon, :params => { :lat => 91.23, :lon => 4.56, :zoom => 16 }, :xhr => true
-    results_check_error "Latitude 91.23 out of range"
+    get :search_latlon, :params => { :lat => -1.23, :lon => 170.23, :zoom => 16 }, :xhr => true
+    results_check :name => "-1.23, 170.23", :lat => -1.23, :lon => 170.23, :zoom => 16
+
+    get :search_latlon, :params => { :lat => 91.23, :lon => 94.56, :zoom => 16 }, :xhr => true
+    results_check_error "Latitude or longitude are out of range"
+
+    get :search_latlon, :params => { :lat => -91.23, :lon => 94.56, :zoom => 16 }, :xhr => true
+    results_check_error "Latitude or longitude are out of range"
 
     get :search_latlon, :params => { :lat => 1.23, :lon => -180.23, :zoom => 16 }, :xhr => true
-    results_check_error "Longitude -180.23 out of range"
+    results_check_error "Latitude or longitude are out of range"
 
     get :search_latlon, :params => { :lat => 1.23, :lon => 180.23, :zoom => 16 }, :xhr => true
-    results_check_error "Longitude 180.23 out of range"
+    results_check_error "Latitude or longitude are out of range"
   end
 
   ##


### PR DESCRIPTION
The website allows for searching by a coordinate in "lat, lon" format. Quite often the order is opposite, with longitude coming first. GeoJSON, WKT, OpenLayers and many other formats and services use "lon, lat". To search by such coordinate on the OSM website, one needs to manually swap the numbers.

This pull request modifies the `search_latlon` function so that it adds not one, but two lines to its results: both "lat, lon" and "lon, lat" coordinates.