### PR TITLE
Use ERB Lint to improve erb templates

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,55 @@
+---
+linters:
+  SelfClosingTag:
+    enabled: false
+  SpaceInHtmlTag:
+    enabled: false # TODO
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingBlankLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Naming/FileName:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Metrics/LineLength:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      Rails/OutputSafety:
+        Enabled: false
+      Style/StringLiterals:
+        Enabled: false # TODO
+      Style/BracesAroundHashParameters:
+        Enabled: false # TODO
+      Rails/DynamicFindBy:
+        Enabled: false # TODO
+      Style/AndOr:
+        Enabled: false # TODO
+      Style/WordArray:
+        Enabled: false # TODO
+      Style/MethodCallWithoutArgsParentheses:
+        Enabled: false # TODO
+      Layout/LeadingBlankLines:
+        Enabled: false # TODO
+      Style/NestedParenthesizedCalls:
+        Enabled: false # TODO
+      Rails/LinkToBlank:
+        Enabled: false # TODO
+      Style/HashSyntax:
+        Enabled: false # TODO
+      Style/SymbolProc:
+        Enabled: false # TODO
+      Style/Not:
+        Enabled: false # TODO
+      Style/NegatedIf:
+        Enabled: false # TODO
+      Style/ConditionalAssignment:
+        Enabled: false # TODO

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -53,3 +53,5 @@ linters:
         Enabled: false # TODO
       Style/ConditionalAssignment:
         Enabled: false # TODO
+exclude:
+  - '**/vendor/**'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Rails:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,5 @@ before_script:
 script:
   - bundle exec rubocop -f fuubar
   - bundle exec rake jshint
+  - bundle exec erblint .
   - bundle exec rake test:db

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.3
+  - 2.5.1
 cache: bundler
 addons:
   postgresql: 9.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.5.3
 cache: bundler
 addons:
   postgresql: 9.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,15 +3,15 @@
 
 ## Coding style
 
-When writing code it is generally a good idea to try and match your
-formatting to that of any existing code in the same file, or to other
-similar files if you are writing new code. Consistency of layout is
-far more important than the layout itself as it makes reading code
-much easier.
+We use [Rubocop](https://github.com/rubocop-hq/rubocop) (for ruby files)
+and [ERB Lint](https://github.com/Shopify/erb-lint) (for erb templates)
+to help maintain consistency in our code. You can run these utilities during
+development to check that your code matches our guidelines:
 
-One golden rule of formatting -- please don't use tabs in your code
-as they will cause the file to be formatted differently for different
-people depending on how they have their editor configured.
+```
+bundle exec rubocop
+bundle exec erblint .
+```
 
 ## Testing
 

--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,7 @@ end
 group :development, :test do
   gem "capybara", "~> 2.13"
   gem "coveralls", :require => false
+  gem "erb_lint", :require => false
   gem "factory_bot_rails"
   gem "jshint"
   gem "poltergeist"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,14 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    better_html (1.0.11)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (1.1.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -145,6 +153,13 @@ GEM
       dry-logic (~> 0.5, >= 0.5.0)
       dry-types (~> 0.14, >= 0.14)
     dynamic_form (1.1.4)
+    erb_lint (0.0.28)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      rainbow
+      rubocop (~> 0.51)
+      smart_properties
     erubi (1.8.0)
     execjs (2.7.0)
     exifr (1.3.6)
@@ -165,6 +180,7 @@ GEM
       activesupport (>= 4.2.0)
     hashdiff (0.3.8)
     hashie (3.6.0)
+    html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     http_accept_language (2.0.5)
     i18n (0.9.5)
@@ -381,6 +397,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    smart_properties (1.13.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -443,6 +460,7 @@ DEPENDENCIES
   dalli
   delayed_job_active_record
   dynamic_form
+  erb_lint
   factory_bot_rails
   fakefs
   faraday

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ If you want to deploy the software for your own project, then see the notes at t
 
 You can install the software directly on your machine, which is the traditional and probably best-supported approach. However, there is an alternative which may be easier: Vagrant. This installs the software into a virtual machine, which makes it easier to get a consistent development environment and may avoid installation difficulties. For Vagrant instructions, see [VAGRANT.md](VAGRANT.md).
 
-These instructions are based on Ubuntu 16.04 LTS, which is the platform used by the OSMF servers.
+These instructions are based on Ubuntu 18.04 LTS, which is the platform used by the OSMF servers.
 The instructions also work, with only minor amendments, for all other current Ubuntu releases, Fedora and MacOSX
 
 We don't recommend attempting to develop or deploy this software on Windows. If you need to use Windows, then try developing this software using Ubuntu in a virtual machine, or use [Vagrant](VAGRANT.md).
@@ -18,8 +18,7 @@ of packages required before you can get the various gems installed.
 
 ## Minimum requirements
 
-* Ruby 2.3
-* RubyGems 1.3.1+
+* Ruby 2.5+
 * PostgreSQL 9.1+
 * ImageMagick
 * Bundler
@@ -28,12 +27,12 @@ of packages required before you can get the various gems installed.
 These can be installed on Ubuntu 16.04 or later with:
 
 ```
-sudo apt-get install ruby2.3 libruby2.3 ruby2.3-dev \
+sudo apt-get install ruby2.5 libruby2.5 ruby2.5-dev \
                      libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
                      apache2 apache2-dev build-essential git-core \
                      postgresql postgresql-contrib libpq-dev postgresql-server-dev-all \
                      libsasl2-dev imagemagick libffi-dev
-sudo gem2.3 install bundler
+sudo gem2.5 install bundler
 ```
 
 ### Alternative platforms

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -17,11 +17,11 @@ class GeocoderController < ApplicationController
       @sources.push "osm_nominatim_reverse"
       @sources.push "geonames_reverse" if Settings.key?(:geonames_username)
     elsif @params[:query]
-      if /^\d{5}(-\d{4})?$/.match?(@params[:query])
+      if @params[:query].match?(/^\d{5}(-\d{4})?$/)
         @sources.push "osm_nominatim"
-      elsif /^(GIR 0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]|[A-HK-Y][0-9]([0-9]|[ABEHMNPRV-Y]))|[0-9][A-HJKS-UW])\s*[0-9][ABD-HJLNP-UW-Z]{2})$/i.match?(@params[:query])
+      elsif @params[:query].match?(/^(GIR 0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]|[A-HK-Y][0-9]([0-9]|[ABEHMNPRV-Y]))|[0-9][A-HJKS-UW])\s*[0-9][ABD-HJLNP-UW-Z]{2})$/i)
         @sources.push "osm_nominatim"
-      elsif /^[A-Z]\d[A-Z]\s*\d[A-Z]\d$/i.match?(@params[:query])
+      elsif @params[:query].match?(/^[A-Z]\d[A-Z]\s*\d[A-Z]\d$/i)
         @sources.push "ca_postcode"
         @sources.push "osm_nominatim"
       else

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -17,11 +17,11 @@ class GeocoderController < ApplicationController
       @sources.push "osm_nominatim_reverse"
       @sources.push "geonames_reverse" if Settings.key?(:geonames_username)
     elsif @params[:query]
-      if @params[:query] =~ /^\d{5}(-\d{4})?$/
+      if /^\d{5}(-\d{4})?$/.match?(@params[:query])
         @sources.push "osm_nominatim"
-      elsif @params[:query] =~ /^(GIR 0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]|[A-HK-Y][0-9]([0-9]|[ABEHMNPRV-Y]))|[0-9][A-HJKS-UW])\s*[0-9][ABD-HJLNP-UW-Z]{2})$/i
+      elsif /^(GIR 0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]|[A-HK-Y][0-9]([0-9]|[ABEHMNPRV-Y]))|[0-9][A-HJKS-UW])\s*[0-9][ABD-HJLNP-UW-Z]{2})$/i.match?(@params[:query])
         @sources.push "osm_nominatim"
-      elsif @params[:query] =~ /^[A-Z]\d[A-Z]\s*\d[A-Z]\d$/i
+      elsif /^[A-Z]\d[A-Z]\s*\d[A-Z]\d$/i.match?(@params[:query])
         @sources.push "ca_postcode"
         @sources.push "osm_nominatim"
       else

--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -120,7 +120,7 @@ module BrowseTagsHelper
     #
     # Also accepting / as a visual separator although not given in RFC 3966,
     # because it is used as a visual separator in OSM data in some countries.
