### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,9 @@ Rails/SkipsModelValidations:
 Style/BracesAroundHashParameters:
   EnforcedStyle: context_dependent
 
+Style/Documentation:
+  Enabled: false
+
 Style/FormatStringToken:
   EnforcedStyle: template
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -211,4 +211,4 @@ Style/NumericLiterals:
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
-  Max: 307
+  Max: 260

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -174,10 +174,6 @@ Style/AsciiComments:
   Exclude:
     - 'test/models/message_test.rb'
 
-# Offense count: 263
-Style/Documentation:
-  Enabled: false
-
 # Offense count: 27
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: annotated, template, unannotated

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -40,7 +40,11 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         assert_difference("ActionMailer::Base.deliveries.size", 0) do
           perform_enqueued_jobs do
             post "/user/new",
-                 :params => { :user => { :email => dup_email, :email_confirmation => dup_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } },
+                 :params => { :user => { :email => dup_email,
+                                         :email_confirmation => dup_email,
+                                         :display_name => display_name,
+                                         :pass_crypt => "testtest",
+                                         :pass_crypt_confirmation => "testtest" } },
                  :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
           end
         end
@@ -61,7 +65,11 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         assert_difference("ActionMailer::Base.deliveries.size", 0) do
           perform_enqueued_jobs do
             post "/user/new",
-                 :params => { :user => { :email => email, :email_confirmation => email, :display_name => dup_display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } },
+                 :params => { :user => { :email => email,
+                                         :email_confirmation => email,
+                                         :display_name => dup_display_name,
+                                         :pass_crypt => "testtest",
+                                         :pass_crypt_confirmation => "testtest" } },
                  :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
           end
         end
@@ -82,7 +90,11 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         assert_difference("ActionMailer::Base.deliveries.size", 0) do
           perform_enqueued_jobs do
             post "/user/new",
-                 :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+                 :params => { :user => { :email => new_email,
+                                         :email_confirmation => new_email,
+                                         :display_name => display_name,
+                                         :pass_crypt => "testtest",
+                                         :pass_crypt_confirmation => "testtest" } }
           end
         end
       end
@@ -124,7 +136,11 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         assert_difference("ActionMailer::Base.deliveries.size", 0) do
           perform_enqueued_jobs do
             post "/user/new",
-                 :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" } }
+                 :params => { :user => { :email => new_email,
+                                         :email_confirmation => new_email,
+                                         :display_name => display_name,
+                                         :pass_crypt => "testtest",
+                                         :pass_crypt_confirmation => "testtest" } }
           end
         end
       end
@@ -160,10 +176,20 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => password, :pass_crypt_confirmation => password }, :referer => referer }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :pass_crypt => password,
+                                       :pass_crypt_confirmation => password },
+                            :referer => referer }
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :pass_crypt => password, :pass_crypt_confirmation => password }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :pass_crypt => password,
+                                       :pass_crypt_confirmation => password },
+                            :read_ct => 1, :read_tou => 1 }
           follow_redirect!
         end
       end
@@ -208,7 +234,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "openid",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
@@ -218,7 +250,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => password, :pass_crypt_confirmation => password }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "openid",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => password,
+                                       :pass_crypt_confirmation => password },
+                            :read_ct => 1, :read_tou => 1 }
           assert_response :redirect
           follow_redirect!
         end
@@ -241,7 +280,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "openid",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
@@ -273,7 +318,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "openid",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" },
+                            :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
@@ -283,7 +335,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "openid", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "openid",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" },
+                            :read_ct => 1, :read_tou => 1 }
           follow_redirect!
         end
       end
@@ -330,7 +389,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "google",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
           follow_redirect!
@@ -340,7 +404,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "google",
+                                       :auth_uid => "123454321",
+                                       :pass_crypt => password,
+                                       :pass_crypt_confirmation => password },
+                            :read_ct => 1, :read_tou => 1 }
           assert_response :redirect
           follow_redirect!
         end
