### PR TITLE
Refactor Friend into Friendships

### DIFF
--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -53,7 +53,7 @@ class ChangesetsController < ApplicationController
       elsif @params[:bbox]
         changesets = conditions_bbox(changesets, BoundingBox.from_bbox_params(params))
       elsif @params[:friends] && current_user
-        changesets = changesets.where(:user_id => current_user.friend_users.identifiable)
+        changesets = changesets.where(:user_id => current_user.friends.identifiable)
       elsif @params[:nearby] && current_user
         changesets = changesets.where(:user_id => current_user.nearby)
       end

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -129,7 +129,7 @@ class DiaryEntriesController < ApplicationController
     elsif params[:friends]
       if current_user
         @title = t "diary_entries.index.title_friends"
-        @entries = DiaryEntry.where(:user_id => current_user.friend_users)
+        @entries = DiaryEntry.where(:user_id => current_user.friends)
       else
         require_user
         return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -388,16 +388,16 @@ class UsersController < ApplicationController
 
     if @new_friend
       if request.post?
-        friend = Friend.new
-        friend.befriender = current_user
-        friend.befriendee = @new_friend
+        friendship = Friendship.new
+        friendship.befriender = current_user
+        friendship.befriendee = @new_friend
         if current_user.is_friends_with?(@new_friend)
           flash[:warning] = t "users.make_friend.already_a_friend", :name => @new_friend.display_name
-        elsif friend.save
+        elsif friendship.save
           flash[:notice] = t "users.make_friend.success", :name => @new_friend.display_name
-          Notifier.friend_notification(friend).deliver_later
+          Notifier.friend_notification(friendship).deliver_later
         else
-          friend.add_error(t("users.make_friend.failed", :name => @new_friend.display_name))
+          friendship.add_error(t("users.make_friend.failed", :name => @new_friend.display_name))
         end
 
         if params[:referer]
@@ -417,7 +417,7 @@ class UsersController < ApplicationController
     if @friend
       if request.post?
         if current_user.is_friends_with?(@friend)
-          Friend.where(:user_id => current_user.id, :friend_user_id => @friend.id).delete_all
+          Friendship.where(:user_id => current_user.id, :friend_user_id => @friend.id).delete_all
           flash[:notice] = t "users.remove_friend.success", :name => @friend.display_name
         else
           flash[:error] = t "users.remove_friend.not_a_friend", :name => @friend.display_name

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -417,7 +417,7 @@ class UsersController < ApplicationController
     if @friend
       if request.post?
         if current_user.is_friends_with?(@friend)
-          Friendship.where(:user_id => current_user.id, :friend_user_id => @friend.id).delete_all
+          Friendship.where(:befriender => current_user, :befriendee => @friend).delete_all
           flash[:notice] = t "users.remove_friend.success", :name => @friend.display_name
         else
           flash[:error] = t "users.remove_friend.not_a_friend", :name => @friend.display_name

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -17,7 +17,9 @@
 #  friends_user_id_fkey         (user_id => users.id)
 #
 
-class Friend < ActiveRecord::Base
+class Friendship < ActiveRecord::Base
+  self.table_name = "friends"
+
   belongs_to :befriender, :class_name => "User", :foreign_key => :user_id
   belongs_to :befriendee, :class_name => "User", :foreign_key => :friend_user_id
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ActiveRecord::Base
   has_many :new_messages, -> { where(:to_user_visible => true, :message_read => false).order(:sent_on => :desc) }, :class_name => "Message", :foreign_key => :to_user_id
   has_many :sent_messages, -> { where(:from_user_visible => true).order(:sent_on => :desc).preload(:sender, :recipient) }, :class_name => "Message", :foreign_key => :from_user_id
   has_many :friendships, -> { joins(:befriendee).where(:users => { :status => %w[active confirmed] }) }
