### PR TITLE
Diary refactoring

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,7 +40,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 262
+  Max: 263
 
 # Offense count: 11
 # Configuration parameters: CountBlocks.

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -36,7 +36,7 @@ class Ability
 
       if Settings.status != "database_offline"
         can [:index, :new, :create, :show, :edit, :update, :destroy], ClientApplication
-        can [:create, :edit, :comment, :subscribe, :unsubscribe], DiaryEntry
+        can [:new, :create, :edit, :update, :comment, :subscribe, :unsubscribe], DiaryEntry
         can [:new, :create, :reply, :show, :inbox, :outbox, :mark, :destroy], Message
         can [:close, :reopen], Note
         can [:new, :create], Report

--- a/app/views/diary_entries/_form.html.erb
+++ b/app/views/diary_entries/_form.html.erb
@@ -1,0 +1,35 @@
+<div class="diary_entry standard-form">
+  <fieldset>
+    <div class='form-row'>
+      <label class="standard-label"><%= t ".subject" -%></label>
+      <%= f.text_field :title, :class => "richtext_title" %>
+    </div>
+    <div class='form-row'>
+      <label class="standard-label"><%= t ".body" -%></label>
+      <%= richtext_area :diary_entry, :body, :cols => 80, :rows => 20, :format => @diary_entry.body_format %>
+    </div>
+    <div class='form-row'>
+      <label class="standard-label"><%= t ".language" -%></label>
+      <%= f.collection_select :language_code, Language.order(:english_name), :code, :name %>
+  </div>
+  </fieldset>
+  <fieldset class='location'>
+    <label class="standard-label"><%= t ".location" -%></label>
+    <%= content_tag "div", "", :id => "map", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
+    <div class='form-row clearfix'>
+      <div class='form-column'>
+        <label class="secondary standard-label"><%= t ".latitude" -%></label>
+        <%= f.text_field :latitude, :size => 20, :id => "latitude" %>
+      </div>
+      <div class='form-column'>
+        <label class="secondary standard-label"><%= t ".longitude" -%></label>
+        <%= f.text_field :longitude, :size => 20, :id => "longitude" %>
+      </div>
+      <div class='form-column'>
+        <a href="#" id="usemap"><%= t ".use_map_link" -%></a>
+      </div>
+    </div>
+  </fieldset>
+
+  <%= f.submit %>
+</div>

--- a/app/views/diary_entries/edit.html.erb
+++ b/app/views/diary_entries/edit.html.erb
@@ -9,5 +9,5 @@
 <%= error_messages_for "diary_entry" %>
 
 <%= form_for @diary_entry, :url => diary_entry_path(current_user, @diary_entry), :html => { :method => :put } do |f| %>
-  <%= render :partial => "form", :locals =>  { :f => f } %>
+  <%= render :partial => "form", :locals => { :f => f } %>
 <% end %>

--- a/app/views/diary_entries/edit.html.erb
+++ b/app/views/diary_entries/edit.html.erb
@@ -9,39 +9,5 @@
 <%= error_messages_for "diary_entry" %>
 
 <%= form_for @diary_entry, :url => diary_entry_path(current_user, @diary_entry), :html => { :method => :put } do |f| %>
-  <div class="diary_entry standard-form">
-    <fieldset>
-      <div class='form-row'>
-        <label class="standard-label"><%= t ".subject" -%></label>
-        <%= f.text_field :title, :class => "richtext_title" %>
-      </div>
-      <div class='form-row'>
-        <label class="standard-label"><%= t ".body" -%></label>
-        <%= richtext_area :diary_entry, :body, :cols => 80, :rows => 20, :format => @diary_entry.body_format %>
-      </div>
-      <div class='form-row'>
-        <label class="standard-label"><%= t ".language" -%></label>
-        <%= f.collection_select :language_code, Language.order(:english_name), :code, :name %>
-    </div>
-    </fieldset>
-    <fieldset class='location'>
-      <label class="standard-label"><%= t ".location" -%></label>
-      <%= content_tag "div", "", :id => "map", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
-      <div class='form-row clearfix'>
-        <div class='form-column'>
-          <label class="secondary standard-label"><%= t ".latitude" -%></label>
-          <%= f.text_field :latitude, :size => 20, :id => "latitude" %>
-        </div>
-        <div class='form-column'>
-          <label class="secondary standard-label"><%= t ".longitude" -%></label>
-          <%= f.text_field :longitude, :size => 20, :id => "longitude" %>
-        </div>
-        <div class='form-column'>
-          <a href="#" id="usemap"><%= t ".use_map_link" -%></a>
-        </div>
-      </div>
-    </fieldset>
-
-    <%= submit_tag t(".save_button") %>
-  </div>
+  <%= render :partial => "form", :locals =>  { :f => f } %>
 <% end %>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -13,13 +13,13 @@
       <% if @user %>
         <% if @user == current_user %>
           <div>
