### PR TITLE
Selected rubocop changes (ruby for good)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,14 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 34
-Lint/AmbiguousOperator:
-  Exclude:
-    - 'test/controllers/amf_controller_test.rb'
-    - 'test/controllers/changeset_controller_test.rb'
-    - 'test/lib/bounding_box_test.rb'
-    - 'test/lib/country_test.rb'
-
 # Offense count: 32
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,11 +38,6 @@ Lint/HandleExceptions:
     - 'app/controllers/amf_controller.rb'
     - 'app/controllers/user_controller.rb'
 
-# Offense count: 2
-Lint/ShadowingOuterLocalVariable:
-  Exclude:
-    - 'app/views/changeset/list.atom.builder'
-
 # Offense count: 690
 Metrics/AbcSize:
   Max: 280

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,10 +14,6 @@ Lint/AmbiguousOperator:
     - 'test/lib/bounding_box_test.rb'
     - 'test/lib/country_test.rb'
 
-# Offense count: 96
-Lint/AmbiguousRegexpLiteral:
-  Enabled: false
-
 # Offense count: 32
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:

--- a/app/helpers/notifier_helper.rb
+++ b/app/helpers/notifier_helper.rb
@@ -29,6 +29,6 @@ module NotifierHelper
     # Because we can't use stylesheets in HTML emails, we need to inline the
     # styles. Rather than copy-paste the same string of CSS into every message,
     # we apply it once here, after the message has been composed.
-    html.gsub /<p>/, '<p style="color: black; margin: 0.75em 0; font-family: \'Helvetica Neue\', Arial, Sans-Serif">'
+    html.gsub(/<p>/, '<p style="color: black; margin: 0.75em 0; font-family: \'Helvetica Neue\', Arial, Sans-Serif">')
   end
 end

--- a/test/controllers/amf_controller_test.rb
+++ b/test/controllers/amf_controller_test.rb
@@ -73,7 +73,7 @@ class AmfControllerTest < ActionController::TestCase
     assert_response :success
     amf_parse_response
     result = amf_result("/1")
-    assert_equal -4, result[0]
+    assert_equal(-4, result[0])
     assert_equal "way", result[1]
     assert_equal id, result[2]
     assert(result[3].nil? && result[4].nil? && result[5].nil? && result[6].nil?)
@@ -154,7 +154,7 @@ class AmfControllerTest < ActionController::TestCase
     assert_response :success
     amf_parse_response
     way = amf_result("/1")
-    assert_equal -4, way[0]
+    assert_equal(-4, way[0])
     assert_equal "way", way[1]
     assert_equal 0, way[2]
     assert(way[3].nil?) && way[4].nil? && way[5].nil? && way[6].nil?
@@ -370,7 +370,7 @@ class AmfControllerTest < ActionController::TestCase
       assert_response :success
       amf_parse_response
       returned_way = amf_result("/1")
-      assert_equal -1, returned_way[0]
+      assert_equal(-1, returned_way[0])
       assert returned_way[3].nil?
       assert returned_way[4].nil?
       assert returned_way[5].nil?
@@ -391,7 +391,7 @@ class AmfControllerTest < ActionController::TestCase
       assert_response :success
       amf_parse_response
       returned_way = amf_result("/1")
-      assert_equal -1, returned_way[0]
+      assert_equal(-1, returned_way[0])
       assert returned_way[3].nil?
       assert returned_way[4].nil?
       assert returned_way[5].nil?
@@ -408,7 +408,7 @@ class AmfControllerTest < ActionController::TestCase
       assert_response :success
       amf_parse_response
       returned_way = amf_result("/1")
-      assert_equal -1, returned_way[0]
+      assert_equal(-1, returned_way[0])
       assert returned_way[3].nil?
       assert returned_way[4].nil?
       assert returned_way[5].nil?
@@ -498,7 +498,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 2, result.length
-    assert_equal -1, result[0]
+    assert_equal(-1, result[0])
     assert_match(/must be logged in/, result[1])
 
     blocked_user = create(:user)
@@ -510,7 +510,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 2, result.length
-    assert_equal -1, result[0]
+    assert_equal(-1, result[0])
     assert_match(/access to the API has been blocked/, result[1])
   end
 
@@ -546,7 +546,7 @@ class AmfControllerTest < ActionController::TestCase
 
     # find by name fails as it uses mysql text search syntax...
     assert_equal 2, result.length
-    assert_equal -2, result[0]
+    assert_equal(-2, result[0])
   end
 
   def test_findrelations_by_id
@@ -636,7 +636,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 3, result.length
-    assert_equal -4, result[0]
+    assert_equal(-4, result[0])
     assert_equal "node", result[1]
     assert_equal 999999, result[2]
   end
@@ -671,7 +671,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 3, result.length
-    assert_equal -4, result[0]
+    assert_equal(-4, result[0])
     assert_equal "node", result[1]
     assert_equal node.node_id, result[2]
 
@@ -682,7 +682,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 3, result.length
-    assert_equal -4, result[0]
+    assert_equal(-4, result[0])
     assert_equal "node", result[1]
     assert_equal 999999, result[2]
   end
