### PR TITLE
Ignore the users.nearby column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,8 @@
 class User < ActiveRecord::Base
   require "xml/libxml"
 
+  self.ignored_columns = ["nearby"]
+
   has_many :traces, -> { where(:visible => true) }
   has_many :diary_entries, -> { order(:created_at => :desc) }
   has_many :diary_comments, -> { order(:created_at => :desc) }


### PR DESCRIPTION
This is the first step of removing the column, see #2417. It needs to be deployed before a migration to remove it, since the columns are cached in ActiveRecord and things break if objects exist in memory
that expect the database column to be there.

Thanks to `strong_migrations` for pointing this out when I tried creating the migration first!