### PR TITLE
Remove fallback to hostip.info

### DIFF
--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -513,15 +513,8 @@ module OSM
   def self.ip_to_country(ip_address)
     ipinfo = maxmind_database.lookup(ip_address) if Settings.key?(:maxmind_database)
 
-    if ipinfo&.found?
-      country = ipinfo.country.iso_code
-    else
-      country = http_client.get("https://api.hostip.info/country.php?ip=#{ip_address}").body
-      country = "GB" if country == "UK"
-    end
+    return ipinfo.country.iso_code if ipinfo&.found?
 
-    country
-  rescue StandardError
     nil
   end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -13,12 +13,6 @@ end
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :poltergeist, :screen_size => [1400, 1400], :options => { :timeout => 120 }
 
-  def initialize(*args)
-    stub_request(:get, "https://api.hostip.info/country.php?ip=127.0.0.1")
-      .to_return(:status => 404)
-    super(*args)
-  end
-
   # Phantomjs can pick up browser Accept-Language preferences from your desktop environment.
   # We don't want this to happen during the tests!
   setup do

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -2,12 +2,6 @@ require "test_helper"
 
 module Api
   class UsersControllerTest < ActionController::TestCase
-    def setup
-      super
-
-      stub_hostip_requests
-    end
-
     ##
     # test all routes which lead to this controller
     def test_routes

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -8,8 +8,6 @@ class SiteControllerTest < ActionController::TestCase
 
     Settings.id_key = create(:client_application).key
     Settings.potlatch2_key = create(:client_application).key
-
-    stub_hostip_requests
   end
 
   ##

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,12 +1,6 @@
 require "test_helper"
 
 class UsersControllerTest < ActionController::TestCase
-  def setup
-    super
-
-    stub_hostip_requests
-  end
-
   ##
   # test all routes which lead to this controller
   def test_routes

--- a/test/integration/oauth_test.rb
+++ b/test/integration/oauth_test.rb
@@ -3,10 +3,6 @@ require "test_helper"
 class OAuthTest < ActionDispatch::IntegrationTest
   include OAuth::Helper
 
-  def setup
-    stub_hostip_requests
-  end
-
   def test_oauth10_web_app
     client = create(:client_application, :callback_url => "http://some.web.app.example.org/callback", :allow_read_prefs => true, :allow_write_api => true, :allow_read_gpx => true)
 

--- a/test/integration/page_locale_test.rb
+++ b/test/integration/page_locale_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class PageLocaleTest < ActionDispatch::IntegrationTest
   def setup
     I18n.locale = "en"
-    stub_hostip_requests
   end
 
   def teardown

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -7,7 +7,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     OmniAuth.config.test_mode = true
 
     stub_request(:get, /.*gravatar.com.*d=404/).to_return(:status => 404)
-    stub_hostip_requests
   end
 
   def teardown

--- a/test/integration/user_terms_seen_test.rb
+++ b/test/integration/user_terms_seen_test.rb
@@ -1,10 +1,6 @@
 require "test_helper"
 
 class UserTermsSeenTest < ActionDispatch::IntegrationTest
-  def setup
-    stub_hostip_requests
-  end
-
   def test_api_blocked
     user = create(:user, :terms_seen => false, :terms_agreed => nil)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -159,12 +159,6 @@ module ActiveSupport
       stub_request(:get, url).and_return(:status => status, :body => body)
     end
 
-    def stub_hostip_requests
-      # Controller tests and integration tests use different IPs
-      stub_request(:get, "https://api.hostip.info/country.php?ip=0.0.0.0")
-      stub_request(:get, "https://api.hostip.info/country.php?ip=127.0.0.1")
-    end
-
     def email_text_parts(message)
       message.parts.each_with_object([]) do |part, text_parts|
         if part.content_type.start_with?("text/")
@@ -176,7 +170,6 @@ module ActiveSupport
     end
 
     def sign_in_as(user)
-      stub_hostip_requests
       visit login_path
       fill_in "username", :with => user.email
       fill_in "password", :with => "test"


### PR DESCRIPTION
We haven't used hostip.info in production for years, except for when we did so by accident, leading to a two hour partial outage when it went down.