### PR TITLE
Avoid using `raw` with translation strings

### DIFF
--- a/app/views/browse/_containing_relation.html.erb
+++ b/app/views/browse/_containing_relation.html.erb
@@ -1,7 +1,7 @@
 <li><%= linked_name = link_to h(printable_name(containing_relation.relation)), :action => "relation", :id => containing_relation.relation.id.to_s
         if containing_relation.member_role.blank?
-          raw t ".entry", :relation_name => linked_name
+          t ".entry_html", :relation_name => linked_name
         else
-          raw t ".entry_role", :relation_name => linked_name, :relation_role => h(containing_relation.member_role)
+          t ".entry_role_html", :relation_name => linked_name, :relation_role => h(containing_relation.member_role)
         end %>
 </li>

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -3,8 +3,8 @@
    type_str = t ".type." + relation_member.member_type.downcase %>
 <li class="<%= member_class %>">
   <%= if relation_member.member_role.blank?
-        raw t ".entry", :type => type_str, :name => linked_name
+        t ".entry_html", :type => type_str, :name => linked_name
       else
-        raw t ".entry_role", :type => type_str, :name => linked_name, :role => h(relation_member.member_role)
+        t ".entry_role_html", :type => type_str, :name => linked_name, :role => h(relation_member.member_role)
       end %>
 </li>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -25,7 +25,7 @@
             <%= link_to printable_name(wn.node), { :action => "node", :id => wn.node_id.to_s }, { :class => link_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>
             <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
             <% if related_ways.size > 0 then %>
-              (<%= raw t ".also_part_of", :count => related_ways.size, :related_ways => related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, { :class => link_class("way", w), :title => link_title(w) }) }.to_sentence %>)
+              (<%= t ".also_part_of_html", :count => related_ways.size, :related_ways => to_sentence(related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, { :class => link_class("way", w), :title => link_title(w) }) }) %>)
             <% end %>
           </li>
         <% end %>

--- a/app/views/browse/feature.html.erb
+++ b/app/views/browse/feature.html.erb
@@ -2,7 +2,7 @@
 
 <h2>
   <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-  <%= raw t("browse.#{@type}.title", :name => printable_name(@feature)) %>
+  <%= t("browse.#{@type}.title_html", :name => printable_name(@feature)) %>
 </h2>
 
 <%= render :partial => @type, :object => @feature %>

--- a/app/views/browse/history.html.erb
+++ b/app/views/browse/history.html.erb
@@ -2,7 +2,7 @@
 
 <h2>
   <a class="geolink" href="<%= root_path %>"><span class="icon close"></span></a>
-  <%= raw t("browse.#{@type}.history_title", :name => printable_name(@feature)) %>
+  <%= t("browse.#{@type}.history_title_html", :name => printable_name(@feature)) %>
 </h2>
 
 <%= render :partial => @type, :collection => @feature.send("old_#{@type}s").reverse %>

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="clearfix diary-comment<%= " deemphasize" unless diary_comment.visible? %>">
   <%= user_thumbnail diary_comment.user %>
