### PR TITLE
API key dispenser

### DIFF
--- a/app/controllers/third_party_keys_controller.rb
+++ b/app/controllers/third_party_keys_controller.rb
@@ -1,0 +1,113 @@
+class ThirdPartyKeysController < ApplicationController
+  layout "site"
+
+  before_action :authorize
+  before_action :authorize_web
+  before_action :set_locale
+  before_action :require_user
+
+  def index
+    @keys = ThirdPartyKey.all.where("user_ref = ? and (revoked_ref = 0 or revoked_ref is null)",
+        current_user.id)
+  end
+
+  def create
+    input = params.require(:third_party_key).permit(:gdpr, :attentive, :disclose, :service_to_use)
+    service = ThirdPartyService.where(uri: input[:service_to_use]).take
+    if !service
+      @error = 'No service with this URI known.'
+      render :action => "new"
+      return
+    end
+    if service.access_key == ''
+      @error = 'Service has been discontinued.'
+      render :action => "new"
+      return
+    end
+    @key = ThirdPartyKey.where(user_ref: current_user.id, third_party_service: service).take
+    if @key
+      redirect_to action: "show", id: @key.id
+      return
+    end
+    if input[:gdpr] != '1' || input[:attentive] == '1' || input[:disclose] == '1'
+      @error = 'Please read the text, check the appropriate checkboxes, and uncheck the others.'
+      render :action => "new"
+      return
+    end
+    event = ThirdPartyKeyEvent.new
+    event.save
+    @key = ThirdPartyKey.new
+    @key.created_ref = event.id
+    @key.third_party_service = service
+    @key.user_ref = current_user.id
+    @key.data = SecureRandom.hex(20)
+    if @key.save
+      redirect_to action: "show", id: @key.id
+    else
+      render :action => "new"
+    end
+  end
+
+  def edit
+    @key = ThirdPartyKey.find(params[:id])
+    if !@key
+      redirect_to action: "index"
+    else
+      if @key.user_ref != current_user.id
+        render :action => "show"
+      end
+    end
+  end
+
+  def show
+    @key = ThirdPartyKey.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to action: "index"
+  end
+
+  def update
+    @key = ThirdPartyKey.find(params[:id])
+    if @key.user_ref != current_user.id
+      redirect_to @key
+    else
+      event = ThirdPartyKeyEvent.new
+      event.save
+      @key.revoked_ref = event.id
+      @key.save
+      if @key.third_party_service && @key.third_party_service.access_key == ''
+        redirect_to action: "edit"
+        return
+      end
+      service = @key.third_party_service
+
+      event = ThirdPartyKeyEvent.new
+      event.save
+      @key = ThirdPartyKey.new
+      @key.created_ref = event.id
+      @key.third_party_service = service
+      @key.user_ref = current_user.id
+      @key.data = SecureRandom.hex(20)
+      if @key.save
+        redirect_to action: "show", id: @key.id
+      else
+        render :action => "edit"
+      end
+    end
+  end
+
+  def destroy
+    @key = ThirdPartyKey.find(params[:id])
+    if @key.user_ref != current_user.id
+      redirect_to @key
+    else
+      event = ThirdPartyKeyEvent.new
+      event.save
+      @key.revoked_ref = event.id
+      if @key.save
+        redirect_to @key
+      else
+        redirect_to action: "edit"
+      end
+    end
+  end
+end

--- a/app/controllers/third_party_keys_controller.rb
+++ b/app/controllers/third_party_keys_controller.rb
@@ -1,4 +1,6 @@
 class ThirdPartyKeysController < ApplicationController
+  skip_authorization_check
+
   layout "site"
 
   before_action :authorize

--- a/app/controllers/third_party_services_controller.rb
+++ b/app/controllers/third_party_services_controller.rb
@@ -1,4 +1,6 @@
 class ThirdPartyServicesController < ApplicationController
+  skip_authorization_check
+
   require "xml/libxml"
 
   layout "site"

--- a/app/controllers/third_party_services_controller.rb
+++ b/app/controllers/third_party_services_controller.rb
@@ -1,0 +1,104 @@
+class ThirdPartyServicesController < ApplicationController
+  require "xml/libxml"
+
+  layout "site"
+
+  #skip_before_action :verify_authenticity_token
+  before_action :authorize, :only => [:index, :create, :edit, :show, :update, :destroy]
+  before_action :authorize_web, :only => [:index, :create, :edit, :show, :update, :destroy]
+  before_action :set_locale, :only => [:index, :create, :edit, :update, :destroy]
+  before_action :require_user, :only => [:index, :create, :edit, :update, :destroy]
+  around_action :api_call_handle_error, :api_call_timeout
+
+  def index
+    @services = ThirdPartyService.all.where(user_ref: current_user.id)
+  end
+
+  def create
+    @service = ThirdPartyService.new(application_params)
+    @service.user_ref = current_user.id
+    @service.access_key = SecureRandom.hex(20)
+    if @service.save
+      redirect_to action: "show", id: @service.id
+    else
+      render :action => "new"
+    end
+  end
+
+  def edit
+    @service = ThirdPartyService.find(params[:id])
+    if !(@service && @service.user_ref == current_user.id)
+      render :action => "show"
+    end
+  end
+
+  def show
+    @service = ThirdPartyService.find(params[:id])
+    @service_owner = User.find(@service.user_ref)
+  rescue ActiveRecord::RecordNotFound
+    redirect_to action: "index"
+  end
+
+  def update
+    @service = ThirdPartyService.find(params[:id])
+    if @service.user_ref != current_user.id
+      redirect_to @service
+    else
+      @service.access_key = SecureRandom.hex(20)
+      if @service.save
+        redirect_to @service
+      else
+        redirect_to action: "edit"
+      end
+    end
+  end
+
+  def destroy
+    @service = ThirdPartyService.find(params[:id])
+    if @service.user_ref != current_user.id
+      redirect_to @service
+    else
+      @service.access_key = ''
+      if @service.save
+        redirect_to @service
+      else
+        redirect_to action: "edit"
+      end
+    end
+  end
+
+  def retrieve_keys
+    raise OSM::APIBadUserInput, "The parameters service, key, and beyond are required" unless params["service"] && params["key"] && params["beyond"]
+
+    service = ThirdPartyService.find_by uri: params["service"]
+    raise OSM::APIBadUserInput, "Service not found" unless service
+    raise OSM::APIPreconditionFailedError, "Access key does not match" unless service.access_key == params["key"]
+
+    beyond = params[:beyond]
+
+    doc = OSM::API.new.get_xml_credentials_doc
+
+    ThirdPartyKey.where("third_party_service_id = ? and revoked_ref > ? and created_ref <= ?",
+        service.id, beyond, beyond).each do |key|
+      doc.root << key.to_xml_for_retrieve
+    end
+    ThirdPartyKey.where("third_party_service_id = ? and created_ref > ? and (revoked_ref is null or revoked_ref = 0)",
+        service.id, beyond).each do |key|
+      doc.root << key.to_xml_for_retrieve
+    end
+
+    latest_event = ThirdPartyKeyEvent.last
+
+    el = XML::Node.new "keyid"
+    el["max"] = latest_event ? latest_event.id.to_s : "0"
+    doc.root << el
+
+    render :xml => doc.to_s
+  end
+
+  private
+
+  def application_params
+    params.require(:third_party_service).permit(:uri)
+  end
+end