@@ -363,7 +434,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "google",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
           follow_redirect!
@@ -397,7 +473,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "google",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" },
+                            :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
           follow_redirect!
@@ -407,7 +489,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "google", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "google",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" },
+                            :read_ct => 1, :read_tou => 1 }
           follow_redirect!
         end
       end
@@ -452,7 +541,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "facebook",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
           follow_redirect!
@@ -462,7 +556,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "facebook",
+                                       :auth_uid => "123454321",
+                                       :pass_crypt => password,
+                                       :pass_crypt_confirmation => password },
+                            :read_ct => 1, :read_tou => 1 }
           assert_response :redirect
           follow_redirect!
         end
@@ -485,7 +586,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "facebook",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
           follow_redirect!
@@ -517,7 +623,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "facebook",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" },
+                            :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
           follow_redirect!
@@ -527,7 +639,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "facebook", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "facebook",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" },
+                            :read_ct => 1, :read_tou => 1 }
           follow_redirect!
         end
       end
@@ -572,7 +691,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "windowslive",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
           follow_redirect!
@@ -582,7 +706,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "windowslive",
+                                       :auth_uid => "123454321",
+                                       :pass_crypt => password,
+                                       :pass_crypt_confirmation => password },
+                            :read_ct => 1, :read_tou => 1 }
           assert_response :redirect
           follow_redirect!
         end
@@ -605,7 +736,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "windowslive",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
           follow_redirect!
@@ -637,7 +773,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "windowslive",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" },
+                            :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
           follow_redirect!
@@ -647,7 +789,14 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "windowslive", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "windowslive",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" },
+                            :read_ct => 1, :read_tou => 1 }
           follow_redirect!
         end
       end
@@ -692,7 +841,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "github",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
           follow_redirect!
@@ -702,7 +856,15 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "github",
+                                       :auth_uid => "123454321",
+                                       :pass_crypt => password,
+                                       :pass_crypt_confirmation => password },
+                            :read_ct => 1,
+                            :read_tou => 1 }
           assert_response :redirect
           follow_redirect!
         end
@@ -725,7 +887,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "github",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
           follow_redirect!
@@ -757,7 +924,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "github",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" },
+                            :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
           follow_redirect!
@@ -767,7 +940,15 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "github", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "github",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" },
+                            :read_ct => 1,
+                            :read_tou => 1 }
           follow_redirect!
         end
       end
@@ -812,7 +993,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "wikipedia",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
@@ -822,7 +1008,15 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :auth_uid => "123454321", :pass_crypt => password, :pass_crypt_confirmation => password }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "wikipedia",
+                                       :auth_uid => "123454321",
+                                       :pass_crypt => password,
+                                       :pass_crypt_confirmation => password },
+                            :read_ct => 1,
+                            :read_tou => 1 }
           assert_response :redirect
           follow_redirect!
         end
@@ -845,7 +1039,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" } }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "wikipedia",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
@@ -877,7 +1076,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
           post "/user/new",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :pass_crypt => "", :pass_crypt_confirmation => "" }, :referer => referer }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "wikipedia",
+                                       :pass_crypt => "",
+                                       :pass_crypt_confirmation => "" },
+                            :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
@@ -887,7 +1092,15 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
-               :params => { :user => { :email => new_email, :email_confirmation => new_email, :display_name => display_name, :auth_provider => "wikipedia", :auth_uid => "http://localhost:1123/new.tester", :pass_crypt => "testtest", :pass_crypt_confirmation => "testtest" }, :read_ct => 1, :read_tou => 1 }
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :auth_provider => "wikipedia",
+                                       :auth_uid => "http://localhost:1123/new.tester",
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" },
+                            :read_ct => 1,
+                            :read_tou => 1 }
           follow_redirect!
         end
       end


### PR DESCRIPTION
Just two rubocop fixes while I was doing other stuff, namely:

* We're unlikely to ever document every method of our ruby code, so move the config out of the todo list
* Refactor some params hashes in the tests to reduce the maximum line length