@@ -864,7 +864,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 2, result.size
-    assert_equal -1, result[0], "Expected to get the status FAIL in the amf"
+    assert_equal(-1, result[0], "Expected to get the status FAIL in the amf")
     assert_equal "One of the tags is invalid. Linux users may need to upgrade to Flash Player 10.1.", result[1]
   end
 
@@ -904,7 +904,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 3, result.size
-    assert_equal -4, result[0]
+    assert_equal(-4, result[0])
     assert_equal "node", result[1]
     assert_equal nd.id, result[2]
   end
@@ -922,7 +922,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 3, result.size
-    assert_equal -4, result[0]
+    assert_equal(-4, result[0])
     assert_equal "node", result[1]
     assert_equal 999999, result[2]
   end
@@ -940,7 +940,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 2, result.size
-    assert_equal -2, result[0]
+    assert_equal(-2, result[0])
     assert_match(/Node is not in the world/, result[1])
   end
 
@@ -966,8 +966,8 @@ class AmfControllerTest < ActionController::TestCase
     assert_equal 8, result.size
     assert_equal 0, result[0]
     assert_equal "", result[1]
-    assert_equal -1, result[2]
-    assert_not_equal -1, result[3]
+    assert_equal(-1, result[2])
+    assert_not_equal(-1, result[3])
     assert_equal({}, result[4])
     assert_equal 1, result[5]
     assert_equal({}, result[6])
@@ -988,8 +988,8 @@ class AmfControllerTest < ActionController::TestCase
     assert_equal 8, result.size
     assert_equal 0, result[0]
     assert_equal "", result[1]
-    assert_equal -1, result[2]
-    assert_not_equal -1, result[3]
+    assert_equal(-1, result[2])
+    assert_not_equal(-1, result[3])
     assert_equal({}, result[4])
     assert_equal 1, result[5]
     assert_equal({}, result[6])
@@ -1011,8 +1011,8 @@ class AmfControllerTest < ActionController::TestCase
     assert_equal 8, result.size
     assert_equal 0, result[0]
     assert_equal "", result[1]
-    assert_equal -1, result[2]
-    assert_not_equal -1, result[3]
+    assert_equal(-1, result[2])
+    assert_not_equal(-1, result[3])
     assert_equal({ "-1" => new_node_id }, result[4])
     assert_equal 1, result[5]
     assert_equal({ new_node_id.to_s => 1, d.to_s => 2 }, result[6])
