### PR TITLE
Sort and order notes

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -294,10 +294,14 @@ module Api
           raise OSM::APIBadUserInput, "Date #{params[:to]} is in a wrong format"
         end
 
-        @notes = params[:sort] == "created_at" ? @notes.where(:created_at => from..to) : @notes.where(:updated_at => from..to)
+        @notes = if params[:sort] == "updated_at"
+                   @notes.where(:updated_at => from..to)
+                 else
+                   @notes.where(:created_at => from..to)
+                 end
       end
 
-      # Find the notes we want to return
+      # Choose the sort order
       @notes = if params[:sort] == "created_at"
                  if params[:order] == "oldest"
                    @notes.order("created_at ASC")
@@ -312,6 +316,7 @@ module Api
                  end
                end
 
+      # Find the notes we want to return
       @notes = @notes.distinct.limit(result_limit).preload(:comments)
 
       # Render the result

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -294,11 +294,14 @@ module Api
           raise OSM::APIBadUserInput, "Date #{params[:to]} is in a wrong format"
         end
 
-        @notes = @notes.where(:created_at => from..to)
+        @notes = params[:sort] == "created_at" ? @notes.where(:created_at => from..to) : @notes.where(:updated_at => from..to)
       end
 
       # Find the notes we want to return
-      @notes = @notes.order("updated_at DESC").limit(result_limit).preload(:comments)
+      sort_by = params[:sort_by] == "created_at" ? "created_at" : "updated_at"
+      order_by = params[:order_by] == "ASC" ? "ASC" : "DESC"
+
+      @notes = @notes.order("#{sort_by} #{order_by}").limit(result_limit).preload(:comments)
 
       # Render the result
       respond_to do |format|

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -298,10 +298,21 @@ module Api
       end
 
       # Find the notes we want to return
-      sort_by = params[:sort_by] == "created_at" ? "created_at" : "updated_at"
-      order_by = params[:order_by] == "ASC" ? "ASC" : "DESC"
+      @notes = if params[:sort] == "created_at"
+                 if params[:order] == "oldest"
+                   @notes.order("created_at ASC")
+                 else
+                   @notes.order("created_at DESC")
+                 end
+               else
+                 if params[:order] == "oldest"
+                   @notes.order("updated_at ASC")
+                 else
+                   @notes.order("updated_at DESC")
+                 end
+               end
 
-      @notes = @notes.order("#{sort_by} #{order_by}").limit(result_limit).preload(:comments)
+      @notes = @notes.distinct.limit(result_limit).preload(:comments)
 
       # Render the result
       respond_to do |format|


### PR DESCRIPTION
Adds two new parameters to the notes search API to be able to
- specify the value the notes should be sorted by (either `created_at` or `updated_at`, `updated_at` remains the default value)
- specify the order of the returned notes (either `ASC` or `DESC`, `DESC` remains the default)

A new call to the notes search API may look like this:
[/api/0.6/notes/search?**sort_by=created_at&order_by=ASC**](https://api.openstreetmap.org/api/0.6/notes/search?sort_by=created_at&order_by=ASC)

See also #2380 for the reason of this pull request.