### PR TITLE
Remove Node.to_xml

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -200,28 +200,6 @@ class Node < ActiveRecord::Base
     save_with_history!
   end
 
-  def to_xml
-    doc = OSM::API.new.get_xml_doc
-    doc.root << to_xml_node
-    doc
-  end
-
-  def to_xml_node(changeset_cache = {}, user_display_name_cache = {})
-    el = XML::Node.new "node"
-    el["id"] = id.to_s
-
-    add_metadata_to_xml_node(el, self, changeset_cache, user_display_name_cache)
-
-    if visible?
-      el["lat"] = lat.to_s
-      el["lon"] = lon.to_s
-    end
-
-    add_tags_to_xml_node(el, node_tags)
-
-    el
-  end
-
   def tags_as_hash
     tags
   end

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -461,7 +461,7 @@ CHANGESET
       delete << super_relation.to_xml_node
       delete << used_relation.to_xml_node
       delete << used_way.to_xml_node
-      delete << used_node.to_xml_node
+      delete << xml_node_for_node(used_node)
 
       # update the changeset to one that this user owns
       %w[node way relation].each do |type|
@@ -592,7 +592,7 @@ CHANGESET
       diff.root << delete
       delete << other_relation.to_xml_node
       delete << used_way.to_xml_node
-      delete << used_node.to_xml_node
+      delete << xml_node_for_node(used_node)
 
       # update the changeset to one that this user owns
       %w[node way relation].each do |type|
@@ -635,7 +635,7 @@ CHANGESET
       delete["if-unused"] = ""
       delete << used_relation.to_xml_node
       delete << used_way.to_xml_node
-      delete << used_node.to_xml_node
+      delete << xml_node_for_node(used_node)
 
       # update the changeset to one that this user owns
       %w[node way relation].each do |type|
@@ -1137,7 +1137,7 @@ CHANGESET
       diff = XML::Document.new
       diff.root = XML::Node.new "osmChange"
       modify = XML::Node.new "modify"
-      xml_old_node = old_node.to_xml_node
+      xml_old_node = xml_node_for_node(old_node)
       xml_old_node["lat"] = 2.0.to_s
       xml_old_node["lon"] = 2.0.to_s
       xml_old_node["changeset"] = changeset_id.to_s
@@ -1228,7 +1228,7 @@ CHANGESET
       diff.root = XML::Node.new "osmChange"
       delete = XML::Node.new "delete"
       diff.root << delete
-      delete << node.to_xml_node
+      delete << xml_node_for_node(node)
 
       # upload it
       error_format "xml"

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -147,6 +147,15 @@ module Api
       assert_response :not_found
     end
 
+    # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05
+    def test_lat_lon_xml_format
+      node = create(:node, :latitude => (0.00004 * OldNode::SCALE).to_i, :longitude => (0.00008 * OldNode::SCALE).to_i)
+
+      get :show, :params => { :id => node.id }
+      assert_match(/lat="0.0000400"/, response.body)
+      assert_match(/lon="0.0000800"/, response.body)
+    end
+
     # this tests deletion restrictions - basic deletion is tested in the unit
     # tests for node!
     def test_delete

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -43,7 +43,7 @@ module Api
       basic_authorization private_user.email, "test"
 
       # setup a simple XML node
-      xml_doc = private_node.to_xml
+      xml_doc = xml_for_node(private_node)
       xml_node = xml_doc.find("//osm/node").first
       nodeid = private_node.id
 
@@ -91,7 +91,7 @@ module Api
 
       # setup a simple XML node
 
-      xml_doc = node.to_xml
+      xml_doc = xml_for_node(node)
       xml_node = xml_doc.find("//osm/node").first
       nodeid = node.id
 

--- a/test/models/node_test.rb
+++ b/test/models/node_test.rb
@@ -68,14 +68,6 @@ class NodeTest < ActiveSupport::TestCase
     assert_in_delta 76.543 * OldNode::SCALE, node.longitude, 0.000001
   end
 
-  # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05
-  def test_lat_lon_xml_format
-    node = build(:node, :latitude => 0.00004 * OldNode::SCALE, :longitude => 0.00008 * OldNode::SCALE)
-
-    assert_match(/lat="0.0000400"/, node.to_xml.to_s)
-    assert_match(/lon="0.0000800"/, node.to_xml.to_s)
-  end
-
   # Check that you can create a node and store it
   def test_create
     changeset = create(:changeset)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -170,5 +170,31 @@ module ActiveSupport
       fill_in "password", :with => "test"
       click_on "Login", :match => :first
     end
+
+    def xml_for_node(node)
+      doc = OSM::API.new.get_xml_doc
+      doc.root << xml_node_for_node(node)
+      doc
+    end
+
+    def xml_node_for_node(node)
+      el = XML::Node.new "node"
+      el["id"] = node.id.to_s
+
+      OMHelper.add_metadata_to_xml_node(el, node, {}, {})
+
+      if node.visible?
+        el["lat"] = node.lat.to_s
+        el["lon"] = node.lon.to_s
+      end
+
+      OMHelper.add_tags_to_xml_node(el, node.node_tags)
+
+      el
+    end
+
+    class OMHelper
+      extend ObjectMetadata
+    end
   end
 end


### PR DESCRIPTION
The `.to_xml` and `.to_xml_node` methods are only used in the tests, for creating 'fixture'-style payloads, and aren't used by the application code. This PR moves those methods into the tests as helper methods. 

It also changes the lat/lon formatting test, to test the rendered response from the controller. This should probably have been done when the output was refactored to use the xml builders, but I overlooked this during that review.

Followup work involves doing similar work for the other elements with .to_xml methods.