### PR TITLE
Make the logo on the error pages clickable

### DIFF
--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -6,7 +6,12 @@
     <%= stylesheet_link_tag "errors", :media => "screen" %>
   </head>
   <body>
-    <%= image_tag "osm_logo.png", :class => "logo" %>
+    <a href="<%= root_path %>">
+      <picture>
+        <source srcset="<%= image_path "osm_logo.svg" %>" type="image/svg+xml"></source>
+        <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :class => "logo" %>
+      </picture>
+    </a>
     <div class="details">
       <%= yield %>
     </div>


### PR DESCRIPTION
When reviewing #1550 I realised that the logo isn't clickable, whereas elsewhere on this site the logo in the top left links to the front page.

It's a reasonable convention so one I that I feel is worth implementing. I've used the same srcset/picture code as in the main header.