### PR TITLE
Add support for an unversioned 'versions' API call

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -9,6 +9,7 @@ class ApiAbility
     can :index, :map
     can :show, :permission
     can [:search_all, :search_nodes, :search_ways, :search_relations], :search
+    can :show, :version
 
     if Settings.status != "database_offline"
       can [:show, :download, :query], Changeset

--- a/app/controllers/api/versions_controller.rb
+++ b/app/controllers/api/versions_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  class VersionsController < ApiController
+    authorize_resource :class => false
+
+    around_action :api_call_handle_error, :api_call_timeout
+
+    # Show the list of available API versions. This will replace the global
+    # unversioned capabilities call in due course.
+    # Currently we only support deploying one version at a time, but this will
+    # hopefully change soon.
+    def show
+      @versions = [Settings.api_version]
+    end
+  end
+end

--- a/app/views/api/versions/show.builder
+++ b/app/views/api/versions/show.builder
@@ -1,0 +1,8 @@
+xml.instruct! :xml, :version => "1.0"
+xml.osm(OSM::API.new.xml_root_attributes.except("version")) do |osm|
+  osm.api do |api|
+    @versions.each do |version|
+      api.version version
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 OpenStreetMap::Application.routes.draw do
   # API
   namespace :api do
-    get "capabilities" => "capabilities#show"
+    get "capabilities" => "capabilities#show" # Deprecated, remove when 0.6 support is removed
+    get "versions" => "versions#show"
   end
 
   scope "api/0.6" do

--- a/test/controllers/api/versions_controller_test.rb
+++ b/test/controllers/api/versions_controller_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+module Api
+  class VersionsControllerTest < ActionController::TestCase
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/api/versions", :method => :get },
+        { :controller => "api/versions", :action => "show" }
+      )
+      assert_recognizes(
+        { :controller => "api/versions", :action => "show" },
+        { :path => "/api/versions", :method => :get }
+      )
+    end
+
+    def test_versions
+      get :show
+      assert_response :success
+      assert_select "osm[generator='#{Settings.generator}']", :count => 1 do
+        assert_select "api", :count => 1 do
+          assert_select "version", Settings.api_version
+        end
+      end
+    end
+
+    def test_no_version_in_root_element
+      get :show
+      assert_response :success
+      assert_select "osm[version]", :count => 0
+    end
+  end
+end


### PR DESCRIPTION
This will eventually replace the unversioned 'capabilities' call.

Client applications can use this versions call to find out what versions are available, if they support multiple versions. The capabilities of each version, and the format of the capabilities call, is then
able to change between versions. If a client only supports one version they can jump straight to the versioned capabilities call.

Additionally, supported versions are now a list of version identifiers, without any implications surrounding min/max values (e.g. guesswork for supported intermediate versions).

Fixes #2162