-  <p class="deemphasize comment-heading" id="comment<%= diary_comment.id %>"><%= raw(t(".comment_from", :link_user => (link_to h(diary_comment.user.display_name), user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}"))) %>
+  <p class="deemphasize comment-heading" id="comment<%= diary_comment.id %>"><%= t(".comment_from_html", :link_user => (link_to h(diary_comment.user.display_name), user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}")) %>
     <% if current_user and diary_comment.user.id != current_user.id %>
       | <%= report_link(t(".report"), diary_comment) %>
     <% end %>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -7,7 +7,7 @@
     <h2><%= link_to h(diary_entry.title), diary_entry_path(diary_entry.user, diary_entry) %></h2>
 
     <small class='deemphasize'>
-      <%= raw(t(".posted_by", :link_user => (link_to h(diary_entry.user.display_name), user_path(diary_entry.user)), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to h(diary_entry.language.name), :controller => "diary_entries", :action => "index", :display_name => nil, :language => diary_entry.language_code))) %>
+      <%= t(".posted_by_html", :link_user => (link_to h(diary_entry.user.display_name), user_path(diary_entry.user)), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to diary_entry.language.name, :controller => "diary_entries", :action => "index", :display_name => nil, :language => diary_entry.language_code)) %>
     </small>
 
   </div>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -29,7 +29,7 @@
       <div class="diary-subscribe-buttons"><%= link_to t("javascripts.changesets.show.subscribe"), diary_entry_subscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => :button %></div>
     <% end %>
   <% else %>
-    <h3 id="newcomment"><%= raw t(".login_to_leave_a_comment", :login_link => link_to(t(".login"), :controller => "users", :action => "login", :referer => request.fullpath)) %></h3>
+    <h3 id="newcomment"><%= t(".login_to_leave_a_comment_html", :login_link => link_to(t(".login"), :controller => "users", :action => "login", :referer => request.fullpath)) %></h3>
   <% end %>
 </div>
 

--- a/app/views/geocoder/search.html.erb
+++ b/app/views/geocoder/search.html.erb
@@ -5,7 +5,7 @@
     <%= t("site.sidebar.search_results") %>
 </h2>
 <% @sources.each do |source| %>
-  <h4 class="inner12"><%= raw(t(".title.#{source}")) %></h4>
+  <h4 class="inner12"><%= t(".title.#{source}_html") %></h4>
   <div class="search_results_entry" data-href="<%= url_for @params.merge(:action => "search_#{source}") %>">
     <%= image_tag "searching.gif", :class => "loader" %>
   </div>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -24,5 +24,5 @@
     </tbody>
   </table>
 <% else %>
-  <div><%= raw(t(".no_messages_yet", :people_mapping_nearby_link => link_to(t(".people_mapping_nearby"), user_path(current_user)))) %></div>
+  <div><%= t(".no_messages_yet_html", :people_mapping_nearby_link => link_to(t(".people_mapping_nearby"), user_path(current_user))) %></div>
 <% end %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= raw(t(".send_message_to", :name => link_to(h(@message.recipient.display_name), user_path(@message.recipient)))) %></h2>
+  <h2><%= t(".send_message_to_html", :name => link_to(h(@message.recipient.display_name), user_path(@message.recipient))) %></h2>
 <% end %>
 
 <%= error_messages_for "message" %>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h2><%= raw(t(".my_inbox", :inbox_link => link_to(t(".inbox"), inbox_messages_path))) %>/<%= t ".outbox" %></h2>
+  <h2><%= t(".my_inbox_html", :inbox_link => link_to(t(".inbox"), inbox_messages_path)) %>/<%= t ".outbox" %></h2>
 <% end %>
 
 <h4><%= t ".messages", :count => current_user.sent_messages.size %></h4>
@@ -23,5 +23,5 @@
     </tbody>
   </table>
 <% else %>
-  <div class="messages"><%= raw(t(".no_sent_messages", :people_mapping_nearby_link => link_to(t(".people_mapping_nearby"), user_path(current_user)))) %></div>
+  <div class="messages"><%= t(".no_sent_messages_html", :people_mapping_nearby_link => link_to(t(".people_mapping_nearby"), user_path(current_user))) %></div>
 <% end %>

--- a/app/views/oauth/authorize.html.erb
+++ b/app/views/oauth/authorize.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
-<p><%= raw t(".request_access", :app_name => link_to(@token.client_application.name, @token.client_application.url), :user => link_to(current_user.display_name, user_path(current_user))) %></p>
+<p><%= t(".request_access_html", :app_name => link_to(@token.client_application.name, @token.client_application.url), :user => link_to(current_user.display_name, user_path(current_user))) %></p>
 
 <%= form_tag authorize_url do %>
   <%= hidden_field_tag "oauth_token", @token.token %>

--- a/app/views/oauth/authorize_success.html.erb
+++ b/app/views/oauth/authorize_success.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
-<p><%= raw t(".allowed", :app_name => link_to(@token.client_application.name, @token.client_application.url)) %></p>
+<p><%= t(".allowed_html", :app_name => link_to(@token.client_application.name, @token.client_application.url)) %></p>
 
 <% if @token.oob? and not @token.oauth10? %>
 <p><%= t ".verification", :code => @token.verifier %></p>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -29,7 +29,7 @@
 <% end %>
 <h3><%= t ".my_apps" %></h3>
 <% if @client_applications.empty? %>
-<p><%= raw(t(".no_apps", :oauth => "<a href=\"https://oauth.net\">OAuth</a>")) %></p>
+<p><%= t(".no_apps_html", :oauth => link_to(t(".oauth"), "https://oauth.net" )) %></p>
 <% else %>
 <p><%= t ".registered_apps" %></p>
 <% @client_applications.each do |client| %>

--- a/app/views/site/_potlatch.html.erb
+++ b/app/views/site/_potlatch.html.erb
@@ -6,5 +6,5 @@
   <% data[:lat] = @lat if @lat -%>
   <% data[:lon] = @lon if @lon -%>
   <% data[:zoom] = @zoom if @zoom -%>
-  <%= content_tag :div, raw(t("site.edit.flash_player_required")), :id => "potlatch", :data => data %>
+  <%= content_tag :div, t("site.edit.flash_player_required_html"), :id => "potlatch", :data => data %>
 </div>

--- a/app/views/site/_potlatch2.html.erb
+++ b/app/views/site/_potlatch2.html.erb
@@ -15,5 +15,5 @@
   <% end %>
   <% data[:locale] = Locale.list(Potlatch2::LOCALES.keys).preferred(preferred_languages).to_s -%>
   <% data[:locale_path] = asset_path("potlatch2/locales/#{Potlatch2::LOCALES[data[:locale]]}.swf") -%>
-  <%= content_tag :div, raw(t("site.edit.flash_player_required")), :id => "potlatch", :data => data %>
+  <%= content_tag :div, t("site.edit.flash_player_required_html"), :id => "potlatch", :data => data %>
 </div>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -5,7 +5,7 @@
 
   <div class='user-image'></div>
 
-  <h1><%= raw t ".used_by", :name => "<span class='user-name'>OpenStreetMap</span>" %></h1>
+  <h1><%= t ".used_by_html", :name => content_tag(:span, "OpenStreetMap", :class => "user-name") %></h1>
 </div>
 
 <div class='text'>

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -6,14 +6,14 @@
       <%= tag.h1 :lang => @locale, :dir => t("html.dir", :locale => @locale) do %>
         <h1><%= t ".native.title" %></h1>
         <p>
-          <%= raw t ".native.text",
-                    :native_link => link_to(t(".native.native_link"),
-                                            :controller => "site",
-                                            :action => "copyright",
-                                            :copyright_locale => nil),
-                    :mapping_link => link_to(t(".native.mapping_link"),
-                                             :controller => "site",
-                                             :action => "index") %>
+          <%= t ".native.html",
+              :native_link => link_to(t(".native.native_link"),
+                                      :controller => "site",
+                                      :action => "copyright",
+                                      :copyright_locale => nil),
+              :mapping_link => link_to(t(".native.mapping_link"),
+                                       :controller => "site",
+                                       :action => "index") %>
         </p>
       <% end %>
       <hr />
@@ -24,11 +24,11 @@
       <% if t(".legal_babble", :locale => @locale) != t(".legal_babble", :locale => :en) %>
         <h1><%= t ".foreign.title" %></h1>
         <p>
-          <%= raw t ".foreign.text",
-                    :english_original_link => link_to(t(".foreign.english_link"),
-                                                      :controller => "site",
-                                                      :action => "copyright",
-                                                      :copyright_locale => "en") %>
+          <%= t ".foreign.html",
+              :english_original_link => link_to(t(".foreign.english_link"),
+                                                :controller => "site",
+                                                :action => "copyright",
+                                                :copyright_locale => "en") %>
         </p>
       <% end %>
       <hr />

--- a/app/views/site/edit.html.erb
+++ b/app/views/site/edit.html.erb
@@ -5,8 +5,8 @@
     <p><%= t "layouts.osm_read_only" %></p>
   <% elsif !current_user.data_public? %>
     <p><%= t ".not_public" %></p>
-    <p><%= raw t ".not_public_description", :user_page => (link_to t(".user_page_link"), :controller => "users", :action => "account", :display_name => current_user.display_name, :anchor => "public") %></p>
-    <p><%= raw t "site.edit.anon_edits", :link => link_to(t(".anon_edits_link_text"), t(".anon_edits_link")) %></p>
+    <p><%= t ".not_public_description_html", :user_page => (link_to t(".user_page_link"), :controller => "users", :action => "account", :display_name => current_user.display_name, :anchor => "public") %></p>
+    <p><%= t ".anon_edits_html", :link => link_to(t(".anon_edits_link_text"), t(".anon_edits_link")) %></p>
   <% else %>
     <%= render :partial => preferred_editor %>
   <% end %>

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -21,7 +21,7 @@
   </div>
 
   <h4><%= t ".licence" %></h4>
-  <p><%= raw t ".export_details" %></p>
+  <p><%= t ".export_details_html" %></p>
 
   <div id="export_osm_too_large">
     <p class="warning">

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -24,7 +24,7 @@
     <%= t ".by" %> <%= link_to h(trace.user.display_name), user_path(trace.user) %>
     <% if !trace.tags.empty? %>
       <%= t ".in" %>
-      <%= raw(trace.tags.collect { |tag| link_to_tag tag.tag }.join(", ")) %>
+      <%= safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>
     <% end %>
   </td>
 </tr>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -40,7 +40,7 @@
     <td><%= t ".tags" %></td>
     <td>
     <% unless @trace.tags.empty? %>
-      <%= raw(@trace.tags.collect { |tag| link_to tag.tag, :controller => "traces", :action => "index", :tag => tag.tag, :id => nil }.join(", ")) %>
+      <%= safe_join(@trace.tags.collect { |tag| link_to tag.tag, :controller => "traces", :action => "index", :tag => tag.tag, :id => nil }, ", ") %>
     <% else %>
       <i><%= t ".none" %></i>
     <% end %>

--- a/app/views/user_blocks/blocks_by.html.erb
+++ b/app/views/user_blocks/blocks_by.html.erb
@@ -1,6 +1,6 @@
 <% @title = t(".title", :name => h(@user.display_name)) %>
 <% content_for :heading do %>
-  <h1><%= raw(t(".heading", :name => link_to(h(@user.display_name), user_path(@user)))) %></h1>
+  <h1><%= t(".heading_html", :name => link_to(@user.display_name, user_path(@user))) %></h1>
 <% end %>
 
 <% unless @user_blocks.empty? %>

--- a/app/views/user_blocks/blocks_on.html.erb
+++ b/app/views/user_blocks/blocks_on.html.erb
@@ -1,6 +1,6 @@
 <% @title = t(".title", :name => h(@user.display_name)) %>
 <% content_for :heading do %>
-  <h1><%= raw(t(".heading", :name => link_to(h(@user.display_name), user_path(@user)))) %></h1>
+  <h1><%= t(".heading_html", :name => link_to(@user.display_name, user_path(@user))) %></h1>
 <% end %>
 <% unless @user_blocks.empty? %>
 <%= render :partial => "blocks", :locals => { :show_revoke_link => can?(:revoke, UserBlock), :show_user_name => false, :show_creator_name => true } %>

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -1,8 +1,8 @@
 <% @title = t ".title", :name => h(@user_block.user.display_name) %>
 <% content_for :heading do %>
-  <h1><%= raw t(".title",
-                :name => link_to(h(@user_block.user.display_name),
-                                 user_path(@user_block.user))) %></h1>
+  <h1><%= t(".heading_html",
+            :name => link_to(@user_block.user.display_name,
+                             user_path(@user_block.user))) %></h1>
   <ul class='secondary-actions clearfix'>
     <li><%= link_to t(".show"), @user_block %></li>
     <li><%= link_to t(".back"), user_blocks_path %></li>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -1,8 +1,8 @@
 <% @title = t ".title", :name => h(@user.display_name) %>
 <% content_for :heading do %>
-  <h1><%= raw t(".heading",
-                :name => link_to(h(@user.display_name),
-                                 user_path(@user))) %></h1>
+  <h1><%= t(".heading_html",
+            :name => link_to(@user.display_name,
+                             user_path(@user))) %></h1>
 <% end %>
 <%= form_for(@user_block) do |f| %>
   <%= f.error_messages %>

--- a/app/views/user_blocks/revoke.html.erb
+++ b/app/views/user_blocks/revoke.html.erb
@@ -3,11 +3,11 @@
               :block_by => h(@user_block.creator.display_name)) %>
 
 <% content_for :heading do %>
