### PR TITLE
Use a post link to logout

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -269,7 +269,7 @@ class UsersController < ApplicationController
   def logout
     @title = t "users.logout.title"
 
-    if params[:session] == session.id
+    if request.post?
       if session[:token]
         token = UserToken.find_by(:token => session[:token])
         token&.destroy

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -102,7 +102,7 @@
             <%= yield :greeting %>
           </li>
           <li>
-            <%= link_to t("layouts.logout"), logout_path(:session => session.id, :referer => request.fullpath), :class => "geolink" %>
+            <%= link_to t("layouts.logout"), logout_path(:referer => request.fullpath), :method => "post", :class => "geolink" %>
           </li>
         </ul>
       </div>

--- a/app/views/users/logout.html.erb
+++ b/app/views/users/logout.html.erb
@@ -4,6 +4,5 @@
 
 <%= form_tag :action => "logout" do %>
   <%= hidden_field_tag("referer", h(params[:referer])) %>
-  <%= hidden_field_tag("session", session.id) %>
   <%= submit_tag t(".logout_button") %>
 <% end %>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -344,27 +344,13 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def test_logout_without_referer
-    get :logout
-    assert_response :success
-    assert_template :logout
-    assert_select "input[name=referer][value=?]", ""
-
-    session_id = assert_select("input[name=session]").first["value"]
-
-    get :logout, :params => { :session => session_id }
+    post :logout
     assert_response :redirect
     assert_redirected_to root_path
   end
 
   def test_logout_with_referer
-    get :logout, :params => { :referer => "/test" }
-    assert_response :success
-    assert_template :logout
-    assert_select "input[name=referer][value=?]", "/test"
-
-    session_id = assert_select("input[name=session]").first["value"]
-
-    get :logout, :params => { :session => session_id, :referer => "/test" }
+    post :logout, :params => { :referer => "/test" }
     assert_response :redirect
     assert_redirected_to "/test"
   end
@@ -374,16 +360,7 @@ class UsersControllerTest < ActionController::TestCase
 
     session[:token] = token.token
 
-    get :logout
-    assert_response :success
-    assert_template :logout
-    assert_select "input[name=referer][value=?]", ""
-    assert_equal token.token, session[:token]
-    assert_not_nil UserToken.where(:id => token.id).first
-
-    session_id = assert_select("input[name=session]").first["value"]
-
-    get :logout, :params => { :session => session_id }
+    post :logout
     assert_response :redirect
     assert_redirected_to root_path
     assert_nil session[:token]

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -355,6 +355,20 @@ class UsersControllerTest < ActionController::TestCase
     assert_redirected_to "/test"
   end
 
+  def test_logout_fallback_without_referer
+    get :logout
+    assert_response :success
+    assert_template :logout
+    assert_select "input[name=referer][value=?]", ""
+  end
+
+  def test_logout_fallback_with_referer
+    get :logout, :params => { :referer => "/test" }
+    assert_response :success
+    assert_template :logout
+    assert_select "input[name=referer][value=?]", "/test"
+  end
+
   def test_logout_with_token
     token = create(:user).tokens.create
 

--- a/test/system/user_logout_test.rb
+++ b/test/system/user_logout_test.rb
@@ -1,0 +1,22 @@
+require "application_system_test_case"
+
+class UserLogoutTest < ApplicationSystemTestCase
+  test "Sign out via link" do
+    user = create(:user)
+    sign_in_as(user)
+
+    click_on user.display_name
+    click_on "Log Out"
+    assert page.has_content? "Log In"
+  end
+
+  test "Sign out via fallback page" do
+    sign_in_as(create(:user))
+
+    visit logout_path
+    assert page.has_content? "Logout from OpenStreetMap"
+
+    click_button "Logout"
+    assert page.has_content? "Log In"
+  end
+end

--- a/test/system/user_logout_test.rb
+++ b/test/system/user_logout_test.rb
@@ -4,19 +4,45 @@ class UserLogoutTest < ApplicationSystemTestCase
   test "Sign out via link" do
     user = create(:user)
     sign_in_as(user)
+    assert_not page.has_content? "Log In"
 
     click_on user.display_name
     click_on "Log Out"
     assert page.has_content? "Log In"
   end
 
+  test "Sign out via link with referer" do
+    user = create(:user)
+    sign_in_as(user)
+    visit traces_path
+    assert_not page.has_content? "Log In"
+
+    click_on user.display_name
+    click_on "Log Out"
+    assert page.has_content? "Log In"
+    assert page.has_content? "Public GPS traces"
+  end
+
   test "Sign out via fallback page" do
     sign_in_as(create(:user))
+    assert_not page.has_content? "Log In"
 
     visit logout_path
     assert page.has_content? "Logout from OpenStreetMap"
 
     click_button "Logout"
     assert page.has_content? "Log In"
+  end
+
+  test "Sign out via fallback page with referer" do
+    sign_in_as(create(:user))
+    assert_not page.has_content? "Log In"
+
+    visit logout_path(:referer => "/traces")
+    assert page.has_content? "Logout from OpenStreetMap"
+
+    click_button "Logout"
+    assert page.has_content? "Log In"
+    assert page.has_content? "Public GPS traces"
   end
 end


### PR DESCRIPTION
This avoids needing to access the session id, which is currently only working with the memcache store.

The fallback page is preserved for anyone who wants to logout without using javascript.

Refs #2488