### PR TITLE
[WIP] XML generation: nodes, ways, relations, map controller → view; JSON output

### DIFF
--- a/app/controllers/api/map_controller.rb
+++ b/app/controllers/api/map_controller.rb
@@ -35,10 +35,8 @@ module Api
         return
       end
 
-      doc = OSM::API.new.get_xml_doc
-
       # add bounds
-      doc.root << bbox.add_bounds_to(XML::Node.new("bounds"))
+      @bounds = bbox
 
       # get ways
       # find which ways are needed
@@ -62,21 +60,22 @@ module Api
       nodes += Node.includes(:node_tags).find(nodes_to_fetch) unless nodes_to_fetch.empty?
 
       visible_nodes = {}
-      changeset_cache = {}
-      user_display_name_cache = {}
-
+      # changeset_cache = {}
+      # user_display_name_cache = {}
+      @nodes = []
       nodes.each do |node|
         if node.visible?
-          doc.root << node.to_xml_node(changeset_cache, user_display_name_cache)
           visible_nodes[node.id] = node
+          @nodes << node
         end
       end
 
+      @ways = []
       way_ids = []
       ways.each do |way|
         if way.visible?
-          doc.root << way.to_xml_node(visible_nodes, changeset_cache, user_display_name_cache)
           way_ids << way.id
+          @ways << way
         end
       end
 
@@ -92,13 +91,17 @@ module Api
 
       # this "uniq" may be slightly inefficient; it may be better to first collect and output
       # all node-related relations, then find the *not yet covered* way-related ones etc.
+      @relations = []
       relations.uniq.each do |relation|
-        doc.root << relation.to_xml_node(changeset_cache, user_display_name_cache)
+        @relations << relation
       end
 
       response.headers["Content-Disposition"] = "attachment; filename=\"map.osm\""
-
-      render :xml => doc.to_s
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
+      end
     end
   end
 end

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -31,7 +31,13 @@ module Api
       response.last_modified = node.timestamp
 
       if node.visible
-        render :xml => node.to_xml.to_s
+        @nodes = [node]
+
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
       else
         head :gone
       end
@@ -69,13 +75,13 @@ module Api
 
       raise OSM::APIBadUserInput, "No nodes were given to search for" if ids.empty?
 
-      doc = OSM::API.new.get_xml_doc
+      @nodes = Node.find(ids)
 
-      Node.find(ids).each do |node|
-        doc.root << node.to_xml_node
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
       end
-
-      render :xml => doc.to_s
     end
   end
 end

--- a/app/controllers/api/old_controller.rb
+++ b/app/controllers/api/old_controller.rb
@@ -22,19 +22,23 @@ module Api
       # to do that ourselves.
       raise OSM::APINotFoundError if @elements.empty?
 
-      doc = OSM::API.new.get_xml_doc
-
       visible_elements = if show_redactions?
                            @elements
                          else
                            @elements.unredacted
                          end
 
+      @elems = []
+
       visible_elements.each do |element|
-        doc.root << element.to_xml_node
+        @elems << element
       end
 
-      render :xml => doc.to_s
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
+      end
     end
 
     def version
@@ -44,10 +48,13 @@ module Api
       else
         response.last_modified = @old_element.timestamp
 
-        doc = OSM::API.new.get_xml_doc
-        doc.root << @old_element.to_xml_node
+        @elems = [@old_element]
 
-        render :xml => doc.to_s
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
       end
     end
 

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -25,7 +25,13 @@ module Api
       relation = Relation.find(params[:id])
       response.last_modified = relation.timestamp
       if relation.visible
-        render :xml => relation.to_xml.to_s
+        @relations = [relation]
+
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
       else
         head :gone
       end
@@ -88,35 +94,40 @@ module Api
         node_ids += way_node_ids.flatten
         nodes = Node.where(:id => node_ids.uniq).includes(:node_tags)
 
-        # create XML.
-        doc = OSM::API.new.get_xml_doc
         visible_nodes = {}
-        changeset_cache = {}
-        user_display_name_cache = {}
+        # changeset_cache = {}
+        # user_display_name_cache = {}
 
+        @nodes = []
         nodes.each do |node|
           next unless node.visible? # should be unnecessary if data is consistent.
 
-          doc.root << node.to_xml_node(changeset_cache, user_display_name_cache)
+          @nodes << node
           visible_nodes[node.id] = node
         end
 
+        @ways = []
         ways.each do |way|
           next unless way.visible? # should be unnecessary if data is consistent.
 
-          doc.root << way.to_xml_node(visible_nodes, changeset_cache, user_display_name_cache)
+          @ways << way
         end
 
+        @relations = []
         relations.each do |rel|
           next unless rel.visible? # should be unnecessary if data is consistent.
 
-          doc.root << rel.to_xml_node(changeset_cache, user_display_name_cache)
+          @relations << rel
         end
 
-        # finally add self and output
-        doc.root << relation.to_xml_node(changeset_cache, user_display_name_cache)
-        render :xml => doc.to_s
+        # finally add self
+        @relations << relation
 
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
       else
         head :gone
       end
@@ -129,13 +140,13 @@ module Api
 
       raise OSM::APIBadUserInput, "No relations were given to search for" if ids.empty?
 
-      doc = OSM::API.new.get_xml_doc
+      @relations = Relation.find(ids)
 
-      Relation.find(ids).each do |relation|
-        doc.root << relation.to_xml_node
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
       end
-
-      render :xml => doc.to_s
     end
 
     def relations_for_way
@@ -155,13 +166,17 @@ module Api
     def relations_for_object(objtype)
       relationids = RelationMember.where(:member_type => objtype, :member_id => params[:id]).collect(&:relation_id).uniq
 
-      doc = OSM::API.new.get_xml_doc
+      @relations = []
 
       Relation.find(relationids).each do |relation|
-        doc.root << relation.to_xml_node if relation.visible
+        @relations << relation if relation.visible
       end
 
-      render :xml => doc.to_s
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
+      end
     end
   end
 end

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -27,7 +27,13 @@ module Api
       response.last_modified = way.timestamp
 
       if way.visible
-        render :xml => way.to_xml.to_s
+        @ways = [way]
+
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
       else
         head :gone
       end
@@ -63,19 +69,25 @@ module Api
 
       if way.visible
         visible_nodes = {}
-        changeset_cache = {}
-        user_display_name_cache = {}
+        # changeset_cache = {}
+        # user_display_name_cache = {}
 
-        doc = OSM::API.new.get_xml_doc
+        @nodes = []
+
         way.nodes.uniq.each do |node|
           if node.visible
-            doc.root << node.to_xml_node(changeset_cache, user_display_name_cache)
+            @nodes << node
             visible_nodes[node.id] = node
           end
         end
-        doc.root << way.to_xml_node(visible_nodes, changeset_cache, user_display_name_cache)
 
-        render :xml => doc.to_s
+        @ways = [way]
+
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
       else
         head :gone
       end
@@ -90,13 +102,13 @@ module Api
 
       raise OSM::APIBadUserInput, "No ways were given to search for" if ids.empty?
 
-      doc = OSM::API.new.get_xml_doc
+      @ways = Way.find(ids)
 
-      Way.find(ids).each do |way|
-        doc.root << way.to_xml_node
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
       end
-
-      render :xml => doc.to_s
     end
 
     ##
@@ -106,13 +118,13 @@ module Api
     def ways_for_node
       wayids = WayNode.where(:node_id => params[:id]).collect { |ws| ws.id[0] }.uniq
 
-      doc = OSM::API.new.get_xml_doc
+      @ways = Way.where(:id => wayids, :visible => true)
 
-      Way.find(wayids).each do |way|
-        doc.root << way.to_xml_node if way.visible
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
       end
-
-      render :xml => doc.to_s
     end
   end
 end

--- a/app/views/api/map/_bounds.xml.builder
+++ b/app/views/api/map/_bounds.xml.builder
@@ -1,0 +1,8 @@
+attrs = {
+  "minlat" => format("%.7f", @bounds.min_lat),
+  "minlon" => format("%.7f", @bounds.min_lon),
+  "maxlat" => format("%.7f", @bounds.max_lat),
+  "maxlon" => format("%.7f", @bounds.max_lon)
+}
+
+xml.bounds(attrs)

--- a/app/views/api/map/_node.json.jsonify
+++ b/app/views/api/map/_node.json.jsonify
@@ -1,0 +1,18 @@
+json.type "node"
+json.id node.id
+if node.visible
+  json.lat node.lat.to_f
+  json.lon node.lon.to_f
+end
+json.timestamp node.timestamp.xmlschema
+json.version node.version
+json.changeset node.changeset_id
+json.user node.changeset.user.display_name
+json.uid node.changeset.user_id
+if !node.visible
+  json.visible node.visible
+end
+
+if !node.tags.empty?
+  json.tags node.tags
+end

