### PR TITLE
Fix any_relations always being false

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -372,7 +372,7 @@ class Relation < ActiveRecord::Base
       # reasonable on the assumption that adding or removing members doesn't
       # materially change the rest of the relation.
       any_relations =
-        changed_members.collect { |_id, type| type == "relation" }
+        changed_members.collect { |type, _id| type == "Relation" }
                        .inject(false) { |acc, elem| acc || elem }
 
       update_members = if tags_changed || any_relations


### PR DESCRIPTION
In relation.members, the order of columns is [type, id, role]. And the value of type is among "Node", "Way" and "Relation".