-  has_many :friend_users, :through => :friendships, :source => :befriendee
+  has_many :friends, :through => :friendships, :source => :befriendee
   has_many :tokens, :class_name => "UserToken"
   has_many :preferences, :class_name => "UserPreference"
   has_many :changesets, -> { order(:created_at => :desc) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,8 +57,8 @@ class User < ActiveRecord::Base
   has_many :messages, -> { where(:to_user_visible => true).order(:sent_on => :desc).preload(:sender, :recipient) }, :foreign_key => :to_user_id
   has_many :new_messages, -> { where(:to_user_visible => true, :message_read => false).order(:sent_on => :desc) }, :class_name => "Message", :foreign_key => :to_user_id
   has_many :sent_messages, -> { where(:from_user_visible => true).order(:sent_on => :desc).preload(:sender, :recipient) }, :class_name => "Message", :foreign_key => :from_user_id
-  has_many :friends, -> { joins(:befriendee).where(:users => { :status => %w[active confirmed] }) }
-  has_many :friend_users, :through => :friends, :source => :befriendee
+  has_many :friendships, -> { joins(:befriendee).where(:users => { :status => %w[active confirmed] }) }
+  has_many :friend_users, :through => :friendships, :source => :befriendee
   has_many :tokens, :class_name => "UserToken"
   has_many :preferences, :class_name => "UserPreference"
   has_many :changesets, -> { order(:created_at => :desc) }
@@ -224,7 +224,7 @@ class User < ActiveRecord::Base
   end
 
   def is_friends_with?(new_friend)
-    friends.where(:friend_user_id => new_friend.id).exists?
+    friendships.where(:friend_user_id => new_friend.id).exists?
   end
 
   ##

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -224,7 +224,7 @@ class User < ActiveRecord::Base
   end
 
   def is_friends_with?(new_friend)
-    friendships.where(:friend_user_id => new_friend.id).exists?
+    friendships.where(:befriendee => new_friend).exists?
   end
 
   ##

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -194,7 +194,7 @@
       <%= content_tag "div", "", :id => "map", :class => "content_map", :data => { :user => user_data } %>
     <% end %>
 
-    <% friends = @user.friend_users %>
+    <% friends = @user.friends %>
     <% nearby = @user.nearby - friends %>
 
   <div class="activity-block column-1">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -194,7 +194,7 @@
       <%= content_tag "div", "", :id => "map", :class => "content_map", :data => { :user => user_data } %>
     <% end %>
 
-    <% friends = @user.friends.collect(&:befriendee) %>
+    <% friends = @user.friend_users %>
     <% nearby = @user.nearby - friends %>
 
   <div class="activity-block column-1">

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -147,7 +147,7 @@ class ChangesetsControllerTest < ActionController::TestCase
     assert_response :success
     assert_template "index"
 
-    check_index_result(Changeset.where(:user => private_user.friend_users.identifiable))
+    check_index_result(Changeset.where(:user => private_user.friends.identifiable))
   end
 
   ##

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -130,8 +130,8 @@ class ChangesetsControllerTest < ActionController::TestCase
   # Checks the display of the friends changesets listing
   def test_index_friends
     private_user = create(:user, :data_public => true)
-    friend = create(:friend, :befriender => private_user)
-    create(:changeset, :user => friend.befriendee)
+    friendship = create(:friendship, :befriender => private_user)
+    create(:changeset, :user => friendship.befriendee)
 
     get :index, :params => { :friends => true }
     assert_response :redirect

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -528,8 +528,8 @@ class DiaryEntriesControllerTest < ActionController::TestCase
   def test_index_friends
     user = create(:user)
     other_user = create(:user)
-    friend = create(:friend, :befriender => user)
-    diary_entry = create(:diary_entry, :user => friend.befriendee)
+    friendship = create(:friendship, :befriender => user)
+    diary_entry = create(:diary_entry, :user => friendship.befriendee)
     _other_entry = create(:diary_entry, :user => other_user)
 
     # Try a list of diary entries for your friends when not logged in

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -988,7 +988,7 @@ class UsersControllerTest < ActionController::TestCase
     # Test a normal user
     user = create(:user, :home_lon => 1.1, :home_lat => 1.1)
     friend_user = create(:user, :home_lon => 1.2, :home_lat => 1.2)
-    create(:friend, :befriender => user, :befriendee => friend_user)
+    create(:friendship, :befriender => user, :befriendee => friend_user)
     create(:changeset, :user => friend_user)
 
     get :show, :params => { :display_name => user.display_name }
@@ -1113,7 +1113,7 @@ class UsersControllerTest < ActionController::TestCase
     friend = create(:user)
 
     # Check that the users aren't already friends
-    assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When not logged in a GET should ask us to login
     get :make_friend, :params => { :display_name => friend.display_name }
@@ -1122,7 +1122,7 @@ class UsersControllerTest < ActionController::TestCase
     # When not logged in a POST should error
     post :make_friend, :params => { :display_name => friend.display_name }
     assert_response :forbidden
-    assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When logged in a GET should get a confirmation page
     get :make_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
@@ -1132,7 +1132,7 @@ class UsersControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][name='referer']", 0
       assert_select "input[type='submit']", 1
     end