-            <li><%= link_to image_tag("new.png", :class => "small_icon", :border => 0) + t(".new"), diary_new_path, :title => t(".new_title") %></li>
+            <li><%= link_to image_tag("new.png", :class => "small_icon", :border => 0) + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
           </div>
         <% end %>
       <% else %>
         <% if current_user %>
           <div>
-            <li><%= link_to image_tag("new.png", :class => "small_icon", :border => 0) + t(".new"), diary_new_path, :title => t(".new_title") %></li>
+            <li><%= link_to image_tag("new.png", :class => "small_icon", :border => 0) + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
           </div>
         <% end %>
       <% end %>

--- a/app/views/diary_entries/new.html.erb
+++ b/app/views/diary_entries/new.html.erb
@@ -9,39 +9,5 @@
 <%= error_messages_for "diary_entry" %>
 
 <%= form_for @diary_entry do |f| %>
-  <div class="diary_entry standard-form">
-    <fieldset>
-      <div class='form-row'>
-        <label class="standard-label"><%= t ".subject" -%></label>
-        <%= f.text_field :title, :class => "richtext_title" %>
-      </div>
-      <div class='form-row'>
-        <label class="standard-label"><%= t ".body" -%></label>
-        <%= richtext_area :diary_entry, :body, :cols => 80, :rows => 20, :format => @diary_entry.body_format %>
-      </div>
-      <div class='form-row'>
-        <label class="standard-label"><%= t ".language" -%></label>
-        <%= f.collection_select :language_code, Language.order(:english_name), :code, :name %>
-    </div>
-    </fieldset>
-    <fieldset class='location'>
-      <label class="standard-label"><%= t ".location" -%></label>
-      <%= content_tag "div", "", :id => "map", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
-      <div class='form-row clearfix'>
-        <div class='form-column'>
-          <label class="secondary standard-label"><%= t ".latitude" -%></label>
-          <%= f.text_field :latitude, :size => 20, :id => "latitude" %>
-        </div>
-        <div class='form-column'>
-          <label class="secondary standard-label"><%= t ".longitude" -%></label>
-          <%= f.text_field :longitude, :size => 20, :id => "longitude" %>
-        </div>
-        <div class='form-column'>
-          <a href="#" id="usemap"><%= t ".use_map_link" -%></a>
-        </div>
-      </div>
-    </fieldset>
-
-    <%= submit_tag t("diary_entries.new.publish_button") %>
-  </div>
+  <%= render :partial => "form", :locals =>  { :f => f } %>
 <% end %>

--- a/app/views/diary_entries/new.html.erb
+++ b/app/views/diary_entries/new.html.erb
@@ -8,7 +8,7 @@
 
 <%= error_messages_for "diary_entry" %>
 
-<%= form_for @diary_entry, :url => diary_entry_path(current_user, @diary_entry), :html => { :method => :put } do |f| %>
+<%= form_for @diary_entry do |f| %>
   <div class="diary_entry standard-form">
     <fieldset>
       <div class='form-row'>
@@ -42,6 +42,6 @@
       </div>
     </fieldset>
 
-    <%= submit_tag t(".save_button") %>
+    <%= submit_tag t("diary_entries.new.publish_button") %>
   </div>
 <% end %>

--- a/app/views/diary_entries/new.html.erb
+++ b/app/views/diary_entries/new.html.erb
@@ -9,5 +9,5 @@
 <%= error_messages_for "diary_entry" %>
 
 <%= form_for @diary_entry do |f| %>
-  <%= render :partial => "form", :locals =>  { :f => f } %>
+  <%= render :partial => "form", :locals => { :f => f } %>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -49,7 +49,7 @@
         </li>
       <% end %>
       <li class="compact-hide <%= current_page_class(traces_path) %>"><%= link_to t("layouts.gps_traces"), traces_path %></li>
