### PR TITLE
Show deleted diaries and diary comments to admins

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -51,7 +51,7 @@ class Ability
         end
 
         if user.administrator?
-          can [:hide, :unhide, :hidecomment], [DiaryEntry, DiaryComment]
+          can [:hide, :unhide, :hidecomment, :unhidecomment], [DiaryEntry, DiaryComment]
           can [:index, :show, :resolve, :ignore, :reopen], Issue
           can :create, IssueComment
           can [:set_status, :delete, :index], User

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -51,7 +51,7 @@ class Ability
         end
 
         if user.administrator?
-          can [:hide, :hidecomment], [DiaryEntry, DiaryComment]
+          can [:hide, :unhide, :hidecomment], [DiaryEntry, DiaryComment]
           can [:index, :show, :resolve, :ignore, :reopen], Issue
           can :create, IssueComment
           can [:set_status, :delete, :index], User

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -157,7 +157,7 @@ class DiaryEntriesController < ApplicationController
     @page = (params[:page] || 1).to_i
     @page_size = 20
 
-    @entries = @entries.visible
+    @entries = @entries.visible unless current_user&.administrator?
     @entries = @entries.order("created_at DESC")
     @entries = @entries.offset((@page - 1) * @page_size)
     @entries = @entries.limit(@page_size)

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -214,6 +214,12 @@ class DiaryEntriesController < ApplicationController
     redirect_to :action => "index", :display_name => entry.user.display_name
   end
 
+  def unhide
+    entry = DiaryEntry.find(params[:id])
+    entry.update(:visible => true)
+    redirect_to :action => "index", :display_name => entry.user.display_name
+  end
+
   def hidecomment
     comment = DiaryComment.find(params[:comment])
     comment.update(:visible => false)

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -74,6 +74,7 @@ class DiaryEntriesController < ApplicationController
 
   def comment
     @entry = DiaryEntry.find(params[:id])
+    @comments = @entry.visible_comments
     @diary_comment = @entry.comments.build(comment_params)
     @diary_comment.user = current_user
     if @diary_comment.save
@@ -202,6 +203,7 @@ class DiaryEntriesController < ApplicationController
     @entry = @user.diary_entries.visible.where(:id => params[:id]).first
     if @entry
       @title = t "diary_entries.show.title", :user => params[:display_name], :title => @entry.title
+      @comments = current_user&.administrator? ? @entry.comments : @entry.visible_comments
     else
       @title = t "diary_entries.no_such_entry.title", :id => params[:id]
       render :action => "no_such_entry", :status => :not_found

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -226,6 +226,12 @@ class DiaryEntriesController < ApplicationController
     redirect_to diary_entry_path(comment.diary_entry.user, comment.diary_entry)
   end
 
