### PR TITLE
Switch to using kramdown for markdown formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem "omniauth-openid"
 gem "omniauth-windowslive"
 
 # Markdown formatting support
-gem "redcarpet"
+gem "kramdown"
 
 # For status transitions of Issues
 gem "aasm"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
       jsonify (< 0.4.0)
     jwt (2.1.0)
     kgio (2.11.2)
+    kramdown (1.17.0)
     libv8 (3.16.14.19)
     libxml-ruby (3.1.0)
     listen (3.1.5)
@@ -303,7 +304,6 @@ GEM
       ffi (~> 1.0)
     record_tag_helper (1.0.0)
       actionview (~> 5.x)
-    redcarpet (3.4.0)
     ref (2.0.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -412,6 +412,7 @@ DEPENDENCIES
   json
   jsonify-rails
   kgio
+  kramdown
   libxml-ruby (>= 2.0.5)
   listen
   logstasher
@@ -438,7 +439,6 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n (~> 4.0.0)
   record_tag_helper
-  redcarpet
   rinku (>= 1.2.2)
   rotp
   rubocop

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2342,11 +2342,11 @@ a.button {
     margin-left: $lineheight;
   }
 
-  ul li {
+  ul > li {
     list-style: disc;
   }
 
-  ol li {
+  ol > li {
     list-style: decimal;
   }
 }

--- a/config/initializers/sanitize.rb
+++ b/config/initializers/sanitize.rb
@@ -1,5 +1,5 @@
 Sanitize::Config::OSM = Sanitize::Config::RELAXED.dup
 
 Sanitize::Config::OSM[:elements] -= %w[div style]
-Sanitize::Config::OSM[:add_attributes] = { "a" => { "rel" => "nofollow" } }
+Sanitize::Config::OSM[:add_attributes] = { "a" => { "rel" => "nofollow noopener noreferer" } }
 Sanitize::Config::OSM[:remove_contents] = %w[script style]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1626,7 +1626,7 @@ en:
       edit: Edit
       preview: Preview
     markdown_help:
-      title_html: Parsed with <a href="https://daringfireball.net/projects/markdown/">Markdown</a>
+      title_html: Parsed with <a href="https://kramdown.gettalong.org/quickref.html">kramdown</a>
       headings: Headings
       heading: Heading
       subheading: Subheading

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -55,11 +55,15 @@ module RichText
       SimpleFormat.new.simple_format(text)
     end
 
-    def linkify(text)
+    def sanitize(text)
+      Sanitize.clean(text, Sanitize::Config::OSM).html_safe
+    end
+
+    def linkify(text, mode = :urls)
       if text.html_safe?
-        Rinku.auto_link(text, :urls, tag_builder.tag_options(:rel => "nofollow")).html_safe
+        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow")).html_safe
       else
-        Rinku.auto_link(text, :urls, tag_builder.tag_options(:rel => "nofollow"))
+        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow"))
       end
     end
   end
@@ -72,29 +76,15 @@ module RichText
     def to_text
       to_s
     end
-
-    private
-
-    def sanitize(text)
-      Sanitize.clean(text, Sanitize::Config::OSM).html_safe
-    end
   end
 
   class Markdown < Base
     def to_html
-      Markdown.html_parser.render(self).html_safe
+      linkify(sanitize(Kramdown::Document.new(self).to_html), :all)
     end
 
     def to_text
       to_s
-    end
-
-    def self.html_renderer
-      @html_renderer ||= Redcarpet::Render::XHTML.new(:filter_html => true, :safe_links_only => true, :link_attributes => { :rel => "nofollow" })
-    end
-
-    def self.html_parser
-      @html_parser ||= Redcarpet::Markdown.new(html_renderer, :no_intra_emphasis => true, :autolink => true, :space_after_headers => true)
     end
   end
 

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -61,9 +61,9 @@ module RichText
 
     def linkify(text, mode = :urls)
       if text.html_safe?
-        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow")).html_safe
+        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow noopener noreferer")).html_safe
       else
-        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow"))
+        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow noopener noreferer"))
       end
     end
   end

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -8,14 +8,14 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow']", 1
+      assert_select "a[rel='nofollow noopener noreferer']", 1
     end
 
     r = RichText.new("html", "foo <a href='http://example.com/'>bar</a> baz")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow']", 1
+      assert_select "a[rel='nofollow noopener noreferer']", 1
     end
 
     r = RichText.new("html", "foo example@example.com bar")
@@ -27,7 +27,7 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='mailto:example@example.com']", 1
-      assert_select "a[rel='nofollow']", 1
+      assert_select "a[rel='nofollow noopener noreferer']", 1
     end
 
     r = RichText.new("html", "foo <div>bar</div> baz")
@@ -64,28 +64,28 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow']", 1
+      assert_select "a[rel='nofollow noopener noreferer']", 1
     end
 
     r = RichText.new("markdown", "foo [bar](http://example.com/) baz")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow']", 1
+      assert_select "a[rel='nofollow noopener noreferer']", 1
     end
 
     r = RichText.new("markdown", "foo example@example.com bar")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='mailto:example@example.com']", 1
-      assert_select "a[rel='nofollow']", 1
+      assert_select "a[rel='nofollow noopener noreferer']", 1
     end
 
     r = RichText.new("markdown", "foo [bar](mailto:example@example.com) bar")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='mailto:example@example.com']", 1
-      assert_select "a[rel='nofollow']", 1
+      assert_select "a[rel='nofollow noopener noreferer']", 1
     end
 
     r = RichText.new("markdown", "foo ![bar](http://example.com/example.png) bar")
@@ -162,7 +162,7 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow']", 1
+      assert_select "a[rel='nofollow noopener noreferer']", 1
     end
 
     r = RichText.new("text", "foo example@example.com bar")


### PR DESCRIPTION
As suggested by @gravitystorm in #2103 this switches our markdown formatting to use kramdown instead of redcarpet.

As kramdown doesn't have the builtin sanitisation features of redcarpet I have passed the resulting HTML through the sanitiser used for other formats and have also added a few extra restrictions to links in user generated content.

Note that this doesn't fix all the issues in #2103 as bullet lists nested in numbered lists still don't seem to work as the reporter there is expecting.

Also I noticed that redcarpet was turning thinks which look like links but have no link markup into links which kramdown doesn't - we could fix that by running our autolinker if we wanted.