### PR TITLE
add links to Welcome Mat on /welcome and /help

### DIFF
--- a/app/views/site/help.html.erb
+++ b/app/views/site/help.html.erb
@@ -4,7 +4,7 @@
 
 <p class='introduction'><%= t ".introduction" %></p>
 
-<% ['welcome', 'beginners_guide', 'help', 'mailing_lists', 'forums', 'irc', 'switch2osm', 'wiki'].each do |site| %>
+<% ['welcome', 'beginners_guide', 'help', 'mailing_lists', 'forums', 'irc', 'switch2osm', 'welcomemat', 'wiki'].each do |site| %>
   <% unless site == 'welcome' && !current_user %>
   <div class='<%= site %> help-item'>
   <h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1531,6 +1531,10 @@ en:
         url: https://switch2osm.org/
         title: switch2osm
         description: Help for companies and organisations switching to OpenStreetMap based maps and other services.
+      welcomemat:
+        url: https://welcome.openstreetmap.org/
+        title: Welcome Mat
+        description: With an organization making plans for OpenStreetMap? Find what you need to know!
       wiki:
         url: https://wiki.openstreetmap.org/
         title: wiki.openstreetmap.org
@@ -1677,7 +1681,7 @@ en:
         paragraph_1_html: |
           OpenStreetMap has several resources for learning about the project, asking and answering
           questions, and collaboratively discussing and documenting mapping topics.
-          <a href='%{help_url}'>Get help here</a>.
+          <a href='%{help_url}'>Get help here</a>. With an organization making plans for OpenStreetMap? <a href='https://welcome.openstreetmap.org/'>Check out the Welcome Mat</a>.
       start_mapping: Start Mapping
       add_a_note:
         title: No Time To Edit? Add a Note!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1533,8 +1533,8 @@ en:
         description: Help for companies and organisations switching to OpenStreetMap based maps and other services.
       welcomemat:
         url: https://welcome.openstreetmap.org/
-        title: Welcome Mat
-        description: With an organization making plans for OpenStreetMap? Find what you need to know!
+        title: For Organizations
+        description: With an organization making plans for OpenStreetMap? Find what you need to know in the "Welcome Mat"!!
       wiki:
         url: https://wiki.openstreetmap.org/
         title: wiki.openstreetmap.org


### PR DESCRIPTION
Work on the [Welcome Mat](https://welcome.openstreetmap.org/) has stabilized and it's ready to link from other sites in OSM. This PR adds links on /welcome and /help