--- a/app/models/third_party_key.rb
+++ b/app/models/third_party_key.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: third_party_keys
+#
+#  id                     :bigint(8)        not null, primary key
+#  third_party_service_id :bigint(8)
+#  user_ref               :bigint(8)
+#  data                   :string
+#  created_ref            :bigint(8)
+#  revoked_ref            :bigint(8)
+#
+# Indexes
+#
+#  index_third_party_keys_on_third_party_service_id  (third_party_service_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_ref => third_party_key_events.id)
+#  fk_rails_...  (revoked_ref => third_party_key_events.id)
+#  fk_rails_...  (third_party_service_id => third_party_services.id)
+#  fk_rails_...  (user_ref => users.id)
+#
+
+class ThirdPartyKey < ActiveRecord::Base
+  belongs_to :third_party_service
+
+  def to_xml_for_retrieve
+    if revoked_ref then
+      el = XML::Node.new "revoked"
+      el["key"] = data
+      el
+    else
+      el = XML::Node.new "apikey"
+      el["key"] = data
+      if created_ref then
+        event = ThirdPartyKeyEvent.find(created_ref);
+        el["created"] = event.created_at.xmlschema
+      end
+      el
+    end
+  end
+end

--- a/app/models/third_party_key_event.rb
+++ b/app/models/third_party_key_event.rb
@@ -1,0 +1,10 @@
+# == Schema Information
+#
+# Table name: third_party_key_events
+#
+#  id         :bigint(8)        not null, primary key
+#  created_at :datetime         not null
+#
+
+class ThirdPartyKeyEvent < ActiveRecord::Base
+end

--- a/app/models/third_party_service.rb
+++ b/app/models/third_party_service.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: third_party_services
+#
+#  id         :bigint(8)        not null, primary key
+#  user_ref   :bigint(8)
+#  uri        :string
+#  access_key :string
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_ref => users.id)
+#
+
+class ThirdPartyService < ActiveRecord::Base
+  self.table_name = "third_party_services"
+
+  has_many :third_party_keys
+
+  validates :uri, :uniqueness => true
+end

--- a/app/views/third_party_keys/edit.html.erb
+++ b/app/views/third_party_keys/edit.html.erb
@@ -1,0 +1,49 @@
+<% content_for :heading do %>
+  <h1><%= t '.title' %></h1>
+  <ul class='secondary-actions clearfix'>
+    <li><%= link_to t('third_party_keys.index.title'), third_party_keys_path %></li>
+  </ul>
+<% end %>
+
+<p>
+  <% if @key.third_party_service %>
+  <strong><%= @key.third_party_service[:uri] %></strong>
+  <% else %>
+  <strong>Error: Key is an orphan</strong>
+  <% end %>
+  <br/>
+  <% if @key.user_ref == current_user.id %>
+    <% if @key.data != ''&& !@key.revoked_ref %>
+    Key: <%= @key.data %><br/>
+    <% else %>
+      <% if @key.third_party_service && @key.third_party_service.access_key == '' %>
+      <em>Service has been discontinued</em><br/>
+      <% else %>
+      <em>Key has been revoked</em><br/>
+      <% end %>
+    <% end %>
+  <% else %>
+  <em>This key does not belong to you</em>
+  <% end %>
+</p>
+
+<%= form_with model: @key, local: true do |f| %>
+<% if @key && @key.errors.any? %>
+<p><strong>Cannot update this key.</strong>
+Reasons:
+<ul>
+<% @key.errors.full_messages.each do |msg| %>
+   <li>&nbsp;&nbsp;<strong><%= msg %></strong></li>
+<% end %>
+</ul>
+</p>
+<% end %>
+
+  <% if @key.user_ref == current_user.id %>
+  <%= f.submit 'Renew API Key' %>
+  <% end %>
+<% end %>
+
+<p>&nbsp;</p> <!-- Fix vertical spacing -->
+
+<p><%= link_to t('third_party_keys.revoke.title'), third_party_key_path, method: :delete %></p>

--- a/app/views/third_party_keys/index.html.erb
+++ b/app/views/third_party_keys/index.html.erb
@@ -1,0 +1,33 @@
+<% content_for :heading do %>
+  <h1><%= t '.title' %></h1>
+  <ul class='secondary-actions clearfix'>
+    <li><%= link_to t('.return to profile'), user_path(current_user) %></li>
+    <li><%= link_to t('third_party_keys.index.title'), third_party_keys_path %></li>
+    <li><%= link_to t('third_party_services.index.title'), third_party_services_path %></li>
+  </ul>
+<% end %>
+
+<h3><%= t '.get_new_key' %></h3>
+
+<table>
+<% @keys.each do |key| %>
+  <tr>
+  <% if key.third_party_service %>
+  <td><%= link_to key.third_party_service[:uri], edit_third_party_key_path(key) %></td>
+  <% else %>
+  <td><em>Error: Key is an orphan</em></td>
+  <% end %>
+  <% if key.data != ''&& !key.revoked_ref %>
+  <td><%= key.data %></td>
+  <% else %>
+    <% if key.third_party_service && key.third_party_service.access_key == '' %>
+    <td><em>Service discontinued</em></td>
+    <% else %>
+    <td><em>Revoked</em></td>
+    <% end %>
+  <% end %>
+  </tr>
+<% end %>
+</table>
+
+<%= link_to t('third_party_keys.new.title'), new_third_party_key_path %>

