### PR TITLE
Use CanCanCan for oauth controller

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -15,6 +15,7 @@ class Ability
     can [:search, :search_latlon, :search_ca_postcode, :search_osm_nominatim,
          :search_geonames, :search_osm_nominatim_reverse, :search_geonames_reverse], :geocoder
     can [:index, :create, :comment, :feed, :show, :search, :mine], Note
+    can [:token, :request_token, :access_token, :test_request], :oauth
     can [:index, :show], Redaction
     can [:search_all, :search_nodes, :search_ways, :search_relations], :search
     can [:trackpoints], :swf
@@ -28,6 +29,7 @@ class Ability
       can [:create, :edit, :comment, :subscribe, :unsubscribe], DiaryEntry
       can [:new, :create, :reply, :show, :inbox, :outbox, :mark, :destroy], Message
       can [:close, :reopen], Note
+      can [:revoke, :authorize], :oauth
       can [:new, :create], Report
       can [:mine, :new, :create, :edit, :update, :delete, :api_create, :api_read, :api_update, :api_delete, :api_data], Trace
       can [:account, :go_public, :make_friend, :remove_friend, :api_details, :api_gpx_files], User

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -5,6 +5,17 @@ class OauthController < ApplicationController
 
   layout "site"
 
+  def revoke
+    @token = current_user.oauth_tokens.find_by :token => params[:token]
+    if @token
+      @token.invalidate!
+      flash[:notice] = t(".flash", :application => @token.client_application.name)
+    end
+    redirect_to oauth_clients_url(:display_name => @token.user.display_name)
+  end
+
+  protected
+
   def login_required
     authorize_web
     set_locale
@@ -25,17 +36,6 @@ class OauthController < ApplicationController
 
     any_auth
   end
-
-  def revoke
-    @token = current_user.oauth_tokens.find_by :token => params[:token]
-    if @token
-      @token.invalidate!
-      flash[:notice] = t(".flash", :application => @token.client_application.name)
-    end
-    redirect_to oauth_clients_url(:display_name => @token.user.display_name)
-  end
-
-  protected
 
   def oauth1_authorize
     override_content_security_policy_directives(:form_action => []) if CSP_ENFORCE || defined?(CSP_REPORT_URL)

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -3,6 +3,10 @@ require "oauth/controllers/provider_controller"
 class OauthController < ApplicationController
   include OAuth::Controllers::ProviderController
 
+  # The ProviderController will call login_required for any action that needs
+  # a login, but we want to check authorization on every action.
+  authorize_resource :class => false
+
   layout "site"
 
   def revoke
@@ -19,7 +23,6 @@ class OauthController < ApplicationController
   def login_required
     authorize_web
     set_locale
-    require_user
   end
 
   def user_authorizes_token?


### PR DESCRIPTION
This PR marks non-action methods in the oauth controller as protected, and uses CanCanCan for access control for the actions.