### PR TITLE
CSS fixes for headings

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -5,11 +5,10 @@
 
 /* Minimal CSS reset */
 
-html, body, ul, ol, li, form, fieldset, legend, h1, h2, h3, h4, h5, h6, p, input {
+html, body, ul, ol, li, form, fieldset, legend, input {
   margin: 0;
   padding: 0;
   border: 0;
-  font-size:100%;
 }
 
 fieldset,img { border: 0; }
@@ -542,8 +541,6 @@ body.compact {
   #sidebar {
     float: left;
     width: $sidebarWidth;
-    background: #fff;
-    font-size: 12px;
 
     #sidebar_loader {
       display: none;
@@ -558,12 +555,13 @@ body.compact {
 
     h2 {
       padding: $lineheight $lineheight $lineheight/2;
+      font-size: 1.5rem;
     }
 
     h3, h4 {
       margin-top: $lineheight;
       margin-bottom: $lineheight/2;
-      font-size: 13px;
+      font-size: 1.25rem;
     }
 
     .close-wrap {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1382,8 +1382,6 @@ tr.turn:hover {
 
 .content-heading {
   background: $lightgrey;
-
-  h1 { font-size: 22px; }
 }
 
 .content-body {
@@ -1680,7 +1678,6 @@ tr.turn:hover {
     h2 {
       margin-top: 0;
       margin-bottom: $lineheight/2;
-      font-size: 24px;
     }
   }
 
@@ -2307,18 +2304,6 @@ a.button {
     padding-bottom: $lineheight/2;
     border-bottom: 1px dashed $grey;
     margin-bottom: $lineheight/2;
-  }
-
-  h1 {
-    font-size: 24px;
-  }
-
-  h2 {
-    font-size: 18px;
-  }
-
-  h3 {
-    font-size: $typeheight;
   }
 
   code {


### PR DESCRIPTION
This fixes a number of issues with the headings, by removing some reset rules (that are acting after the bootstrap reset + defaults and so are messing things up) and by removing some custom heading font sizes and allowing the bootstrap values to be used.

I've overridden the heading sizes for the sidebar temporarily (roughly making h2 the same as bootstrap h3, and h3/h4 the same as bootstrap h5) since there's a bunch of specific style rules preventing me from changing e.g. h2 -> h3. For example, the h2 in sidebar gets extra left padding, since it isn't included in the sidebar browse-section. Fixing all that will come in a future PR.