### PR TITLE
Send trace import result notification immediately

### DIFF
--- a/app/jobs/trace_importer_job.rb
+++ b/app/jobs/trace_importer_job.rb
@@ -5,15 +5,15 @@ class TraceImporterJob < ApplicationJob
     gpx = trace.import
 
     if gpx.actual_points.positive?
-      Notifier.gpx_success(trace, gpx.actual_points).deliver_later
+      Notifier.gpx_success(trace, gpx.actual_points).deliver
     else
-      Notifier.gpx_failure(trace, "0 points parsed ok. Do they all have lat,lng,alt,timestamp?").deliver_later
+      Notifier.gpx_failure(trace, "0 points parsed ok. Do they all have lat,lng,alt,timestamp?").deliver
       trace.destroy
     end
   rescue StandardError => e
     logger.info e.to_s
     e.backtrace.each { |l| logger.info l }
-    Notifier.gpx_failure(trace, e.to_s + "\n" + e.backtrace.join("\n")).deliver_later
+    Notifier.gpx_failure(trace, e.to_s + "\n" + e.backtrace.join("\n")).deliver
     trace.destroy
   end
 end

--- a/test/jobs/trace_importer_job_test.rb
+++ b/test/jobs/trace_importer_job_test.rb
@@ -12,12 +12,8 @@ class TraceImporterJobTest < ActiveJob::TestCase
     end
 
     trace.stub(:import, gpx) do
-      perform_enqueued_jobs do
-        TraceImporterJob.perform_now(trace)
-      end
+      TraceImporterJob.perform_now(trace)
     end
-
-    assert_performed_jobs 1
 
     email = ActionMailer::Base.deliveries.last
     assert_equal trace.user.email, email.to[0]
@@ -36,12 +32,8 @@ class TraceImporterJobTest < ActiveJob::TestCase
     end
 
     trace.stub(:import, gpx) do
-      perform_enqueued_jobs do
-        TraceImporterJob.perform_now(trace)
-      end
+      TraceImporterJob.perform_now(trace)
     end
-
-    assert_performed_jobs 1
 
     email = ActionMailer::Base.deliveries.last
     assert_equal trace.user.email, email.to[0]
@@ -54,12 +46,8 @@ class TraceImporterJobTest < ActiveJob::TestCase
     # Check that the user gets a failure notification when something goes badly wrong
     trace = create(:trace)
     trace.stub(:import, -> { raise }) do
-      perform_enqueued_jobs do
-        TraceImporterJob.perform_now(trace)
-      end
+      TraceImporterJob.perform_now(trace)
     end
-
-    assert_performed_jobs 1
 
     email = ActionMailer::Base.deliveries.last
     assert_equal trace.user.email, email.to[0]


### PR DESCRIPTION
If we delay sending failure notifications then they will fail because the trace will no longer exist.

As trace imports are running in the background anyway there doesn't seem to be any good reason to defer the emails.

Fixes #2312