### PR TITLE
Return 401 Unauthorized when user is not logged in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -490,10 +490,10 @@ class ApplicationController < ActionController::Base
     elsif request.get?
       respond_to do |format|
         format.html { redirect_to :controller => "users", :action => "login", :referer => request.fullpath }
-        format.any { head :forbidden }
+        format.any { head :unauthorized }
       end
     else
-      head :forbidden
+      head :unauthorized
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,7 @@ class ApplicationController < ActionController::Base
       if request.get?
         redirect_to :controller => "users", :action => "login", :referer => request.fullpath
       else
-        head :forbidden
+        head :unauthorized
       end
     end
   end

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -185,7 +185,9 @@ class TracesController < ApplicationController
 
     if !@trace.visible?
       head :not_found
-    elsif current_user.nil? || @trace.user != current_user
+    elsif current_user.nil?
+      head :unauthorized
+    elsif @trace.user != current_user
       head :forbidden
     elsif @trace.update(trace_params)
       flash[:notice] = t ".updated"
@@ -203,7 +205,9 @@ class TracesController < ApplicationController
 
     if !trace.visible?
       head :not_found
-    elsif current_user.nil? || (trace.user != current_user && !current_user.administrator? && !current_user.moderator?)
+    elsif current_user.nil?
+      head :unauthorized
+    elsif trace.user != current_user && !current_user.administrator? && !current_user.moderator?
       head :forbidden
     else
       trace.visible = false

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -371,7 +371,7 @@ class DiaryEntriesControllerTest < ActionController::TestCase
     # Make sure that you are denied when you are not logged in
     post :comment,
          :params => { :display_name => entry.user.display_name, :id => entry.id }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Verify that you get a not found error, when you pass a bogus id
     post :comment,
@@ -718,7 +718,7 @@ class DiaryEntriesControllerTest < ActionController::TestCase
     diary_entry = create(:diary_entry, :user => user)
     post :hide,
          :params => { :display_name => user.display_name, :id => diary_entry.id }
-    assert_response :forbidden
+    assert_response :unauthorized
     assert_equal true, DiaryEntry.find(diary_entry.id).visible
 
     # Now try as a normal user
@@ -746,7 +746,7 @@ class DiaryEntriesControllerTest < ActionController::TestCase
     # Try without logging in
     post :hidecomment,
          :params => { :display_name => user.display_name, :id => diary_entry.id, :comment => diary_comment.id }
-    assert_response :forbidden
+    assert_response :unauthorized
     assert_equal true, DiaryComment.find(diary_comment.id).visible
 
     # Now try as a normal user
@@ -822,7 +822,7 @@ class DiaryEntriesControllerTest < ActionController::TestCase
       post :subscribe,
            :params => { :id => diary_entry.id, :display_name => diary_entry.user.display_name }
     end
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # bad diary id
     post :subscribe,
@@ -869,7 +869,7 @@ class DiaryEntriesControllerTest < ActionController::TestCase
       post :unsubscribe,
            :params => { :id => diary_entry.id, :display_name => diary_entry.user.display_name }
     end
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # bad diary id
     post :unsubscribe,

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -383,7 +383,7 @@ class MessagesControllerTest < ActionController::TestCase
 
     # Check that the marking a message requires us to login
     post :mark, :params => { :message_id => unread_message.id }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Login as a user with no messages
     session[:user] = other_user.id
@@ -440,7 +440,7 @@ class MessagesControllerTest < ActionController::TestCase
 
     # Check that destroying a message requires us to login
     delete :destroy, :params => { :id => read_message.id }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Login as a user with no messages
     session[:user] = other_user.id

--- a/test/controllers/oauth_clients_controller_test.rb
+++ b/test/controllers/oauth_clients_controller_test.rb
@@ -81,7 +81,7 @@ class OauthClientsControllerTest < ActionController::TestCase
     assert_difference "ClientApplication.count", 0 do
       post :create, :params => { :display_name => user.display_name }
     end
-    assert_response :forbidden
+    assert_response :unauthorized
 
     assert_difference "ClientApplication.count", 0 do
       post :create,