-  <h1><%= raw t(".heading",
-                :block_on => link_to(h(@user_block.user.display_name),
-                                     user_path(@user_block.user)),
-                :block_by => link_to(h(@user_block.creator.display_name),
-                                     user_path(@user_block.creator))) %></h1>
+  <h1><%= t(".heading_html",
+            :block_on => link_to(@user_block.user.display_name,
+                                 user_path(@user_block.user)),
+            :block_by => link_to(@user_block.creator.display_name,
+                                 user_path(@user_block.creator))) %></h1>
 <% end %>
 
 <% if @user_block.ends_at > Time.now %>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -3,11 +3,11 @@
               :block_by => @user_block.creator.display_name) %>
 
 <% content_for :heading do %>
-  <h1><%= raw t(".heading",
-                :block_on => link_to(h(@user_block.user.display_name),
-                                     user_path(@user_block.user)),
-                :block_by => link_to(h(@user_block.creator.display_name),
-                                     user_path(@user_block.creator))) %></h1>
+  <h1><%= t(".heading_html",
+            :block_on => link_to(@user_block.user.display_name,
+                                 user_path(@user_block.user)),
+            :block_by => link_to(@user_block.creator.display_name,
+                                 user_path(@user_block.creator))) %></h1>
 <ul class='secondary-actions clearfix'>
   <% if @user_block.ends_at > Time.now.getutc %>
     <% if current_user and current_user.id == @user_block.creator_id %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -7,14 +7,14 @@
   <td>
     <p>
       <% if user.creation_ip %>