-    if %r{^\s*\+[\d\s\(\)/\.-]{6,25}\s*(;\s*\+[\d\s\(\)/\.-]{6,25}\s*)*$}.match?(value)
+    if value.match?(%r{^\s*\+[\d\s\(\)/\.-]{6,25}\s*(;\s*\+[\d\s\(\)/\.-]{6,25}\s*)*$})
       return value.split(";").map do |phone_number|
         # for display, remove leading and trailing whitespace
         phone_number = phone_number.strip

--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -120,7 +120,7 @@ module BrowseTagsHelper
     #
     # Also accepting / as a visual separator although not given in RFC 3966,
     # because it is used as a visual separator in OSM data in some countries.
-    if value =~ %r{^\s*\+[\d\s\(\)/\.-]{6,25}\s*(;\s*\+[\d\s\(\)/\.-]{6,25}\s*)*$}
+    if %r{^\s*\+[\d\s\(\)/\.-]{6,25}\s*(;\s*\+[\d\s\(\)/\.-]{6,25}\s*)*$}.match?(value)
       return value.split(";").map do |phone_number|
         # for display, remove leading and trailing whitespace
         phone_number = phone_number.strip

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -15,14 +15,12 @@ class Language < ActiveRecord::Base
   def self.load(file)
     Language.transaction do
       YAML.safe_load(File.read(file)).each do |k, v|
-        begin
-          Language.update(k, :english_name => v["english"], :native_name => v["native"])
-        rescue ActiveRecord::RecordNotFound
-          Language.create do |l|
-            l.code = k
-            l.english_name = v["english"]
-            l.native_name = v["native"]
-          end
+        Language.update(k, :english_name => v["english"], :native_name => v["native"])
+      rescue ActiveRecord::RecordNotFound
+        Language.create do |l|
+          l.code = k
+          l.english_name = v["english"]
+          l.native_name = v["native"]
         end
       end
     end

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -26,7 +26,7 @@
 <% if @type == "node" and common_details.visible? %>
 <div class="details geo">
   <%= t 'browse.location' %>
-  <%= link_to(content_tag(:span, number_with_delimiter(common_details.lat), :class => "latitude") + ", " + content_tag(:span, number_with_delimiter(common_details.lon), :class => "longitude"), {:controller => 'site', :action => 'index', :anchor => "map=18/#{common_details.lat}/#{common_details.lon}"}) %>
+  <%= link_to(content_tag(:span, number_with_delimiter(common_details.lat), :class => "latitude") + ", " + content_tag(:span, number_with_delimiter(common_details.lon), :class => "longitude"), { :controller => 'site', :action => 'index', :anchor => "map=18/#{common_details.lat}/#{common_details.lon}" }) %>
 </div>
 <% end %>
 

--- a/app/views/browse/_containing_relation.html.erb
+++ b/app/views/browse/_containing_relation.html.erb
@@ -5,4 +5,5 @@
   else
     raw t '.entry_role', :relation_name => linked_name, :relation_role => h(containing_relation.member_role)
   end
-%></li>
+    %>
+</li>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -11,7 +11,7 @@
     <%= render :partial => "common_details", :object => relation %>
 
     <% unless relation.containing_relation_members.empty? %>
-      <h4><%= t'browse.part_of' %></h4>
+      <h4><%= t 'browse.part_of' %></h4>
       <ul><%= render :partial => "containing_relation", :collection => relation.containing_relation_members.uniq %></ul>
     <% end %>
 

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -3,10 +3,12 @@
   linked_name = link_to printable_name(relation_member.member), { :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, :title => link_title(relation_member.member), :rel => link_follow(relation_member.member)
   type_str = t '.type.' + relation_member.member_type.downcase
 %>
-  <li class="<%= member_class %>"><%=
+<li class="<%= member_class %>">
+  <%=
     if relation_member.member_role.blank?
       raw t '.entry', :type => type_str, :name => linked_name
     else
       raw t '.entry_role', :type => type_str, :name => linked_name, :role => h(relation_member.member_role)
     end
-  %></li>
+  %>
+</li>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -11,7 +11,7 @@
     <%= render :partial => "common_details", :object => way %>
 
     <% unless way.containing_relation_members.empty? %>
-      <h4><%= t'browse.part_of' %></h4>
+      <h4><%= t 'browse.part_of' %></h4>
       <ul>
         <%= render :partial => "containing_relation", :collection => way.containing_relation_members.uniq %>
       </ul>
@@ -25,7 +25,7 @@
             <%= link_to printable_name(wn.node), { :action => "node", :id => wn.node_id.to_s }, :class => link_class('node', wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) %>
             <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
             <% if related_ways.size > 0 then %>
-              (<%= raw t '.also_part_of', :count => related_ways.size, :related_ways => related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, :class => link_class('way', w), :title => link_title(w) ) }.to_sentence %>)
+              (<%= raw t '.also_part_of', :count => related_ways.size, :related_ways => related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, :class => link_class('way', w), :title => link_title(w)) }.to_sentence %>)
             <% end %>
           </li>
         <% end %>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -36,8 +36,9 @@
               <li id="c<%= comment.id %>">
                 <small class='deemphasize'>
                   <%= t(".commented_by",
-                    :when => friendly_date(comment.created_at), :exact_time => l(comment.created_at),
-                    :user => link_to(h(comment.author.display_name), user_path(comment.author))).html_safe %>
+                        :when => friendly_date(comment.created_at),
+                        :exact_time => l(comment.created_at),
+                        :user => link_to(h(comment.author.display_name), user_path(comment.author))).html_safe %>
                   <% if current_user and current_user.moderator? %>
                     — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_hide_url(comment.id) %>"><%= t('javascripts.changesets.show.hide_comment') %></span>
                   <% end %>
@@ -48,8 +49,9 @@
               <li id="c<%= comment.id %>">
                 <small class='deemphasize'>
                   <%= t(".hidden_commented_by",
-                    :when => friendly_date(comment.created_at), :exact_time => l(comment.created_at),
-                    :user => link_to(h(comment.author.display_name), user_path(comment.author))).html_safe %>
+                        :when => friendly_date(comment.created_at),
+                        :exact_time => l(comment.created_at),
+                        :user => link_to(h(comment.author.display_name), user_path(comment.author))).html_safe %>
                   — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_unhide_url(comment.id) %>"><%= t('javascripts.changesets.show.unhide_comment') %></span>
                  </small>
                 <%= comment.body.to_html %>
@@ -109,7 +111,7 @@
   <% unless @nodes.empty? %>
     <h4>
       <%= type_and_paginated_count('node', @node_pages) %>
-      <%= render :partial => 'paging_nav', :locals => { :pages => @node_pages, :page_param => "node_page"} %>
+      <%= render :partial => 'paging_nav', :locals => { :pages => @node_pages, :page_param => "node_page" } %>
     </h4>
     <ul>
       <% @nodes.each do |node| %>

--- a/app/views/changeset_comments/_comment.html.erb
+++ b/app/views/changeset_comments/_comment.html.erb
@@ -1,5 +1,6 @@
-<h2><%= t ".comment", :author => comment.author.display_name,
-  :changeset_id => comment.changeset.id.to_s %></h2>
+<h2><%= t ".comment",
+          :author => comment.author.display_name,
+          :changeset_id => comment.changeset.id.to_s %></h2>
 <div class="changeset-comment" style="margin-top: 5px">
   <div class="changeset-comment-description" style="font-size: smaller; color: #999999"><%= t ".commented_at_by_html", :when => friendly_date(comment.created_at), :user => comment.author.display_name %></div>
   <div class="changeset-comment-text"><%= comment.body %></div>

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -1,5 +1,5 @@
 <%
-   changeset_data = {:id => changeset.id}
+   changeset_data = { :id => changeset.id }
 
    if changeset.has_valid_bbox?
      bbox = changeset.bbox.to_unscaled
@@ -12,7 +12,7 @@
    end
 %>
 
-<%= content_tag "li", :id => "changeset_#{changeset.id}", :data => {:changeset => changeset_data} do %>
+<%= content_tag "li", :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data } do %>
   <h4>
     <a class="changeset_id" href="<%= changeset_path(changeset) %>">
       <%= changeset.tags['comment'].to_s.presence || t('browse.no_comment') %>

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -9,7 +9,7 @@
   <div class="richtext"><%= diary_comment.body.to_html %></div>
   <% if current_user && current_user.administrator? %>
     <span>
-      <%= link_to t('.hide_link'), hide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data=> { :confirm => t('.confirm') } %>
+      <%= link_to t('.hide_link'), hide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data => { :confirm => t('.confirm') } %>
     </span>
   <% end %>
 </div>

