### PR TITLE
set <title> upon search

### DIFF
--- a/app/views/geocoder/search.html.erb
+++ b/app/views/geocoder/search.html.erb
@@ -1,3 +1,5 @@
+<% set_title(@params[:query]) %>
+
 <h2>
     <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
     <%= t("site.sidebar.search_results") %>


### PR DESCRIPTION
This is a response to issue: [#2336](https://github.com/openstreetmap/openstreetmap-website/issues/2336)

Prepend search query string to HTML <title>

Example:
If query = `New York`
Title content will be set to: `New York | OpenStreetMaps`