-        <%= raw t "users.index.summary",
-                  :name => link_to(h(user.display_name), user_path(user)),
-                  :ip_address => link_to(user.creation_ip, :ip => user.creation_ip),
-                  :date => l(user.creation_time, :format => :friendly) %>
+        <%= t "users.index.summary_html",
+              :name => link_to(h(user.display_name), user_path(user)),
+              :ip_address => link_to(user.creation_ip, :ip => user.creation_ip),
+              :date => l(user.creation_time, :format => :friendly) %>
       <% else %>
-        <%= raw t "users.index.summary_no_ip",
-                  :name => link_to(h(user.display_name), user_path(user)),
-                  :date => l(user.creation_time, :format => :friendly) %>
+        <%= t "users.index.summary_no_ip_html",
+              :name => link_to(h(user.display_name), user_path(user)),
+              :date => l(user.creation_time, :format => :friendly) %>
       <% end %>
     </p>
     <div class="richtext"><%= user.description.to_html %></div>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -175,6 +175,6 @@
 <% unless current_user.data_public? %>
 <a name="public"></a>
 <h2><%= t ".public editing note.heading" %></h2>
-<%= raw t ".public editing note.text" %>
+<%= t ".public editing note.html" %>
   <%= button_to t(".make edits public button"), :action => :go_public %>
 <% end %>

--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -6,5 +6,5 @@
 
 <div class="message">
   <h1><%= t "users.new.no_auto_account_create" %></h1>
-  <h2><%= raw t "users.new.contact_webmaster", :webmaster => "mailto:#{Settings.support_email}" %></h2>
+  <h2><%= t "users.new.contact_webmaster_html", :webmaster => "mailto:#{Settings.support_email}" %></h2>
 </div>

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -74,7 +74,7 @@
         </ul>
 
         <div id='login_openid_url' class='form-row'>
-          <label for='openid_url' class="standard-label"><%= raw t ".openid", :logo => openid_logo %></label>
+          <label for='openid_url' class="standard-label"><%= t ".openid_html", :logo => openid_logo %></label>
           <%= hidden_field_tag("openid_referer", params[:referer]) if params[:referer] %>
           <%= text_field_tag("openid_url", "", :tabindex => 3, :class => "openid_url") %>
           <span class="minorNote">(<a href="<%= t "users.account.openid.link" %>" target="_new"><%= t "users.account.openid.link text" %></a>)</span>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -26,7 +26,7 @@
       <%= f.email_field(:email_confirmation, :tabindex => 2) %>
       <%= f.error_message_on(:email_confirmation) %>
     </div>
-    <span class="form-help deemphasize"><%= raw(t(".not displayed publicly")) %></span>
+    <span class="form-help deemphasize"><%= t(".not_displayed_publicly_html") %></span>
   </fieldset>
 
   <fieldset>
@@ -43,7 +43,7 @@
   <fieldset class="form-divider" id="auth_field">
     <div class="form-row">
       <label for="openid_url" class="standard-label">
-        <%= raw t ".external auth" %>
+        <%= t ".external auth" %>
       </label>
       <%= f.select(:auth_provider, Auth::PROVIDERS, :default => "", :tabindex => 4) %>
       <%= f.text_field(:auth_uid, :tabindex => 5) %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -70,7 +70,7 @@
   </fieldset>
 
   <div id="auth_prompt" class="form-row">