--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -19,6 +19,6 @@
 </table>
 
 <div class='secondary-actions clearfix'>
-  <span><%= link_to t('.older_comments') , { :page => @comment_pages.current.next} if @comment_pages.current.next %>
+  <span><%= link_to t('.older_comments'), { :page => @comment_pages.current.next } if @comment_pages.current.next %>
   <%= link_to t('.newer_comments'), { :page => @comment_pages.current.previous } if @comment_pages.current.previous %></span>
 </div>

--- a/app/views/diary_entries/edit.html.erb
+++ b/app/views/diary_entries/edit.html.erb
@@ -26,7 +26,7 @@
     </fieldset>
     <fieldset class='location'>
       <label class="standard-label"><%= t '.location' -%></label>
-      <%= content_tag "div", "", :id => "map", :data => {:lat => @lat, :lon => @lon, :zoom => @zoom} %>
+      <%= content_tag "div", "", :id => "map", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
       <div class='form-row clearfix'>
         <div class='form-column'>
           <label class="secondary standard-label"><%= t '.latitude' -%></label>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -13,13 +13,13 @@
       <% if @user %>
         <% if @user == current_user %>
           <div>
-            <li><%= link_to image_tag("new.png", :class => "small_icon", :border=>0) + t('.new'), diary_new_path, {:title => t('.new_title')} %></li>
+            <li><%= link_to image_tag("new.png", :class => "small_icon", :border => 0) + t('.new'), diary_new_path, { :title => t('.new_title') } %></li>
           </div>
         <% end %>
       <% else %>
         <% if current_user %>
           <div>
-            <li><%= link_to image_tag("new.png", :class => "small_icon", :border=>0) + t('.new'), diary_new_path, {:title => t('.new_title')} %></li>
+            <li><%= link_to image_tag("new.png", :class => "small_icon", :border => 0) + t('.new'), diary_new_path, { :title => t('.new_title') } %></li>
           </div>
         <% end %>
       <% end %>
@@ -42,7 +42,7 @@
     <% if @entries.size < @page_size -%>
       <%= t('.older_entries') %>
     <% else -%>
-      <%= link_to t('.older_entries'), @params.merge(:page => @page + 1 ) %>
+      <%= link_to t('.older_entries'), @params.merge(:page => @page + 1) %>
     <% end -%>
 
     |

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -13,7 +13,6 @@
 <%= render :partial => 'diary_comment', :collection => @entry.visible_comments %>
 </div>
 
-
 <div>
   <% if current_user %>
     <h3 id="newcomment"><%= t '.leave_a_comment' %></h3>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,3 +1,3 @@
-<h1>Forbidden</h1>  
+<h1>Forbidden</h1>
 <p>The operation you requested on the OpenStreetMap server is only available to administrators (HTTP 403)</p>
 <p>Feel free to <a href="http://wiki.openstreetmap.org/wiki/Contact" title="Various contact channels explained">contact</a> the OpenStreetMap community if you have found a broken link / bug. Make a note of the exact URL of your request.</p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,3 +1,3 @@
-<h1>File not found</h1>  
+<h1>File not found</h1>
 <p>Couldn't find a file/directory/API operation by that name on the OpenStreetMap server (HTTP 404)</p>
 <p>Feel free to <a href="http://wiki.openstreetmap.org/wiki/Contact" title="Various contact channels explained">contact</a> the OpenStreetMap community if you have found a broken link / bug. Make a note of the exact URL of your request.</p>

--- a/app/views/export/embed.html.erb
+++ b/app/views/export/embed.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>OpenStreetMap Embedded</title>
-    <%= stylesheet_link_tag "embed", :media=> "screen" %>
+    <%= stylesheet_link_tag "embed", :media => "screen" %>
     <%= javascript_include_tag "embed" %>
   </head>
   <body>

--- a/app/views/geocoder/search.html.erb
+++ b/app/views/geocoder/search.html.erb
@@ -1,6 +1,6 @@
 <h2>
     <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-	<%= t('site.sidebar.search_results') %>
+    <%= t('site.sidebar.search_results') %>
 </h2>
 <% @sources.each do |source| %>
   <h4 class="inner12"><%= raw(t ".title.#{source}") %></h4>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -4,10 +4,10 @@
 
 <%= form_tag(issues_path, :method => :get) do %>
 <p><%= t ".search_guidance" %></p>
-<%= select_tag :status, options_for_select(Issue.aasm.states.map(&:name).map{|state| [t(".states.#{state}"), state]}, params[:status]), :include_blank => t(".select_status"), :data => { :behavior => 'category_dropdown' } %>
+<%= select_tag :status, options_for_select(Issue.aasm.states.map(&:name).map { |state| [t(".states.#{state}"), state] }, params[:status]), :include_blank => t(".select_status"), :data => { :behavior => 'category_dropdown' } %>
 <%= select_tag :issue_type, options_for_select(@issue_types, params[:issue_type]), :include_blank => t(".select_type"), :data => { :behavior => 'category_dropdown' } %>
 <%= text_field_tag :search_by_user, params[:search_by_user], placeholder: t(".reported_user") %>
-<%= select_tag :last_updated_by, options_for_select(@users.all.collect{|f| [f.display_name, f.id]} << [ t(".not_updated"), "nil"], params[:last_updated_by]), :include_blank => t(".select_last_updated_by"), :data => { :behavior => 'category_dropdown' } %>
+<%= select_tag :last_updated_by, options_for_select(@users.all.collect { |f| [f.display_name, f.id] } << [t(".not_updated"), "nil"], params[:last_updated_by]), :include_blank => t(".select_last_updated_by"), :data => { :behavior => 'category_dropdown' } %>
 <%= submit_tag t(".search"), :name => nil %>
 <% end %>
 <br/>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -6,8 +6,8 @@
     <%= @issue.assigned_role %>
     | <%= t ".reports", :count => @issue.reports.count %>
     | <%= t ".report_created_at", :datetime => l(@issue.created_at.to_datetime, :format => :friendly) %>
-    <%= " | " + t(".last_resolved_at", :datetime => l(@issue.resolved_at.to_datetime, :format =>:friendly)) if @issue.resolved_at? %>
-    <%= " | " + t(".last_updated_at", :datetime => l(@issue.updated_at.to_datetime, :format => :friendly), :displayname => @issue.user_updated.display_name ) if @issue.user_updated %>
+    <%= " | " + t(".last_resolved_at", :datetime => l(@issue.resolved_at.to_datetime, :format => :friendly)) if @issue.resolved_at? %>
+    <%= " | " + t(".last_updated_at", :datetime => l(@issue.updated_at.to_datetime, :format => :friendly), :displayname => @issue.user_updated.display_name) if @issue.user_updated %>
   </small>
 </p>
 <p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,10 +13,12 @@
     <%= content_for :header %>
     <ul>
       <li id="edit_tab" class="dropdown <%= current_page_class(edit_path) %>">
-        <%= link_to t('layouts.edit'), edit_path, :class => "tab geolink editlink",
+        <%= link_to t('layouts.edit'),
+                    edit_path,
+                    :class => "tab geolink editlink",
                     :id => 'editanchor',
-                    :data => { :editor => preferred_editor }
-        %><a class='dropdown-toggle' data-toggle='dropdown' href='#'><b class="caret"></b></a>
+                    :data => { :editor => preferred_editor } %>
+        <a class='dropdown-toggle' data-toggle='dropdown' href='#'><b class="caret"></b></a>
         <ul class='dropdown-menu'>
           <% Editors::RECOMMENDED_EDITORS.each do |editor| %>
             <li>
@@ -73,10 +75,14 @@
     <% if current_user && current_user.id %>
       <div class='dropdown user-menu logged-in'>
         <a class='dropdown-toggle' data-toggle='dropdown' href="#">
-          <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25)
-          %><%= render :partial => 'layouts/inbox'
-        %><span class="user-button"><span class='username'><%= current_user.display_name %></span>
-          <b class="caret"></b></span>
+          <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25) %>
+          <%= render :partial => 'layouts/inbox' %>
+          <span class="user-button">
+            <span class='username'>
+              <%= current_user.display_name %>
+            </span>
+            <b class="caret"></b>
+          </span>
         </a>
         <ul class='dropdown-menu'>
           <li>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -12,12 +12,12 @@
     <div class="header"><span class="icon close"></span></div>
 
     <div class="line">
