### PR TITLE
bump pg version in doc

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ of packages required before you can get the various gems installed.
 ## Minimum requirements
 
 * Ruby 2.5+
-* PostgreSQL 9.1+
+* PostgreSQL 9.6+
 * ImageMagick
 * Bundler
 * Javascript Runtime


### PR DESCRIPTION
The minimum version of PG is at least 9.6 because structure.sql has "SET idle_in_transaction_session_timeout = 0;" which was introduced in 9.6 (https://www.postgresql.org/docs/9.6/release-9-6.html).