-    <%= link_to raw(t(".use external auth")), "#", :id => "auth_enable" %>
+    <%= link_to t(".use external auth"), "#", :id => "auth_enable" %>
   </div>
 
   <%= submit_tag t(".continue"), :tabindex => 8 %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -183,7 +183,7 @@
   <% if current_user and @user.id == current_user.id %>
     <% if @user.home_lat.nil? or @user.home_lon.nil? %>
       <div id="map" class="content_map">
-        <p id="no_home_location"><%= raw(t(".if set location", :settings_link => (link_to t(".settings_link_text"), :controller => "users", :action => "account", :display_name => current_user.display_name))) %></p>
+        <p id="no_home_location"><%= t(".if_set_location_html", :settings_link => (link_to t(".settings_link_text"), :controller => "users", :action => "account", :display_name => current_user.display_name)) %></p>
       </div>
     <% else %>
       <% content_for :head do %>

--- a/app/views/users/suspended.html.erb
+++ b/app/views/users/suspended.html.erb
@@ -4,4 +4,4 @@
   <h1><%= t ".heading" %></h1>
 <% end %>
 
-<%= raw t ".body", :webmaster => link_to(t(".webmaster"), "mailto:#{Settings.support_email}") %>
+<%= t ".body_html", :webmaster => link_to(t(".webmaster"), "mailto:#{Settings.support_email}") %>

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -35,9 +35,9 @@
 
   <div>
     <p id="contributorGuidance" class="deemphasize">
-      <%= raw t ".guidance",
-                :summary => "https://www.osmfoundation.org/wiki/License/Contributor_Terms_Summary",
-                :translations => "https://www.osmfoundation.org/wiki/License/Contributor_Terms/Informal_Translations" %>
+      <%= t ".guidance_html",
+            :summary => "https://www.osmfoundation.org/wiki/License/Contributor_Terms_Summary",
+            :translations => "https://www.osmfoundation.org/wiki/License/Contributor_Terms/Informal_Translations" %>
     </p>
   </div>
   <div class="form-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -373,14 +373,14 @@ en:
       title: "%{user}'s diary | %{title}"
       user_title: "%{user}'s diary"
       leave_a_comment: "Leave a comment"
-      login_to_leave_a_comment: "%{login_link} to leave a comment"
+      login_to_leave_a_comment_html: "%{login_link} to leave a comment"
       login: "Login"
     no_such_entry:
       title: "No such diary entry"
       heading: "No entry with the id: %{id}"
       body: "Sorry, there is no diary entry or comment with the id %{id}. Please check your spelling, or maybe the link you clicked is wrong."
     diary_entry:
-      posted_by: "Posted by %{link_user} on %{created} in %{language_link}"
+      posted_by_html: "Posted by %{link_user} on %{created} in %{language_link}"
       comment_link: Comment on this entry
       reply_link: Reply to this entry
       comment_count:
@@ -393,7 +393,7 @@ en:
       confirm: Confirm
       report: Report this entry
     diary_comment:
-      comment_from: "Comment from %{link_user} on %{comment_created_at}"
+      comment_from_html: "Comment from %{link_user} on %{comment_created_at}"
       hide_link: Hide this comment
       unhide_link: Unhide this comment
       confirm: Confirm
@@ -1273,7 +1273,7 @@ en:
       from: "From"
       subject: "Subject"
       date: "Date"
-      no_messages_yet: "You have no messages yet. Why not get in touch with some of the %{people_mapping_nearby_link}?"
+      no_messages_yet_html: "You have no messages yet. Why not get in touch with some of the %{people_mapping_nearby_link}?"
       people_mapping_nearby: "people mapping nearby"
     message_summary:
       unread_button: "Mark as unread"
@@ -1282,7 +1282,7 @@ en:
       destroy_button: "Delete"
     new:
       title: "Send message"
-      send_message_to: "Send a new message to %{name}"
+      send_message_to_html: "Send a new message to %{name}"
       subject: "Subject"
       body: "Body"
       back_to_inbox: "Back to inbox"
@@ -1295,7 +1295,7 @@ en:
       body: "Sorry there is no message with that id."
     outbox:
       title: "Outbox"
-      my_inbox: "My %{inbox_link}"
+      my_inbox_html: "My %{inbox_link}"
       inbox: "inbox"
       outbox: "outbox"
       messages:
@@ -1304,7 +1304,7 @@ en:
       to: "To"
       subject: "Subject"
       date: "Date"
-      no_sent_messages: "You have no sent messages yet. Why not get in touch with some of the %{people_mapping_nearby_link}?"
+      no_sent_messages_html: "You have no sent messages yet. Why not get in touch with some of the %{people_mapping_nearby_link}?"
       people_mapping_nearby: "people mapping nearby"
     reply:
       wrong_user: "You are logged in as `%{user}' but the message you have asked to reply to was not sent to that user. Please login as the correct user in order to reply."
@@ -1526,7 +1526,7 @@ en:
       anon_edits: "(%{link})"
       anon_edits_link: "https://wiki.openstreetmap.org/wiki/Disabling_anonymous_edits"
       anon_edits_link_text: "Find out why this is the case."
