### PR TITLE
Trace CSS badges

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -27,7 +27,7 @@
 @import "bootstrap/card";
 // @import "bootstrap/breadcrumb";
 // @import "bootstrap/pagination";
-// @import "bootstrap/badge";
+@import "bootstrap/badge";
 // @import "bootstrap/jumbotron";
 // @import "bootstrap/alert";
 // @import "bootstrap/progress";

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1487,7 +1487,6 @@ tr.turn:hover {
 /* Rules for the trace list shown by the traces tab etc */
 
 #trace_list {
-  font-size: $lineheight/2;
   border-width: 0px;
   text-align: right;
 
@@ -1642,7 +1641,6 @@ tr.turn:hover {
 /* Rules for the user list */
 
 #user_list {
-  font-size: $lineheight/2;
   width: 100%;
 
   tr {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1494,22 +1494,6 @@ tr.turn:hover {
     font-size: 12px;
     color: gray;
   }
-
-  .trace_public {
-    color: green;
-  }
-
-  .trace_identifiable {
-    color: green;
-  }
-
-  .trace_trackable {
-    color: red;
-  }
-
-  .trace_private {
-    color: red;
-  }
 }
 
 /* Rules for the trace view */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1496,14 +1496,6 @@ tr.turn:hover {
   }
 }
 
-/* Rules for the trace view */
-
-.trace-show {
-  .geo {
-    display: inline;
-  }
-}
-
 /* Rules for the new trace form */
 
 #new_trace {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1495,10 +1495,6 @@ tr.turn:hover {
     color: gray;
   }
 
-  .trace_pending {
-    color: red;
-  }
-
   .trace_public {
     color: green;
   }
@@ -1519,10 +1515,6 @@ tr.turn:hover {
 /* Rules for the trace view */
 
 .trace-show {
-  .trace_pending {
-    color: red;
-  }
-
   .geo {
     display: inline;
   }

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -5,7 +5,7 @@
       <% if trace.inserted %>
         <a href="<%= url_for :controller => "traces", :action => "show", :id => trace.id, :display_name => trace.user.display_name %>"><img src="<%= url_for :controller => "traces", :action => "icon", :id => trace.id, :display_name => trace.user.display_name %>" border="0" alt="" /></a>
       <% else %>
-        <span class="trace_pending"><%= t ".pending" %></span>
+        <span class="text-danger"><%= t ".pending" %></span>
       <% end %>
     <% end %>
   </td>

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -17,7 +17,13 @@
       ... <%= time_ago_in_words(trace.timestamp, :scope => :'datetime.distance_in_words_ago') %></span>
       <%= link_to_if trace.inserted?, t(".map"), { :controller => "site", :action => "index", :mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}" }, { :title => t(".view_map") } %> /
       <%= link_to t(".edit"), { :controller => "site", :action => "edit", :gpx => trace.id }, { :title => t(".edit_map") } %>
-      <span class="trace_<%= trace.visibility %>"><%= t("." + trace.visibility) %></span>
+
+      <% badge_class = case trace.visibility
+                       when "public", "identifiable" then "success"
+                       else "danger"
+                       end %>
+      <span class="badge badge-<%= badge_class %> text-white"><%= t("." + trace.visibility) %></span>
+
       <br />
       <%= trace.description %>
     <br />

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -6,7 +6,7 @@
   <% if @trace.inserted %>
     <img src="<%= url_for :controller => "traces", :action => "picture", :id => @trace.id, :display_name => @trace.user.display_name %>">
   <% else %>
-    <span class="trace_pending"><%= t ".pending" %></span>
+    <span class="text-danger"><%= t ".pending" %></span>
   <% end %>
 <% end %>
 

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -25,7 +25,7 @@
     <td><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/, '\1,') %></td></tr>
   <tr>
     <td><%= t ".start_coordinates" %></td>
-    <td><div class="geo"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%= link_to t(".map"), :controller => "site", :action => "index", :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%= link_to t(".edit"), :controller => "site", :action => "edit", :gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
+    <td><div class="d-inline"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%= link_to t(".map"), :controller => "site", :action => "index", :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%= link_to t(".edit"), :controller => "site", :action => "edit", :gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
   </tr>
   <% end %>
   <tr>


### PR DESCRIPTION
This PR makes a few minor changes to the traces display. It replaces some custom CSS with a combination of bootstrap badges, text-styles and inline display for the geo microformat.