### PR TITLE
Remove expand_bbox endpoint

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -37,7 +37,7 @@ class ApiAbility
         can [:read, :read_one, :update, :update_one, :delete_one], UserPreference
 
         if user.terms_agreed?
-          can [:create, :update, :upload, :close, :subscribe, :unsubscribe, :expand_bbox], Changeset
+          can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset
           can :create, ChangesetComment
           can [:create, :update, :delete], Node
           can [:create, :update, :delete], Way

--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -14,7 +14,7 @@ class ApiCapability
       can [:update, :update_one, :delete_one], UserPreference if capability?(token, :allow_write_prefs)
 
       if token&.user&.terms_agreed?
-        can [:create, :update, :upload, :close, :subscribe, :unsubscribe, :expand_bbox], Changeset if capability?(token, :allow_write_api)
+        can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset if capability?(token, :allow_write_api)
         can :create, ChangesetComment if capability?(token, :allow_write_api)
         can [:create, :update, :delete], Node if capability?(token, :allow_write_api)
         can [:create, :update, :delete], Way if capability?(token, :allow_write_api)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ OpenStreetMap::Application.routes.draw do
     put "changeset/create" => "api/changesets#create"
     post "changeset/:id/upload" => "api/changesets#upload", :id => /\d+/
     get "changeset/:id/download" => "api/changesets#download", :as => :changeset_download, :id => /\d+/
-    post "changeset/:id/expand_bbox" => "api/changesets#expand_bbox", :id => /\d+/
     get "changeset/:id" => "api/changesets#show", :as => :changeset_show, :id => /\d+/
     post "changeset/:id/subscribe" => "api/changesets#subscribe", :as => :changeset_subscribe, :id => /\d+/
     post "changeset/:id/unsubscribe" => "api/changesets#unsubscribe", :as => :changeset_unsubscribe, :id => /\d+/


### PR DESCRIPTION
This pull request removes the `expand_bbox` call, see discussion in #2316 for details. I removed more test cases than I originally anticipated, so a bit of extra scrutiny would be advisable.

Note: Analysis of current production log files to spot potential (non-mainstream) users of this endpoint is still pending at this time.

Closes #2316