### PR TITLE
Update annotations to correctly show bigint types

### DIFF
--- a/app/models/acl.rb
+++ b/app/models/acl.rb
@@ -2,7 +2,7 @@
 #
 # Table name: acls
 #
-#  id      :integer          not null, primary key
+#  id      :bigint(8)        not null, primary key
 #  address :inet
 #  k       :string           not null
 #  v       :string

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -2,8 +2,8 @@
 #
 # Table name: changesets
 #
-#  id          :integer          not null, primary key
-#  user_id     :integer          not null
+#  id          :bigint(8)        not null, primary key
+#  user_id     :bigint(8)        not null
 #  created_at  :datetime         not null
 #  min_lat     :integer
 #  max_lat     :integer

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -14,7 +14,7 @@
 #
 # Indexes
 #
-#  changesets_bbox_idx                (min_lat,max_lat,min_lon,max_lon)
+#  changesets_bbox_idx                (min_lat,max_lat,min_lon,max_lon) USING gist
 #  changesets_closed_at_idx           (closed_at)
 #  changesets_created_at_idx          (created_at)
 #  changesets_user_id_created_at_idx  (user_id,created_at)

--- a/app/models/changeset_comment.rb
+++ b/app/models/changeset_comment.rb
@@ -3,8 +3,8 @@
 # Table name: changeset_comments
 #
 #  id           :integer          not null, primary key
-#  changeset_id :integer          not null
-#  author_id    :integer          not null
+#  changeset_id :bigint(8)        not null
+#  author_id    :bigint(8)        not null
 #  body         :text             not null
 #  created_at   :datetime         not null
 #  visible      :boolean          not null

--- a/app/models/changeset_tag.rb
+++ b/app/models/changeset_tag.rb
@@ -2,7 +2,7 @@
 #
 # Table name: changeset_tags
 #
-#  changeset_id :integer          not null, primary key
+#  changeset_id :bigint(8)        not null, primary key
 #  k            :string           default(""), not null, primary key
 #  v            :string           default(""), not null
 #

--- a/app/models/diary_comment.rb
+++ b/app/models/diary_comment.rb
@@ -2,9 +2,9 @@
 #
 # Table name: diary_comments
 #
-#  id             :integer          not null, primary key
-#  diary_entry_id :integer          not null
-#  user_id        :integer          not null
+#  id             :bigint(8)        not null, primary key
+#  diary_entry_id :bigint(8)        not null
+#  user_id        :bigint(8)        not null
 #  body           :text             not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null

--- a/app/models/diary_entry.rb
+++ b/app/models/diary_entry.rb
@@ -2,8 +2,8 @@
 #
 # Table name: diary_entries
 #
-#  id            :integer          not null, primary key
-#  user_id       :integer          not null
+#  id            :bigint(8)        not null, primary key
+#  user_id       :bigint(8)        not null
 #  title         :string           not null
 #  body          :text             not null
 #  created_at    :datetime         not null

--- a/app/models/diary_entry_subscription.rb
+++ b/app/models/diary_entry_subscription.rb
@@ -2,8 +2,8 @@
 #
 # Table name: diary_entry_subscriptions
 #
-#  user_id        :integer          not null, primary key
-#  diary_entry_id :integer          not null, primary key
+#  user_id        :bigint(8)        not null, primary key
+#  diary_entry_id :bigint(8)        not null, primary key
 #
 # Indexes
 #

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -2,9 +2,9 @@
 #
 # Table name: friends
 #
-#  id             :integer          not null, primary key
-#  user_id        :integer          not null
-#  friend_user_id :integer          not null
+#  id             :bigint(8)        not null, primary key
+#  user_id        :bigint(8)        not null
+#  friend_user_id :bigint(8)        not null
 #
 # Indexes
 #

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,13 +2,13 @@
 #
 # Table name: messages
 #
-#  id                :integer          not null, primary key
-#  from_user_id      :integer          not null
+#  id                :bigint(8)        not null, primary key
+#  from_user_id      :bigint(8)        not null
 #  title             :string           not null
 #  body              :text             not null
 #  sent_on           :datetime         not null
 #  message_read      :boolean          default(FALSE), not null
-#  to_user_id        :integer          not null
+#  to_user_id        :bigint(8)        not null
 #  to_user_visible   :boolean          default(TRUE), not null
 #  from_user_visible :boolean          default(TRUE), not null
 #  body_format       :enum             default("markdown"), not null

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -2,14 +2,14 @@
 #
 # Table name: current_nodes
 #
