### PR TITLE
Create a common ApiController for API controllers

### DIFF
--- a/app/controllers/api/amf_controller.rb
+++ b/app/controllers/api/amf_controller.rb
@@ -36,10 +36,9 @@
 # * version conflict when POIs and ways are reverted
 
 module Api
-  class AmfController < ApplicationController
+  class AmfController < ApiController
     include Potlatch
 
-    skip_before_action :verify_authenticity_token
     before_action :check_api_writable
 
     # AMF Controller implements its own authentication and authorization checks

--- a/app/controllers/api/capabilities_controller.rb
+++ b/app/controllers/api/capabilities_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class CapabilitiesController < ApiController
-    before_action :api_deny_access_handler
-
     authorize_resource :class => false
 
     around_action :api_call_handle_error, :api_call_timeout

--- a/app/controllers/api/capabilities_controller.rb
+++ b/app/controllers/api/capabilities_controller.rb
@@ -1,6 +1,5 @@
 module Api
-  class CapabilitiesController < ApplicationController
-    skip_before_action :verify_authenticity_token
+  class CapabilitiesController < ApiController
     before_action :api_deny_access_handler
 
     authorize_resource :class => false

--- a/app/controllers/api/changes_controller.rb
+++ b/app/controllers/api/changes_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class ChangesController < ApiController
-    before_action :api_deny_access_handler
-
     authorize_resource :class => false
 
     before_action :check_api_readable

--- a/app/controllers/api/changes_controller.rb
+++ b/app/controllers/api/changes_controller.rb
@@ -1,6 +1,5 @@
 module Api
-  class ChangesController < ApplicationController
-    skip_before_action :verify_authenticity_token
+  class ChangesController < ApiController
     before_action :api_deny_access_handler
 
     authorize_resource :class => false

--- a/app/controllers/api/changeset_comments_controller.rb
+++ b/app/controllers/api/changeset_comments_controller.rb
@@ -1,6 +1,5 @@
 module Api
-  class ChangesetCommentsController < ApplicationController
-    skip_before_action :verify_authenticity_token
+  class ChangesetCommentsController < ApiController
     before_action :authorize
     before_action :api_deny_access_handler
 

--- a/app/controllers/api/changeset_comments_controller.rb
+++ b/app/controllers/api/changeset_comments_controller.rb
@@ -1,7 +1,6 @@
 module Api
   class ChangesetCommentsController < ApiController
     before_action :authorize
-    before_action :api_deny_access_handler
 
     authorize_resource
 

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -1,11 +1,10 @@
 # The ChangesetController is the RESTful interface to Changeset objects
 
 module Api
-  class ChangesetsController < ApplicationController
+  class ChangesetsController < ApiController
     layout "site"
     require "xml/libxml"
 
-    skip_before_action :verify_authenticity_token
     before_action :authorize, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]
     before_action :api_deny_access_handler, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe, :expand_bbox]
 

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -6,7 +6,6 @@ module Api
     require "xml/libxml"
 
     before_action :authorize, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]
-    before_action :api_deny_access_handler, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe, :expand_bbox]
 
     authorize_resource
 

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -12,7 +12,6 @@ module Api
     before_action :require_public_data, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]
     before_action :check_api_writable, :only => [:create, :update, :upload, :subscribe, :unsubscribe]
     before_action :check_api_readable, :except => [:create, :update, :upload, :download, :query, :subscribe, :unsubscribe]
-    before_action(:only => [:index, :feed]) { |c| c.check_database_readable(true) }
     around_action :api_call_handle_error
     around_action :api_call_timeout, :except => [:upload]
 

--- a/app/controllers/api/map_controller.rb
+++ b/app/controllers/api/map_controller.rb
@@ -1,6 +1,5 @@
 module Api
-  class MapController < ApplicationController
-    skip_before_action :verify_authenticity_token
+  class MapController < ApiController
     before_action :api_deny_access_handler
 
     authorize_resource :class => false

--- a/app/controllers/api/map_controller.rb
+++ b/app/controllers/api/map_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class MapController < ApiController
-    before_action :api_deny_access_handler
-
     authorize_resource :class => false
 
     before_action :check_api_readable

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -1,10 +1,9 @@
 # The NodeController is the RESTful interface to Node objects
 
 module Api
-  class NodesController < ApplicationController
+  class NodesController < ApiController
     require "xml/libxml"
 
