### PR TITLE
Add user_<uid> class to diary entry div

### DIFF
--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -1,4 +1,4 @@
-<div class='diary_post<%= " deemphasize" unless diary_entry.visible %>'>
+<div class='diary_post<%= " deemphasize" unless diary_entry.visible %> user_<%= diary_entry.user.id %>'>
   <div class='post_heading clearfix'>
     <% if !@user %>
       <%= user_thumbnail diary_entry.user %>


### PR DESCRIPTION
This adds a class containing the user ID to the div element enclosing a diary entry.

So, for example, a diary entry I write would get the class `user_165`.

This enables a site viewer to add basic killfile-like functionality with Firefox's usercontent.css or extensions like Stylus.