### PR TITLE
Limit note comment size to 2000 characters

### DIFF
--- a/app/models/note_comment.rb
+++ b/app/models/note_comment.rb
@@ -33,7 +33,8 @@ class NoteComment < ActiveRecord::Base
   validates :visible, :inclusion => [true, false]
   validates :author, :associated => true
   validates :event, :inclusion => %w[opened closed reopened commented hidden]
-  validates :body, :format => /\A[^\x00-\x08\x0b-\x0c\x0e-\x1f\x7f\ufffe\uffff]*\z/
+  validates :body, :allow_blank => false, :length => { :maximum => 2000 },
+                   :format => /\A[^\x00-\x08\x0b-\x0c\x0e-\x1f\x7f\ufffe\uffff]*\z/
 
   # Return the comment text
   def body

--- a/app/views/browse/new_note.html.erb
+++ b/app/views/browse/new_note.html.erb
@@ -10,7 +10,7 @@
   <form action="#">
     <input type="hidden" name="lon">
     <input type="hidden" name="lat">
-    <textarea class="comment" name="text" cols="40" rows="10" placeholder="<%= t('javascripts.notes.new.advice') %>"></textarea>
+    <textarea class="comment" name="text" cols="40" rows="10" maxlength="2000" placeholder="<%= t('javascripts.notes.new.advice') %>"></textarea>
     <div class="buttons clearfix">
       <input type="submit" name="add" value="<%= t('javascripts.notes.new.add') %>" disabled="1">
     </div>

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -42,7 +42,7 @@
 
   <% if @note.status == "open" %>
     <form action="#">
-      <textarea class="comment" name="text" cols="40" rows="5"></textarea>
+      <textarea class="comment" name="text" cols="40" rows="5" maxlength="2000"></textarea>
       <div class="buttons clearfix">
         <% if current_user and current_user.moderator? -%>
           <input type="submit" name="hide" value="<%= t('javascripts.notes.show.hide') %>" class="deemphasize" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, 'json') %>">


### PR DESCRIPTION
Follow up for #1543 

There's essentially no upper limit to notes comments, leaving the upload more or less unprotected to nonsense stuff like https://upload.apis.dev.openstreetmap.org/note/3

PR attempts to set the limit to 2000 characters both in the model, as well in the textarea (to avoid dealing with an unhappy backend). I'm not sure if anything else needs to be done to deal with existing (too long) comments.