-      <%= image_tag "marker-green.png", :class => "routing_marker", :data => { :type =>  "from" }, :draggable => "true" %>
+      <%= image_tag "marker-green.png", :class => "routing_marker", :data => { :type => "from" }, :draggable => "true" %>
       <span class="force_width"><%= text_field_tag "route_from", params[:from], :placeholder => t('site.search.from') %></span>
     </div>
     <div class="line">
       <%= image_tag "marker-red.png", :class => "routing_marker", :data => { :type => "to" }, :draggable => "true" %>
-      <span class="force_width"><%= text_field_tag "route_to"  , params[:to]  , :placeholder => t('site.search.to') %></span>
+      <span class="force_width"><%= text_field_tag "route_to", params[:to], :placeholder => t('site.search.to') %></span>
     </div>
     <div class="line">
       <select class="routing_engines" name="routing_engines"></select>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>OpenStreetMap</title>
-    <%= stylesheet_link_tag "errors", :media=> "screen" %>
+    <%= stylesheet_link_tag "errors", :media => "screen" %>
   </head>
   <body>
     <%= image_tag "osm_logo.png", :class => "logo" %>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -44,9 +44,9 @@
         <div class="close-wrap"><span class="icon close"></span></div>
         <p><%= t 'layouts.intro_text' %></p>
         <p><%= t 'layouts.hosting_partners_html',
-               :ucl => link_to(t('layouts.partners_ucl'), "https://www.ucl.ac.uk"),
-               :bytemark => link_to(t('layouts.partners_bytemark'), "https://www.bytemark.co.uk"),
-               :partners => link_to(t('layouts.partners_partners'), "https://hardware.openstreetmap.org/thanks/") %>
+                 :ucl => link_to(t('layouts.partners_ucl'), "https://www.ucl.ac.uk"),
+                 :bytemark => link_to(t('layouts.partners_bytemark'), "https://www.bytemark.co.uk"),
+                 :partners => link_to(t('layouts.partners_partners'), "https://hardware.openstreetmap.org/thanks/") %>
         </p>
         <a class="button learn-more" href="<%= about_path %>"><%= t('layouts.learn_more') %></a>
         <a class="button sign-up" href="<%= user_new_path %>"><%= t('layouts.start_mapping') %></a>

--- a/app/views/messages/_message_count.html.erb
+++ b/app/views/messages/_message_count.html.erb
@@ -3,6 +3,5 @@
       :new_messages => t("messages.inbox.new_messages",
                          :count => current_user.new_messages.size),
       :old_messages => t("messages.inbox.old_messages",
-                         :count => current_user.messages.size - current_user.new_messages.size)
-%>
+                         :count => current_user.messages.size - current_user.new_messages.size) %>
 </p>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h2><%= t '.my_inbox'%>/<%= link_to t('.outbox'), outbox_messages_path %></h2>
+  <h2><%= t '.my_inbox' %>/<%= link_to t('.outbox'), outbox_messages_path %></h2>
 <% end %>
 
   <h4><%= render :partial => "message_count" %></h4>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h2><%= raw(t '.my_inbox', :inbox_link => link_to(t('.inbox'), inbox_messages_path)) %>/<%= t'.outbox' %></h2>
+  <h2><%= raw(t '.my_inbox', :inbox_link => link_to(t('.inbox'), inbox_messages_path)) %>/<%= t '.outbox' %></h2>
 <% end %>
 
 <h4><%= t '.messages', :count => current_user.sent_messages.size %></h4>

--- a/app/views/notifier/_gpx_description.html.erb
+++ b/app/views/notifier/_gpx_description.html.erb
@@ -1,12 +1,12 @@
-<%= t'notifier.gpx_notification.your_gpx_file' %>
+<%= t 'notifier.gpx_notification.your_gpx_file' %>
 <strong><%= @trace_name %></strong>
-<%= t'notifier.gpx_notification.with_description' %>
+<%= t 'notifier.gpx_notification.with_description' %>
 <em><%= @trace_description %></em>
 <% if @trace_tags.length>0 %>
-  <%= t'notifier.gpx_notification.and_the_tags' %>
+  <%= t 'notifier.gpx_notification.and_the_tags' %>
   <em><% @trace_tags.each do |tag| %>
     <%= tag.tag.rstrip %>
   <% end %></em>
 <% else %>
-  <%= t'notifier.gpx_notification.and_no_tags' %>
+  <%= t 'notifier.gpx_notification.and_no_tags' %>
 <% end %>

--- a/app/views/notifier/_message_body.html.erb
+++ b/app/views/notifier/_message_body.html.erb
@@ -2,17 +2,17 @@
   <tr>
     <td style="width: 50px; min-width: 50px; vertical-align: top; padding: 15px">
       <%= link_to(
-          image_tag(
-            attachments["avatar.png"].url,
-            alt: @author,
-            title: @author,
-            width: 50,
-            height: 50,
-            border: 0
-          ),
-          user_url(@author),
-          :target => "_blank"
-      ) %>
+            image_tag(
+              attachments["avatar.png"].url,
+              alt: @author,
+              title: @author,
+              width: 50,
+              height: 50,
+              border: 0
+            ),
+            user_url(@author),
+            :target => "_blank"
+          ) %>
     </td>
     <td style="text-align: left; vertical-align: top; padding-right: 10px; width: 100%">
       <%= body %>

--- a/app/views/notifier/diary_comment_notification.html.erb
+++ b/app/views/notifier/diary_comment_notification.html.erb
@@ -11,8 +11,8 @@
 
 <% content_for :footer do %>
   <p><%= raw t '.footer',
-             :readurl => link_to(@readurl, @readurl) + tag(:br),
-             :commenturl => link_to(@commenturl, @commenturl) + tag(:br),
-             :replyurl => link_to(@replyurl, @replyurl)
-  %></p>
+               :readurl => link_to(@readurl, @readurl) + tag(:br),
+               :commenturl => link_to(@commenturl, @commenturl) + tag(:br),
+               :replyurl => link_to(@replyurl, @replyurl) %>
+  </p>
 <% end %>

--- a/app/views/notifier/gpx_failure.html.erb
+++ b/app/views/notifier/gpx_failure.html.erb
@@ -1,8 +1,8 @@
-<p><%= t'notifier.gpx_notification.greeting' %></p>
+<p><%= t 'notifier.gpx_notification.greeting' %></p>
 
 <p>
   <%= render :partial => "gpx_description" %>
-  <%= t'notifier.gpx_notification.failure.failed_to_import' %>
+  <%= t 'notifier.gpx_notification.failure.failed_to_import' %>
 </p>
 
 <blockquote>
@@ -10,7 +10,7 @@
 </blockquote>
 
 <p>
-  <%= t'notifier.gpx_notification.failure.more_info_1' %>
-  <%= t'notifier.gpx_notification.failure.more_info_2' %>
-  <%= t'notifier.gpx_notification.failure.import_failures_url' %>
+  <%= t 'notifier.gpx_notification.failure.more_info_1' %>
+  <%= t 'notifier.gpx_notification.failure.more_info_2' %>
+  <%= t 'notifier.gpx_notification.failure.import_failures_url' %>
 </p>

--- a/app/views/notifier/gpx_success.html.erb
+++ b/app/views/notifier/gpx_success.html.erb
@@ -1,6 +1,6 @@
-<p><%= t'notifier.gpx_notification.greeting' %></p>
+<p><%= t 'notifier.gpx_notification.greeting' %></p>
 
 <p>
   <%= render :partial => "gpx_description" %>
-  <%= t'notifier.gpx_notification.success.loaded_successfully', :trace_points => @trace_points, :possible_points => @possible_points %>
+  <%= t 'notifier.gpx_notification.success.loaded_successfully', :trace_points => @trace_points, :possible_points => @possible_points %>
 </p>

--- a/app/views/notifier/message_notification.html.erb
+++ b/app/views/notifier/message_notification.html.erb
@@ -3,9 +3,8 @@
 </p>
 <p>
   <%= raw t '.header',
-          :from_user => link_to_user(@from_user),
-          :subject => content_tag("em", @title)
-  %>
+            :from_user => link_to_user(@from_user),
+            :subject => content_tag("em", @title) %>
 </p>
 
 <%= message_body do %>
@@ -16,7 +15,6 @@
   <p>
     <%= t '.footer_html',
           :readurl => link_to(@readurl, @readurl) + tag(:br),
