### PR TITLE
More authorization refactoring

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -11,6 +11,7 @@ class Ability
          :search_geonames, :search_osm_nominatim_reverse, :search_geonames_reverse], :geocoder
     can [:index, :create, :comment, :feed, :show, :search, :mine], Note
     can [:index, :show], Redaction
+    can [:search_all, :search_nodes, :search_ways, :search_relations], :search
     can [:terms, :api_users, :login, :logout, :new, :create, :save, :confirm, :confirm_resend, :confirm_email, :lost_password, :reset_password, :show, :api_read, :auth_success, :auth_failure], User
     can [:index, :show, :blocks_on, :blocks_by], UserBlock
 

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -4,6 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    can [:relation, :relation_history, :way, :way_history, :node, :node_history, :changeset, :note], :browse
     can :index, ChangesetComment
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id], :site
     can [:index, :rss, :show, :comments], DiaryEntry

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -6,6 +6,7 @@ class Ability
   def initialize(user)
     can [:relation, :relation_history, :way, :way_history, :node, :node_history, :changeset, :note], :browse
     can :index, ChangesetComment
+    can :search, :direction
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id], :site
     can [:index, :rss, :show, :comments], DiaryEntry
     can [:finish, :embed], :export

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -15,6 +15,7 @@ class Ability
     can [:index, :create, :comment, :feed, :show, :search, :mine], Note
     can [:index, :show], Redaction
     can [:search_all, :search_nodes, :search_ways, :search_relations], :search
+    can [:trackpoints], :swf
     can [:terms, :api_users, :login, :logout, :new, :create, :save, :confirm, :confirm_resend, :confirm_email, :lost_password, :reset_password, :show, :api_read, :auth_success, :auth_failure], User
     can [:index, :show, :blocks_on, :blocks_by], UserBlock
 

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -7,6 +7,7 @@ class Ability
     can :index, ChangesetComment
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :preview, :copyright, :key, :id], :site
     can [:index, :rss, :show, :comments], DiaryEntry
+    can [:finish, :embed], :export
     can [:search, :search_latlon, :search_ca_postcode, :search_osm_nominatim,
          :search_geonames, :search_osm_nominatim_reverse, :search_geonames_reverse], :geocoder
     can [:index, :create, :comment, :feed, :show, :search, :mine], Note

--- a/app/controllers/amf_controller.rb
+++ b/app/controllers/amf_controller.rb
@@ -41,6 +41,11 @@ class AmfController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :check_api_writable
 
+  # AMF Controller implements its own authentication and authorization checks
+  # completely independently of the rest of the codebase, so best just to let
+  # it keep doing its own thing.
+  skip_authorization_check
+
   # Main AMF handlers: process the raw AMF string (using AMF library) and
   # calls each action (private method) accordingly.
 

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -6,6 +6,7 @@ class BrowseController < ApplicationController
   before_action(:except => [:query]) { |c| c.check_database_readable(true) }
   before_action :require_oauth
   around_action :web_timeout
+  authorize_resource :class => false
 
   def relation
     @type = "relation"

--- a/app/controllers/directions_controller.rb
+++ b/app/controllers/directions_controller.rb
@@ -2,6 +2,7 @@ class DirectionsController < ApplicationController
   before_action :authorize_web
   before_action :set_locale
   before_action :require_oauth, :only => [:search]
+  authorize_resource :class => false
 
   def search
     render :layout => map_layout

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -2,6 +2,7 @@ class ExportController < ApplicationController
   before_action :authorize_web
   before_action :set_locale
   before_action :update_totp, :only => [:finish]
+  authorize_resource :class => false
 
   caches_page :embed
 

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -6,6 +6,7 @@ class GeocoderController < ApplicationController
   before_action :authorize_web
   before_action :set_locale
   before_action :require_oauth, :only => [:search]
+  authorize_resource :class => false
 
   def search
     @params = normalize_params

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,6 +3,7 @@ class SearchController < ApplicationController
   # Can search by tag k, v, or both (type->k,value->v)
   # Can search by name (k=name,v=....)
   skip_before_action :verify_authenticity_token
+  authorize_resource :class => false
 
   def search_all
     do_search(true, true, true)

--- a/app/controllers/swf_controller.rb
+++ b/app/controllers/swf_controller.rb
@@ -1,6 +1,7 @@
 class SwfController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :check_api_readable
+  authorize_resource :class => false
 
   # to log:
   # RAILS_DEFAULT_LOGGER.error("Args: #{args[0]}, #{args[1]}, #{args[2]}, #{args[3]}")


### PR DESCRIPTION
This PR brings our authorization framework to search, export, browse, directions and swf controller, and ignores authorization for amf_controller since that handles both authorization and authentication itself.