### PR TITLE
Set default format for all API routes

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,4 +3,5 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 Mime::Type.register "application/x-amf", :amf
+Mime::Type.register "application/x-shockwave-flash", :swf
 Mime::Type.register "application/gpx+xml", :gpx

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 OpenStreetMap::Application.routes.draw do
   # API
-  get "api/capabilities" => "api#capabilities"
+  get "api/capabilities" => "api#capabilities", :defaults => { :format => "xml" }
 
-  scope "api/0.6" do
+  scope "api/0.6", :defaults => { :format => "xml" } do
     get "capabilities" => "api#capabilities"
     get "permissions" => "api#permissions"
 
@@ -80,15 +80,15 @@ OpenStreetMap::Application.routes.draw do
     put "gpx/:id" => "traces#api_update", :id => /\d+/
     delete "gpx/:id" => "traces#api_delete", :id => /\d+/
     get "gpx/:id/details" => "traces#api_read", :id => /\d+/
-    get "gpx/:id/data" => "traces#api_data"
+    get "gpx/:id/data" => "traces#api_data", :defaults => { :format => nil }
 
     # AMF (ActionScript) API
-    post "amf/read" => "amf#amf_read"
-    post "amf/write" => "amf#amf_write"
-    get "swf/trackpoints" => "swf#trackpoints"
+    post "amf/read" => "amf#amf_read", :defaults => { :format => "amf" }
+    post "amf/write" => "amf#amf_write", :defaults => { :format => "amf" }
+    get "swf/trackpoints" => "swf#trackpoints", :defaults => { :format => "swf" }
 
     # Map notes API
-    resources :notes, :except => [:new, :edit, :update], :constraints => { :id => /\d+/ }, :defaults => { :format => "xml" } do
+    resources :notes, :except => [:new, :edit, :update], :constraints => { :id => /\d+/ } do
       collection do
         get "search"
         get "feed", :defaults => { :format => "rss" }
@@ -104,8 +104,8 @@ OpenStreetMap::Application.routes.draw do
     post "notes/addPOIexec" => "notes#create"
     post "notes/closePOIexec" => "notes#close"
     post "notes/editPOIexec" => "notes#comment"
-    get "notes/getGPX" => "notes#index", :format => "gpx"
-    get "notes/getRSSfeed" => "notes#feed", :format => "rss"
+    get "notes/getGPX" => "notes#index", :defaults => { :format => "gpx" }
+    get "notes/getRSSfeed" => "notes#feed", :defaults => { :format => "rss" }
   end
 
   # Data browsing

--- a/test/controllers/amf_controller_test.rb
+++ b/test/controllers/amf_controller_test.rb
@@ -9,11 +9,11 @@ class AmfControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/amf/read", :method => :post },
-      { :controller => "amf", :action => "amf_read" }
+      { :controller => "amf", :action => "amf_read", :format => "amf" }
     )
     assert_routing(
       { :path => "/api/0.6/amf/write", :method => :post },
-      { :controller => "amf", :action => "amf_write" }
+      { :controller => "amf", :action => "amf_write", :format => "amf" }
     )
   end
 

