### PR TITLE
Create an ApplicationRecord for models to inherit from

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,9 +38,6 @@ Naming/FileName:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-Rails/ApplicationRecord:
-  Enabled: false
-
 Rails/CreateTableWithTimestamps:
   Enabled: false
 

--- a/app/models/acl.rb
+++ b/app/models/acl.rb
@@ -17,7 +17,7 @@
 #  index_acls_on_mx       (mx)
 #
 
-class Acl < ActiveRecord::Base
+class Acl < ApplicationRecord
   validates :k, :presence => true
 
   def self.match(address, options = {})

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -25,7 +25,7 @@
 #  changesets_user_id_fkey  (user_id => users.id)
 #
 
-class Changeset < ActiveRecord::Base
+class Changeset < ApplicationRecord
   require "xml/libxml"
 
   belongs_to :user, :counter_cache => true

--- a/app/models/changeset_comment.rb
+++ b/app/models/changeset_comment.rb
@@ -19,7 +19,7 @@
 #  changeset_comments_changeset_id_fkey  (changeset_id => changesets.id)
 #
 
-class ChangesetComment < ActiveRecord::Base
+class ChangesetComment < ApplicationRecord
   belongs_to :changeset
   belongs_to :author, :class_name => "User"
 

--- a/app/models/changeset_tag.rb
+++ b/app/models/changeset_tag.rb
@@ -15,7 +15,7 @@
 #  changeset_tags_id_fkey  (changeset_id => changesets.id)
 #
 
-class ChangesetTag < ActiveRecord::Base
+class ChangesetTag < ApplicationRecord
   self.primary_keys = "changeset_id", "k"
 
   belongs_to :changeset

--- a/app/models/client_application.rb
+++ b/app/models/client_application.rb
@@ -30,7 +30,7 @@
 #  client_applications_user_id_fkey  (user_id => users.id)
 #
 
-class ClientApplication < ActiveRecord::Base
+class ClientApplication < ApplicationRecord
   belongs_to :user
   has_many :tokens, :class_name => "OauthToken", :dependent => :delete_all
   has_many :access_tokens

--- a/app/models/diary_comment.rb
+++ b/app/models/diary_comment.rb
@@ -22,7 +22,7 @@
 #  diary_comments_user_id_fkey         (user_id => users.id)
 #
 
-class DiaryComment < ActiveRecord::Base
+class DiaryComment < ApplicationRecord
   belongs_to :user
   belongs_to :diary_entry
 

--- a/app/models/diary_entry.rb
+++ b/app/models/diary_entry.rb
@@ -26,7 +26,7 @@
 #  diary_entries_user_id_fkey        (user_id => users.id)
 #
 
-class DiaryEntry < ActiveRecord::Base
+class DiaryEntry < ApplicationRecord
   belongs_to :user, :counter_cache => true
   belongs_to :language, :foreign_key => "language_code"
 

--- a/app/models/diary_entry_subscription.rb
+++ b/app/models/diary_entry_subscription.rb
@@ -15,7 +15,7 @@
 #  diary_entry_subscriptions_user_id_fkey         (user_id => users.id)
 #
 
-class DiaryEntrySubscription < ActiveRecord::Base
+class DiaryEntrySubscription < ApplicationRecord
   self.primary_keys = "user_id", "diary_entry_id"
 
   belongs_to :user

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -17,7 +17,7 @@
 #  friends_user_id_fkey         (user_id => users.id)
 #
 
-class Friendship < ActiveRecord::Base
+class Friendship < ApplicationRecord
   self.table_name = "friends"
 
   belongs_to :befriender, :class_name => "User", :foreign_key => :user_id

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -30,7 +30,7 @@
 #  issues_updated_by_fkey        (updated_by => users.id)
 #
 
-class Issue < ActiveRecord::Base
+class Issue < ApplicationRecord
   belongs_to :reportable, :polymorphic => true
   belongs_to :reported_user, :class_name => "User", :foreign_key => :reported_user_id
   belongs_to :user_resolved, :class_name => "User", :foreign_key => :resolved_by

