### PR TITLE
Use deliver_later for email sending

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,7 +32,7 @@ Lint/HandleExceptions:
 
 # Offense count: 692
 Metrics/AbcSize:
-  Max: 280
+  Max: 283
 
 # Offense count: 40
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -48,7 +48,7 @@ Metrics/BlockNesting:
 # Offense count: 63
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1795
+  Max: 1801
 
 # Offense count: 72
 Metrics/CyclomaticComplexity:

--- a/app/controllers/changeset_controller.rb
+++ b/app/controllers/changeset_controller.rb
@@ -332,7 +332,7 @@ class ChangesetController < ApplicationController
 
     # Notify current subscribers of the new comment
     changeset.subscribers.visible.each do |user|
-      Notifier.changeset_comment_notification(comment, user).deliver_now if current_user != user
+      Notifier.changeset_comment_notification(comment, user).deliver_later if current_user != user
     end
 
     # Add the commenter to the subscribers if necessary

--- a/app/controllers/diary_entry_controller.rb
+++ b/app/controllers/diary_entry_controller.rb
@@ -65,7 +65,7 @@ class DiaryEntryController < ApplicationController
 
       # Notify current subscribers of the new comment
       @entry.subscribers.visible.each do |user|
-        Notifier.diary_comment_notification(@diary_comment, user).deliver_now if current_user != user
+        Notifier.diary_comment_notification(@diary_comment, user).deliver_later if current_user != user
       end
 
       # Add the commenter to the subscribers if necessary

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -29,7 +29,7 @@ class MessagesController < ApplicationController
       render :action => "new"
     elsif @message.save
       flash[:notice] = t ".message_sent"
-      Notifier.message_notification(@message).deliver_now
+      Notifier.message_notification(@message).deliver_later
       redirect_to :action => :inbox
     else
       render :action => "new"

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -387,7 +387,7 @@ class NotesController < ApplicationController
     comment = note.comments.create!(attributes)
 
     note.comments.map(&:author).uniq.each do |user|
-      Notifier.note_comment_notification(comment, user).deliver_now if notify && user && user != current_user && user.visible?
+      Notifier.note_comment_notification(comment, user).deliver_later if notify && user && user != current_user && user.visible?
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -107,7 +107,7 @@ class UsersController < ApplicationController
             successful_login(current_user)
           else
             session[:token] = current_user.tokens.create.token
-            Notifier.signup_confirm(current_user, current_user.tokens.create(:referer => referer)).deliver_now
+            Notifier.signup_confirm(current_user, current_user.tokens.create(:referer => referer)).deliver_later
             redirect_to :action => "confirm", :display_name => current_user.display_name
           end
         else
@@ -158,7 +158,7 @@ class UsersController < ApplicationController
 
       if user
         token = user.tokens.create
-        Notifier.lost_password(user, token).deliver_now
+        Notifier.lost_password(user, token).deliver_later
         flash[:notice] = t "users.lost_password.notice email on way"
         redirect_to :action => "login"
       else
@@ -339,7 +339,7 @@ class UsersController < ApplicationController
     if user.nil? || token.nil? || token.user != user
       flash[:error] = t "users.confirm_resend.failure", :name => params[:display_name]
     else
-      Notifier.signup_confirm(user, user.tokens.create).deliver_now
+      Notifier.signup_confirm(user, user.tokens.create).deliver_later
       flash[:notice] = t("users.confirm_resend.success", :email => user.email, :sender => SUPPORT_EMAIL).html_safe
     end
 
@@ -432,7 +432,7 @@ class UsersController < ApplicationController
           flash[:warning] = t "users.make_friend.already_a_friend", :name => @new_friend.display_name
         elsif friend.save
           flash[:notice] = t "users.make_friend.success", :name => @new_friend.display_name
-          Notifier.friend_notification(friend).deliver_now
+          Notifier.friend_notification(friend).deliver_later
         else
           friend.add_error(t("users.make_friend.failed", :name => @new_friend.display_name))
         end
