### PR TITLE
Add pure SQL version of xid_to_int4.

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -131,5 +131,5 @@ If you want to deploy The Rails Port for production use, you'll need to make a f
 * The included version of the GPX importer is slow and/or completely inoperable. You should consider using [the high-speed GPX importer](https://git.openstreetmap.org/gpx-import.git/).
 * Make sure you generate the i18n files and precompile the production assets: `RAILS_ENV=production rake i18n:js:export assets:precompile`
 * Make sure the web server user as well as the rails user can read, write and create directories in `tmp/`.
-* If you want to use diff replication then you will need to install the shared library special SQL functions for the `xid_to_int4` function, for which there is no pure SQL alternative. (See the bottom of [INSTALL.md](INSTALL.md))
+* If you want to use diff replication then you might want to consider installing the shared library special SQL functions for the `xid_to_int4` function. A pure SQL version is available, but may become a performance issue on large databases with a high rate of changes. Note that you will need a version of PostgreSQL < 9.6 (yes, _less than_) to use `xid` indexing, whether pure SQL or shared library.
 * If you expect to serve a lot of `/changes` API calls, then you might also want to install the shared library versions of the SQL functions.

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -184,6 +184,30 @@ END;
 $$;
 
 
+--
+-- Name: xid_to_int4(xid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.xid_to_int4(t xid) RETURNS integer
+    LANGUAGE plpgsql STRICT
+    AS $$
+DECLARE
+  tl bigint;
+  ti int;
+BEGIN
+  tl := t;
+
+  IF tl >= 2147483648 THEN
+    tl := tl - 4294967296;
+  END IF;
+
+  ti := tl;
+
+  RETURN ti;
+END;
+$$;
+
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;


### PR DESCRIPTION
Thanks to @mmd-osm and @timwaters for [pointing out](https://github.com/openstreetmap/openstreetmap-website/pull/2383#discussion_r333039034) [there's a pure SQL version of `xid_to_int4`](https://github.com/openstreetmap/openstreetmap-website/pull/2383#commitcomment-35582035), so we might as well include that. I wasn't aware that anyone was using this, but @gravitystorm [knows of some (perhaps former) users](https://github.com/openstreetmap/openstreetmap-website/pull/2383#commitcomment-35587159). So it looks like perhaps this is worth including for completeness / parity?

:crossed_fingers: we get to replace all this soon with something compatible with PostgreSQL 10+.