--- a/app/views/api/map/_node.xml.builder
+++ b/app/views/api/map/_node.xml.builder
@@ -1,0 +1,24 @@
+attrs = {
+  "id" => node.id,
+  "visible" => node.visible,
+  "version" => node.version,
+  "changeset" => node.changeset_id,
+  "timestamp" => node.timestamp.xmlschema,
+  "user" => node.changeset.user.display_name,
+  "uid" => node.changeset.user_id
+}
+
+if node.visible
+  attrs["lat"] = node.lat
+  attrs["lon"] = node.lon
+end
+
+if node.tags.empty?
+  xml.node(attrs)
+else
+  xml.node(attrs) do |nd|
+    node.tags.each do |k, v|
+      nd.tag(:k => k, :v => v)
+    end
+  end
+end

--- a/app/views/api/map/_relation.json.jsonify
+++ b/app/views/api/map/_relation.json.jsonify
@@ -1,0 +1,25 @@
+json.type "relation"
+json.id relation.id
+json.timestamp relation.timestamp.xmlschema
+json.version relation.version
+json.changeset relation.changeset_id
+json.user relation.changeset.user.display_name
+json.uid relation.changeset.user_id
+if !relation.visible
+  json.visible relation.visible
+end
+
+if !relation.relation_members.empty?
+  json.members do |member|
+    relation.relation_members.each do |m|
+      mbr  = {:type => m.member_type.downcase,
+              :ref  => m.member_id,
+              :role => m.member_role}
+      json << mbr
+    end
+  end
+end
+
+if !relation.tags.empty?
+  json.tags relation.tags
+end

--- a/app/views/api/map/_relation.xml.builder
+++ b/app/views/api/map/_relation.xml.builder
@@ -1,0 +1,19 @@
+attrs = {
+  "id" => relation.id,
+  "visible" => relation.visible,
+  "version" => relation.version,
+  "changeset" => relation.changeset_id,
+  "timestamp" => relation.timestamp.xmlschema,
+  "user" => relation.changeset.user.display_name,
+  "uid" => relation.changeset.user_id
+}
+
+xml.relation(attrs) do |r|
+  relation.relation_members.each do |m|
+    r.member(:type => m.member_type.downcase, :ref => m.member_id, :role => m.member_role)
+  end
+
+  relation.tags.each do |k, v|
+    r.tag(:k => k, :v => v)
+  end
+end

--- a/app/views/api/map/_root_attributes.json.jsonify
+++ b/app/views/api/map/_root_attributes.json.jsonify
@@ -1,0 +1,5 @@
+json.version Settings.api_version
+json.generator Settings.generator
+json.copyright Settings.copyright_owner
+json.attribution Settings.attribution_url
+json.license Settings.license_url

--- a/app/views/api/map/_way.json.jsonify
+++ b/app/views/api/map/_way.json.jsonify
@@ -1,0 +1,16 @@
+json.type "way"
+json.id way.id
+json.timestamp way.timestamp.xmlschema
+json.version way.version
+json.changeset way.changeset_id
+json.user way.changeset.user.display_name
+json.uid way.changeset.user_id
+if !way.visible
+  json.visible way.visible
+end
+
+json.nodes way.nodes.ids
+
+if !way.tags.empty?
+  json.tags way.tags
+end

--- a/app/views/api/map/_way.xml.builder
+++ b/app/views/api/map/_way.xml.builder
@@ -1,0 +1,19 @@
+attrs = {
+  "id" => way.id,
+  "visible" => way.visible,
+  "version" => way.version,
+  "changeset" => way.changeset_id,
+  "timestamp" => way.timestamp.xmlschema,
+  "user" => way.changeset.user.display_name,
+  "uid" => way.changeset.user_id
+}
+
+xml.way(attrs) do |w|
+  way.nodes.each do |n|
+    w.nd(:ref => n.id)
+  end
+
+  way.tags.each do |k, v|
+    w.tag(:k => k, :v => v)
+  end
+end

--- a/app/views/api/map/index.json.jsonify
+++ b/app/views/api/map/index.json.jsonify
@@ -1,0 +1,22 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+all = @nodes + @ways + @relations
+
+# FIXME this is really ugly!
+
+json.elements(all) do |obj|
+  if obj.is_a? Node
+     node = obj
+     json.ingest!  render(:partial => "node", :object => node)
+  end
+
+  if obj.is_a? Way
+     way = obj
+     json.ingest! render(:partial => "way", :object => way)
+  end
+
+  if obj.is_a? Relation
+    relation = obj
+    json.ingest! render(:partial => "relation", :object => relation)
+  end
+end

--- a/app/views/api/map/index.xml.builder
+++ b/app/views/api/map/index.xml.builder
@@ -1,0 +1,8 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "bounds") || "")
+  osm << (render(:partial => "node", :collection => @nodes) || "")
+  osm << (render(:partial => "way", :collection => @ways) || "")
+  osm << (render(:partial => "relation", :collection => @relations) || "")
+end

--- a/app/views/api/nodes/index.json.jsonify
+++ b/app/views/api/nodes/index.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@nodes) do |node|
+  json.ingest! render(:partial => "api/map/node", :object => node)
+end

--- a/app/views/api/nodes/index.xml.builder
+++ b/app/views/api/nodes/index.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/node", :collection => @nodes) || "")
+end

--- a/app/views/api/nodes/show.json.jsonify
+++ b/app/views/api/nodes/show.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@nodes) do |node|
+  json.ingest! render(:partial => "api/map/node", :object => node)
+end

--- a/app/views/api/nodes/show.xml.builder
+++ b/app/views/api/nodes/show.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/node", :collection => @nodes) || "")
+end

--- a/app/views/api/old_nodes/_old_node.json.jsonify
+++ b/app/views/api/old_nodes/_old_node.json.jsonify
@@ -1,0 +1,18 @@
+json.type "node"
+json.id old_node.node_id
+if old_node.visible
+  json.lat old_node.lat.to_f
+  json.lon old_node.lon.to_f
+end
+json.timestamp old_node.timestamp.xmlschema
+json.version old_node.version
+json.changeset old_node.changeset_id
+json.user old_node.changeset.user.display_name
+json.uid old_node.changeset.user_id
+if !old_node.visible
+  json.visible old_node.visible
+end
+
+if !old_node.tags.empty?
+  json.tags old_node.tags
+end

--- a/app/views/api/old_nodes/_old_node.xml.builder
+++ b/app/views/api/old_nodes/_old_node.xml.builder
@@ -1,0 +1,24 @@
+attrs = {
+  "id" => old_node.node_id,
+  "visible" => old_node.visible,
+  "version" => old_node.version,
+  "changeset" => old_node.changeset_id,
+  "timestamp" => old_node.timestamp.xmlschema,
+  "user" => old_node.changeset.user.display_name,
+  "uid" => old_node.changeset.user_id
+}
+
+if old_node.visible
+  attrs["lat"] = old_node.lat
+  attrs["lon"] = old_node.lon
+end
+
+if old_node.tags.empty?
+  xml.node(attrs)
+else
+  xml.node(attrs) do |nd|
+    old_node.tags.each do |k, v|
+      nd.tag(:k => k, :v => v)
+    end
+  end
+end

--- a/app/views/api/old_nodes/history.json.jsonify
+++ b/app/views/api/old_nodes/history.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@elems) do |old_node|
+  json.ingest! render(:partial => "old_node", :object => old_node)
+end

--- a/app/views/api/old_nodes/history.xml.builder
+++ b/app/views/api/old_nodes/history.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "old_node", :collection => @elems) || "")
+end

--- a/app/views/api/old_nodes/version.json.jsonify
+++ b/app/views/api/old_nodes/version.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@elems) do |old_node|
+  json.ingest! render(:partial => "old_node", :object => old_node)
+end

--- a/app/views/api/old_nodes/version.xml.builder
+++ b/app/views/api/old_nodes/version.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "old_node", :collection => @elems) || "")
+end

--- a/app/views/api/old_relations/_old_relation.json.jsonify
+++ b/app/views/api/old_relations/_old_relation.json.jsonify
@@ -1,0 +1,25 @@
+json.type "relation"
+json.id old_relation.relation_id
+json.timestamp old_relation.timestamp.xmlschema
+json.version old_relation.version
+json.changeset old_relation.changeset_id
+json.user old_relation.changeset.user.display_name
+json.uid old_relation.changeset.user_id
+if !old_relation.visible
+  json.visible old_relation.visible
+end
+
+if !old_relation.relation_members.empty?
+  json.members do |member|
+     old_relation.relation_members.each do |m|
+       mbr  = {:type => m.member_type.downcase,
+               :ref  => m.member_id,
+               :role => m.member_role}
+       json << mbr
+     end
+  end
+end
+
+if !old_relation.tags.empty?
+  json.tags old_relation.tags
+end

--- a/app/views/api/old_relations/_old_relation.xml.builder
+++ b/app/views/api/old_relations/_old_relation.xml.builder
@@ -1,0 +1,19 @@
+attrs = {
+  "id" => old_relation.relation_id,
+  "visible" => old_relation.visible,
+  "version" => old_relation.version,
+  "changeset" => old_relation.changeset_id,
+  "timestamp" => old_relation.timestamp.xmlschema,
+  "user" => old_relation.changeset.user.display_name,
+  "uid" => old_relation.changeset.user_id
+}
+
+xml.relation(attrs) do |r|
+  old_relation.relation_members.each do |m|
+    r.member(:type => m.member_type.downcase, :ref => m.member_id, :role => m.member_role)
+  end
+
+  old_relation.tags.each do |k, v|
+    r.tag(:k => k, :v => v)
+  end
+end

