### PR TITLE
Rework help page text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1597,7 +1597,7 @@ en:
         and collaboratively discussing and documenting mapping topics.
       welcome:
         url: /welcome
-        title: Welcome to OSM
+        title: Welcome to OpenStreetMap
         description: Start with this quick guide covering the OpenStreetMap basics.
       beginners_guide:
         url: https://wiki.openstreetmap.org/wiki/Beginners%27_guide
@@ -1605,8 +1605,8 @@ en:
         description: Community maintained guide for beginners.
       help:
         url: https://help.openstreetmap.org/
-        title: help.openstreetmap.org
-        description: Ask a question or look up answers on OSM's question-and-answer site.
+        title: Help Forum
+        description: Ask a question or look up answers on OpenStreetMap's question-and-answer site.
       mailing_lists:
         url: https://lists.openstreetmap.org/
         title: Mailing Lists
@@ -1629,8 +1629,8 @@ en:
         description: With an organization making plans for OpenStreetMap? Find what you need to know in the Welcome Mat.
       wiki:
         url: https://wiki.openstreetmap.org/
-        title: wiki.openstreetmap.org
-        description: Browse the wiki for in-depth OSM documentation.
+        title: OpenStreetMap Wiki
+        description: Browse the wiki for in-depth OpenStreetMap documentation.
     sidebar:
       search_results: Search Results
       close: Close


### PR DESCRIPTION
This avoids using the OSM acronym, and uses better titles than urls for the help forum and the wiki. Both titles are based on the title of the linked sites.

Extracted from work on #2321