### PR TITLE
Add In-Reply-To, References headers to email

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -94,13 +94,11 @@ class Notifier < ApplicationMailer
       @readurl = diary_entry_url(comment.diary_entry.user, comment.diary_entry, :anchor => "comment#{comment.id}")
       @commenturl = diary_entry_url(comment.diary_entry.user, comment.diary_entry, :anchor => "newcomment")
       @replyurl = new_message_url(comment.user, :message => { :title => "Re: #{comment.diary_entry.title}" })
-      @ref = "osm-diary-#{comment.diary_entry.id}@#{Settings.server_url}"
       @author = @from_user
 
       attach_user_avatar(comment.user)
 
-      headers["In-Reply-To"] = @ref
-      headers["References"]  = @ref
+      set_references("diary", comment.diary_entry)
 
       mail :from => from_address(comment.user.display_name, "c", comment.id, comment.digest, recipient.id),
            :to => recipient.email,
@@ -129,7 +127,6 @@ class Notifier < ApplicationMailer
       @comment = comment.body
       @owner = recipient == comment.note.author
       @event = comment.event
-      @ref = "osm-note-#{comment.note.id}@#{Settings.server_url}"
 
       @commenter = if comment.author
                      comment.author.display_name
@@ -140,8 +137,7 @@ class Notifier < ApplicationMailer
       @author = @commenter
       attach_user_avatar(comment.author)
 
-      headers["In-Reply-To"] = @ref
-      headers["References"]  = @ref
+      set_references("note", comment.note)
 
       subject = if @owner
                   I18n.t("notifier.note_comment_notification.#{@event}.subject_own", :commenter => @commenter)
@@ -164,7 +160,6 @@ class Notifier < ApplicationMailer
       @time = comment.created_at
       @changeset_author = comment.changeset.user.display_name
       @author = @commenter
-      @ref = "osm-changeset-#{comment.changeset.id}@#{Settings.server_url}"
 
       subject = if @owner
                   I18n.t("notifier.changeset_comment_notification.commented.subject_own", :commenter => @commenter)
@@ -174,8 +169,7 @@ class Notifier < ApplicationMailer
 
       attach_user_avatar(comment.author)
 
-      headers["In-Reply-To"] = @ref
-      headers["References"]  = @ref
+      set_references("changeset", comment.changeset)
 
       mail :to => recipient.email, :subject => subject
     end
@@ -220,5 +214,11 @@ class Notifier < ApplicationMailer
     else
       Settings.email_from
     end
+  end
+
+  def set_references(scope, reference_object)
+    ref = "osm-#{scope}-#{reference_object.id}@#{Settings.server_url}"
+    headers["In-Reply-To"] = ref
+    headers["References"]  = ref
   end
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -94,10 +94,13 @@ class Notifier < ApplicationMailer
       @readurl = diary_entry_url(comment.diary_entry.user, comment.diary_entry, :anchor => "comment#{comment.id}")
       @commenturl = diary_entry_url(comment.diary_entry.user, comment.diary_entry, :anchor => "newcomment")
       @replyurl = new_message_url(comment.user, :message => { :title => "Re: #{comment.diary_entry.title}" })
-
+      @ref = "osm-diary-#{comment.diary_entry.id}@#{Settings.server_url}"
       @author = @from_user
 
       attach_user_avatar(comment.user)
+
+      headers["In-Reply-To"] = @ref
+      headers["References"]  = @ref
 
       mail :from => from_address(comment.user.display_name, "c", comment.id, comment.digest, recipient.id),
            :to => recipient.email,
@@ -126,6 +129,7 @@ class Notifier < ApplicationMailer
       @comment = comment.body
       @owner = recipient == comment.note.author
       @event = comment.event
+      @ref = "osm-note-#{comment.note.id}@#{Settings.server_url}"
 
       @commenter = if comment.author
                      comment.author.display_name
@@ -135,6 +139,9 @@ class Notifier < ApplicationMailer
 
       @author = @commenter
       attach_user_avatar(comment.author)
+
+      headers["In-Reply-To"] = @ref
+      headers["References"]  = @ref
 
       subject = if @owner
                   I18n.t("notifier.note_comment_notification.#{@event}.subject_own", :commenter => @commenter)
@@ -157,6 +164,7 @@ class Notifier < ApplicationMailer
       @time = comment.created_at
       @changeset_author = comment.changeset.user.display_name
       @author = @commenter
+      @ref = "osm-changeset-#{comment.changeset.id}@#{Settings.server_url}"
 
       subject = if @owner
                   I18n.t("notifier.changeset_comment_notification.commented.subject_own", :commenter => @commenter)
@@ -165,6 +173,9 @@ class Notifier < ApplicationMailer
                 end
 
       attach_user_avatar(comment.author)
+
+      headers["In-Reply-To"] = @ref
+      headers["References"]  = @ref
 
       mail :to => recipient.email, :subject => subject
     end


### PR DESCRIPTION
Closes https://github.com/openstreetmap/openstreetmap-website/issues/2430

Context: _I'm subscribed to a blog post/changeset discussion/note and receive lots of emails by users replying to that post. As those emails don't include an In-Reply-To & References header, my inbox fills up with pages and pages of unrelated messages, rather than producing a nice threaded view of all emails._