### PR TITLE
Rephrase changeset comment notifications to clarify the time

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1251,8 +1251,8 @@ en:
       commented:
         subject_own: "[OpenStreetMap] %{commenter} has commented on one of your changesets"
         subject_other: "[OpenStreetMap] %{commenter} has commented on a changeset you are interested in"
-        your_changeset: "%{commenter} has left a comment on one of your changesets created at %{time}"
-        commented_changeset: "%{commenter} has left a comment on a map changeset you are watching created by %{changeset_author} at %{time}"
+        your_changeset: "%{commenter} left a comment at %{time} on one of your changesets"
+        commented_changeset: "%{commenter} left a comment at %{time} on a changeset you are watching created by %{changeset_author}"
         partial_changeset_with_comment: "with comment '%{changeset_comment}'"
         partial_changeset_without_comment: "without comment"
       details: "More details about the changeset can be found at %{url}."


### PR DESCRIPTION
…is for the comment

Refs https://trac.openstreetmap.org/ticket/5307

There's still an unfortunate double use of "comment" to mean both the
ChangesetComment and also the changeset's `comment` tag, but I can't see a
simple way to fix that.