-      flash_player_required: 'You need a Flash player to use Potlatch, the OpenStreetMap Flash editor. You can <a href="https://get.adobe.com/flashplayer/">download Flash Player from Adobe.com</a>. <a href="https://wiki.openstreetmap.org/wiki/Editing">Several other options</a> are also available for editing OpenStreetMap.'
+      flash_player_required_html: 'You need a Flash player to use Potlatch, the OpenStreetMap Flash editor. You can <a href="https://get.adobe.com/flashplayer/">download Flash Player from Adobe.com</a>. <a href="https://wiki.openstreetmap.org/wiki/Editing">Several other options</a> are also available for editing OpenStreetMap.'
       potlatch_unsaved_changes: "You have unsaved changes. (To save in Potlatch, you should deselect the current way or point, if editing in live mode, or click save if you have a save button.)"
       potlatch2_not_configured: "Potlatch 2 has not been configured - please see https://wiki.openstreetmap.org/wiki/The_Rails_Port#Potlatch_2 for more information"
       potlatch2_unsaved_changes: "You have unsaved changes. (To save in Potlatch 2, you should click save.)"
@@ -2142,7 +2142,7 @@ en:
       spam score: "Spam Score:"
       description: Description
       user location: User location
-      if set location: "Set your home location on the %{settings_link} page to see nearby users."
+      if_set_location_html: "Set your home location on the %{settings_link} page to see nearby users."
       settings_link_text: settings
       my friends: My friends
       no friends: You have not added any friends yet.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1330,7 +1330,7 @@ en:
     about:
       next: Next
       copyright_html: <span>&copy;</span>OpenStreetMap<br>contributors
-      used_by: "%{name} powers map data on thousands of web sites, mobile apps, and hardware devices"
+      used_by_html: "%{name} powers map data on thousands of web sites, mobile apps, and hardware devices"
       lede_text: |
         OpenStreetMap is built by a community of mappers that contribute and maintain data
         about roads, trails, cafés, railway stations, and much more, all over the world.
@@ -1996,7 +1996,7 @@ en:
       heading: "Login"
       email or username: "Email Address or Username:"
       password: "Password:"
-      openid: "%{logo} OpenID:"
+      openid_html: "%{logo} OpenID:"
       remember: "Remember me"
       lost password link: "Lost your password?"
       login_button: "Login"
@@ -2072,7 +2072,7 @@ en:
       license_agreement: 'When you confirm your account you will need to agree to the <a href="https://www.osmfoundation.org/wiki/License/Contributor_Terms">contributor terms</a>.'
       email address: "Email Address:"
       confirm email address: "Confirm Email Address:"
-      not displayed publicly: 'Your address is not displayed publicly, see our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" title="OSMF privacy policy including section on email addresses">privacy policy</a> for more information'
+      not_displayed_publicly_html: 'Your address is not displayed publicly, see our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" title="OSMF privacy policy including section on email addresses">privacy policy</a> for more information'
       display name: "Display Name:"
       display name description: "Your publicly displayed username. You can change this later in the preferences."
       external auth: "Third Party Authentication:"
@@ -2335,7 +2335,7 @@ en:
       back: "Back to index"
     new:
       title: "Creating block on %{name}"
-      heading: "Creating block on %{name}"
+      heading_html: "Creating block on %{name}"
       reason: "The reason why %{name} is being blocked. Please be as calm and as reasonable as possible, giving as much detail as you can about the situation, remembering that the message will be publicly visible. Bear in mind that not all users understand the community jargon, so please try to use laymans terms."
       period: "How long, starting now, the user will be blocked from the API for."
       tried_contacting: "I have contacted the user and asked them to stop."
@@ -2344,7 +2344,7 @@ en:
       back: "View all blocks"
     edit:
       title: "Editing block on %{name}"
-      heading: "Editing block on %{name}"
+      heading_html: "Editing block on %{name}"
       reason: "The reason why %{name} is being blocked. Please be as calm and as reasonable as possible, giving as much detail as you can about the situation. Bear in mind that not all users understand the community jargon, so please try to use laymans terms."
       period: "How long, starting now, the user will be blocked from the API for."
       show: "View this block"
@@ -2366,7 +2366,7 @@ en:
       empty: "No blocks have been made yet."
     revoke:
       title: "Revoking block on %{block_on}"
-      heading: "Revoking block on %{block_on} by %{block_by}"
+      heading_html: "Revoking block on %{block_on} by %{block_by}"
       time_future: "This block will end in %{time}."
       past: "This block ended %{time} and cannot be revoked now."
       confirm: "Are you sure you wish to revoke this block?"
@@ -2395,15 +2395,15 @@ en:
           other: "%{count} years"
     blocks_on:
       title: "Blocks on %{name}"
-      heading: "List of blocks on %{name}"
+      heading_html: "List of blocks on %{name}"
       empty: "%{name} has not been blocked yet."
     blocks_by:
       title: "Blocks by %{name}"
-      heading: "List of blocks by %{name}"
+      heading_html: "List of blocks by %{name}"
       empty: "%{name} has not made any blocks yet."
     show:
       title: "%{block_on} blocked by %{block_by}"
-      heading: "%{block_on} blocked by %{block_by}"
+      heading_html: "%{block_on} blocked by %{block_by}"
       created: "Created"
       status: "Status"
       show: "Show"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -221,29 +221,29 @@ en:
       discussion: Discussion
       still_open: "Changeset still open - discussion will open once the changeset is closed."
     node:
-      title: "Node: %{name}"
+      title_html: "Node: %{name}"
       history_title: "Node History: %{name}"
     way:
-      title: "Way: %{name}"
+      title_html: "Way: %{name}"
       history_title: "Way History: %{name}"
       nodes: "Nodes"