--- a/app/views/api/old_relations/history.json.jsonify
+++ b/app/views/api/old_relations/history.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@elems) do |old_relation|
+  json.ingest! render(:partial => "old_relation", :object => old_relation)
+end

--- a/app/views/api/old_relations/history.xml.builder
+++ b/app/views/api/old_relations/history.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "old_relation", :collection => @elems) || "")
+end

--- a/app/views/api/old_relations/version.json.jsonify
+++ b/app/views/api/old_relations/version.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@elems) do |old_relation|
+  json.ingest! render(:partial => "old_relation", :object => old_relation)
+end

--- a/app/views/api/old_relations/version.xml.builder
+++ b/app/views/api/old_relations/version.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "old_relation", :collection => @elems) || "")
+end

--- a/app/views/api/old_ways/_old_way.json.jsonify
+++ b/app/views/api/old_ways/_old_way.json.jsonify
@@ -1,0 +1,16 @@
+json.type "way"
+json.id old_way.way_id
+json.timestamp old_way.timestamp.xmlschema
+json.version old_way.version
+json.changeset old_way.changeset_id
+json.user old_way.changeset.user.display_name
+json.uid old_way.changeset.user_id
+if !old_way.visible
+  json.visible old_way.visible
+end
+
+json.nodes old_way.nds
+
+if !old_way.tags.empty?
+  json.tags old_way.tags
+end

--- a/app/views/api/old_ways/_old_way.xml.builder
+++ b/app/views/api/old_ways/_old_way.xml.builder
@@ -1,0 +1,19 @@
+attrs = {
+  "id" => old_way.way_id,
+  "visible" => old_way.visible,
+  "version" => old_way.version,
+  "changeset" => old_way.changeset_id,
+  "timestamp" => old_way.timestamp.xmlschema,
+  "user" => old_way.changeset.user.display_name,
+  "uid" => old_way.changeset.user_id
+}
+
+xml.way(attrs) do |w|
+  old_way.nds.each do |n|
+    w.nd(:ref => n)
+  end
+
+  old_way.tags.each do |k, v|
+    w.tag(:k => k, :v => v)
+  end
+end

--- a/app/views/api/old_ways/history.json.jsonify
+++ b/app/views/api/old_ways/history.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@elems) do |old_way|
+  json.ingest! render(:partial => "old_way", :object => old_way)
+end

--- a/app/views/api/old_ways/history.xml.builder
+++ b/app/views/api/old_ways/history.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "old_way", :collection => @elems) || "")
+end

--- a/app/views/api/old_ways/version.json.jsonify
+++ b/app/views/api/old_ways/version.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@elems) do |old_way|
+  json.ingest! render(:partial => "old_way", :object => old_way)
+end

--- a/app/views/api/old_ways/version.xml.builder
+++ b/app/views/api/old_ways/version.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "old_way", :collection => @elems) || "")
+end

--- a/app/views/api/relations/full.json.jsonify
+++ b/app/views/api/relations/full.json.jsonify
@@ -1,0 +1,22 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+all = @nodes + @ways + @relations
+
+# FIXME this is really ugly!
+
+json.elements(all) do |obj|
+  if obj.is_a? Node
+     node = obj
+     json.ingest!  render(:partial => "api/map/node", :object => node)
+  end
+
+  if obj.is_a? Way
+     way = obj
+     json.ingest! render(:partial => "api/map/way", :object => way)
+  end
+
+  if obj.is_a? Relation
+    relation = obj
+    json.ingest! render(:partial => "api/map/relation", :object => relation)
+  end
+end

--- a/app/views/api/relations/full.xml.builder
+++ b/app/views/api/relations/full.xml.builder
@@ -1,0 +1,7 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/node", :collection => @nodes) || "")
+  osm << (render(:partial => "api/map/way", :collection => @ways) || "")
+  osm << (render(:partial => "api/map/relation", :collection => @relations) || "")
+end

--- a/app/views/api/relations/index.json.jsonify
+++ b/app/views/api/relations/index.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@relations) do |relation|
+  json.ingest! render(:partial => "api/map/relation", :object => relation)
+end

--- a/app/views/api/relations/index.xml.builder
+++ b/app/views/api/relations/index.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/relation", :collection => @relations) || "")
+end

--- a/app/views/api/relations/relations_for_node.json.jsonify
+++ b/app/views/api/relations/relations_for_node.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@relations) do |relation|
+  json.ingest! render(:partial => "api/map/relation", :object => relation)
+end

--- a/app/views/api/relations/relations_for_node.xml.builder
+++ b/app/views/api/relations/relations_for_node.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/relation", :collection => @relations) || "")
+end

--- a/app/views/api/relations/relations_for_relation.json.jsonify
+++ b/app/views/api/relations/relations_for_relation.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@relations) do |relation|
+  json.ingest! render(:partial => "api/map/relation", :object => relation)
+end

--- a/app/views/api/relations/relations_for_relation.xml.builder
+++ b/app/views/api/relations/relations_for_relation.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/relation", :collection => @relations) || "")
+end

--- a/app/views/api/relations/relations_for_way.json.jsonify
+++ b/app/views/api/relations/relations_for_way.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@relations) do |relation|
+  json.ingest! render(:partial => "api/map/relation", :object => relation)
+end

--- a/app/views/api/relations/relations_for_way.xml.builder
+++ b/app/views/api/relations/relations_for_way.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/relation", :collection => @relations) || "")
+end

--- a/app/views/api/relations/show.json.jsonify
+++ b/app/views/api/relations/show.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@relations) do |relation|
+  json.ingest! render(:partial => "api/map/relation", :object => relation)
+end

--- a/app/views/api/relations/show.xml.builder
+++ b/app/views/api/relations/show.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/relation", :collection => @relations) || "")
+end

--- a/app/views/api/ways/full.json.jsonify
+++ b/app/views/api/ways/full.json.jsonify
@@ -1,0 +1,17 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+all = @nodes + @ways
+
+# FIXME this is really ugly!
+
+json.elements(all) do |obj|
+  if obj.is_a? Node
+     node = obj
+     json.ingest!  render(:partial => "api/map/node", :object => node)
+  end
+
+  if obj.is_a? Way
+     way = obj
+     json.ingest! render(:partial => "api/map/way", :object => way)
+  end
+end

--- a/app/views/api/ways/full.xml.builder
+++ b/app/views/api/ways/full.xml.builder
@@ -1,0 +1,6 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/node", :collection => @nodes) || "")
+  osm << (render(:partial => "api/map/way", :collection => @ways) || "")
+end

--- a/app/views/api/ways/index.json.jsonify
+++ b/app/views/api/ways/index.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@ways) do |way|
+  json.ingest! render(:partial => "api/map/way", :object => way)
+end

--- a/app/views/api/ways/index.xml.builder
+++ b/app/views/api/ways/index.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/way", :collection => @ways) || "")
+end

--- a/app/views/api/ways/show.json.jsonify
+++ b/app/views/api/ways/show.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@ways) do |way|
+  json.ingest! render(:partial => "api/map/way", :object => way)
+end

--- a/app/views/api/ways/show.xml.builder
+++ b/app/views/api/ways/show.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/way", :collection => @ways) || "")
+end

--- a/app/views/api/ways/ways_for_node.json.jsonify
+++ b/app/views/api/ways/ways_for_node.json.jsonify
@@ -1,0 +1,5 @@
+json.ingest! render(:partial => "api/map/root_attributes")
+
+json.elements(@ways) do |way|
+  json.ingest! render(:partial => "api/map/way", :object => way)
+end

--- a/app/views/api/ways/ways_for_node.xml.builder
+++ b/app/views/api/ways/ways_for_node.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/map/way", :collection => @ways) || "")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,39 +23,39 @@ OpenStreetMap::Application.routes.draw do
     post "changeset/comment/:id/unhide" => "api/changeset_comments#restore", :as => :changeset_comment_unhide, :id => /\d+/
 
     put "node/create" => "api/nodes#create"
-    get "node/:id/ways" => "api/ways#ways_for_node", :id => /\d+/
-    get "node/:id/relations" => "api/relations#relations_for_node", :id => /\d+/
-    get "node/:id/history" => "api/old_nodes#history", :id => /\d+/
+    get "node/:id/ways" => "api/ways#ways_for_node", :id => /\d+/, :defaults => { :format => "xml" }
+    get "node/:id/relations" => "api/relations#relations_for_node", :id => /\d+/, :defaults => { :format => "xml" }
+    get "node/:id/history" => "api/old_nodes#history", :id => /\d+/, :defaults => { :format => "xml" }
     post "node/:id/:version/redact" => "api/old_nodes#redact", :version => /\d+/, :id => /\d+/
