### PR TITLE
Ignore the class length of test files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+
 Naming/FileName:
   Exclude:
     - 'script/deliver-message'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -50,7 +50,7 @@ Metrics/BlockNesting:
 # Offense count: 68
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1397
+  Max: 645
 
 # Offense count: 73
 Metrics/CyclomaticComplexity:


### PR DESCRIPTION
There's no sensible way to refactor a controller test into multiple classes, so lets exclude them from the class length metrics to reveal other over-length classes.

Similar reasoning to #2250 