### PR TITLE
Enable simplecov output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,7 @@ You can run the existing test suite with:
 bundle exec rake test
 ```
 
-You can generate test coverage stats with:
-
-```
-sudo gem install rcov
-rcov -x gems test/*/*.rb
-```
+You can view test coverage statistics by browsing the `coverage` directory.
 
 The tests are automatically run on Pull Requests and other commits with the
 results shown on [Travis CI](https://travis-ci.org/openstreetmap/openstreetmap-website).

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,15 @@
 require "coveralls"
 Coveralls.wear!("rails")
 
+# Override the simplecov output message, since it is mostly unwanted noise
+module SimpleCov
+  module Formatter
+    class HTMLFormatter
+      def output_message(_result); end
+    end
+  end
+end
+
 # Output both the local simplecov html and the coveralls report
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [SimpleCov::Formatter::HTMLFormatter,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,12 @@
 require "coveralls"
 Coveralls.wear!("rails")
 
+# Output both the local simplecov html and the coveralls report
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [SimpleCov::Formatter::HTMLFormatter,
+   Coveralls::SimpleCov::Formatter]
+)
+
 ENV["RAILS_ENV"] = "test"
 require_relative "../config/environment"
 require "rails/test_help"


### PR DESCRIPTION
This enables the simplecov output, in case a developer wants to investigate the coverage locally. The instructions on how to do this from coveralls are incorrect, so this approach is slightly different. I've also chosen to silence the output message since it's not usually interesting or actionable.