-      also_part_of:
+      also_part_of_html:
         one: "part of way %{related_ways}"
         other: "part of ways %{related_ways}"
     relation:
-      title: "Relation: %{name}"
+      title_html: "Relation: %{name}"
       history_title: "Relation History: %{name}"
       members: "Members"
     relation_member:
-      entry: "%{type} %{name}"
-      entry_role: "%{type} %{name} as %{role}"
+      entry_html: "%{type} %{name}"
+      entry_role_html: "%{type} %{name} as %{role}"
       type:
         node: "Node"
         way: "Way"
         relation: "Relation"
     containing_relation:
-      entry: "Relation %{relation_name}"
-      entry_role: "Relation %{relation_name} (as %{relation_role})"
+      entry_html: "Relation %{relation_name}"
+      entry_role_html: "Relation %{relation_name} (as %{relation_role})"
     not_found:
       sorry: "Sorry, %{type} #%{id} could not be found."
       type:
@@ -422,12 +422,12 @@ en:
   geocoder:
     search:
       title:
-        latlon: 'Results from <a href="https://openstreetmap.org/">Internal</a>'
-        ca_postcode: 'Results from <a href="https://geocoder.ca/">Geocoder.CA</a>'
-        osm_nominatim: 'Results from <a href="https://nominatim.openstreetmap.org/">OpenStreetMap Nominatim</a>'
-        geonames: 'Results from <a href="http://www.geonames.org/">GeoNames</a>'
-        osm_nominatim_reverse: 'Results from <a href="https://nominatim.openstreetmap.org/">OpenStreetMap Nominatim</a>'
-        geonames_reverse: 'Results from <a href="http://www.geonames.org/">GeoNames</a>'
+        latlon_html: 'Results from <a href="https://openstreetmap.org/">Internal</a>'
+        ca_postcode_html: 'Results from <a href="https://geocoder.ca/">Geocoder.CA</a>'
+        osm_nominatim_html: 'Results from <a href="https://nominatim.openstreetmap.org/">OpenStreetMap Nominatim</a>'
+        geonames_html: 'Results from <a href="http://www.geonames.org/">GeoNames</a>'
+        osm_nominatim_reverse_html: 'Results from <a href="https://nominatim.openstreetmap.org/">OpenStreetMap Nominatim</a>'
+        geonames_reverse_html: 'Results from <a href="http://www.geonames.org/">GeoNames</a>'
     search_osm_nominatim:
       prefix_format: "%{name}"
       prefix:
@@ -1373,11 +1373,11 @@ en:
     copyright:
       foreign:
         title: About this translation
-        text: In the event of a conflict between this translated page and %{english_original_link}, the English page shall take precedence
+        html: In the event of a conflict between this translated page and %{english_original_link}, the English page shall take precedence
         english_link: the English original
       native:
         title: About this page
-        text: You are viewing the English version of the copyright page. You can go back to the %{native_link} of this page or you can stop reading about copyright and %{mapping_link}.
+        html: You are viewing the English version of the copyright page. You can go back to the %{native_link} of this page or you can stop reading about copyright and %{mapping_link}.
         native_link: THIS_LANGUAGE_NAME_HERE version
         mapping_link: start mapping
       legal_babble:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,17 +222,17 @@ en:
       still_open: "Changeset still open - discussion will open once the changeset is closed."
     node:
       title_html: "Node: %{name}"
-      history_title: "Node History: %{name}"
+      history_title_html: "Node History: %{name}"
     way:
       title_html: "Way: %{name}"
-      history_title: "Way History: %{name}"
+      history_title_html: "Way History: %{name}"
       nodes: "Nodes"
       also_part_of_html:
         one: "part of way %{related_ways}"
         other: "part of ways %{related_ways}"
     relation:
       title_html: "Relation: %{name}"
-      history_title: "Relation History: %{name}"
+      history_title_html: "Relation History: %{name}"
       members: "Members"
     relation_member:
       entry_html: "%{type} %{name}"
@@ -1911,7 +1911,7 @@ en:
   oauth:
     authorize:
       title: "Authorize access to your account"
-      request_access: "The application %{app_name} is requesting access to your account, %{user}. Please check whether you would like the application to have the following capabilities. You may choose as many or as few as you like."
+      request_access_html: "The application %{app_name} is requesting access to your account, %{user}. Please check whether you would like the application to have the following capabilities. You may choose as many or as few as you like."
       allow_to: "Allow the client application to:"
       allow_read_prefs:  "read your user preferences."
       allow_write_prefs: "modify your user preferences."
@@ -1923,7 +1923,7 @@ en:
       grant_access: "Grant Access"
     authorize_success:
       title: "Authorization request allowed"
-      allowed: "You have granted application %{app_name} access to your account."
+      allowed_html: "You have granted application %{app_name} access to your account."
       verification: "The verification code is %{code}."
     authorize_failure:
       title: "Authorization request failed"
@@ -1965,7 +1965,8 @@ en:
       issued_at: "Issued At"
       revoke: "Revoke!"
       my_apps: "My Client Applications"
-      no_apps: "Do you have an application you would like to register for use with us using the %{oauth} standard? You must register your web application before it can make OAuth requests to this service."
+      no_apps_html: "Do you have an application you would like to register for use with us using the %{oauth} standard? You must register your web application before it can make OAuth requests to this service."
+      oauth: OAuth
       registered_apps: "You have the following client applications registered:"
       register_new: "Register your application"
     form:
@@ -2275,8 +2276,8 @@ en:
       showing:
         one: Page %{page} (%{first_item} of %{items})
         other: Page %{page} (%{first_item}-%{last_item} of %{items})
-      summary: "%{name} created from %{ip_address} on %{date}"
-      summary_no_ip: "%{name} created on %{date}"
+      summary_html: "%{name} created from %{ip_address} on %{date}"
+      summary_no_ip_html: "%{name} created on %{date}"
       confirm: Confirm Selected Users
       hide: Hide Selected Users
       empty: No matching users found

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1521,9 +1521,9 @@ en:
       remote_failed: "Editing failed - make sure JOSM or Merkaartor is loaded and the remote control option is enabled"
     edit:
       not_public: "You have not set your edits to be public."
-      not_public_description: "You can no longer edit the map unless you do so. You can set your edits as public from your %{user_page}."
+      not_public_description_html: "You can no longer edit the map unless you do so. You can set your edits as public from your %{user_page}."
       user_page_link: user page
-      anon_edits: "(%{link})"
+      anon_edits_html: "(%{link})"
       anon_edits_link: "https://wiki.openstreetmap.org/wiki/Disabling_anonymous_edits"
       anon_edits_link_text: "Find out why this is the case."
       flash_player_required_html: 'You need a Flash player to use Potlatch, the OpenStreetMap Flash editor. You can <a href="https://get.adobe.com/flashplayer/">download Flash Player from Adobe.com</a>. <a href="https://wiki.openstreetmap.org/wiki/Editing">Several other options</a> are also available for editing OpenStreetMap.'
@@ -1541,7 +1541,7 @@ en:
       map_image: "Map Image (shows standard layer)"
       embeddable_html: "Embeddable HTML"
       licence: "Licence"
-      export_details: 'OpenStreetMap data is licensed under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Data Commons Open Database License</a> (ODbL).'
+      export_details_html: 'OpenStreetMap data is licensed under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Data Commons Open Database License</a> (ODbL).'
       too_large:
         advice: "If the above export fails, please consider using one of the sources listed below:"
         body: "This area is too large to be exported as OpenStreetMap XML Data. Please zoom in or select a smaller area, or use one of the sources listed below for bulk data downloads."
@@ -2062,7 +2062,7 @@ en:
     new:
       title: "Sign Up"
       no_auto_account_create: "Unfortunately we are not currently able to create an account for you automatically."
-      contact_webmaster: 'Please contact the <a href="%{webmaster}">webmaster</a> to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
+      contact_webmaster_html: 'Please contact the <a href="%{webmaster}">webmaster</a> to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
       about:
         header: Free and editable
         html: |
@@ -2096,7 +2096,7 @@ en:
       consider_pd: "In addition to the above, I consider my contributions to be in the Public Domain"
       consider_pd_why: "what's this?"
       consider_pd_why_url: https://www.osmfoundation.org/wiki/License/Why_would_I_want_my_contributions_to_be_public_domain
-      guidance: 'Information to help understand these terms: a <a href="%{summary}">human readable summary</a> and some <a href="%{translations}">informal translations</a>'
+      guidance_html: 'Information to help understand these terms: a <a href="%{summary}">human readable summary</a> and some <a href="%{translations}">informal translations</a>'
       continue: Continue
       declined: "https://wiki.openstreetmap.org/wiki/Contributor_Terms_Declined"
       decline: "Decline"
@@ -2198,7 +2198,7 @@ en:
         disabled link text: "why can't I edit?"
       public editing note:
         heading: "Public editing"
-        text: "Currently your edits are anonymous and people cannot send you messages or see your location. To show what you edited and allow people to contact you through the website, click the button below. <b>Since the 0.6 API changeover, only public users can edit map data</b>. (<a href=\"https://wiki.openstreetmap.org/wiki/Anonymous_edits\">find out why</a>).<ul><li>Your email address will not be revealed by becoming public.</li><li>This action cannot be reversed and all new users are now public by default.</li></ul>"
+        html: "Currently your edits are anonymous and people cannot send you messages or see your location. To show what you edited and allow people to contact you through the website, click the button below. <b>Since the 0.6 API changeover, only public users can edit map data</b>. (<a href=\"https://wiki.openstreetmap.org/wiki/Anonymous_edits\">find out why</a>).<ul><li>Your email address will not be revealed by becoming public.</li><li>This action cannot be reversed and all new users are now public by default.</li></ul>"
       contributor terms:
         heading: "Contributor Terms:"
         agreed: "You have agreed to the new Contributor Terms."
@@ -2284,7 +2284,7 @@ en:
       title: Account Suspended
       heading: Account Suspended
       webmaster: webmaster
-      body: |
+      body_html: |
         <p>
           Sorry, your account has been automatically suspended due to
           suspicious activity.


### PR DESCRIPTION
We use `raw` extensively with translation strings, mainly so that the end result can contain links. This is mostly fine, but sometimes risks a security problem, when any part of the string might have come from user input (e.g. display names) and therefore needs careful handling.

A generally safer way to do this is to use translation keys ending in 'html'. This tells rails that we want to avoid escaping the html, while at the same time allowing rails to still manage potentially unsafe text, like display names, and escaping those properly automatically.

This PR refactors most places where we have previously used `raw`. (There is still raw used in the notifications, in the terms page, and for pagination links.)

@translatewiki This PR contains many translation key renames. Is it helpful for me to list them here for you, or is that not worth doing?