### PR TITLE
Add parsing of bare #zoom/lat/lon style hashes

### DIFF
--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -148,20 +148,25 @@ OSM = {
       return args;
     }
 
-    hash = querystring.parse(hash.substr(i + 1));
+    let hash_map;
+    if (/\d/.test(hash.substr(i + 1, 1))) {
+      hash_map = hash.substr(i + 1);
+    } else {             
+      hash = querystring.parse(hash.substr(i + 1));
 
-    var map = (hash.map || '').split('/'),
-      zoom = parseInt(map[0], 10),
-      lat = parseFloat(map[1]),
-      lon = parseFloat(map[2]);
+      if (hash.layers) {
+        args.layers = hash.layers;
+      }
+      hash_map = (hash.map || '');
+    }
+    var map = hash_map.split('/'),
+        zoom = parseInt(map[0], 10),
+        lat = parseFloat(map[1]),
+        lon = parseFloat(map[2]);
 
     if (!isNaN(zoom) && !isNaN(lat) && !isNaN(lon)) {
       args.center = new L.LatLng(lat, lon);
       args.zoom = zoom;
-    }
-
-    if (hash.layers) {
-      args.layers = hash.layers;
     }
 
     return args;

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -153,6 +153,11 @@ describe("OSM", function () {
       var args = OSM.parseHash("#map=5/57.6247/-3.6845&layers=M");
       expect(args).to.have.property("layers", "M");
     });
+    it("parses bare zoom/lat/lon hash", function() {
+      var args = OSM.parseHash("#8/52.123/-5.987");
+      expect(args).to.have.property("center").deep.equal(L.latLng(52.123, -5.987));
+      expect(args).to.have.property("zoom", 8);
+    });      
   });
 
   describe(".formatHash", function () {


### PR DESCRIPTION
mapbox-gl-js creates bare hashes without a querystring; this (very small) change will enable OSM to respond correctly to them, if people paste them in by accident.

I've also made a PR for the reverse: https://github.com/mapbox/mapbox-gl-js/pull/7725