### PR TITLE
Calculate bounding box when deleting relations

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -2,11 +2,11 @@
 #
 # Table name: current_relations
 #
-#  id           :integer          not null, primary key
-#  changeset_id :integer          not null
+#  id           :bigint(8)        not null, primary key
+#  changeset_id :bigint(8)        not null
 #  timestamp    :datetime         not null
 #  visible      :boolean          not null
-#  version      :integer          not null
+#  version      :bigint(8)        not null
 #
 # Indexes
 #
@@ -384,7 +384,9 @@ class Relation < ActiveRecord::Base
         changed_members.collect { |type, _id, _role| type == "Relation" }
                        .inject(false) { |acc, elem| acc || elem }
 
-      update_members = if tags_changed || any_relations
+      # if the relation is being deleted tags_changed will be true and members empty
+      # so we need to use changed_members to create a correct bounding box
+      update_members = if self.visible && (tags_changed || any_relations)
                          # add all non-relation bounding boxes to the changeset
                          # FIXME: check for tag changes along with element deletions and
                          # make sure that the deleted element's bounding box is hit.

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -386,7 +386,7 @@ class Relation < ActiveRecord::Base
 
       # if the relation is being deleted tags_changed will be true and members empty
       # so we need to use changed_members to create a correct bounding box
-      update_members = if self.visible && (tags_changed || any_relations)
+      update_members = if visible && (tags_changed || any_relations)
                          # add all non-relation bounding boxes to the changeset
                          # FIXME: check for tag changes along with element deletions and
                          # make sure that the deleted element's bounding box is hit.

--- a/test/models/relation_test.rb
+++ b/test/models/relation_test.rb
@@ -209,12 +209,11 @@ class RelationTest < ActiveSupport::TestCase
   end
 
   def test_changeset_bbox_delete_relation
-    relation = create(:relation)
     orig_relation = create(:relation)
     node1 = create(:node, :longitude => 116, :latitude => 39)
     node2 = create(:node, :longitude => 39, :latitude => 116)
-    node_member1 = create(:relation_member, :relation => orig_relation, :member_type => "Node", :member_id => node1.id)
-    node_member2 = create(:relation_member, :relation => orig_relation, :member_type => "Node", :member_id => node2.id)
+    create(:relation_member, :relation => orig_relation, :member_type => "Node", :member_id => node1.id)
+    create(:relation_member, :relation => orig_relation, :member_type => "Node", :member_id => node2.id)
     user = create(:user)
     changeset = create(:changeset, :user => user)
     assert_nil changeset.min_lon

--- a/test/models/relation_test.rb
+++ b/test/models/relation_test.rb
@@ -207,4 +207,30 @@ class RelationTest < ActiveSupport::TestCase
     assert_equal 39, changeset.min_lat
     assert_equal 39, changeset.max_lat
   end
+
+  def test_changeset_bbox_delete_relation
+    relation = create(:relation)
+    orig_relation = create(:relation)
+    node1 = create(:node, :longitude => 116, :latitude => 39)
+    node2 = create(:node, :longitude => 39, :latitude => 116)
+    node_member1 = create(:relation_member, :relation => orig_relation, :member_type => "Node", :member_id => node1.id)
+    node_member2 = create(:relation_member, :relation => orig_relation, :member_type => "Node", :member_id => node2.id)
+    user = create(:user)
+    changeset = create(:changeset, :user => user)
+    assert_nil changeset.min_lon
+    assert_nil changeset.max_lon
+    assert_nil changeset.max_lat
+    assert_nil changeset.min_lat
+
+    new_relation = Relation.new
+    new_relation.id = orig_relation.id
+    new_relation.version = orig_relation.version
+    new_relation.changeset_id = changeset.id
+    orig_relation.delete_with_history!(new_relation, user)
+    changeset.reload
+    assert_equal 39, changeset.min_lon
+    assert_equal 116, changeset.max_lon
+    assert_equal 39, changeset.min_lat
+    assert_equal 116, changeset.max_lat
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/2020

This uses the original members in a relation to calculate a bounding box when the relation is deleted and adds a test for this.

Note this simply removes the bug, it should be considered if it wouldn't be a good idea to recurse one level down in to members that are relations. However there are differing opinions on this (and if adding a bounding box for any kind of deletion is a good idea in the first place). 