-#  id           :integer          not null, primary key
+#  id           :bigint(8)        not null, primary key
 #  latitude     :integer          not null
 #  longitude    :integer          not null
-#  changeset_id :integer          not null
+#  changeset_id :bigint(8)        not null
 #  visible      :boolean          not null
 #  timestamp    :datetime         not null
-#  tile         :integer          not null
-#  version      :integer          not null
+#  tile         :bigint(8)        not null
+#  version      :bigint(8)        not null
 #
 # Indexes
 #

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -2,7 +2,7 @@
 #
 # Table name: current_node_tags
 #
-#  node_id :integer          not null, primary key
+#  node_id :bigint(8)        not null, primary key
 #  k       :string           default(""), not null, primary key
 #  v       :string           default(""), not null
 #

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,10 +2,10 @@
 #
 # Table name: notes
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  latitude   :integer          not null
 #  longitude  :integer          not null
-#  tile       :integer          not null
+#  tile       :bigint(8)        not null
 #  updated_at :datetime         not null
 #  created_at :datetime         not null
 #  status     :enum             not null

--- a/app/models/note_comment.rb
+++ b/app/models/note_comment.rb
@@ -2,12 +2,12 @@
 #
 # Table name: note_comments
 #
-#  id         :integer          not null, primary key
-#  note_id    :integer          not null
+#  id         :bigint(8)        not null, primary key
+#  note_id    :bigint(8)        not null
 #  visible    :boolean          not null
 #  created_at :datetime         not null
 #  author_ip  :inet
-#  author_id  :integer
+#  author_id  :bigint(8)
 #  body       :text
 #  event      :enum
 #

--- a/app/models/note_comment.rb
+++ b/app/models/note_comment.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_note_comments_on_body        (to_tsvector('english'::regconfig, body))
+#  index_note_comments_on_body        (to_tsvector('english'::regconfig, body)) USING gin
 #  index_note_comments_on_created_at  (created_at)
 #  note_comments_note_id_idx          (note_id)
 #

--- a/app/models/old_node.rb
+++ b/app/models/old_node.rb
@@ -2,14 +2,14 @@
 #
 # Table name: nodes
 #
-#  node_id      :integer          not null, primary key
+#  node_id      :bigint(8)        not null, primary key
 #  latitude     :integer          not null
 #  longitude    :integer          not null
-#  changeset_id :integer          not null
+#  changeset_id :bigint(8)        not null
 #  visible      :boolean          not null
 #  timestamp    :datetime         not null
-#  tile         :integer          not null
-#  version      :integer          not null, primary key
+#  tile         :bigint(8)        not null
+#  version      :bigint(8)        not null, primary key
 #  redaction_id :integer
 #
 # Indexes

--- a/app/models/old_node_tag.rb
+++ b/app/models/old_node_tag.rb
@@ -2,8 +2,8 @@
 #
 # Table name: node_tags
 #
-#  node_id :integer          not null, primary key
-#  version :integer          not null, primary key
+#  node_id :bigint(8)        not null, primary key
+#  version :bigint(8)        not null, primary key
 #  k       :string           default(""), not null, primary key
 #  v       :string           default(""), not null
 #

--- a/app/models/old_relation.rb
+++ b/app/models/old_relation.rb
@@ -2,10 +2,10 @@
 #
 # Table name: relations
 #
-#  relation_id  :integer          default(0), not null, primary key
-#  changeset_id :integer          not null
+#  relation_id  :bigint(8)        default(0), not null, primary key
+#  changeset_id :bigint(8)        not null
 #  timestamp    :datetime         not null
-#  version      :integer          not null, primary key
+#  version      :bigint(8)        not null, primary key
 #  visible      :boolean          default(TRUE), not null
 #  redaction_id :integer
 #

--- a/app/models/old_relation_member.rb
+++ b/app/models/old_relation_member.rb
@@ -2,11 +2,11 @@
 #
 # Table name: relation_members
 #
-#  relation_id :integer          default(0), not null, primary key
+#  relation_id :bigint(8)        default(0), not null, primary key
 #  member_type :enum             not null
-#  member_id   :integer          not null
+#  member_id   :bigint(8)        not null
 #  member_role :string           not null
-#  version     :integer          default(0), not null, primary key
+#  version     :bigint(8)        default(0), not null, primary key
 #  sequence_id :integer          default(0), not null, primary key
 #
 # Indexes

