### PR TITLE
Require terms agreement for api write abilities and capabilities

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -16,12 +16,15 @@ class Ability
 
     if user
       can :welcome, :site
-      can :create, ChangesetComment
       can [:create, :edit, :comment, :subscribe, :unsubscribe], DiaryEntry
       can [:close, :reopen], Note
       can [:new, :create], Report
       can [:account, :go_public, :make_friend, :remove_friend, :api_details, :api_gpx_files], User
       can [:read, :read_one, :update, :update_one, :delete_one], UserPreference
+
+      if user.terms_agreed? || !REQUIRE_TERMS_AGREED # rubocop:disable Style/IfUnlessModifier
+        can :create, ChangesetComment
+      end
 
       if user.moderator?
         can [:destroy, :restore], ChangesetComment

--- a/app/abilities/capability.rb
+++ b/app/abilities/capability.rb
@@ -4,12 +4,15 @@ class Capability
   include CanCan::Ability
 
   def initialize(token)
-    can :create, ChangesetComment if capability?(token, :allow_write_api)
     can [:create, :comment, :close, :reopen], Note if capability?(token, :allow_write_notes)
     can [:api_details], User if capability?(token, :allow_read_prefs)
     can [:api_gpx_files], User if capability?(token, :allow_read_gpx)
     can [:read, :read_one], UserPreference if capability?(token, :allow_read_prefs)
     can [:update, :update_one, :delete_one], UserPreference if capability?(token, :allow_write_prefs)
+
+    if token&.user&.terms_agreed? || !REQUIRE_TERMS_AGREED
+      can :create, ChangesetComment if capability?(token, :allow_write_api)
+    end
 
     if token&.user&.moderator?
       can [:destroy, :restore], ChangesetComment if capability?(token, :allow_write_api)

--- a/test/controllers/changeset_comments_controller_test.rb
+++ b/test/controllers/changeset_comments_controller_test.rb
@@ -248,4 +248,73 @@ class ChangesetCommentsControllerTest < ActionController::TestCase
     get :index, :params => { :format => "rss", :limit => 100001 }
     assert_response :bad_request
   end
+
+  # This test ensures that token capabilities behave correctly for a method that
+  # requires the terms to have been agreed.
+  # (This would be better as an integration or system testcase, since the changeset_comment
+  # create method is simply a stand-in for any method that requires terms agreement.
+  # But writing oauth tests is hard, and so it's easier to put in a controller test.)
+  def test_api_write_and_terms_agreed_via_token
+    with_terms_agreed(true) do
+      user = create(:user, :terms_agreed => nil)
+      token = create(:access_token, :user => user, :allow_write_api => true)
+      changeset = create(:changeset, :closed)
+
+      # Hack together an oauth request - an alternative would be to sign the request properly
+      @request.env["oauth.version"] = 1
+      @request.env["oauth.strategies"] = [:token]
+      @request.env["oauth.token"] = token
+
+      assert_difference "ChangesetComment.count", 0 do
+        post :create, :params => { :id => changeset.id, :text => "This is a comment" }
+      end
+      assert_response :forbidden
+
+      # Try again, after agreement with the terms
+      user.terms_agreed = Time.now
+      user.save!
+
+      assert_difference "ChangesetComment.count", 1 do
+        post :create, :params => { :id => changeset.id, :text => "This is a comment" }
+      end
+      assert_response :success
+    end
+  end
+
+  # This test does the same as above, but with basic auth, to similarly test that the
+  # abilities take into account terms agreement too.
+  def test_api_write_and_terms_agreed_via_basic_auth
+    with_terms_agreed(true) do
+      user = create(:user, :terms_agreed => nil)
+      changeset = create(:changeset, :closed)
+
+      basic_authorization user.email, "test"
+
+      assert_difference "ChangesetComment.count", 0 do
+        post :create, :params => { :id => changeset.id, :text => "This is a comment" }
+      end
+      assert_response :forbidden
+
+      # Try again, after agreement with the terms
+      user.terms_agreed = Time.now
+      user.save!
+
+      assert_difference "ChangesetComment.count", 1 do
+        post :create, :params => { :id => changeset.id, :text => "This is a comment" }
+      end
+      assert_response :success
+    end
+  end
+
+  private
+
+  def with_terms_agreed(value)
+    require_terms_agreed = Object.send("remove_const", "REQUIRE_TERMS_AGREED")
+    Object.const_set("REQUIRE_TERMS_AGREED", value)
+
+    yield
+
+    Object.send("remove_const", "REQUIRE_TERMS_AGREED")
+    Object.const_set("REQUIRE_TERMS_AGREED", require_terms_agreed)
+  end
 end


### PR DESCRIPTION
I spotted a flaw in my refactoring in 8f70fb21146b1e8b90125e02d54e70bceea1d5fd , since it omitted the check for terms agreement that was previously a side effect of the `require_allow_write_api` method. This PR ensures that api-write-related abilities (and token capabilities) are only granted if the user has agreed to the terms.

There's still a small behaviour change, since the user is not informed precisely why they are denied access, but I don't think it's worth the effort of trying to resolve this.