### PR TITLE
Do not display two coordinates on 'where am I' click

### DIFF
--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -34,7 +34,7 @@ OSM.Search = function(map) {
     e.preventDefault();
     var center = map.getCenter().wrap(),
       precision = OSM.zoomPrecision(map.getZoom());
-    OSM.router.route("/search?query=" + encodeURIComponent(
+    OSM.router.route("/search?whereami=1&query=" + encodeURIComponent(
       center.lat.toFixed(precision) + "," + center.lng.toFixed(precision)
     ));
   });

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -305,7 +305,7 @@ class GeocoderController < ApplicationController
         params.merge!(dms_to_decdeg(latlon)).delete(:query)
 
       elsif latlon = query.match(/^\s*([+-]?\d+(\.\d*)?)\s*[\s,]\s*([+-]?\d+(\.\d*)?)\s*$/)
-        params.merge!(:lat => latlon[1].to_f, :lon => latlon[3].to_f, :latlon_digits => true).delete(:query)
+        params.merge!(:lat => latlon[1].to_f, :lon => latlon[3].to_f, :latlon_digits => !params[:whereami]).delete(:query)
       end
     end
 


### PR DESCRIPTION
This should fix an issue where a user clicks "Where am I" and gets two coordinates instead of one, [reported by mmd](https://github.com/openstreetmap/openstreetmap-website/pull/1958#issuecomment-418008909).