### PR TITLE
add bulk_upload

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,7 +48,7 @@ Metrics/BlockNesting:
 # Offense count: 63
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1910
+  Max: 1924
 
 # Offense count: 72
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,7 +48,7 @@ Metrics/BlockNesting:
 # Offense count: 63
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1795
+  Max: 1910
 
 # Offense count: 72
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,11 +48,11 @@ Metrics/BlockNesting:
 # Offense count: 63
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1924
+  Max: 1980
 
 # Offense count: 72
 Metrics/CyclomaticComplexity:
-  Max: 20
+  Max: 24
 
 # Offense count: 691
 # Configuration parameters: CountComments.
@@ -71,7 +71,7 @@ Metrics/ParameterLists:
 
 # Offense count: 72
 Metrics/PerceivedComplexity:
-  Max: 23
+  Max: 28
 
 # Offense count: 6
 Naming/AccessorMethodName:

--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,9 @@ gem "canonical-rails"
 # Used to generate logstash friendly log files
 gem "logstasher"
 
+# Bulk import
+gem "activerecord-import"
+
 # Gems useful for development
 group :development do
   gem "annotate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       activemodel (= 5.2.0)
       activesupport (= 5.2.0)
       arel (>= 9.0)
+    activerecord-import (0.25.0)
+      activerecord (>= 3.2)
     activestorage (5.2.0)
       actionpack (= 5.2.0)
       activerecord (= 5.2.0)
@@ -381,6 +383,7 @@ DEPENDENCIES
   SystemTimer (>= 1.1.3)
   aasm
   actionpack-page_caching
+  activerecord-import
   annotate
   autoprefixer-rails (~> 8.6.3)
   better_errors
@@ -445,4 +448,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -2,14 +2,14 @@
 #
 # Table name: current_nodes
 #
-#  id           :bigint(8)        not null, primary key
+#  id           :integer          not null, primary key
 #  latitude     :integer          not null
 #  longitude    :integer          not null
-#  changeset_id :bigint(8)        not null
+#  changeset_id :integer          not null
 #  visible      :boolean          not null
 #  timestamp    :datetime         not null
-#  tile         :bigint(8)        not null
-#  version      :bigint(8)        not null
+#  tile         :integer          not null
+#  version      :integer          not null
 #
 # Indexes
 #

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -179,7 +179,7 @@ class Node < ActiveRecord::Base
       # check if node ids exists
       node_ids = node_hash.keys
       old_nodes = Node.select("id, version, visible").where(:id => node_ids).lock
-      raise OSM::APIBadUserInput, "Node not exist. id: " + (node_ids - old_nodes.collect(&:id)).join(", ") unless node_ids.length == old_nodes.length
+      raise ActiveRecord::RecordNotFound unless old_nodes.length == node_ids.length
 
       old_nodes.each do |old|
         unless old.visible
@@ -264,6 +264,8 @@ class Node < ActiveRecord::Base
       # get lat, lon to update changeset
       # lock for update
       old_nodes = Node.select("id, latitude, longitude, version").where(:id => node_ids).order(:id).lock
+      raise ActiveRecord::RecordNotFound unless old_nodes.length == node_ids.length
+
       node_ids.length.times do |i|
         nodes[i].changeset = changeset
         old_nodes[i].check_consistency(old_nodes[i], nodes[i], changeset.user)

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -17,7 +17,8 @@ class NodeTag < ActiveRecord::Base
 
   belongs_to :node
 
-  validates :node, :presence => true, :associated => true
+  attr_accessor :skip_uniqueness
+  validates :node, :presence => true, :associated => true, :unless => :skip_uniqueness
   validates :k, :v, :allow_blank => true, :length => { :maximum => 255 }
-  validates :k, :uniqueness => { :scope => :node_id }
+  validates :k, :uniqueness => { :scope => :node_id }, :unless => :skip_uniqueness
 end

--- a/app/models/old_node.rb
+++ b/app/models/old_node.rb
@@ -104,6 +104,14 @@ class OldNode < ActiveRecord::Base
     end
   end
 