-    get "node/:id/:version" => "api/old_nodes#version", :id => /\d+/, :version => /\d+/
-    get "node/:id" => "api/nodes#show", :id => /\d+/
+    get "node/:id/:version" => "api/old_nodes#version", :id => /\d+/, :version => /\d+/, :defaults => { :format => "xml" }
+    get "node/:id" => "api/nodes#show", :id => /\d+/, :defaults => { :format => "xml" }
     put "node/:id" => "api/nodes#update", :id => /\d+/
     delete "node/:id" => "api/nodes#delete", :id => /\d+/
-    get "nodes" => "api/nodes#index"
+    get "nodes" => "api/nodes#index", :defaults => { :format => "xml" }
 
     put "way/create" => "api/ways#create"
-    get "way/:id/history" => "api/old_ways#history", :id => /\d+/
-    get "way/:id/full" => "api/ways#full", :id => /\d+/
-    get "way/:id/relations" => "api/relations#relations_for_way", :id => /\d+/
+    get "way/:id/history" => "api/old_ways#history", :id => /\d+/, :defaults => { :format => "xml" }
+    get "way/:id/full" => "api/ways#full", :id => /\d+/, :defaults => { :format => "xml" }
+    get "way/:id/relations" => "api/relations#relations_for_way", :id => /\d+/, :defaults => { :format => "xml" }
     post "way/:id/:version/redact" => "api/old_ways#redact", :version => /\d+/, :id => /\d+/
-    get "way/:id/:version" => "api/old_ways#version", :id => /\d+/, :version => /\d+/
-    get "way/:id" => "api/ways#show", :id => /\d+/
+    get "way/:id/:version" => "api/old_ways#version", :id => /\d+/, :version => /\d+/, :defaults => { :format => "xml" }
+    get "way/:id" => "api/ways#show", :id => /\d+/, :defaults => { :format => "xml" }
     put "way/:id" => "api/ways#update", :id => /\d+/
     delete "way/:id" => "api/ways#delete", :id => /\d+/
-    get "ways" => "api/ways#index"
+    get "ways" => "api/ways#index", :defaults => { :format => "xml" }
 
     put "relation/create" => "api/relations#create"
-    get "relation/:id/relations" => "api/relations#relations_for_relation", :id => /\d+/
-    get "relation/:id/history" => "api/old_relations#history", :id => /\d+/
-    get "relation/:id/full" => "api/relations#full", :id => /\d+/
+    get "relation/:id/relations" => "api/relations#relations_for_relation", :id => /\d+/, :defaults => { :format => "xml" }
+    get "relation/:id/history" => "api/old_relations#history", :id => /\d+/, :defaults => { :format => "xml" }
+    get "relation/:id/full" => "api/relations#full", :id => /\d+/, :defaults => { :format => "xml" }
     post "relation/:id/:version/redact" => "api/old_relations#redact", :version => /\d+/, :id => /\d+/
-    get "relation/:id/:version" => "api/old_relations#version", :id => /\d+/, :version => /\d+/
-    get "relation/:id" => "api/relations#show", :id => /\d+/
+    get "relation/:id/:version" => "api/old_relations#version", :id => /\d+/, :version => /\d+/, :defaults => { :format => "xml" }
+    get "relation/:id" => "api/relations#show", :id => /\d+/, :defaults => { :format => "xml" }
     put "relation/:id" => "api/relations#update", :id => /\d+/
     delete "relation/:id" => "api/relations#delete", :id => /\d+/
-    get "relations" => "api/relations#index"
+    get "relations" => "api/relations#index", :defaults => { :format => "xml" }
 
-    get "map" => "api/map#index"
+    get "map" => "api/map#index", :defaults => { :format => "xml" }
 
     get "trackpoints" => "api/tracepoints#index"
 

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -1768,7 +1768,7 @@ CHANGESET
         assert_response :success, "can't create a new node"
         node_id = @response.body.to_i
 
-        get :show, :params => { :id => node_id }
+        get :show, :params => { :id => node_id }, :format => "xml"
         assert_response :success, "can't read back new node"
         node_doc = XML::Parser.string(@response.body).parse
         node_xml = node_doc.find("//osm/node").first

--- a/test/controllers/api/map_controller_test.rb
+++ b/test/controllers/api/map_controller_test.rb
@@ -21,7 +21,7 @@ module Api
     def test_routes
       assert_routing(
         { :path => "/api/0.6/map", :method => :get },
-        { :controller => "api/map", :action => "index" }
+        { :controller => "api/map", :action => "index", :format => "xml" }
       )
     end
 
@@ -43,7 +43,7 @@ module Api
       maxlon = node.lon + 0.1
       maxlat = node.lat + 0.1
       bbox = "#{minlon},#{minlat},#{maxlon},#{maxlat}"
-      get :index, :params => { :bbox => bbox }
+      get :index, :params => { :bbox => bbox }, :format => :xml
       if $VERBOSE
         print @request.to_yaml
         print @response.body
@@ -73,7 +73,7 @@ module Api
       relation = create(:relation_member, :member => node).relation
 
       bbox = "#{node.lon},#{node.lat},#{node.lon},#{node.lat}"
-      get :index, :params => { :bbox => bbox }
+      get :index, :params => { :bbox => bbox }, :format => :xml
       assert_response :success, "The map call should have succeeded"
       assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
         assert_select "bounds[minlon='#{node.lon}'][minlat='#{node.lat}'][maxlon='#{node.lon}'][maxlat='#{node.lat}']", :count => 1
@@ -101,7 +101,7 @@ module Api
       relation = create(:relation_member, :member => way1).relation
 
       bbox = "#{node.lon},#{node.lat},#{node.lon},#{node.lat}"
-      get :index, :params => { :bbox => bbox }
+      get :index, :params => { :bbox => bbox }, :format => :xml
       assert_response :success, "The map call should have succeeded"
       assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
         assert_select "bounds[minlon='#{node.lon}'][minlat='#{node.lat}'][maxlon='#{node.lon}'][maxlat='#{node.lat}']", :count => 1
@@ -118,7 +118,7 @@ module Api
     end
 
     def test_map_empty
-      get :index, :params => { :bbox => "179.998,89.998,179.999.1,89.999" }
+      get :index, :params => { :bbox => "179.998,89.998,179.999.1,89.999" }, :format => :xml
       assert_response :success, "The map call should have succeeded"
       assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
         assert_select "bounds[minlon='179.9980000'][minlat='89.9980000'][maxlon='179.9990000'][maxlat='89.9990000']", :count => 1
@@ -136,7 +136,7 @@ module Api
 
     def test_bbox_too_big
       @badbigbbox.each do |bbox|
-        get :index, :params => { :bbox => bbox }
+        get :index, :params => { :bbox => bbox }, :format => :xml
         assert_response :bad_request, "The bbox:#{bbox} was expected to be too big"
         assert_equal "The maximum bbox size is #{Settings.max_request_area}, and your request was too large. Either request a smaller area, or use planet.osm", @response.body, "bbox: #{bbox}"
       end
@@ -144,7 +144,7 @@ module Api
 
     def test_bbox_malformed
       @badmalformedbbox.each do |bbox|
-        get :index, :params => { :bbox => bbox }
+        get :index, :params => { :bbox => bbox }, :format => :xml
         assert_response :bad_request, "The bbox:#{bbox} was expected to be malformed"
         assert_equal "The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat", @response.body, "bbox: #{bbox}"
       end
@@ -152,7 +152,7 @@ module Api
 
     def test_bbox_lon_mixedup
       @badlonmixedbbox.each do |bbox|
-        get :index, :params => { :bbox => bbox }
+        get :index, :params => { :bbox => bbox }, :format => :xml
         assert_response :bad_request, "The bbox:#{bbox} was expected to have the longitude mixed up"
         assert_equal "The minimum longitude must be less than the maximum longitude, but it wasn't", @response.body, "bbox: #{bbox}"
       end
@@ -160,7 +160,7 @@ module Api
 
     def test_bbox_lat_mixedup
       @badlatmixedbbox.each do |bbox|
