### PR TITLE
Adjust submit labels to use built-in i18n handling

### DIFF
--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -19,9 +19,9 @@
 
     <%= error_messages_for "diary_comment" %>
 
-    <%= form_for :diary_comment, :url => { :action => "comment" } do |f| %>
+    <%= form_for @entry.comments.new, :url => { :action => "comment" } do |f| %>
       <%= richtext_area :diary_comment, :body, :cols => 80, :rows => 15 %>
-      <%= submit_tag t(".save_button") %>
+      <%= f.submit %>
     <% end %>
     <% if @entry.subscribers.exists?(current_user.id) %>
       <div class="diary-subscribe-buttons"><%= link_to t("javascripts.changesets.show.unsubscribe"), diary_entry_unsubscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => :button %></div>

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -20,6 +20,6 @@
   <%= label_tag :reassign, t(".reassign_param") %> <%= check_box_tag :reassign, true %>
   <br />
   <br />
-  <%= submit_tag "Submit" %>
+  <%= f.submit %>
   <% end %>
 </div>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -16,7 +16,7 @@
       <%= richtext_area :message, :body, :cols => 80, :rows => 20 %>
     </div>
     <div class='buttons'>
-      <%= submit_tag t(".send_button") %>
+      <%= f.submit %>
       <%= link_to t(".back_to_inbox"), inbox_messages_path, :class => "deemphasize button" %>
     </div>
   </fieldset>

--- a/app/views/oauth_clients/edit.html.erb
+++ b/app/views/oauth_clients/edit.html.erb
@@ -4,5 +4,5 @@
 
 <%= form_for @client_application, :url => oauth_client_path(@client_application.user.display_name, @client_application), :html => { :method => :put } do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
-  <%= submit_tag t ".submit" %>
+  <%= f.submit %>
 <% end %>

--- a/app/views/oauth_clients/new.html.erb
+++ b/app/views/oauth_clients/new.html.erb
@@ -3,8 +3,8 @@
 <% end %>
 
 <div class='standard-form'>
-  <%= form_for :client_application, :url => { :action => :create } do |f| %>
+  <%= form_for @client_application, :url => { :action => :create } do |f| %>
     <%= render :partial => "form", :locals => { :f => f } %>
-    <%= submit_tag t(".submit") %>
+    <%= f.submit %>
   <% end %>
 </div>

--- a/app/views/redactions/edit.html.erb
+++ b/app/views/redactions/edit.html.erb
@@ -16,6 +16,6 @@
     <%= richtext_area :redaction, :description, :cols => 80, :rows => 20, :format => @redaction.description_format %>
   </p>
   <p>
-    <%= f.submit t(".submit") %>
+    <%= f.submit %>
   </p>
 <% end %>

--- a/app/views/redactions/new.html.erb
+++ b/app/views/redactions/new.html.erb
@@ -15,6 +15,6 @@
     <%= richtext_area :redaction, :description, :cols => 80, :rows => 20, :format => @redaction.description_format %>
   </p>
   <p>
-    <%= f.submit t(".submit") %>
+    <%= f.submit %>
   </p>
 <% end %>

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -50,6 +50,6 @@
 
 </div>
 
-<%= submit_tag t ".save_button" %>
+<%= f.submit %>
 
 <% end %>

--- a/app/views/traces/new.html.erb
+++ b/app/views/traces/new.html.erb
@@ -27,7 +27,7 @@
       </div>
     </fieldset>
 
-    <%= submit_tag t(".upload_button") %>
+    <%= f.submit %>
     <span class="form-help deemphasize"><a href="<%= t ".help_url" %>"><%= t ".help" %></a></span>
   </div>
 <% end %>

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -25,6 +25,6 @@
     <%= f.label :needs_view, t(".needs_view") %>
   </p>
   <p>
-    <%= f.submit t(".submit") %>
+    <%= f.submit %>
   </p>
 <% end %>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -21,7 +21,7 @@
   </p>
   <p>
     <%= hidden_field_tag "display_name", @user.display_name %>
-    <%= f.submit t(".submit") %>
+    <%= f.submit %>
   </p>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,9 @@ en:
       diary_entry:
         create: "Publish"
         update: "Update"
+      redaction:
+        create: Create redaction
+        update: Save redaction
       user_block:
         create: Create block
         update: Update block
@@ -2573,7 +2576,6 @@ en:
     edit:
       description: "Description"
       heading: "Edit redaction"
-      submit: "Save redaction"
       title: "Edit redaction"
     index:
       empty: "No redactions to show."
@@ -2582,7 +2584,6 @@ en:
     new:
       description: "Description"
       heading: "Enter information for new redaction"
-      submit: "Create redaction"
       title: "Creating new redaction"
     show:
       description: "Description:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,9 @@ en:
       redaction:
         create: Create redaction
         update: Save redaction
+      trace:
+        create: Upload
+        update: Save Changes
       user_block:
         create: Create block
         update: Update block
@@ -1758,7 +1761,6 @@ en:
       visibility: "Visibility:"
       visibility_help: "what does this mean?"
       visibility_help_url: "https://wiki.openstreetmap.org/wiki/Visibility_of_GPS_traces"
-      upload_button: "Upload"
       help: "Help"
       help_url: "https://wiki.openstreetmap.org/wiki/Upload"
     create:
@@ -1782,7 +1784,6 @@ en:
       description: "Description:"
       tags: "Tags:"
       tags_help: "comma delimited"
