### PR TITLE
Disentangle the api abilities from the web abilities

### DIFF
--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Capability
+class ApiCapability
   include CanCan::Ability
 
   def initialize(token)

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -16,6 +16,15 @@ class ApiController < ApplicationController
     end
   end
 
+  def current_ability
+    # Use capabilities from the oauth token if it exists and is a valid access token
+    if Authenticator.new(self, [:token]).allow?
+      ApiAbility.new(nil).merge(ApiCapability.new(current_token))
+    else
+      ApiAbility.new(current_user)
+    end
+  end
+
   def deny_access(_exception)
     if current_token
       set_locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -329,12 +329,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_ability
-    # Use capabilities from the oauth token if it exists and is a valid access token
-    if Authenticator.new(self, [:token]).allow?
-      Ability.new(nil).merge(Capability.new(current_token))
-    else
-      Ability.new(current_user)
-    end
+    Ability.new(current_user)
   end
 
   def deny_access(_exception)

--- a/test/abilities/abilities_test.rb
+++ b/test/abilities/abilities_test.rb
@@ -30,12 +30,8 @@ class GuestAbilityTest < AbilityTest
   test "note permissions for a guest" do
     ability = Ability.new nil
 
-    [:index, :create, :comment, :feed, :show, :search, :mine].each do |action|
+    [:mine].each do |action|
       assert ability.can?(action, Note), "should be able to #{action} Notes"
-    end
-
-    [:close, :reopen, :destroy].each do |action|
-      assert ability.cannot?(action, Note), "should not be able to #{action} Notes"
     end
   end
 
@@ -65,18 +61,6 @@ class UserAbilityTest < AbilityTest
       assert ability.cannot?(action, Issue), "should not be able to #{action} Issues"
     end
   end
-
-  test "Note permissions" do
-    ability = Ability.new create(:user)
-
-    [:index, :create, :comment, :feed, :show, :search, :mine, :close, :reopen].each do |action|
-      assert ability.can?(action, Note), "should be able to #{action} Notes"
-    end
-
-    [:destroy].each do |action|
-      assert ability.cannot?(action, Note), "should not be able to #{action} Notes"
-    end
-  end
 end
 
 class ModeratorAbilityTest < AbilityTest
@@ -85,14 +69,6 @@ class ModeratorAbilityTest < AbilityTest
 
     [:index, :show, :resolve, :ignore, :reopen].each do |action|
       assert ability.can?(action, Issue), "should be able to #{action} Issues"
-    end
-  end
-
-  test "Note permissions" do
-    ability = Ability.new create(:moderator_user)
-
-    [:index, :create, :comment, :feed, :show, :search, :mine, :close, :reopen, :destroy].each do |action|
-      assert ability.can?(action, Note), "should be able to #{action} Notes"
     end
   end
 

--- a/test/abilities/api_abilities_test.rb
+++ b/test/abilities/api_abilities_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApiAbilityTest < ActiveSupport::TestCase
+end
+
+class GuestApiAbilityTest < ApiAbilityTest
+  test "note permissions for a guest" do
+    ability = ApiAbility.new nil
+
+    [:index, :create, :comment, :feed, :show, :search].each do |action|
+      assert ability.can?(action, Note), "should be able to #{action} Notes"
+    end
+
+    [:close, :reopen, :destroy].each do |action|
+      assert ability.cannot?(action, Note), "should not be able to #{action} Notes"
+    end
+  end
+end
+
+class UserApiAbilityTest < ApiAbilityTest
+  test "Note permissions" do
+    ability = ApiAbility.new create(:user)
+
+    [:index, :create, :comment, :feed, :show, :search, :close, :reopen].each do |action|
+      assert ability.can?(action, Note), "should be able to #{action} Notes"
+    end
+
+    [:destroy].each do |action|
+      assert ability.cannot?(action, Note), "should not be able to #{action} Notes"
+    end
+  end
+end
+
+class ModeratorApiAbilityTest < ApiAbilityTest
+  test "Note permissions" do
+    ability = ApiAbility.new create(:moderator_user)
+
+    [:index, :create, :comment, :feed, :show, :search, :close, :reopen, :destroy].each do |action|
+      assert ability.can?(action, Note), "should be able to #{action} Notes"
+    end
+  end
+end

--- a/test/abilities/api_capability_test.rb
+++ b/test/abilities/api_capability_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class CapabilityTest < ActiveSupport::TestCase
+class ApiCapabilityTest < ActiveSupport::TestCase
   def tokens(*toks)
     AccessToken.new do |token|
       toks.each do |t|
@@ -12,10 +12,10 @@ class CapabilityTest < ActiveSupport::TestCase
   end
 end
 
