### PR TITLE
Remove the dashed underline from prose headings

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2269,12 +2269,6 @@ a.button {
 
 .richtext,
 .prose {
-  h1, h2 {
-    padding-bottom: $lineheight/2;
-    border-bottom: 1px dashed $grey;
-    margin-bottom: $lineheight/2;
-  }
-
   code {
     font-size: 13px;
     background: $lightgrey;


### PR DESCRIPTION
No other headings are underlined, and the underlines look more like a section separator (e.g. dashed hr) and so visually separated the heading from its content.