-      <li class="compact-hide <%= current_page_class(diary_path) %>"><%= link_to t("layouts.user_diaries"), diary_path %></li>
+      <li class="compact-hide <%= current_page_class(diary_entries_path) %>"><%= link_to t("layouts.user_diaries"), diary_entries_path %></li>
       <li class="compact-hide <%= current_page_class(copyright_path) %>"><%= link_to t("layouts.copyright"), copyright_path %></li>
       <li class="compact-hide <%= current_page_class(help_path) %>"><%= link_to t("layouts.help"), help_path %></li>
       <li class="compact-hide <%= current_page_class(about_path) %>"><%= link_to t("layouts.about"), about_path %></li>
@@ -65,7 +65,7 @@
             </li>
           <% end %>
           <li class="<%= current_page_class(traces_path) %>"><%= link_to t("layouts.gps_traces"), traces_path %></li>
-          <li class="<%= current_page_class(diary_path) %>"><%= link_to t("layouts.user_diaries"), diary_path %></li>
+          <li class="<%= current_page_class(diary_entries_path) %>"><%= link_to t("layouts.user_diaries"), diary_entries_path %></li>
           <li class="<%= current_page_class(copyright_path) %>"><%= link_to t("layouts.copyright"), copyright_path %></li>
           <li class="<%= current_page_class(help_path) %>"><%= link_to t("layouts.help"), help_path %></li>
           <li class="<%= current_page_class(about_path) %>"><%= link_to t("layouts.about"), about_path %></li>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -17,7 +17,7 @@
 
   <div class='section'>
     <h2><div class='icon community'></div><%= t ".community_driven_title" %></h2>
-    <p><%= t ".community_driven_html", :diary_path => diary_path %></p>
+    <p><%= t ".community_driven_html", :diary_path => diary_entries_path %></p>
   </div>
 
   <div class='section' id='open-data'>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -205,7 +205,7 @@
     <% else %>
       <ul class='secondary-actions clearfix'>
         <li><%= link_to t(".friends_changesets"), friend_changesets_path %></li>
-        <li><%= link_to t(".friends_diaries"), friend_diaries_path %></li>
+        <li><%= link_to t(".friends_diaries"), friends_diary_entries_path %></li>
       </ul>
       <div id="friends-container">
         <%= render :partial => "contact", :collection => friends, :locals => { :type => "friend" } %>
@@ -221,7 +221,7 @@
     <% else %>
       <ul class='secondary-actions clearfix'>
         <li><%= link_to t(".nearby_changesets"), nearby_changesets_path %></li>
