### PR TITLE
Move to_xml methods from ways and relations into the tests

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -121,31 +121,6 @@ class Relation < ActiveRecord::Base
     relation
   end
 
-  def to_xml
-    doc = OSM::API.new.get_xml_doc
-    doc.root << to_xml_node
-    doc
-  end
-
-  def to_xml_node(changeset_cache = {}, user_display_name_cache = {})
-    el = XML::Node.new "relation"
-    el["id"] = id.to_s
-
-    add_metadata_to_xml_node(el, self, changeset_cache, user_display_name_cache)
-
-    relation_members.each do |member|
-      member_el = XML::Node.new "member"
-      member_el["type"] = member.member_type.downcase
-      member_el["ref"] = member.member_id.to_s
-      member_el["role"] = member.member_role
-      el << member_el
-    end
-
-    add_tags_to_xml_node(el, relation_tags)
-
-    el
-  end
-
   # FIXME: is this really needed?
   def members
     @members ||= relation_members.map do |member|

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -106,44 +106,6 @@ class Way < ActiveRecord::Base
     way
   end
 
-  # Find a way given it's ID, and in a single SQL call also grab its nodes and tags
-  def to_xml
-    doc = OSM::API.new.get_xml_doc
-    doc.root << to_xml_node
-    doc
-  end
-
-  def to_xml_node(visible_nodes = nil, changeset_cache = {}, user_display_name_cache = {})
-    el = XML::Node.new "way"
-    el["id"] = id.to_s
-
-    add_metadata_to_xml_node(el, self, changeset_cache, user_display_name_cache)
-
-    # make sure nodes are output in sequence_id order
-    ordered_nodes = []
-    way_nodes.each do |nd|
-      if visible_nodes
-        # if there is a list of visible nodes then use that to weed out deleted nodes
-        ordered_nodes[nd.sequence_id] = nd.node_id.to_s if visible_nodes[nd.node_id]
-      else
-        # otherwise, manually go to the db to check things
-        ordered_nodes[nd.sequence_id] = nd.node_id.to_s if nd.node&.visible?
-      end
-    end
-
-    ordered_nodes.each do |nd_id|
-      next unless nd_id && nd_id != "0"
-
-      node_el = XML::Node.new "nd"
-      node_el["ref"] = nd_id
-      el << node_el
-    end
-
-    add_tags_to_xml_node(el, way_tags)
-
-    el
-  end
-
   def nds
     @nds ||= way_nodes.collect(&:node_id)
   end

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -460,7 +460,7 @@ CHANGESET
       diff.root << delete
       delete << super_relation.to_xml_node
       delete << used_relation.to_xml_node
-      delete << used_way.to_xml_node
+      delete << xml_node_for_way(used_way)
       delete << xml_node_for_node(used_node)
 
       # update the changeset to one that this user owns
@@ -591,7 +591,7 @@ CHANGESET
       delete = XML::Node.new "delete"
       diff.root << delete
       delete << other_relation.to_xml_node
-      delete << used_way.to_xml_node
+      delete << xml_node_for_way(used_way)
       delete << xml_node_for_node(used_node)
 
       # update the changeset to one that this user owns
@@ -634,7 +634,7 @@ CHANGESET
       diff.root << delete
       delete["if-unused"] = ""
       delete << used_relation.to_xml_node
-      delete << used_way.to_xml_node
+      delete << xml_node_for_way(used_way)
       delete << xml_node_for_node(used_node)
 
       # update the changeset to one that this user owns
@@ -1175,7 +1175,7 @@ CHANGESET
       diff = XML::Document.new
       diff.root = XML::Node.new "osmChange"
       modify = XML::Node.new "modify"
-      xml_old_way = old_way.to_xml_node
+      xml_old_way = xml_node_for_way(old_way)
       nd_ref = XML::Node.new "nd"
       nd_ref["ref"] = create(:node, :lat => 3, :lon => 3).id.to_s
       xml_old_way << nd_ref
@@ -1487,7 +1487,7 @@ CHANGESET
 
       # add (delete) a way to it, which contains a point at (3,3)
       with_controller(WaysController.new) do
-        xml = update_changeset(way.to_xml, changeset_id)
+        xml = update_changeset(xml_for_way(way), changeset_id)
         put :delete, :params => { :id => way.id }, :body => xml.to_s
         assert_response :success, "Couldn't delete a way."
       end

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -458,8 +458,8 @@ CHANGESET
       diff.root = XML::Node.new "osmChange"
       delete = XML::Node.new "delete"
       diff.root << delete
-      delete << super_relation.to_xml_node
-      delete << used_relation.to_xml_node
+      delete << xml_node_for_relation(super_relation)
+      delete << xml_node_for_relation(used_relation)
       delete << xml_node_for_way(used_way)
       delete << xml_node_for_node(used_node)
 
@@ -590,7 +590,7 @@ CHANGESET
       diff.root = XML::Node.new "osmChange"
       delete = XML::Node.new "delete"
       diff.root << delete
-      delete << other_relation.to_xml_node
+      delete << xml_node_for_relation(other_relation)
       delete << xml_node_for_way(used_way)
       delete << xml_node_for_node(used_node)
 
@@ -633,7 +633,7 @@ CHANGESET
       delete = XML::Node.new "delete"
       diff.root << delete
       delete["if-unused"] = ""
-      delete << used_relation.to_xml_node
+      delete << xml_node_for_relation(used_relation)
       delete << xml_node_for_way(used_way)
       delete << xml_node_for_node(used_node)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -193,6 +193,37 @@ module ActiveSupport
       el
     end
 
+    def xml_for_way(way)
+      doc = OSM::API.new.get_xml_doc
+      doc.root << xml_node_for_way(way)
+      doc
+    end
+
+    def xml_node_for_way(way)
+      el = XML::Node.new "way"
+      el["id"] = way.id.to_s
+
+      OMHelper.add_metadata_to_xml_node(el, way, {}, {})
+
+      # make sure nodes are output in sequence_id order
+      ordered_nodes = []
+      way.way_nodes.each do |nd|
+        ordered_nodes[nd.sequence_id] = nd.node_id.to_s if nd.node&.visible?
+      end
+
+      ordered_nodes.each do |nd_id|
+        next unless nd_id && nd_id != "0"
+
+        node_el = XML::Node.new "nd"
+        node_el["ref"] = nd_id
+        el << node_el
+      end
+
+      OMHelper.add_tags_to_xml_node(el, way.way_tags)
+
+      el
+    end
+
     class OMHelper
       extend ObjectMetadata
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -224,6 +224,31 @@ module ActiveSupport
       el
     end
 
+    def xml_for_relation(relation)
+      doc = OSM::API.new.get_xml_doc
+      doc.root << xml_node_for_relation(relation)
+      doc
+    end
+
+    def xml_node_for_relation(relation)
+      el = XML::Node.new "relation"
+      el["id"] = relation.id.to_s
+
+      OMHelper.add_metadata_to_xml_node(el, relation, {}, {})
+
+      relation.relation_members.each do |member|
+        member_el = XML::Node.new "member"
+        member_el["type"] = member.member_type.downcase
+        member_el["ref"] = member.member_id.to_s
+        member_el["role"] = member.member_role
+        el << member_el
+      end
+
+      OMHelper.add_tags_to_xml_node(el, relation.relation_tags)
+
+      el
+    end
+
     class OMHelper
       extend ObjectMetadata
     end


### PR DESCRIPTION
This is a followup to #2433, and makes the same change for ways and relations.