--- a/app/models/issue_comment.rb
+++ b/app/models/issue_comment.rb
@@ -20,7 +20,7 @@
 #  issue_comments_user_id_fkey   (user_id => users.id)
 #
 
-class IssueComment < ActiveRecord::Base
+class IssueComment < ApplicationRecord
   belongs_to :issue
   belongs_to :user
 

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -7,7 +7,7 @@
 #  native_name  :string
 #
 
-class Language < ActiveRecord::Base
+class Language < ApplicationRecord
   self.primary_key = "code"
 
   has_many :diary_entries, :foreign_key => "language"

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -24,7 +24,7 @@
 #  messages_to_user_id_fkey    (to_user_id => users.id)
 #
 
-class Message < ActiveRecord::Base
+class Message < ApplicationRecord
   belongs_to :sender, :class_name => "User", :foreign_key => :from_user_id
   belongs_to :recipient, :class_name => "User", :foreign_key => :to_user_id
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -21,7 +21,7 @@
 #  current_nodes_changeset_id_fkey  (changeset_id => changesets.id)
 #
 
-class Node < ActiveRecord::Base
+class Node < ApplicationRecord
   require "xml/libxml"
 
   include GeoRecord

--- a/app/models/node_tag.rb
+++ b/app/models/node_tag.rb
@@ -11,7 +11,7 @@
 #  current_node_tags_id_fkey  (node_id => current_nodes.id)
 #
 
-class NodeTag < ActiveRecord::Base
+class NodeTag < ApplicationRecord
   self.table_name = "current_node_tags"
   self.primary_keys = "node_id", "k"
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -18,7 +18,7 @@
 #  notes_updated_at_idx   (updated_at)
 #
 