--- a/test/controllers/api_controller_test.rb
+++ b/test/controllers/api_controller_test.rb
@@ -20,27 +20,27 @@ class ApiControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/capabilities", :method => :get },
-      { :controller => "api", :action => "capabilities" }
+      { :controller => "api", :action => "capabilities", :format => "xml" }
     )
     assert_recognizes(
-      { :controller => "api", :action => "capabilities" },
+      { :controller => "api", :action => "capabilities", :format => "xml" },
       { :path => "/api/0.6/capabilities", :method => :get }
     )
     assert_routing(
       { :path => "/api/0.6/permissions", :method => :get },
-      { :controller => "api", :action => "permissions" }
+      { :controller => "api", :action => "permissions", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/map", :method => :get },
-      { :controller => "api", :action => "map" }
+      { :controller => "api", :action => "map", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/trackpoints", :method => :get },
-      { :controller => "api", :action => "trackpoints" }
+      { :controller => "api", :action => "trackpoints", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changes", :method => :get },
-      { :controller => "api", :action => "changes" }
+      { :controller => "api", :action => "changes", :format => "xml" }
     )
   end
 

--- a/test/controllers/changeset_comments_controller_test.rb
+++ b/test/controllers/changeset_comments_controller_test.rb
@@ -6,15 +6,15 @@ class ChangesetCommentsControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/changeset/1/comment", :method => :post },
-      { :controller => "changeset_comments", :action => "create", :id => "1" }
+      { :controller => "changeset_comments", :action => "create", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/comment/1/hide", :method => :post },
-      { :controller => "changeset_comments", :action => "destroy", :id => "1" }
+      { :controller => "changeset_comments", :action => "destroy", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/comment/1/unhide", :method => :post },
-      { :controller => "changeset_comments", :action => "restore", :id => "1" }
+      { :controller => "changeset_comments", :action => "restore", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/changeset/1/comments/feed", :method => :get },

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -6,43 +6,43 @@ class ChangesetsControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/changeset/create", :method => :put },
-      { :controller => "changesets", :action => "create" }
+      { :controller => "changesets", :action => "create", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/1/upload", :method => :post },
-      { :controller => "changesets", :action => "upload", :id => "1" }
+      { :controller => "changesets", :action => "upload", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/1/download", :method => :get },
-      { :controller => "changesets", :action => "download", :id => "1" }
+      { :controller => "changesets", :action => "download", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/1/expand_bbox", :method => :post },
-      { :controller => "changesets", :action => "expand_bbox", :id => "1" }
+      { :controller => "changesets", :action => "expand_bbox", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/1", :method => :get },
-      { :controller => "changesets", :action => "read", :id => "1" }
+      { :controller => "changesets", :action => "read", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/1/subscribe", :method => :post },
-      { :controller => "changesets", :action => "subscribe", :id => "1" }
+      { :controller => "changesets", :action => "subscribe", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/1/unsubscribe", :method => :post },
-      { :controller => "changesets", :action => "unsubscribe", :id => "1" }
+      { :controller => "changesets", :action => "unsubscribe", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/1", :method => :put },
-      { :controller => "changesets", :action => "update", :id => "1" }
+      { :controller => "changesets", :action => "update", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changeset/1/close", :method => :put },
-      { :controller => "changesets", :action => "close", :id => "1" }
+      { :controller => "changesets", :action => "close", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/changesets", :method => :get },
-      { :controller => "changesets", :action => "query" }
+      { :controller => "changesets", :action => "query", :format => "xml" }
     )
     assert_routing(
       { :path => "/user/name/history", :method => :get },

--- a/test/controllers/nodes_controller_test.rb
+++ b/test/controllers/nodes_controller_test.rb
@@ -6,23 +6,23 @@ class NodesControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/node/create", :method => :put },
-      { :controller => "nodes", :action => "create" }
+      { :controller => "nodes", :action => "create", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/node/1", :method => :get },
-      { :controller => "nodes", :action => "read", :id => "1" }
+      { :controller => "nodes", :action => "read", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/node/1", :method => :put },
-      { :controller => "nodes", :action => "update", :id => "1" }
+      { :controller => "nodes", :action => "update", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/node/1", :method => :delete },
-      { :controller => "nodes", :action => "delete", :id => "1" }
+      { :controller => "nodes", :action => "delete", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/nodes", :method => :get },
-      { :controller => "nodes", :action => "nodes" }
+      { :controller => "nodes", :action => "nodes", :format => "xml" }
     )
   end
 

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -99,15 +99,15 @@ class NotesControllerTest < ActionController::TestCase
     )
 
     assert_recognizes(
-      { :controller => "notes", :action => "create" },
+      { :controller => "notes", :action => "create", :format => "xml" },
       { :path => "/api/0.6/notes/addPOIexec", :method => :post }
     )
     assert_recognizes(
-      { :controller => "notes", :action => "close" },
+      { :controller => "notes", :action => "close", :format => "xml" },
       { :path => "/api/0.6/notes/closePOIexec", :method => :post }
     )
     assert_recognizes(
-      { :controller => "notes", :action => "comment" },
+      { :controller => "notes", :action => "comment", :format => "xml" },
       { :path => "/api/0.6/notes/editPOIexec", :method => :post }
     )
     assert_recognizes(

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -10,15 +10,15 @@ class OldNodesControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/node/1/history", :method => :get },
-      { :controller => "old_nodes", :action => "history", :id => "1" }
+      { :controller => "old_nodes", :action => "history", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/node/1/2", :method => :get },
-      { :controller => "old_nodes", :action => "version", :id => "1", :version => "2" }
+      { :controller => "old_nodes", :action => "version", :id => "1", :version => "2", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/node/1/2/redact", :method => :post },
-      { :controller => "old_nodes", :action => "redact", :id => "1", :version => "2" }
+      { :controller => "old_nodes", :action => "redact", :id => "1", :version => "2", :format => "xml" }
     )
   end
 

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -6,15 +6,15 @@ class OldRelationsControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/relation/1/history", :method => :get },
-      { :controller => "old_relations", :action => "history", :id => "1" }
+      { :controller => "old_relations", :action => "history", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relation/1/2", :method => :get },
-      { :controller => "old_relations", :action => "version", :id => "1", :version => "2" }
+      { :controller => "old_relations", :action => "version", :id => "1", :version => "2", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relation/1/2/redact", :method => :post },
-      { :controller => "old_relations", :action => "redact", :id => "1", :version => "2" }
+      { :controller => "old_relations", :action => "redact", :id => "1", :version => "2", :format => "xml" }
     )
   end
 

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -6,15 +6,15 @@ class OldWaysControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/way/1/history", :method => :get },
-      { :controller => "old_ways", :action => "history", :id => "1" }
+      { :controller => "old_ways", :action => "history", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/way/1/2", :method => :get },
-      { :controller => "old_ways", :action => "version", :id => "1", :version => "2" }
+      { :controller => "old_ways", :action => "version", :id => "1", :version => "2", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/way/1/2/redact", :method => :post },
-      { :controller => "old_ways", :action => "redact", :id => "1", :version => "2" }
+      { :controller => "old_ways", :action => "redact", :id => "1", :version => "2", :format => "xml" }
     )
   end
 

--- a/test/controllers/relations_controller_test.rb
+++ b/test/controllers/relations_controller_test.rb
@@ -6,40 +6,40 @@ class RelationsControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/relation/create", :method => :put },
-      { :controller => "relations", :action => "create" }
+      { :controller => "relations", :action => "create", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relation/1/full", :method => :get },
-      { :controller => "relations", :action => "full", :id => "1" }
+      { :controller => "relations", :action => "full", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relation/1", :method => :get },
-      { :controller => "relations", :action => "read", :id => "1" }
+      { :controller => "relations", :action => "read", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relation/1", :method => :put },
-      { :controller => "relations", :action => "update", :id => "1" }
+      { :controller => "relations", :action => "update", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relation/1", :method => :delete },
-      { :controller => "relations", :action => "delete", :id => "1" }
+      { :controller => "relations", :action => "delete", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relations", :method => :get },
-      { :controller => "relations", :action => "relations" }
+      { :controller => "relations", :action => "relations", :format => "xml" }
     )
 
     assert_routing(
       { :path => "/api/0.6/node/1/relations", :method => :get },
-      { :controller => "relations", :action => "relations_for_node", :id => "1" }
+      { :controller => "relations", :action => "relations_for_node", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/way/1/relations", :method => :get },
-      { :controller => "relations", :action => "relations_for_way", :id => "1" }
+      { :controller => "relations", :action => "relations_for_way", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relation/1/relations", :method => :get },
-      { :controller => "relations", :action => "relations_for_relation", :id => "1" }
+      { :controller => "relations", :action => "relations_for_relation", :id => "1", :format => "xml" }
     )
   end
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -6,19 +6,19 @@ class SearchControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/search", :method => :get },
-      { :controller => "search", :action => "search_all" }
+      { :controller => "search", :action => "search_all", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/nodes/search", :method => :get },
-      { :controller => "search", :action => "search_nodes" }
+      { :controller => "search", :action => "search_nodes", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/ways/search", :method => :get },
-      { :controller => "search", :action => "search_ways" }
+      { :controller => "search", :action => "search_ways", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/relations/search", :method => :get },
-      { :controller => "search", :action => "search_relations" }
+      { :controller => "search", :action => "search_relations", :format => "xml" }
     )
   end
 

--- a/test/controllers/swf_controller_test.rb
+++ b/test/controllers/swf_controller_test.rb
@@ -6,7 +6,7 @@ class SwfControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/swf/trackpoints", :method => :get },
-      { :controller => "swf", :action => "trackpoints" }
+      { :controller => "swf", :action => "trackpoints", :format => "swf" }
     )
   end
 

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -27,27 +27,27 @@ class TracesControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/gpx/create", :method => :post },
-      { :controller => "traces", :action => "api_create" }
+      { :controller => "traces", :action => "api_create", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/gpx/1", :method => :get },
-      { :controller => "traces", :action => "api_read", :id => "1" }
+      { :controller => "traces", :action => "api_read", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/gpx/1", :method => :put },
-      { :controller => "traces", :action => "api_update", :id => "1" }
+      { :controller => "traces", :action => "api_update", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/gpx/1", :method => :delete },
-      { :controller => "traces", :action => "api_delete", :id => "1" }
+      { :controller => "traces", :action => "api_delete", :id => "1", :format => "xml" }
     )
     assert_recognizes(
-      { :controller => "traces", :action => "api_read", :id => "1" },
+      { :controller => "traces", :action => "api_read", :id => "1", :format => "xml" },
       { :path => "/api/0.6/gpx/1/details", :method => :get }
     )
     assert_routing(
       { :path => "/api/0.6/gpx/1/data", :method => :get },
-      { :controller => "traces", :action => "api_data", :id => "1" }
+      { :controller => "traces", :action => "api_data", :id => "1", :format => nil }
     )
     assert_routing(
       { :path => "/api/0.6/gpx/1/data.xml", :method => :get },

--- a/test/controllers/user_preferences_controller_test.rb
+++ b/test/controllers/user_preferences_controller_test.rb
@@ -6,23 +6,23 @@ class UserPreferencesControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/user/preferences", :method => :get },
-      { :controller => "user_preferences", :action => "read" }
+      { :controller => "user_preferences", :action => "read", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/user/preferences", :method => :put },
-      { :controller => "user_preferences", :action => "update" }
+      { :controller => "user_preferences", :action => "update", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/user/preferences/key", :method => :get },
-      { :controller => "user_preferences", :action => "read_one", :preference_key => "key" }
+      { :controller => "user_preferences", :action => "read_one", :preference_key => "key", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/user/preferences/key", :method => :put },
-      { :controller => "user_preferences", :action => "update_one", :preference_key => "key" }
+      { :controller => "user_preferences", :action => "update_one", :preference_key => "key", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/user/preferences/key", :method => :delete },
-      { :controller => "user_preferences", :action => "delete_one", :preference_key => "key" }
+      { :controller => "user_preferences", :action => "delete_one", :preference_key => "key", :format => "xml" }
     )
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -10,19 +10,19 @@ class UsersControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/user/1", :method => :get },
-      { :controller => "users", :action => "api_read", :id => "1" }
+      { :controller => "users", :action => "api_read", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/user/details", :method => :get },
-      { :controller => "users", :action => "api_details" }
+      { :controller => "users", :action => "api_details", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/user/gpx_files", :method => :get },
-      { :controller => "users", :action => "api_gpx_files" }
+      { :controller => "users", :action => "api_gpx_files", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/users", :method => :get },
-      { :controller => "users", :action => "api_users" }
+      { :controller => "users", :action => "api_users", :format => "xml" }
     )
 
     assert_routing(

--- a/test/controllers/ways_controller_test.rb
+++ b/test/controllers/ways_controller_test.rb
@@ -6,27 +6,27 @@ class WaysControllerTest < ActionController::TestCase
   def test_routes
     assert_routing(
       { :path => "/api/0.6/way/create", :method => :put },
-      { :controller => "ways", :action => "create" }
+      { :controller => "ways", :action => "create", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/way/1/full", :method => :get },
-      { :controller => "ways", :action => "full", :id => "1" }
+      { :controller => "ways", :action => "full", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/way/1", :method => :get },
-      { :controller => "ways", :action => "read", :id => "1" }
+      { :controller => "ways", :action => "read", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/way/1", :method => :put },
-      { :controller => "ways", :action => "update", :id => "1" }
+      { :controller => "ways", :action => "update", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/way/1", :method => :delete },
-      { :controller => "ways", :action => "delete", :id => "1" }
+      { :controller => "ways", :action => "delete", :id => "1", :format => "xml" }
     )
     assert_routing(
       { :path => "/api/0.6/ways", :method => :get },
-      { :controller => "ways", :action => "ways" }
+      { :controller => "ways", :action => "ways", :format => "xml" }
     )
   end
 


### PR DESCRIPTION
This makes the change I proposed in #2064 to add a default format to all API routes.