### PR TITLE
Simplify partial rendering when the partial is named after the model

### DIFF
--- a/app/views/api/changesets/changeset.builder
+++ b/app/views/api/changesets/changeset.builder
@@ -3,5 +3,5 @@ xml.instruct! :xml, :version => "1.0"
 # basic attributes
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << render(:partial => "api/changesets/changeset.builder", :locals => { :changeset => @changeset })
+  osm << render(@changeset)
 end

--- a/app/views/api/changesets/changesets.builder
+++ b/app/views/api/changesets/changesets.builder
@@ -4,6 +4,6 @@ xml.instruct! :xml, :version => "1.0"
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
   @changesets.each do |changeset|
-    osm << render(:partial => "api/changesets/changeset.builder", :locals => { :changeset => changeset })
+    osm << render(changeset)
   end
 end

--- a/app/views/api/notes/index.gpx.builder
+++ b/app/views/api/notes/index.gpx.builder
@@ -5,5 +5,5 @@ xml.gpx("version" => "1.1",
         "xmlns" => "http://www.topografix.com/GPX/1/1",
         "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
         "xsi:schemaLocation" => "http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd") do
-  xml << (render(:partial => "note", :collection => @notes) || "")
+  xml << (render(@notes) || "")
 end

--- a/app/views/api/notes/index.json.jsonify
+++ b/app/views/api/notes/index.json.jsonify
@@ -1,5 +1,5 @@
 json.type "FeatureCollection"
 
 json.features(@notes) do |note|
-  json.ingest! render(:partial => "note", :object => note)
+  json.ingest! render(note)
 end

--- a/app/views/api/notes/index.rss.builder
+++ b/app/views/api/notes/index.rss.builder
@@ -9,6 +9,6 @@ xml.rss("version" => "2.0",
     xml.description t("api.notes.rss.description_area", :min_lat => @min_lat, :min_lon => @min_lon, :max_lat => @max_lat, :max_lon => @max_lon)
     xml.link url_for(:controller => "/site", :action => "index", :only_path => false)
 
-    xml << (render(:partial => "note", :collection => @notes) || "")
+    xml << (render(@notes) || "")
   end
 end

--- a/app/views/api/notes/index.xml.builder
+++ b/app/views/api/notes/index.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(:partial => "note", :collection => @notes) || "")
+  osm << (render(@notes) || "")
 end

--- a/app/views/api/notes/show.gpx.builder
+++ b/app/views/api/notes/show.gpx.builder
@@ -5,5 +5,5 @@ xml.gpx("version" => "1.1",
         "xmlns" => "http://www.topografix.com/GPX/1/1",
         "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance",
         "xsi:schemaLocation" => "http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd") do
-  xml << render(:partial => "note", :object => @note)
+  xml << render(@note)
 end

--- a/app/views/api/notes/show.json.jsonify
+++ b/app/views/api/notes/show.json.jsonify
@@ -1,1 +1,1 @@
-json.ingest! render(:partial => "note", :object => @note)
+json.ingest! render(@note)

--- a/app/views/api/notes/show.rss.builder
+++ b/app/views/api/notes/show.rss.builder
@@ -8,6 +8,6 @@ xml.rss("version" => "2.0",
     xml.description t("api.notes.rss.description_item", :id => @note.id)
     xml.link url_for(:controller => "/site", :action => "index", :only_path => false)
 
-    xml << render(:partial => "note", :object => @note)
+    xml << render(@note)
   end
 end

--- a/app/views/api/notes/show.xml.builder
+++ b/app/views/api/notes/show.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << render(:partial => "note", :object => @note)
+  osm << render(@note)
 end

--- a/app/views/api/users/index.builder
+++ b/app/views/api/users/index.builder
@@ -1,4 +1,4 @@
 xml.instruct! :xml, :version => "1.0"
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << render(:partial => "user", :collection => @users)
+  osm << render(@users)
 end

--- a/app/views/api/users/show.builder
+++ b/app/views/api/users/show.builder
@@ -1,4 +1,4 @@
 xml.instruct! :xml, :version => "1.0"
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << render(:partial => "user", :object => @user)
+  osm << render(@user)
 end

--- a/app/views/diary_entries/_diary_index_entry.html.erb
+++ b/app/views/diary_entries/_diary_index_entry.html.erb
@@ -1,1 +1,0 @@
-<%= render :partial => "diary_entry", :object => diary_index_entry %>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -32,11 +32,7 @@
 <% else %>
   <h4><%= t ".recent_entries" %></h4>
 
-  <% if @user %>
-    <%= render :partial => "diary_entry", :collection => @entries %>
-  <% else %>
-    <%= render :partial => "diary_index_entry", :collection => @entries %>
-  <% end %>
+  <%= render @entries %>
 
   <div class="pagination">
     <% if @entries.size < @page_size -%>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -6,7 +6,7 @@
   </div>
 <% end %>
 
-<%= render :partial => "diary_entry", :object => @entry %>
+<%= render @entry %>
 
 <a id="comments"></a>
 <div class='comments'>

--- a/app/views/redactions/_redactions.html.erb
+++ b/app/views/redactions/_redactions.html.erb
@@ -1,3 +1,0 @@
-<ul id="redaction_list">
-  <%= render :partial => "redaction", :collection => @redactions %>
-</ul>

--- a/app/views/redactions/index.html.erb
+++ b/app/views/redactions/index.html.erb
@@ -4,7 +4,9 @@
 <% end %>
 
 <% unless @redactions.empty? %>
-  <%= render :partial => "redactions" %>
+  <ul id="redaction_list">
+    <%= render @redactions %>
+  </ul>
 <% else %>
   <p><%= t ".empty" %></p>
 <% end %>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -33,7 +33,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render :partial => "trace", :collection => @traces unless @traces.nil? %>
+      <%= render @traces unless @traces.nil? %>
     </tbody>
   </table>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,7 +30,7 @@
           <%= check_box_tag "user_all", "1", false %>
         </td>
       </tr>
-      <%= render :partial => "user", :collection => @users %>
+      <%= render @users %>
     </table>
 
     <div id="user_list_actions buttons">


### PR DESCRIPTION
During review of #2207 I realised that we can simplify a bunch of our partial calls. For example, if @trace is a `Trace` model, then instead of:

```
<%= render :partial => "trace", :object => @trace %>
```
... you can instead call...
```
<%= render @trace %>
```
... and Rails will find the partial named after the model, and pass the object into the partial automatically. It also works with collections.