-          :replyurl => link_to(@replyurl, @replyurl)
-    %>
+          :replyurl => link_to(@replyurl, @replyurl) %>
   </p>
 <% end %>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -8,15 +8,15 @@
 <table>
   <tr><th><%= t '.application' %></th>
     <th><%= t '.issued_at' %></th><th>&nbsp;</th></tr>
-  <% @tokens.each do |token|%>
+  <% @tokens.each do |token| %>
     <%= content_tag_for :tr, token do %>
       <td><%= link_to token.client_application.name, token.client_application.url %></td>
       <td><%= token.authorized_at %></td>
       <td>
-	<%= form_tag :controller => 'oauth', :action => 'revoke' do %>
-	<%= hidden_field_tag 'token', token.token %>
-	<%= submit_tag t('.revoke') %>
-	<% end %>
+  <%= form_tag :controller => 'oauth', :action => 'revoke' do %>
+  <%= hidden_field_tag 'token', token.token %>
+  <%= submit_tag t('.revoke') %>
+  <% end %>
       </td>
     <% end %>
   <% end %>
@@ -27,7 +27,7 @@
 <p><%= raw(t('.no_apps', :oauth => "<a href=\"https://oauth.net\">OAuth</a>")) %></p>
 <% else %>
 <p><%= t '.registered_apps' %></p>
-<% @client_applications.each do |client|%>
+<% @client_applications.each do |client| %>
   <%= div_for client do %>
     <%= link_to client.name, :action => :show, :id => client.id %>
   <% end %>

--- a/app/views/oauth_clients/show.html.erb
+++ b/app/views/oauth_clients/show.html.erb
@@ -3,19 +3,19 @@
 <% end %>
 <div class='prose'>
   <p>
-    <strong><%= t '.key' %></strong> <%=@client_application.key %>
+    <strong><%= t '.key' %></strong> <%= @client_application.key %>
   </p>
   <p>
-    <strong><%= t '.secret' %></strong> <%=@client_application.secret %>
+    <strong><%= t '.secret' %></strong> <%= @client_application.secret %>
   </p>
   <p>
-    <strong><%= t '.url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.request_token_path %>
+    <strong><%= t '.url' %></strong> http<%= 's' if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.request_token_path %>
   </p>
   <p>
-    <strong><%= t '.access_url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.access_token_path %>
+    <strong><%= t '.access_url' %></strong> http<%= 's' if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.access_token_path %>
   </p>
   <p>
-    <strong><%= t '.authorize_url' %></strong> http<%='s' if request.ssl? %>://<%= request.host_with_port %><%=@client_application.oauth_server.authorize_path %>
+    <strong><%= t '.authorize_url' %></strong> http<%= 's' if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.authorize_path %>
   </p>
 
   <p><%= t '.requests' %></p>
@@ -28,6 +28,6 @@
   <p><%= t '.support_notice' %></p>
 </div>
 <div class="buttons">
-  <%= button_to t('.edit'), edit_oauth_client_path(@client_application.user.display_name, @client_application), :method => :get, :class=> "oauth-edit" %>
-  <%= button_to t('.delete'), oauth_client_path(@client_application.user.display_name, @client_application), :method => :delete, :data => { :confirm => t('.confirm') }, :class=> "oauth-delete deemphasize" %>
+  <%= button_to t('.edit'), edit_oauth_client_path(@client_application.user.display_name, @client_application), :method => :get, :class => "oauth-edit" %>
+  <%= button_to t('.delete'), oauth_client_path(@client_application.user.display_name, @client_application), :method => :delete, :data => { :confirm => t('.confirm') }, :class => "oauth-delete deemphasize" %>
 </div>

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -7,13 +7,13 @@
         <h1><%= t '.native.title' %></h1>
         <p>
           <%= raw t '.native.text',
-                      :native_link => link_to(t('.native.native_link'),
-                                                  :controller => 'site',
-                                                  :action => 'copyright',
-                                                  :copyright_locale => nil),
-                      :mapping_link => link_to(t('.native.mapping_link'),
-                                                  :controller => 'site',
-                                                  :action => 'index') %>
+                    :native_link => link_to(t('.native.native_link'),
+                                            :controller => 'site',
+                                            :action => 'copyright',
+                                            :copyright_locale => nil),
+                    :mapping_link => link_to(t('.native.mapping_link'),
+                                             :controller => 'site',
+                                             :action => 'index') %>
         </p>
       <% end %>
       <hr />
@@ -25,10 +25,10 @@
         <h1><%= t '.foreign.title' %></h1>
         <p>
           <%= raw t '.foreign.text',
-                      :english_original_link => link_to(t('.foreign.english_link'),
-                                                            :controller => 'site',
-                                                            :action => 'copyright',
-                                                            :copyright_locale => 'en') %>
+                    :english_original_link => link_to(t('.foreign.english_link'),
+                                                      :controller => 'site',
+                                                      :action => 'copyright',
+                                                      :copyright_locale => 'en') %>
         </p>
       <% end %>
       <hr />

--- a/app/views/site/edit.html.erb
+++ b/app/views/site/edit.html.erb
@@ -5,7 +5,7 @@
     <p><%= t 'layouts.osm_read_only' %></p>
   <% elsif !current_user.data_public? %>
     <p><%= t '.not_public' %></p>
-    <p><%= raw t '.not_public_description', :user_page => (link_to t('.user_page_link'), {:controller => 'user', :action => 'account', :display_name => current_user.display_name, :anchor => 'public'}) %></p>
+    <p><%= raw t '.not_public_description', :user_page => (link_to t('.user_page_link'), { :controller => 'user', :action => 'account', :display_name => current_user.display_name, :anchor => 'public' }) %></p>
     <p><%= raw t 'site.edit.anon_edits', :link => link_to(t('.anon_edits_link_text'), t('.anon_edits_link')) %></p>
   <% else %>
     <%= render :partial => preferred_editor %>

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -5,7 +5,7 @@
   <%= t '.title' %>
 </h2>
 
-<%= form_tag({:controller => "export", :action => "finish"}, :class => "export_form") do %>
+<%= form_tag({ :controller => "export", :action => "finish" }, :class => "export_form") do %>
   <%= hidden_field_tag 'format', 'osm' %>
 
   <div class='export_area_inputs'>

--- a/app/views/site/offline.html.erb
+++ b/app/views/site/offline.html.erb
@@ -4,4 +4,4 @@
 <% else %>
 <p><%= t 'layouts.osm_read_only' %>
 </p>
-<% end  %>
+<% end %>

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -12,16 +12,16 @@
   <td class="<%= cl %>"><%= link_to trace.name, { :controller => 'traces', :action => 'show', :display_name => trace.user.display_name, :id => trace.id } %>
     <span class="trace_summary" title="<%= trace.timestamp %>"> ...
       <% if trace.inserted %>
-        (<%= t '.count_points', :count => trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/,'\1,') %>)
+        (<%= t '.count_points', :count => trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/, '\1,') %>)
       <% end %>
       ... <%= t '.ago', :time_in_words_ago => time_ago_in_words(trace.timestamp) %></span>
-      <%= link_to_if trace.inserted?, t('.map'), {:controller => 'site', :action => 'index', :mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}"}, {:title => t('.view_map')} %> /
-      <%= link_to t('.edit'), {:controller => 'site', :action => 'edit', :gpx => trace.id }, {:title => t('.edit_map')} %>
+      <%= link_to_if trace.inserted?, t('.map'), { :controller => 'site', :action => 'index', :mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}" }, { :title => t('.view_map') } %> /
+      <%= link_to t('.edit'), { :controller => 'site', :action => 'edit', :gpx => trace.id }, { :title => t('.edit_map') } %>
       <span class="trace_<%= trace.visibility %>"><%= t('.' + trace.visibility) %></span>
       <br />
       <%= trace.description %>
     <br />
-    <%= t '.by' %> <%=link_to h(trace.user.display_name), user_path(trace.user) %>
+    <%= t '.by' %> <%= link_to h(trace.user.display_name), user_path(trace.user) %>
     <% if !trace.tags.empty? %>
       <%= t '.in' %>
       <%= raw(trace.tags.collect { |tag| link_to_tag tag.tag }.join(", ")) %>

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -19,7 +19,7 @@
   <% if @trace.inserted? %>
     <div class='form-row'>
       <label class='standard-label'><%= t '.points' %></label>
-      <p class='deemphasize'><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/,'\1,') %></p>
+      <p class='deemphasize'><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/, '\1,') %></p>
     </div>
     <div class='form-row'>
       <label class='standard-label'><%= t '.start_coord' %></label>