-        <li><%= link_to t(".nearby_diaries"), nearby_diaries_path %></li>
+        <li><%= link_to t(".nearby_diaries"), nearby_diary_entries_path %></li>
       </ul>
       <div id="nearbyusers">
         <%= render :partial => "contact", :collection => nearby, :locals => { :type => "nearby mapper" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,11 @@ en:
     formats:
       friendly: "%e %B %Y at %H:%M"
       blog: "%e %B %Y"
+  helpers:
+    submit:
+      diary_entry:
+        create: "Publish"
+        update: "Update"
   activerecord:
     errors:
       messages:
@@ -282,6 +287,7 @@ en:
   diary_entries:
     new:
       title: New Diary Entry
+    form:
       subject: "Subject:"
       body: "Body:"
       language: "Language:"
@@ -289,8 +295,6 @@ en:
       latitude: "Latitude:"
       longitude: "Longitude:"
       use_map_link: "use map"
-      marker_text: Diary entry location
-      publish_button: "Publish"
     index:
       title: "Users' diaries"
       title_friends: "Friends' diaries"
@@ -304,15 +308,7 @@ en:
       older_entries: Older Entries
       newer_entries: Newer Entries
     edit:
-      title: "Edit diary entry"
-      subject: "Subject:"
-      body: "Body:"
-      language: "Language:"
-      location: "Location:"
-      latitude: "Latitude:"
-      longitude: "Longitude:"
-      use_map_link: "use map"
-      save_button: "Save"
+      title: Edit Diary Entry
       marker_text: Diary entry location
     show:
       title: "%{user}'s diary | %{title}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,14 @@ en:
   diary_entries:
     new:
       title: New Diary Entry
+      subject: "Subject:"
+      body: "Body:"
+      language: "Language:"
+      location: "Location:"
+      latitude: "Latitude:"
+      longitude: "Longitude:"
+      use_map_link: "use map"
+      marker_text: Diary entry location
       publish_button: "Publish"
     index:
       title: "Users' diaries"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,7 +216,7 @@ OpenStreetMap::Application.routes.draw do
   post "/trace/:id/delete" => "traces#delete", :id => /\d+/
 
   # diary pages
-  match "/diary/new" => "diary_entries#new", :via => [:get, :post]
+  resources :diary_entries, :path => "diary", :only => [:new, :create]
   get "/diary/friends" => "diary_entries#index", :friends => true, :as => "friend_diaries"
   get "/diary/nearby" => "diary_entries#index", :nearby => true, :as => "nearby_diaries"
   get "/user/:display_name/diary/rss" => "diary_entries#rss", :defaults => { :format => :rss }
@@ -227,9 +227,10 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/diary" => "diary_entries#index"
   get "/diary/:language" => "diary_entries#index"
   get "/diary" => "diary_entries#index"
-  get "/user/:display_name/diary/:id" => "diary_entries#show", :id => /\d+/, :as => :diary_entry
+  scope "/user/:display_name" do
+    resources :diary_entries, :path => "diary", :only => [:edit, :update, :show]
+  end
   post "/user/:display_name/diary/:id/newcomment" => "diary_entries#comment", :id => /\d+/
-  match "/user/:display_name/diary/:id/edit" => "diary_entries#edit", :via => [:get, :post], :id => /\d+/
   post "/user/:display_name/diary/:id/hide" => "diary_entries#hide", :id => /\d+/, :as => :hide_diary_entry
   post "/user/:display_name/diary/:id/hidecomment/:comment" => "diary_entries#hidecomment", :id => /\d+/, :comment => /\d+/, :as => :hide_diary_comment
   post "/user/:display_name/diary/:id/subscribe" => "diary_entries#subscribe", :as => :diary_entry_subscribe, :id => /\d+/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,9 +216,12 @@ OpenStreetMap::Application.routes.draw do
   post "/trace/:id/delete" => "traces#delete", :id => /\d+/
 
   # diary pages
-  resources :diary_entries, :path => "diary", :only => [:new, :create]
-  get "/diary/friends" => "diary_entries#index", :friends => true, :as => "friend_diaries"
-  get "/diary/nearby" => "diary_entries#index", :nearby => true, :as => "nearby_diaries"
+  resources :diary_entries, :path => "diary", :only => [:new, :create, :index] do
+    collection do
+      get "friends" => "diary_entries#index", :friends => true
+      get "nearby" => "diary_entries#index", :nearby => true
+    end
+  end
   get "/user/:display_name/diary/rss" => "diary_entries#rss", :defaults => { :format => :rss }
   get "/diary/:language/rss" => "diary_entries#rss", :defaults => { :format => :rss }
   get "/diary/rss" => "diary_entries#rss", :defaults => { :format => :rss }
@@ -226,7 +229,6 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/diary/comments/" => "diary_entries#comments"
   get "/user/:display_name/diary" => "diary_entries#index"
   get "/diary/:language" => "diary_entries#index"
-  get "/diary" => "diary_entries#index"
   scope "/user/:display_name" do
     resources :diary_entries, :path => "diary", :only => [:edit, :update, :show]
   end

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -279,9 +279,9 @@ class DiaryEntriesControllerTest < ActionController::TestCase
         :params => { :display_name => entry.user.display_name, :id => entry.id },
         :session => { :user => entry.user }
     assert_response :success
-    assert_select "title", :text => /Edit diary entry/, :count => 1
+    assert_select "title", :text => /Edit Diary Entry/, :count => 1
     assert_select "div.content-heading", :count => 1 do
-      assert_select "h1", :text => /Edit diary entry/, :count => 1
+      assert_select "h1", :text => /Edit Diary Entry/, :count => 1
     end
     assert_select "div#content", :count => 1 do
       assert_select "form[action='/user/#{ERB::Util.u(entry.user.display_name)}/diary/#{entry.id}'][method=post]", :count => 1 do
@@ -290,7 +290,7 @@ class DiaryEntriesControllerTest < ActionController::TestCase
         assert_select "select#diary_entry_language_code", :count => 1
         assert_select "input#latitude[name='diary_entry[latitude]']", :count => 1
         assert_select "input#longitude[name='diary_entry[longitude]']", :count => 1
-        assert_select "input[name=commit][type=submit][value=Save]", :count => 1
+        assert_select "input[name=commit][type=submit][value=Update]", :count => 1
         assert_select "input[name=commit][type=submit][value=Edit]", :count => 1
         assert_select "input[name=commit][type=submit][value=Preview]", :count => 1
         assert_select "input", :count => 8

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -445,34 +445,34 @@ class UsersControllerTest < ActionController::TestCase
   def test_confirm_success_no_token_with_referer
     user = create(:user, :pending)
     stub_gravatar_request(user.email)
-    confirm_string = user.tokens.create(:referer => diary_new_path).token
+    confirm_string = user.tokens.create(:referer => new_diary_entry_path).token
 
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
-    assert_redirected_to login_path(:referer => diary_new_path)
+    assert_redirected_to login_path(:referer => new_diary_entry_path)
     assert_match(/Confirmed your account/, flash[:notice])
   end
 
   def test_confirm_success_good_token_with_referer
     user = create(:user, :pending)
     stub_gravatar_request(user.email)
-    confirm_string = user.tokens.create(:referer => diary_new_path).token
+    confirm_string = user.tokens.create(:referer => new_diary_entry_path).token
     token = user.tokens.create.token
 
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }, :session => { :token => token }
-    assert_redirected_to diary_new_path
+    assert_redirected_to new_diary_entry_path
   end
 
   def test_confirm_success_bad_token_with_referer
     user = create(:user, :pending)
     stub_gravatar_request(user.email)
