### PR TITLE
Remove rubocop reference to quad_tile code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,10 +56,6 @@ Style/FormatStringToken:
 Style/IfInsideElse:
   Enabled: false
 
-Style/GlobalVars:
-  Exclude:
-    - 'lib/quad_tile/extconf.rb'
-
 Style/GuardClause:
   Enabled: false
 


### PR DESCRIPTION
No longer required