+  def self.save_with_dependencies_bulk!(old_nodes)
+    OldNode.import old_nodes, :validate => false
+    tag_values = old_nodes.flat_map do |node|
+      node.tags.collect { |k, v| [node.node_id, k, v, node.version] }
+    end
+    OldNodeTag.import [:node_id, :k, :v, :version], tag_values, :validate => false
+  end
+
   def tags
     @tags ||= Hash[old_tags.collect { |t| [t.k, t.v] }]
   end

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -227,7 +227,7 @@ class Relation < ActiveRecord::Base
     Relation.transaction do
       relation_ids = relation_hash.keys
       old_relations = Relation.select("id, version, visible").where(:id => relation_ids).lock
-      raise OSM::APIBadUserInput, "Relation not exist. id: " + (relation_ids - old_relations.collect(&:id)).join(", ") unless relation_ids.length == old_relations.length
+      raise ActiveRecord::RecordNotFound unless old_relations.length == relation_ids.length
 
       old_relations.each do |old|
         unless old.visible
@@ -286,6 +286,8 @@ class Relation < ActiveRecord::Base
       relations.sort_by!(&:id)
       relation_ids = relations.collect(&:id)
       old_relations = Relation.select("id, version").where(:id => relation_ids).order(:id).lock
+      raise ActiveRecord::RecordNotFound unless old_relations.length == relation_ids.length
+
       relation_ids.length.times do |i|
         relations[i].changeset = changeset
         old_relations[i].check_consistency(old_relations[i], relations[i], changeset.user)

--- a/app/models/relation_tag.rb
+++ b/app/models/relation_tag.rb
@@ -17,7 +17,8 @@ class RelationTag < ActiveRecord::Base
 
   belongs_to :relation
 
-  validates :relation, :presence => true, :associated => true
+  attr_accessor :skip_uniqueness
+  validates :relation, :presence => true, :associated => true, :unless => :skip_uniqueness
   validates :k, :v, :allow_blank => true, :length => { :maximum => 255 }
-  validates :k, :uniqueness => { :scope => :relation_id }
+  validates :k, :uniqueness => { :scope => :relation_id }, :unless => :skip_uniqueness
 end

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -201,6 +201,8 @@ class Way < ActiveRecord::Base
       ways.sort_by!(&:id)
       way_ids = ways.collect(&:id)
       old_ways = Way.select("id, version").where(:id => way_ids).order(:id).lock
+      raise ActiveRecord::RecordNotFound unless old_ways.length == way_ids.length
+
       way_ids.length.times do |i|
         ways[i].changeset = changeset
         old_ways[i].check_consistency(old_ways[i], ways[i], changeset.user)
@@ -309,7 +311,7 @@ class Way < ActiveRecord::Base
     Way.transaction do
       way_ids = way_hash.keys
       old_ways = Way.select("id, version, visible").where(:id => way_ids).lock
-      raise OSM::APIBadUserInput, "Way not exist. id: " + (way_ids - old_ways.collect(&:id)).join(", ") unless way_ids.length == old_ways.length
+      raise ActiveRecord::RecordNotFound unless old_ways.length == way_ids.length
 
       old_ways.each do |old|
         unless old.visible

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -2,11 +2,11 @@
 #
 # Table name: current_ways
 #
-#  id           :bigint(8)        not null, primary key
-#  changeset_id :bigint(8)        not null
+#  id           :integer          not null, primary key
+#  changeset_id :integer          not null
 #  timestamp    :datetime         not null
 #  visible      :boolean          not null
-#  version      :bigint(8)        not null
+#  version      :integer          not null
 #
 # Indexes
 #

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -2,11 +2,11 @@
 #
 # Table name: current_ways
 #
-#  id           :integer          not null, primary key
-#  changeset_id :integer          not null
+#  id           :bigint(8)        not null, primary key
+#  changeset_id :bigint(8)        not null
 #  timestamp    :datetime         not null
 #  visible      :boolean          not null
