### PR TITLE
Various CSS fixes

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -214,17 +214,15 @@ OSM.Query = function (map) {
 
           if (interestingFeature(element)) {
             var $li = $("<li>")
-              .addClass("query-result")
+              .addClass("query-result list-group-item")
               .data("geometry", featureGeometry(element))
-              .appendTo($ul);
-            var $p = $("<p>")
               .text(featurePrefix(element) + " ")
-              .appendTo($li);
+              .appendTo($ul);
 
             $("<a>")
               .attr("href", "/" + element.type + "/" + element.id)
               .text(featureName(element))
-              .appendTo($p);
+              .appendTo($li);
           }
         }
 

--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -32,7 +32,7 @@
 @import "bootstrap/alert";
 // @import "bootstrap/progress";
 // @import "bootstrap/media";
-// @import "bootstrap/list-group";
+@import "bootstrap/list-group";
 // @import "bootstrap/close";
 // @import "bootstrap/toasts";
 // @import "bootstrap/modal";

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1191,7 +1191,6 @@ tr.turn:hover {
     background-color: #F6F6F6;
     border: 1px solid $grey;
     border-radius: 3px;
-    font-size: 12px;
     table-layout: fixed;
     border-collapse: separate;
 
@@ -1223,8 +1222,8 @@ tr.turn:hover {
 
     .colour-preview-box {
       float: right;
-      width: 12px;
-      height: 12px;
+      width: 14px;
+      height: 14px;
       margin: 4px 0px;
       border: 1px solid rgba(0, 0, 0, .1);
       // add color via inline css on element: background-color: <tag value>;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2077,13 +2077,6 @@ abbr.geo {
   border-bottom: none;
 }
 
-/* Rules for RSS buttons */
-
-.rsssmall {
-  position: relative;
-  top: 3px;
-}
-
 /* General styles for action lists / subnavs / pager navs */
 
 ul.secondary-actions {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1108,19 +1108,10 @@ tr.turn:hover {
 
 #sidebar .changesets {
   li {
-    padding: 15px 20px;
-    border-bottom: 1px solid $grey;
     cursor: pointer;
 
     &.selected { background: $list-highlight; }
     /* color is derived from changeset bbox fillColor in history.js */
-  }
-
-  h4 {
-    margin: 0;
-    a {
-      color: #000;
-    }
   }
 
   .comments {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1277,17 +1277,10 @@ tr.turn:hover {
 
   .query-results {
     display: none;
-
-    h3 {
-      padding: $lineheight $lineheight $lineheight/2;
-      margin: 0;
-    }
+    padding: 0 $lineheight $lineheight/2;
 
     ul {
       li {
-        padding: 15px 20px;
-        border-bottom: 1px solid $grey;
-
         &.query-result {
           cursor: pointer;
         }

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -6,7 +6,7 @@
 </h2>
 
 <div class="browse-section">
-  <h4><%= linkify(h(@changeset.tags["comment"].to_s.presence || t("browse.no_comment"))) %></h4>
+  <h6><%= linkify(h(@changeset.tags["comment"].to_s.presence || t("browse.no_comment"))) %></h6>
   <div class="details"><%= changeset_details(@changeset) %></div>
 
   <%= render :partial => "tag_details", :object => @changeset.tags.except("comment") %>

--- a/app/views/browse/query.html.erb
+++ b/app/views/browse/query.html.erb
@@ -12,11 +12,15 @@
 <div id="query-nearby" class="query-results">
   <h3><%= t(".nearby") %></h3>
   <%= image_tag "searching.gif", :class => "loader" %>
-  <ul class="query-results-list"></ul>
+  <div>
+    <ul class="query-results-list list-group list-group-flush"></ul>
+  </div>
 </div>
 
 <div id="query-isin" class="query-results">
   <h3><%= t(".enclosing") %></h3>
   <%= image_tag "searching.gif", :class => "loader" %>
-  <ul class="query-results-list"></ul>
+  <div>
+    <ul class="query-results-list list-group list-group-flush"></ul>
+  </div>
 </div>

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -10,12 +10,12 @@
      }
    end %>
 
-<%= content_tag "li", :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data } do %>
-  <h4>
-    <a class="changeset_id" href="<%= changeset_path(changeset) %>">
+<%= content_tag "li", :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item" do %>
+  <h6>
+    <a class="changeset_id text-dark" href="<%= changeset_path(changeset) %>">
       <%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %>
     </a>
-  </h4>
+  </h6>
   <div class="comments comments-<%= changeset.comments.length %>">
     <%= changeset.comments.length %>
     <span class="icon note grey"></span>

--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -1,5 +1,5 @@
 <% if @changesets.present? %>
-  <ol class="changesets">
+  <ol class="changesets list-group list-group-flush">
     <%= render @changesets %>
   </ol>
 <% if @changesets.size == 20 -%>


### PR DESCRIPTION
This PR fixes a few CSS issues that were highlighted in #2492 and others that I noticed while working on that. In summary:

* Uses bootstrap's list-group-flush to replace custom css, for sidebars with lists-with-lines-between
* Uses h6 for the changeset comment tag text
* Removes some unnecessary custom css rules
* Tweaks the rss icon to line it up with other icons
