### PR TITLE
Use only token capabilities when a token is provided

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -446,9 +446,9 @@ class ApplicationController < ActionController::Base
   end
 
   def current_ability
-    # Add in capabilities from the oauth token if it exists and is a valid access token
+    # Use capabilities from the oauth token if it exists and is a valid access token
     if Authenticator.new(self, [:token]).allow?
-      Ability.new(current_user).merge(Capability.new(current_token))
+      Capability.new(current_token)
     else
       Ability.new(current_user)
     end


### PR DESCRIPTION
The Authenticate#allow? method (from oauth-plugin) sets `current_user` as a side effect of checking the token. But this allowed a valid token to access all actions that are available to that user, beyond the capabilities for that token.

This PR changes that, so that if there is a token, only the permissions from the Capability class are used. I've added a couple of tests that illustrate the change, to show that with the new approach you definitely need the allow_read_prefs permission on a token.

I went for the @request.env fiddling to make the request, since creating a fully signed request (as used in test/integration/oauth_test) is a bit more complex than I would like. But I'm open to other suggestions.