-#  version      :integer          not null
+#  version      :bigint(8)        not null
 #
 # Indexes
 #
@@ -38,14 +38,15 @@ class Way < ActiveRecord::Base
   has_many :containing_relation_members, :class_name => "RelationMember", :as => :member
   has_many :containing_relations, :class_name => "Relation", :through => :containing_relation_members, :source => :relation
 
+  attr_accessor :skip_uniqueness
   validates :id, :uniqueness => true, :presence => { :on => :update },
-                 :numericality => { :on => :update, :integer_only => true }
+                 :numericality => { :on => :update, :integer_only => true }, :unless => :skip_uniqueness
   validates :version, :presence => true,
                       :numericality => { :integer_only => true }
   validates :changeset_id, :presence => true,
                            :numericality => { :integer_only => true }
   validates :timestamp, :presence => true
-  validates :changeset, :associated => true
+  validates :changeset, :associated => true, :unless => :skip_uniqueness
   validates :visible, :inclusion => [true, false]
 
   scope :visible, -> { where(:visible => true) }
@@ -195,6 +196,22 @@ class Way < ActiveRecord::Base
     end
   end
 
+  def self.update_from_bulk(ways, changeset)
+    Way.transaction do
+      ways.sort_by!(&:id)
+      way_ids = ways.collect(&:id)
+      old_ways = Way.select("id, version").where(:id => way_ids).order(:id).lock
+      way_ids.length.times do |i|
+        ways[i].changeset = changeset
+        old_ways[i].check_consistency(old_ways[i], ways[i], changeset.user)
+        ways[i].visible = true
+      end
+      old_nodes = WayNode.select("node_id").where(:way_id => way_ids).collect(&:node_id)
+      raise OSM::APIPreconditionFailedError, "Cannot update ways: data is invalid." unless preconditions_bulk_ok?(ways, old_nodes)
+      save_with_history_bulk!(ways, changeset)
+    end
+  end
+
   def create_with_history(user)
     check_create_consistency(self, user)
     raise OSM::APIPreconditionFailedError, "Cannot create way: data is invalid." unless preconditions_ok?
@@ -202,6 +219,15 @@ class Way < ActiveRecord::Base
     self.version = 0
     self.visible = true
     save_with_history!
+  end
+
+  def self.create_with_history_bulk(ways, changeset)
+    raise OSM::APIPreconditionFailedError, "Cannot create way: data is invalid." unless preconditions_bulk_ok?(ways)
+    ways.each do |way|
+      way.version = 0
+      way.visible = true
+    end
+    save_with_history_bulk!(ways, changeset)
   end
 
   def preconditions_ok?(old_nodes = [])
@@ -226,6 +252,29 @@ class Way < ActiveRecord::Base
     true
   end
 
+  def self.preconditions_bulk_ok?(ways, old_nodes = [])
+    all_nds = ways.flat_map do |way|
+      raise OSM::APIPreconditionFailedError, "Way #{way.id} has an empty node list." if way.nds.empty?
+      raise OSM::APITooManyWayNodesError.new(way.id, way.nds.length, MAX_NUMBER_OF_WAY_NODES) if way.nds.length > MAX_NUMBER_OF_WAY_NODES
+      way.nds
+    end.sort.uniq
+    all_nds -= old_nodes
+    unless all_nds.empty?
+      # NOTE: nodes are locked here to ensure they can't be deleted before
+      # the current transaction commits.
+      db_nds = Node.select("id").where(:id => all_nds, :visible => true).lock("for share")
+
+      if db_nds.length < all_nds.length
+        missing = all_nds - db_nds.collect(&:id)
+        ways.each do |way|
+          this_missing = way.nds & missing
+          raise OSM::APIPreconditionFailedError, "Way #{way.id} requires the nodes with id in (#{this_missing.join(',')}), which either do not exist, or are not visible." unless this_missing.empty?
+        end
+      end
+    end
+    true
+  end
+
   def delete_with_history!(new_way, user)
     raise OSM::APIAlreadyDeletedError.new("way", new_way.id) unless visible
 
