### PR TITLE
Fix unwanted trailing whitespace in locale file

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1024,7 +1024,7 @@ en:
           other_label: Other
     create:
       successful_report: Your report has been registered sucessfully
-      provide_details: Please provide the required details      
+      provide_details: Please provide the required details
   layouts:
     project_name:
       # in <title>


### PR DESCRIPTION
Otherwise it drives me nuts using an editor that fixes it on unrelated saves! Introduced in 2aca6920dc3488a381b275d21a31344da02029e6