-    assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When logged in a POST should add the friendship
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
@@ -1142,7 +1142,7 @@ class UsersControllerTest < ActionController::TestCase
     end
     assert_redirected_to user_path(friend)
     assert_match(/is now your friend/, flash[:notice])
-    assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal friend.email, email.to.first
@@ -1156,7 +1156,7 @@ class UsersControllerTest < ActionController::TestCase
     end
     assert_redirected_to user_path(friend)
     assert_match(/You are already friends with/, flash[:warning])
-    assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
   end
 
   def test_make_friend_with_referer
@@ -1165,7 +1165,7 @@ class UsersControllerTest < ActionController::TestCase
     friend = create(:user)
 
     # Check that the users aren't already friends
-    assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # The GET should preserve any referer
     get :make_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
@@ -1175,7 +1175,7 @@ class UsersControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][name='referer'][value='/test']", 1
       assert_select "input[type='submit']", 1
     end
-    assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When logged in a POST should add the friendship and refer us
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
@@ -1185,7 +1185,7 @@ class UsersControllerTest < ActionController::TestCase
     end
     assert_redirected_to "/test"
     assert_match(/is now your friend/, flash[:notice])
-    assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal friend.email, email.to.first
@@ -1203,10 +1203,10 @@ class UsersControllerTest < ActionController::TestCase
     # Get users to work with
     user = create(:user)
     friend = create(:user)
-    create(:friend, :befriender => user, :befriendee => friend)
+    create(:friendship, :befriender => user, :befriendee => friend)
 
     # Check that the users are friends
-    assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When not logged in a GET should ask us to login
     get :remove_friend, :params => { :display_name => friend.display_name }
@@ -1215,7 +1215,7 @@ class UsersControllerTest < ActionController::TestCase
     # When not logged in a POST should error
     post :remove_friend, :params => { :display_name => friend.display_name }
     assert_response :forbidden
-    assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When logged in a GET should get a confirmation page
     get :remove_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
@@ -1225,29 +1225,29 @@ class UsersControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][name='referer']", 0
       assert_select "input[type='submit']", 1
     end
-    assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When logged in a POST should remove the friendship
     post :remove_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
     assert_redirected_to user_path(friend)
     assert_match(/was removed from your friends/, flash[:notice])
-    assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # A second POST should report that the friendship does not exist
     post :remove_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
     assert_redirected_to user_path(friend)
     assert_match(/is not one of your friends/, flash[:error])
-    assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
   end
 
   def test_remove_friend_with_referer
     # Get users to work with
     user = create(:user)
     friend = create(:user)