@@ -246,6 +295,52 @@ class Way < ActiveRecord::Base
       self.visible = false
       save_with_history!
     end
+  end
+
+  def self.delete_with_history_bulk!(ways, changeset, if_unused = false)
+    way_hash = ways.collect { |way| [way.id, way] }.to_h
+    skipped = {}
+    # need to start the transaction here, so that the database can
+    # provide repeatable reads for the used-by checks. this means it
+    # shouldn't be possible to get race conditions.
+    Way.transaction do
+      way_ids = way_hash.keys
+      old_ways = Way.select("id, version, visible").where(:id => way_ids).lock
+      raise OSM::APIBadUserInput, "Way not exist. id: " + (way_ids - old_ways.collect(&:id)).join(", ") unless way_ids.length == old_ways.length
+      old_ways.each do |old|
+        unless old.visible
+          # already deleted
+          raise OSM::APIAlreadyDeletedError.new("way", old.id) unless if_unused
+          # if-unused: ignore and do next.
+          # return old db version to client.
+          way_hash[old.id].version = old.version
+          skipped[old.id] = way_hash[old.id]
+          way_hash.delete old.id
+          next
+        end
+        # check if client version equals db version
+        new = way_hash[old.id]
+        new.changeset = changeset
+        old.check_consistency(old, new, changeset.user)
+      end
+      # discover ways referred by relations
+      rel_members = RelationMember.select("member_id, relation_id").where(:member_type => "Way", :member_id => way_hash.keys).group_by(&:member_id)
+      raise OSM::APIPreconditionFailedError, "Way #{rel_members.first[0]} is still used by relations #{rel_members.first[1].collect(&:relation_id).join(',')}." unless rel_members.empty? || if_unused
+      rel_members.each_key do |id|
+        skipped[id] = way_hash[id]
+        way_hash.delete id
+      end
+      # modify columns to delete
+      to_deletes = way_hash.values
+      to_deletes.each do |way|
+        way.tags = {}
+        way.nds = []
+        way.visible = false
+      end
+      # save
+      save_with_history_bulk!(to_deletes, changeset)
+    end
+    skipped
   end
 
   ##
@@ -322,6 +417,70 @@ class Way < ActiveRecord::Base
       cs.add_changes! 1
 
       cs.save!
+    end
+  end
+
+  class << self
+    def update_changeset_bbox_bulk(changeset, way_ids)
+      private_class_method
+      rows = Node.select("min(longitude) as min_lon, min(latitude) as min_lat, max(longitude) as max_lon, max(latitude) as max_lat")
+                 .joins(:way_nodes).where(:current_way_nodes => { :way_id => way_ids.uniq })
+      temp_bbox = BoundingBox.new rows[0]["min_lon"], rows[0]["min_lat"], rows[0]["max_lon"], rows[0]["max_lat"]
+      changeset.update_bbox!(temp_bbox)
+    end
+
+    def save_with_history_bulk!(ways, changeset)
+      # for modify and delete, update bbox of changeset
+      way_ids = ways.collect(&:id)
+      update_changeset_bbox_bulk(changeset, way_ids) unless way_ids.all?(&:nil?)
+
+      t = Time.now.getutc
+      Way.transaction do
+        clones = ways.collect do |way|
+          way.version += 1
+          way.timestamp = t
+          way.skip_uniqueness = true
+          way.clone
+        end
+        # clone the object before saving it so that the original is
+        # still marked as dirty if we retry the transaction
+        Way.import clones, :on_duplicate_key_update => [:changeset_id, :timestamp, :visible, :version]
+
+        # get allocated id after create
+        way_ids = ways.collect(&:id)
+
+        WayTag.where(:way_id => way_ids).delete_all
+        tag_values = ways.flat_map do |way|
+          way.tags.collect do |k, v|
+            wt = WayTag.new(:way_id => way.id, :k => k, :v => v)
+            wt.skip_uniqueness = true
+            wt
+          end
+        end
+        WayTag.import tag_values
+
+        WayNode.where(:way_id => way_ids).delete_all
+        way_node_values = ways.flat_map do |way|
+          sequence = 0
+          way.nds.collect do |n|
+            [way.id, n, sequence += 1]
+          end
+        end
+        way_node_columns = [:way_id, :node_id, :sequence_id]
+        WayNode.import way_node_columns, way_node_values, :validate => false
+
+        old_ways = ways.collect do |way|
+          OldWay.from_way(way)
+        end
+        OldWay.save_with_dependencies_bulk!(old_ways)
+
+        update_changeset_bbox_bulk(changeset, way_ids) unless way_ids.all?(&:nil?)
+
+        # tell the changeset we updated one element only
+        changeset.add_changes! ways.length
+
+        changeset.save!
+      end
     end
   end
 end