--- a/app/models/old_relation_tag.rb
+++ b/app/models/old_relation_tag.rb
@@ -2,10 +2,10 @@
 #
 # Table name: relation_tags
 #
-#  relation_id :integer          default(0), not null, primary key
+#  relation_id :bigint(8)        default(0), not null, primary key
 #  k           :string           default(""), not null, primary key
 #  v           :string           default(""), not null
-#  version     :integer          not null, primary key
+#  version     :bigint(8)        not null, primary key
 #
 # Foreign Keys
 #

--- a/app/models/old_way.rb
+++ b/app/models/old_way.rb
@@ -2,10 +2,10 @@
 #
 # Table name: ways
 #
-#  way_id       :integer          default(0), not null, primary key
-#  changeset_id :integer          not null
+#  way_id       :bigint(8)        default(0), not null, primary key
+#  changeset_id :bigint(8)        not null
 #  timestamp    :datetime         not null
-#  version      :integer          not null, primary key
+#  version      :bigint(8)        not null, primary key
 #  visible      :boolean          default(TRUE), not null
 #  redaction_id :integer
 #

--- a/app/models/old_way_node.rb
+++ b/app/models/old_way_node.rb
@@ -2,10 +2,10 @@
 #
 # Table name: way_nodes
 #
-#  way_id      :integer          not null, primary key
-#  node_id     :integer          not null
-#  version     :integer          not null, primary key
-#  sequence_id :integer          not null, primary key
+#  way_id      :bigint(8)        not null, primary key
+#  node_id     :bigint(8)        not null
+#  version     :bigint(8)        not null, primary key
+#  sequence_id :bigint(8)        not null, primary key
 #
 # Indexes
 #

--- a/app/models/old_way_tag.rb
+++ b/app/models/old_way_tag.rb
@@ -2,10 +2,10 @@
 #
 # Table name: way_tags
 #
-#  way_id  :integer          default(0), not null, primary key
+#  way_id  :bigint(8)        default(0), not null, primary key
 #  k       :string           not null, primary key
 #  v       :string           not null
-#  version :integer          not null, primary key
+#  version :bigint(8)        not null, primary key
 #
 # Foreign Keys
 #

--- a/app/models/redaction.rb
+++ b/app/models/redaction.rb
@@ -7,7 +7,7 @@
 #  description        :text
 #  created_at         :datetime
 #  updated_at         :datetime
-#  user_id            :integer          not null
+#  user_id            :bigint(8)        not null
 #  description_format :enum             default("markdown"), not null
 #
 # Foreign Keys

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -2,11 +2,11 @@
 #
 # Table name: current_relations
 #
-#  id           :integer          not null, primary key
-#  changeset_id :integer          not null
+#  id           :bigint(8)        not null, primary key
+#  changeset_id :bigint(8)        not null
 #  timestamp    :datetime         not null
 #  visible      :boolean          not null
-#  version      :integer          not null
+#  version      :bigint(8)        not null
 #
 # Indexes
 #

--- a/app/models/relation_member.rb
+++ b/app/models/relation_member.rb
@@ -2,9 +2,9 @@
 #
 # Table name: current_relation_members
 #
-#  relation_id :integer          not null, primary key
+#  relation_id :bigint(8)        not null, primary key
 #  member_type :enum             not null
-#  member_id   :integer          not null
+#  member_id   :bigint(8)        not null
 #  member_role :string           not null
 #  sequence_id :integer          default(0), not null, primary key
 #

--- a/app/models/relation_tag.rb
+++ b/app/models/relation_tag.rb
@@ -2,7 +2,7 @@
 #
 # Table name: current_relation_tags
 #
-#  relation_id :integer          not null, primary key
+#  relation_id :bigint(8)        not null, primary key
 #  k           :string           default(""), not null, primary key
 #  v           :string           default(""), not null
 #

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -2,11 +2,11 @@
 #
 # Table name: gpx_files
 #
-#  id          :integer          not null, primary key
-#  user_id     :integer          not null
+#  id          :bigint(8)        not null, primary key
+#  user_id     :bigint(8)        not null
 #  visible     :boolean          default(TRUE), not null
 #  name        :string           default(""), not null
-#  size        :integer
+#  size        :bigint(8)
 #  latitude    :float
 #  longitude   :float
 #  timestamp   :datetime         not null