--- a/app/views/third_party_keys/new.html.erb
+++ b/app/views/third_party_keys/new.html.erb
@@ -1,0 +1,59 @@
+<% content_for :heading do %>
+  <h1><%= t '.title' %></h1>
+  <ul class='secondary-actions clearfix'>
+    <li><%= link_to t('third_party_keys.index.title'), third_party_keys_path %></li>
+  </ul>
+<% end %>
+
+<%= form_with scope: :third_party_key, url: third_party_keys_path, local: true do |f| %>
+<% if @error || (@key && @key.errors.any?) %>
+<p><strong>Cannot create this key.</strong>
+Reasons:
+<ul>
+<% if @error %>
+  <li>&nbsp;&nbsp;<strong><%= @error %></strong></li>
+<% end %>
+<% if @key && @key.errors.any? %>
+<% @key.errors.full_messages.each do |msg| %>
+  <li>&nbsp;&nbsp;<strong><%= msg %></strong></li>
+<% end %>
+<% end %>
+</ul>
+</p>
+<% end %>
+
+<p>For the sake of privacy protection,
+you need to prove to any 3rd party service that works with privacy relevant OSM data
+that you are a genuine OSM user yourself.</p>
+
+<p>While you could sign up with OSM crendentials there
+we would like to protect the privacy of your OSM account there, too.
+For that purpose we generate per OSM user and third party service one or more API keys
+such that you can prove to the service that you are an OSM user.
+We tell the service the key but not your user name.
+Thus the service cannot identify you beyond being an OSM user.</p>
+
+<p>The sole purpose of this API key is to transmit it as a credential to the respective service.
+<strong>Do not publish this key or send it to somebody else</strong>.
+If your key has been lost, you can at any time get here a new one.
+The old one is revoked automatically in that process.</p>
+
+<%= f.label :gdpr do %>
+  <%= f.check_box :gdpr %>
+  I understand that the data of other OSM users is subject to the GDPR and I may store or process it only for a legitimate reason.
+<% end %>
+<br/>
+<%= f.label :disclose do %>
+  <%= f.check_box :disclose %>
+  I confirm that I may hand over the key to at least some third parties if I am asked to do so.
+<% end %>
+<br/>
+<%= f.label :attentive do %>
+  <%= f.check_box :attentive %>
+  I confirm that I missed the content of the text.
+<% end %>
+<br/><br/>
+
+<%= f.select :service_to_use, ThirdPartyService.where.not(access_key: '').all.map { |s| s.uri } %>
+<%= f.submit 'Get Key' %>
+<% end %>

--- a/app/views/third_party_keys/show.html.erb
+++ b/app/views/third_party_keys/show.html.erb
@@ -1,0 +1,31 @@
+<% content_for :heading do %>
+  <h1><%= t '.title' %></h1>
+  <ul class='secondary-actions clearfix'>
+    <li><%= link_to t('third_party_keys.index.title'), third_party_keys_path %></li>
+  </ul>
+<% end %>
+
+<% if @key.user_ref == current_user.id %>
+
+<p>
+  <strong><%= @key.third_party_service[:uri] %></strong><br/>
+  <% if @key.data != '' && !@key.revoked_ref %>
+  Key: <%= @key.data %><br/>
+  <% else %>
+    <% if @key.third_party_service && @key.third_party_service.access_key == '' %>
+    <em>Service has been discontinued</em><br/>
+    <% else %>
+    <em>Key has been revoked</em><br/>
+    <% end %>
+  <% end %>
+</p>
+
+<p><%= link_to t('third_party_keys.edit.title'), edit_third_party_key_path %></p>
+
+<% else %>
+
+<p>
+  <em>This key does not belong to you</em>
+</p>
+
+<% end %>

--- a/app/views/third_party_services/edit.html.erb
+++ b/app/views/third_party_services/edit.html.erb
@@ -1,0 +1,38 @@
+<% content_for :heading do %>
+  <h1><%= t '.title' %></h1>
+  <ul class='secondary-actions clearfix'>
+    <li><%= link_to t('third_party_services.index.title'), third_party_services_path %></li>
+  </ul>
+<% end %>
+
+<p>
+  <strong><%= @service.uri %></strong><br/>
+  <% if @service.user_ref == current_user.id %>
+    <% if @service.access_key != '' %>
+    Key: <%= @service.access_key %><br/>
+    <% else %>
+    <em>Service inactive</em>, service key is revoked<br/>
+    <% end %>
+  <% end %>
+</p>
+
+<%= form_with model: @service, local: true do |f| %>
+<% if @service && @service.errors.any? %>
+<p><strong>Cannot update this service.</strong>
+Reasons:
+<ul>
+<% @service.errors.full_messages.each do |msg| %>
+   <li>&nbsp;&nbsp;<strong><%= msg %></strong></li>
+<% end %>
+</ul>
+</p>
+<% end %>
+
+  <% if @service.user_ref == current_user.id %>
+  <%= f.submit 'Request New Service Key' %>
+  <% end %>
+<% end %>
+
+<p>&nbsp;</p> <!-- Fix vertical spacing -->
+
+<p><%= link_to t('third_party_services.discontinue.title'), third_party_service_path, method: :delete %></p>

--- a/app/views/third_party_services/index.html.erb
+++ b/app/views/third_party_services/index.html.erb
@@ -1,0 +1,15 @@
+<% content_for :heading do %>
+  <h1><%= t '.title' %></h1>
+<% end %>
+
+<ul>
+<% @services.each do |service| %>
+  <% if service.access_key != '' %>
+  <li><%= link_to service.uri, edit_third_party_service_path(service) %></li>
+  <% else %>
+  <li><s><%= link_to service.uri, edit_third_party_service_path(service) %></s></li>
+  <% end %>
+<% end %>
+</ul>
+
+<%= link_to t('third_party_services.new.title'), new_third_party_service_path %>