@@ -1193,7 +1193,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 2, result.size
-    assert_equal -1, result[0]
+    assert_equal(-1, result[0])
     assert_match(/Way #{way.id} is still used/, result[1])
 
     new_way = Way.find(way.id)
@@ -1225,8 +1225,8 @@ class AmfControllerTest < ActionController::TestCase
     assert_equal 5, result.size
     assert_equal 0, result[0]
     assert_equal "", result[1]
-    assert_equal -1, result[2]
-    assert_not_equal -1, result[3]
+    assert_equal(-1, result[2])
+    assert_not_equal(-1, result[3])
     assert_equal 1, result[4]
 
     new_relation = Relation.find(new_relation_id)
@@ -1307,7 +1307,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 2, result.size
-    assert_equal -1, result[0]
+    assert_equal(-1, result[0])
     assert_match(/relation #{relation.id} is used in/, result[1])
 
     new_relation = Relation.find(relation.id)
@@ -1404,7 +1404,7 @@ class AmfControllerTest < ActionController::TestCase
     result = amf_result("/1")
 
     assert_equal 2, result.size
-    assert_equal -2, result[0]
+    assert_equal(-2, result[0])
     assert_equal "The user doesn't own that changeset", result[1]
 
     cs = Changeset.find(cs_id)

--- a/test/controllers/amf_controller_test.rb
+++ b/test/controllers/amf_controller_test.rb
@@ -499,7 +499,7 @@ class AmfControllerTest < ActionController::TestCase
 
     assert_equal 2, result.length
     assert_equal -1, result[0]
-    assert_match /must be logged in/, result[1]
+    assert_match(/must be logged in/, result[1])
 
     blocked_user = create(:user)
     create(:user_block, :user => blocked_user)
@@ -511,7 +511,7 @@ class AmfControllerTest < ActionController::TestCase
 
     assert_equal 2, result.length
     assert_equal -1, result[0]
-    assert_match /access to the API has been blocked/, result[1]
+    assert_match(/access to the API has been blocked/, result[1])
   end
 
   def test_findgpx_by_id
@@ -941,7 +941,7 @@ class AmfControllerTest < ActionController::TestCase
 
     assert_equal 2, result.size
     assert_equal -2, result[0]
-    assert_match /Node is not in the world/, result[1]
+    assert_match(/Node is not in the world/, result[1])
   end
 
   # check that we can create a way
@@ -1194,7 +1194,7 @@ class AmfControllerTest < ActionController::TestCase
 
     assert_equal 2, result.size
     assert_equal -1, result[0]
-    assert_match /Way #{way.id} is still used/, result[1]
+    assert_match(/Way #{way.id} is still used/, result[1])
 
     new_way = Way.find(way.id)
     assert_equal way.version, new_way.version
@@ -1308,7 +1308,7 @@ class AmfControllerTest < ActionController::TestCase
 
     assert_equal 2, result.size
     assert_equal -1, result[0]
-    assert_match /relation #{relation.id} is used in/, result[1]
+    assert_match(/relation #{relation.id} is used in/, result[1])
 
     new_relation = Relation.find(relation.id)
     assert_equal relation.version, new_relation.version

--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -469,9 +469,9 @@ CHANGESET
     new_rel_id = doc.find("//diffResult/relation").first["new_id"].to_i
 
     # check the old IDs are all present and negative one
-    assert_equal -1, doc.find("//diffResult/node").first["old_id"].to_i
-    assert_equal -1, doc.find("//diffResult/way").first["old_id"].to_i
-    assert_equal -1, doc.find("//diffResult/relation").first["old_id"].to_i
+    assert_equal(-1, doc.find("//diffResult/node").first["old_id"].to_i)
+    assert_equal(-1, doc.find("//diffResult/way").first["old_id"].to_i)
+    assert_equal(-1, doc.find("//diffResult/relation").first["old_id"].to_i)
 
     # check the versions are present and equal one
     assert_equal 1, doc.find("//diffResult/node").first["new_version"].to_i

--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -213,7 +213,7 @@ class ChangesetControllerTest < ActionController::TestCase
         get :read, :params => { :id => id }
         assert_response :not_found, "should get a not found"
       rescue ActionController::UrlGenerationError => ex
-        assert_match /No route matches/, ex.to_s
+        assert_match(/No route matches/, ex.to_s)
       end
     end
   end
@@ -287,7 +287,7 @@ class ChangesetControllerTest < ActionController::TestCase
         put :close, :params => { :id => id }
         assert_response :unauthorized, "Shouldn't be able close the non-existant changeset #{id}, when not authorized"
       rescue ActionController::UrlGenerationError => ex
-        assert_match /No route matches/, ex.to_s
+        assert_match(/No route matches/, ex.to_s)
       end
     end
 
@@ -298,7 +298,7 @@ class ChangesetControllerTest < ActionController::TestCase
         put :close, :params => { :id => id }
         assert_response :not_found, "The changeset #{id} doesn't exist, so can't be closed"
       rescue ActionController::UrlGenerationError => ex
-        assert_match /No route matches/, ex.to_s
+        assert_match(/No route matches/, ex.to_s)
       end
     end
   end

--- a/test/controllers/diary_entry_controller_test.rb
+++ b/test/controllers/diary_entry_controller_test.rb
@@ -414,8 +414,8 @@ class DiaryEntryControllerTest < ActionController::TestCase
     email = ActionMailer::Base.deliveries.first
     assert_equal [user.email], email.to
     assert_equal "[OpenStreetMap] #{other_user.display_name} commented on a diary entry", email.subject
-    assert_match /New comment/, email.text_part.decoded
-    assert_match /New comment/, email.html_part.decoded
+    assert_match(/New comment/, email.text_part.decoded)
+    assert_match(/New comment/, email.html_part.decoded)
     ActionMailer::Base.deliveries.clear
     comment = DiaryComment.order(:id).last
     assert_equal entry.id, comment.diary_entry_id

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -180,8 +180,8 @@ class MessagesControllerTest < ActionController::TestCase
     e = ActionMailer::Base.deliveries.first
     assert_equal [recipient_user.email], e.to
     assert_equal "[OpenStreetMap] Test Message", e.subject
-    assert_match /Test message body/, e.text_part.decoded
-    assert_match /Test message body/, e.html_part.decoded
+    assert_match(/Test message body/, e.text_part.decoded)
+    assert_match(/Test message body/, e.html_part.decoded)
     assert_match %r{#{SERVER_URL}/messages/[0-9]+}, e.text_part.decoded
     ActionMailer::Base.deliveries.clear
     m = Message.last

--- a/test/controllers/old_node_controller_test.rb
+++ b/test/controllers/old_node_controller_test.rb
@@ -161,7 +161,7 @@ class OldNodeControllerTest < ActionController::TestCase
     get :version, :params => { :id => id, :version => version }
     assert_response :not_found
   rescue ActionController::UrlGenerationError => ex
-    assert_match /No route matches/, ex.to_s
+    assert_match(/No route matches/, ex.to_s)
   end
 
   ##

--- a/test/controllers/redactions_controller_test.rb
+++ b/test/controllers/redactions_controller_test.rb
@@ -112,7 +112,7 @@ class RedactionsControllerTest < ActionController::TestCase
     delete :destroy, :params => { :id => redaction.id }
     assert_response :redirect
     assert_redirected_to(redaction_path(redaction))
-    assert_match /^Redaction is not empty/, flash[:error]
+    assert_match(/^Redaction is not empty/, flash[:error])
   end
 
   def test_delete_non_moderator

--- a/test/controllers/swf_controller_test.rb
+++ b/test/controllers/swf_controller_test.rb
@@ -26,19 +26,19 @@ class SwfControllerTest < ActionController::TestCase
     get :trackpoints, :params => { :xmin => -1, :xmax => 1, :ymin => 51, :ymax => 52, :baselong => 0, :basey => 0, :masterscale => 1 }
     assert_response :success
     assert_equal "application/x-shockwave-flash", response.content_type
-    assert_match /^FWS/, response.body
+    assert_match(/^FWS/, response.body)
     assert_equal 80, response.body.length
 
     get :trackpoints, :params => { :xmin => -1, :xmax => 1, :ymin => 51, :ymax => 52, :baselong => 0, :basey => 0, :masterscale => 1, :token => other_user.tokens.create.token }
     assert_response :success
     assert_equal "application/x-shockwave-flash", response.content_type
-    assert_match /^FWS/, response.body
+    assert_match(/^FWS/, response.body)
     assert_equal 67, response.body.length
 
     get :trackpoints, :params => { :xmin => -1, :xmax => 1, :ymin => 51, :ymax => 52, :baselong => 0, :basey => 0, :masterscale => 1, :token => user.tokens.create.token }
     assert_response :success
     assert_equal "application/x-shockwave-flash", response.content_type
-    assert_match /^FWS/, response.body
+    assert_match(/^FWS/, response.body)
     assert_equal 74, response.body.length
   end
 end

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -593,7 +593,7 @@ class TracesControllerTest < ActionController::TestCase
     post :create, :params => { :trace => { :gpx_file => file, :description => "New Trace", :tagstring => "new,trace", :visibility => "trackable" } }, :session => { :user => user }
     assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
-    assert_match /file has been uploaded/, flash[:notice]
+    assert_match(/file has been uploaded/, flash[:notice])
     trace = Trace.order(:id => :desc).first
     assert_equal "a.gpx", trace.name
     assert_equal "New Trace", trace.description

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -245,7 +245,7 @@ class UserControllerTest < ActionController::TestCase
     register_email = ActionMailer::Base.deliveries.first
 
     assert_equal register_email.to[0], user.email
-    assert_match /#{@url}/, register_email.body.to_s
+    assert_match(/#{@url}/, register_email.body.to_s)
 
     # Check the page
     assert_redirected_to :action => "confirm", :display_name => user.display_name
@@ -404,7 +404,7 @@ class UserControllerTest < ActionController::TestCase
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
     assert_redirected_to login_path
-    assert_match /Confirmed your account/, flash[:notice]
+    assert_match(/Confirmed your account/, flash[:notice])
   end
 
   def test_confirm_success_good_token_no_referer
@@ -427,7 +427,7 @@ class UserControllerTest < ActionController::TestCase
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }, :session => { :token => token }
     assert_redirected_to login_path
-    assert_match /Confirmed your account/, flash[:notice]
+    assert_match(/Confirmed your account/, flash[:notice])
   end
 
   def test_confirm_success_no_token_with_referer
@@ -438,7 +438,7 @@ class UserControllerTest < ActionController::TestCase
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
     assert_redirected_to login_path(:referer => diary_new_path)
-    assert_match /Confirmed your account/, flash[:notice]
+    assert_match(/Confirmed your account/, flash[:notice])
   end
 
   def test_confirm_success_good_token_with_referer
@@ -461,7 +461,7 @@ class UserControllerTest < ActionController::TestCase
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }, :session => { :token => token }
     assert_redirected_to login_path(:referer => diary_new_path)
-    assert_match /Confirmed your account/, flash[:notice]
+    assert_match(/Confirmed your account/, flash[:notice])
   end
 
   def test_confirm_expired_token
@@ -471,7 +471,7 @@ class UserControllerTest < ActionController::TestCase
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
     assert_redirected_to :action => "confirm"
-    assert_match /confirmation code has expired/, flash[:error]
+    assert_match(/confirmation code has expired/, flash[:error])
   end
 
   def test_confirm_already_confirmed
@@ -481,7 +481,7 @@ class UserControllerTest < ActionController::TestCase
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
     assert_redirected_to :action => "login"
-    assert_match /already been confirmed/, flash[:error]
+    assert_match(/already been confirmed/, flash[:error])
   end
 
   def test_confirm_resend_success
@@ -494,7 +494,7 @@ class UserControllerTest < ActionController::TestCase
 
     assert_response :redirect
     assert_redirected_to login_path
-    assert_match /sent a new confirmation/, flash[:notice]
+    assert_match(/sent a new confirmation/, flash[:notice])
 
     email = ActionMailer::Base.deliveries.last
 
@@ -541,7 +541,7 @@ class UserControllerTest < ActionController::TestCase
     post :confirm_email, :params => { :confirm_string => confirm_string }
     assert_response :redirect
     assert_redirected_to :action => :account, :display_name => user.display_name
-    assert_match /Confirmed your change of email address/, flash[:notice]
+    assert_match(/Confirmed your change of email address/, flash[:notice])
   end
 
   def test_confirm_email_already_confirmed
@@ -551,14 +551,14 @@ class UserControllerTest < ActionController::TestCase
     post :confirm_email, :params => { :confirm_string => confirm_string }
     assert_response :redirect
     assert_redirected_to :action => :account, :display_name => user.display_name
-    assert_match /already been confirmed/, flash[:error]
+    assert_match(/already been confirmed/, flash[:error])
   end
 
   def test_confirm_email_bad_token
     post :confirm_email, :params => { :confirm_string => "XXXXX" }
     assert_response :success
     assert_template :confirm_email
-    assert_match /confirmation code has expired or does not exist/, flash[:error]
+    assert_match(/confirmation code has expired or does not exist/, flash[:error])
   end
 
   ##
@@ -575,7 +575,7 @@ class UserControllerTest < ActionController::TestCase
     post :confirm_email, :params => { :confirm_string => confirm_string }
     assert_response :redirect
     assert_redirected_to :action => :account, :display_name => user.display_name
-    assert_match /Confirmed your change of email address/, flash[:notice]
+    assert_match(/Confirmed your change of email address/, flash[:notice])
     # gravatar use should now be enabled
     assert User.find(user.id).image_use_gravatar
   end
@@ -590,7 +590,7 @@ class UserControllerTest < ActionController::TestCase
     post :confirm_email, :params => { :confirm_string => confirm_string }
     assert_response :redirect
     assert_redirected_to :action => :account, :display_name => user.display_name
-    assert_match /Confirmed your change of email address/, flash[:notice]
+    assert_match(/Confirmed your change of email address/, flash[:notice])
     # gravatar use should now be disabled
     assert_not User.find(user.id).image_use_gravatar
   end
@@ -678,7 +678,7 @@ class UserControllerTest < ActionController::TestCase
     end
     assert_response :redirect
     assert_redirected_to :action => :login
-    assert_match /^Sorry you lost it/, flash[:notice]
+    assert_match(/^Sorry you lost it/, flash[:notice])
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal user.email, email.to.first
@@ -691,7 +691,7 @@ class UserControllerTest < ActionController::TestCase
     end
     assert_response :redirect
     assert_redirected_to :action => :login
-    assert_match /^Sorry you lost it/, flash[:notice]
+    assert_match(/^Sorry you lost it/, flash[:notice])
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal uppercase_user.email, email.to.first
@@ -714,7 +714,7 @@ class UserControllerTest < ActionController::TestCase
     end
     assert_response :redirect
     assert_redirected_to :action => :login
-    assert_match /^Sorry you lost it/, flash[:notice]
+    assert_match(/^Sorry you lost it/, flash[:notice])
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal third_user.email, email.to.first
@@ -727,7 +727,7 @@ class UserControllerTest < ActionController::TestCase
     end
     assert_response :redirect
     assert_redirected_to :action => :login
-    assert_match /^Sorry you lost it/, flash[:notice]
+    assert_match(/^Sorry you lost it/, flash[:notice])
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal third_user.email, email.to.first
@@ -1251,7 +1251,7 @@ class UserControllerTest < ActionController::TestCase
       post :make_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
     end
     assert_redirected_to user_path(:display_name => friend.display_name)
-    assert_match /is now your friend/, flash[:notice]
+    assert_match(/is now your friend/, flash[:notice])
     assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
@@ -1263,7 +1263,7 @@ class UserControllerTest < ActionController::TestCase
       post :make_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
     end
     assert_redirected_to user_path(:display_name => friend.display_name)
-    assert_match /You are already friends with/, flash[:warning]
+    assert_match(/You are already friends with/, flash[:warning])
     assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
   end
 
@@ -1290,7 +1290,7 @@ class UserControllerTest < ActionController::TestCase
       post :make_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
     end
     assert_redirected_to "/test"
-    assert_match /is now your friend/, flash[:notice]
+    assert_match(/is now your friend/, flash[:notice])
     assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
@@ -1336,13 +1336,13 @@ class UserControllerTest < ActionController::TestCase
     # When logged in a POST should remove the friendship
     post :remove_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
     assert_redirected_to user_path(:display_name => friend.display_name)
-    assert_match /was removed from your friends/, flash[:notice]
+    assert_match(/was removed from your friends/, flash[:notice])
     assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # A second POST should report that the friendship does not exist
     post :remove_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
     assert_redirected_to user_path(:display_name => friend.display_name)
-    assert_match /is not one of your friends/, flash[:error]
+    assert_match(/is not one of your friends/, flash[:error])
     assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
   end
 
@@ -1368,7 +1368,7 @@ class UserControllerTest < ActionController::TestCase
     # When logged in a POST should remove the friendship and refer
     post :remove_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
     assert_redirected_to "/test"
-    assert_match /was removed from your friends/, flash[:notice]
+    assert_match(/was removed from your friends/, flash[:notice])
     assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
   end
 

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -95,7 +95,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
       assert_equal register_email.to.first, new_email
       # Check that the confirm account url is correct
-      assert_match /#{@url}/, register_email.body.to_s
+      assert_match(/#{@url}/, register_email.body.to_s)
 
       # Check the page
       assert_response :success

--- a/test/lib/bounding_box_test.rb
+++ b/test/lib/bounding_box_test.rb
@@ -168,8 +168,8 @@ class BoundingBoxTest < ActiveSupport::TestCase
     @bad_negative_boundary_bbox.each do |bbox_string|
       bbox = BoundingBox.from_bbox_params(:bbox => bbox_string)
       array = bbox.to_a
-      assert_equal -180, [array[0], array[2]].min
-      assert_equal -90, [array[1], array[3]].min
+      assert_equal(-180, [array[0], array[2]].min)
+      assert_equal(-90, [array[1], array[3]].min)
     end
   end
 

--- a/test/lib/country_test.rb
+++ b/test/lib/country_test.rb
@@ -5,7 +5,7 @@ class CountryTest < ActiveSupport::TestCase
     gb = Country.find("GB")
     assert_not_nil gb
     assert_equal "GB", gb.code
-    assert_equal -8.623555, gb.min_lon
+    assert_equal(-8.623555, gb.min_lon)
     assert_equal 59.360249, gb.max_lat
     assert_equal 1.759, gb.max_lon
     assert_equal 49.906193, gb.min_lat
@@ -16,9 +16,9 @@ class CountryTest < ActiveSupport::TestCase
     assert_not_nil au
     assert_equal "AU", au.code
     assert_equal 112.911057, au.min_lon
-    assert_equal -10.062805, au.max_lat
+    assert_equal(-10.062805, au.max_lat)
     assert_equal 153.639252, au.max_lon
-    assert_equal -43.64397, au.min_lat
+    assert_equal(-43.64397, au.min_lat)
   end
 
   def test_xx

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -6,11 +6,11 @@ class ChangesetTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Changeset.from_xml(no_text, true)
     end
-    assert_match /Must specify a string with one or more characters/, message_create.message
+    assert_match(/Must specify a string with one or more characters/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Changeset.from_xml(no_text, false)
     end
-    assert_match /Must specify a string with one or more characters/, message_update.message
+    assert_match(/Must specify a string with one or more characters/, message_update.message)
   end
 
   def test_from_xml_no_changeset
@@ -30,11 +30,11 @@ class ChangesetTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Changeset.from_xml(nokv, true)
     end
-    assert_match /tag is missing key/, message_create.message
+    assert_match(/tag is missing key/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Changeset.from_xml(nokv, false)
     end
-    assert_match /tag is missing key/, message_update.message
+    assert_match(/tag is missing key/, message_update.message)
   end
 
   def test_from_xml_no_v
@@ -42,11 +42,11 @@ class ChangesetTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Changeset.from_xml(no_v, true)
     end
-    assert_match /tag is missing value/, message_create.message
+    assert_match(/tag is missing value/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Changeset.from_xml(no_v, false)
     end
-    assert_match /tag is missing value/, message_update.message
+    assert_match(/tag is missing value/, message_update.message)
   end
 
   def test_from_xml_duplicate_k

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -106,7 +106,7 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal recipient_user, message.recipient
     assert_equal mail.date, message.sent_on
     assert_equal "Test message", message.title
-    assert_match /^ *This is a test & a message *$/, message.body
+    assert_match(/^ *This is a test & a message *$/, message.body)
     assert_equal "text", message.body_format
   end
 
@@ -153,7 +153,7 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal recipient_user, message.recipient
     assert_equal mail.date, message.sent_on
     assert_equal "Test message", message.title
-    assert_match /^ *This is a test & a message in HTML format *$/, message.body
+    assert_match(/^ *This is a test & a message in HTML format *$/, message.body)
     assert_equal "text", message.body_format
   end
 

--- a/test/models/node_test.rb
+++ b/test/models/node_test.rb
@@ -63,8 +63,8 @@ class NodeTest < ActiveSupport::TestCase
   def test_lat_lon_xml_format
     node = build(:node, :latitude => 0.00004 * OldNode::SCALE, :longitude => 0.00008 * OldNode::SCALE)
 
-    assert_match /lat="0.0000400"/, node.to_xml.to_s
-    assert_match /lon="0.0000800"/, node.to_xml.to_s
+    assert_match(/lat="0.0000400"/, node.to_xml.to_s)
+    assert_match(/lon="0.0000800"/, node.to_xml.to_s)
   end
 
   # Check that you can create a node and store it
@@ -173,7 +173,7 @@ class NodeTest < ActiveSupport::TestCase
     message = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(noid, false)
     end
-    assert_match /ID is required when updating./, message.message
+    assert_match(/ID is required when updating./, message.message)
   end
 
   def test_from_xml_no_lat
@@ -181,11 +181,11 @@ class NodeTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nolat, true)
     end
-    assert_match /lat missing/, message_create.message
+    assert_match(/lat missing/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nolat, false)
     end
-    assert_match /lat missing/, message_update.message
+    assert_match(/lat missing/, message_update.message)
   end
 
   def test_from_xml_no_lon
@@ -193,11 +193,11 @@ class NodeTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nolon, true)
     end
-    assert_match /lon missing/, message_create.message
+    assert_match(/lon missing/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nolon, false)
     end
-    assert_match /lon missing/, message_update.message
+    assert_match(/lon missing/, message_update.message)
   end
 
   def test_from_xml_no_changeset_id
@@ -205,11 +205,11 @@ class NodeTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nocs, true)
     end
-    assert_match /Changeset id is missing/, message_create.message
+    assert_match(/Changeset id is missing/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nocs, false)
     end
-    assert_match /Changeset id is missing/, message_update.message
+    assert_match(/Changeset id is missing/, message_update.message)
   end
 
   def test_from_xml_no_version
@@ -220,7 +220,7 @@ class NodeTest < ActiveSupport::TestCase
     message_update = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(no_version, false)
     end
-    assert_match /Version is required when updating/, message_update.message
+    assert_match(/Version is required when updating/, message_update.message)
   end
 
   def test_from_xml_double_lat
@@ -228,11 +228,11 @@ class NodeTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nocs, true)
     end
-    assert_match /Fatal error: Attribute lat redefined at/, message_create.message
+    assert_match(/Fatal error: Attribute lat redefined at/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nocs, false)
     end
-    assert_match /Fatal error: Attribute lat redefined at/, message_update.message
+    assert_match(/Fatal error: Attribute lat redefined at/, message_update.message)
   end
 
   def test_from_xml_id_zero
@@ -245,7 +245,7 @@ class NodeTest < ActiveSupport::TestCase
       message_update = assert_raise(OSM::APIBadUserInput) do
         Node.from_xml(zero_id, false)
       end
-      assert_match /ID of node cannot be zero when updating/, message_update.message
+      assert_match(/ID of node cannot be zero when updating/, message_update.message)
     end
   end
 
@@ -254,11 +254,11 @@ class NodeTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(no_text, true)
     end
-    assert_match /Must specify a string with one or more characters/, message_create.message
+    assert_match(/Must specify a string with one or more characters/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(no_text, false)
     end
-    assert_match /Must specify a string with one or more characters/, message_update.message
+    assert_match(/Must specify a string with one or more characters/, message_update.message)
   end
 
   def test_from_xml_no_node
@@ -278,11 +278,11 @@ class NodeTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nokv, true)
     end
-    assert_match /tag is missing key/, message_create.message
+    assert_match(/tag is missing key/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(nokv, false)
     end
-    assert_match /tag is missing key/, message_update.message
+    assert_match(/tag is missing key/, message_update.message)
   end
 
   def test_from_xml_no_v
@@ -290,11 +290,11 @@ class NodeTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(no_v, true)
     end
-    assert_match /tag is missing value/, message_create.message
+    assert_match(/tag is missing value/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Node.from_xml(no_v, false)
     end
-    assert_match /tag is missing value/, message_update.message
+    assert_match(/tag is missing value/, message_update.message)
   end
 
   def test_from_xml_duplicate_k

--- a/test/models/old_node_test.rb
+++ b/test/models/old_node_test.rb
@@ -63,8 +63,8 @@ class OldNodeTest < ActiveSupport::TestCase
   def test_lat_lon_xml_format
     old_node = build(:old_node, :latitude => 0.00004 * OldNode::SCALE, :longitude => 0.00008 * OldNode::SCALE)
 
-    assert_match /lat="0.0000400"/, old_node.to_xml.to_s
-    assert_match /lon="0.0000800"/, old_node.to_xml.to_s
+    assert_match(/lat="0.0000400"/, old_node.to_xml.to_s)
+    assert_match(/lon="0.0000800"/, old_node.to_xml.to_s)
   end
 
   def test_node_tags

--- a/test/models/relation_test.rb
+++ b/test/models/relation_test.rb
@@ -9,7 +9,7 @@ class RelationTest < ActiveSupport::TestCase
     message = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(noid, false)
     end
-    assert_match /ID is required when updating/, message.message
+    assert_match(/ID is required when updating/, message.message)
   end
 
   def test_from_xml_no_changeset_id
@@ -17,11 +17,11 @@ class RelationTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(nocs, true)
     end
-    assert_match /Changeset id is missing/, message_create.message
+    assert_match(/Changeset id is missing/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(nocs, false)
     end
-    assert_match /Changeset id is missing/, message_update.message
+    assert_match(/Changeset id is missing/, message_update.message)
   end
 
   def test_from_xml_no_version
@@ -32,7 +32,7 @@ class RelationTest < ActiveSupport::TestCase
     message_update = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(no_version, false)
     end
-    assert_match /Version is required when updating/, message_update.message
+    assert_match(/Version is required when updating/, message_update.message)
   end
 
   def test_from_xml_id_zero
@@ -45,7 +45,7 @@ class RelationTest < ActiveSupport::TestCase
       message_update = assert_raise(OSM::APIBadUserInput) do
         Relation.from_xml(zero_id, false)
       end
-      assert_match /ID of relation cannot be zero when updating/, message_update.message
+      assert_match(/ID of relation cannot be zero when updating/, message_update.message)
     end
   end
 
@@ -54,11 +54,11 @@ class RelationTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(no_text, true)
     end
-    assert_match /Must specify a string with one or more characters/, message_create.message
+    assert_match(/Must specify a string with one or more characters/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(no_text, false)
     end
-    assert_match /Must specify a string with one or more characters/, message_update.message
+    assert_match(/Must specify a string with one or more characters/, message_update.message)
   end
 
   def test_from_xml_no_k_v
@@ -66,11 +66,11 @@ class RelationTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(nokv, true)
     end
-    assert_match /tag is missing key/, message_create.message
+    assert_match(/tag is missing key/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(nokv, false)
     end
-    assert_match /tag is missing key/, message_update.message
+    assert_match(/tag is missing key/, message_update.message)
   end
 
   def test_from_xml_no_v
@@ -78,11 +78,11 @@ class RelationTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(no_v, true)
     end
-    assert_match /tag is missing value/, message_create.message
+    assert_match(/tag is missing value/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Relation.from_xml(no_v, false)
     end
-    assert_match /tag is missing value/, message_update.message
+    assert_match(/tag is missing value/, message_update.message)
   end
 
   def test_from_xml_duplicate_k

--- a/test/models/tracepoint_test.rb
+++ b/test/models/tracepoint_test.rb
@@ -12,7 +12,7 @@ class TracepointTest < ActiveSupport::TestCase
   def test_lat_lon_xml_format
     tracepoint = build(:tracepoint, :latitude => 0.00004 * GeoRecord::SCALE, :longitude => 0.00008 * GeoRecord::SCALE)
 
-    assert_match /lat="0.0000400"/, tracepoint.to_xml_node.to_s
-    assert_match /lon="0.0000800"/, tracepoint.to_xml_node.to_s
+    assert_match(/lat="0.0000400"/, tracepoint.to_xml_node.to_s)
+    assert_match(/lon="0.0000800"/, tracepoint.to_xml_node.to_s)
   end
 end

--- a/test/models/way_test.rb
+++ b/test/models/way_test.rb
@@ -48,7 +48,7 @@ class WayTest < ActiveSupport::TestCase
     message = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(noid, false)
     end
-    assert_match /ID is required when updating/, message.message
+    assert_match(/ID is required when updating/, message.message)
   end
 
   def test_from_xml_no_changeset_id
@@ -56,11 +56,11 @@ class WayTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(nocs, true)
     end
-    assert_match /Changeset id is missing/, message_create.message
+    assert_match(/Changeset id is missing/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(nocs, false)
     end
-    assert_match /Changeset id is missing/, message_update.message
+    assert_match(/Changeset id is missing/, message_update.message)
   end
 
   def test_from_xml_no_version
@@ -71,7 +71,7 @@ class WayTest < ActiveSupport::TestCase
     message_update = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(no_version, false)
     end
-    assert_match /Version is required when updating/, message_update.message
+    assert_match(/Version is required when updating/, message_update.message)
   end
 
   def test_from_xml_id_zero
@@ -84,7 +84,7 @@ class WayTest < ActiveSupport::TestCase
       message_update = assert_raise(OSM::APIBadUserInput) do
         Way.from_xml(zero_id, false)
       end
-      assert_match /ID of way cannot be zero when updating/, message_update.message
+      assert_match(/ID of way cannot be zero when updating/, message_update.message)
     end
   end
 
@@ -93,11 +93,11 @@ class WayTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(no_text, true)
     end
-    assert_match /Must specify a string with one or more characters/, message_create.message
+    assert_match(/Must specify a string with one or more characters/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(no_text, false)
     end
-    assert_match /Must specify a string with one or more characters/, message_update.message
+    assert_match(/Must specify a string with one or more characters/, message_update.message)
   end
 
   def test_from_xml_no_k_v
@@ -105,11 +105,11 @@ class WayTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(nokv, true)
     end
-    assert_match /tag is missing key/, message_create.message
+    assert_match(/tag is missing key/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(nokv, false)
     end
-    assert_match /tag is missing key/, message_update.message
+    assert_match(/tag is missing key/, message_update.message)
   end
 
   def test_from_xml_no_v
@@ -117,11 +117,11 @@ class WayTest < ActiveSupport::TestCase
     message_create = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(no_v, true)
     end
-    assert_match /tag is missing value/, message_create.message
+    assert_match(/tag is missing value/, message_create.message)
     message_update = assert_raise(OSM::APIBadXMLError) do
       Way.from_xml(no_v, false)
     end
-    assert_match /tag is missing value/, message_update.message
+    assert_match(/tag is missing value/, message_update.message)
   end
 
   def test_from_xml_duplicate_k


### PR DESCRIPTION
This PR pulls in three of the rubocop-related changes from the Ruby For Good refactoring PR (#1918). One of them was already fixed in the meantime.