### PR TITLE
Remove ignoring of nearby column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,8 +46,6 @@
 class User < ApplicationRecord
   require "xml/libxml"
 
-  self.ignored_columns = ["nearby"]
-
   has_many :traces, -> { where(:visible => true) }
   has_many :diary_entries, -> { order(:created_at => :desc) }
   has_many :diary_comments, -> { order(:created_at => :desc) }


### PR DESCRIPTION
This is the final stage in the process. Now that the migrations are run, and apps restarted, it is safe to remove the ignore_column declaration.

Refs #2417 #2432 #2439 