### PR TITLE
Wrap table header rows in thead

### DIFF
--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -3,11 +3,13 @@
 <% end %>
 
 <table class="messages" width="100%">
-  <tr>
-    <th width="25%"><%= t ".post" %></th>
-    <th width="25%"><%= t ".when" %></th>
-    <th width="50%"><%= t ".comment" %></th>
-  </tr>
+  <thead>
+    <tr>
+      <th width="25%"><%= t ".post" %></th>
+      <th width="25%"><%= t ".when" %></th>
+      <th width="50%"><%= t ".comment" %></th>
+    </tr>
+  </thead>
   <% @comments.each do |comment| -%>
   <% cl = cycle("table0", "table1") %>
   <tr class="<%= cl %><%= " deemphasize" unless comment.visible? %>">

--- a/app/views/notes/mine.html.erb
+++ b/app/views/notes/mine.html.erb
@@ -6,14 +6,16 @@
 <%= render :partial => "notes_paging_nav" %>
 
 <table class="note_list">
-  <tr>
-    <th></th>
-    <th><%= t ".id" %></th>
-    <th><%= t ".creator" %></th>
-    <th><%= t ".description" %></th>
-    <th><%= t ".created_at" %></th>
-    <th><%= t ".last_changed" %></th>
-  </tr>
+  <thead>
+    <tr>
+      <th></th>
+      <th><%= t ".id" %></th>
+      <th><%= t ".creator" %></th>
+      <th><%= t ".description" %></th>
+      <th><%= t ".created_at" %></th>
+      <th><%= t ".last_changed" %></th>
+    </tr>
+  </thead>
 <% @notes.each do |note| -%>
   <tr<% if note.author == @user %> class="creator"<% end %>>
     <td>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -6,11 +6,13 @@
 <h3><%= t ".my_tokens" %></h3>
 <p><%= t ".list_tokens" %></p>
 <table>
-  <tr>
-    <th><%= t ".application" %></th>
-    <th><%= t ".issued_at" %></th>
-    <th>&nbsp;</th>
-  </tr>
+  <thead>
+    <tr>
+      <th><%= t ".application" %></th>
+      <th><%= t ".issued_at" %></th>
+      <th>&nbsp;</th>
+    </tr>
+  </thead>
   <% @tokens.each do |token| %>
     <tr>
       <td><%= link_to token.client_application.name, token.client_application.url %></td>

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -1,20 +1,22 @@
 <table id="block_list" cellpadding="3">
-  <tr>
-    <% if show_user_name %>
-    <th><%= t ".display_name" %></th>
-    <% end %>
-    <% if show_creator_name %>
-    <th><%= t ".creator_name" %></th>
-    <% end %>
-    <th><%= t ".reason" %></th>
-    <th><%= t ".status" %></th>
-    <th><%= t ".revoker_name" %></th>
-    <th></th>
-    <th></th>
-    <% if show_revoke_link %>
-    <th></th>
-    <% end %>
-  </tr>
+  <thead>
+    <tr>
+      <% if show_user_name %>
+      <th><%= t ".display_name" %></th>
+      <% end %>
+      <% if show_creator_name %>
+      <th><%= t ".creator_name" %></th>
+      <% end %>
+      <th><%= t ".reason" %></th>
+      <th><%= t ".status" %></th>
+      <th><%= t ".revoker_name" %></th>
+      <th></th>
+      <th></th>
+      <% if show_revoke_link %>
+      <th></th>
+      <% end %>
+    </tr>
+  </thead>
   <%= render :partial => "block", :locals => { :show_revoke_link => show_revoke_link, :show_user_name => show_user_name, :show_creator_name => show_creator_name }, :collection => @user_blocks %>
 </table>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,22 +14,24 @@
     <%= hidden_field_tag :ip, params[:ip] if params[:ip] %>
     <%= hidden_field_tag :page, params[:page] if params[:page] %>
     <table id="user_list">
-      <tr>
-        <td colspan="2">
-          <%= t ".showing",
-                :page => @user_pages.current_page.number,
-                :first_item => @user_pages.current_page.first_item,
-                :last_item => @user_pages.current_page.last_item,
-                :items => @user_pages.item_count,
-                :count => @user_pages.current_page.last_item - @user_pages.current_page.first_item + 1 %>
-          <% if @user_pages.page_count > 1 %>
-          | <%= raw pagination_links_each(@user_pages, {}) { |n| link_to n, @params.merge(:page => n) } %>
-          <% end %>
-        </td>
-        <td>
-          <%= check_box_tag "user_all", "1", false %>
-        </td>
-      </tr>
+      <thead>
+        <tr>
+          <td colspan="2">
+            <%= t ".showing",
+                  :page => @user_pages.current_page.number,
+                  :first_item => @user_pages.current_page.first_item,
+                  :last_item => @user_pages.current_page.last_item,
+                  :items => @user_pages.item_count,
+                  :count => @user_pages.current_page.last_item - @user_pages.current_page.first_item + 1 %>
+            <% if @user_pages.page_count > 1 %>
+            | <%= raw pagination_links_each(@user_pages, {}) { |n| link_to n, @params.merge(:page => n) } %>
+            <% end %>
+          </td>
+          <td>
+            <%= check_box_tag "user_all", "1", false %>
+          </td>
+        </tr>
+      </thead>
       <%= render @users %>
     </table>
 


### PR DESCRIPTION
While working on replacing our stripy table logic with an out-of-the-box bootstrap solution, I ran into a problem with table header rows getting the stripes applied to them. This is because we're missing `<thead>` wrappers on some tables.

This PR adds those wrappers, which currently do nothing much, but will make the future bootstrap work easier and those future commits much smaller.