### PR TITLE
Allow a configurable delay for diary entry feeds

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -166,6 +166,10 @@ class DiaryEntriesController < ApplicationController
     else
       @entries = DiaryEntry.joins(:user).where(:users => { :status => %w[active confirmed] })
 
+      # Items can't be flagged as deleted in the RSS format.
+      # For the general feeds, allow a delay before publishing, to help spam fighting
+      @entries = @entries.where("created_at < :time", :time => Settings.diary_feed_delay.hours.ago)
+
       if params[:language]
         @entries = @entries.where(:language_code => params[:language])
         @title = t("diary_entries.feed.language.title", :language_name => Language.find(params[:language]).english_name)
@@ -177,7 +181,6 @@ class DiaryEntriesController < ApplicationController
         @link = url_for :action => "index", :host => Settings.server_url, :protocol => Settings.server_protocol
       end
     end
-
     @entries = @entries.visible.includes(:user).order("created_at DESC").limit(20)
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,6 +57,8 @@ nearby_users: 30
 nearby_radius: 50
 # Spam threshold
 spam_threshold: 50
+# Delay diary entries from appearing in the feed for this many hours
+diary_feed_delay: 0
 # Default legale (jurisdiction location) for contributor terms
 default_legale: GB
 # Use the built-in jobs queue for importing traces

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,8 @@
 # Trace directories for testing
 gpx_trace_dir: <%= Rails.root.join("test", "gpx", "traces") %>
 gpx_image_dir: <%= Rails.root.join("test", "gpx", "images") %>
+# Ignore the diary feed delay unless we're specifically testing it
+diary_feed_delay: 0
 # Geonames credentials for testing
 geonames_username: "dummy"
 # External authentication credentials for testing


### PR DESCRIPTION
* This is to provide another tool to help spam fighting. It is, of course, not a panacea.
* The configuration value is set to zero hours in order to be 'least surprising' for anyone else deploying the code.
* You can change the setting without interfering with your test suite.

If this is merged, then it will be up to the sysadmins what value they want to set for osm.org. I would suggest 6 hours as a reasonable compromise between unnecessary delays and allowing enough time to allow admins (and/or moderators, see #2226) to take action. Of course, it's a setting that can be adjusted, and can be set back to 0 hours in the future.