### PR TITLE
Animated images for traces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem "canonical-rails"
 gem "logstasher"
 
 # Used to generate images for traces
-gem "gd2-ffij", :git => "https://github.com/mmd-osm/gd2-ffij.git", :branch => "animated_gif"
+gem "gd2-ffij", "= 0.4.0.dev"
 
 # Used for browser detection
 gem "browser"

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem "canonical-rails"
 gem "logstasher"
 
 # Used to generate images for traces
-gem "gd2-ffij"
+gem "gd2-ffij", :git => 'git@github.com:mmd-osm/gd2-ffij.git', :branch => 'animated_gif'
 
 # Used for browser detection
 gem "browser"

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem "canonical-rails"
 gem "logstasher"
 
 # Used to generate images for traces
-gem "gd2-ffij", "= 0.4.0.dev"
+gem "gd2-ffij", ">= 0.4.0"
 
 # Used for browser detection
 gem "browser"

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem "canonical-rails"
 gem "logstasher"
 
 # Used to generate images for traces
-gem "gd2-ffij", :git => "git@github.com:mmd-osm/gd2-ffij.git", :branch => "animated_gif"
+gem "gd2-ffij", :git => "https://github.com/mmd-osm/gd2-ffij.git", :branch => "animated_gif"
 
 # Used for browser detection
 gem "browser"

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ gem "canonical-rails"
 gem "logstasher"
 
 # Used to generate images for traces
-gem "gd2-ffij", :git => 'git@github.com:mmd-osm/gd2-ffij.git', :branch => 'animated_gif'
+gem "gd2-ffij", :git => "git@github.com:mmd-osm/gd2-ffij.git", :branch => "animated_gif"
 
 # Used for browser detection
 gem "browser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
     fspath (3.1.0)
-    gd2-ffij (0.4.0.dev)
+    gd2-ffij (0.4.0)
       ffi (>= 1.0.0)
     geoip (1.6.4)
     globalid (0.4.2)
@@ -462,7 +462,7 @@ DEPENDENCIES
   factory_bot_rails
   fakefs
   faraday