-    skip_before_action :verify_authenticity_token
     before_action :authorize, :only => [:create, :update, :delete]
     before_action :api_deny_access_handler
 

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -5,7 +5,6 @@ module Api
     require "xml/libxml"
 
     before_action :authorize, :only => [:create, :update, :delete]
-    before_action :api_deny_access_handler
 
     authorize_resource
 

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -5,7 +5,6 @@ module Api
     before_action :check_api_readable
     before_action :setup_user_auth, :only => [:create, :comment, :show]
     before_action :authorize, :only => [:close, :reopen, :destroy]
-    before_action :api_deny_access_handler
 
     authorize_resource
 

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -1,8 +1,7 @@
 module Api
-  class NotesController < ApplicationController
+  class NotesController < ApiController
     layout "site", :only => [:mine]
 
-    skip_before_action :verify_authenticity_token
     before_action :check_api_readable
     before_action :setup_user_auth, :only => [:create, :comment, :show]
     before_action :authorize, :only => [:close, :reopen, :destroy]

--- a/app/controllers/api/old_controller.rb
+++ b/app/controllers/api/old_controller.rb
@@ -6,7 +6,6 @@ module Api
     require "xml/libxml"
 
     before_action :setup_user_auth, :only => [:history, :version]
-    before_action :api_deny_access_handler
     before_action :authorize, :only => [:redact]
 
     authorize_resource

--- a/app/controllers/api/old_controller.rb
+++ b/app/controllers/api/old_controller.rb
@@ -2,10 +2,9 @@
 # into one place. as it turns out, the API methods for historical
 # nodes, ways and relations are basically identical.
 module Api
-  class OldController < ApplicationController
+  class OldController < ApiController
     require "xml/libxml"
 
-    skip_before_action :verify_authenticity_token
     before_action :setup_user_auth, :only => [:history, :version]
     before_action :api_deny_access_handler
     before_action :authorize, :only => [:redact]

--- a/app/controllers/api/permissions_controller.rb
+++ b/app/controllers/api/permissions_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class PermissionsController < ApiController
-    before_action :api_deny_access_handler
-
     authorize_resource :class => false
 
     before_action :check_api_readable

--- a/app/controllers/api/permissions_controller.rb
+++ b/app/controllers/api/permissions_controller.rb
@@ -1,6 +1,5 @@
 module Api
-  class PermissionsController < ApplicationController
-    skip_before_action :verify_authenticity_token
+  class PermissionsController < ApiController
     before_action :api_deny_access_handler
 
     authorize_resource :class => false

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -1,8 +1,7 @@
 module Api
-  class RelationsController < ApplicationController
+  class RelationsController < ApiController
     require "xml/libxml"
 
-    skip_before_action :verify_authenticity_token
     before_action :authorize, :only => [:create, :update, :delete]
     before_action :api_deny_access_handler
 

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -3,7 +3,6 @@ module Api
     require "xml/libxml"
 
     before_action :authorize, :only => [:create, :update, :delete]
-    before_action :api_deny_access_handler
 
     authorize_resource
 

--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -1,9 +1,8 @@
 module Api
-  class SearchController < ApplicationController
+  class SearchController < ApiController
     # Support searching for nodes, ways, or all
     # Can search by tag k, v, or both (type->k,value->v)
     # Can search by name (k=name,v=....)
-    skip_before_action :verify_authenticity_token
     authorize_resource :class => false
 
     def search_all

--- a/app/controllers/api/swf_controller.rb
+++ b/app/controllers/api/swf_controller.rb
@@ -1,6 +1,5 @@
 module Api
-  class SwfController < ApplicationController
-    skip_before_action :verify_authenticity_token
+  class SwfController < ApiController
     before_action :check_api_readable
     authorize_resource :class => false
 

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class TracepointsController < ApiController
-    before_action :api_deny_access_handler
-
     authorize_resource
 
     before_action :check_api_readable

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -1,6 +1,5 @@
 module Api
-  class TracepointsController < ApplicationController
-    skip_before_action :verify_authenticity_token
+  class TracepointsController < ApiController
     before_action :api_deny_access_handler
 
     authorize_resource

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -1,8 +1,7 @@
 module Api
-  class TracesController < ApplicationController
+  class TracesController < ApiController
     layout "site", :except => :georss
 