--- a/app/views/third_party_services/new.html.erb
+++ b/app/views/third_party_services/new.html.erb
@@ -1,0 +1,31 @@
+<% content_for :heading do %>
+  <h1><%= t '.title' %></h1>
+  <ul class='secondary-actions clearfix'>
+    <li><%= link_to t('third_party_services.index.title'), third_party_services_path %></li>
+  </ul>
+<% end %>
+
+<p>OpenStreetMap offers a mechanism to confirm that somebody is an OSM user without revealing the user's identity.
+If you need such a mechanism for your service then you can announce it here.</p>
+
+<p>Users then can create keys on their own via the <em>third_party_keys</em> page.
+Your service shall use the <em>API key API</em> to retrieve the keys that are valid for your service.</p>
+
+<p>We suggest that you use a URI that is associated with your service as identifier for the service.
+That way it is ensured that the service identifiers are unique.</p>
+
+<%= form_with scope: :third_party_service, url: third_party_services_path, local: true do |f| %>
+<% if @service && @service.errors.any? %>
+<p><strong>Cannot create this service.</strong>
+Reasons:
+<ul>
+<% @service.errors.full_messages.each do |msg| %>
+   <li>&nbsp;&nbsp;<strong><%= msg %></strong></li>
+<% end %>
+</ul>
+</p>
+<% end %>
+
+<%= f.text_field :uri %>
+<%= f.submit 'Announce Service' %>
+<% end %>

--- a/app/views/third_party_services/show.html.erb
+++ b/app/views/third_party_services/show.html.erb
@@ -1,0 +1,32 @@
+<% content_for :heading do %>
+  <h1><%= t '.title' %></h1>
+  <ul class='secondary-actions clearfix'>
+    <li><%= link_to t('third_party_services.index.title'), third_party_services_path %></li>
+  </ul>
+<% end %>
+
+<% if current_user && @service.user_ref == current_user.id %>
+
+<p>
+  <strong><%= @service.uri %></strong><br/>
+  <% if @service.access_key != '' %>
+  Key: <%= @service.access_key %><br/>
+  <% else %>
+  <em>Service inactive</em>, service key is revoked<br/>
+  <% end %>
+</p>
+
+<p><%= link_to t('third_party_services.edit.title'), edit_third_party_service_path %></p>
+
+<% else %>
+
+<p>
+  <strong><%= @service.uri %></strong><br/>
+  <% if @service_owner %>
+  Registered by: <%= @service_owner.display_name %><br/>
+  <% else %>
+  Registered by: User #<%= @service.user_ref %><br/>
+  <% end %>
+</p>
+
+<% end %>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -7,6 +7,8 @@
   <ul class='secondary-actions clearfix'>
     <li><%= link_to t('.return to profile'), user_path(current_user) %></li>
     <li><%= link_to t('users.show.oauth settings'), :controller => 'oauth_clients', :action => 'index' %></li>
+    <li><%= link_to t('third_party_keys.index.title'), third_party_keys_path %></li>
+    <li><%= link_to t('third_party_services.index.title'), third_party_services_path %></li>
   </ul>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,10 +6,6 @@ en:
       friendly: "%e %B %Y at %H:%M"
       blog: "%e %B %Y"
   activerecord:
-    errors:
-      messages:
-        invalid_email_address: does not appear to be a valid e-mail address
-        email_address_not_routable: is not routable
     # Translates all the model names, which is used in error handling on the web site
     models:
       acl: "Access Control List"
@@ -868,7 +864,7 @@ en:
           "yes": "Shop"
         tourism:
           alpine_hut: "Alpine Hut"
-          apartment: "Holiday Apartment"
+          apartment: "Apartment"
           artwork: "Artwork"
           attraction: "Attraction"
           bed_and_breakfast: "Bed and Breakfast"
@@ -1630,7 +1626,7 @@ en:
       edit: Edit
       preview: Preview
     markdown_help:
-      title_html: Parsed with <a href="https://kramdown.gettalong.org/quickref.html">kramdown</a>
+      title_html: Parsed with <a href="https://daringfireball.net/projects/markdown/">Markdown</a>
       headings: Headings
       heading: Heading
       subheading: Subheading
@@ -1881,6 +1877,7 @@ en:
       no_apps: "Do you have an application you would like to register for use with us using the %{oauth} standard? You must register your web application before it can make OAuth requests to this service."
       registered_apps: "You have the following client applications registered:"
       register_new: "Register your application"
+      foobar: "This is an h3 Headline"
     form:
       name: "Name"
       required: "Required"
@@ -1903,6 +1900,28 @@ en:
       flash: "Updated the client information successfully"
     destroy:
       flash: "Destroyed the client application registration"
+  third_party_keys:
+    new:
+      title: "Request a New API Key"
+    index:
+      title: "My API Keys for 3rd Party Services"
+    edit:
+      title: "Administer this API Key"
+    revoke:
+      title: "Revoke this API key"
+    show:
+      title: "Show Registered Service For API Keys"
+  third_party_services:
+    index:
+      title: "My Registered Services For API Keys"
+    new:
+      title: "Announce New Service For API Keys"
+    edit:
+      title: "Administer Service"
+    discontinue:
+      title: "Discontinue Service"
+    show:
+      title: "Show Registered Service For API Keys"
   users:
     login:
       title: "Login"
@@ -2179,6 +2198,8 @@ en:
       button: "Unfriend"
       success: "%{name} was removed from your friends."
       not_a_friend: "%{name} is not one of your friends."
+    filter:
+      not_an_administrator: "You need to be an administrator to perform that action."
     index:
       title: Users
       heading: Users
@@ -2442,12 +2463,13 @@ en:
     directions:
       ascend: "Ascend"
       engines:
-        fossgis_osrm_bike: "Bicycle (OSRM)"
-        fossgis_osrm_car: "Car (OSRM)"
-        fossgis_osrm_foot: "Foot (OSRM)"
         graphhopper_bicycle: "Bicycle (GraphHopper)"
         graphhopper_car: "Car (GraphHopper)"
         graphhopper_foot: "Foot (GraphHopper)"
+        mapquest_bicycle: "Bicycle (MapQuest)"
+        mapquest_car: "Car (MapQuest)"
+        mapquest_foot: "Foot (MapQuest)"
+        osrm_car: "Car (OSRM)"
       descend: "Descend"
       directions: "Directions"
       distance: "Distance"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ OpenStreetMap::Application.routes.draw do
     post "changeset/:id/upload" => "changesets#upload", :id => /\d+/
     get "changeset/:id/download" => "changesets#download", :as => :changeset_download, :id => /\d+/
     post "changeset/:id/expand_bbox" => "changesets#expand_bbox", :id => /\d+/
-    get "changeset/:id" => "changesets#show", :as => :changeset_show, :id => /\d+/
+    get "changeset/:id" => "changesets#read", :as => :changeset_read, :id => /\d+/
     post "changeset/:id/subscribe" => "changesets#subscribe", :as => :changeset_subscribe, :id => /\d+/
     post "changeset/:id/unsubscribe" => "changesets#unsubscribe", :as => :changeset_unsubscribe, :id => /\d+/
     put "changeset/:id" => "changesets#update", :id => /\d+/