@@ -735,7 +735,7 @@ class UsersController < ApplicationController
           flash.now[:notice] = t "users.account.flash update success confirm needed"
 
           begin
-            Notifier.email_confirm(user, user.tokens.create).deliver_now
+            Notifier.email_confirm(user, user.tokens.create).deliver_later
           rescue StandardError
             # Ignore errors sending email
           end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
+
+  # Use the test adapter for ActiveJob during testing
+  config.active_job.queue_adapter = :test
 end

--- a/test/controllers/changeset_controller_test.rb
+++ b/test/controllers/changeset_controller_test.rb
@@ -2153,7 +2153,9 @@ CHANGESET
 
     assert_difference "ChangesetComment.count", 1 do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
-        post :comment, :params => { :id => private_user_closed_changeset.id, :text => "This is a comment" }
+        perform_enqueued_jobs do
+          post :comment, :params => { :id => private_user_closed_changeset.id, :text => "This is a comment" }
+        end
       end
     end
     assert_response :success
@@ -2166,7 +2168,9 @@ CHANGESET
 
     assert_difference "ChangesetComment.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 1 do
-        post :comment, :params => { :id => changeset.id, :text => "This is a comment" }
+        perform_enqueued_jobs do
+          post :comment, :params => { :id => changeset.id, :text => "This is a comment" }
+        end
       end
     end
     assert_response :success
@@ -2182,7 +2186,9 @@ CHANGESET
 
     assert_difference "ChangesetComment.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 2 do
-        post :comment, :params => { :id => changeset.id, :text => "This is a comment" }
+        perform_enqueued_jobs do
+          post :comment, :params => { :id => changeset.id, :text => "This is a comment" }
+        end
       end
     end
     assert_response :success

--- a/test/controllers/diary_entry_controller_test.rb
+++ b/test/controllers/diary_entry_controller_test.rb
@@ -390,9 +390,11 @@ class DiaryEntryControllerTest < ActionController::TestCase
     assert_no_difference "ActionMailer::Base.deliveries.size" do
       assert_no_difference "DiaryComment.count" do
         assert_no_difference "entry.subscribers.count" do
-          post :comment,
-               :params => { :display_name => entry.user.display_name, :id => entry.id, :diary_comment => { :body => "" } },
-               :session => { :user => other_user }
+          perform_enqueued_jobs do
+            post :comment,
+                 :params => { :display_name => entry.user.display_name, :id => entry.id, :diary_comment => { :body => "" } },
+                 :session => { :user => other_user }
+          end
         end
       end
     end
@@ -403,9 +405,11 @@ class DiaryEntryControllerTest < ActionController::TestCase
     assert_difference "ActionMailer::Base.deliveries.size", entry.subscribers.count do
       assert_difference "DiaryComment.count", 1 do
         assert_difference "entry.subscribers.count", 1 do
-          post :comment,
-               :params => { :display_name => entry.user.display_name, :id => entry.id, :diary_comment => { :body => "New comment" } },
-               :session => { :user => other_user }
+          perform_enqueued_jobs do
+            post :comment,
+                 :params => { :display_name => entry.user.display_name, :id => entry.id, :diary_comment => { :body => "New comment" } },
+                 :session => { :user => other_user }
+          end
         end
       end
     end
@@ -450,9 +454,11 @@ class DiaryEntryControllerTest < ActionController::TestCase
     # Try creating a spammy comment
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
       assert_difference "DiaryComment.count", 1 do
-        post :comment,
-             :params => { :display_name => entry.user.display_name, :id => entry.id, :diary_comment => { :body => spammy_text } },
-             :session => { :user => other_user }
+        perform_enqueued_jobs do
+          post :comment,
+               :params => { :display_name => entry.user.display_name, :id => entry.id, :diary_comment => { :body => spammy_text } },
+               :session => { :user => other_user }
+        end
       end
     end
     assert_response :redirect

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -83,9 +83,11 @@ class MessagesControllerTest < ActionController::TestCase
     # Check that we can't send a message from a GET request
     assert_difference "ActionMailer::Base.deliveries.size", 0 do
       assert_difference "Message.count", 0 do
