### PR TITLE
Refactor layout for the about page

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2650,53 +2650,12 @@ input.richtext_title[type="text"] {
   background-size: cover;
   background-attachment: fixed;
 
-  .caption {
-    max-width: 200px;
-    font: 13px/20px Helvetica, Arial, sans-serif;
-    position: fixed;
-    text-align: right;
-    right: 20px;
-    bottom: 60px;
-    text-shadow: #000 0px 1px 5px;
-    color: $lightgrey;
-    opacity: 0.8;
-    display: none;
-  }
-
-  .caption a {
-    color: white;
-    white-space: nowrap;
-    text-decoration: none;
-  }
-
-  a.next {
-    display: block;
-    position: fixed;
-    right: 10px;
-    bottom: 10px;
-    width: 40px;
-    height: 40px;
-    border-radius: 5px;
-    text-indent: -9999px;
-    overflow: hidden;
-    background: image-url('about/sprite.png') -120px 0px no-repeat;
-    background-color: #000;
-    background-color: rgba(0, 0, 0, 0.5);
-  }
 
   .content-inner {
     position: relative;
     color: #333;
     min-width: 320px;
     max-width: 640px;
-
-    .section {
-      margin-bottom: 30px;
-    }
-
-    .section:last-child {
-      margin-bottom: 0;
-    }
   }
 
   .text {
@@ -2754,10 +2713,6 @@ input.richtext_title[type="text"] {
       width: 20px;
       margin-left: -20px;
     }
-  }
-
-  h2 {
-    margin-bottom: 10px;
   }
 
   .icon {

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -28,7 +28,8 @@
 
     <div class='section' id='legal'>
       <h2><div class='icon legal'></div><%= t ".legal_title", :locale => @locale %></h2>
-      <p><%= t ".legal_html", :locale => @locale %></p>
+      <p><%= t ".legal_1_html", :locale => @locale %></p>
+      <p><%= t ".legal_2_html", :locale => @locale %></p>
     </div>
 
     <div class='section' id='partners'>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1358,13 +1358,13 @@ en:
         under the same licence. See the <a href='%{copyright_path}'>Copyright and
         License page</a> for details.
       legal_title: Legal
-      legal_html: |
+      legal_1_html: |
         This site and many other related services are formally operated by the
         <a href='https://osmfoundation.org/'>OpenStreetMap Foundation</a> (OSMF)
         on behalf of the community. Use of all OSMF operated services is subject
         to our <a href="https://wiki.osmfoundation.org/wiki/Terms_of_Use">Terms of Use</a>, <a href="https://wiki.openstreetmap.org/wiki/Acceptable_Use_Policy">
-        Acceptable Use Policies</a> and our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy">Privacy Policy</a>
-        <br>
+        Acceptable Use Policies</a> and our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy">Privacy Policy</a>.
+      legal_2_html: |
         Please <a href='https://osmfoundation.org/Contact'>contact the OSMF</a>
         if you have licensing, copyright or other legal questions.
         <br>


### PR DESCRIPTION
This is a minor refactoring of the about page. It splits one of the translation strings into two paragraphs, rather than having a <br> tag in the translation. And it removes some unused and some unnecessary custom CSS rules.