@@ -26,10 +26,10 @@ OpenStreetMap::Application.routes.draw do
     get "node/:id/history" => "old_nodes#history", :id => /\d+/
     post "node/:id/:version/redact" => "old_nodes#redact", :version => /\d+/, :id => /\d+/
     get "node/:id/:version" => "old_nodes#version", :id => /\d+/, :version => /\d+/
-    get "node/:id" => "nodes#show", :id => /\d+/
+    get "node/:id" => "nodes#read", :id => /\d+/
     put "node/:id" => "nodes#update", :id => /\d+/
     delete "node/:id" => "nodes#delete", :id => /\d+/
-    get "nodes" => "nodes#index"
+    get "nodes" => "nodes#nodes"
 
     put "way/create" => "ways#create"
     get "way/:id/history" => "old_ways#history", :id => /\d+/
@@ -37,10 +37,10 @@ OpenStreetMap::Application.routes.draw do
     get "way/:id/relations" => "relations#relations_for_way", :id => /\d+/
     post "way/:id/:version/redact" => "old_ways#redact", :version => /\d+/, :id => /\d+/
     get "way/:id/:version" => "old_ways#version", :id => /\d+/, :version => /\d+/
-    get "way/:id" => "ways#show", :id => /\d+/
+    get "way/:id" => "ways#read", :id => /\d+/
     put "way/:id" => "ways#update", :id => /\d+/
     delete "way/:id" => "ways#delete", :id => /\d+/
-    get "ways" => "ways#index"
+    get "ways" => "ways#ways"
 
     put "relation/create" => "relations#create"
     get "relation/:id/relations" => "relations#relations_for_relation", :id => /\d+/
@@ -48,10 +48,10 @@ OpenStreetMap::Application.routes.draw do
     get "relation/:id/full" => "relations#full", :id => /\d+/
     post "relation/:id/:version/redact" => "old_relations#redact", :version => /\d+/, :id => /\d+/
     get "relation/:id/:version" => "old_relations#version", :id => /\d+/, :version => /\d+/
-    get "relation/:id" => "relations#show", :id => /\d+/
+    get "relation/:id" => "relations#read", :id => /\d+/
     put "relation/:id" => "relations#update", :id => /\d+/
     delete "relation/:id" => "relations#delete", :id => /\d+/
-    get "relations" => "relations#index"
+    get "relations" => "relations#relations"
 
     get "map" => "api#map"
 
@@ -106,6 +106,9 @@ OpenStreetMap::Application.routes.draw do
     post "notes/editPOIexec" => "notes#comment"
     get "notes/getGPX" => "notes#index", :format => "gpx"
     get "notes/getRSSfeed" => "notes#feed", :format => "rss"
+
+    # third party API keys
+    get "third_party_services/keys" => "third_party_services#retrieve_keys"
   end
 
   # Data browsing
@@ -274,6 +277,9 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/outbox", :to => redirect(:path => "/messages/outbox")
   get "/message/new/:display_name" => "messages#new", :as => "new_message"
   get "/message/read/:message_id", :to => redirect(:path => "/messages/%{message_id}")
+
+  resources :third_party_keys
+  resources :third_party_services
 
   # oauth admin pages (i.e: for setting up new clients, etc...)
   scope "/user/:display_name" do

--- a/db/migrate/20190213050630_create_third_party_keys_structures.rb
+++ b/db/migrate/20190213050630_create_third_party_keys_structures.rb
@@ -1,0 +1,26 @@
+class CreateThirdPartyKeysStructures < ActiveRecord::Migration[5.2]
+  def change
+    create_table :third_party_services do |t|
+      t.bigint :user_ref
+      t.string :uri
+      t.string :access_key
+    end
+    add_foreign_key :third_party_services, :users, column: :user_ref, primary_key: "id"
+
+    create_table :third_party_key_events do |t|
+      t.datetime :created_at, null: false
+    end
+
+    create_table :third_party_keys do |t|
+      t.references :third_party_service, foreign_key: true
+      t.bigint :created_ref
+      t.bigint :revoked_ref
+      t.bigint :user_ref
+      t.string :data
+    end
+
+    add_foreign_key :third_party_keys, :third_party_key_events, column: :created_ref, primary_key: "id"
+    add_foreign_key :third_party_keys, :third_party_key_events, column: :revoked_ref, primary_key: "id"
+    add_foreign_key :third_party_keys, :users, column: :user_ref, primary_key: "id"
+  end
+end

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -494,19 +494,23 @@ module OSM
       doc = XML::Document.new
       doc.encoding = XML::Encoding::UTF_8
       root = XML::Node.new "osm"
-      xml_root_attributes.each do |k, v|
-        root[k] = v
-      end
+      root["version"] = API_VERSION.to_s
+      root["generator"] = GENERATOR
+      root["copyright"] = COPYRIGHT_OWNER
+      root["attribution"] = ATTRIBUTION_URL
+      root["license"] = LICENSE_URL
       doc.root = root
       doc
     end
 
-    def xml_root_attributes
-      { "version" => API_VERSION.to_s,
-        "generator" => GENERATOR,
-        "copyright" => COPYRIGHT_OWNER,
-        "attribution" => ATTRIBUTION_URL,
-        "license" => LICENSE_URL }
+    def get_xml_credentials_doc
+      doc = XML::Document.new
+      doc.encoding = XML::Encoding::UTF_8
+      root = XML::Node.new "osm"
+      root["version"] = API_VERSION.to_s
+      root["generator"] = GENERATOR
+      doc.root = root
+      doc
     end
   end
 