@@ -28,7 +28,7 @@
       <span class="latitude"><%= @trace.latitude %></span>;
       <span class="longitude"><%= @trace.longitude %></span>
     </div>
-    (<%=link_to t('.map'), :controller => 'site', :action => 'index', :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%=link_to t('.edit'), :controller => 'site', :action => 'edit', :gpx=> @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)
+    (<%= link_to t('.map'), :controller => 'site', :action => 'index', :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%= link_to t('.edit'), :controller => 'site', :action => 'edit', :gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)
   <% end %>
     <div class='form-row'>
       <label class='standard-label'><%= t '.owner' %></label>
@@ -44,7 +44,7 @@
     </div>
     <div class='form-row'>
       <label class='standard-label'><%= t '.visibility' %></label>
-      <%= f.select :visibility, [[t('traces.visibility.private'),"private"], [t('traces.visibility.public'),"public"], [t('traces.visibility.trackable'),"trackable"], [t('traces.visibility.identifiable'),"identifiable"]] %> (<a href="<%= t '.visibility_help_url' %>"><%= t '.visibility_help' %></a>)
+      <%= f.select :visibility, [[t('traces.visibility.private'), "private"], [t('traces.visibility.public'), "public"], [t('traces.visibility.trackable'), "trackable"], [t('traces.visibility.identifiable'), "identifiable"]] %> (<a href="<%= t '.visibility_help_url' %>"><%= t '.visibility_help' %></a>)
     </div>
   </fieldset>
 

--- a/app/views/traces/new.html.erb
+++ b/app/views/traces/new.html.erb
@@ -22,7 +22,7 @@
       </div>
       <div class='form-row'>
         <label class="standard-label"><%= t '.visibility' %></label>
-        <%= f.select :visibility, [[t('traces.visibility.private'),"private"],[t('traces.visibility.public'),"public"],[t('traces.visibility.trackable'),"trackable"],[t('traces.visibility.identifiable'),"identifiable"]] %>
+        <%= f.select :visibility, [[t('traces.visibility.private'), "private"], [t('traces.visibility.public'), "public"], [t('traces.visibility.trackable'), "trackable"], [t('traces.visibility.identifiable'), "identifiable"]] %>
         <span class="form-help deemphasize">(<a href="<%= t '.visibility_help_url' %>"><%= t '.visibility_help' %></a>)</span>
       </div>
     </fieldset>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -22,10 +22,10 @@
   <% if @trace.inserted? %>
   <tr>
     <td><%= t '.points' %></td>
-    <td><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/,'\1,') %></td></tr>
+    <td><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/, '\1,') %></td></tr>
   <tr>
     <td><%= t '.start_coordinates' %></td>
-    <td><div class="geo"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%=link_to t('.map'), :controller => 'site', :action => 'index', :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%=link_to t('.edit'), :controller => 'site', :action => 'edit', :gpx=> @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
+    <td><div class="geo"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%= link_to t('.map'), :controller => 'site', :action => 'index', :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%= link_to t('.edit'), :controller => 'site', :action => 'edit', :gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
   </tr>
   <% end %>
   <tr>
@@ -54,7 +54,7 @@
 
 <br /><br />
 
-<% if current_user && (current_user==@trace.user || current_user.administrator? || current_user.moderator?)%>
+<% if current_user && (current_user==@trace.user || current_user.administrator? || current_user.moderator?) %>
   <div class="buttons">
     <% if current_user == @trace.user %>
       <%= link_to t('.edit_trace'), edit_trace_path(@trace), :class => "button" %>

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -7,8 +7,8 @@
   <% if show_creator_name %>
   <td class="<%= c1 %>"><%= link_to h(block.creator.display_name), user_path(block.creator) %></td>
   <% end %>
-  <td class="<%= c1 %>"><%=h truncate(block.reason) %></td>
-  <td class="<%= c1 %>"><%=h block_status(block) %></td>
+  <td class="<%= c1 %>"><%= h truncate(block.reason) %></td>
+  <td class="<%= c1 %>"><%= h block_status(block) %></td>
   <td class="<%= c1 %>">
     <% if block.revoker_id.nil? %>
       <%= t('.not_revoked') %>

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -15,7 +15,7 @@
     <th></th>
     <% end %>
   </tr>
