### PR TITLE
Don't duplicate note comments in RSS feeds for new notes

### DIFF
--- a/app/views/notes/_entry.html.erb
+++ b/app/views/notes/_entry.html.erb
@@ -1,4 +1,6 @@
 <h2><%= t ".comment" %></h2>
 <%= render :partial => "comment", :object => entry %>
+<% if entry.note.comments.count > 1 %>
 <h2><%= t ".full" %></h2>
 <%= render :partial => "description", :object => entry.note %>
+<% end %>

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -1066,13 +1066,13 @@ class NotesControllerTest < ActionController::TestCase
     assert_equal "application/rss+xml", @response.content_type
     assert_select "rss", :count => 1 do
       assert_select "channel", :count => 1 do
-        assert_select "item", :count => 2;
+        assert_select "item", :count => 2
 
         # There is only 1 note, which has no comments, so it shouldn't include the "full" section
         assert_select "item" do
-            assert_select "description", :text => /This is note comment 2/
-            assert_select "description", :count => 0, :text => /Full note/
-            assert_select "description", :count=>0, :text => /This is note comment 2.*This is note comment 2.*/m
+          assert_select "description", :text => /This is note comment 2/
+          assert_select "description", :count => 0, :text => /Full note/
+          assert_select "description", :count => 0, :text => /This is note comment 2.*This is note comment 2.*/m
         end
       end
     end
@@ -1085,12 +1085,12 @@ class NotesControllerTest < ActionController::TestCase
     assert_equal "application/rss+xml", @response.content_type
     assert_select "rss", :count => 1 do
       assert_select "channel", :count => 1 do
-        assert_select "item", :count => 2;
+        assert_select "item", :count => 2
         assert_select "item" do
-            assert_select "description", :text => /Full note/
-            assert_select "description", :text => /This is note comment 6/
-            assert_select "description", :text => /This is note comment 5/
-            assert_select "description", :text => /Comment.*This is note comment 6.*Full note.*This is note comment 5.*This is note comment 6.*/m
+          assert_select "description", :text => /Full note/
+          assert_select "description", :text => /This is note comment 6/
+          assert_select "description", :text => /This is note comment 5/
+          assert_select "description", :text => /Comment.*This is note comment 6.*Full note.*This is note comment 5.*This is note comment 6.*/m
         end
       end
     end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -1067,13 +1067,30 @@ class NotesControllerTest < ActionController::TestCase
     assert_select "rss", :count => 1 do
       assert_select "channel", :count => 1 do
         assert_select "item", :count => 2;
+
+        # There is only 1 note, which has no comments, so it shouldn't include the "full" section
         assert_select "item" do
-            assert_select "description", {:text => %r{<h2>Comment</h2>
-<div class="note-comment" style="margin-top: 5px">
-  <div class="note-comment-description" style="font-size: smaller; color: #999999">Created <span title=".*">less than a minute</span> ago</div>
-  <div class="note-comment-text">This is note comment 2</div>
-</div>
-</div>}}
+            assert_select "description", :text => /This is note comment 2/
+            assert_select "description", :count => 0, :text => /Full note/
+            assert_select "description", :count=>0, :text => /This is note comment 2.*This is note comment 2.*/m
+        end
+      end
+    end
+
+    # Create a note with 2 comments and ensure the full part is in the RSS
+    position = (20 * GeoRecord::SCALE).to_i
+    create(:note_with_comments, :latitude => position, :longitude => position, :comments_count => 2)
+    get :feed, :params => { :bbox => "19,19,21,21", :format => "rss" }
+    assert_response :success
+    assert_equal "application/rss+xml", @response.content_type
+    assert_select "rss", :count => 1 do
+      assert_select "channel", :count => 1 do
+        assert_select "item", :count => 2;
+        assert_select "item" do
+            assert_select "description", :text => /Full note/
+            assert_select "description", :text => /This is note comment 6/
+            assert_select "description", :text => /This is note comment 5/
+            assert_select "description", :text => /Comment.*This is note comment 6.*Full note.*This is note comment 5.*This is note comment 6.*/m
         end
       end
     end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -1066,7 +1066,15 @@ class NotesControllerTest < ActionController::TestCase
     assert_equal "application/rss+xml", @response.content_type
     assert_select "rss", :count => 1 do
       assert_select "channel", :count => 1 do
-        assert_select "item", :count => 2
+        assert_select "item", :count => 2;
+        assert_select "item" do
+            assert_select "description", {:text => %r{<h2>Comment</h2>
+<div class="note-comment" style="margin-top: 5px">
+  <div class="note-comment-description" style="font-size: smaller; color: #999999">Created <span title=".*">less than a minute</span> ago</div>
+  <div class="note-comment-text">This is note comment 2</div>
+</div>
+</div>}}
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, in the RSS feed of note activity, when a note is created, the note is included twice, because it includes the comment on the note, and then the whole note. With only one comment, the latter is redudant.

e.g.:
> new note (near Dolphin's Barn, Ushers E ED, Dublin 8, Dublin, County Dublin, Leinster, D08 WN40, Ireland)
> 20 October 2018, 17:13
> Comment
> Created 10 minutes ago by ManAboutCouch
> closed
> Full note
> Created 10 minutes ago by ManAboutCouch
> closed

This is my attempt to fix that. I know very little about Ruby, or Rails, so please excuse any beginner mistakes. :) Feel free to rip this apart and do it properly, if needed. This is my first patch to the OSM-website. :)

I think this should also apply to the email content as well, right?