-        get :new,
-            :params => { :display_name => recipient_user.display_name,
-                         :message => { :title => "Test Message", :body => "Test message body" } }
+        perform_enqueued_jobs do
+          get :new,
+              :params => { :display_name => recipient_user.display_name,
+                           :message => { :title => "Test Message", :body => "Test message body" } }
+        end
       end
     end
     assert_response :success
@@ -112,9 +114,11 @@ class MessagesControllerTest < ActionController::TestCase
     # Check that the subject is preserved over errors
     assert_difference "ActionMailer::Base.deliveries.size", 0 do
       assert_difference "Message.count", 0 do
-        post :new,
-             :params => { :display_name => recipient_user.display_name,
-                          :message => { :title => "Test Message", :body => "" } }
+        perform_enqueued_jobs do
+          post :new,
+               :params => { :display_name => recipient_user.display_name,
+                            :message => { :title => "Test Message", :body => "" } }
+        end
       end
     end
     assert_response :success
@@ -141,9 +145,11 @@ class MessagesControllerTest < ActionController::TestCase
     # Check that the body text is preserved over errors
     assert_difference "ActionMailer::Base.deliveries.size", 0 do
       assert_difference "Message.count", 0 do
-        post :new,
-             :params => { :display_name => recipient_user.display_name,
-                          :message => { :title => "", :body => "Test message body" } }
+        perform_enqueued_jobs do
+          post :new,
+               :params => { :display_name => recipient_user.display_name,
+                            :message => { :title => "", :body => "Test message body" } }
+        end
       end
     end
     assert_response :success
@@ -170,9 +176,11 @@ class MessagesControllerTest < ActionController::TestCase
     # Check that sending a message works
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
       assert_difference "Message.count", 1 do
-        post :create,
-             :params => { :display_name => recipient_user.display_name,
-                          :message => { :title => "Test Message", :body => "Test message body" } }
+        perform_enqueued_jobs do
+          post :create,
+               :params => { :display_name => recipient_user.display_name,
+                            :message => { :title => "Test Message", :body => "Test message body" } }
+        end
       end
     end
     assert_redirected_to inbox_messages_path
@@ -211,12 +219,14 @@ class MessagesControllerTest < ActionController::TestCase
     assert_no_difference "ActionMailer::Base.deliveries.size" do
       assert_no_difference "Message.count" do
         with_message_limit(0) do
-          post :create,
-               :params => { :display_name => recipient_user.display_name,
-                            :message => { :title => "Test Message", :body => "Test message body" } }
-          assert_response :success
-          assert_template "new"
-          assert_select ".error", /wait a while/
+          perform_enqueued_jobs do
+            post :create,
+                 :params => { :display_name => recipient_user.display_name,
+                              :message => { :title => "Test Message", :body => "Test message body" } }
+            assert_response :success
+            assert_template "new"
+            assert_select ".error", /wait a while/
+          end
         end
       end
     end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -228,7 +228,9 @@ class NotesControllerTest < ActionController::TestCase
     open_note_with_comment = create(:note_with_comments)
     assert_difference "NoteComment.count", 1 do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
-        post :comment, :params => { :id => open_note_with_comment.id, :text => "This is an additional comment", :format => "json" }
+        perform_enqueued_jobs do
+          post :comment, :params => { :id => open_note_with_comment.id, :text => "This is an additional comment", :format => "json" }
+        end
       end
     end
     assert_response :success
@@ -265,7 +267,9 @@ class NotesControllerTest < ActionController::TestCase
     end
     assert_difference "NoteComment.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 2 do
-        post :comment, :params => { :id => note_with_comments_by_users.id, :text => "This is an additional comment", :format => "json" }
+        perform_enqueued_jobs do
+          post :comment, :params => { :id => note_with_comments_by_users.id, :text => "This is an additional comment", :format => "json" }
+        end
       end
     end
     assert_response :success
