### PR TITLE
Use CanCanCan for changeset comments

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -4,6 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    can :index, ChangesetComment
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id], :site
     can [:index, :rss, :show, :comments], DiaryEntry
     can [:search, :search_latlon, :search_ca_postcode, :search_osm_nominatim,
@@ -13,11 +14,13 @@ class Ability
 
     if user
       can :welcome, :site
+      can :create, ChangesetComment
       can [:create, :edit, :comment, :subscribe, :unsubscribe], DiaryEntry
       can [:new, :create], Report
       can [:read, :read_one, :update, :update_one, :delete_one], UserPreference
 
       if user.moderator?
+        can [:destroy, :restore], ChangesetComment
         can [:index, :show, :resolve, :ignore, :reopen], Issue
         can :create, IssueComment
         can [:new, :create, :edit, :update, :destroy], Redaction

--- a/app/abilities/capability.rb
+++ b/app/abilities/capability.rb
@@ -4,8 +4,13 @@ class Capability
   include CanCan::Ability
 
   def initialize(token)
+    can :create, ChangesetComment if capability?(token, :allow_write_api)
     can [:read, :read_one], UserPreference if capability?(token, :allow_read_prefs)
     can [:update, :update_one, :delete_one], UserPreference if capability?(token, :allow_write_prefs)
+
+    if token&.user&.moderator?
+      can [:destroy, :restore], ChangesetComment if capability?(token, :allow_write_api)
+    end
   end
 
   private

--- a/app/controllers/changeset_comments_controller.rb
+++ b/app/controllers/changeset_comments_controller.rb
@@ -3,8 +3,10 @@ class ChangesetCommentsController < ApplicationController
   before_action :authorize_web, :only => [:index]
   before_action :set_locale, :only => [:index]
   before_action :authorize, :only => [:create, :destroy, :restore]
-  before_action :require_moderator, :only => [:destroy, :restore]
-  before_action :require_allow_write_api, :only => [:create, :destroy, :restore]
+  before_action :api_deny_access_handler, :only => [:create, :destroy, :restore]
+
+  authorize_resource
+
   before_action :require_public_data, :only => [:create]
   before_action :check_api_writable, :only => [:create, :destroy, :restore]
   before_action :check_api_readable, :except => [:create, :index]

--- a/test/abilities/capability_test.rb
+++ b/test/abilities/capability_test.rb
@@ -12,6 +12,48 @@ class CapabilityTest < ActiveSupport::TestCase
   end
 end
 
+class ChangesetCommentCapabilityTest < CapabilityTest
+  test "as a normal user with permissionless token" do
+    token = create(:access_token)
+    capability = Capability.new token
+
+    [:create, :destroy, :restore].each do |action|
+      assert capability.cannot? action, ChangesetComment
+    end
+  end
+
+  test "as a normal user with allow_write_api token" do
+    token = create(:access_token, :allow_write_api => true)
+    capability = Capability.new token
+
+    [:destroy, :restore].each do |action|
+      assert capability.cannot? action, ChangesetComment
+    end
+
+    [:create].each do |action|
+      assert capability.can? action, ChangesetComment
+    end
+  end
+
+  test "as a moderator with permissionless token" do
+    token = create(:access_token, :user => create(:moderator_user))
+    capability = Capability.new token
+
+    [:create, :destroy, :restore].each do |action|
+      assert capability.cannot? action, ChangesetComment
+    end
+  end
+
+  test "as a moderator with allow_write_api token" do
+    token = create(:access_token, :user => create(:moderator_user), :allow_write_api => true)
+    capability = Capability.new token
+
+    [:create, :destroy, :restore].each do |action|
+      assert capability.can? action, ChangesetComment
+    end
+  end
+end
+
 class UserCapabilityTest < CapabilityTest
   test "user preferences" do
     # a user with no tokens

--- a/test/factories/access_tokens.rb
+++ b/test/factories/access_tokens.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :access_token do
+    user
+    client_application
+  end
+end


### PR DESCRIPTION
This introduces different deny_access handlers for web and api requests, since we want to avoid sending redirects as API responses. See #2064 for discussion.

I think in the long term, we'll have separate deny_access handlers for web and api requests using controller inheritance, but I think this works as an intermediate stage while we're refactoring. 