--- a/app/models/way_tag.rb
+++ b/app/models/way_tag.rb
@@ -17,7 +17,8 @@ class WayTag < ActiveRecord::Base
 
   belongs_to :way
 
-  validates :way, :presence => true, :associated => true
+  attr_accessor :skip_uniqueness
+  validates :way, :presence => true, :associated => true, :unless => :skip_uniqueness
   validates :k, :v, :allow_blank => true, :length => { :maximum => 255 }
-  validates :k, :uniqueness => { :scope => :way_id }
+  validates :k, :uniqueness => { :scope => :way_id }, :unless => :skip_uniqueness
 end

--- a/lib/diff_reader.rb
+++ b/lib/diff_reader.rb
@@ -170,7 +170,7 @@ class DiffReader
 
           # check if the placeholder ID has been given before and throw
           # an exception if it has - we can't create the same element twice.
-          raise OSM::APIBadUserInput, "Placeholder IDs must be unique for created elements." if wait_hash.include? placeholder_id
+          raise OSM::APIBadUserInput, "Placeholder IDs must be unique for created elements." if ids[model_sym].include?(placeholder_id) || wait_hash.include?(placeholder_id)
 
           wait_hash[placeholder_id] = new
         end

--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -1068,6 +1068,24 @@ CHANGESET
     post :upload, :params => { :id => changeset.id }
     assert_response :bad_request,
                     "shouldn't be able to re-use placeholder IDs"
+
+    # placeholder_ids must be unique across all action blocks
+    diff = <<CHANGESET.strip_heredoc
+      <osmChange>
+       <create>
+        <node id='-1' lon='0' lat='0' changeset='#{changeset.id}' version='1'/>
+       </create>
+       <create>
+        <node id='-1' lon='1' lat='1' changeset='#{changeset.id}' version='1'/>
+       </create>
+      </osmChange>
+CHANGESET
+
+    # upload it
+    content diff
+    post :upload, :params => { :id => changeset.id }
+    assert_response :bad_request,
+                    "shouldn't be able to re-use placeholder IDs"
   end
 
   ##


### PR DESCRIPTION
Key optimization
1. Reduce redundant check
    Since all changes in an upload request belong to the same changeset. It's not necessary to query 
    changesets table for every object in the osmChange file.
2. Skip uniqueness rails validation
    Skip uniqueness validation and that in associated model. Delegate it to database unique index.
3. Bulk check
    Bulk select data from database. Check it in batch.
    There can be dependencies between objects in one batch operation, which result in new problems 
    to solve. Basically, we divide one batch into multi batch.
    a. batch create relation
        If relation1 is a member of relation2, and they are in same create batch. We can't save them in one 
        batch. We have to save relation1 first to get its id, then use this id to replace the placeholder id 
        and save relation2.
    b. batch delete relation
        If relation1 is a member of relation2, and they are in same delete batch. We just delete them all 
        and don't raise an exception for the "used constraint".
4. Bulk save
    a. Delete
        delete from ... where id in (...)
    b. Create
        Use activerecord-import gem to implement conveniently.
    c. Modify
        Postgres supports INSERT ... ON CONFLICT DO UPDATE
5. update changeset bbox
    a. Before: query longitude and latitude for every object, update bbox for every object.
    b. After: query max, min of longitude and latitude once, update bbox once.