### PR TITLE
Use the trace jobs for creating and destroy traces via the API

### DIFF
--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -44,6 +44,7 @@ module Api
       if trace.user == current_user
         trace.visible = false
         trace.save!
+        TraceDestroyerJob.perform_later(trace) if Settings.trace_use_job_queue
 
         head :ok
       else
@@ -84,6 +85,7 @@ module Api
         trace = do_create(params[:file], tags, description, visibility)
 
         if trace.id
+          TraceImporterJob.perform_later(@trace) if Settings.trace_use_job_queue
           render :plain => trace.id.to_s
         elsif trace.valid?
           head :internal_server_error


### PR DESCRIPTION
I spotted that this was only implemented for the non-api methods in https://github.com/gravitystorm/openstreetmap-website/commit/e59f1b610817ad8442bc639d479cebe0a851c05a and https://github.com/gravitystorm/openstreetmap-website/commit/581eca3bbe3f2e8a657d5f72afe6cbe261d4d8bf