@@ -307,7 +311,9 @@ class NotesControllerTest < ActionController::TestCase
 
     assert_difference "NoteComment.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 2 do
-        post :comment, :params => { :id => note_with_comments_by_users.id, :text => "This is an additional comment", :format => "json" }
+        perform_enqueued_jobs do
+          post :comment, :params => { :id => note_with_comments_by_users.id, :text => "This is an additional comment", :format => "json" }
+        end
       end
     end
     assert_response :success

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -237,7 +237,9 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_difference "User.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 1 do
-        post :save, :session => { :new_user => user }
+        perform_enqueued_jobs do
+          post :save, :session => { :new_user => user }
+        end
       end
     end
 
@@ -259,7 +261,9 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_no_difference "User.count" do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
-        post :save, :session => { :new_user => user }
+        perform_enqueued_jobs do
+          post :save, :session => { :new_user => user }
+        end
       end
     end
 
@@ -274,7 +278,9 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_no_difference "User.count" do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
-        post :save, :session => { :new_user => user }
+        perform_enqueued_jobs do
+          post :save, :session => { :new_user => user }
+        end
       end
     end
 
@@ -289,7 +295,9 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_no_difference "User.count" do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
-        post :save, :session => { :new_user => user }
+        perform_enqueued_jobs do
+          post :save, :session => { :new_user => user }
+        end
       end
     end
 
@@ -304,7 +312,9 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_no_difference "User.count" do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
-        post :save, :session => { :new_user => user }
+        perform_enqueued_jobs do
+          post :save, :session => { :new_user => user }
+        end
       end
     end
 
@@ -318,8 +328,10 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_difference "User.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 1 do
-        post :save, :session => { :new_user => user,
-                                  :referer => "/edit?editor=id#map=1/2/3" }
+        perform_enqueued_jobs do
+          post :save, :session => { :new_user => user,
+                                    :referer => "/edit?editor=id#map=1/2/3" }
+        end
       end
     end
 
@@ -489,7 +501,9 @@ class UsersControllerTest < ActionController::TestCase
     session[:token] = user.tokens.create.token
 
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      get :confirm_resend, :params => { :display_name => user.display_name }
+      perform_enqueued_jobs do
+        get :confirm_resend, :params => { :display_name => user.display_name }
+      end
     end
 
     assert_response :redirect
@@ -506,7 +520,9 @@ class UsersControllerTest < ActionController::TestCase
   def test_confirm_resend_no_token
     user = create(:user, :pending)
     assert_no_difference "ActionMailer::Base.deliveries.size" do
-      get :confirm_resend, :params => { :display_name => user.display_name }
+      perform_enqueued_jobs do
+        get :confirm_resend, :params => { :display_name => user.display_name }
+      end
     end
 
     assert_response :redirect
@@ -516,7 +532,9 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_confirm_resend_unknown_user
     assert_no_difference "ActionMailer::Base.deliveries.size" do
-      get :confirm_resend, :params => { :display_name => "No Such User" }
+      perform_enqueued_jobs do
+        get :confirm_resend, :params => { :display_name => "No Such User" }
+      end
     end
 
     assert_response :redirect
@@ -674,7 +692,9 @@ class UsersControllerTest < ActionController::TestCase
     uppercase_user = build(:user, :email => user.email.upcase).tap { |u| u.save(:validate => false) }
 
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post :lost_password, :params => { :user => { :email => user.email } }
+      perform_enqueued_jobs do
+        post :lost_password, :params => { :user => { :email => user.email } }
+      end
     end
     assert_response :redirect
     assert_redirected_to :action => :login
@@ -687,7 +707,9 @@ class UsersControllerTest < ActionController::TestCase
     # Test resetting using an address that matches a different user
     # that has the same address in a different case
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post :lost_password, :params => { :user => { :email => user.email.upcase } }
+      perform_enqueued_jobs do
+        post :lost_password, :params => { :user => { :email => user.email.upcase } }
+      end
     end
     assert_response :redirect
     assert_redirected_to :action => :login