-    confirm_string = user.tokens.create(:referer => diary_new_path).token
+    confirm_string = user.tokens.create(:referer => new_diary_entry_path).token
     token = create(:user).tokens.create.token
 
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }, :session => { :token => token }
-    assert_redirected_to login_path(:referer => diary_new_path)
+    assert_redirected_to login_path(:referer => new_diary_entry_path)
     assert_match(/Confirmed your account/, flash[:notice])
   end
 
@@ -488,7 +488,7 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_confirm_already_confirmed
     user = create(:user)
-    confirm_string = user.tokens.create(:referer => diary_new_path).token
+    confirm_string = user.tokens.create(:referer => new_diary_entry_path).token
 
     @request.cookies["_osm_session"] = user.display_name
     post :confirm, :params => { :display_name => user.display_name, :confirm_string => confirm_string }

--- a/test/integration/user_diaries_test.rb
+++ b/test/integration/user_diaries_test.rb
@@ -29,7 +29,7 @@ class UserDiariesTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_response :success
-    assert_template "diary_entries/edit"
+    assert_template "diary_entries/new"
     # print @response.body
     # print @html_document.to_yaml
 
@@ -42,7 +42,7 @@ class UserDiariesTest < ActionDispatch::IntegrationTest
       assert_select "h1", "New Diary Entry"
     end
     assert_select "div#content" do
-      assert_select "form[action='/diary/new']" do
+      assert_select "form[action='/diary']" do
         assert_select "input[id=diary_entry_title]"
       end
     end

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -8,7 +8,7 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
 
   test "reply to diary entry should prefill the message subject" do
     sign_in_as(create(:user))
-    visit diary_path
+    visit diary_entries_path
 
     click_on "Reply to this entry"
 


### PR DESCRIPTION
This PR contains some refactoring of diary entries, to use `:create` and `:update` methods separate from the `:new` and `:edit` methods. The routes are also partially refactored to use resources, and various path names are therefore adjusted.

@Nikerabbit this PR contains some i18n key renames:

* diary_entries.new.publish_button -> helpers.submit.diary_entry.create
* diary_entries.edit.subject -> diary_entries.form.subject
* diary_entries.edit.body -> diary_entries.form.body
* diary_entries.edit.language -> diary_entries.form.language
* diary_entries.edit.location -> diary_entries.form.location
* diary_entries.edit.latitude -> diary_entries.form.latitude
* diary_entries.edit.longitude -> diary_entries.form.longitude
* diary_entries.edit.use_map_link -> diary_entries.form.use_map_link