### PR TITLE
Add "view" tab to main navigation

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -323,6 +323,10 @@ $(document).ready(function () {
       return map.getState();
     };
 
+    page.unload = function () {
+      $("#view_tab").removeClass("current");
+    }
+
     return page;
   };
 
@@ -356,7 +360,6 @@ $(document).ready(function () {
 
     page.unload = function () {
       map.removeObject();
-      $("#view_tab").removeClass("current");
     };
 
     return page;

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -307,6 +307,7 @@ $(document).ready(function () {
     var page = {};
 
     page.pushstate = page.popstate = function () {
+      $("#view_tab").addClass("current");
       map.setSidebarOverlaid(true);
       document.title = I18n.t("layouts.project_name.title");
     };
@@ -355,6 +356,7 @@ $(document).ready(function () {
 
     page.unload = function () {
       map.removeObject();
+      $("#view_tab").removeClass("current");
     };
 
     return page;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,6 +12,9 @@
   <nav class='primary'>
     <%= content_for :header %>
     <ul>
+      <li id="view_tab" class="<%= current_page_class(root_path) %>">
+        <%= link_to t("layouts.view"), root_path, :class => "tab geolink" %>
+      </li>
       <li id="edit_tab" class="dropdown <%= current_page_class(edit_path) %>">
         <%= link_to t("layouts.edit"),
                     edit_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1132,6 +1132,7 @@ en:
     sign_up: Sign Up
     start_mapping: Start Mapping
     sign_up_tooltip: Create an account for editing
+    view: View
     edit: Edit
     history: History
     export: Export


### PR DESCRIPTION
This is one of my two solutions to the problem of the UI not presenting a clear way to return to the "view" page. I finally realized you can just click the logo, but this isn't very clear and I've seen several people online face the same issue. This solution works by adding a "View" tab to the main navigation menu. Here's an example of it working: ![viewtab](https://user-images.githubusercontent.com/42590338/68001467-8fa88700-fc3a-11e9-9dc2-629cbe515018.gif).

