### PR TITLE
Use an xml builder to generate the capabilities response

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -253,48 +253,9 @@ class ApiController < ApplicationController
   # * maximum area that can be requested in a bbox request in square degrees
   # * number of tracepoints that are returned in each tracepoints page
   def capabilities
-    doc = OSM::API.new.get_xml_doc
-
-    api = XML::Node.new "api"
-    version = XML::Node.new "version"
-    version["minimum"] = API_VERSION.to_s
-    version["maximum"] = API_VERSION.to_s
-    api << version
-    area = XML::Node.new "area"
-    area["maximum"] = MAX_REQUEST_AREA.to_s
-    api << area
-    notearea = XML::Node.new "note_area"
-    notearea["maximum"] = MAX_NOTE_REQUEST_AREA.to_s
-    api << notearea
-    tracepoints = XML::Node.new "tracepoints"
-    tracepoints["per_page"] = TRACEPOINTS_PER_PAGE.to_s
-    api << tracepoints
-    waynodes = XML::Node.new "waynodes"
-    waynodes["maximum"] = MAX_NUMBER_OF_WAY_NODES.to_s
-    api << waynodes
-    changesets = XML::Node.new "changesets"
-    changesets["maximum_elements"] = Changeset::MAX_ELEMENTS.to_s
-    api << changesets
-    timeout = XML::Node.new "timeout"
-    timeout["seconds"] = API_TIMEOUT.to_s
-    api << timeout
-    status = XML::Node.new "status"
-    status["database"] = database_status.to_s
-    status["api"] = api_status.to_s
-    status["gpx"] = gpx_status.to_s
-    api << status
-    doc.root << api
-    policy = XML::Node.new "policy"
-    blacklist = XML::Node.new "imagery"
-    IMAGERY_BLACKLIST.each do |url_regex|
-      xnd = XML::Node.new "blacklist"
-      xnd["regex"] = url_regex.to_s
-      blacklist << xnd
-    end
-    policy << blacklist
-    doc.root << policy
-
-    render :xml => doc.to_s
+    @database_status = database_status
+    @api_status = api_status
+    @gpx_status = gpx_status
   end
 
   # External apps that use the api are able to query which permissions

--- a/app/views/api/capabilities.builder
+++ b/app/views/api/capabilities.builder
@@ -1,0 +1,22 @@
+xml.instruct! :xml, :version => "1.0"
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm.api do |api|
+    api.version(:minimum => API_VERSION.to_s, :maximum => API_VERSION.to_s)
+    api.area(:maximum => MAX_REQUEST_AREA.to_s)
+    api.note_area(:maximum => MAX_NOTE_REQUEST_AREA.to_s)
+    api.tracepoints(:per_page => TRACEPOINTS_PER_PAGE.to_s)
+    api.waynodes(:maximum => MAX_NUMBER_OF_WAY_NODES.to_s)
+    api.changesets(:maximum_elements => Changeset::MAX_ELEMENTS.to_s)
+    api.timeout(:seconds => API_TIMEOUT.to_s)
+    api.status(:database => @database_status.to_s,
+               :api => @api_status.to_s,
+               :gpx => @gpx_status.to_s)
+  end
+  osm.policy do |policy|
+    policy.imagery do |imagery|
+      IMAGERY_BLACKLIST.each do |url_regex|
+        imagery.blacklist(:regex => url_regex.to_s)
+      end
+    end
+  end
+end

--- a/app/views/api/permissions.builder
+++ b/app/views/api/permissions.builder
@@ -1,6 +1,6 @@
 # create list of permissions
 xml.instruct! :xml, :version => "1.0"
-xml.osm("version" => API_VERSION.to_s, "generator" => "OpenStreetMap Server") do
+xml.osm(OSM::API.new.xml_root_attributes) do
   xml.permissions do
     @permissions.each do |permission|
       xml.permission :name => permission

--- a/app/views/notes/index.xml.builder
+++ b/app/views/notes/index.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
 
-xml.osm(:version => API_VERSION, :generator => GENERATOR) do |osm|
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
   osm << (render(:partial => "note", :collection => @notes) || "")
 end

--- a/app/views/notes/show.xml.builder
+++ b/app/views/notes/show.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
 
-xml.osm(:version => API_VERSION, :generator => GENERATOR) do |osm|
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
   osm << render(:partial => "note", :object => @note)
 end

--- a/app/views/users/api_read.builder
+++ b/app/views/users/api_read.builder
@@ -1,4 +1,4 @@
 xml.instruct! :xml, :version => "1.0"
-xml.osm("version" => API_VERSION, "generator" => GENERATOR) do |osm|
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
   osm << render(:partial => "api_user", :object => @user)
 end

--- a/app/views/users/api_users.builder
+++ b/app/views/users/api_users.builder
@@ -1,4 +1,4 @@
 xml.instruct! :xml, :version => "1.0"
-xml.osm("version" => API_VERSION, "generator" => GENERATOR) do |osm|
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
   osm << render(:partial => "api_user", :collection => @users)
 end

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -494,13 +494,19 @@ module OSM
       doc = XML::Document.new
       doc.encoding = XML::Encoding::UTF_8
       root = XML::Node.new "osm"
-      root["version"] = API_VERSION.to_s
-      root["generator"] = GENERATOR
-      root["copyright"] = COPYRIGHT_OWNER
-      root["attribution"] = ATTRIBUTION_URL
-      root["license"] = LICENSE_URL
+      xml_root_attributes.each do |k, v|
+        root[k] = v
+      end
       doc.root = root
       doc
+    end
+
+    def xml_root_attributes
+      { "version" => API_VERSION.to_s,
+        "generator" => GENERATOR,
+        "copyright" => COPYRIGHT_OWNER,
+        "attribution" => ATTRIBUTION_URL,
+        "license" => LICENSE_URL }
     end
   end
 


### PR DESCRIPTION
This PR uses an xml builder template to create the API capabilities response, rather than building the xml response 'by hand' in the controller. This makes the code easier to read, as well as more closely following the MVC conventions.

It also refactors the other builder-based XML responses to use the same set of root attributes (i.e. adding copyright, attribution and license attributes) as the other XML responses.