--- a/test/controllers/third_party_keys_controller_test.rb
+++ b/test/controllers/third_party_keys_controller_test.rb
@@ -1,0 +1,193 @@
+require "test_helper"
+
+class ThirdPartyKeysControllerTest < ActionController::TestCase
+  ##
+  # test all routes which lead to this controller
+  def test_routes
+    assert_routing(
+      { :path => "/third_party_keys", :method => :post },
+      { :controller => "third_party_keys", :action => "create" }
+    )
+    assert_routing(
+      { :path => "/third_party_keys", :method => :get },
+      { :controller => "third_party_keys", :action => "index" }
+    )
+    assert_routing(
+      { :path => "/third_party_keys/1", :method => :get },
+      { :controller => "third_party_keys", :action => "show", :id => "1" }
+    )
+    assert_routing(
+      { :path => "/third_party_keys/1/edit", :method => :get },
+      { :controller => "third_party_keys", :action => "edit", :id => "1" }
+    )
+    assert_routing(
+      { :path => "/third_party_keys/1", :method => :put },
+      { :controller => "third_party_keys", :action => "update", :id => "1" }
+    )
+    assert_routing(
+      { :path => "/third_party_keys/1", :method => :delete },
+      { :controller => "third_party_keys", :action => "destroy", :id => "1" }
+    )
+  end
+
+  def test_direct_create
+    user = create(:user)
+    alt_user = create(:user)
+    service = ThirdPartyService.new
+    service.user_ref = user.id
+    service.uri = "key-create.test"
+    service.access_key = "aaaa123456789012345678901234567890bbccdd"
+    assert service.save
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 0
+
+    post :create
+    assert_response :unauthorized, "third_party_keys create did not return unauthorized status"
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 0
+
+    basic_authorization user.email, "test"
+    post :create, :params => { :third_party_key =>
+        { :gdpr => "0", :attentive => "1", :disclose => "0", :service_to_use => "key-create.test" } }
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 0
+
+    basic_authorization user.email, "test"
+    post :create, :params => { :third_party_key =>
+        { :gdpr => "1", :attentive => "1", :disclose => "0", :service_to_use => "key-create.test" } }
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 0
+
+    basic_authorization user.email, "test"
+    post :create, :params => { :third_party_key =>
+        { :gdpr => "1", :attentive => "0", :disclose => "1", :service_to_use => "key-create.test" } }
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 0
+
+    basic_authorization user.email, "test"
+    post :create, :params => { :third_party_key =>
+        { :gdpr => "1", :attentive => "0", :disclose => "0", :service_to_use => "key-create.test" } }
+    assert_response :redirect, "third_party_keys create did not forward to show"
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 1
+    assert found_keys[0].user_ref == user.id
+    assert found_keys[0].data && found_keys[0].data.length == 40
+    assert found_keys[0].created_ref > 0
+    assert !found_keys[0].revoked_ref
+
+    basic_authorization alt_user.email, "test"
+    post :create, :params => { :third_party_key =>
+        { :gdpr => "1", :attentive => "0", :disclose => "0", :service_to_use => "key-create.test" } }
+    assert_response :redirect, "third_party_keys create did not forward to show"
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 2
+    assert ((found_keys[0].user_ref == user.id && found_keys[1].user_ref == alt_user.id) || (found_keys[1].user_ref == user.id && found_keys[0].user_ref == alt_user.id))
+    assert found_keys[0].data && found_keys[0].data.length == 40
+    assert found_keys[1].data && found_keys[1].data.length == 40
+    assert found_keys[0].data != found_keys[1].data
+    assert found_keys[0].created_ref > 0 && !found_keys[0].revoked_ref
+    assert found_keys[1].created_ref > 0 && !found_keys[1].revoked_ref
+  end
+
+  def test_direct_update
+    user = create(:user)
+    alt_user = create(:user)
+    service = ThirdPartyService.new
+    service.user_ref = user.id
+    service.uri = "key-update.test"
+    service.access_key = "aaaa123456789012345678901234567890bbccdd"
+    assert service.save
+
+    #Create key to update
+    key_event_1 = ThirdPartyKeyEvent.new
+    assert key_event_1.save
+    old_key = ThirdPartyKey.new
+    old_key.created_ref = key_event_1.id
+    old_key.data = "cccccc123456789012345678901234567890bbccdd"
+    old_key.user_ref = alt_user.id
+    old_key.third_party_service = service
+    assert old_key.save
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 1
+    assert found_keys[0].user_ref == alt_user.id
+    assert found_keys[0].data == "cccccc123456789012345678901234567890bbccdd"
+    assert found_keys[0].created_ref == key_event_1.id && !found_keys[0].revoked_ref
+
+    # User A cannot change user B's key
+    basic_authorization user.email, "test"
+    put :update, :params => { :id => old_key.id }
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 1
+    assert found_keys[0].user_ref == alt_user.id
+    assert found_keys[0].data == "cccccc123456789012345678901234567890bbccdd"
+    assert found_keys[0].created_ref == key_event_1.id && !found_keys[0].revoked_ref
+
+    # An update triggers a revoke plus a new key
+    basic_authorization alt_user.email, "test"
+    put :update, :params => { :id => old_key.id }
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 2
+    assert found_keys[0].user_ref == alt_user.id && found_keys[1].user_ref == alt_user.id
+    assert found_keys[0].data == "cccccc123456789012345678901234567890bbccdd"
+    assert found_keys[1].data && found_keys[1].data.length == 40
+    assert found_keys[1].data != "cccccc123456789012345678901234567890bbccdd"
+    assert found_keys[0].created_ref == key_event_1.id && found_keys[0].revoked_ref > 0
+    assert found_keys[1].created_ref > 0 && !found_keys[1].revoked_ref
+  end
+
+  def test_direct_destroy
+    user = create(:user)
+    alt_user = create(:user)
+    service = ThirdPartyService.new
+    service.user_ref = user.id
+    service.uri = "key-update.test"
+    service.access_key = "aaaa123456789012345678901234567890bbccdd"
+    assert service.save
+
+    #Create key to delete
+    key_event_1 = ThirdPartyKeyEvent.new
+    assert key_event_1.save
+    old_key = ThirdPartyKey.new
+    old_key.created_ref = key_event_1.id
+    old_key.data = "cccccc123456789012345678901234567890bbccdd"
+    old_key.user_ref = alt_user.id
+    old_key.third_party_service = service
+    assert old_key.save
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 1
+    assert found_keys[0].user_ref == alt_user.id
+    assert found_keys[0].data == "cccccc123456789012345678901234567890bbccdd"
+    assert found_keys[0].created_ref == key_event_1.id && !found_keys[0].revoked_ref
+
+    # User A cannot delete user B's key
+    basic_authorization user.email, "test"
+    put :destroy, :params => { :id => old_key.id }
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 1
+    assert found_keys[0].user_ref == alt_user.id
+    assert found_keys[0].data == "cccccc123456789012345678901234567890bbccdd"
+    assert found_keys[0].created_ref == key_event_1.id && !found_keys[0].revoked_ref
+
+    # An update fills revoked_ref with a meaningful reference
+    basic_authorization alt_user.email, "test"
+    put :destroy, :params => { :id => old_key.id }
+
+    found_keys = ThirdPartyKey.where(third_party_service_id: service)
+    assert found_keys.count == 1
+    assert found_keys[0].user_ref == alt_user.id
+    assert found_keys[0].data == "cccccc123456789012345678901234567890bbccdd"
+    assert found_keys[0].created_ref == key_event_1.id && found_keys[0].revoked_ref > 0
+  end
+end

