### PR TITLE
Remove unnecessary require statements from tests

### DIFF
--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "api_controller"
 
 class ApiControllerTest < ActionController::TestCase
   def setup

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "browse_controller"
 
 class BrowseControllerTest < ActionController::TestCase
   ##

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "geocoder_controller"
 
 class GeocoderControllerTest < ActionController::TestCase
   ##

--- a/test/controllers/redactions_controller_test.rb
+++ b/test/controllers/redactions_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "redactions_controller"
 
 class RedactionsControllerTest < ActionController::TestCase
   ##

--- a/test/models/redaction_test.rb
+++ b/test/models/redaction_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "osm"
 
 class RedactionTest < ActiveSupport::TestCase
   def test_cannot_redact_current


### PR DESCRIPTION
I think these were first introduced around 2007, but they aren't needed currently.