### PR TITLE
Use a warning alert for reporting new issues

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -29,7 +29,7 @@
 // @import "bootstrap/pagination";
 // @import "bootstrap/badge";
 // @import "bootstrap/jumbotron";
-// @import "bootstrap/alert";
+@import "bootstrap/alert";
 // @import "bootstrap/progress";
 // @import "bootstrap/media";
 // @import "bootstrap/list-group";

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2890,12 +2890,6 @@ input.richtext_title[type="text"] {
 }
 
 .report-disclaimer {
-  background: #fff1f0;
-  color: #d85030;
-  border-color: rgba(216, 80, 48, 0.3);
-  padding: 10px 20px;
-  margin-bottom: $lineheight;
-
   ul {
     padding-left: $lineheight;
     margin-bottom: 0;

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t ".title_html", :link => link_to(reportable_title(@report.issue.reportable), reportable_url(@report.issue.reportable)) %></h1>
 <% end %>
 
-<div class="report-disclaimer">
+<div class="alert alert-warning report-disclaimer">
   <%= t(".disclaimer.intro") %>
   <ul>
     <li> <%= t(".disclaimer.not_just_mistake") %> </li>


### PR DESCRIPTION
This removes custom colouring for the alert. The list overrides need to stay until we unpick more of our custom styling.