### PR TITLE
Raise error when note has no comments

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -84,6 +84,8 @@ class BrowseController < ApplicationController
     else
       @note = Note.visible.find(params[:id])
       @note_comments = @note.comments
+
+      raise ActiveRecord::RecordNotFound if @note.comments.empty?
     end
   rescue ActiveRecord::RecordNotFound
     render :action => "not_found", :status => :not_found


### PR DESCRIPTION
Temporary fix for #2146 

- Raises `RecordNotFound` exception when note has no comments (avoiding 500 Error)