-class Note < ActiveRecord::Base
+class Note < ApplicationRecord
   include GeoRecord
 
   has_many :comments, -> { left_joins(:author).where(:visible => true, :users => { :status => [nil, "active", "confirmed"] }).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id

--- a/app/models/note_comment.rb
+++ b/app/models/note_comment.rb
@@ -23,7 +23,7 @@
 #  note_comments_note_id_fkey    (note_id => notes.id)
 #
 
-class NoteComment < ActiveRecord::Base
+class NoteComment < ApplicationRecord
   belongs_to :note, :foreign_key => :note_id, :touch => true
   belongs_to :author, :class_name => "User", :foreign_key => :author_id
 

--- a/app/models/oauth_nonce.rb
+++ b/app/models/oauth_nonce.rb
@@ -15,7 +15,7 @@
 
 # Simple store of nonces. The OAuth Spec requires that any given pair of nonce and timestamps are unique.
 # Thus you can use the same nonce with a different timestamp and viceversa.
-class OauthNonce < ActiveRecord::Base
+class OauthNonce < ApplicationRecord
   validates :timestamp, :presence => true
   validates :nonce, :presence => true, :uniqueness => { :scope => :timestamp }
 

--- a/app/models/oauth_token.rb
+++ b/app/models/oauth_token.rb
@@ -35,7 +35,7 @@
 #  oauth_tokens_user_id_fkey                (user_id => users.id)
 #
 
-class OauthToken < ActiveRecord::Base
+class OauthToken < ApplicationRecord
   belongs_to :client_application
   belongs_to :user
 

--- a/app/models/old_node.rb
+++ b/app/models/old_node.rb
@@ -24,7 +24,7 @@
 #  nodes_redaction_id_fkey  (redaction_id => redactions.id)
 #
 
-class OldNode < ActiveRecord::Base
+class OldNode < ApplicationRecord
   include GeoRecord
   include ConsistencyValidations
   include ObjectMetadata

--- a/app/models/old_node_tag.rb
+++ b/app/models/old_node_tag.rb
@@ -12,7 +12,7 @@
 #  node_tags_id_fkey  (node_id => nodes.node_id)
 #
 
-class OldNodeTag < ActiveRecord::Base
+class OldNodeTag < ApplicationRecord
   self.table_name = "node_tags"
   self.primary_keys = "node_id", "version", "k"
 

--- a/app/models/old_relation.rb
+++ b/app/models/old_relation.rb
@@ -20,7 +20,7 @@
 #  relations_redaction_id_fkey  (redaction_id => redactions.id)
 #
 
-class OldRelation < ActiveRecord::Base
+class OldRelation < ApplicationRecord
   include ConsistencyValidations
   include ObjectMetadata
 

--- a/app/models/old_relation_member.rb
+++ b/app/models/old_relation_member.rb
@@ -18,7 +18,7 @@
 #  relation_members_id_fkey  (relation_id => relations.relation_id)
 #
 
-class OldRelationMember < ActiveRecord::Base
+class OldRelationMember < ApplicationRecord
   self.table_name = "relation_members"
   self.primary_keys = "relation_id", "version", "sequence_id"
 

--- a/app/models/old_relation_tag.rb
+++ b/app/models/old_relation_tag.rb
@@ -12,7 +12,7 @@
 #  relation_tags_id_fkey  (relation_id => relations.relation_id)
 #
 
-class OldRelationTag < ActiveRecord::Base
+class OldRelationTag < ApplicationRecord
   self.table_name = "relation_tags"
   self.primary_keys = "relation_id", "version", "k"
 

--- a/app/models/old_way.rb
+++ b/app/models/old_way.rb
@@ -20,7 +20,7 @@
 #  ways_redaction_id_fkey  (redaction_id => redactions.id)
 #
 
-class OldWay < ActiveRecord::Base
+class OldWay < ApplicationRecord
   include ConsistencyValidations
   include ObjectMetadata
 

--- a/app/models/old_way_node.rb
+++ b/app/models/old_way_node.rb
@@ -16,7 +16,7 @@
 #  way_nodes_id_fkey  (way_id => ways.way_id)
 #
 
-class OldWayNode < ActiveRecord::Base
+class OldWayNode < ApplicationRecord
   self.table_name = "way_nodes"
   self.primary_keys = "way_id", "version", "sequence_id"
 

--- a/app/models/old_way_tag.rb
+++ b/app/models/old_way_tag.rb
@@ -12,7 +12,7 @@
 #  way_tags_id_fkey  (way_id => ways.way_id)
 #
 
-class OldWayTag < ActiveRecord::Base
+class OldWayTag < ApplicationRecord
   self.table_name = "way_tags"
   self.primary_keys = "way_id", "version", "k"
 

--- a/app/models/redaction.rb
+++ b/app/models/redaction.rb
@@ -24,7 +24,7 @@
 # record's title and description fields, which can be
 # displayed linked from the redacted records.
 #
-class Redaction < ActiveRecord::Base
+class Redaction < ApplicationRecord
   belongs_to :user
 
   has_many :old_nodes

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -17,7 +17,7 @@
 #  current_relations_changeset_id_fkey  (changeset_id => changesets.id)
 #
 
-class Relation < ActiveRecord::Base
+class Relation < ApplicationRecord
   require "xml/libxml"
 
   include ConsistencyValidations

--- a/app/models/relation_member.rb
+++ b/app/models/relation_member.rb
@@ -17,7 +17,7 @@
 #  current_relation_members_id_fkey  (relation_id => current_relations.id)
 #
 
-class RelationMember < ActiveRecord::Base
+class RelationMember < ApplicationRecord
   self.table_name = "current_relation_members"
   self.primary_keys = "relation_id", "sequence_id"
 

--- a/app/models/relation_tag.rb
+++ b/app/models/relation_tag.rb
@@ -11,7 +11,7 @@
 #  current_relation_tags_id_fkey  (relation_id => current_relations.id)
 #
 
-class RelationTag < ActiveRecord::Base
+class RelationTag < ApplicationRecord
   self.table_name = "current_relation_tags"
   self.primary_keys = "relation_id", "k"
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -21,7 +21,7 @@
 #  reports_user_id_fkey   (user_id => users.id)
 #
 
-class Report < ActiveRecord::Base
+class Report < ApplicationRecord
   belongs_to :issue, :counter_cache => true
   belongs_to :user
 

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -25,7 +25,7 @@
 #  gpx_files_user_id_fkey  (user_id => users.id)
 #
 
-class Trace < ActiveRecord::Base
+class Trace < ApplicationRecord
   self.table_name = "gpx_files"
 
   belongs_to :user, :counter_cache => true

--- a/app/models/tracepoint.rb
+++ b/app/models/tracepoint.rb
@@ -20,7 +20,7 @@
 #  gps_points_gpx_id_fkey  (gpx_id => gpx_files.id)
 #
 
-class Tracepoint < ActiveRecord::Base
+class Tracepoint < ApplicationRecord
   include GeoRecord
 
   self.table_name = "gps_points"

--- a/app/models/tracetag.rb
+++ b/app/models/tracetag.rb
@@ -16,7 +16,7 @@
 #  gpx_file_tags_gpx_id_fkey  (gpx_id => gpx_files.id)
 #
 
-class Tracetag < ActiveRecord::Base
+class Tracetag < ApplicationRecord
   self.table_name = "gpx_file_tags"
 
   belongs_to :trace, :foreign_key => "gpx_id"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@
 #  users_home_idx                (home_tile)
 #
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   require "xml/libxml"
 
   self.ignored_columns = ["nearby"]

--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -24,7 +24,7 @@
 #  user_blocks_user_id_fkey       (user_id => users.id)
 #
 
-class UserBlock < ActiveRecord::Base
+class UserBlock < ApplicationRecord
   validate :moderator_permissions
   validates :reason, :characters => true
 

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -11,7 +11,7 @@
 #  user_preferences_user_id_fkey  (user_id => users.id)
 #
 
-class UserPreference < ActiveRecord::Base
+class UserPreference < ApplicationRecord
   self.primary_keys = "user_id", "k"
 
   belongs_to :user

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -19,7 +19,7 @@
 #  user_roles_user_id_fkey     (user_id => users.id)
 #
 
-class UserRole < ActiveRecord::Base
+class UserRole < ApplicationRecord
   belongs_to :user
   belongs_to :granter, :class_name => "User"
 

--- a/app/models/user_token.rb
+++ b/app/models/user_token.rb
@@ -18,7 +18,7 @@
 #  user_tokens_user_id_fkey  (user_id => users.id)
 #
 
-class UserToken < ActiveRecord::Base
+class UserToken < ApplicationRecord
   belongs_to :user
 
   after_initialize :set_defaults

--- a/app/models/way.rb
+++ b/app/models/way.rb
@@ -17,7 +17,7 @@
 #  current_ways_changeset_id_fkey  (changeset_id => changesets.id)
 #
 
-class Way < ActiveRecord::Base
+class Way < ApplicationRecord
   require "xml/libxml"
 
   include ConsistencyValidations

--- a/app/models/way_node.rb
+++ b/app/models/way_node.rb
@@ -16,7 +16,7 @@
 #  current_way_nodes_node_id_fkey  (node_id => current_nodes.id)
 #
 
-class WayNode < ActiveRecord::Base
+class WayNode < ApplicationRecord
   self.table_name = "current_way_nodes"
   self.primary_keys = "way_id", "sequence_id"
 

--- a/app/models/way_tag.rb
+++ b/app/models/way_tag.rb
@@ -11,7 +11,7 @@
 #  current_way_tags_id_fkey  (way_id => current_ways.id)
 #
 
-class WayTag < ActiveRecord::Base
+class WayTag < ApplicationRecord
   self.table_name = "current_way_tags"
   self.primary_keys = "way_id", "k"
 


### PR DESCRIPTION
This is the default for Rails 5+, and also paves the way for multiple database support.

This is needed for multiple databases for two reasons. Firstly, it allows us to define the read/write database connections in one place. But more importantly, [from the docs](https://guides.rubyonrails.org/active_record_multiple_databases.html):

> It's important to connect to your database in a single model and then inherit from that model for the tables rather than connect multiple individual models to the same database. Database clients have a limit to the number of open connections there can be and if you do this it will multiply the number of connections you have since Rails uses the model class name for the connection specification name.

I've enabled the rubocop cop for this too, so that we don't use ActiveRecord::Base by mistake in PRs etc.