### PR TITLE
add australia copyright notice for PSMA Australia

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -56,6 +56,7 @@
 <p><%= t ".legal_babble.contributors_intro_html", :locale => @locale %></p>
 <ul id="contributors">
   <li><%= t ".legal_babble.contributors_at_html", :locale => @locale %></li>
+  <li><%= t ".legal_babble.contributors_au_html", :locale => @locale %></li>
   <li><%= t ".legal_babble.contributors_ca_html", :locale => @locale %></li>
   <li><%= t ".legal_babble.contributors_fi_html", :locale => @locale %></li>
   <li><%= t ".legal_babble.contributors_fr_html", :locale => @locale %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1347,6 +1347,11 @@ en:
           <a href="https://creativecommons.org/licenses/by/3.0/at/deed.de">CC BY</a>),
           <a href="https://www.vorarlberg.at/vorarlberg/bauen_wohnen/bauen/vermessung_geoinformation/weitereinformationen/services/wmsdienste.htm">Land Vorarlberg</a> and
           Land Tirol (under <a href="https://www.tirol.gv.at/applikationen/e-government/data/nutzungsbedingungen/">CC BY AT with amendments</a>).
+        contributors_au_html: |
+          <strong>Australia</strong>: Contains data sourced from
+          <a href="https://www.psma.com.au/psma-data-copyright-and-disclaimer">PSMA Australia Limited</a>
+          licensed by the Commonwealth of Australia under
+          <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
         contributors_ca_html: |
           <strong>Canada</strong>: Contains data from
           GeoBase&reg;, GeoGratis (&copy; Department of Natural


### PR DESCRIPTION
The [Australian community wants to import](https://lists.openstreetmap.org/pipermail/talk-au/2018-October/012085.html) suburb, locality and municipality admin boundaries into OSM from a government CC BY 4.0 source, as [documented](https://wiki.openstreetmap.org/wiki/Import/Catalogue/PSMA_Admin_Boundaries), and we'll need this notice in place before the import can happen.

The source did agree to and complete the the OSMF's CC BY waiver, unfortunately it was the first revision which mentioned openstreetmap.org/copyright instead of the wiki contributors page. It took 6 months passing through multiple bureaucrats, so I'd rather not try to re-negotiate this to the wiki contributors page.

Hopefully it's okay to add a new contributor to this page for this substantial contribution, until we can address #1878