### PR TITLE
Reinstate background colour for sidebars

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -541,6 +541,7 @@ body.compact {
   #sidebar {
     float: left;
     width: $sidebarWidth;
+    background: #fff;
 
     #sidebar_loader {
       display: none;


### PR DESCRIPTION
This is required when the sidebar overlaps the map, for example whenit is not full height on the welcome message.