### PR TITLE
Use parameters for various colours

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1236,7 +1236,7 @@ tr.turn:hover {
       width: 12px;
       height: 12px;
       margin: 4px 0px;
-      border: 1px solid rgba(0, 0, 0, .1); 
+      border: 1px solid rgba(0, 0, 0, .1);
       // add color via inline css on element: background-color: <tag value>;
     }
   }
@@ -1867,7 +1867,7 @@ tr.turn:hover {
   }
 
   .inbox-row {
-    background: #f8f8ff;
+    background: $offwhite;
   }
 
   .inbox-row-unread {
@@ -2434,7 +2434,7 @@ input.richtext_title[type="text"] {
     display: inline-block;
     vertical-align: top;
     margin-left: 15px;
-    background-color: #f8f8ff;
+    background-color: $offwhite;
     padding: $lineheight/2;
     width: 220px;
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -202,8 +202,8 @@ a {
 
 hr {
   border: none;
-  background-color: #ccc;
-  color: #ccc;
+  background-color: $grey;
+  color: $grey;
   height: 1px;
 }
 
@@ -229,7 +229,7 @@ table {
 /* Utility for de-emphasizing content */
 
 .deemphasize {
-  color: #999;
+  color: $darkgrey;
   a {
     color: $blue;
   }
@@ -330,11 +330,11 @@ nav.primary {
   }
 
   .disabled a {
-    color: #ccc;
+    color: $grey;
     cursor: default;
 
     .caret {
-      border-top-color: #ccc;
+      border-top-color: $grey;
     }
   }
 
@@ -692,7 +692,7 @@ body.compact {
     overflow: auto;
 
     .section {
-      border-bottom: 1px solid #DDD;
+      border-bottom: 1px solid $grey;
       padding: 10px 20px;
     }
 
@@ -702,14 +702,14 @@ body.compact {
       font-size:20px;
       line-height:10px;
       color:#222;
-      border:1px solid #ddd;
+      border:1px solid $grey;
     }
 
     .tooltip {
       opacity: 1;
-      border: 1px solid #ccc;
+      border: 1px solid $grey;
       .tooltip-arrow {
-        border-top-color: #ccc;
+        border-top-color: $grey;
       }
     }
   }
@@ -768,7 +768,7 @@ body.compact {
       font-size: 13px;
       margin-bottom: 8px;
     }
-    li.disabled { color: #999; }
+    li.disabled { color: $darkgrey; }
   }
 }
 
@@ -872,7 +872,7 @@ body.compact {
   position: relative;
   padding: $lineheight/2 $lineheight;
   // background: $offwhite;
-  // border-bottom: 1px solid #ccc;
+  // border-bottom: 1px solid $grey;
   > .close {
     float: right;
     margin-top: 2px;
@@ -1085,10 +1085,10 @@ p#routing_summary {
 td.instruction, td.distance {
     padding-top: $lineheight/5;
     padding-bottom: $lineheight/5;
-    border-bottom: 1px solid #DDD;
+    border-bottom: 1px solid $grey;
 }
 td.distance {
-    color: #BBB;
+    color: $darkgrey;
     text-align: right;
     font-size: x-small;
 }
@@ -1119,7 +1119,7 @@ tr.turn:hover {
 #sidebar .changesets {
   li {
     padding: 15px 20px;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid $grey;
     cursor: pointer;
 
     &.selected { background: $list-highlight; }
@@ -1135,7 +1135,7 @@ tr.turn:hover {
 
   .comments {
     float: right;
-    color: #999;
+    color: $darkgrey;
   }
 
   .comments-0 {
@@ -1153,7 +1153,7 @@ tr.turn:hover {
 #sidebar_content {
   .browse-section {
     padding: $lineheight/2 $lineheight;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid $grey;
 
     h4:first-child {
       margin-top: 0;
@@ -1168,7 +1168,7 @@ tr.turn:hover {
   .paginate {
     float: right;
     padding: 1px 6px;
-    border: 1px solid #eee;
+    border: 1px solid $lightgrey;
     border-radius: 3px;
   }
 
@@ -1182,7 +1182,7 @@ tr.turn:hover {
     h4 {
       padding: 5px 0 5px 10px;
       font-size: 12px;
-      border: 1px solid #CCC;
+      border: 1px solid $grey;
       border-radius: 4px 4px 0 0;
       background-color: #F6F6F6;
     }
@@ -1191,7 +1191,7 @@ tr.turn:hover {
       padding: 7px 10px;
       font-size: 12px;
       background-color: #FFF;
-      border: 1px solid #CCC;
+      border: 1px solid $grey;
       border-top: 0;
       border-radius: 0 0 4px 4px;
     }
@@ -1199,14 +1199,14 @@ tr.turn:hover {
 
   .browse-tag-list {
     background-color: #F6F6F6;
-    border: 1px solid #ddd;
+    border: 1px solid $grey;
     border-radius: 3px;
     font-size: 12px;
     table-layout: fixed;
     border-collapse: separate;
 
     th, td {
-      border-bottom: 1px solid #ddd;
+      border-bottom: 1px solid $grey;
     }
 
     tr:last-child th, tr:last-child td {
@@ -1227,7 +1227,7 @@ tr.turn:hover {
     }
 
     .browse-tag-v {
-      border-left: 1px solid #ddd;
+      border-left: 1px solid $grey;
       background-color: #fff;
     }
 
@@ -1296,7 +1296,7 @@ tr.turn:hover {
     ul {
       li {
         padding: 15px 20px;
-        border-bottom: 1px solid #ddd;
+        border-bottom: 1px solid $grey;
 
         &.query-result {
           cursor: pointer;
@@ -1330,8 +1330,8 @@ tr.turn:hover {
   }
 
   .export_boxy {
-    background: #eee;
-    border: 1px solid #ccc;
+    background: $lightgrey;
+    border: 1px solid $grey;
     border-radius: 3px;
 
     #maxlat { margin-top: -1px; }
@@ -1488,7 +1488,7 @@ tr.turn:hover {
   position: relative;
   width: 45%;
   height: 400px;
-  border: 1px solid #ccc;
+  border: 1px solid $grey;
   margin-bottom: $lineheight;
   float: right;
 }
@@ -1590,7 +1590,7 @@ tr.turn:hover {
 
 .activity-block {
   clear: left;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid $grey;
   padding-bottom: $lineheight;
   float: left;
   h3 {
@@ -1675,7 +1675,7 @@ tr.turn:hover {
   position: relative;
   padding-top: $lineheight;
   padding-bottom: $lineheight/2;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid $grey;
 
   &:first-of-type {
     margin-top: $lineheight/2;
@@ -1716,12 +1716,12 @@ tr.turn:hover {
     position: relative;
     width: 90%;
     height: 400px;
-    border: 1px solid #ccc;
+    border: 1px solid $grey;
     display: none;
     margin-bottom: $lineheight;
   }
   #newcomment {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid $grey;
     padding-top: $lineheight;
     margin-top: $lineheight/2;
   }
@@ -1729,13 +1729,13 @@ tr.turn:hover {
     max-width: 740px;
   }
   .diary-comment {
-    border-top: 1px dashed #ccc;
+    border-top: 1px dashed $grey;
     padding-top: $lineheight/2;
     padding-bottom: $lineheight/2;
     &:first-child {
       margin-top: $lineheight/2;
       padding-top: $lineheight;
-      border-top: 1px solid #ccc;
+      border-top: 1px solid $grey;
     }
     &.deemphasize {
       background-color: #fee;
@@ -1776,7 +1776,7 @@ tr.turn:hover {
 
 .users-terms {
   .legale {
-    border: 1px solid #ccc;
+    border: 1px solid $grey;
     padding: $lineheight;
     margin-bottom: $lineheight;
     overflow: auto;
@@ -1805,7 +1805,7 @@ tr.turn:hover {
   position: relative;
   width: 500px;
   height: 400px;
-  border: 1px solid #ccc;
+  border: 1px solid $grey;
 }
 
 #accountForm .user_image {
@@ -1857,13 +1857,13 @@ tr.turn:hover {
 
 .messages {
   width: 100%;
-  border: 1px solid #ddd;
+  border: 1px solid $grey;
 
   input[type="submit"] {
     margin: auto;
   }
   tbody tr {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid $grey;
   }
 
   .inbox-row {
@@ -1902,7 +1902,7 @@ tr.turn:hover {
 .info-line {
   margin-bottom: $lineheight;
   padding: $lineheight/4 0px 4px 0px;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid $grey;
 
   form, form div {
     display: inline;
@@ -2091,7 +2091,7 @@ input[type="password"],
 textarea {
   color: #222;
   background-color: #fff;
-  border: 1px solid #ccc;
+  border: 1px solid $grey;
   padding: 2px 5px;
   margin: 0;
   width: 200px;
@@ -2111,7 +2111,7 @@ textarea {
 img.user_image {
   max-width: 100px;
   max-height: 100px;
-  border: 1px solid #ccc;
+  border: 1px solid $grey;
   margin-bottom: $lineheight;
   float: left;
   margin-right: $lineheight;
@@ -2120,7 +2120,7 @@ img.user_image {
 img.user_thumbnail {
   max-width: 50px;
   max-height: 50px;
-  border: 1px solid #ccc;
+  border: 1px solid $grey;
   margin-right: $lineheight;
 }
 
@@ -2129,7 +2129,7 @@ img.user_thumbnail_tiny {
   height: auto;
   max-width: 25px;
   max-height: 25px;
-  border: 1px solid #ccc;
+  border: 1px solid $grey;
 }
 
 /* Rules for geo microformats */
@@ -2159,7 +2159,7 @@ ul.secondary-actions {
     display: block;
     float: left;
     list-style: none;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid $grey;
     padding-left: $lineheight/2;
     margin-right: $lineheight/2;
     &:first-child {
@@ -2316,7 +2316,7 @@ a.button {
 .prose {
   h1, h2 {
     padding-bottom: $lineheight/2;
-    border-bottom: 1px dashed #cccccc;
+    border-bottom: 1px dashed $grey;
     margin-bottom: $lineheight/2;
   }
 
@@ -2334,13 +2334,13 @@ a.button {
 
   code {
     font-size: 13px;
-    background: #e8e8e8;
+    background: $lightgrey;
     padding: 2px 3px;
   }
 
   pre {
     font-size: 13px;
-    background: #e8e8e8;
+    background: $lightgrey;
     padding: 2px 3px;
     white-space: pre-wrap;
 
@@ -2361,7 +2361,7 @@ a.button {
     border-left: $lineheight solid $offwhite;
     padding-left: $lineheight;
     margin: 0;
-    color: #7E7E7E;
+    color: $darkgrey;
   }
 
   ul, ol {
@@ -2443,7 +2443,7 @@ input.richtext_title[type="text"] {
     }
 
     h4.heading, li {
-      border-bottom: 1px solid #ccc;
+      border-bottom: 1px solid $grey;
       margin-bottom: $lineheight/4;
       padding-bottom: $lineheight/4;
     }
@@ -2472,7 +2472,7 @@ input.richtext_title[type="text"] {
 
 .note_list {
   tr.creator {
-    background-color: #eeeeee;
+    background-color: $lightgrey;
   }
 
   td {
@@ -2534,7 +2534,7 @@ input.richtext_title[type="text"] {
   margin: 0;
   list-style: none;
   background-color: #ffffff;
-  border: 1px solid #ccc;
+  border: 1px solid $grey;
   border-radius: 0 3px 3px;
   *border-right-width: 2px;
   *border-bottom-width: 2px;
@@ -2553,7 +2553,7 @@ input.richtext_title[type="text"] {
   margin: 9px 1px;
   *margin: -5px 0 5px;
   overflow: hidden;
-  background-color: #e5e5e5;
+  background-color: $lightgrey;
   border-bottom: 1px solid #ffffff;
 }
 
@@ -2588,7 +2588,7 @@ input.richtext_title[type="text"] {
 .dropdown-menu > .disabled > a,
 .dropdown-menu > .disabled > a:hover,
 .dropdown-menu > .disabled > a:focus {
-  color: #999999;
+  color: $darkgrey;
 }
 
 .dropdown-menu > .disabled > a:hover,
@@ -2701,8 +2701,7 @@ input.richtext_title[type="text"] {
 }
 
 .site-about #content {
-  //background-color: #000;
-  background-color: #eee;
+  background-color: $lightgrey;
   background-position: 50% 50%;
   background-repeat: no-repeat;
   background-size: cover;
@@ -2716,7 +2715,7 @@ input.richtext_title[type="text"] {
     right: 20px;
     bottom: 60px;
     text-shadow: #000 0px 1px 5px;
-    color: #eee;
+    color: $lightgrey;
     opacity: 0.8;
     display: none;
   }
@@ -2861,7 +2860,7 @@ input.richtext_title[type="text"] {
 }
 
 .read-reports {
-  background: #eee;
+  background: $lightgrey;
   opacity: 0.7;
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -505,7 +505,7 @@ body.compact {
   }
 
   &.active {
-    background-color: #9ed485;
+    background-color: $vibrant-green;
   }
 
   .icon {
@@ -939,7 +939,7 @@ header .search_forms,
 
   input:focus {
     outline: none;
-    box-shadow: 0px 0px 7px #9ED485;
+    box-shadow: 0px 0px 7px $vibrant-green;
   }
 
   input[type=submit].float {
@@ -2775,7 +2775,7 @@ input.richtext_title[type="text"] {
       font-weight: 300;
       font-size: 34px;
       span {
-        color: #76c551;
+        color: $vibrant-green;
       }
     }
 
@@ -2789,7 +2789,7 @@ input.richtext_title[type="text"] {
       background-repeat: no-repeat;
       background-image: image-url('about/osm.png');
       background-size: cover;
-      background-color: #76c551;
+      background-color: $vibrant-green;
     }
 
     .byosm {
@@ -2803,7 +2803,7 @@ input.richtext_title[type="text"] {
       font: 500 20px/24px Helvetica, Arial, sans-serif;
       white-space: nowrap;
       color: #fff;
-      background: #76c551;
+      background: $vibrant-green;
     }
 
     .byosm span {

--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -6,6 +6,7 @@ $offwhite: #f8f8ff;
 $blue: #7092FF;
 $lightblue: #B8C5F0;
 $green: #7ebc6f;
+$vibrant-green: #76c551;
 $grey: #CCC;
 $red: red;
 $lightgrey: #EEE;

--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -2,7 +2,7 @@
 $lineheight: 20px;
 $typeheight: 14px;
 
-$offwhite: #f4f4ff;
+$offwhite: #f8f8ff;
 $blue: #7092FF;
 $lightblue: #B8C5F0;
 $green: #7ebc6f;


### PR DESCRIPTION
While working on some bootstrap-related stuff I noticed that we have multiple similar colours for off-white backgrounds, and then I noticed we have a lot of places where grey colours are hard-coded and either match or are slightly different from the grey colour parameters.

This PR refactors many of the explicit colours to use the colour parameters instead. Both off-whites have been unified and the lighter is now used. For the greens, I chickened out and kept the more vibrant ones separate from the standard ones, for now at least. Perhaps they can be unified with some colour functions like lighten. Also the greys have been combined into the three different greys from the palette, which cuts down on the number of different `1px solid X` variations.