--- a/app/models/tracepoint.rb
+++ b/app/models/tracepoint.rb
@@ -6,9 +6,9 @@
 #  trackid   :integer          not null
 #  latitude  :integer          not null
 #  longitude :integer          not null
-#  gpx_id    :integer          not null
+#  gpx_id    :bigint(8)        not null
 #  timestamp :datetime
-#  tile      :integer
+#  tile      :bigint(8)
 #
 # Indexes
 #

--- a/app/models/tracetag.rb
+++ b/app/models/tracetag.rb
@@ -2,9 +2,9 @@
 #
 # Table name: gpx_file_tags
 #
-#  gpx_id :integer          default(0), not null
+#  gpx_id :bigint(8)        default(0), not null
 #  tag    :string           not null
-#  id     :integer          not null, primary key
+#  id     :bigint(8)        not null, primary key
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  email               :string           not null
-#  id                  :integer          not null, primary key
+#  id                  :bigint(8)        not null, primary key
 #  pass_crypt          :string           not null
 #  creation_time       :datetime         not null
 #  display_name        :string           default(""), not null
@@ -33,7 +33,7 @@
 #  image_use_gravatar  :boolean          default(FALSE), not null
 #  image_content_type  :string
 #  auth_provider       :string
-#  home_tile           :integer
+#  home_tile           :bigint(8)
 #  tou_agreed          :datetime
 #
 # Indexes

--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -3,12 +3,12 @@
 # Table name: user_blocks
 #
 #  id            :integer          not null, primary key
-#  user_id       :integer          not null
-#  creator_id    :integer          not null
+#  user_id       :bigint(8)        not null
+#  creator_id    :bigint(8)        not null
 #  reason        :text             not null
 #  ends_at       :datetime         not null
 #  needs_view    :boolean          default(FALSE), not null
-#  revoker_id    :integer
+#  revoker_id    :bigint(8)
 #  created_at    :datetime
 #  updated_at    :datetime
 #  reason_format :enum             default("markdown"), not null

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -2,7 +2,7 @@
 #
 # Table name: user_preferences
 #
-#  user_id :integer          not null, primary key
+#  user_id :bigint(8)        not null, primary key
 #  k       :string           not null, primary key
 #  v       :string           not null
 #

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -3,11 +3,11 @@
 # Table name: user_roles
 #
 #  id         :integer          not null, primary key
-#  user_id    :integer          not null
+#  user_id    :bigint(8)        not null
 #  role       :enum             not null
 #  created_at :datetime
 #  updated_at :datetime
-#  granter_id :integer          not null
+#  granter_id :bigint(8)        not null
 #
 # Indexes
 #

--- a/app/models/user_token.rb
+++ b/app/models/user_token.rb
@@ -2,8 +2,8 @@
 #
 # Table name: user_tokens
 #
-#  id      :integer          not null, primary key
-#  user_id :integer          not null
+#  id      :bigint(8)        not null, primary key
+#  user_id :bigint(8)        not null
 #  token   :string           not null
 #  expiry  :datetime         not null
 #  referer :text

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -2,11 +2,11 @@
 #
 # Table name: current_ways
 #
-#  id           :integer          not null, primary key
-#  changeset_id :integer          not null
+#  id           :bigint(8)        not null, primary key
+#  changeset_id :bigint(8)        not null
 #  timestamp    :datetime         not null
 #  visible      :boolean          not null
-#  version      :integer          not null
+#  version      :bigint(8)        not null
 #
 # Indexes
 #

--- a/app/models/way_node.rb
+++ b/app/models/way_node.rb
@@ -2,9 +2,9 @@
 #
 # Table name: current_way_nodes
 #
-#  way_id      :integer          not null, primary key
-#  node_id     :integer          not null
-#  sequence_id :integer          not null, primary key
+#  way_id      :bigint(8)        not null, primary key
+#  node_id     :bigint(8)        not null
+#  sequence_id :bigint(8)        not null, primary key
 #
 # Indexes
 #

--- a/app/models/way_tag.rb
+++ b/app/models/way_tag.rb
@@ -2,7 +2,7 @@
 #
 # Table name: current_way_tags
 #
-#  way_id :integer          not null, primary key
+#  way_id :bigint(8)        not null, primary key
 #  k      :string           default(""), not null, primary key
 #  v      :string           default(""), not null
 #


### PR DESCRIPTION
In https://github.com/ctran/annotate_models/pull/515 the annotation gem started to distinguish `bigint` columns from `integer` columns. This PR updates the relevant annotations.