### PR TITLE
fix: in rtl language min and max lon are replaced in export

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1324,11 +1324,11 @@ tr.turn:hover {
     #maxlat { margin-top: -1px; }
     #minlon {
       float: left;
-      margin-left: -1px;
+      /* no-r2 */ margin-left: -1px;
     }
     #maxlon {
       float: right;
-      margin-right: -1px;
+      /* no-r2 */ margin-right: -1px;
     }
     #minlat { margin-bottom: 0; }
   }


### PR DESCRIPTION
There is a bug in rtl language when trying to export data, and selecting area using hand selection, the min and max lon are replaced and when you resize the box the opposite sides are showing the changed lon.

the bug is resolved in this fork.

First photo, before resizing:
<img width="1431" alt="screen shot 2018-10-17 at 21 51 22" src="https://user-images.githubusercontent.com/22100671/47115178-6c48af00-d266-11e8-8473-6e9dda6ee80e.png">

Second photo after resizing from right side to left, the lon changed only in the **left** instead of the right! :
<img width="1438" alt="screen shot 2018-10-17 at 21 52 00" src="https://user-images.githubusercontent.com/22100671/47115197-7ec2e880-d266-11e8-889f-f2036bb66928.png">

