### PR TITLE
Replace custom grid CSS with bootstrap grid

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -13,7 +13,7 @@
 @import "bootstrap/type";
 // @import "bootstrap/images";
 // @import "bootstrap/code";
-// @import "bootstrap/grid";
+@import "bootstrap/grid";
 // @import "bootstrap/tables";
 // @import "bootstrap/forms";
 // @import "bootstrap/buttons";

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1405,18 +1405,6 @@ tr.turn:hover {
 /* Overrides for pages that use new layout conventions */
 
 .users-new,
-.users-create {
-  .content-body .content-inner {
-    padding: 0;
-
-    .message {
-      margin-top: 80px;
-      padding: 20px;
-    }
-  }
-}
-
-.users-new,
 .users-create,
 .users-terms,
 .users-confirm {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1405,8 +1405,7 @@ tr.turn:hover {
 /* Overrides for pages that use new layout conventions */
 
 .users-new,
-.users-create,
-.users-terms {
+.users-create {
   .content-body .content-inner {
     padding: 0;
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2627,11 +2627,6 @@ input.richtext_title[type="text"] {
     text-decoration: none;
   }
 
-  .note-box {
-    margin-top: 20px;
-    background-color: $offwhite;
-  }
-
   .icon.note {
     background-color: #333;
     border-radius: 4px;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -58,36 +58,6 @@ strong {
     clear: both;
 }
 
-/* Basic grid */
-
-.col0    { float:left; width:04.1666%; }
-.col1    { float:left; width:08.3333%; }
-.col2    { float:left; width:16.6666%; }
-.col3    { float:left; width:25.0000%; }
-.col4    { float:left; width:33.3333%; }
-.col5    { float:left; width:41.6666%; }
-.col6    { float:left; width:50.0000%; }
-.col7    { float:left; width:58.3333%; }
-.col8    { float:left; width:66.6666%; }
-.col9    { float:left; width:75.0000%; }
-.col10   { float:left; width:83.3333%; }
-.col11   { float:left; width:91.6666%; }
-.col12   { width:100%; }
-
-.margin0  { margin-left:04.1666%; }
-.margin1  { margin-left:08.3333%; }
-.margin2  { margin-left:16.6666%; }
-.margin3  { margin-left:25.0000%; }
-.margin4  { margin-left:33.3333%; }
-.margin5  { margin-left:41.6666%; }
-.margin6  { margin-left:50.0000%; }
-.margin7  { margin-left:58.3333%; }
-.margin8  { margin-left:66.6666%; }
-.margin9  { margin-left:75.0000%; }
-.margin10 { margin-left:83.3333%; }
-.margin11 { margin-left:91.6666%; }
-.margin12 { margin-left:100.0000%; }
-
 .fillL { background-color: white; }
 
 /* Default rules for the body of every page */

--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -182,19 +182,6 @@ body.small {
     top: auto;
   }
 
-  /* Rules for the sign-up page */
-
-  &.user-new,
-  &.user-create {
-    .col6 {
-      width: 100%;
-    }
-
-    .aside {
-      display: none;
-    }
-  }
-
   &.site-about #content .attr h1 {
     font-size: 28px;
   }

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -12,16 +12,16 @@
 <h3><%= t ".how_to_help.title" %></h3>
 
 <div class='container'>
-  <div class='row' %>
+  <div class='row'>
     <div class='col-sm'>
-      <h5><%= t ".how_to_help.join_the_community.title" %></h3>
+      <h5><%= t ".how_to_help.join_the_community.title" %></h5>
       <p><%= t ".how_to_help.join_the_community.explanation_html" %></p>
       <p class='text-center'>
         <a class="button sign-up" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
       </p>
     </div>
     <div class='col-sm'>
-      <h5><%= t "site.welcome.add_a_note.title" %></h3>
+      <h5><%= t "site.welcome.add_a_note.title" %></h5>
       <p><%= t "site.welcome.add_a_note.paragraph_1_html" %></p>
       <p><%= t ".how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
     </div>

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -7,31 +7,30 @@
 <% end %>
 
 <h3><%= t "layouts.intro_header" %></h3>
-
 <p><%= t "layouts.intro_text" %></p>
 
 <h3><%= t ".how_to_help.title" %></h3>
 
-<div class='clearfix'>
-  <div class='col6 inner11'>
-    <h3><%= t ".how_to_help.join_the_community.title" %></h3>
-    <%= t ".how_to_help.join_the_community.explanation_html" %>
-    <div class='clearfix center'>
-      <a class="button sign-up" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+<div class='container'>
+  <div class='row' %>
+    <div class='col-sm'>
+      <h5><%= t ".how_to_help.join_the_community.title" %></h3>
+      <p><%= t ".how_to_help.join_the_community.explanation_html" %></p>
+      <p class='text-center'>
+        <a class="button sign-up" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+      </p>
     </div>
-  </div>
-  <div class='col6 inner11'>
-    <h3><%= t "site.welcome.add_a_note.title" %></h3>
-    <p><%= t "site.welcome.add_a_note.paragraph_1_html" %></p>
-    <p><%= t ".how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
+    <div class='col-sm'>
+      <h5><%= t "site.welcome.add_a_note.title" %></h3>
+      <p><%= t "site.welcome.add_a_note.paragraph_1_html" %></p>
+      <p><%= t ".how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
+    </div>
   </div>
 </div>
 
 <h3><%= t ".other_concerns.title" %></h3>
 <p><%= t ".other_concerns.explanation_html" %></p>
 
-<div class='col12 clearfix icon-list'>
-  <h3><%= t "site.welcome.questions.title" %></h3>
-  <span class='sprite small term question'></span>
-  <p><%= t "site.welcome.questions.paragraph_1_html", :help_url => help_path %></p>
-</div>
+<h3><%= t "site.welcome.questions.title" %></h3>
+<span class='sprite small term question'></span>
+<p><%= t "site.welcome.questions.paragraph_1_html", :help_url => help_path %></p>

--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -10,15 +10,15 @@
 
 <h3><%= t ".whats_on_the_map.title" %></h3>
 
-<div class=' clearfix'>
-  <div class='col6 inner11'>
-    <div class='center clearfix inner11'>
+<div class='row'>
+  <div class='col'>
+    <div class='center'>
       <span class='sprite small check'></span>
     </div>
     <p><%= t ".whats_on_the_map.on_html" %></p>
   </div>
-  <div class='col6 inner11'>
-    <div class='center clearfix inner11'>
+  <div class='col'>
+    <div class='center'>
       <span class='sprite small x'></span>
     </div>
     <p><%= t ".whats_on_the_map.off_html" %></p>
@@ -29,7 +29,7 @@
 
 <p><%= t ".basic_terms.paragraph_1_html" %></p>
 
-<div class='col12 clearfix icon-list'>
+<div class='clearfix icon-list'>
   <div class='clearfix'>
     <span class='sprite small term editor'></span>
     <p><%= t ".basic_terms.editor_html" %></p>
@@ -48,26 +48,24 @@
   </div>
 </div>
 
-<div class='col12 clearfix icon-list'>
+<div class='clearfix icon-list'>
   <h3><%= t ".rules.title" %></h3>
   <span class='sprite small term rules'></span>
   <p><%= t ".rules.paragraph_1_html" %></p>
 </div>
 
-<div class='col12 clearfix icon-list'>
+<div class='clearfix icon-list'>
   <h3><%= t ".questions.title" %></h3>
   <span class='sprite small term question'></span>
   <p><%= t ".questions.paragraph_1_html", :help_url => help_path %></p>
 </div>
 
 <div class='clearfix center'>
-  <a href="<%= edit_path %>" class="button start-mapping"><%= t ".start_mapping" %></a>
+  <p><a href="<%= edit_path %>" class="button start-mapping"><%= t ".start_mapping" %></a></p>
 </div>
 
-<div class='note-box'>
-  <div class='inner22'>
-    <h3><%= t ".add_a_note.title" %></h3>
-    <p><%= t ".add_a_note.paragraph_1_html" %></p>
-    <p><%= t ".add_a_note.paragraph_2_html", :map_url => root_path %></p>
-  </div>
+<div class='alert alert-primary'>
+  <h3><%= t ".add_a_note.title" %></h3>
+  <p><%= t ".add_a_note.paragraph_1_html" %></p>
+  <p><%= t ".add_a_note.paragraph_2_html", :map_url => root_path %></p>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -8,75 +8,79 @@
   <div class='header-illustration new-user-arm'></div>
 <% end %>
 
-<%= form_for current_user, :url => { :action => "create" }, :html => { :class => "standard-form fillL col6 inner22" } do |f| %>
-  <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
-
-  <fieldset>
-    <div class="form-row">
-      <label for="email" class="standard-label">
-        <%= t ".email address" %>
-      </label>
-      <%= f.email_field(:email, :tabindex => 1) %>
-      <%= f.error_message_on(:email) %>
-    </div>
-    <div class="form-row">
-      <label for="email_confirmation" class="standard-label">
-        <%= t ".confirm email address" %>
-      </label>
-      <%= f.email_field(:email_confirmation, :tabindex => 2) %>
-      <%= f.error_message_on(:email_confirmation) %>
-    </div>
-    <span class="form-help deemphasize"><%= t(".not_displayed_publicly_html") %></span>
-  </fieldset>
-
-  <fieldset>
-    <div class="form-row">
-      <label for="display_name" class="standard-label">
-        <%= t ".display name" %>
-      </label>
-      <%= f.text_field(:display_name, :tabindex => 3) %>
-      <%= f.error_message_on(:display_name) %>
-    </div>
-    <span class="form-help deemphasize"><%= t ".display name description" %></span>
-  </fieldset>
-
-  <fieldset class="form-divider" id="auth_field">
-    <div class="form-row">
-      <label for="openid_url" class="standard-label">
-        <%= t ".external auth" %>
-      </label>
-      <%= f.select(:auth_provider, Auth::PROVIDERS, :default => "", :tabindex => 4) %>
-      <%= f.text_field(:auth_uid, :tabindex => 5) %>
-      <%= f.error_message_on(:auth_uid) %>
-    </div>
-    <span class="form-help deemphasize"><%= t ".auth no password" %></span>
-  </fieldset>
-
-  <fieldset>
-    <div class="form-row">
-      <label for='user[pass_crypt]' class="standard-label">
-        <%= t ".password" %>
-      </label>
-      <%= f.password_field(:pass_crypt, :tabindex => 6) %>
-      <%= f.error_message_on(:pass_crypt) %>
-    </div>
-    <div class="form-row">
-      <label class="standard-label">
-        <%= t ".confirm password" %>
-      </label>
-      <%= f.password_field(:pass_crypt_confirmation, :tabindex => 7) %>
-      <%= f.error_message_on(:pass_crypt_confirmation) %>
-    </div>
-  </fieldset>
-
-  <div id="auth_prompt" class="form-row">
-    <%= link_to t(".use external auth"), "#", :id => "auth_enable" %>
+<div class="row">
+  <div class='text-muted col-sm order-sm-2'>
+    <h4><%= t ".about.header" %></h4>
+    <%= t ".about.html" %>
   </div>
 
-  <%= submit_tag t(".continue"), :tabindex => 8 %>
-<% end %>
+  <div class="col-sm">
+    <%= form_for current_user, :url => { :action => "create" }, :html => { :class => "standard-form" } do |f| %>
+      <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
 
-<div class='aside col6 deemphasize inner22'>
-  <h4><%= t ".about.header" %></h4>
-  <%= t ".about.html" %>
+      <fieldset>
+        <div class="form-row">
+          <label for="email" class="standard-label">
+            <%= t ".email address" %>
+          </label>
+          <%= f.email_field(:email, :tabindex => 1) %>
+          <%= f.error_message_on(:email) %>
+        </div>
+        <div class="form-row">
+          <label for="email_confirmation" class="standard-label">
+            <%= t ".confirm email address" %>
+          </label>
+          <%= f.email_field(:email_confirmation, :tabindex => 2) %>
+          <%= f.error_message_on(:email_confirmation) %>
+        </div>
+        <span class="form-help deemphasize"><%= t(".not_displayed_publicly_html") %></span>
+      </fieldset>
+
+      <fieldset>
+        <div class="form-row">
+          <label for="display_name" class="standard-label">
+            <%= t ".display name" %>
+          </label>
+          <%= f.text_field(:display_name, :tabindex => 3) %>
+          <%= f.error_message_on(:display_name) %>
+        </div>
+        <span class="form-help deemphasize"><%= t ".display name description" %></span>
+      </fieldset>
+
+      <fieldset class="form-divider" id="auth_field">
+        <div class="form-row">
+          <label for="openid_url" class="standard-label">
+            <%= t ".external auth" %>
+          </label>
+          <%= f.select(:auth_provider, Auth::PROVIDERS, :default => "", :tabindex => 4) %>
+          <%= f.text_field(:auth_uid, :tabindex => 5) %>
+          <%= f.error_message_on(:auth_uid) %>
+        </div>
+        <span class="form-help deemphasize"><%= t ".auth no password" %></span>
+      </fieldset>
+
+      <fieldset>
+        <div class="form-row">
+          <label for='user[pass_crypt]' class="standard-label">
+            <%= t ".password" %>
+          </label>
+          <%= f.password_field(:pass_crypt, :tabindex => 6) %>
+          <%= f.error_message_on(:pass_crypt) %>
+        </div>
+        <div class="form-row">
+          <label class="standard-label">
+            <%= t ".confirm password" %>
+          </label>
+          <%= f.password_field(:pass_crypt_confirmation, :tabindex => 7) %>
+          <%= f.error_message_on(:pass_crypt_confirmation) %>
+        </div>
+      </fieldset>
+
+      <div id="auth_prompt" class="form-row">
+        <%= link_to t(".use external auth"), "#", :id => "auth_enable" %>
+      </div>
+
+      <%= submit_tag t(".continue"), :tabindex => 8 %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -7,13 +7,13 @@
   <div class='header-illustration new-user-terms'></div>
 <% end %>
 
-<%= form_tag({ :action => "save" }, { :class => " inner22 standard-form fillL" }) do %>
+<%= form_tag({ :action => "save" }, { :class => "standard-form fillL" }) do %>
   <!-- legale is <%= @legale %> -->
   <p class="deemphasize"><%= t ".read and accept with tou" %></p>
-  <label class="standard-label">
+  <h4>
     <%= t ".heading_ct" %>
-  </label>
-  <div class='form-row horizontal-list'>
+  </h4>
+  <div class='form-row horizontal-list clearfix'>
     <p class="deemphasize"><%= t ".contributor_terms_explain" %></p>
     <label class="standard-label">
       <%= t ".legale_select" %>
@@ -29,7 +29,7 @@
     <% end %>
   </div>
 
-  <div id="contributorTerms" class="col12 legale">
+  <div id="contributorTerms" class="legale">
     <%= render :partial => "terms" %>
   </div>
 
@@ -47,9 +47,9 @@
     </label>
   </div>
 
-  <label class="standard-label">
+  <h4>
     <%= t "layouts.tou" %>
-  </label>
+  </h4>
   <p class="deemphasize"><%= t ".tou_explain_html", :tou_link => link_to(t("layouts.tou"), "https://wiki.osmfoundation.org/wiki/Terms_of_Use", :target => :new) %></p>
   <div class="form-row">
     <label for="read_tou">
@@ -59,7 +59,7 @@
 
     <%= hidden_field_tag("referer", h(params[:referer])) unless params[:referer].nil? %>
 
-    <div class="buttons form-row inner20 clearfix">
+    <div class="buttons form-row py-3 clearfix">
       <%= submit_tag("Continue", :name => "continue", :id => "continue", :disabled => true) %>
       <%= submit_tag("Cancel", :name => "decline", :id => "decline") %>
     </div>


### PR DESCRIPTION
This refactors various pages in order to remove our custom layout grid, and to use the bootstrap grid instead. Since the bootstrap grid is responsive, it means that some pages (e.g. the fixthemap page) now look much better on small screens.

I changed very little on the /user/new page, but adding a wrapper div caused the diff to blow up. 

The commit messages contain further details on each change.