@@ -165,7 +165,7 @@ class OauthClientsControllerTest < ActionController::TestCase
 
     put :update,
         :params => { :display_name => user.display_name, :id => client.id }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     put :update,
         :params => { :display_name => user.display_name, :id => other_client.id },
@@ -199,7 +199,7 @@ class OauthClientsControllerTest < ActionController::TestCase
       delete :destroy,
              :params => { :display_name => user.display_name, :id => client.id }
     end
-    assert_response :forbidden
+    assert_response :unauthorized
 
     assert_difference "ClientApplication.count", 0 do
       delete :destroy,

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -582,7 +582,7 @@ class TracesControllerTest < ActionController::TestCase
 
     # First with no auth
     post :create, :params => { :trace => { :gpx_file => file, :description => "New Trace", :tagstring => "new,trace", :visibility => "trackable" } }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Rewind the file
     file.rewind
@@ -657,7 +657,7 @@ class TracesControllerTest < ActionController::TestCase
 
     # First with no auth
     put :update, :params => { :display_name => public_trace_file.user.display_name, :id => public_trace_file.id, :trace => new_details }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Now with some other user, which should fail
     put :update, :params => { :display_name => public_trace_file.user.display_name, :id => public_trace_file.id, :trace => new_details }, :session => { :user => create(:user) }
@@ -688,7 +688,7 @@ class TracesControllerTest < ActionController::TestCase
 
     # First with no auth
     post :delete, :params => { :display_name => public_trace_file.user.display_name, :id => public_trace_file.id }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Now with some other user, which should fail
     post :delete, :params => { :display_name => public_trace_file.user.display_name, :id => public_trace_file.id }, :session => { :user => create(:user) }

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -225,7 +225,7 @@ class UserBlocksControllerTest < ActionController::TestCase
 
     # Not logged in yet, so creating a block should fail
     post :create
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Login as a normal user
     session[:user] = create(:user).id
@@ -288,7 +288,7 @@ class UserBlocksControllerTest < ActionController::TestCase
 
     # Not logged in yet, so updating a block should fail
     put :update, :params => { :id => active_block.id }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Login as a normal user
     session[:user] = create(:user).id

--- a/test/controllers/user_roles_controller_test.rb
+++ b/test/controllers/user_roles_controller_test.rb
@@ -24,7 +24,7 @@ class UserRolesControllerTest < ActionController::TestCase
 
     # Granting should fail when not logged in
     post :grant, :params => { :display_name => target_user.display_name, :role => "moderator" }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Login as an unprivileged user
     session[:user] = normal_user.id
@@ -85,7 +85,7 @@ class UserRolesControllerTest < ActionController::TestCase
 
     # Revoking should fail when not logged in
     post :revoke, :params => { :display_name => target_user.display_name, :role => "moderator" }
-    assert_response :forbidden
+    assert_response :unauthorized
 
     # Login as an unprivileged user
     session[:user] = normal_user.id

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1277,7 +1277,7 @@ class UsersControllerTest < ActionController::TestCase
 
     # When not logged in a POST should error
     post :make_friend, :params => { :display_name => friend.display_name }
-    assert_response :forbidden
+    assert_response :unauthorized
     assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When logged in a GET should get a confirmation page
@@ -1370,7 +1370,7 @@ class UsersControllerTest < ActionController::TestCase
 
     # When not logged in a POST should error
     post :remove_friend, :params => { :display_name => friend.display_name }
-    assert_response :forbidden
+    assert_response :unauthorized
     assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When logged in a GET should get a confirmation page


### PR DESCRIPTION
This PR changes the `require_user` and `deny_access` methods to return 401 Unauthorized to web requests when the user hasn't yet logged in, and updates the affected tests. This brings us better in line with the HTTP specs.

I came across this while doing some more work on CanCanCan refactoring. The `authorize` method, used by all the API actions, has always returned 401 in this situation, so this PR makes the behaviour the same for non-API actions and simplifies some other work-in-progress that I have.