-  <%= render :partial => 'block', :locals => {:show_revoke_link => show_revoke_link, :show_user_name => show_user_name, :show_creator_name => show_creator_name }, :collection => @user_blocks %>
+  <%= render :partial => 'block', :locals => { :show_revoke_link => show_revoke_link, :show_user_name => show_user_name, :show_creator_name => show_creator_name }, :collection => @user_blocks %>
 </table>
 
 <ul class='secondary-actions'>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -1,8 +1,7 @@
 <% @title = t '.title', :name => h(@user.display_name) %>
 <% content_for :heading do %>
   <h1><%= raw t('.heading',
-                :name => link_to(
-                                 h(@user.display_name),
+                :name => link_to(h(@user.display_name),
                                  user_path(@user))) %></h1>
 <% end %>
 <%= form_for(@user_block) do |f| %>
@@ -14,7 +13,7 @@
   </p>
   <p>
     <%= label_tag 'user_block_period', t('.period') %><br />
-    <%= select_tag('user_block_period', options_for_select(UserBlock::PERIODS.collect { |h| [t('user_blocks.period', :count => h), h.to_s] }, params[:user_block_period] )) %>
+    <%= select_tag('user_block_period', options_for_select(UserBlock::PERIODS.collect { |h| [t('user_blocks.period', :count => h), h.to_s] }, params[:user_block_period])) %>
   </p>
   <p>
     <%= f.check_box :needs_view %>

--- a/app/views/user_blocks/not_found.html.erb
+++ b/app/views/user_blocks/not_found.html.erb
@@ -1,3 +1,3 @@
-<p><%= t'.sorry', :id => params[:id] %></p>
+<p><%= t '.sorry', :id => params[:id] %></p>
 
 <%= link_to t('.back'), user_blocks_path %>

--- a/app/views/user_blocks/revoke.html.erb
+++ b/app/views/user_blocks/revoke.html.erb
@@ -4,11 +4,9 @@
 
 <% content_for :heading do %>
   <h1><%= raw t('.heading',
-                :block_on => link_to(
-                                     h(@user_block.user.display_name),
+                :block_on => link_to(h(@user_block.user.display_name),
                                      user_path(@user_block.user)),
-                :block_by => link_to(
-                                     h(@user_block.creator.display_name),
+                :block_by => link_to(h(@user_block.creator.display_name),
                                      user_path(@user_block.creator))) %></h1>
 <% end %>
 

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -4,11 +4,9 @@
 
 <% content_for :heading do %>
   <h1><%= raw t('.heading',
-                :block_on => link_to(
-                                     h(@user_block.user.display_name),
+                :block_on => link_to(h(@user_block.user.display_name),
                                      user_path(@user_block.user)),
-                :block_by => link_to(
-                                     h(@user_block.creator.display_name),
+                :block_by => link_to(h(@user_block.creator.display_name),
                                      user_path(@user_block.creator))) %></h1>
 <ul class='secondary-actions clearfix'>
   <% if @user_block.ends_at > Time.now.getutc %>
@@ -16,7 +14,7 @@
       <li><%= link_to t('.edit'), edit_user_block_path(@user_block) %></li>
     <% end %>
     <% if current_user and current_user.moderator? %>
-      <li><%= link_to(t('.revoke'),{:controller => 'user_blocks', :action => 'revoke', :id => @user_block.id}) %></li>
+      <li><%= link_to(t('.revoke'), { :controller => 'user_blocks', :action => 'revoke', :id => @user_block.id }) %></li>
     <% end %>
   <% end %>
   <li><%= link_to t('.back'), user_blocks_path %></li>
@@ -25,14 +23,14 @@
 
 <% if @user_block.revoker %>
 <p>
-  <b><%= t'.revoker' %></b>
+  <b><%= t '.revoker' %></b>
   <%= link_to h(@user_block.revoker.display_name), user_path(@user_block.revoker) %>
 </p>
 <% end %>
 
-<p><b><%= t'.created' %></b>: <%= raw t'.ago', :time => friendly_date(@user_block.created_at) %></p>
+<p><b><%= t '.created' %></b>: <%= raw t '.ago', :time => friendly_date(@user_block.created_at) %></p>
 
-<p><b><%= t'.status' %></b>: <%= block_status(@user_block) %></p>
+<p><b><%= t '.status' %></b>: <%= block_status(@user_block) %></p>
 
-<p><b><%= t'.reason' %></b></p>
+<p><b><%= t '.reason' %></b></p>
 <div class="richtext"><%= @user_block.reason.to_html %></div>

--- a/app/views/users/_contact.html.erb
+++ b/app/views/users/_contact.html.erb
@@ -3,10 +3,10 @@
      :lon => contact.home_lon,
      :lat => contact.home_lat,
      :icon => image_path(type == "friend" ? "marker-blue.png" : "marker-green.png"),
-     :description => render(:partial => "popup", :object => contact, :locals => {:type => type})
+     :description => render(:partial => "popup", :object => contact, :locals => { :type => type })
    }
 %>
-<%= content_tag :div, :class => "contact-activity clearfix", :data => {:user => user_data} do %>
+<%= content_tag :div, :class => "contact-activity clearfix", :data => { :user => user_data } do %>
   <%= user_thumbnail contact %>
   <div class='activity-details'>
     <p class='deemphasize'>
@@ -26,11 +26,10 @@
         <%= t('users.show.latest edit', :ago => t('users.show.ago', :time_in_words_ago => time_ago_in_words(changeset.created_at))) %>
         <% comment = changeset.tags['comment'].to_s != '' ? changeset.tags['comment'] : t('browse.no_comment') %>
         "<%= link_to(comment,
-                            {:controller => 'browse', :action => 'changeset', :id => changeset.id},
-                            {:title => t('changesets.changeset.view_changeset_details')})
-        %>"
+                     { :controller => 'browse', :action => 'changeset', :id => changeset.id },
+                     { :title => t('changesets.changeset.view_changeset_details') }) %>"
       <% else %>
-       <%= t'changesets.changeset.no_edits' %>
+       <%= t 'changesets.changeset.no_edits' %>
       <% end %>
     </p>
 

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -8,15 +8,13 @@
     <p>
       <% if user.creation_ip %>
         <%= raw t 'users.index.summary',
-            :name => link_to(h(user.display_name), user_path(user)),
-            :ip_address => link_to(user.creation_ip, :ip => user.creation_ip),
-            :date => l(user.creation_time, :format => :friendly)
-        %>
+                  :name => link_to(h(user.display_name), user_path(user)),
+                  :ip_address => link_to(user.creation_ip, :ip => user.creation_ip),
+                  :date => l(user.creation_time, :format => :friendly) %>
       <% else %>
         <%= raw t 'users.index.summary_no_ip',
-            :name => link_to(h(user.display_name), user_path(user)),
-            :date => l(user.creation_time, :format => :friendly)
-        %>
+                  :name => link_to(h(user.display_name), user_path(user)),
+                  :date => l(user.creation_time, :format => :friendly) %>
       <% end %>
     </p>
     <div class="richtext"><%= user.description.to_html %></div>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -51,7 +51,7 @@
       <%= f.select :auth_provider, Auth::PROVIDERS %>
       <%= f.text_field :auth_uid %>
       <span class="form-help deemphasize">(<a href="<%= t '.openid.link' %>" target="_new"><%= t '.openid.link text' %></a>)</span>
-    </diV>
+    </div>
   </fieldset>
 
   <fieldset class="form-divider">

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -36,12 +36,12 @@
   <fieldset>
     <div class="form-row">
         <label class="standard-label"><%= t 'users.new.password' %></label>
-      <%= f.password_field :pass_crypt, {:value => '', :autocomplete => :off} %>
+      <%= f.password_field :pass_crypt, { :value => '', :autocomplete => :off } %>
     </div>
 
     <div class="form-row">
       <label class="standard-label"><%= t 'users.new.confirm password' %></label>
-      <%= f.password_field :pass_crypt_confirmation, {:value => '', :autocomplete => :off} %>
+      <%= f.password_field :pass_crypt_confirmation, { :value => '', :autocomplete => :off } %>
     </div>
   </fieldset>
 
@@ -149,7 +149,7 @@
   <fieldset class="form-divider">
     <div class='form-row location clearfix'>
     <label class="standard-label"><%= t '.home location' %></label>
-    <div id="homerow" <% unless current_user.home_lat and current_user.home_lon %>class="nohome"<%end%> >
+    <div id="homerow" <% unless current_user.home_lat and current_user.home_lon %>class="nohome"<% end %> >
       <p class="message form-help deemphasize"><%= t '.no home location' %></p>
         <div class='form-column'>
           <label class="standard-label secondary"><%= t '.latitude' %></label>

--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -26,5 +26,5 @@
   </h1>
 
   <p class='deemphasize'><%= t ".reconfirm_html",
-                               :reconfirm => url_for(:action => 'confirm_resend')%></p>
+                               :reconfirm => url_for(:action => 'confirm_resend') %></p>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,12 +17,11 @@
       <tr>
         <td colspan="2">
           <%= t '.showing',
-              :page => @user_pages.current_page.number,
-              :first_item => @user_pages.current_page.first_item,
-              :last_item => @user_pages.current_page.last_item,
-              :items => @user_pages.item_count,
-              :count => @user_pages.current_page.last_item - @user_pages.current_page.first_item + 1
-          %>
+                :page => @user_pages.current_page.number,
+                :first_item => @user_pages.current_page.first_item,
+                :last_item => @user_pages.current_page.last_item,
+                :items => @user_pages.item_count,
+                :count => @user_pages.current_page.last_item - @user_pages.current_page.first_item + 1 %>
           <% if @user_pages.page_count > 1 %>
           | <%= raw pagination_links_each(@user_pages, {}) { |n| link_to n, @params.merge(:page => n) } %>
           <% end %>

--- a/app/views/users/lost_password.html.erb
+++ b/app/views/users/lost_password.html.erb
@@ -7,7 +7,7 @@
 <%= form_tag :action => 'lost_password' do %>
   <div class="standard-form">
     <label class="standard-label"><%= t '.email address' %></label>
-    <%= text_field('user', 'email', { :tabindex => 1} ) %>
+    <%= text_field('user', 'email', { :tabindex => 1 }) %>
     <%= submit_tag t('.new password button'), :tabindex => 2 %>
   </div>
 <% end %>

--- a/app/views/users/reset_password.html.erb
+++ b/app/views/users/reset_password.html.erb
@@ -9,11 +9,11 @@
   <div class="standard-form">
     <fieldset>
       <label class="standard-label"><%= t '.password' %></label>
-      <%= password_field(:user, :pass_crypt, {:value => '', :tabindex => 4}) %>
+      <%= password_field(:user, :pass_crypt, { :value => '', :tabindex => 4 }) %>
     </fieldset>
     <fieldset>
       <label class="standard-label"><%= t '.confirm password' %></label>
-      <%= password_field(:user, :pass_crypt_confirmation, {:value => '', :tabindex => 5}) %>
+      <%= password_field(:user, :pass_crypt_confirmation, { :value => '', :tabindex => 5 }) %>
     </fieldset>
     <%= submit_tag t('.reset'), :tabindex => 6 %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
             <span class='count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
           </li>
           <li>
-            <%= link_to t('.my notes'), :controller => 'notes', :action=> 'mine' %>
+            <%= link_to t('.my notes'), :controller => 'notes', :action => 'mine' %>
           </li>
           <li>
             <%= link_to t('.my traces'), :controller => 'traces', :action => 'mine' %>
@@ -22,7 +22,7 @@
             <span class='count-number'><%= number_with_delimiter(current_user.diary_entries.size) %></span>
           </li>
           <li>
-            <%= link_to t('.my comments' ), :controller => 'diary_entries', :action => 'comments', :display_name => current_user.display_name %>
+            <%= link_to t('.my comments'), :controller => 'diary_entries', :action => 'comments', :display_name => current_user.display_name %>
           </li>
           <li>
             <%= link_to t('.my settings'), :controller => 'users', :action => 'account', :display_name => current_user.display_name %>
@@ -53,7 +53,7 @@
             <span class='count-number'><%= number_with_delimiter(@user.changesets.size) %></span>
           </li>
           <li>
-            <%= link_to t('.notes'), :controller => 'notes', :action=> 'mine' %>
+            <%= link_to t('.notes'), :controller => 'notes', :action => 'mine' %>
           </li>
           <li>
             <%= link_to t('.traces'), :controller => 'traces', :action => 'index', :display_name => @user.display_name %>
@@ -190,10 +190,10 @@
           :lon => current_user.home_lon,
           :lat => current_user.home_lat,
           :icon => image_path("marker-red.png"),
-          :description => render(:partial => "popup", :object => current_user, :locals => {:type => "your location"})
+          :description => render(:partial => "popup", :object => current_user, :locals => { :type => "your location" })
         }
       %>
-      <%= content_tag "div", "", :id => "map", :class => "content_map", :data => {:user => user_data} %>
+      <%= content_tag "div", "", :id => "map", :class => "content_map", :data => { :user => user_data } %>
     <% end %>
 
     <% friends = @user.friends.collect { |f| f.befriendee } %>
@@ -210,7 +210,7 @@
         <li><%= link_to t('.friends_diaries'), friend_diaries_path %></li>
       </ul>
       <div id="friends-container">
-        <%= render :partial => "contact", :collection => friends, :locals => {:type => "friend"} %>
+        <%= render :partial => "contact", :collection => friends, :locals => { :type => "friend" } %>
       </div>
     <% end %>
   </div>
@@ -226,7 +226,7 @@
         <li><%= link_to t('.nearby_diaries'), nearby_diaries_path %></li>
       </ul>
       <div id="nearbyusers">
-        <%= render :partial => "contact", :collection => nearby, :locals => {:type => "nearby mapper"} %>
+        <%= render :partial => "contact", :collection => nearby, :locals => { :type => "nearby mapper" } %>
       </div>
     <% end %>
   </div>

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -7,7 +7,7 @@
   <div class='header-illustration new-user-terms'></div>
 <% end %>
 
-<%= form_tag({:action => "save"}, { :class => " inner22 standard-form fillL" }) do %>
+<%= form_tag({ :action => "save" }, { :class => " inner22 standard-form fillL" }) do %>
   <!-- legale is <%= @legale %> -->
   <div class='form-row horizontal-list'>
     <label class="standard-label">
@@ -33,7 +33,7 @@
       <%= check_box('user', 'consider_pd') %>
       <%= t '.consider_pd' %>
     </label>
-    <span class="minorNote">(<%= link_to(t('.consider_pd_why'), t('.consider_pd_why_url'), :target => :new)%>)</span>
+    <span class="minorNote">(<%= link_to(t('.consider_pd_why'), t('.consider_pd_why_url'), :target => :new) %>)</span>
 
     <%= hidden_field_tag('referer', h(params[:referer])) unless params[:referer].nil? %>
 

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,11 +1,9 @@
 #!/usr/bin/env ruby
 APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarnpkg", *ARGV
-  rescue Errno::ENOENT
-    warn "Yarn executable was not detected in the system."
-    warn "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarnpkg", *ARGV
+rescue Errno::ENOENT
+  warn "Yarn executable was not detected in the system."
+  warn "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end

--- a/lib/password_hash.rb
+++ b/lib/password_hash.rb
@@ -18,7 +18,7 @@ module PasswordHash
   def self.check(hash, salt, candidate)
     if salt.nil?
       candidate = Digest::MD5.hexdigest(candidate)
-    elsif salt =~ /!/
+    elsif /!/.match?(salt)
       algorithm, iterations, salt = salt.split("!")
       size = Base64.strict_decode64(hash).length
       candidate = self.hash(candidate, salt, iterations.to_i, size, algorithm)
@@ -32,7 +32,7 @@ module PasswordHash
   def self.upgrade?(hash, salt)
     if salt.nil?
       return true
-    elsif salt =~ /!/
+    elsif /!/.match?(salt)
       algorithm, iterations, salt = salt.split("!")
       return true if Base64.strict_decode64(salt).length != SALT_BYTE_SIZE
       return true if Base64.strict_decode64(hash).length != HASH_BYTE_SIZE

--- a/lib/password_hash.rb
+++ b/lib/password_hash.rb
@@ -18,7 +18,7 @@ module PasswordHash
   def self.check(hash, salt, candidate)
     if salt.nil?
       candidate = Digest::MD5.hexdigest(candidate)
-    elsif /!/.match?(salt)
+    elsif salt.match?(/!/)
       algorithm, iterations, salt = salt.split("!")
       size = Base64.strict_decode64(hash).length
       candidate = self.hash(candidate, salt, iterations.to_i, size, algorithm)
@@ -32,7 +32,7 @@ module PasswordHash
   def self.upgrade?(hash, salt)
     if salt.nil?
       return true
-    elsif /!/.match?(salt)
+    elsif salt.match?(/!/)
       algorithm, iterations, salt = salt.split("!")
       return true if Base64.strict_decode64(salt).length != SALT_BYTE_SIZE
       return true if Base64.strict_decode64(hash).length != HASH_BYTE_SIZE

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -165,12 +165,10 @@ module Api
     # check that a changeset that doesn't exist returns an appropriate message
     def test_show_not_found
       [0, -32, 233455644, "afg", "213"].each do |id|
-        begin
-          get :show, :params => { :id => id }
-          assert_response :not_found, "should get a not found"
-        rescue ActionController::UrlGenerationError => ex
-          assert_match(/No route matches/, ex.to_s)
-        end
+        get :show, :params => { :id => id }
+        assert_response :not_found, "should get a not found"
+      rescue ActionController::UrlGenerationError => ex
+        assert_match(/No route matches/, ex.to_s)
       end
     end
 
@@ -239,23 +237,19 @@ module Api
 
       # First try to do it with no auth
       cs_ids.each do |id|
-        begin
-          put :close, :params => { :id => id }
-          assert_response :unauthorized, "Shouldn't be able close the non-existant changeset #{id}, when not authorized"
-        rescue ActionController::UrlGenerationError => ex
-          assert_match(/No route matches/, ex.to_s)
-        end
+        put :close, :params => { :id => id }
+        assert_response :unauthorized, "Shouldn't be able close the non-existant changeset #{id}, when not authorized"
+      rescue ActionController::UrlGenerationError => ex
+        assert_match(/No route matches/, ex.to_s)
       end
 
       # Now try with auth
       basic_authorization create(:user).email, "test"
       cs_ids.each do |id|
-        begin
-          put :close, :params => { :id => id }
-          assert_response :not_found, "The changeset #{id} doesn't exist, so can't be closed"
-        rescue ActionController::UrlGenerationError => ex
-          assert_match(/No route matches/, ex.to_s)
-        end
+        put :close, :params => { :id => id }
+        assert_response :not_found, "The changeset #{id} doesn't exist, so can't be closed"
+      rescue ActionController::UrlGenerationError => ex
+        assert_match(/No route matches/, ex.to_s)
       end
     end
 

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -53,20 +53,18 @@ class MessageTest < ActiveSupport::TestCase
                          "\x82\x82",     # multibyte continuations without multibyte identifier
                          "\xe1\x82\x4a"] # three-byte identifier, contination and (incorrectly) plain ASCII
     invalid_sequences.each do |char|