-    skip_before_action :verify_authenticity_token
     before_action :authorize_web
     before_action :set_locale
     before_action :authorize

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -5,7 +5,6 @@ module Api
     before_action :authorize_web
     before_action :set_locale
     before_action :authorize
-    before_action :api_deny_access_handler
 
     authorize_resource
 

--- a/app/controllers/api/user_preferences_controller.rb
+++ b/app/controllers/api/user_preferences_controller.rb
@@ -1,7 +1,6 @@
 # Update and read user preferences, which are arbitrayr key/val pairs
 module Api
-  class UserPreferencesController < ApplicationController
-    skip_before_action :verify_authenticity_token
+  class UserPreferencesController < ApiController
     before_action :authorize
 
     authorize_resource

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,8 +1,7 @@
 module Api
-  class UsersController < ApplicationController
+  class UsersController < ApiController
     layout "site", :except => [:api_details]
 
-    skip_before_action :verify_authenticity_token
     before_action :disable_terms_redirect, :only => [:api_details]
     before_action :authorize, :only => [:api_details, :api_gpx_files]
     before_action :api_deny_access_handler

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -4,7 +4,6 @@ module Api
 
     before_action :disable_terms_redirect, :only => [:api_details]
     before_action :authorize, :only => [:api_details, :api_gpx_files]
-    before_action :api_deny_access_handler
 
     authorize_resource
 

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -1,8 +1,7 @@
 module Api
-  class WaysController < ApplicationController
+  class WaysController < ApiController
     require "xml/libxml"
 
-    skip_before_action :verify_authenticity_token
     before_action :authorize, :only => [:create, :update, :delete]
     before_action :api_deny_access_handler
 

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -3,7 +3,6 @@ module Api
     require "xml/libxml"
 
     before_action :authorize, :only => [:create, :update, :delete]
-    before_action :api_deny_access_handler
 
     authorize_resource
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,6 +1,19 @@
 class ApiController < ApplicationController
   skip_before_action :verify_authenticity_token
 
+  def authorize(realm = "Web Password", errormessage = "Couldn't authenticate you")
+    # make the current_user object from any auth sources we have
+    setup_user_auth
+
+    # handle authenticate pass/fail
+    unless current_user
+      # no auth, the user does not exist or the password was wrong
+      response.headers["WWW-Authenticate"] = "Basic realm=\"#{realm}\""
+      render :plain => errormessage, :status => :unauthorized
+      return false
+    end
+  end
+
   def deny_access(_exception)
     if current_token
       set_locale

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,3 @@
+class ApiController < ApplicationController
+  skip_before_action :verify_authenticity_token
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,3 +1,17 @@
 class ApiController < ApplicationController
   skip_before_action :verify_authenticity_token
+
+  def deny_access(_exception)
+    if current_token
+      set_locale
+      report_error t("oauth.permissions.missing"), :forbidden
+    elsif current_user
+      head :forbidden
+    else
+      realm = "Web Password"
+      errormessage = "Couldn't authenticate you"
+      response.headers["WWW-Authenticate"] = "Basic realm=\"#{realm}\""
+      render :plain => errormessage, :status => :unauthorized
+    end
+  end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,6 +1,8 @@
 class ApiController < ApplicationController
   skip_before_action :verify_authenticity_token
 
+  private
+
   def authorize(realm = "Web Password", errormessage = "Couldn't authenticate you")
     # make the current_user object from any auth sources we have
     setup_user_auth

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -29,4 +29,51 @@ class ApiController < ApplicationController
       render :plain => errormessage, :status => :unauthorized
     end
   end
+
+  def gpx_status
+    status = database_status
+    status = :offline if status == :online && Settings.status == "gpx_offline"
+    status
+  end
+
+  ##
+  # sets up the current_user for use by other methods. this is mostly called
+  # from the authorize method, but can be called elsewhere if authorisation
+  # is optional.
+  def setup_user_auth
+    # try and setup using OAuth
+    unless Authenticator.new(self, [:token]).allow?
+      username, passwd = get_auth_data # parse from headers
+      # authenticate per-scheme
+      self.current_user = if username.nil?
+                            nil # no authentication provided - perhaps first connect (client should retry after 401)
+                          elsif username == "token"
+                            User.authenticate(:token => passwd) # preferred - random token for user from db, passed in basic auth
+                          else
+                            User.authenticate(:username => username, :password => passwd) # basic auth
+                          end
+    end
+
+    # have we identified the user?
+    if current_user
+      # check if the user has been banned
+      user_block = current_user.blocks.active.take
+      unless user_block.nil?
+        set_locale
+        if user_block.zero_hour?
+          report_error t("application.setup_user_auth.blocked_zero_hour"), :forbidden
+        else
+          report_error t("application.setup_user_auth.blocked"), :forbidden
+        end
+      end
+
+      # if the user hasn't seen the contributor terms then don't
+      # allow editing - they have to go to the web site and see
+      # (but can decline) the CTs to continue.
+      if !current_user.terms_seen && flash[:skip_terms].nil?
+        set_locale
+        report_error t("application.setup_user_auth.need_to_see_terms"), :forbidden
+      end
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,8 @@ class ApplicationController < ActionController::Base
   attr_accessor :current_user
   helper_method :current_user
 