-        get :index, :params => { :bbox => bbox }
+        get :index, :params => { :bbox => bbox }, :format => :xml
         assert_response :bad_request, "The bbox:#{bbox} was expected to have the latitude mixed up"
         assert_equal "The minimum latitude must be less than the maximum latitude, but it wasn't", @response.body, "bbox: #{bbox}"
       end

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -11,7 +11,7 @@ module Api
       )
       assert_routing(
         { :path => "/api/0.6/node/1", :method => :get },
-        { :controller => "api/nodes", :action => "show", :id => "1" }
+        { :controller => "api/nodes", :action => "show", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/node/1", :method => :put },
@@ -23,7 +23,7 @@ module Api
       )
       assert_routing(
         { :path => "/api/0.6/nodes", :method => :get },
-        { :controller => "api/nodes", :action => "index" }
+        { :controller => "api/nodes", :action => "index", :format => "xml" }
       )
     end
 
@@ -135,15 +135,15 @@ module Api
 
     def test_show
       # check that a visible node is returned properly
-      get :show, :params => { :id => create(:node).id }
+      get :show, :params => { :id => create(:node).id }, :format => :xml
       assert_response :success
 
       # check that an deleted node is not returned
-      get :show, :params => { :id => create(:node, :deleted).id }
+      get :show, :params => { :id => create(:node, :deleted).id }, :format => :xml
       assert_response :gone
 
       # check chat a non-existent node is not returned
-      get :show, :params => { :id => 0 }
+      get :show, :params => { :id => 0 }, :format => :xml
       assert_response :not_found
     end
 
@@ -436,15 +436,15 @@ module Api
       node5 = create(:node, :deleted, :with_history, :version => 2)
 
       # check error when no parameter provided
-      get :index
+      get :index, :format => :xml
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get :index, :params => { :nodes => "" }
+      get :index, :params => { :nodes => "" }, :format => :xml
       assert_response :bad_request
 
       # test a working call
-      get :index, :params => { :nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}" }
+      get :index, :params => { :nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}" }, :format => :xml
       assert_response :success
       assert_select "osm" do
         assert_select "node", :count => 5
@@ -456,7 +456,7 @@ module Api
       end
 
       # check error when a non-existent node is included
-      get :index, :params => { :nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id},0" }
+      get :index, :params => { :nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id},0" }, :format => :xml
       assert_response :not_found
     end
 
@@ -519,7 +519,7 @@ module Api
       assert_not_nil checknode, "node not found in data base after upload"
 
       # and grab it using the api
-      get :show, :params => { :id => nodeid }
+      get :show, :params => { :id => nodeid }, :format => :xml
       assert_response :success
       apinode = Node.from_xml(@response.body)
       assert_not_nil apinode, "downloaded node is nil, but shouldn't be"

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -11,11 +11,11 @@ module Api
     def test_routes
       assert_routing(
         { :path => "/api/0.6/node/1/history", :method => :get },
-        { :controller => "api/old_nodes", :action => "history", :id => "1" }
+        { :controller => "api/old_nodes", :action => "history", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/node/1/2", :method => :get },
-        { :controller => "api/old_nodes", :action => "version", :id => "1", :version => "2" }
+        { :controller => "api/old_nodes", :action => "version", :id => "1", :version => "2", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/node/1/2/redact", :method => :post },
@@ -134,7 +134,7 @@ module Api
 
       # check all the versions
       versions.each_key do |key|
-        get :version, :params => { :id => nodeid, :version => key.to_i }
+        get :version, :params => { :id => nodeid, :version => key.to_i }, :format => :xml
 
         assert_response :success,
                         "couldn't get version #{key.to_i} of node #{nodeid}"
@@ -154,7 +154,7 @@ module Api
     end
 
     def check_not_found_id_version(id, version)
-      get :version, :params => { :id => id, :version => version }
+      get :version, :params => { :id => id, :version => version }, :format => :xml
       assert_response :not_found
     rescue ActionController::UrlGenerationError => ex
       assert_match(/No route matches/, ex.to_s)
@@ -234,12 +234,12 @@ module Api
       node_v1 = node.old_nodes.find_by(:version => 1)
       node_v1.redact!(create(:redaction))
 
-      get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }
+      get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }, :format => :xml
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
 
       # not even to a logged-in user
       basic_authorization create(:user).email, "test"
-      get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }
+      get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }, :format => :xml
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API, even when logged in."
     end
 
@@ -250,13 +250,13 @@ module Api
       node_v1 = node.old_nodes.find_by(:version => 1)
       node_v1.redact!(create(:redaction))
 
