### PR TITLE
Copy i18n strings from validates_email_format_of plugin

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,10 @@ en:
       friendly: "%e %B %Y at %H:%M"
       blog: "%e %B %Y"
   activerecord:
+    errors:
+      messages:
+        invalid_email_address: does not appear to be a valid e-mail address
+        email_address_not_routable: is not routable
     # Translates all the model names, which is used in error handling on the web site
     models:
       acl: "Access Control List"


### PR DESCRIPTION
This allows our translators to work in languages not yet supported by the upstream plugin. Fixes #2128