### PR TITLE
Use activerecord-import for bulk importing tracepoint records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem "image_optim_rails"
 # Load rails plugins
 gem "actionpack-page_caching"
 gem "active_record_union"
+gem "activerecord-import"
 gem "cancancan"
 gem "composite_primary_keys", "~> 11.1.0"
 gem "config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       activemodel (= 5.2.2.1)
       activesupport (= 5.2.2.1)
       arel (>= 9.0)
+    activerecord-import (0.28.1)
+      activerecord (>= 3.2)
     activestorage (5.2.2.1)
       actionpack (= 5.2.2.1)
       activerecord (= 5.2.2.1)
@@ -423,6 +425,7 @@ DEPENDENCIES
   aasm
   actionpack-page_caching
   active_record_union
+  activerecord-import
   annotate
   autoprefixer-rails (~> 8.6.3)
   better_errors

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -289,31 +289,35 @@ class Trace < ActiveRecord::Base
     # If there are any existing points for this trace then delete them
     Tracepoint.where(:gpx_id => id).delete_all
 
-    # Gather the trace points together for a bulk import
-    tracepoints = []
-    gpx.points do |point|
-      if first
-        f_lat = point.latitude
-        f_lon = point.longitude
-        first = false
+    gpx.points.each_slice(1_000) do |points|
+      # Gather the trace points together for a bulk import
+      tracepoints = []
+
+      points.each do |point|
+        if first
+          f_lat = point.latitude
+          f_lon = point.longitude
+          first = false
+        end
+
+        tp = Tracepoint.new
+        tp.lat = point.latitude
+        tp.lon = point.longitude
+        tp.altitude = point.altitude
+        tp.timestamp = point.timestamp
+        tp.gpx_id = id
+        tp.trackid = point.segment
+        tracepoints << tp
       end
 
-      tp = Tracepoint.new
-      tp.lat = point.latitude
-      tp.lon = point.longitude
-      tp.altitude = point.altitude
-      tp.timestamp = point.timestamp
-      tp.gpx_id = id
-      tp.trackid = point.segment
-      tracepoints << tp
-    end
+      # Run the before_save and before_create callbacks, and then import them in bulk with activerecord-import
+      tracepoints.each do |tp|
+        tp.run_callbacks(:save) { false }
+        tp.run_callbacks(:create) { false }
+      end
 
-    # Run the before_save and before_create callbacks, and then import them in bulk with activerecord-import
-    tracepoints.each do |tp|
-      tp.run_callbacks(:save) { false }
-      tp.run_callbacks(:create) { false }
+      Tracepoint.import!(tracepoints)
     end
-    Tracepoint.import!(tracepoints, :batch_size => 1_000)
 
     if gpx.actual_points.positive?
       max_lat = Tracepoint.where(:gpx_id => id).maximum(:latitude)

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -313,7 +313,7 @@ class Trace < ActiveRecord::Base
       tp.run_callbacks(:save) { false }
       tp.run_callbacks(:create) { false }
     end
-    Tracepoint.import(tracepoints)
+    Tracepoint.import!(tracepoints, :batch_size => 1_000)
 
     if gpx.actual_points.positive?
       max_lat = Tracepoint.where(:gpx_id => id).maximum(:latitude)

--- a/lib/gpx.rb
+++ b/lib/gpx.rb
@@ -13,6 +13,8 @@ module GPX
     end
 
     def points
+      return enum_for(:points) unless block_given?
+
       @possible_points = 0
       @actual_points = 0
       @tracksegs = 0

--- a/test/models/trace_test.rb
+++ b/test/models/trace_test.rb
@@ -206,6 +206,10 @@ class TraceTest < ActiveSupport::TestCase
 
       trace.reload
       assert_equal 1, Tracepoint.where(:gpx_id => trace.id).count
+
+      # Check that the tile has been set prior to the bulk import
+      # i.e. that the callbacks have been run correctly
+      assert_equal 3221331576, Tracepoint.where(:gpx_id => trace.id).first.tile
     end
   end
 


### PR DESCRIPTION
Non-rigourous testing shows a significant speedup, even on ssds.