### PR TITLE
Use SI unit symbols for leaflet-locatecontrol

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -108,6 +108,8 @@ $(document).ready(function () {
     icon: "icon geolocate",
     iconLoading: "icon geolocate",
     strings: {
+      metersUnit: 'm',
+      feetUnit: 'ft',
       title: I18n.t("javascripts.map.locate.title"),
       popup: I18n.t("javascripts.map.locate.popup")
     }


### PR DESCRIPTION
As an alternative to #2475, this PR uses the [SI unit symbols](https://en.wikipedia.org/wiki/International_System_of_Units) "m"/"ft" instead of the English strings "meters"/"feet".

According to https://ja.wikipedia.org/wiki/%E3%83%A1%E3%83%BC%E3%83%88%E3%83%AB, https://ru.wikipedia.org/wiki/%D0%9C%D0%B5%D1%82%D1%80, https://zh.wikipedia.org/wiki/%E7%B1%B3_(%E5%8D%95%E4%BD%8D), https://www.wikidata.org/wiki/Q11573, "m" seems to be in use for many/most languages.