### PR TITLE
Remove extra div wrappings from list items

### DIFF
--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -12,15 +12,11 @@
 
       <% if @user %>
         <% if @user == current_user %>
-          <div>
-            <li><%= link_to image_tag("new.png", :class => "small_icon", :border => 0) + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
-          </div>
+          <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
         <% end %>
       <% else %>
         <% if current_user %>
-          <div>
-            <li><%= link_to image_tag("new.png", :class => "small_icon", :border => 0) + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
-          </div>
+          <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
         <% end %>
       <% end %>
     </ul>


### PR DESCRIPTION
These are unnecessary, and also prevent the secondary-actions vertical border from appearing.