### PR TITLE
Advise to run i18n:js:export before assets:precompile

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -127,5 +127,5 @@ If you want to deploy The Rails Port for production use, you'll need to make a f
 * Your production database will also need the extensions and functions installed - see [INSTALL.md](INSTALL.md)
 * The included version of the map call is quite slow and eats a lot of memory. You should consider using [CGIMap](https://github.com/zerebubuth/openstreetmap-cgimap) instead.
 * The included version of the GPX importer is slow and/or completely inoperable. You should consider using [the high-speed GPX importer](https://git.openstreetmap.org/gpx-import.git/).
-* Make sure you generate the l18n files and precompile the production assets: `RAILS_ENV=production rake i18n:js:export assets:precompile`
+* Make sure you generate the i18n files and precompile the production assets: `RAILS_ENV=production rake i18n:js:export assets:precompile`
 * Make sure the web server user as well as the rails user can read, write and create directories in `tmp/`.

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -127,5 +127,5 @@ If you want to deploy The Rails Port for production use, you'll need to make a f
 * Your production database will also need the extensions and functions installed - see [INSTALL.md](INSTALL.md)
 * The included version of the map call is quite slow and eats a lot of memory. You should consider using [CGIMap](https://github.com/zerebubuth/openstreetmap-cgimap) instead.
 * The included version of the GPX importer is slow and/or completely inoperable. You should consider using [the high-speed GPX importer](https://git.openstreetmap.org/gpx-import.git/).
-* Make sure you precompile the production assets: `RAILS_ENV=production rake assets:precompile`
+* Make sure you generate the l18n files and precompile the production assets: `RAILS_ENV=production rake i18n:js:export assets:precompile`
 * Make sure the web server user as well as the rails user can read, write and create directories in `tmp/`.


### PR DESCRIPTION
When setting up a development-Server, ` i18n:js:export` is, according to [The i18n-js docs](https://www.rubydoc.info/gems/i18n-js/2.1.2) run automatically.

When setting up a production-Server it is required to run it manually before precompiling the assets.