### PR TITLE
Avoid stating the action to render when it just matches the current action

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -13,7 +13,7 @@ module Api
 
     def show
       if @user.visible?
-        render :action => :show, :content_type => "text/xml"
+        render :content_type => "text/xml"
       else
         head :gone
       end
@@ -33,7 +33,7 @@ module Api
 
       @users = User.visible.find(ids)
 
-      render :action => :index, :content_type => "text/xml"
+      render :content_type => "text/xml"
     end
 
     def gpx_files

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -126,7 +126,7 @@ class SiteController < ApplicationController
       :style_src => %w['unsafe-inline']
     )
 
-    render "id", :layout => false
+    render :layout => false
   end
 
   private


### PR DESCRIPTION
Similar to #2278 , this simplifies render calls from within controllers when the action isn't being overridden.