### PR TITLE
Check validity token in changesets controller

### DIFF
--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -4,7 +4,6 @@ class ChangesetsController < ApplicationController
   layout "site"
   require "xml/libxml"
 
-  skip_before_action :verify_authenticity_token, :except => [:index]
   before_action :authorize_web
   before_action :set_locale
   before_action -> { check_database_readable(true) }, :only => [:index, :feed]


### PR DESCRIPTION
It makes no difference today, but prevents problems in future if methods accepting post requests are added to this controller in future.

I didn't pick this up as being unnecessary during earlier refactorings, since it currently applies to one of the methods in this controller, but there's no need for it to do so.