@@ -700,7 +722,9 @@ class UsersControllerTest < ActionController::TestCase
     # Test resetting using an address that is a case insensitive match
     # for more than one user but not an exact match for either
     assert_no_difference "ActionMailer::Base.deliveries.size" do
-      post :lost_password, :params => { :user => { :email => user.email.titlecase } }
+      perform_enqueued_jobs do
+        post :lost_password, :params => { :user => { :email => user.email.titlecase } }
+      end
     end
     assert_response :success
     assert_template :lost_password
@@ -710,7 +734,9 @@ class UsersControllerTest < ActionController::TestCase
     # address which is case insensitively unique
     third_user = create(:user)
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post :lost_password, :params => { :user => { :email => third_user.email } }
+      perform_enqueued_jobs do
+        post :lost_password, :params => { :user => { :email => third_user.email } }
+      end
     end
     assert_response :redirect
     assert_redirected_to :action => :login
@@ -723,7 +749,9 @@ class UsersControllerTest < ActionController::TestCase
     # Test resetting using an address that matches a user that has the
     # same (case insensitively unique) address in a different case
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post :lost_password, :params => { :user => { :email => third_user.email.upcase } }
+      perform_enqueued_jobs do
+        post :lost_password, :params => { :user => { :email => third_user.email.upcase } }
+      end
     end
     assert_response :redirect
     assert_redirected_to :action => :login
@@ -898,7 +926,9 @@ class UsersControllerTest < ActionController::TestCase
     # Changing email to one that exists should fail
     user.new_email = create(:user).email
     assert_no_difference "ActionMailer::Base.deliveries.size" do
-      post :account, :params => { :display_name => user.display_name, :user => user.attributes }, :session => { :user => user }
+      perform_enqueued_jobs do
+        post :account, :params => { :display_name => user.display_name, :user => user.attributes }, :session => { :user => user }
+      end
     end
     assert_response :success
     assert_template :account
@@ -909,7 +939,9 @@ class UsersControllerTest < ActionController::TestCase
     # Changing email to one that exists should fail, regardless of case
     user.new_email = create(:user).email.upcase
     assert_no_difference "ActionMailer::Base.deliveries.size" do
-      post :account, :params => { :display_name => user.display_name, :user => user.attributes }, :session => { :user => user }
+      perform_enqueued_jobs do
+        post :account, :params => { :display_name => user.display_name, :user => user.attributes }, :session => { :user => user }
+      end
     end
     assert_response :success
     assert_template :account
@@ -920,7 +952,9 @@ class UsersControllerTest < ActionController::TestCase
     # Changing email to one that doesn't exist should work
     user.new_email = "new_tester@example.com"
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post :account, :params => { :display_name => user.display_name, :user => user.attributes }, :session => { :user => user }
+      perform_enqueued_jobs do
+        post :account, :params => { :display_name => user.display_name, :user => user.attributes }, :session => { :user => user }
+      end
     end
     assert_response :success
     assert_template :account
@@ -1258,7 +1292,9 @@ class UsersControllerTest < ActionController::TestCase
 
     # When logged in a POST should add the friendship
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post :make_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
+      perform_enqueued_jobs do
+        post :make_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
+      end
     end
     assert_redirected_to user_path(friend)
     assert_match(/is now your friend/, flash[:notice])
@@ -1270,7 +1306,9 @@ class UsersControllerTest < ActionController::TestCase
 
     # A second POST should report that the friendship already exists
     assert_no_difference "ActionMailer::Base.deliveries.size" do
-      post :make_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
+      perform_enqueued_jobs do
+        post :make_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
+      end
     end
     assert_redirected_to user_path(friend)
     assert_match(/You are already friends with/, flash[:warning])