+  private
+
   def authorize_web
     if session[:user]
       self.current_user = User.where(:id => session[:user]).where("status IN ('active', 'confirmed', 'suspended')").first
@@ -401,8 +403,6 @@ class ApplicationController < ActionController::Base
       head :forbidden
     end
   end
-
-  private
 
   # extract authorisation credentials from headers, returns user = nil if none
   def get_auth_data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -112,19 +112,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def authorize(realm = "Web Password", errormessage = "Couldn't authenticate you")
-    # make the current_user object from any auth sources we have
-    setup_user_auth
-
-    # handle authenticate pass/fail
-    unless current_user
-      # no auth, the user does not exist or the password was wrong
-      response.headers["WWW-Authenticate"] = "Basic realm=\"#{realm}\""
-      render :plain => errormessage, :status => :unauthorized
-      return false
-    end
-  end
-
   def check_database_readable(need_api = false)
     if Settings.status == "database_offline" || (need_api && Settings.status == "api_offline")
       if request.xhr?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -395,15 +395,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def deny_access(exception)
-    if @api_deny_access_handling
-      api_deny_access(exception)
-    else
-      web_deny_access(exception)
-    end
-  end
-
-  def web_deny_access(_exception)
+  def deny_access(_exception)
     if current_token
       set_locale
       report_error t("oauth.permissions.missing"), :forbidden
@@ -421,26 +413,6 @@ class ApplicationController < ActionController::Base
     else
       head :forbidden
     end
-  end
-
-  def api_deny_access(_exception)
-    if current_token
-      set_locale
-      report_error t("oauth.permissions.missing"), :forbidden
-    elsif current_user
-      head :forbidden
-    else
-      realm = "Web Password"
-      errormessage = "Couldn't authenticate you"
-      response.headers["WWW-Authenticate"] = "Basic realm=\"#{realm}\""
-      render :plain => errormessage, :status => :unauthorized
-    end
-  end
-
-  attr_accessor :api_access_handling
-
-  def api_deny_access_handler
-    @api_deny_access_handling = true
   end
 
   private

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -3,7 +3,7 @@ class BrowseController < ApplicationController
 
   before_action :authorize_web
   before_action :set_locale
-  before_action(:except => [:query]) { |c| c.check_database_readable(true) }
+  before_action -> { check_database_readable(true) }
   before_action :require_oauth
   around_action :web_timeout
   authorize_resource :class => false

--- a/app/controllers/changeset_comments_controller.rb
+++ b/app/controllers/changeset_comments_controller.rb
@@ -4,7 +4,7 @@ class ChangesetCommentsController < ApplicationController
 
   authorize_resource
 
-  before_action(:only => [:index]) { |c| c.check_database_readable(true) }
+  before_action -> { check_database_readable(true) }
   around_action :web_timeout
 
   ##

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -7,7 +7,7 @@ class ChangesetsController < ApplicationController
   skip_before_action :verify_authenticity_token, :except => [:index]
   before_action :authorize_web
   before_action :set_locale
-  before_action(:only => [:index, :feed]) { |c| c.check_database_readable(true) }
+  before_action -> { check_database_readable(true) }, :only => [:index, :feed]
 
   authorize_resource
 


### PR DESCRIPTION
Follows on from #2160 and #2161 

This PR refactors the API controllers to inherit from a common ApiController. This allows us to move some methods out of ApplicationController, and simplify other things like the deny_access handler.

I've also taken the opportunity to mark all these methods as private, to avoid surprises if there's ever controller actions with the same name, and adjusted some before_actions appropriately.

There's more work to be done on this topic, but this makes a good start. 