-  gd2-ffij (= 0.4.0.dev)
+  gd2-ffij (>= 0.4.0)
   geoip
   htmlentities
   http_accept_language (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/mmd-osm/gd2-ffij.git
-  revision: c92057a8f699a36b5f6d208db3d11eb3bae185dd
-  branch: animated_gif
-  specs:
-    gd2-ffij (0.3.1)
-      ffi (>= 1.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -181,6 +173,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
     fspath (3.1.0)
+    gd2-ffij (0.4.0.dev)
+      ffi (>= 1.0.0)
     geoip (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -468,7 +462,7 @@ DEPENDENCIES
   factory_bot_rails
   fakefs
   faraday
-  gd2-ffij!
+  gd2-ffij (= 0.4.0.dev)
   geoip
   htmlentities
   http_accept_language (~> 2.0.0)
@@ -518,4 +512,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git@github.com:mmd-osm/gd2-ffij.git
+  revision: c92057a8f699a36b5f6d208db3d11eb3bae185dd
+  branch: animated_gif
+  specs:
+    gd2-ffij (0.3.1)
+      ffi (>= 1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -173,8 +181,6 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
     fspath (3.1.0)
-    gd2-ffij (0.3.0)
-      ffi (>= 1.0.0)
     geoip (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -462,7 +468,7 @@ DEPENDENCIES
   factory_bot_rails
   fakefs
   faraday
-  gd2-ffij
+  gd2-ffij!
   geoip
   htmlentities
   http_accept_language (~> 2.0.0)
@@ -512,4 +518,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:mmd-osm/gd2-ffij.git
+  remote: https://github.com/mmd-osm/gd2-ffij.git
   revision: c92057a8f699a36b5f6d208db3d11eb3bae185dd
   branch: animated_gif
   specs:

--- a/lib/gpx.rb
+++ b/lib/gpx.rb
@@ -100,16 +100,15 @@ module GPX
         end
       end
 
-      res = GD2::AnimatedGif.gif_anim_begin(frames[0])
-      res << GD2::AnimatedGif.gif_anim_add(frames[0], nil, delay)
-      (1...nframes).each do |n|
-        res << GD2::AnimatedGif.gif_anim_add(frames[n],
-                                             (frames[n] == frames[n - 1] ? nil : frames[n - 1]),
-                                             delay)
+      image = GD2::AnimatedGif.new
+      frames.each do |frame|
+        image.add(frame, :delay => delay)
       end
-      res << GD2::AnimatedGif.gif_anim_end
+      image.end
 
-      res
+      output = StringIO.new
+      image.export(output)
+      output.read
     end
 
     def icon(min_lat, min_lon, max_lat, max_lon)

--- a/lib/gpx.rb
+++ b/lib/gpx.rb
@@ -102,7 +102,7 @@ module GPX
 
       res = GD2::AnimatedGif::gif_anim_begin(frames[0])
       res << GD2::AnimatedGif::gif_anim_add(frames[0], nil, delay)
-      (0..nframes - 1).each do |n|
+      (1..nframes - 1).each do |n|
         res << GD2::AnimatedGif::gif_anim_add(frames[n], frames[n-1], delay)
       end
       res << GD2::AnimatedGif::gif_anim_end()

--- a/lib/gpx.rb
+++ b/lib/gpx.rb
@@ -103,7 +103,9 @@ module GPX
       res = GD2::AnimatedGif.gif_anim_begin(frames[0])
       res << GD2::AnimatedGif.gif_anim_add(frames[0], nil, delay)
       (1...nframes).each do |n|
-        res << GD2::AnimatedGif.gif_anim_add(frames[n], frames[n - 1], delay)
+        res << GD2::AnimatedGif.gif_anim_add(frames[n],
+                                             (frames[n] == frames[n - 1] ? nil : frames[n - 1]),
+                                             delay)
       end
       res << GD2::AnimatedGif.gif_anim_end
 

--- a/lib/gpx.rb
+++ b/lib/gpx.rb
@@ -57,7 +57,7 @@ module GPX
 
       proj = OSM::Mercator.new(min_lat, min_lon, max_lat, max_lon, width, height)
 
-      frames = Array.new(nframes,  GD2::Image::IndexedColor.new(width, height))
+      frames = []
 
       (0..nframes - 1).each do |n|
         frames[n] = GD2::Image::IndexedColor.new(width, height)

--- a/lib/gpx.rb
+++ b/lib/gpx.rb
@@ -47,19 +47,19 @@ module GPX
       end
     end
 
-    def picture(min_lat, min_lon, max_lat, max_lon, _num_points)
+    def picture(min_lat, min_lon, max_lat, max_lon, num_points)
       nframes = 10
       width = 250
       height = 250
       delay = 50
 
-      ptsper = _num_points / nframes;
+      points_per_frame = num_points / nframes
 
       proj = OSM::Mercator.new(min_lat, min_lon, max_lat, max_lon, width, height)
 
       frames = []
 
-      (0..nframes - 1).each do |n|
+      (0...nframes).each do |n|
         frames[n] = GD2::Image::IndexedColor.new(width, height)
         black = frames[n].palette.allocate(GD2::Color[0, 0, 0])
         white = frames[n].palette.allocate(GD2::Color[255, 255, 255])
@@ -84,28 +84,28 @@ module GPX
             px = proj.x(p.longitude)
             py = proj.y(p.latitude)
 
-            if ((pt >= (ptsper * n)) && (pt <= (ptsper * (n+1))))
-              pen.thickness=(3)
+            if (pt >= (points_per_frame * n)) && (pt <= (points_per_frame * (n + 1)))
+              pen.thickness = 3
               pen.color = black
             else
-              pen.thickness=(1)
+              pen.thickness = 1
               pen.color = grey
             end
 
             pen.line(px, py, oldpx, oldpy) unless first
-              first = false
-              oldpy = py
-              oldpx = px
+            first = false
+            oldpy = py
+            oldpx = px
           end
         end
       end
 
-      res = GD2::AnimatedGif::gif_anim_begin(frames[0])
-      res << GD2::AnimatedGif::gif_anim_add(frames[0], nil, delay)
-      (1..nframes - 1).each do |n|
-        res << GD2::AnimatedGif::gif_anim_add(frames[n], frames[n-1], delay)
+      res = GD2::AnimatedGif.gif_anim_begin(frames[0])
+      res << GD2::AnimatedGif.gif_anim_add(frames[0], nil, delay)
+      (1...nframes).each do |n|
+        res << GD2::AnimatedGif.gif_anim_add(frames[n], frames[n - 1], delay)
       end
-      res << GD2::AnimatedGif::gif_anim_end()
+      res << GD2::AnimatedGif.gif_anim_end
 
       res
     end


### PR DESCRIPTION
Here's a pull request based on @mmd-osm's work with a few minor changes from me. It produces animated gifs that look identical to those generated by the external importer.

This PR contains two notable caveats:

* We uncovered [a bug](https://github.com/libgd/libgd/issues/499) in libgd itself. This PR works around the bug, and I wouldn't propose waiting for that bug to be fixed and the fix to work its way into distribution packages since that could take a while.
* We are using a forked version of the gd2-ffij gem, until the animation code is available in the upstream gem. I'm fine with that from a bundler point of view, but of course there's the risk that the animation code is either not upstreamed, or upstream ends up with a different implementation.