@@ -1297,7 +1335,9 @@ class UsersControllerTest < ActionController::TestCase
 
     # When logged in a POST should add the friendship and refer us
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
-      post :make_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
+      perform_enqueued_jobs do
+        post :make_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
+      end
     end
     assert_redirected_to "/test"
     assert_match(/is now your friend/, flash[:notice])

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -37,9 +37,11 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       display_name = "#{locale}_new_tester"
       assert_difference("User.count", 0) do
         assert_difference("ActionMailer::Base.deliveries.size", 0) do
-          post "/user/new",
-               :params => { :user => { :email => dup_email, :email_confirmation => dup_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } },
-               :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
+          perform_enqueued_jobs do
+            post "/user/new",
+                 :params => { :user => { :email => dup_email, :email_confirmation => dup_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } },
+                 :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
+          end
         end
       end
       assert_response :success
@@ -56,9 +58,11 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       email = "#{locale}_new_tester"
       assert_difference("User.count", 0) do
         assert_difference("ActionMailer::Base.deliveries.size", 0) do
-          post "/user/new",
-               :params => { :user => { :email => email, :email_confirmation => email, :display_name => dup_display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } },
-               :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
+          perform_enqueued_jobs do
+            post "/user/new",
+                 :params => { :user => { :email => email, :email_confirmation => email, :display_name => dup_display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } },
+                 :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
+          end
         end
       end
       assert_response :success
@@ -75,8 +79,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
       assert_difference("User.count", 0) do
         assert_difference("ActionMailer::Base.deliveries.size", 0) do
-          post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+          perform_enqueued_jobs do
+            post "/user/new",
+                 :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+          end
         end
       end
 
@@ -84,9 +90,11 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
       assert_difference("User.count") do
         assert_difference("ActionMailer::Base.deliveries.size", 1) do
-          post "/user/save",
-               :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
-          follow_redirect!
+          perform_enqueued_jobs do
+            post "/user/save",
+                 :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
+            follow_redirect!
+          end
         end
       end
 
@@ -122,12 +130,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     referer = "/traces/mine"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => password, :pass_crypt_confirmation => password }, :referer => referer }
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => password, :pass_crypt_confirmation => password } }
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => password, :pass_crypt_confirmation => password }, :referer => referer }
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => password, :pass_crypt_confirmation => password } }
+          follow_redirect!
+        end
       end
     end
 
@@ -168,20 +178,22 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     password = "testtest"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => password, :pass_crypt_confirmation => password } }
-        assert_response :redirect
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => password, :pass_crypt_confirmation => password } }
+          assert_response :redirect
+          follow_redirect!
+        end
       end
     end
 
@@ -199,21 +211,23 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     display_name = "new_tester-openid2"
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_failure_path(:strategy => "openid", :message => "connection_failed", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        follow_redirect!
-        assert_response :success
-        assert_template "users/new"
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_failure_path(:strategy => "openid", :message => "connection_failed", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          follow_redirect!
+          assert_response :success
+          assert_template "users/new"
+        end
       end
     end
 
@@ -229,19 +243,21 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     referer = "/traces/mine"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+          follow_redirect!
+        end
       end
     end
 
@@ -284,20 +300,22 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     password = "testtest"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "google")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
-        assert_response :redirect
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "google")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
+          assert_response :redirect
+          follow_redirect!
+        end
       end
     end
 
@@ -315,21 +333,23 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     display_name = "new_tester-google2"
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "google")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_failure_path(:strategy => "google", :message => "connection_failed", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        follow_redirect!
-        assert_response :success
-        assert_template "users/new"
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "google")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_failure_path(:strategy => "google", :message => "connection_failed", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          follow_redirect!
+          assert_response :success
+          assert_template "users/new"
+        end
       end
     end
 
@@ -347,19 +367,21 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     referer = "/traces/mine"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "google")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "google")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+          follow_redirect!
+        end
       end
     end
 
