### PR TITLE
Build fix: Removed bogus translations with unknown interpolation variable exit

### DIFF
--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -2625,8 +2625,6 @@ tr:
           %{directions} yönüne doğru'
         offramp_right_with_name: Sağdaki rampayı kullanarak %{name} girin
         offramp_right_with_directions: '%{directions} yönünde sağdaki rampadan'
-        offramp_right_with_name_directions: '%{exit}''den çıkış yap soldaki %{name}
-          %{directions} yönüne doğru'
         onramp_right_without_exit: Rampadan sağa dönerek %{name} girin
         onramp_right_without_directions: Rampaya doğru sağa dönün
         onramp_right: Rampaya doğru sağa dönün
@@ -2647,8 +2645,6 @@ tr:
           %{directions} yönüne doğru'
         offramp_left_with_name: Soldaki rampayı kullanarak %{name} girin
         offramp_left_with_directions: '%{directions} yönünde soldaki rampadan'
-        offramp_left_with_name_directions: '%{exit}''den çıkış yap soldaki %{name}
-          %{directions} yönüne doğru'
         onramp_left_without_exit: Rampadan sola dönerek %{name} girin
         onramp_left_with_directions: '%{directions} doğru rampadan sola dönün'
         onramp_left_without_directions: Rampaya doğru sola dönün


### PR DESCRIPTION
It seems that some Turkish translations in translatewiki brings in the unknown interpolation variable.