### PR TITLE
Move gpx_file (trace) xml generation out of model and into view

### DIFF
--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -16,14 +16,9 @@ module Api
     around_action :api_call_handle_error
 
     def show
-      trace = Trace.visible.find(params[:id])
+      @trace = Trace.visible.find(params[:id])
 
-      if trace.public? || trace.user == current_user
-        @traces = [trace]
-        render "trace"
-      else
-        head :forbidden
-      end
+      head :forbidden unless @trace.public? || @trace.user == current_user
     end
 
     def update

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -19,7 +19,8 @@ module Api
       trace = Trace.visible.find(params[:id])
 
       if trace.public? || trace.user == current_user
-        render :xml => trace.to_xml.to_s
+        @traces = [trace]
+        render "trace"
       else
         head :forbidden
       end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -37,11 +37,8 @@ module Api
     end
 
     def gpx_files
-      doc = OSM::API.new.get_xml_doc
-      current_user.traces.reload.each do |trace|
-        doc.root << trace.to_xml_node
-      end
-      render :xml => doc.to_s
+      @traces = current_user.traces.reload
+      render "api/traces/trace", :content_type => "application/xml"
     end
 
     private

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -38,7 +38,7 @@ module Api
 
     def gpx_files
       @traces = current_user.traces.reload
-      render "api/traces/trace", :content_type => "application/xml"
+      render :content_type => "application/xml"
     end
 
     private

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -169,36 +169,6 @@ class Trace < ActiveRecord::Base
     extension
   end
 
-  def to_xml
-    doc = OSM::API.new.get_xml_doc
-    doc.root << to_xml_node
-    doc
-  end
-
-  def to_xml_node
-    el1 = XML::Node.new "gpx_file"
-    el1["id"] = id.to_s
-    el1["name"] = name.to_s
-    el1["lat"] = latitude.to_s if inserted
-    el1["lon"] = longitude.to_s if inserted
-    el1["user"] = user.display_name
-    el1["visibility"] = visibility
-    el1["pending"] = inserted ? "false" : "true"
-    el1["timestamp"] = timestamp.xmlschema
-
-    el2 = XML::Node.new "description"
-    el2 << description
-    el1 << el2
-
-    tags.each do |tag|
-      el2 = XML::Node.new("tag")
-      el2 << tag.tag
-      el1 << el2
-    end
-
-    el1
-  end
-
   def update_from_xml(xml, create = false)
     p = XML::Parser.string(xml, :options => XML::Parser::Options::NOERROR)
     doc = p.parse

--- a/app/views/api/traces/_trace.builder
+++ b/app/views/api/traces/_trace.builder
@@ -1,0 +1,22 @@
+# basic attributes
+
+attrs = {
+  "id" => trace.id,
+  "name" => trace.name,
+  "user" => trace.user.display_name,
+  "visibility" => trace.visibility,
+  "pending" => trace.inserted ? "false" : "true",
+  "timestamp" => trace.timestamp.xmlschema
+}
+
+if trace.inserted
+  attrs["lat"] = trace.latitude.to_s
+  attrs["lon"] = trace.longitude.to_s
+end
+
+xml.gpx_file(attrs) do |trace_xml_node|
+  trace_xml_node.description(trace.description)
+  trace.tags.each do |t|
+    trace_xml_node.tag(t.tag)
+  end
+end

--- a/app/views/api/traces/show.builder
+++ b/app/views/api/traces/show.builder
@@ -1,0 +1,5 @@
+xml.instruct! :xml, :version => "1.0"
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << render(@trace)
+end

--- a/app/views/api/traces/trace.builder
+++ b/app/views/api/traces/trace.builder
@@ -1,0 +1,9 @@
+xml.instruct! :xml, :version => "1.0"
+
+# basic attributes
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  @traces.each do |trace|
+    osm << render(:partial => "api/traces/trace.builder", :locals => { :trace => trace })
+  end
+end

--- a/app/views/api/users/gpx_files.builder
+++ b/app/views/api/users/gpx_files.builder
@@ -1,9 +1,7 @@
 xml.instruct! :xml, :version => "1.0"
 
-# basic attributes
-
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
   @traces.each do |trace|
-    osm << render(:partial => "api/traces/trace.builder", :locals => { :trace => trace })
+    osm << render(:partial => "api/traces/trace", :locals => { :trace => trace })
   end
 end


### PR DESCRIPTION
This continues the work from #2164 for the "trace" class.