### PR TITLE
Use strong_migrations 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem "rack-cors"
 gem "rails-i18n", "~> 4.0.0"
 gem "record_tag_helper"
 gem "rinku", ">= 2.0.6", :require => "rails_rinku"
+gem "strong_migrations"
 gem "validates_email_format_of", ">= 1.5.1"
 
 # Native OSM extensions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    strong_migrations (0.3.1)
+      activerecord (>= 3.2.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     terrapin (0.6.0)
@@ -510,6 +512,7 @@ DEPENDENCIES
   sanitize
   sassc-rails
   secure_headers
+  strong_migrations
   therubyracer
   uglifier (>= 1.3.0)
   validates_email_format_of (>= 1.5.1)

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,1 @@
+StrongMigrations.start_after = 20190518115041 # rubocop:disable Style/NumericLiterals


### PR DESCRIPTION
… to help developers avoid problems in production database schema changes.

I've used this gem in other projects and I find it really useful. For many developers it's not clear which migrations can be done near-instantly (e.g. adding a new column) and which migrations will lock a table, potentially for hours (e.g. adding a new column with a default value).

This gem highlights bad migrations during development, so that the developers can learn what the problems might be before the sysadmins find out in production. I've set it to ignore all existing migrations since some of them won't have been safe, but that no longer matters.