-      get :history, :params => { :id => node_v1.node_id }
+      get :history, :params => { :id => node_v1.node_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm node[id='#{node_v1.node_id}'][version='#{node_v1.version}']", 0, "redacted node #{node_v1.node_id} version #{node_v1.version} shouldn't be present in the history."
 
       # not even to a logged-in user
       basic_authorization create(:user).email, "test"
-      get :history, :params => { :id => node_v1.node_id }
+      get :history, :params => { :id => node_v1.node_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm node[id='#{node_v1.node_id}'][version='#{node_v1.version}']", 0, "redacted node #{node_v1.node_id} version #{node_v1.version} shouldn't be present in the history, even when logged in."
     end
@@ -274,16 +274,16 @@ module Api
 
       # check moderator can still see the redacted data, when passing
       # the appropriate flag
-      get :version, :params => { :id => node_v3.node_id, :version => node_v3.version }
+      get :version, :params => { :id => node_v3.node_id, :version => node_v3.version }, :format => :xml
       assert_response :forbidden, "After redaction, node should be gone for moderator, when flag not passed."
-      get :version, :params => { :id => node_v3.node_id, :version => node_v3.version, :show_redactions => "true" }
+      get :version, :params => { :id => node_v3.node_id, :version => node_v3.version, :show_redactions => "true" }, :format => :xml
       assert_response :success, "After redaction, node should not be gone for moderator, when flag passed."
 
       # and when accessed via history
-      get :history, :params => { :id => node_v3.node_id }
+      get :history, :params => { :id => node_v3.node_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm node[id='#{node_v3.node_id}'][version='#{node_v3.version}']", 0, "node #{node_v3.node_id} version #{node_v3.version} should not be present in the history for moderators when not passing flag."
-      get :history, :params => { :id => node_v3.node_id, :show_redactions => "true" }
+      get :history, :params => { :id => node_v3.node_id, :show_redactions => "true" }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm node[id='#{node_v3.node_id}'][version='#{node_v3.version}']", 1, "node #{node_v3.node_id} version #{node_v3.version} should still be present in the history for moderators when passing flag."
     end
@@ -302,11 +302,11 @@ module Api
       basic_authorization create(:user).email, "test"
 
       # check can't see the redacted data
-      get :version, :params => { :id => node_v3.node_id, :version => node_v3.version }
+      get :version, :params => { :id => node_v3.node_id, :version => node_v3.version }, :format => :xml
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
 
       # and when accessed via history
-      get :history, :params => { :id => node_v3.node_id }
+      get :history, :params => { :id => node_v3.node_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm node[id='#{node_v3.node_id}'][version='#{node_v3.version}']", 0, "redacted node #{node_v3.node_id} version #{node_v3.version} shouldn't be present in the history."
     end
@@ -354,22 +354,22 @@ module Api
 
       # check moderator can now see the redacted data, when not
       # passing the aspecial flag
-      get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }
+      get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }, :format => :xml
       assert_response :success, "After unredaction, node should not be gone for moderator."
 
       # and when accessed via history
-      get :history, :params => { :id => node_v1.node_id }
+      get :history, :params => { :id => node_v1.node_id }, :format => :xml
       assert_response :success, "Unredaction shouldn't have stopped history working."
       assert_select "osm node[id='#{node_v1.node_id}'][version='#{node_v1.version}']", 1, "node #{node_v1.node_id} version #{node_v1.version} should now be present in the history for moderators without passing flag."
 
       basic_authorization create(:user).email, "test"
 
       # check normal user can now see the redacted data
-      get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }
+      get :version, :params => { :id => node_v1.node_id, :version => node_v1.version }, :format => :xml
       assert_response :success, "After unredaction, node should be visible to normal users."
 
       # and when accessed via history
-      get :history, :params => { :id => node_v1.node_id }
+      get :history, :params => { :id => node_v1.node_id }, :format => :xml
       assert_response :success, "Unredaction shouldn't have stopped history working."
       assert_select "osm node[id='#{node_v1.node_id}'][version='#{node_v1.version}']", 1, "node #{node_v1.node_id} version #{node_v1.version} should now be present in the history for normal users without passing flag."
     end
@@ -377,7 +377,7 @@ module Api
     private
 
     def do_redact_node(node, redaction)
-      get :version, :params => { :id => node.node_id, :version => node.version }
+      get :version, :params => { :id => node.node_id, :version => node.version }, :format => :xml
       assert_response :success, "should be able to get version #{node.version} of node #{node.node_id}."
 
       # now redact it
@@ -387,14 +387,14 @@ module Api
     def check_current_version(node_id)
       # get the current version of the node
       current_node = with_controller(NodesController.new) do
-        get :show, :params => { :id => node_id }
+        get :show, :params => { :id => node_id }, :format => :xml
         assert_response :success, "cant get current node #{node_id}"
         Node.from_xml(@response.body)
       end
       assert_not_nil current_node, "getting node #{node_id} returned nil"
 
       # get the "old" version of the node from the old_node interface
-      get :version, :params => { :id => node_id, :version => current_node.version }
+      get :version, :params => { :id => node_id, :version => current_node.version }, :format => :xml
       assert_response :success, "cant get old node #{node_id}, v#{current_node.version}"
       old_node = Node.from_xml(@response.body)
 

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -7,11 +7,11 @@ module Api
     def test_routes
       assert_routing(
         { :path => "/api/0.6/relation/1/history", :method => :get },
-        { :controller => "api/old_relations", :action => "history", :id => "1" }
+        { :controller => "api/old_relations", :action => "history", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/relation/1/2", :method => :get },
-        { :controller => "api/old_relations", :action => "version", :id => "1", :version => "2" }
+        { :controller => "api/old_relations", :action => "version", :id => "1", :version => "2", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/relation/1/2/redact", :method => :post },
@@ -24,11 +24,11 @@ module Api
     # -------------------------------------
     def test_history
       # check that a visible relations is returned properly
-      get :history, :params => { :id => create(:relation, :with_history).id }
+      get :history, :params => { :id => create(:relation, :with_history).id }, :format => :xml
       assert_response :success
 
       # check chat a non-existent relations is not returned
-      get :history, :params => { :id => 0 }
+      get :history, :params => { :id => 0 }, :format => :xml
       assert_response :not_found
     end
 
@@ -77,12 +77,12 @@ module Api
       relation_v1 = relation.old_relations.find_by(:version => 1)
       relation_v1.redact!(create(:redaction))
 
-      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
+      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }, :format => :xml
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
 
       # not even to a logged-in user
       basic_authorization create(:user).email, "test"
-      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
+      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }, :format => :xml
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API, even when logged in."
     end
 
@@ -93,14 +93,14 @@ module Api
       relation_v1 = relation.old_relations.find_by(:version => 1)
       relation_v1.redact!(create(:redaction))
 
-      get :history, :params => { :id => relation_v1.relation_id }
+      get :history, :params => { :id => relation_v1.relation_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 0, "redacted relation #{relation_v1.relation_id} version #{relation_v1.version} shouldn't be present in the history."
 
       # not even to a logged-in user
       basic_authorization create(:user).email, "test"
-      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
-      get :history, :params => { :id => relation_v1.relation_id }
+      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }, :format => :xml
+      get :history, :params => { :id => relation_v1.relation_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 0, "redacted relation #{relation_v1.relation_id} version #{relation_v1.version} shouldn't be present in the history, even when logged in."
     end
@@ -119,16 +119,16 @@ module Api
 
       # check moderator can still see the redacted data, when passing
       # the appropriate flag
-      get :version, :params => { :id => relation_v3.relation_id, :version => relation_v3.version }
+      get :version, :params => { :id => relation_v3.relation_id, :version => relation_v3.version }, :format => :xml
       assert_response :forbidden, "After redaction, relation should be gone for moderator, when flag not passed."
-      get :version, :params => { :id => relation_v3.relation_id, :version => relation_v3.version, :show_redactions => "true" }
+      get :version, :params => { :id => relation_v3.relation_id, :version => relation_v3.version, :show_redactions => "true" }, :format => :xml
       assert_response :success, "After redaction, relation should not be gone for moderator, when flag passed."
 
       # and when accessed via history
-      get :history, :params => { :id => relation_v3.relation_id }
+      get :history, :params => { :id => relation_v3.relation_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v3.relation_id}'][version='#{relation_v3.version}']", 0, "relation #{relation_v3.relation_id} version #{relation_v3.version} should not be present in the history for moderators when not passing flag."
-      get :history, :params => { :id => relation_v3.relation_id, :show_redactions => "true" }
+      get :history, :params => { :id => relation_v3.relation_id, :show_redactions => "true" }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v3.relation_id}'][version='#{relation_v3.version}']", 1, "relation #{relation_v3.relation_id} version #{relation_v3.version} should still be present in the history for moderators when passing flag."
     end
@@ -148,11 +148,11 @@ module Api
       basic_authorization create(:user).email, "test"
 
       # check can't see the redacted data
-      get :version, :params => { :id => relation_v3.relation_id, :version => relation_v3.version }
+      get :version, :params => { :id => relation_v3.relation_id, :version => relation_v3.version }, :format => :xml
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
 
       # and when accessed via history
-      get :history, :params => { :id => relation_v3.relation_id }
+      get :history, :params => { :id => relation_v3.relation_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v3.relation_id}'][version='#{relation_v3.version}']", 0, "redacted relation #{relation_v3.relation_id} version #{relation_v3.version} shouldn't be present in the history."
     end
@@ -198,22 +198,22 @@ module Api
 
       # check moderator can still see the redacted data, without passing
       # the appropriate flag
-      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
+      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }, :format => :xml
       assert_response :success, "After unredaction, relation should not be gone for moderator."
 
       # and when accessed via history
-      get :history, :params => { :id => relation_v1.relation_id }
+      get :history, :params => { :id => relation_v1.relation_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 1, "relation #{relation_v1.relation_id} version #{relation_v1.version} should still be present in the history for moderators."
 
       basic_authorization create(:user).email, "test"
 
       # check normal user can now see the redacted data
-      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }
+      get :version, :params => { :id => relation_v1.relation_id, :version => relation_v1.version }, :format => :xml
       assert_response :success, "After redaction, node should not be gone for normal user."
 
       # and when accessed via history
-      get :history, :params => { :id => relation_v1.relation_id }
+      get :history, :params => { :id => relation_v1.relation_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 1, "relation #{relation_v1.relation_id} version #{relation_v1.version} should still be present in the history for normal users."
     end
@@ -226,14 +226,14 @@ module Api
     def check_current_version(relation_id)
       # get the current version
       current_relation = with_controller(RelationsController.new) do
-        get :show, :params => { :id => relation_id }
+        get :show, :params => { :id => relation_id }, :format => :xml
         assert_response :success, "can't get current relation #{relation_id}"
         Relation.from_xml(@response.body)
       end
       assert_not_nil current_relation, "getting relation #{relation_id} returned nil"
 
       # get the "old" version of the relation from the version method
-      get :version, :params => { :id => relation_id, :version => current_relation.version }
+      get :version, :params => { :id => relation_id, :version => current_relation.version }, :format => :xml
       assert_response :success, "can't get old relation #{relation_id}, v#{current_relation.version}"
       old_relation = Relation.from_xml(@response.body)
 
@@ -245,7 +245,7 @@ module Api
     # look at all the versions of the relation in the history and get each version from
     # the versions call. check that they're the same.
     def check_history_equals_versions(relation_id)
-      get :history, :params => { :id => relation_id }
+      get :history, :params => { :id => relation_id }, :format => :xml
       assert_response :success, "can't get relation #{relation_id} from API"
       history_doc = XML::Parser.string(@response.body).parse
       assert_not_nil history_doc, "parsing relation #{relation_id} history failed"
@@ -254,7 +254,7 @@ module Api
         history_relation = Relation.from_xml_node(relation_doc)
         assert_not_nil history_relation, "parsing relation #{relation_id} version failed"
 
-        get :version, :params => { :id => relation_id, :version => history_relation.version }
+        get :version, :params => { :id => relation_id, :version => history_relation.version }, :format => :xml
         assert_response :success, "couldn't get relation #{relation_id}, v#{history_relation.version}"
         version_relation = Relation.from_xml(@response.body)
         assert_not_nil version_relation, "failed to parse #{relation_id}, v#{history_relation.version}"
@@ -264,7 +264,7 @@ module Api
     end
 
     def do_redact_relation(relation, redaction)
-      get :version, :params => { :id => relation.relation_id, :version => relation.version }
+      get :version, :params => { :id => relation.relation_id, :version => relation.version }, :format => :xml
       assert_response :success, "should be able to get version #{relation.version} of relation #{relation.relation_id}."
 
       # now redact it

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -7,11 +7,11 @@ module Api
     def test_routes
       assert_routing(
         { :path => "/api/0.6/way/1/history", :method => :get },
-        { :controller => "api/old_ways", :action => "history", :id => "1" }
+        { :controller => "api/old_ways", :action => "history", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/way/1/2", :method => :get },
-        { :controller => "api/old_ways", :action => "version", :id => "1", :version => "2" }
+        { :controller => "api/old_ways", :action => "version", :id => "1", :version => "2", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/way/1/2/redact", :method => :post },
@@ -25,19 +25,19 @@ module Api
 
     def test_history_visible
       # check that a visible way is returned properly
-      get :history, :params => { :id => create(:way, :with_history).id }
+      get :history, :params => { :id => create(:way, :with_history).id }, :format => :xml
       assert_response :success
     end
 
     def test_history_invisible
       # check that an invisible way's history is returned properly
-      get :history, :params => { :id => create(:way, :with_history, :deleted).id }
+      get :history, :params => { :id => create(:way, :with_history, :deleted).id }, :format => :xml
       assert_response :success
     end
 
     def test_history_invalid
       # check chat a non-existent way is not returned
-      get :history, :params => { :id => 0 }
+      get :history, :params => { :id => 0 }, :format => :xml
       assert_response :not_found
     end
 
@@ -118,12 +118,12 @@ module Api
       way_v1 = way.old_ways.find_by(:version => 1)
       way_v1.redact!(create(:redaction))
 
-      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }
+      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }, :format => :xml
       assert_response :forbidden, "Redacted way shouldn't be visible via the version API."
 
       # not even to a logged-in user
       basic_authorization create(:user).email, "test"
-      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }
+      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }, :format => :xml
       assert_response :forbidden, "Redacted way shouldn't be visible via the version API, even when logged in."
     end
 
@@ -134,14 +134,14 @@ module Api
       way_v1 = way.old_ways.find_by(:version => 1)
       way_v1.redact!(create(:redaction))
 
-      get :history, :params => { :id => way_v1.way_id }
+      get :history, :params => { :id => way_v1.way_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 0, "redacted way #{way_v1.way_id} version #{way_v1.version} shouldn't be present in the history."
 
       # not even to a logged-in user
       basic_authorization create(:user).email, "test"
-      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }
-      get :history, :params => { :id => way_v1.way_id }
+      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }, :format => :xml
+      get :history, :params => { :id => way_v1.way_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 0, "redacted node #{way_v1.way_id} version #{way_v1.version} shouldn't be present in the history, even when logged in."
     end
@@ -159,16 +159,16 @@ module Api
 
       # check moderator can still see the redacted data, when passing
       # the appropriate flag
-      get :version, :params => { :id => way_v3.way_id, :version => way_v3.version }
+      get :version, :params => { :id => way_v3.way_id, :version => way_v3.version }, :format => :xml
       assert_response :forbidden, "After redaction, node should be gone for moderator, when flag not passed."
-      get :version, :params => { :id => way_v3.way_id, :version => way_v3.version, :show_redactions => "true" }
+      get :version, :params => { :id => way_v3.way_id, :version => way_v3.version, :show_redactions => "true" }, :format => :xml
       assert_response :success, "After redaction, node should not be gone for moderator, when flag passed."
 
       # and when accessed via history
-      get :history, :params => { :id => way_v3.way_id }
+      get :history, :params => { :id => way_v3.way_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v3.way_id}'][version='#{way_v3.version}']", 0, "way #{way_v3.way_id} version #{way_v3.version} should not be present in the history for moderators when not passing flag."
-      get :history, :params => { :id => way_v3.way_id, :show_redactions => "true" }
+      get :history, :params => { :id => way_v3.way_id, :show_redactions => "true" }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v3.way_id}'][version='#{way_v3.version}']", 1, "way #{way_v3.way_id} version #{way_v3.version} should still be present in the history for moderators when passing flag."
     end