@@ -400,20 +422,22 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     password = "testtest"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "facebook")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
-        assert_response :redirect
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "facebook")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
+          assert_response :redirect
+          follow_redirect!
+        end
       end
     end
 
@@ -431,21 +455,23 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     display_name = "new_tester-facebook2"
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "facebook")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_failure_path(:strategy => "facebook", :message => "connection_failed", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        follow_redirect!
-        assert_response :success
-        assert_template "users/new"
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "facebook")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_failure_path(:strategy => "facebook", :message => "connection_failed", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          follow_redirect!
+          assert_response :success
+          assert_template "users/new"
+        end
       end
     end
 
@@ -461,19 +487,21 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     referer = "/traces/mine"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "facebook")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "facebook")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+          follow_redirect!
+        end
       end
     end
 
@@ -514,20 +542,22 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     password = "testtest"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "windowslive")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
-        assert_response :redirect
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "windowslive")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
+          assert_response :redirect
+          follow_redirect!
+        end
       end
     end
 
@@ -545,21 +575,23 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     display_name = "new_tester-windowslive2"
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "windowslive")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_failure_path(:strategy => "windowslive", :message => "connection_failed", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        follow_redirect!
-        assert_response :success
-        assert_template "users/new"
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "windowslive")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_failure_path(:strategy => "windowslive", :message => "connection_failed", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          follow_redirect!
+          assert_response :success
+          assert_template "users/new"
+        end
       end
     end
 
@@ -575,19 +607,21 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     referer = "/traces/mine"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "windowslive")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "windowslive")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+          follow_redirect!
+        end
       end
     end
 
@@ -628,20 +662,22 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     password = "testtest"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "github")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
-        assert_response :redirect
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "github")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
+          assert_response :redirect
+          follow_redirect!
+        end
       end
     end
 
@@ -659,21 +695,23 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     display_name = "new_tester-github2"
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "github")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_failure_path(:strategy => "github", :message => "connection_failed", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        follow_redirect!
-        assert_response :success
-        assert_template "users/new"
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "github")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_failure_path(:strategy => "github", :message => "connection_failed", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          follow_redirect!
+          assert_response :success
+          assert_template "users/new"
+        end
       end
     end
 
@@ -689,19 +727,21 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     referer = "/traces/mine"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "github")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "github")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+          follow_redirect!
+        end
       end
     end
 
@@ -742,20 +782,22 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     password = "testtest"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
-        assert_response :redirect
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password } }
+          assert_response :redirect
+          follow_redirect!
+        end
       end
     end
 
@@ -773,21 +815,23 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     display_name = "new_tester-wikipedia2"
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" } }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_failure_path(:strategy => "wikipedia", :message => "connection_failed", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        follow_redirect!
-        assert_response :success
-        assert_template "users/new"
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_failure_path(:strategy => "wikipedia", :message => "connection_failed", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          follow_redirect!
+          assert_response :success
+          assert_template "users/new"
+        end
       end
     end
 
@@ -803,19 +847,21 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     referer = "/traces/mine"
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
-        post "/user/new",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
-        assert_response :redirect
-        assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
-        follow_redirect!
-        assert_response :redirect
-        assert_redirected_to "/user/terms"
-        post "/user/save",
-             :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
-        follow_redirect!
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+          assert_response :redirect
+          assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
+          follow_redirect!
+          assert_response :redirect
+          assert_redirected_to "/user/terms"
+          post "/user/save",
+               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+          follow_redirect!
+        end
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ WebMock.disable_net_connect!(:allow_localhost => true)
 module ActiveSupport
   class TestCase
     include FactoryBot::Syntax::Methods
+    include ActiveJob::TestHelper
 
     ##
     # takes a block which is executed in the context of a different


### PR DESCRIPTION
This PR builds on #2037 and configures email sending as a background task.

Note that this depends on having the setup for delayed_job (#2037) already merged, along with having workers running in production (https://github.com/openstreetmap/chef/issues/201), before this can be deployed - so I'm marking it as WIP until those prerequisites are met.