-    create(:friend, :user_id => user.id, :friend_user_id => friend.id)
+    create(:friendship, :user_id => user.id, :friend_user_id => friend.id)
 
     # Check that the users are friends
-    assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # The GET should preserve any referer
     get :remove_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
@@ -1257,13 +1257,13 @@ class UsersControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][name='referer'][value='/test']", 1
       assert_select "input[type='submit']", 1
     end
-    assert Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
 
     # When logged in a POST should remove the friendship and refer
     post :remove_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
     assert_redirected_to "/test"
     assert_match(/was removed from your friends/, flash[:notice])
-    assert_nil Friend.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
   end
 
   def test_remove_friend_unkown_user

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1244,7 +1244,7 @@ class UsersControllerTest < ActionController::TestCase
     # Get users to work with
     user = create(:user)
     friend = create(:user)
-    create(:friendship, :user_id => user.id, :friend_user_id => friend.id)
+    create(:friendship, :befriender => user, :befriendee => friend)
 
     # Check that the users are friends
     assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1113,7 +1113,7 @@ class UsersControllerTest < ActionController::TestCase
     friend = create(:user)
 
     # Check that the users aren't already friends
-    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:befriender => user, :befriendee => friend).first
 
     # When not logged in a GET should ask us to login
     get :make_friend, :params => { :display_name => friend.display_name }
@@ -1122,7 +1122,7 @@ class UsersControllerTest < ActionController::TestCase
     # When not logged in a POST should error
     post :make_friend, :params => { :display_name => friend.display_name }
     assert_response :forbidden
-    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:befriender => user, :befriendee => friend).first
 
     # When logged in a GET should get a confirmation page
     get :make_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
@@ -1132,7 +1132,7 @@ class UsersControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][name='referer']", 0
       assert_select "input[type='submit']", 1
     end
-    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:befriender => user, :befriendee => friend).first
 
     # When logged in a POST should add the friendship
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
@@ -1142,7 +1142,7 @@ class UsersControllerTest < ActionController::TestCase
     end
     assert_redirected_to user_path(friend)
     assert_match(/is now your friend/, flash[:notice])
-    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:befriender => user, :befriendee => friend).first
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal friend.email, email.to.first
@@ -1156,7 +1156,7 @@ class UsersControllerTest < ActionController::TestCase
     end
     assert_redirected_to user_path(friend)
     assert_match(/You are already friends with/, flash[:warning])
-    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:befriender => user, :befriendee => friend).first
   end
 
   def test_make_friend_with_referer
@@ -1165,7 +1165,7 @@ class UsersControllerTest < ActionController::TestCase
     friend = create(:user)
 
     # Check that the users aren't already friends
-    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:befriender => user, :befriendee => friend).first
 
     # The GET should preserve any referer
     get :make_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
@@ -1175,7 +1175,7 @@ class UsersControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][name='referer'][value='/test']", 1
       assert_select "input[type='submit']", 1
     end
-    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:befriender => user, :befriendee => friend).first
 
     # When logged in a POST should add the friendship and refer us
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
@@ -1185,7 +1185,7 @@ class UsersControllerTest < ActionController::TestCase
     end
     assert_redirected_to "/test"
     assert_match(/is now your friend/, flash[:notice])
-    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:befriender => user, :befriendee => friend).first
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal friend.email, email.to.first
@@ -1206,7 +1206,7 @@ class UsersControllerTest < ActionController::TestCase
     create(:friendship, :befriender => user, :befriendee => friend)
 
     # Check that the users are friends
-    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:befriender => user, :befriendee => friend).first
 
     # When not logged in a GET should ask us to login
     get :remove_friend, :params => { :display_name => friend.display_name }
@@ -1215,7 +1215,7 @@ class UsersControllerTest < ActionController::TestCase
     # When not logged in a POST should error
     post :remove_friend, :params => { :display_name => friend.display_name }
     assert_response :forbidden
