### PR TITLE
Remove references to libpgosm during travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ script:
   - bundle exec rake eslint
   - bundle exec erblint .
   - bundle exec rake db:structure:dump
-  - sed -e "/idle_in_transaction_session_timeout/d" -e 's/ IMMUTABLE / /' -e "s/AS '.*libpgosm.*',/AS 'libpgosm',/" -e "/^--/d" db/structure.sql > db/structure.actual
+  - sed -e "/idle_in_transaction_session_timeout/d" -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.actual
   - diff -uw db/structure.expected db/structure.actual
   - bundle exec rake test:db


### PR DESCRIPTION
These were removed from the structure file in 098e73479b466902cf48a07627f050dadd2fd73e