### PR TITLE
Add translations for distance_in_time_ago

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,45 @@ en:
         description: "Description"
         languages: "Languages"
         pass_crypt: "Password"
+  datetime:
+    distance_in_words_ago:
+      about_x_hours:
+        one: about 1 hour ago
+        other: about %{count} hours ago
+      about_x_months:
+        one: about 1 month ago
+        other: about %{count} months ago
+      about_x_years:
+        one: about 1 year ago
+        other: about %{count} years ago
+      almost_x_years:
+        one: almost 1 year ago
+        other: almost %{count} years ago
+      half_a_minute: half a minute ago
+      less_than_x_seconds:
+        one: less than 1 second ago
+        other: less than %{count} seconds ago
+      less_than_x_minutes:
+        one: less than a minute ago
+        other: less than %{count} minutes ago
+      over_x_years:
+        one: over 1 year ago
+        other: over %{count} years ago
+      x_seconds:
+        one: 1 second ago
+        other: "%{count} seconds ago"
+      x_minutes:
+        one: 1 minute ago
+        other: "%{count} minutes ago"
+      x_days:
+        one: 1 day ago
+        other: "%{count} days ago"
+      x_months:
+        one: 1 month ago
+        other: "%{count} months ago"
+      x_years:
+        one: 1 year ago
+        other: "%{count} years ago"
   printable_name:
     with_id: "%{id}"
     with_version: "%{id}, v%{version}"


### PR DESCRIPTION
This allows translators to accurately translate times when they need to modify the distance_in_time beyond just adding 'ago'.

This PR represents the first step of the action plan in #2255

@Nikerabbit I wanted to check with you that all these translations will show up as "count" translations in Translatewiki? For example, so that 'x_seconds' will allow translators to use the normal "one/few/many/other" style count translations. Do we need to do anything special for that?