-      save_button: "Save Changes"
       visibility: "Visibility:"
       visibility_help: "what does this mean?"
       visibility_help_url: "https://wiki.openstreetmap.org/wiki/Visibility_of_GPS_traces"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,9 @@ en:
         create: Add Comment
       message:
         create: Send
+      client_application:
+        create: Register
+        update: Edit
       redaction:
         create: Create redaction
         update: Save redaction
@@ -1891,10 +1894,8 @@ en:
   oauth_clients:
     new:
       title: "Register a new application"
-      submit: "Register"
     edit:
       title: "Edit your application"
-      submit: "Edit"
     show:
       title: "OAuth details for %{app_name}"
       key: "Consumer Key:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,8 @@ en:
       blog: "%e %B %Y"
   helpers:
     submit:
+      diary_comment:
+        create: Save
       diary_entry:
         create: "Publish"
         update: "Update"
@@ -324,7 +326,6 @@ en:
       leave_a_comment: "Leave a comment"
       login_to_leave_a_comment: "%{login_link} to leave a comment"
       login: "Login"
-      save_button: "Save"
     no_such_entry:
       title: "No such diary entry"
       heading: "No entry with the id: %{id}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
       diary_entry:
         create: "Publish"
         update: "Update"
+      issue_comment:
+        create: Add Comment
       message:
         create: Send
       redaction:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,9 @@ en:
       diary_entry:
         create: "Publish"
         update: "Update"
+      user_block:
+        create: Create block
+        update: Update block
   activerecord:
     errors:
       messages:
@@ -2287,7 +2290,6 @@ en:
       heading: "Creating block on %{name}"
       reason: "The reason why %{name} is being blocked. Please be as calm and as reasonable as possible, giving as much detail as you can about the situation, remembering that the message will be publicly visible. Bear in mind that not all users understand the community jargon, so please try to use laymans terms."
       period: "How long, starting now, the user will be blocked from the API for."
-      submit: "Create block"
       tried_contacting: "I have contacted the user and asked them to stop."
       tried_waiting: "I have given a reasonable amount of time for the user to respond to those communications."
       needs_view: "User needs to log in before this block will be cleared"
@@ -2297,7 +2299,6 @@ en:
       heading: "Editing block on %{name}"
       reason: "The reason why %{name} is being blocked. Please be as calm and as reasonable as possible, giving as much detail as you can about the situation. Bear in mind that not all users understand the community jargon, so please try to use laymans terms."
       period: "How long, starting now, the user will be blocked from the API for."
-      submit: "Update block"
       show: "View this block"
       back: "View all blocks"
       needs_view: "Does the user need to log in before this block will be cleared?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,8 @@ en:
       diary_entry:
         create: "Publish"
         update: "Update"
+      message:
+        create: Send
       redaction:
         create: Create redaction
         update: Save redaction
@@ -1234,7 +1236,6 @@ en:
       send_message_to: "Send a new message to %{name}"
       subject: "Subject"
       body: "Body"
-      send_button: "Send"
       back_to_inbox: "Back to inbox"
     create:
       message_sent: "Message sent"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,4 +18,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       .to_return(:status => 404)
     super(*args)
   end
+
+  # Phantomjs can pick up browser Accept-Language preferences from your desktop environment.
+  # We don't want this to happen during the tests!
+  setup do
+    page.driver.add_headers("Accept-Language" => "en")
+  end
 end

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -78,7 +78,7 @@ class IssuesTest < ApplicationSystemTestCase
     visit issue_path(issue)
 
     fill_in :issue_comment_body, :with => "test comment"
-    click_on "Submit"
+    click_on "Add Comment"
     assert page.has_content?(I18n.t("issue_comments.create.comment_created"))
     assert page.has_content?("test comment")
 
@@ -95,7 +95,7 @@ class IssuesTest < ApplicationSystemTestCase
 
     fill_in :issue_comment_body, :with => "reassigning to moderators"
     check :reassign
-    click_on "Submit"
+    click_on "Add Comment"
 
     issue.reload
     assert_equal "moderator", issue.assigned_role


### PR DESCRIPTION
I noticed this while working on the diary entries, so now I'm rolling it out more widely. In many cases we've been avoiding using the built-in translation keys for submit buttons, and hard-coding translations based on the file the form is in (rather than based on the model for the form). This has made some form refactoring harder than it needs to be, as well as just being a bit of a waste of time. Sometimes this has been done just because of copying other places where it was done first.

There's ample opportunity to improve these labels in the future - too many saves and not enough updates in my opinion! But I'll leave the strings mostly unchanged for now.

@nikerabbit this PR contains a few translation key renames:

* `diary_entries.show.save_button` -> `helpers.submit.diary_comment.create`
* `messages.new.send_button` -> `helpers.submit.message.create`
* `oauth_clients.new.submit` -> `helpers.submit.client_application.create`
* `oauth_clients.edit.submit` -> `helpers.submit.client_application.update`
* `redactions.new.submit` -> `helpers.submit.redaction.create`
* `redactions.edit.submit` -> `helpers.submit.redaction.update`
* `traces.new.upload_button` -> `helpers.submit.trace.create`
* `traces.edit.save_button` -> `helpers.submit.trace.update`
* `user_blocks.new.submit` -> `helpers.submit.user_block.create`
* `user_blocks.edit.submit` -> `helpers.submit.user_block.update`