@@ -187,11 +187,11 @@ module Api
       basic_authorization create(:user).email, "test"
 
       # check can't see the redacted data
-      get :version, :params => { :id => way_v3.way_id, :version => way_v3.version }
+      get :version, :params => { :id => way_v3.way_id, :version => way_v3.version }, :format => :xml
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
 
       # and when accessed via history
-      get :history, :params => { :id => way_v3.way_id }
+      get :history, :params => { :id => way_v3.way_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v3.way_id}'][version='#{way_v3.version}']", 0, "redacted way #{way_v3.way_id} version #{way_v3.version} shouldn't be present in the history."
     end
@@ -238,22 +238,22 @@ module Api
 
       # check moderator can still see the unredacted data, without passing
       # the appropriate flag
-      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }
+      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }, :format => :xml
       assert_response :success, "After unredaction, node should not be gone for moderator."
 
       # and when accessed via history
-      get :history, :params => { :id => way_v1.way_id }
+      get :history, :params => { :id => way_v1.way_id }, :format => :xml
       assert_response :success, "Unredaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 1, "way #{way_v1.way_id} version #{way_v1.version} should still be present in the history for moderators."
 
       basic_authorization create(:user).email, "test"
 
       # check normal user can now see the unredacted data
-      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }
+      get :version, :params => { :id => way_v1.way_id, :version => way_v1.version }, :format => :xml
       assert_response :success, "After redaction, node should not be gone for moderator, when flag passed."
 
       # and when accessed via history
-      get :history, :params => { :id => way_v1.way_id }
+      get :history, :params => { :id => way_v1.way_id }, :format => :xml
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 1, "way #{way_v1.way_id} version #{way_v1.version} should still be present in the history for normal users."
     end
@@ -266,14 +266,14 @@ module Api
     def check_current_version(way_id)
       # get the current version
       current_way = with_controller(WaysController.new) do
-        get :show, :params => { :id => way_id }
+        get :show, :params => { :id => way_id }, :format => :xml
         assert_response :success, "can't get current way #{way_id}"
         Way.from_xml(@response.body)
       end
       assert_not_nil current_way, "getting way #{way_id} returned nil"
 
       # get the "old" version of the way from the version method
-      get :version, :params => { :id => way_id, :version => current_way.version }
+      get :version, :params => { :id => way_id, :version => current_way.version }, :format => :xml
       assert_response :success, "can't get old way #{way_id}, v#{current_way.version}"
       old_way = Way.from_xml(@response.body)
 
@@ -285,7 +285,7 @@ module Api
     # look at all the versions of the way in the history and get each version from
     # the versions call. check that they're the same.
     def check_history_equals_versions(way_id)
-      get :history, :params => { :id => way_id }
+      get :history, :params => { :id => way_id }, :format => :xml
       assert_response :success, "can't get way #{way_id} from API"
       history_doc = XML::Parser.string(@response.body).parse
       assert_not_nil history_doc, "parsing way #{way_id} history failed"
@@ -294,7 +294,7 @@ module Api
         history_way = Way.from_xml_node(way_doc)
         assert_not_nil history_way, "parsing way #{way_id} version failed"
 
-        get :version, :params => { :id => way_id, :version => history_way.version }
+        get :version, :params => { :id => way_id, :version => history_way.version }, :format => :xml
         assert_response :success, "couldn't get way #{way_id}, v#{history_way.version}"
         version_way = Way.from_xml(@response.body)
         assert_not_nil version_way, "failed to parse #{way_id}, v#{history_way.version}"
@@ -304,7 +304,7 @@ module Api
     end
 
     def do_redact_way(way, redaction)
