### PR TITLE
Add link to my messages to users/show navigation

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,6 +7,10 @@
         <!-- Displaying user's own profile page to themself -->
         <ul class='secondary-actions clearfix'>
           <li>
+            <%= link_to t(".my messages"), inbox_messages_path %>
+            <span class='count-number'><%= number_with_delimiter(current_user.new_messages.size) %></span>
+          </li>
+          <li>
             <%= link_to t(".my edits"), :controller => "changesets", :action => "index", :display_name => current_user.display_name %>
             <span class='count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
           </li>


### PR DESCRIPTION
The my messages page can be accessed via the user dropdown, but not via the user navigation on my logged in user-profile page. This adds the link when logged in to have a consistent access to all my sub-pages.

# Current header

<img width="958" alt="Bildschirmfoto 2019-09-22 um 19 47 49" src="https://user-images.githubusercontent.com/111561/65392162-ee443080-dd71-11e9-8d3e-7d9e4f766da8.png">

# New header

<img width="932" alt="Bildschirmfoto 2019-09-22 um 19 47 57" src="https://user-images.githubusercontent.com/111561/65392169-f7cd9880-dd71-11e9-8438-5f36f4dfcb2f.png">

--- 

# Open questions

- [ ] The new navi uses the same translation string as the dropdown (as do all those links). The german translation for the `.my messages` only says "Nachrichten" (EN: Messages). This is consistent in the dropdown, but not on the user-page. Suggestion: Duplicate the translations in all languages so the dropdown can have it's own variation. Right now the dropdown forces the translation with `<%= t("users.show.my messages") %>`
