### PR TITLE
Ignore the block length of the routes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ Lint/PercentStringArray:
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/site_controller.rb'
 
+Metrics/BlockLength:
+  Exclude:
+    - 'config/routes.rb'
+
 Naming/FileName:
   Exclude:
     - 'script/deliver-message'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,7 +40,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 263
+  Max: 71
 
 # Offense count: 15
 # Configuration parameters: CountBlocks.


### PR DESCRIPTION
Since the routes are more of a dsl than code, we've been happy to repeatedly bump up this number. But then that hides other code which has over-long block lengths hiding behind.

So instead let's exclude the routes from this metric.

Also, I keep getting failed travis builds due to this, so it's self-interested :-)