### PR TITLE
Models in migrations

### DIFF
--- a/db/migrate/005_tile_tracepoints.rb
+++ b/db/migrate/005_tile_tracepoints.rb
@@ -1,6 +1,10 @@
 require "migrate"
 
 class TileTracepoints < ActiveRecord::Migration[4.2]
+  class Tracepoint < ActiveRecord::Base
+    self.table_name = "gps_points"
+  end
+
   def self.up
     add_column "gps_points", "tile", :bigint
     add_index "gps_points", ["tile"], :name => "points_tile_idx"

--- a/db/migrate/006_tile_nodes.rb
+++ b/db/migrate/006_tile_nodes.rb
@@ -1,6 +1,14 @@
 require "migrate"
 
 class TileNodes < ActiveRecord::Migration[4.2]
+  class Node < ActiveRecord::Base
+    self.table_name = "current_nodes"
+  end
+
+  class OldNode < ActiveRecord::Base
+    self.table_name = "nodes"
+  end
+
   def self.upgrade_table(from_table, to_table, model)
     if ENV["USE_DB_FUNCTIONS"]
       execute <<-SQL

--- a/db/migrate/013_add_email_valid.rb
+++ b/db/migrate/013_add_email_valid.rb
@@ -1,4 +1,7 @@
 class AddEmailValid < ActiveRecord::Migration[4.2]
+  class User < ActiveRecord::Base
+  end
+
   def self.up
     add_column "users", "email_valid", :boolean, :default => false, :null => false
     User.update_all("email_valid = (active != 0)") # email_valid is :boolean, but active is :integer. "email_valid = active" (see r11802 or earlier) will fail for stricter dbs than mysql

--- a/db/migrate/039_add_more_controls_to_gpx_files.rb
+++ b/db/migrate/039_add_more_controls_to_gpx_files.rb
@@ -1,6 +1,10 @@
 require "migrate"
 
 class AddMoreControlsToGpxFiles < ActiveRecord::Migration[4.2]
+  class Trace < ActiveRecord::Base
+    self.table_name = "gpx_files"
+  end
+
   def self.up
     create_enumeration :gpx_visibility_enum, %w[private public trackable identifiable]
     add_column :gpx_files, :visibility, :gpx_visibility_enum, :default => "public", :null => false

--- a/db/migrate/044_create_user_roles.rb
+++ b/db/migrate/044_create_user_roles.rb
@@ -1,6 +1,12 @@
 require "migrate"
 
 class CreateUserRoles < ActiveRecord::Migration[4.2]
+  class User < ActiveRecord::Base
+  end
+
+  class UserRole < ActiveRecord::Base
+  end
+
   def self.up
     create_enumeration :user_role_enum, %w[administrator moderator]
 

--- a/db/migrate/046_alter_user_roles_and_blocks.rb
+++ b/db/migrate/046_alter_user_roles_and_blocks.rb
@@ -1,6 +1,9 @@
 require "migrate"
 
 class AlterUserRolesAndBlocks < ActiveRecord::Migration[4.2]
+  class UserRole < ActiveRecord::Base
+  end
+
   def self.up
     # the initial granter IDs can be "self" - there are none of these
     # in the current live DB, but there may be some in people's own local

--- a/db/migrate/051_add_status_to_user.rb
+++ b/db/migrate/051_add_status_to_user.rb
@@ -1,6 +1,9 @@
 require "migrate"
 
 class AddStatusToUser < ActiveRecord::Migration[4.2]
+  class User < ActiveRecord::Base
+  end
+
   def self.up
     create_enumeration :user_status_enum, %w[pending active confirmed suspended deleted]
 

--- a/db/migrate/20110322001319_add_terms_seen_to_user.rb
+++ b/db/migrate/20110322001319_add_terms_seen_to_user.rb
@@ -1,4 +1,7 @@
 class AddTermsSeenToUser < ActiveRecord::Migration[4.2]
+  class User < ActiveRecord::Base
+  end
+
   def self.up
     add_column :users, :terms_seen, :boolean, :null => false, :default => false
 

--- a/db/migrate/20120208122334_merge_acl_address_and_mask.rb
+++ b/db/migrate/20120208122334_merge_acl_address_and_mask.rb
@@ -11,6 +11,9 @@ class IPAddr
 end
 
 class MergeAclAddressAndMask < ActiveRecord::Migration[4.2]
