### PR TITLE
Convert various user attribute tests to use permissions system

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -158,7 +158,7 @@ class DiaryEntriesController < ApplicationController
     @page = (params[:page] || 1).to_i
     @page_size = 20
 
-    @entries = @entries.visible unless current_user&.administrator?
+    @entries = @entries.visible unless can? :unhide, DiaryEntry
     @entries = @entries.order("created_at DESC")
     @entries = @entries.offset((@page - 1) * @page_size)
     @entries = @entries.limit(@page_size)
@@ -203,7 +203,7 @@ class DiaryEntriesController < ApplicationController
     @entry = @user.diary_entries.visible.where(:id => params[:id]).first
     if @entry
       @title = t "diary_entries.show.title", :user => params[:display_name], :title => @entry.title
-      @comments = current_user&.administrator? ? @entry.comments : @entry.visible_comments
+      @comments = can?(:unhidecomment, DiaryEntry) ? @entry.comments : @entry.visible_comments
     else
       @title = t "diary_entries.no_such_entry.title", :id => params[:id]
       render :action => "no_such_entry", :status => :not_found
@@ -237,7 +237,7 @@ class DiaryEntriesController < ApplicationController
   def comments
     conditions = { :user_id => @user }
 
-    conditions[:visible] = true unless current_user&.administrator?
+    conditions[:visible] = true unless can? :unhidecomment, DiaryEntry
 
     @comment_pages, @comments = paginate(:diary_comments,
                                          :conditions => conditions,

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -40,7 +40,7 @@
   </nav>
   <nav class='secondary'>
     <ul>
-      <% if current_user and ( current_user.administrator? or current_user.moderator? ) %>
+      <% if can? :index, Issue %>
         <li class="compact-hide <%= current_page_class(issues_path) %>">
           <%= link_to issues_path(:status => "open") do %>
             <%= t("layouts.issues") %>

--- a/app/views/redactions/show.html.erb
+++ b/app/views/redactions/show.html.erb
@@ -12,9 +12,13 @@
   <%= @redaction.description.to_html %>
 </div>
 
-<% if current_user and current_user.moderator? %>
+<% if can?(:edit, Redaction) || can?(:destroy, Redaction) %>
 <div class="buttons">
-  <%= button_to t(".edit"), edit_redaction_path(@redaction), :method => :get %></td>
-  <%= button_to t(".destroy"), @redaction, :method => "delete", :remote => true, :data => { :confirm => t(".confirm") } %>
+  <% if can?(:edit, Redaction) %>
+    <%= button_to t(".edit"), edit_redaction_path(@redaction), :method => :get %></td>
+  <% end %>
+  <% if can?(:destroy, Redaction) %>
+    <%= button_to t(".destroy"), @redaction, :method => "delete", :remote => true, :data => { :confirm => t(".confirm") } %>
+  <% end %>
 </div>
 <% end %>

--- a/app/views/user_blocks/blocks_by.html.erb
+++ b/app/views/user_blocks/blocks_by.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <% unless @user_blocks.empty? %>
-<%= render :partial => "blocks", :locals => { :show_revoke_link => (current_user && current_user.moderator?), :show_user_name => true, :show_creator_name => false } %>
+<%= render :partial => "blocks", :locals => { :show_revoke_link => can?(:revoke, UserBlock), :show_user_name => true, :show_creator_name => false } %>
 <% else %>
 <p><%= t ".empty", :name => h(@user.display_name) %></p>
 <% end %>

--- a/app/views/user_blocks/blocks_on.html.erb
+++ b/app/views/user_blocks/blocks_on.html.erb
@@ -3,7 +3,7 @@
   <h1><%= raw(t(".heading", :name => link_to(h(@user.display_name), user_path(@user)))) %></h1>
 <% end %>
 <% unless @user_blocks.empty? %>
-<%= render :partial => "blocks", :locals => { :show_revoke_link => (current_user && current_user.moderator?), :show_user_name => false, :show_creator_name => true } %>
+<%= render :partial => "blocks", :locals => { :show_revoke_link => can?(:revoke, UserBlock), :show_user_name => false, :show_creator_name => true } %>
 <% else %>
 <p><%= t ".empty", :name => h(@user.display_name) %></p>
 <% end %>

--- a/app/views/user_blocks/index.html.erb
+++ b/app/views/user_blocks/index.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <% unless @user_blocks.empty? %>
-<%= render :partial => "blocks", :locals => { :show_revoke_link => (current_user && current_user.moderator?), :show_user_name => true, :show_creator_name => true } %>
+<%= render :partial => "blocks", :locals => { :show_revoke_link => can?(:revoke, UserBlock), :show_user_name => true, :show_creator_name => true } %>
 <% else %>
 <p><%= t ".empty" %></p>
 <% end %>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -13,7 +13,7 @@
     <% if current_user and current_user.id == @user_block.creator_id %>
       <li><%= link_to t(".edit"), edit_user_block_path(@user_block) %></li>
     <% end %>
-    <% if current_user and current_user.moderator? %>
+    <% if can?(:revoke, UserBlock) %>
       <li><%= link_to(t(".revoke"), :controller => "user_blocks", :action => "revoke", :id => @user_block.id) %></li>
     <% end %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,7 @@
             </li>
           <% end %>
 
-          <% if current_user and current_user.moderator? and current_user.blocks_created.exists? %>
+          <% if can?(:create, UserBlock) and current_user.blocks_created.exists? %>
             <li>
               <%= link_to t(".blocks by me"), :controller => "user_blocks", :action => "blocks_by", :display_name => current_user.display_name %>
               <span class='count-number'><%= number_with_delimiter(current_user.blocks_created.active.size) %></span>
@@ -96,7 +96,7 @@
             </li>
           <% end %>
 
-          <% if current_user and current_user.moderator? %>
+          <% if can?(:create, UserBlock) %>
             <li>
             <%= link_to t(".create_block"), :controller => "user_blocks", :action => "new", :display_name => @user.display_name %>
             </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -111,34 +111,38 @@
 
       <% end %>
 
-      <% if current_user and current_user.administrator? %>
+      <% if can?(:set_status, User) || can?(:delete, User) %>
 
         <ul class='secondary-actions clearfix'>
-          <% if ["active", "confirmed"].include? @user.status %>
-            <li>
-              <%= link_to t(".deactivate_user"), set_status_user_path(:status => "pending", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
-            </li>
-          <% elsif ["pending"].include? @user.status %>
-            <li>
-              <%= link_to t(".activate_user"), set_status_user_path(:status => "active", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
-            </li>
-          <% end %>
+          <% if can? :set_status, User %>
+            <% if ["active", "confirmed"].include? @user.status %>
+              <li>
+                <%= link_to t(".deactivate_user"), set_status_user_path(:status => "pending", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
+              </li>
+            <% elsif ["pending"].include? @user.status %>
+              <li>
+                <%= link_to t(".activate_user"), set_status_user_path(:status => "active", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
+              </li>
+            <% end %>
 
-          <% if ["active", "suspended"].include? @user.status %>
+            <% if ["active", "suspended"].include? @user.status %>
+              <li>
+                <%= link_to t(".confirm_user"), set_status_user_path(:status => "confirmed", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
+              </li>
+            <% end %>
+              <li>
+                <% if ["pending", "active", "confirmed", "suspended"].include? @user.status %>
+                  <%= link_to t(".hide_user"), set_status_user_path(:status => "deleted", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
+              <% else %>
+                <%= link_to t(".unhide_user"), set_status_user_path(:status => "active", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
+              </li>
+            <% end %>
+          <% end %>
+          <% if can? :delete, User %>
             <li>
-              <%= link_to t(".confirm_user"), set_status_user_path(:status => "confirmed", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
+              <%= link_to t(".delete_user"), delete_user_path(:display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
             </li>
           <% end %>
-            <li>
-              <% if ["pending", "active", "confirmed", "suspended"].include? @user.status %>
-                <%= link_to t(".hide_user"), set_status_user_path(:status => "deleted", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
-            <% else %>
-              <%= link_to t(".unhide_user"), set_status_user_path(:status => "active", :display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
-            </li>
-          <% end %>
-          <li>
-            <%= link_to t(".delete_user"), delete_user_path(:display_name => @user.display_name), :data => { :confirm => t(".confirm") } %>
-          </li>
         </ul>
 
         <% end %>


### PR DESCRIPTION
This replaces various (but not all) uses of `current_user.administrator?` and `current_user.moderator?` to use the permissions system. This is what we would like to see new code follow, as it allows more flexibility for changing abilities in the future. 