+  def unhidecomment
+    comment = DiaryComment.find(params[:comment])
+    comment.update(:visible => true)
+    redirect_to diary_entry_path(comment.diary_entry.user, comment.diary_entry)
+  end
+
   def comments
     @comment_pages, @comments = paginate(:diary_comments,
                                          :conditions => {

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -9,7 +9,11 @@
   <div class="richtext"><%= diary_comment.body.to_html %></div>
   <% if current_user && current_user.administrator? %>
     <span>
-      <%= link_to t(".hide_link"), hide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+      <% if diary_comment.visible? %>
+        <%= link_to t(".hide_link"), hide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+      <% else %>
+        <%= link_to t(".unhide_link"), unhide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+      <% end %>
     </span>
   <% end %>
 </div>

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="clearfix diary-comment">
+<div class="clearfix diary-comment<%= ' deemphasize' unless diary_comment.visible? %>">
   <%= user_thumbnail diary_comment.user %>
   <p class="deemphasize comment-heading" id="comment<%= diary_comment.id %>"><%= raw(t(".comment_from", :link_user => (link_to h(diary_comment.user.display_name), user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}"))) %>
     <% if current_user and diary_comment.user.id != current_user.id %>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -39,7 +39,11 @@
 
     <% if current_user && current_user.administrator? %>
       <li>
-        <%= link_to t(".hide_link"), hide_diary_entry_path(:display_name => diary_entry.user.display_name, :id => diary_entry.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+        <% if diary_entry.visible %>
+          <%= link_to t(".hide_link"), hide_diary_entry_path(:display_name => diary_entry.user.display_name, :id => diary_entry.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+        <% else %>
+          <%= link_to t(".unhide_link"), unhide_diary_entry_path(:display_name => diary_entry.user.display_name, :id => diary_entry.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+        <% end %>
       </li>
     <% end %>
   </ul>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -1,4 +1,4 @@
-<div class='diary_post'>
+<div class='diary_post<%= ' deemphasize' unless diary_entry.visible %>'>
   <div class='post_heading clearfix'>
     <% if !@user %>
       <%= user_thumbnail diary_entry.user %>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -10,7 +10,7 @@
 
 <a id="comments"></a>
 <div class='comments'>
-<%= render :partial => "diary_comment", :collection => @entry.visible_comments %>
+<%= render :partial => "diary_comment", :collection => @comments %>
 </div>
 
 <div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -331,6 +331,7 @@ en:
         other: "%{count} comments"
       edit_link: Edit this entry
       hide_link: Hide this entry
+      unhide_link: Unhide this entry
       confirm: Confirm
       report: Report this entry
     diary_comment:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -337,6 +337,7 @@ en:
     diary_comment:
       comment_from: "Comment from %{link_user} on %{comment_created_at}"
       hide_link: Hide this comment
+      unhide_link: Unhide this comment
       confirm: Confirm
       report: Report this comment
     location:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,7 @@ OpenStreetMap::Application.routes.draw do
   end
   post "/user/:display_name/diary/:id/newcomment" => "diary_entries#comment", :id => /\d+/
   post "/user/:display_name/diary/:id/hide" => "diary_entries#hide", :id => /\d+/, :as => :hide_diary_entry
+  post "/user/:display_name/diary/:id/unhide" => "diary_entries#unhide", :id => /\d+/, :as => :unhide_diary_entry
   post "/user/:display_name/diary/:id/hidecomment/:comment" => "diary_entries#hidecomment", :id => /\d+/, :comment => /\d+/, :as => :hide_diary_comment
   post "/user/:display_name/diary/:id/subscribe" => "diary_entries#subscribe", :as => :diary_entry_subscribe, :id => /\d+/
   post "/user/:display_name/diary/:id/unsubscribe" => "diary_entries#unsubscribe", :as => :diary_entry_unsubscribe, :id => /\d+/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,6 +236,7 @@ OpenStreetMap::Application.routes.draw do
   post "/user/:display_name/diary/:id/hide" => "diary_entries#hide", :id => /\d+/, :as => :hide_diary_entry
   post "/user/:display_name/diary/:id/unhide" => "diary_entries#unhide", :id => /\d+/, :as => :unhide_diary_entry
   post "/user/:display_name/diary/:id/hidecomment/:comment" => "diary_entries#hidecomment", :id => /\d+/, :comment => /\d+/, :as => :hide_diary_comment
+  post "/user/:display_name/diary/:id/unhidecomment/:comment" => "diary_entries#unhidecomment", :id => /\d+/, :comment => /\d+/, :as => :unhide_diary_comment
   post "/user/:display_name/diary/:id/subscribe" => "diary_entries#subscribe", :as => :diary_entry_subscribe, :id => /\d+/
   post "/user/:display_name/diary/:id/unsubscribe" => "diary_entries#unsubscribe", :as => :diary_entry_unsubscribe, :id => /\d+/
 

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -43,4 +43,22 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
 
     assert_not page.has_content? @deleted_entry.title
   end
+
+  test "deleted diary comments should be hidden for regular users" do
+    @deleted_comment = create(:diary_comment, :diary_entry => @diary_entry, :visible => false)
+
+    sign_in_as(create(:user))
+    visit diary_entry_path(@diary_entry.user, @diary_entry)
+
+    assert_not page.has_content? @deleted_comment.body
+  end
+
+  test "deleted diary comments should be shown to administrators" do
+    @deleted_comment = create(:diary_comment, :diary_entry => @diary_entry, :visible => false)
+
+    sign_in_as(create(:administrator_user))
+    visit diary_entry_path(@diary_entry.user, @diary_entry)
+
+    assert page.has_content? @deleted_comment.body
+  end
 end

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -15,4 +15,32 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     assert page.has_content? "Send a new message"
     assert_equal "Re: #{@diary_entry.title}", page.find_field("Subject").value
   end
+
+  test "deleted diary entries should be hidden for regular users" do
+    @deleted_entry = create(:diary_entry, :visible => false)
+
+    sign_in_as(create(:user))
+    visit diary_entries_path
+
+    assert_not page.has_content? @deleted_entry.title
+  end
+
+  test "deleted diary entries should be shown to administrators for review" do
+    @deleted_entry = create(:diary_entry, :visible => false)
+
+    sign_in_as(create(:administrator_user))
+    visit diary_entries_path
+
+    assert page.has_content? @deleted_entry.title
+  end
+
+  test "deleted diary entries should not be shown to admins when the user is also deleted" do
+    @deleted_user = create(:user, :status => :deleted)
+    @deleted_entry = create(:diary_entry, :visible => false, :user => @deleted_user)
+
+    sign_in_as(create(:administrator_user))
+    visit diary_entries_path
+
+    assert_not page.has_content? @deleted_entry.title
+  end
 end


### PR DESCRIPTION
In https://github.com/openstreetmap/openstreetmap-website/pull/2226 @tomhuges wrote:

> I do really need an easy way to be able to see the user's diary posts or comments with deleted entries included. 

So here we go! This PR shows deleted diary entries to administrators, so long as the user hasn't also been deleted. It also shows deleted diary comments to administrators. It shows these deleted things deemphasized, and allows admins to restore them if desired.

There's a small difference in functionality between entries and comments, because comments are always shown (i.e. not filtered by user status). However, that was more complexity and we're already getting into some deep hypothetical weeds here.