+  class Acl < ActiveRecord::Base
+  end
+
   def up
     Acl.find_each do |acl|
       address = IPAddr.new(acl.address)

--- a/db/migrate/20120219161649_add_user_image_fingerprint.rb
+++ b/db/migrate/20120219161649_add_user_image_fingerprint.rb
@@ -1,4 +1,7 @@
 class AddUserImageFingerprint < ActiveRecord::Migration[4.2]
+  class User < ActiveRecord::Base
+  end
+
   def up
     add_column :users, :image_fingerprint, :string, :null => true
 

--- a/db/migrate/20120808231205_add_counter_caches.rb
+++ b/db/migrate/20120808231205_add_counter_caches.rb
@@ -1,4 +1,11 @@
 class AddCounterCaches < ActiveRecord::Migration[4.2]
+  class Changeset < ActiveRecord::Base
+  end
+
+  class Trace < ActiveRecord::Base
+    self.table_name = "gpx_files"
+  end
+
   def self.up
     add_column :users, :changesets_count, :integer, :null => false, :default => 0
     add_column :users, :traces_count, :integer, :null => false, :default => 0

--- a/db/migrate/20121005195010_add_diary_entry_counter_caches.rb
+++ b/db/migrate/20121005195010_add_diary_entry_counter_caches.rb
@@ -1,4 +1,10 @@
 class AddDiaryEntryCounterCaches < ActiveRecord::Migration[4.2]
+  class DiaryEntry < ActiveRecord::Base
+  end
+
+  class User < ActiveRecord::Base
+  end
+
   def self.up
     add_column :users, :diary_entries_count, :integer, :null => false, :default => 0
 

--- a/db/migrate/20121012044047_add_image_use_gravatar_to_users.rb
+++ b/db/migrate/20121012044047_add_image_use_gravatar_to_users.rb
@@ -1,4 +1,7 @@
 class AddImageUseGravatarToUsers < ActiveRecord::Migration[4.2]
+  class User < ActiveRecord::Base
+  end
+
   def self.up
     add_column :users, :image_use_gravatar, :boolean, :null => false, :default => false
 

--- a/db/migrate/20150111192335_subscribe_old_changesets.rb
+++ b/db/migrate/20150111192335_subscribe_old_changesets.rb
@@ -1,4 +1,7 @@
 class SubscribeOldChangesets < ActiveRecord::Migration[4.2]
+  class Changeset < ActiveRecord::Base
+  end
+
   def up
     Changeset.find_each do |changeset|
       changeset.subscribers << changeset.user unless changeset.subscribers.exists?(changeset.user.id)

--- a/db/migrate/20150222101847_rename_openid_url.rb
+++ b/db/migrate/20150222101847_rename_openid_url.rb
@@ -1,4 +1,7 @@
 class RenameOpenidUrl < ActiveRecord::Migration[4.2]
+  class User < ActiveRecord::Base
+  end
+
   def change
     rename_column :users, :openid_url, :auth_uid
     add_column :users, :auth_provider, :string

--- a/db/migrate/20161011010929_subscribe_authors_to_diary_entries.rb
+++ b/db/migrate/20161011010929_subscribe_authors_to_diary_entries.rb
@@ -1,4 +1,7 @@
 class SubscribeAuthorsToDiaryEntries < ActiveRecord::Migration[4.2]
+  class DiaryEntry < ActiveRecord::Base
+  end
+
   def up
     DiaryEntry.find_each do |diary_entry|
       diary_entry.subscriptions.create(:user => diary_entry.user) unless diary_entry.subscribers.exists?(diary_entry.user.id)

--- a/db/migrate/20180204153242_tile_users.rb
+++ b/db/migrate/20180204153242_tile_users.rb
@@ -1,4 +1,7 @@
 class TileUsers < ActiveRecord::Migration[5.1]
+  class User < ActiveRecord::Base
+  end
+
   def up
     add_column :users, :home_tile, :bigint
     add_index :users, [:home_tile], :name => "users_home_idx"


### PR DESCRIPTION
A recent change to the user model triggered breakages in the database migrations. This is because the migrations have, until now, been using the live model in old migrations. When there is a table name change, or certain column changes, in the live model, this can blow up the old migration.

Instead, it's best practise that if a model is needed during the migration, the model is defined within the migration. This ensures that the model picks up the table name, columns etc that match what's in the database at that stage.
