### PR TITLE
CanCanCan for user blocks and redactions

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -8,6 +8,7 @@ class Ability
     can [:index, :rss, :show, :comments], DiaryEntry
     can [:search, :search_latlon, :search_ca_postcode, :search_osm_nominatim,
          :search_geonames, :search_osm_nominatim_reverse, :search_geonames_reverse], :geocoder
+    can [:index, :show], Redaction
     can [:index, :show, :blocks_on, :blocks_by], UserBlock
 
     if user
@@ -19,6 +20,7 @@ class Ability
       if user.moderator?
         can [:index, :show, :resolve, :ignore, :reopen], Issue
         can :create, IssueComment
+        can [:new, :create, :edit, :update, :destroy], Redaction
         can [:new, :edit, :create, :update, :revoke], UserBlock
       end
 

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -8,6 +8,7 @@ class Ability
     can [:index, :rss, :show, :comments], DiaryEntry
     can [:search, :search_latlon, :search_ca_postcode, :search_osm_nominatim,
          :search_geonames, :search_osm_nominatim_reverse, :search_geonames_reverse], :geocoder
+    can [:index, :show, :blocks_on, :blocks_by], UserBlock
 
     if user
       can :welcome, :site
@@ -18,6 +19,7 @@ class Ability
       if user.moderator?
         can [:index, :show, :resolve, :ignore, :reopen], Issue
         can :create, IssueComment
+        can [:new, :edit, :create, :update, :revoke], UserBlock
       end
 
       if user.administrator?

--- a/app/controllers/redactions_controller.rb
+++ b/app/controllers/redactions_controller.rb
@@ -3,8 +3,9 @@ class RedactionsController < ApplicationController
 
   before_action :authorize_web
   before_action :set_locale
-  before_action :require_user, :only => [:new, :create, :edit, :update, :destroy]
-  before_action :require_moderator, :only => [:new, :create, :edit, :update, :destroy]
+
+  authorize_resource
+
   before_action :lookup_redaction, :only => [:show, :edit, :update, :destroy]
   before_action :check_database_readable
   before_action :check_database_writable, :only => [:create, :update, :destroy]

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -3,8 +3,9 @@ class UserBlocksController < ApplicationController
 
   before_action :authorize_web
   before_action :set_locale
-  before_action :require_user, :only => [:new, :create, :edit, :update, :revoke]
-  before_action :require_moderator, :only => [:new, :create, :edit, :update, :revoke]
+
+  authorize_resource
+
   before_action :lookup_user, :only => [:new, :create, :blocks_on, :blocks_by]
   before_action :lookup_user_block, :only => [:show, :edit, :update, :revoke]
   before_action :require_valid_params, :only => [:create, :update]

--- a/test/controllers/redactions_controller_test.rb
+++ b/test/controllers/redactions_controller_test.rb
@@ -64,8 +64,7 @@ class RedactionsControllerTest < ActionController::TestCase
     session[:user] = create(:user).id
 
     get :new
-    assert_response :redirect
-    assert_redirected_to redactions_path
+    assert_response :forbidden
   end
 
   def test_create_moderator
@@ -141,8 +140,7 @@ class RedactionsControllerTest < ActionController::TestCase
     session[:user] = create(:user).id
 
     get :edit, :params => { :id => create(:redaction).id }
-    assert_response :redirect
-    assert_redirected_to(redactions_path)
+    assert_response :forbidden
   end
 
   def test_update_moderator

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -145,8 +145,7 @@ class UserBlocksControllerTest < ActionController::TestCase
 
     # Check that normal users can't load the block creation page
     get :new, :params => { :display_name => target_user.display_name }
-    assert_redirected_to user_blocks_path
-    assert_equal "You need to be a moderator to perform that action.", flash[:error]
+    assert_response :forbidden
 
     # Login as a moderator
     session[:user] = create(:moderator_user).id
@@ -189,8 +188,7 @@ class UserBlocksControllerTest < ActionController::TestCase
 
     # Check that normal users can't load the block edit page
     get :edit, :params => { :id => active_block.id }
-    assert_redirected_to user_blocks_path
-    assert_equal "You need to be a moderator to perform that action.", flash[:error]
+    assert_response :forbidden
 
     # Login as a moderator
     session[:user] = create(:moderator_user).id
@@ -361,8 +359,7 @@ class UserBlocksControllerTest < ActionController::TestCase
 
     # Check that normal users can't load the block revoke page
     get :revoke, :params => { :id => active_block.id }
-    assert_redirected_to user_blocks_path
-    assert_equal "You need to be a moderator to perform that action.", flash[:error]
+    assert_response :forbidden
 
     # Login as a moderator
     session[:user] = create(:moderator_user).id


### PR DESCRIPTION
This PR refactors user blocks and redactions to use CanCanCan. 

This does change the response slightly for forbidden actions, rather than redirecting to :index with a flash message. But I'm happy with the simplification and I doubt anyone will notice the difference.