### PR TITLE
Alter the Makefile to be robust against bundler warnings

### DIFF
--- a/db/functions/Makefile
+++ b/db/functions/Makefile
@@ -1,7 +1,7 @@
 PG_CONFIG ?= pg_config
 DESTDIR ?= .
 
-QTDIR=$(shell bundle show quad_tile)/ext/quad_tile
+QTDIR=$(shell bundle show quad_tile | tail -n 1)/ext/quad_tile
 
 OS=$(shell uname -s)
 ifeq (${OS},Darwin)


### PR DESCRIPTION
In bundle < 2.0, warnings are printed to stdout, along with the path information that we need. This takes the final line of the output and assumes it's the path.

Fixes #1930