--- a/test/controllers/third_party_services_controller_test.rb
+++ b/test/controllers/third_party_services_controller_test.rb
@@ -1,0 +1,375 @@
+require "test_helper"
+
+class ThirdPartyServicesControllerTest < ActionController::TestCase
+  ##
+  # test all routes which lead to this controller
+  def test_routes
+    assert_routing(
+      { :path => "/third_party_services", :method => :post },
+      { :controller => "third_party_services", :action => "create" }
+    )
+    assert_routing(
+      { :path => "/third_party_services", :method => :get },
+      { :controller => "third_party_services", :action => "index" }
+    )
+    assert_routing(
+      { :path => "/third_party_services/1", :method => :get },
+      { :controller => "third_party_services", :action => "show", :id => "1" }
+    )
+    assert_routing(
+      { :path => "/third_party_services/1/edit", :method => :get },
+      { :controller => "third_party_services", :action => "edit", :id => "1" }
+    )
+    assert_routing(
+      { :path => "/third_party_services/1", :method => :put },
+      { :controller => "third_party_services", :action => "update", :id => "1" }
+    )
+    assert_routing(
+      { :path => "/third_party_services/1", :method => :delete },
+      { :controller => "third_party_services", :action => "destroy", :id => "1" }
+    )
+    assert_routing(
+      { :path => "/api/0.6/third_party_services/keys", :method => :get },
+      { :controller => "third_party_services", :action => "retrieve_keys" }
+    )
+  end
+
+  def test_direct_create
+    user = create(:user)
+
+    post :create
+    assert_response :unauthorized, "third_party_services create did not return unauthorized status"
+
+    basic_authorization user.email, "test"
+    post :create, :params => { :third_party_service => { :uri => "direct-create.test" } }
+    assert_response :redirect, "third_party_services create did not forward to show"
+
+    service = ThirdPartyService.find_by uri: "direct-create.test"
+    assert service
+    assert service.user_ref == user.id
+    assert service.uri == "direct-create.test"
+    assert service.access_key && service.access_key.length == 40
+  end
+
+  def test_no_double_create
+    user = create(:user)
+    service = ThirdPartyService.new
+    service.user_ref = user.id
+    service.uri = "direct-create-orig.test"
+    service.access_key = "aaaa123456789012345678901234567890bbccdd"
+    assert service.save
+
+    alt_user = create(:user)
+    assert user.id != alt_user.id && user.email != alt_user.email
+
+    basic_authorization alt_user.email, "test"
+    post :create, :params => { :third_party_service => { :uri => "direct-create-orig.test" } }
+
+    found_services = ThirdPartyService.where(uri: "direct-create-orig.test")
+    assert found_services.count == 1
+    assert found_services[0].id == service.id
+    assert found_services[0].user_ref == user.id
+
+    basic_authorization user.email, "test"
+    post :create, :params => { :third_party_service => { :uri => "direct-create-orig.test" } }
+
+    found_services = ThirdPartyService.where(uri: "direct-create-orig.test")
+    assert found_services.count == 1
+    assert found_services[0].id == service.id
+    assert found_services[0].user_ref == user.id
+  end
+
+  def test_direct_update
+    user = create(:user)
+    service = ThirdPartyService.new
+    service.user_ref = user.id
+    service.uri = "direct-update.test"
+    service.access_key = "aaaa123456789012345678901234567890bbccdd"
+    assert service.save
+
+    alt_user = create(:user)
+    assert user.id != alt_user.id && user.email != alt_user.email
+
+    basic_authorization alt_user.email, "test"
+    put :update, :params => { :id => service.id }
+
+    found_services = ThirdPartyService.where(uri: "direct-update.test")
+    assert found_services.count == 1
+    assert found_services[0].id == service.id
+    assert found_services[0].user_ref == user.id
+    assert found_services[0].access_key == service.access_key
+
+    basic_authorization user.email, "test"
+    put :update, :params => { :id => service.id }
+
+    found_services = ThirdPartyService.where(uri: "direct-update.test")
+    assert found_services.count == 1
+    assert found_services[0].id == service.id
+    assert found_services[0].user_ref == user.id
+    assert found_services[0].access_key && found_services[0].access_key.length == 40
+    assert found_services[0].access_key != service.access_key
+  end
+
+  def test_direct_destroy
+    user = create(:user)
+    service = ThirdPartyService.new
+    service.user_ref = user.id
+    service.uri = "direct-destroy.test"
+    service.access_key = "aaaa123456789012345678901234567890bbccdd"
+    assert service.save
+
+    alt_user = create(:user)
+    assert user.id != alt_user.id && user.email != alt_user.email
+
+    basic_authorization alt_user.email, "test"
+    post :destroy, :params => { :id => service.id }
+    assert_response :redirect, "third_party_services create did not forward to show for foreign user"
+
+    found_service = ThirdPartyService.find_by uri: "direct-destroy.test"
+    assert found_service
+    assert found_service.user_ref = user.id
+    assert found_service.access_key && found_service.access_key.length == 40
+
+    basic_authorization user.email, "test"
+    post :destroy, :params => { :id => service.id }
+    assert_response :redirect, "third_party_services create did not forward to show after revoking key"
+
+    found_service = ThirdPartyService.find_by uri: "direct-destroy.test"
+    assert found_service
+    assert found_service.user_ref = user.id
+    assert found_service.access_key == ""
+  end
+
+  def test_retrieve_keys_empty
+    user = create(:user)
+    service = ThirdPartyService.new
+    service.user_ref = user.id
+    service.uri = "retrieve-keys-empty.test"
+    service.access_key = "aaaa123456789012345678901234567890bbccdd"
+    assert service.save
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-empty.test", :key => service.access_key,
+                                     :beyond => 0 }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    assert response.find("//osm/keyid").count > 0
+  end
+
+  def test_retrieve_keys_full
+    user_1 = create(:user)
+    user_2 = create(:user)
+    user_3 = create(:user)
+    user_4 = create(:user)
+    service = ThirdPartyService.new
+    service.user_ref = user_1.id
+    service.uri = "retrieve-keys-full.test"
+    service.access_key = "aaaa123456789012345678901234567890bbccdd"
+    assert service.save
+
+    # Create three keys
+    key_event_1 = ThirdPartyKeyEvent.new
+    assert key_event_1.save
+    key_1 = ThirdPartyKey.new
+    key_1.created_ref = key_event_1.id
+    key_1.data = "01cccc123456789012345678901234567890bbccdd"
+    key_1.user_ref = user_1.id
+    key_1.third_party_service = service
+    assert key_1.save
+
+    key_event_2 = ThirdPartyKeyEvent.new
+    assert key_event_2.save
+    key_2 = ThirdPartyKey.new
+    key_2.created_ref = key_event_2.id
+    key_2.data = "02cccc123456789012345678901234567890bbccdd"
+    key_2.user_ref = user_2.id
+    key_2.third_party_service = service
+    assert key_2.save
+    assert key_1.created_ref < key_2.created_ref
+
+    key_event_3 = ThirdPartyKeyEvent.new
+    assert key_event_3.save
+    key_3 = ThirdPartyKey.new
+    key_3.created_ref = key_event_3.id
+    key_3.data = "03cccc123456789012345678901234567890bbccdd"
+    key_3.user_ref = user_3.id
+    key_3.third_party_service = service
+    assert key_3.save
+    assert key_2.created_ref < key_3.created_ref
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => 0 }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"] && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_3.id
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 3
+    apikeys.each do |key|
+      assert key["key"] && key["created"]
+    end
+    assert apikeys[0]["key"] == key_1.data
+    assert apikeys[1]["key"] == key_2.data
+    assert apikeys[2]["key"] == key_3.data
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => key_event_1.id }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"] && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_3.id
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 2
+    apikeys.each do |key|
+      assert key["key"] && key["created"]
+    end
+    assert apikeys[0]["key"] == key_2.data
+    assert apikeys[1]["key"] == key_3.data
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => key_event_2.id }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"] && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_3.id
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 1
+    apikeys.each do |key|
+      assert key["key"] && key["created"]
+    end
+    assert apikeys[0]["key"] == key_3.data
+
+    # Revoke one key
+    key_event_4 = ThirdPartyKeyEvent.new
+    assert key_event_4.save
+    key_1.revoked_ref = key_event_4.id
+    assert key_1.save
+    assert key_3.created_ref < key_1.revoked_ref
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => 0 }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"]  && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_4.id
+    revoked_keys = response.find("//osm/revoked")
+    assert revoked_keys.count == 0
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 2
+    apikeys.each do |key|
+      assert key["key"] && key["created"]
+    end
+    assert apikeys[0]["key"] == key_2.data
+    assert apikeys[1]["key"] == key_3.data
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => key_event_1.id }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"]  && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_4.id
+    revoked_keys = response.find("//osm/revoked")
+    assert revoked_keys.count == 1
+    assert revoked_keys[0]["key"]
+    assert revoked_keys[0]["key"] == key_1.data
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 2
+    apikeys.each do |key|
+      assert key["key"] && key["created"]
+    end
+    assert apikeys[0]["key"] == key_2.data
+    assert apikeys[1]["key"] == key_3.data
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => key_event_4.id }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"]  && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_4.id
+    revoked_keys = response.find("//osm/revoked")
+    assert revoked_keys.count == 0
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 0
+
+    # Create another one
+    key_event_5 = ThirdPartyKeyEvent.new
+    assert key_event_5.save
+    key_4 = ThirdPartyKey.new
+    key_4.created_ref = key_event_5.id
+    key_4.data = "05cccc123456789012345678901234567890bbccdd"
+    key_4.user_ref = user_4.id
+    key_4.third_party_service = service
+    assert key_4.save
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => 0 }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"]  && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_4.id
+    revoked_keys = response.find("//osm/revoked")
+    assert revoked_keys.count == 0
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 3
+    apikeys.each do |key|
+      assert key["key"] && key["created"]
+    end
+    assert apikeys[0]["key"] == key_2.data
+    assert apikeys[1]["key"] == key_3.data
+    assert apikeys[2]["key"] == key_4.data
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => key_event_1.id }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"]  && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_4.id
+    revoked_keys = response.find("//osm/revoked")
+    assert revoked_keys.count == 1
+    assert revoked_keys[0]["key"]
+    assert revoked_keys[0]["key"] == key_1.data
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 3
+    apikeys.each do |key|
+      assert key["key"] && key["created"]
+    end
+    assert apikeys[0]["key"] == key_2.data
+    assert apikeys[1]["key"] == key_3.data
+    assert apikeys[2]["key"] == key_4.data
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => key_event_4.id }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"]  && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_4.id
+    revoked_keys = response.find("//osm/revoked")
+    assert revoked_keys.count == 0
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 1
+    apikeys.each do |key|
+      assert key["key"] && key["created"]
+    end
+    assert apikeys[0]["key"] == key_4.data
+
+    get :retrieve_keys, :params => { :service => "retrieve-keys-full.test", :key => service.access_key,
+                                     :beyond => key_event_5.id }
+    assert :success
+    response = XML::Parser.string(@response.body).parse
+    keyid_nodes = response.find("//osm/keyid")
+    assert keyid_nodes.count == 1
+    assert keyid_nodes[0]["max"]  && keyid_nodes[0]["max"].to_f && keyid_nodes[0]["max"].to_f >= key_event_4.id
+    revoked_keys = response.find("//osm/revoked")
+    assert revoked_keys.count == 0
+    apikeys = response.find("//osm/apikey")
+    assert apikeys.count == 0
+  end
+end


### PR DESCRIPTION
This is an implementation of the API key dispenser intended to help with GDPR requirements.

It is as minimal as possible:
- OSM users can register services by submitting an URI for the service.
- OSM users can request an API key for each registered service.
- For a registered service there is a stream of new and revoked keys with a similar mechanism to the minute updates via the new API endpoint _third_party_services/keys_

The data held on the Main Db is
- a table of services where the URI is unique
- a ledger of keys, implemented as two tables where _third_party_keys_ hold the actual data and _third_party_key_events_ is used as a PG sequence to properly sort out create and revoke events

Tests with full coverage have been added. Please take the whole thing still with a grain of salt: I have little Rails experience. For example, _CanCan_ did insist in various error messages I should add _skip_authorization_check_ to every controller, but this does sound like the proper solution.