-      get :version, :params => { :id => way.way_id, :version => way.version }
+      get :version, :params => { :id => way.way_id, :version => way.version }, :format => :xml
       assert_response :success, "should be able to get version #{way.version} of way #{way.way_id}."
 
       # now redact it

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -11,11 +11,11 @@ module Api
       )
       assert_routing(
         { :path => "/api/0.6/relation/1/full", :method => :get },
-        { :controller => "api/relations", :action => "full", :id => "1" }
+        { :controller => "api/relations", :action => "full", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/relation/1", :method => :get },
-        { :controller => "api/relations", :action => "show", :id => "1" }
+        { :controller => "api/relations", :action => "show", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/relation/1", :method => :put },
@@ -27,20 +27,20 @@ module Api
       )
       assert_routing(
         { :path => "/api/0.6/relations", :method => :get },
-        { :controller => "api/relations", :action => "index" }
+        { :controller => "api/relations", :action => "index", :format => "xml" }
       )
 
       assert_routing(
         { :path => "/api/0.6/node/1/relations", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_node", :id => "1" }
+        { :controller => "api/relations", :action => "relations_for_node", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/way/1/relations", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_way", :id => "1" }
+        { :controller => "api/relations", :action => "relations_for_way", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/relation/1/relations", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_relation", :id => "1" }
+        { :controller => "api/relations", :action => "relations_for_relation", :id => "1", :format => "xml" }
       )
     end
 
@@ -50,15 +50,15 @@ module Api
 
     def test_show
       # check that a visible relation is returned properly
-      get :show, :params => { :id => create(:relation).id }
+      get :show, :params => { :id => create(:relation).id }, :format => :xml
       assert_response :success
 
       # check that an invisible relation is not returned
-      get :show, :params => { :id => create(:relation, :deleted).id }
+      get :show, :params => { :id => create(:relation, :deleted).id }, :format => :xml
       assert_response :gone
 
       # check chat a non-existent relation is not returned
-      get :show, :params => { :id => 0 }
+      get :show, :params => { :id => 0 }, :format => :xml
       assert_response :not_found
     end
 
@@ -129,7 +129,7 @@ module Api
 
     def check_relations_for_element(method, type, id, expected_relations)
       # check the "relations for relation" mode
-      get method, :params => { :id => id }
+      get method, :params => { :id => id }, :format => :xml
       assert_response :success
 
       # count one osm element
@@ -148,13 +148,13 @@ module Api
 
     def test_full
       # check the "full" mode
-      get :full, :params => { :id => 999999 }
+      get :full, :params => { :id => 999999 }, :format => :xml
       assert_response :not_found
 
-      get :full, :params => { :id => create(:relation, :deleted).id }
+      get :full, :params => { :id => create(:relation, :deleted).id }, :format => :xml
       assert_response :gone
 
-      get :full, :params => { :id => create(:relation).id }
+      get :full, :params => { :id => create(:relation).id }, :format => :xml
       assert_response :success
       # FIXME: check whether this contains the stuff we want!
     end
@@ -169,15 +169,15 @@ module Api
       relation4.old_relations.find_by(:version => 1).redact!(create(:redaction))
 
       # check error when no parameter provided
-      get :index
+      get :index, :format => :xml
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get :index, :params => { :relations => "" }
+      get :index, :params => { :relations => "" }, :format => :xml
       assert_response :bad_request
 
       # test a working call
-      get :index, :params => { :relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}" }
+      get :index, :params => { :relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}" }, :format => :xml
       assert_response :success
       assert_select "osm" do
         assert_select "relation", :count => 4
@@ -188,7 +188,7 @@ module Api
       end
 
       # check error when a non-existent relation is included
-      get :index, :params => { :relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id},0" }
+      get :index, :params => { :relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id},0" }, :format => :xml
       assert_response :not_found
     end
 
@@ -271,7 +271,7 @@ module Api
       assert_equal true, checkrelation.visible,
                    "saved relation is not visible"
       # ok the relation is there but can we also retrieve it?
-      get :show, :params => { :id => relationid }
+      get :show, :params => { :id => relationid }, :format => :xml
       assert_response :success
 
       ###
@@ -302,7 +302,7 @@ module Api
                    "saved relation is not visible"
       # ok the relation is there but can we also retrieve it?
 
-      get :show, :params => { :id => relationid }
+      get :show, :params => { :id => relationid }, :format => :xml
       assert_response :success
 
       ###
@@ -332,7 +332,7 @@ module Api
                    "saved relation is not visible"
       # ok the relation is there but can we also retrieve it?
 
-      get :show, :params => { :id => relationid }
+      get :show, :params => { :id => relationid }, :format => :xml
       assert_response :success
 
       ###
@@ -362,7 +362,7 @@ module Api
       assert_equal true, checkrelation.visible,
                    "saved relation is not visible"
       # ok the relation is there but can we also retrieve it?
-      get :show, :params => { :id => relationid }
+      get :show, :params => { :id => relationid }, :format => :xml
       assert_response :success
     end
 
@@ -691,7 +691,7 @@ module Api
           assert_response :success, "can't update relation for add #{element.class}/bbox test: #{@response.body}"
 
           # get it back and check the ordering
-          get :show, :params => { :id => relation.id }
+          get :show, :params => { :id => relation.id }, :format => :xml
           assert_response :success, "can't read back the relation: #{@response.body}"
           check_ordering(relation_xml, @response.body)
         end
@@ -754,7 +754,7 @@ OSM
       relation_id = @response.body.to_i
 
       # get it back and check the ordering
-      get :show, :params => { :id => relation_id }
+      get :show, :params => { :id => relation_id }, :format => :xml
       assert_response :success, "can't read back the relation: #{@response.body}"
       check_ordering(doc, @response.body)
 
@@ -774,13 +774,13 @@ OSM
       assert_equal 2, @response.body.to_i
 
       # get it back again and check the ordering again
-      get :show, :params => { :id => relation_id }
+      get :show, :params => { :id => relation_id }, :format => :xml
       assert_response :success, "can't read back the relation: #{@response.body}"
       check_ordering(doc, @response.body)
 
       # check the ordering in the history tables:
       with_controller(OldRelationsController.new) do
-        get :version, :params => { :id => relation_id, :version => 2 }
+        get :version, :params => { :id => relation_id, :version => 2 }, :format => :xml
         assert_response :success, "can't read back version 2 of the relation #{relation_id}"
         check_ordering(doc, @response.body)
       end
@@ -821,7 +821,7 @@ OSM
       relation_id = @response.body.to_i
 
       # get it back and check the ordering
-      get :show, :params => { :id => relation_id }
+      get :show, :params => { :id => relation_id }, :format => :xml
       assert_response :success, "can't read back the relation: #{relation_id}"
       check_ordering(doc, @response.body)
     end
@@ -854,13 +854,13 @@ OSM
       relation_id = @response.body.to_i
 
       # check the ordering in the current tables:
-      get :show, :params => { :id => relation_id }
+      get :show, :params => { :id => relation_id }, :format => :xml
       assert_response :success, "can't read back the relation: #{@response.body}"
       check_ordering(doc, @response.body)
 
       # check the ordering in the history tables:
       with_controller(OldRelationsController.new) do
-        get :version, :params => { :id => relation_id, :version => 1 }
+        get :version, :params => { :id => relation_id, :version => 1 }, :format => :xml
         assert_response :success, "can't read back version 1 of the relation: #{@response.body}"
         check_ordering(doc, @response.body)
       end
@@ -953,7 +953,7 @@ OSM
 
       # now download the changeset to check its bounding box
       with_controller(Api::ChangesetsController.new) do
-        get :show, :params => { :id => changeset_id }
+        get :show, :params => { :id => changeset_id }, :format => :xml
         assert_response :success, "can't re-read changeset for modify test"
         assert_select "osm>changeset", 1, "Changeset element doesn't exist in #{@response.body}"
         assert_select "osm>changeset[id='#{changeset_id}']", 1, "Changeset id=#{changeset_id} doesn't exist in #{@response.body}"
@@ -970,10 +970,10 @@ OSM
     # doc is returned.
     def with_relation(id, ver = nil)
       if ver.nil?
-        get :show, :params => { :id => id }
+        get :show, :params => { :id => id }, :format => :xml
       else
         with_controller(OldRelationsController.new) do
-          get :version, :params => { :id => id, :version => ver }
+          get :version, :params => { :id => id, :version => ver }, :format => :xml
         end
       end
       assert_response :success
@@ -991,7 +991,7 @@ OSM
       version = @response.body.to_i
 
       # now get the new version
-      get :show, :params => { :id => rel_id }
+      get :show, :params => { :id => rel_id }, :format => :xml
       assert_response :success
       new_rel = xml_parse(@response.body)
 
@@ -1023,7 +1023,7 @@ OSM
       end
 
       # now get the new version
-      get :show, :params => { :id => rel_id }
+      get :show, :params => { :id => rel_id }, :format => :xml
       assert_response :success
       new_rel = xml_parse(@response.body)
 

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -11,11 +11,11 @@ module Api
       )
       assert_routing(
         { :path => "/api/0.6/way/1/full", :method => :get },
-        { :controller => "api/ways", :action => "full", :id => "1" }
+        { :controller => "api/ways", :action => "full", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/way/1", :method => :get },
-        { :controller => "api/ways", :action => "show", :id => "1" }
+        { :controller => "api/ways", :action => "show", :id => "1", :format => "xml" }
       )
       assert_routing(
         { :path => "/api/0.6/way/1", :method => :put },
@@ -27,7 +27,7 @@ module Api
       )
       assert_routing(
         { :path => "/api/0.6/ways", :method => :get },
-        { :controller => "api/ways", :action => "index" }
+        { :controller => "api/ways", :action => "index", :format => "xml" }
       )
     end
 
@@ -37,15 +37,15 @@ module Api
 
     def test_show
       # check that a visible way is returned properly
-      get :show, :params => { :id => create(:way).id }
+      get :show, :params => { :id => create(:way).id }, :format => :xml
       assert_response :success
 
       # check that an invisible way is not returned
-      get :show, :params => { :id => create(:way, :deleted).id }
+      get :show, :params => { :id => create(:way, :deleted).id }, :format => :xml
       assert_response :gone
 
       # check chat a non-existent way is not returned
-      get :show, :params => { :id => 0 }
+      get :show, :params => { :id => 0 }, :format => :xml
       assert_response :not_found
     end
 
@@ -86,15 +86,15 @@ module Api
       way4 = create(:way)
 
       # check error when no parameter provided
-      get :index
+      get :index, :format => :xml
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get :index, :params => { :ways => "" }
+      get :index, :params => { :ways => "" }, :format => :xml
       assert_response :bad_request
 
       # test a working call
-      get :index, :params => { :ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}" }
+      get :index, :params => { :ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}" }, :format => :xml
       assert_response :success
       assert_select "osm" do
         assert_select "way", :count => 4
@@ -105,7 +105,7 @@ module Api
       end
 
       # check error when a non-existent way is included
-      get :index, :params => { :ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id},0" }
+      get :index, :params => { :ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id},0" }, :format => :xml
       assert_response :not_found
     end
 
@@ -711,7 +711,7 @@ module Api
       _way3_v2 = create(:old_way, :current_way => way3_v1.current_way, :version => 2)
       create(:old_way_node, :old_way => way3_v1, :node => node)
 
-      get :ways_for_node, :params => { :id => node.id }
+      get :ways_for_node, :params => { :id => node.id }, :format => :xml
       assert_response :success
       ways_xml = XML::Parser.string(@response.body).parse
       assert_not_nil ways_xml, "failed to parse ways_for_node response"


### PR DESCRIPTION
As the issue title suggests, this is still very much WIP with the intention to gather some early feedback, go through a number of iterations to fix issues, etc.

Topics in this PR:

(1) Move the XML generation from the controller to the view for the following controllers:

* nodes_controller
* ways_controller
* relations_controller
* old_controller
* map_controller

(2) Adding JSON output according to the Overpass API JSON format spec for nodes, ways, relations, and the map call.

TODO:

- [ ] Remove XML generation methods in models
- [x] Finish off remaining methods in all 5 controllers
- [ ] Add "redaction" flag in XML response, check if anything else if missing
- [ ] Test cases
- [ ] A good approach to keep using changeset_cache, user_display_name_cache


Follow up for https://github.com/openstreetmap/iD/issues/3765