### PR TITLE
Set img.button dimensions to 20x20px

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -978,6 +978,8 @@ header .search_forms,
 
   img.button {
     display: block;
+    width: 20px;
+    height: 20px;
   }
 
   span.force_width {


### PR DESCRIPTION
This patch sets a default width and height for the _search_form_ and _directions_form_ image button, matching directions.png dimensions of 20x20px. `.icon ` already uses the same hint to avoid content jumping in the browser.

![bildschirmfoto von 2018-09-11 20-49-36](https://user-images.githubusercontent.com/5842757/45380953-41828f80-b604-11e8-9419-b58c0cdef3b2.png)
