### PR TITLE
Allow user_blocks to be created for longer periods

### DIFF
--- a/app/helpers/user_blocks_helper.rb
+++ b/app/helpers/user_blocks_helper.rb
@@ -22,4 +22,19 @@ module UserBlocksHelper
       I18n.t("user_blocks.helper.time_past", :time => friendly_date(last_time)).html_safe
     end
   end
+
+  def block_duration_in_words(duration)
+    parts = ActiveSupport::Duration.build(duration).parts
+    if duration < 1.day
+      I18n.t("user_blocks.helper.block_duration.hours", :count => parts[:hours])
+    elsif duration < 1.week
+      I18n.t("user_blocks.helper.block_duration.days", :count => parts[:days])
+    elsif duration < 1.month
+      I18n.t("user_blocks.helper.block_duration.weeks", :count => parts[:weeks])
+    elsif duration < 1.year
+      I18n.t("user_blocks.helper.block_duration.months", :count => parts[:months])
+    else
+      I18n.t("user_blocks.helper.block_duration.years", :count => parts[:years])
+    end
+  end
 end

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -18,7 +18,7 @@
   </p>
   <p>
     <%= label_tag "user_block_period", t(".period") %><br />
-    <%= select_tag("user_block_period", options_for_select(UserBlock::PERIODS.collect { |h| [t("user_blocks.period", :count => h), h.to_s] }, params[:user_block_period])) %>
+    <%= select_tag("user_block_period", options_for_select(UserBlock::PERIODS.collect { |h| [block_duration_in_words(h.hours), h.to_s] }, params[:user_block_period])) %>
   </p>
   <p>
     <%= f.check_box :needs_view %>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -13,7 +13,7 @@
   </p>
   <p>
     <%= label_tag "user_block_period", t(".period") %><br />
-    <%= select_tag("user_block_period", options_for_select(UserBlock::PERIODS.collect { |h| [t("user_blocks.period", :count => h), h.to_s] }, params[:user_block_period])) %>
+    <%= select_tag("user_block_period", options_for_select(UserBlock::PERIODS.collect { |h| [block_duration_in_words(h.hours), h.to_s] }, params[:user_block_period])) %>
   </p>
   <p>
     <%= f.check_box :needs_view %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2311,14 +2311,27 @@ en:
       confirm: "Are you sure you wish to revoke this block?"
       revoke: "Revoke!"
       flash: "This block has been revoked."
-    period:
-      one: "1 hour"
-      other: "%{count} hours"
     helper:
       time_future: "Ends in %{time}."
       until_login: "Active until the user logs in."
       time_future_and_until_login: "Ends in %{time} and after the user has logged in."
       time_past: "Ended %{time} ago."
+      block_duration:
+        hours:
+          one: "1 hour"
+          other: "%{count} hours"
+        days:
+          one: "1 day"
+          other: "%{count} days"
+        weeks:
+          one: "1 week"
+          other: "%{count} weeks"
+        months:
+          one: "1 month"
+          other: "%{count} months"
+        years:
+          one: "1 year"
+          other: "%{count} years"
     blocks_on:
       title: "Blocks on %{name}"
       heading: "List of blocks on %{name}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,7 +42,7 @@ api_timeout: 300
 # Timeout for web pages in seconds
 web_timeout: 30
 # Periods (in hours) which are allowed for user blocks
-user_block_periods: [0, 1, 3, 6, 12, 24, 48, 96]
+user_block_periods: [0, 1, 3, 6, 12, 24, 48, 96, 168, 336, 731, 4383, 8766, 87660]
 # Rate limit for message sending
 max_messages_per_hour: 60
 # Domain for handling message replies


### PR DESCRIPTION
This avoids admins from having to manually change end periods in the database.

Most of this diff is the helper to display durations in the dropdown menu in more friendly terms than e.g. "8766 hours". The hours are carefully picked to show up as rounded durations. It's possible to pick particular hours that don't fit the pattern, e.g. 36 hours, but handling those situations was becoming an exercise in over-engineering.

![Screenshot from 2019-05-15 11-44-47](https://user-images.githubusercontent.com/360803/57766250-52d9e980-7707-11e9-971d-ac5867c9dc5d.png)


 I also wanted to preserve the "0 hours" label since that's how those blocks are referred to in common parlance, and to avoid e.g. "about 1 month" and similar vagueness, so that precluded using the standard rails time_to_words helpers.