### PR TITLE
Avoid double-escaping display names through the translation system

### DIFF
--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :heading do %>
   <div id="userinformation">
     <%= user_image @entry.user %>
-    <h2><%= link_to t(".user_title", :user => h(@entry.user.display_name)), :action => :index %></h2>
+    <h2><%= link_to t(".user_title", :user => @entry.user.display_name), :action => :index %></h2>
     <p><%= rss_link_to :action => :rss, :display_name => @entry.user.display_name %></p>
   </div>
 <% end %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t(".send_message_to_html", :name => link_to(h(@message.recipient.display_name), user_path(@message.recipient))) %></h2>
+  <h2><%= t(".send_message_to_html", :name => link_to(@message.recipient.display_name, user_path(@message.recipient))) %></h2>
 <% end %>
 
 <%= error_messages_for "message" %>

--- a/app/views/user_blocks/blocks_by.html.erb
+++ b/app/views/user_blocks/blocks_by.html.erb
@@ -1,4 +1,4 @@
-<% @title = t(".title", :name => h(@user.display_name)) %>
+<% @title = t(".title", :name => @user.display_name) %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html", :name => link_to(@user.display_name, user_path(@user))) %></h1>
 <% end %>
@@ -6,5 +6,5 @@
 <% unless @user_blocks.empty? %>
 <%= render :partial => "blocks", :locals => { :show_revoke_link => can?(:revoke, UserBlock), :show_user_name => true, :show_creator_name => false } %>
 <% else %>
-<p><%= t ".empty", :name => h(@user.display_name) %></p>
+<p><%= t ".empty", :name => @user.display_name %></p>
 <% end %>

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -1,4 +1,4 @@
-<% @title = t ".title", :name => h(@user_block.user.display_name) %>
+<% @title = t ".title", :name => @user_block.user.display_name %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html",
             :name => link_to(@user_block.user.display_name,
@@ -13,7 +13,7 @@
   <%= f.error_messages %>
 
   <p>
-    <%= f.label :reason, t(".reason", :name => h(@user_block.user.display_name)) %><br />
+    <%= f.label :reason, t(".reason", :name => @user_block.user.display_name) %><br />
     <%= richtext_area :user_block, :reason, :cols => 80, :rows => 20, :format => @user_block.reason_format %>
   </p>
   <p>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -1,4 +1,4 @@
-<% @title = t ".title", :name => h(@user.display_name) %>
+<% @title = t ".title", :name => @user.display_name %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html",
             :name => link_to(@user.display_name,

--- a/app/views/users/no_such_user.html.erb
+++ b/app/views/users/no_such_user.html.erb
@@ -1,4 +1,4 @@
 <% content_for :heading do %>
-  <h1><%= t ".heading", :user => h(@not_found_user) %></h1>
+  <h1><%= t ".heading", :user => @not_found_user %></h1>
 <% end %>
-<p><%= t ".body", :user => h(@not_found_user) %></p>
+<p><%= t ".body", :user => @not_found_user %></p>


### PR DESCRIPTION
They are escaped properly without the h() call, and doing that just double-escapes them.

As part of #2494 I set my local users to have all kinds of weird usernames, and today I spotted some places where they are being double-escaped. I suspect that almost all our uses of h() have been redundant since rails 3.x, but I haven't checked the rest.