-      begin
-        # create a message and save to the database
-        msg = make_message(char, 1)
-        # if the save throws, thats fine and the test should pass, as we're
-        # only testing invalid sequences anyway.
-        msg.save!
+      # create a message and save to the database
+      msg = make_message(char, 1)
+      # if the save throws, thats fine and the test should pass, as we're
+      # only testing invalid sequences anyway.
+      msg.save!
 
-        # get the saved message back and check that it is identical - i.e:
-        # its OK to accept invalid UTF-8 as long as we return it unmodified.
-        db_msg = msg.class.find(msg.id)
-        assert_equal char, db_msg.title, "Database silently truncated message title"
-      rescue ArgumentError => ex
-        assert_equal ex.to_s, "invalid byte sequence in UTF-8"
-      end
+      # get the saved message back and check that it is identical - i.e:
+      # its OK to accept invalid UTF-8 as long as we return it unmodified.
+      db_msg = msg.class.find(msg.id)
+      assert_equal char, db_msg.title, "Database silently truncated message title"
+    rescue ArgumentError => ex
+      assert_equal ex.to_s, "invalid byte sequence in UTF-8"
     end
   end
 


### PR DESCRIPTION
[ERB Lint](https://github.com/Shopify/erb-lint) brings a useful amount of linting to our html.erb templates. It also allows us to run rubocop on the code embedded in the templates, which is useful too.

As a proof of concept, I've disabled most of the erb linters and many of the rubocop linters too, and just made whitespace changes. These are trivial but were also drowning out everything else, so it's nice to fix them first.

This adds erblint to the travis config, and updates the contributing guide to refer to it too.

The intention is to work through everything marked TODO in the config file, and fix those issues later. The rubocop-related configurations not marked as TODO are those that the ERB Lint docs suggest disabling permanently. 