### PR TITLE
Notifier message pluralization

### DIFF
--- a/app/views/notifier/gpx_success.html.erb
+++ b/app/views/notifier/gpx_success.html.erb
@@ -3,7 +3,5 @@
 <p>
   <%= render :partial => "gpx_description" %>
   <%= t("notifier.gpx_notification.success.loaded_successfully",
-        :trace_points => @trace_points,
-        :possible_points => @possible_points,
-        :count => @possible_points) %>
+        :trace_points => @trace_points, :possible_points => @possible_points, :count => @possible_points) %>
 </p>

--- a/app/views/notifier/gpx_success.html.erb
+++ b/app/views/notifier/gpx_success.html.erb
@@ -2,5 +2,8 @@
 
 <p>
   <%= render :partial => "gpx_description" %>
-  <%= t "notifier.gpx_notification.success.loaded_successfully", :trace_points => @trace_points, :possible_points => @possible_points %>
+  <%= t("notifier.gpx_notification.success.loaded_successfully",
+        :trace_points => @trace_points,
+        :possible_points => @possible_points,
+        :count => @possible_points) %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1200,7 +1200,9 @@ en:
         import_failures_url: "https://wiki.openstreetmap.org/wiki/GPX_Import_Failures"
       success:
         subject: "[OpenStreetMap] GPX Import success"
-        loaded_successfully: loaded successfully with %{trace_points} out of a possible %{possible_points} points.
+        loaded_successfully:
+          one: loaded successfully with %{trace_points} out of a possible 1 point.
+          other: loaded successfully with %{trace_points} out of a possible %{possible_points} points.
     signup_confirm:
       subject: "[OpenStreetMap] Welcome to OpenStreetMap"
       greeting: "Hi there!"


### PR DESCRIPTION
### Feature
Correctly pluralize the word point in the notification message based on the given possible points.

The `count` parameter is needed in order to provide the necessary information to i18n choose the right message.

Solves #2397 