### PR TITLE
Make 'back' button not look disabled.

### DIFF
--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -36,5 +36,5 @@
 
 <% end %>
 
-  <%= link_to t(".back"), outbox_messages_path, :class => "button deemphasize" %>
+  <%= link_to t(".back"), outbox_messages_path, :class => "button" %>
   </div>


### PR DESCRIPTION
When viewing a message in the inbox, the "back" button looks paler than the other buttons below the message. This can be mistaken for that button to be disabled, and thus there being no way (other than the browser's own "back" button or accessing it anew from the logged-in-user drop down menu) to get back to the list of messages in the inbox. (Actually, the button is just "`deemphasize`d", whatever that's supposed to mean.)

This change makes it no longer deemphazized, thus displaying it in the same style as the other buttons there.