-    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:befriender => user, :befriendee => friend).first
 
     # When logged in a GET should get a confirmation page
     get :remove_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
@@ -1225,19 +1225,19 @@ class UsersControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][name='referer']", 0
       assert_select "input[type='submit']", 1
     end
-    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:befriender => user, :befriendee => friend).first
 
     # When logged in a POST should remove the friendship
     post :remove_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
     assert_redirected_to user_path(friend)
     assert_match(/was removed from your friends/, flash[:notice])
-    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:befriender => user, :befriendee => friend).first
 
     # A second POST should report that the friendship does not exist
     post :remove_friend, :params => { :display_name => friend.display_name }, :session => { :user => user }
     assert_redirected_to user_path(friend)
     assert_match(/is not one of your friends/, flash[:error])
-    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:befriender => user, :befriendee => friend).first
   end
 
   def test_remove_friend_with_referer
@@ -1247,7 +1247,7 @@ class UsersControllerTest < ActionController::TestCase
     create(:friendship, :befriender => user, :befriendee => friend)
 
     # Check that the users are friends
-    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:befriender => user, :befriendee => friend).first
 
     # The GET should preserve any referer
     get :remove_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
@@ -1257,13 +1257,13 @@ class UsersControllerTest < ActionController::TestCase
       assert_select "input[type='hidden'][name='referer'][value='/test']", 1
       assert_select "input[type='submit']", 1
     end
-    assert Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert Friendship.where(:befriender => user, :befriendee => friend).first
 
     # When logged in a POST should remove the friendship and refer
     post :remove_friend, :params => { :display_name => friend.display_name, :referer => "/test" }, :session => { :user => user }
     assert_redirected_to "/test"
     assert_match(/was removed from your friends/, flash[:notice])
-    assert_nil Friendship.where(:user_id => user.id, :friend_user_id => friend.id).first
+    assert_nil Friendship.where(:befriender => user, :befriendee => friend).first
   end
 
   def test_remove_friend_unkown_user

--- a/test/factories/friendships.rb
+++ b/test/factories/friendships.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :friend do
+  factory :friendship do
     association :befriender, :factory => :user
     association :befriendee, :factory => :user
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -105,7 +105,7 @@ class UserTest < ActiveSupport::TestCase
     alice = create(:user, :active)
     bob = create(:user, :active)
     charlie = create(:user, :active)
-    create(:friend, :befriender => alice, :befriendee => bob)
+    create(:friendship, :befriender => alice, :befriendee => bob)
 
     assert alice.is_friends_with?(bob)
     assert_not alice.is_friends_with?(charlie)
@@ -139,7 +139,7 @@ class UserTest < ActiveSupport::TestCase
   def test_friend_users
     norm = create(:user, :active)
     sec = create(:user, :active)
-    create(:friend, :befriender => norm, :befriendee => sec)
+    create(:friendship, :befriender => norm, :befriendee => sec)
 
     assert_equal [sec], norm.friend_users
     assert_equal 1, norm.friend_users.size

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -136,16 +136,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [], vagrant_user.nearby
   end
 
-  def test_friend_users
+  def test_friends
     norm = create(:user, :active)
     sec = create(:user, :active)
     create(:friendship, :befriender => norm, :befriendee => sec)
 
-    assert_equal [sec], norm.friend_users
-    assert_equal 1, norm.friend_users.size
+    assert_equal [sec], norm.friends
+    assert_equal 1, norm.friends.size
 
-    assert_equal [], sec.friend_users
-    assert_equal 0, sec.friend_users.size
+    assert_equal [], sec.friends
+    assert_equal 0, sec.friends.size
   end
 
   def test_user_preferred_editor


### PR DESCRIPTION
This PR refactors the Friend model and related code, primarily by renaming it to Friendship to more accurately describe the model. 

This also allows us to remove some naming gymnastics, so that user.friends is now a list of user objects.

I haven't actually renamed the database table, since that's a ton more work :smile: