### PR TITLE
Use offwhite instead of grey for browse pages tag tables

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1175,7 +1175,7 @@ tr.turn:hover {
       font-size: 12px;
       border: 1px solid $grey;
       border-radius: 4px 4px 0 0;
-      background-color: #F6F6F6;
+      background-color: $offwhite;
     }
 
     p {
@@ -1189,7 +1189,7 @@ tr.turn:hover {
   }
 
   .browse-tag-list {
-    background-color: #F6F6F6;
+    background-color: $offwhite;
     border: 1px solid $grey;
     border-radius: 3px;
     font-size: 12px;
@@ -1214,7 +1214,7 @@ tr.turn:hover {
 
     .browse-tag-k {
       font-weight: 500;
-      background-color: #F6F6F6;
+      background-color: $offwhite;
     }
 
     .browse-tag-v {


### PR DESCRIPTION
The makes the tag tables more consistent with other tables, like messages, gps traces, user_blocks etc that use an offwhite background colour.