### PR TITLE
Enable trace jobs by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,9 +60,9 @@ spam_threshold: 50
 # Default legale (jurisdiction location) for contributor terms
 default_legale: GB
 # Use the built-in jobs queue for importing traces
-# Leave as false if you are using the external high-speed gpx importer
+# Set to false if you are using the external high-speed gpx importer
 # https://github.com/openstreetmap/gpx-import
-trace_use_job_queue: false
+trace_use_job_queue: true
 # Location of GPX traces and images
 gpx_trace_dir: "/home/osm/traces"
 gpx_image_dir: "/home/osm/images"


### PR DESCRIPTION
I think it's a good idea to use the trace jobs queue by default now, even while we wait on #2132.