### PR TITLE
Improve textarea behaviour

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2106,9 +2106,6 @@ textarea {
   padding: 5px;
   width: 100%;
   min-height: 50px;
-}
-
-textarea.comment {
   resize: vertical;
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2092,6 +2092,7 @@ textarea {
   color: #222;
   background-color: #fff;
   border: 1px solid $grey;
+  border-radius: 3px;
   padding: 2px 5px;
   margin: 0;
   width: 200px;
@@ -2104,6 +2105,11 @@ textarea {
 textarea {
   padding: 5px;
   width: 100%;
+  min-height: 50px;
+}
+
+textarea.comment {
+  resize: vertical;
 }
 
 /* Rules for user images */


### PR DESCRIPTION
This PR adds the `resize: vertical` CSS property to comment textareas to fix a problem, where they could be dragged beyond the sidebar.
Furthermore, I've added a `min-height` to all textareas to not let them be too small to enable the display of a scrolling bar.
I've also added a `border-radius` to form fields, to make them more consistent with what we do with buttons and tables.