### PR TITLE
Use CanCanCan for changesets controller

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -4,6 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    can [:index, :feed, :read, :download, :query], Changeset
     can :index, ChangesetComment
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id], :site
     can [:index, :rss, :show, :comments], DiaryEntry
@@ -22,7 +23,8 @@ class Ability
       can [:account, :go_public, :make_friend, :remove_friend, :api_details, :api_gpx_files], User
       can [:read, :read_one, :update, :update_one, :delete_one], UserPreference
 
-      if user.terms_agreed? || !REQUIRE_TERMS_AGREED # rubocop:disable Style/IfUnlessModifier
+      if user.terms_agreed? || !REQUIRE_TERMS_AGREED
+        can [:create, :update, :upload, :close, :subscribe, :unsubscribe, :expand_bbox], Changeset
         can :create, ChangesetComment
       end
 

--- a/app/abilities/capability.rb
+++ b/app/abilities/capability.rb
@@ -11,6 +11,7 @@ class Capability
     can [:update, :update_one, :delete_one], UserPreference if capability?(token, :allow_write_prefs)
 
     if token&.user&.terms_agreed? || !REQUIRE_TERMS_AGREED
+      can [:create, :update, :upload, :close, :subscribe, :unsubscribe, :expand_bbox], Changeset if capability?(token, :allow_write_api)
       can :create, ChangesetComment if capability?(token, :allow_write_api)
     end
 

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -8,7 +8,10 @@ class ChangesetsController < ApplicationController
   before_action :authorize_web, :only => [:index, :feed]
   before_action :set_locale, :only => [:index, :feed]
   before_action :authorize, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]
-  before_action :require_allow_write_api, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]
+  before_action :api_deny_access_handler, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe, :expand_bbox]
+
+  authorize_resource
+
   before_action :require_public_data, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]
   before_action :check_api_writable, :only => [:create, :update, :upload, :subscribe, :unsubscribe]
   before_action :check_api_readable, :except => [:create, :update, :upload, :download, :query, :index, :feed, :subscribe, :unsubscribe]


### PR DESCRIPTION
The expand_bbox method now needs `require_write_api` capability on tokens. 

I'm not sure whether this omission was intended previously, but I think it makes sense to require it from now on. I think it's quite unlikely that anyone has been creating changesets with one token and expanding the bbox with another, less privileged token.