-class ChangesetCommentCapabilityTest < CapabilityTest
+class ChangesetCommentApiCapabilityTest < ApiCapabilityTest
   test "as a normal user with permissionless token" do
     token = create(:access_token)
-    capability = Capability.new token
+    capability = ApiCapability.new token
 
     [:create, :destroy, :restore].each do |action|
       assert capability.cannot? action, ChangesetComment
@@ -24,7 +24,7 @@ class ChangesetCommentCapabilityTest < CapabilityTest
 
   test "as a normal user with allow_write_api token" do
     token = create(:access_token, :allow_write_api => true)
-    capability = Capability.new token
+    capability = ApiCapability.new token
 
     [:destroy, :restore].each do |action|
       assert capability.cannot? action, ChangesetComment
@@ -37,7 +37,7 @@ class ChangesetCommentCapabilityTest < CapabilityTest
 
   test "as a moderator with permissionless token" do
     token = create(:access_token, :user => create(:moderator_user))
-    capability = Capability.new token
+    capability = ApiCapability.new token
 
     [:create, :destroy, :restore].each do |action|
       assert capability.cannot? action, ChangesetComment
@@ -46,7 +46,7 @@ class ChangesetCommentCapabilityTest < CapabilityTest
 
   test "as a moderator with allow_write_api token" do
     token = create(:access_token, :user => create(:moderator_user), :allow_write_api => true)
-    capability = Capability.new token
+    capability = ApiCapability.new token
 
     [:create, :destroy, :restore].each do |action|
       assert capability.can? action, ChangesetComment
@@ -54,10 +54,10 @@ class ChangesetCommentCapabilityTest < CapabilityTest
   end
 end
 
-class NoteCapabilityTest < CapabilityTest
+class NoteApiCapabilityTest < ApiCapabilityTest
   test "as a normal user with permissionless token" do
     token = create(:access_token)
-    capability = Capability.new token
+    capability = ApiCapability.new token
 
     [:create, :comment, :close, :reopen, :destroy].each do |action|
       assert capability.cannot? action, Note
@@ -66,7 +66,7 @@ class NoteCapabilityTest < CapabilityTest
 
   test "as a normal user with allow_write_notes token" do
     token = create(:access_token, :allow_write_notes => true)
-    capability = Capability.new token
+    capability = ApiCapability.new token
 
     [:destroy].each do |action|
       assert capability.cannot? action, Note
@@ -79,7 +79,7 @@ class NoteCapabilityTest < CapabilityTest
 
   test "as a moderator with permissionless token" do
     token = create(:access_token, :user => create(:moderator_user))
-    capability = Capability.new token
+    capability = ApiCapability.new token
 
     [:destroy].each do |action|
       assert capability.cannot? action, Note
@@ -88,7 +88,7 @@ class NoteCapabilityTest < CapabilityTest
 
   test "as a moderator with allow_write_notes token" do
     token = create(:access_token, :user => create(:moderator_user), :allow_write_notes => true)
-    capability = Capability.new token
+    capability = ApiCapability.new token
 
     [:destroy].each do |action|
       assert capability.can? action, Note
@@ -96,22 +96,22 @@ class NoteCapabilityTest < CapabilityTest
   end
 end
 
-class UserCapabilityTest < CapabilityTest
+class UserApiCapabilityTest < ApiCapabilityTest
   test "user preferences" do
     # a user with no tokens
-    capability = Capability.new nil
+    capability = ApiCapability.new nil
     [:read, :read_one, :update, :update_one, :delete_one].each do |act|
       assert capability.cannot? act, UserPreference
     end
 
     # A user with empty tokens
-    capability = Capability.new tokens
+    capability = ApiCapability.new tokens
 
     [:read, :read_one, :update, :update_one, :delete_one].each do |act|
       assert capability.cannot? act, UserPreference
     end
 
-    capability = Capability.new tokens(:allow_read_prefs)
+    capability = ApiCapability.new tokens(:allow_read_prefs)
 
     [:update, :update_one, :delete_one].each do |act|
       assert capability.cannot? act, UserPreference
@@ -121,7 +121,7 @@ class UserCapabilityTest < CapabilityTest
       assert capability.can? act, UserPreference
     end
 
-    capability = Capability.new tokens(:allow_write_prefs)
+    capability = ApiCapability.new tokens(:allow_write_prefs)
     [:read, :read_one].each do |act|
       assert capability.cannot? act, UserPreference
     end


### PR DESCRIPTION
This will allow us to rename actions without causing permissions headaches. The choice of abilities files is made by inheriting from either `api_controller` or `application_controller`.

Also rename `capabilities` to `api_capabilites`, for consistency.