### PR TITLE
Cleanup custom CSS

### DIFF
--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -48,7 +48,7 @@ L.OSM.share = function (options) {
       .appendTo($linkSection);
 
     $("<div>")
-      .attr("class", "form-row")
+      .attr("class", "standard-form-row")
       .appendTo($form)
       .append(
         $("<label>")
@@ -91,7 +91,7 @@ L.OSM.share = function (options) {
       });
 
     $("<div>")
-      .attr("class", "form-row share-tab")
+      .attr("class", "standard-form-row share-tab")
       .css("display", "block")
       .appendTo($form)
       .append($("<input>")
@@ -100,7 +100,7 @@ L.OSM.share = function (options) {
         .on("click", select));
 
     $("<div>")
-      .attr("class", "form-row share-tab")
+      .attr("class", "standard-form-row share-tab")
       .appendTo($form)
       .append($("<input>")
         .attr("id", "short_input")
@@ -108,7 +108,7 @@ L.OSM.share = function (options) {
         .on("click", select));
 
     $("<div>")
-      .attr("class", "form-row share-tab")
+      .attr("class", "standard-form-row share-tab")
       .appendTo($form)
       .append(
         $("<textarea>")
@@ -159,7 +159,7 @@ L.OSM.share = function (options) {
       .appendTo($imageSection);
 
     $("<div>")
-      .attr("class", "form-row")
+      .attr("class", "standard-form-row")
       .appendTo($form)
       .append(
         $("<label>")
@@ -172,7 +172,7 @@ L.OSM.share = function (options) {
           .append(I18n.t("javascripts.share.custom_dimensions")));
 
     $("<div>")
-      .attr("class", "form-row")
+      .attr("class", "standard-form-row")
       .appendTo($form)
       .append(
         $("<label>")
@@ -187,7 +187,7 @@ L.OSM.share = function (options) {
         .append($("<option>").val("pdf").text("PDF")));
 
     $("<div>")
-      .attr("class", "form-row")
+      .attr("class", "standard-form-row")
       .appendTo($form)
       .append($("<label>")
         .attr("for", "mapnik_scale")

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -3,19 +3,6 @@
 
 /* Styles common to large and small screens */
 
-/* Minimal CSS reset */
-
-html, body {
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
 .fillL { background-color: white; }
 
 /* Default rules for the body of every page */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1450,7 +1450,7 @@ tr.turn:hover {
 /* Rules for the edit trace form */
 
 .edit_trace {
-  .form-row p {
+  .standard-form-row p {
     margin-bottom: 0px;
   }
 
@@ -1948,11 +1948,11 @@ tr.turn:hover {
     padding-top: $lineheight;
     border-top: 1px solid $lightgrey;
   }
-  .horizontal-list .form-row {
+  .horizontal-list .standard-form-row {
     float: left;
     padding-right: 10px;
   }
-  .form-row {
+  .standard-form-row {
     margin-bottom: $lineheight/2;
   }
   .form-list {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -5,7 +5,7 @@
 
 /* Minimal CSS reset */
 
-html, body, ul, ol, li, form, fieldset, legend, input {
+html, body, form, fieldset, legend, input {
   margin: 0;
   padding: 0;
   border: 0;
@@ -29,8 +29,6 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
-
-li { list-style: none; }
 
 input,
 select,
@@ -251,6 +249,7 @@ header {
 
 nav.primary {
   > ul {
+    padding: 0;
     $border: 1px solid $green;
 
     border: $border;
@@ -317,6 +316,9 @@ nav.secondary {
 
   > ul {
     vertical-align: middle;
+    margin: 0;
+    padding: 0;
+
     a, .dropdown-toggle {
       display: inline-block;
       text-decoration: none;
@@ -336,6 +338,7 @@ nav.secondary {
     border: $border;
     border-radius: $border-radius;
     margin-left: 10px;
+    padding: 0;
 
     > li {
       border-right: $border;
@@ -1002,9 +1005,14 @@ header .search_forms,
 /* Rules for search sidebar */
 
 #sidebar .search_results_entry {
+  ul {
+   padding: 0;
+  }
+
   ul li {
     border-bottom: $keyline;
     cursor: pointer;
+    list-style-type: none;
     &:first-child { border-top: $keyline; }
     &.selected { background: $list-highlight; }
   }
@@ -1121,10 +1129,6 @@ tr.turn:hover {
     padding: 1px 6px;
     border: 1px solid $lightgrey;
     border-radius: 3px;
-  }
-
-  .paginate ul {
-    padding-left: 20px;
   }
 
   .browse-field {
@@ -1505,10 +1509,6 @@ tr.turn:hover {
 .activity-details p {
   margin-left: 70px;
   margin-bottom: 0;
-}
-
-#friends-container .contact-activity ul {
-  margin-left: 70px;
 }
 
 .users-show {
@@ -1908,15 +1908,6 @@ tr.turn:hover {
     margin-bottom: 0px;
     padding: $lineheight/4;
   }
-
-  ul {
-    padding-left: $lineheight;
-
-    li {
-      font-size: 12px;
-      list-style: disc;
-    }
-  }
 }
 
 /* Rules for forms */
@@ -1960,7 +1951,8 @@ tr.turn:hover {
   }
   .form-list li {
     margin-bottom: 5px;
-   }
+    list-style-type: none;
+  }
   input[type="checkbox"],
   input[type="radio"] {
     float: left;
@@ -2044,6 +2036,7 @@ ul.secondary-actions {
   font-style: normal;
   margin-bottom: 0;
   margin-left: 0;
+  padding: 0;
   &.pager {
     display: inline-block;
     margin-right: 60px;
@@ -2237,20 +2230,6 @@ a.button {
     padding-left: $lineheight;
     margin: 0;
     color: $darkgrey;
-  }
-
-  ul, ol {
-    padding-left: $lineheight;
-    margin-bottom: $lineheight;
-    margin-left: $lineheight;
-  }
-
-  ul > li {
-    list-style: disc;
-  }
-
-  ol > li {
-    list-style: decimal;
   }
 }
 
@@ -2689,30 +2668,8 @@ input.richtext_title[type="text"] {
   opacity: 0.7;
 }
 
-.related-reports {
-  ul {
-    padding-left: $lineheight;
-    margin-bottom: 0;
-
-    li {
-      list-style: disc;
-    }
-  }
-}
-
 .issues-list {
   td:nth-child(2) {
     white-space: nowrap;
-  }
-}
-
-.report-disclaimer {
-  ul {
-    padding-left: $lineheight;
-    margin-bottom: 0;
-
-    li {
-      list-style: disc;
-    }
   }
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -5,24 +5,10 @@
 
 /* Minimal CSS reset */
 
-html, body, form, fieldset, legend, input {
+html, body {
   margin: 0;
   padding: 0;
   border: 0;
-}
-
-fieldset,img { border: 0; }
-
-legend { color: #000; }
-
-sup {
-  vertical-align: super;
-  font-size: smaller;
-}
-
-sub {
-  vertical-align: sub;
-  font-size: smaller;
 }
 
 table {
@@ -30,18 +16,9 @@ table {
   border-spacing: 0;
 }
 
-input,
-select,
-textarea,
-body { font: #{$typeheight}/#{$lineheight} "Helvetica Neue",Arial,sans-serif; }
-
 .fillL { background-color: white; }
 
 /* Default rules for the body of every page */
-
-* {
-  box-sizing: border-box;
-}
 
 body {
   font-family: 'Helvetica Neue',Arial,sans-serif;
@@ -126,15 +103,6 @@ a {
   &:hover {
     text-decoration: underline;
   }
-}
-
-/* Rules for horizontal lines */
-
-hr {
-  border: none;
-  background-color: $grey;
-  color: $grey;
-  height: 1px;
 }
 
 /* General styles for tables */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -35,27 +35,6 @@ select,
 textarea,
 body { font: #{$typeheight}/#{$lineheight} "Helvetica Neue",Arial,sans-serif; }
 
-abbr, acronym {
-  text-decoration: underline dotted;
-  cursor: help;
-}
-
-strong {
-  font-weight: bold;
-}
-
-/* Micro Clearfix | Details: http://nicolasgallagher.com/micro-clearfix-hack/ */
-
-.clearfix:before,
-.clearfix:after {
-    content: " ";
-    display: table;
-}
-
-.clearfix:after {
-    clear: both;
-}
-
 .fillL { background-color: white; }
 
 /* Default rules for the body of every page */

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -89,7 +89,7 @@
       <%= type_and_paginated_count("way", @way_pages) %>
       <%= render :partial => "paging_nav", :locals => { :pages => @way_pages, :page_param => "way_page" } %>
     </h4>
-    <ul>
+    <ul class="list-unstyled">
       <% @ways.each do |way| %>
         <li><%= link_to printable_name(way, true), { :action => "way", :id => way.way_id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
       <% end %>
@@ -101,7 +101,7 @@
       <%= type_and_paginated_count("relation", @relation_pages) %>
       <%= render :partial => "paging_nav", :locals => { :pages => @relation_pages, :page_param => "relation_page" } %>
     </h4>
-    <ul>
+    <ul class="list-unstyled">
       <% @relations.each do |relation| %>
         <li><%= link_to printable_name(relation, true), { :action => "relation", :id => relation.relation_id.to_s }, { :class => link_class("relation", relation), :title => link_title(relation) } %></li>
       <% end %>
@@ -113,7 +113,7 @@
       <%= type_and_paginated_count("node", @node_pages) %>
       <%= render :partial => "paging_nav", :locals => { :pages => @node_pages, :page_param => "node_page" } %>
     </h4>
-    <ul>
+    <ul class="list-unstyled">
       <% @nodes.each do |node| %>
         <li><%= link_to printable_name(node, true), { :action => "node", :id => node.node_id.to_s }, { :class => link_class("node", node), :title => link_title(node), :rel => link_follow(node) } %></li>
       <% end %>

--- a/app/views/diary_entries/_form.html.erb
+++ b/app/views/diary_entries/_form.html.erb
@@ -1,14 +1,14 @@
 <div class="diary_entry standard-form">
   <fieldset>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class="standard-label"><%= t ".subject" -%></label>
       <%= f.text_field :title, :class => "richtext_title" %>
     </div>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class="standard-label"><%= t ".body" -%></label>
       <%= richtext_area :diary_entry, :body, :cols => 80, :rows => 20, :format => @diary_entry.body_format %>
     </div>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class="standard-label"><%= t ".language" -%></label>
       <%= f.collection_select :language_code, Language.order(:english_name), :code, :name %>
   </div>
@@ -16,7 +16,7 @@
   <fieldset class='location'>
     <label class="standard-label"><%= t ".location" -%></label>
     <%= content_tag "div", "", :id => "map", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
-    <div class='form-row clearfix'>
+    <div class='standard-form-row clearfix'>
       <div class='form-column'>
         <label class="secondary standard-label"><%= t ".latitude" -%></label>
         <%= f.text_field :latitude, :size => 20, :id => "latitude" %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -39,7 +39,7 @@
   </div>
 
   <% if @issue.reported_user %>
-    <div class="col-md-4 related-reports">
+    <div class="col-md-4">
       <h3><%= t ".other_issues_against_this_user" %></h3>
       <% if @related_issues.count > 1 %>
         <ul>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -7,11 +7,11 @@
 <%= form_for @message, :html => { :class => "standard-form" } do |f| %>
   <%= hidden_field_tag :display_name, @message.recipient.display_name %>
   <fieldset>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class="standard-label" for="message_title"><%= t ".subject" %></label>
       <%= f.text_field :title, :size => 60, :class => "richtext_title" %>
     </div>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class="standard-label" for="message_body"><%= t ".body" %></label>
       <%= richtext_area :message, :body, :cols => 80, :rows => 20 %>
     </div>

--- a/app/views/oauth_clients/_form.html.erb
+++ b/app/views/oauth_clients/_form.html.erb
@@ -1,18 +1,18 @@
 <div class='standard-form'>
   <fieldset>
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class='standard-label' for="client_application_name"><%= t ".name" %> (<%= t ".required" %>)</label>
       <%= f.text_field :name %>
     </div>
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class='standard-label' for="client_application_url"><%= t ".url" %> (<%= t ".required" %>)</label>
       <%= f.text_field :url %>
     </div>
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class='standard-label' for="client_application_callback_url"><%= t ".callback_url" %></label>
       <%= f.text_field :callback_url %>
     </div>
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class='standard-label' for="client_application_support_url"><%= t ".support_url" %></label>
       <%= f.text_field :support_url %>
     </div>
@@ -20,7 +20,7 @@
   <fieldset class='form-divider'>
       <p><%= t ".requests" %></p>
       <% ClientApplication.all_permissions.each do |perm| %>
-        <div class="form-row">
+        <div class="standard-form-row">
           <%= f.check_box perm %>
           <label class='standard-label' for="client_application_<%= perm.to_s %>"><%= t("." + perm.to_s) %></label>
         </div>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -19,7 +19,7 @@
       <%= issue_form.hidden_field :reportable_type %>
     <% end %>
 
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <p><%= t(".select") %></p>
       <ul>
       <% Report.categories_for(@report.issue.reportable).each do |c| %>
@@ -31,7 +31,7 @@
       </ul>
     </div>
 
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <%= text_area :report, :details, :cols => 20, :rows => 5, :placeholder => t(".details") %>
     </div>
 

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -2,9 +2,9 @@
   <h1><%= t ".title_html", :link => link_to(reportable_title(@report.issue.reportable), reportable_url(@report.issue.reportable)) %></h1>
 <% end %>
 
-<div class="alert alert-warning report-disclaimer">
+<div class="alert alert-warning">
   <%= t(".disclaimer.intro") %>
-  <ul>
+  <ul class="mb-0">
     <li> <%= t(".disclaimer.not_just_mistake") %> </li>
     <li> <%= t(".disclaimer.unable_to_fix") %> </li>
     <li> <%= t(".disclaimer.resolve_with_user") %> </li>
@@ -13,7 +13,7 @@
 
 <%= form_for(@report) do |f| %>
   <%= f.error_messages %>
-  <fieldset>
+  <fieldset class="standard-form">
     <%= f.fields_for @report.issue do |issue_form| %>
       <%= issue_form.hidden_field :reportable_id %>
       <%= issue_form.hidden_field :reportable_type %>
@@ -21,11 +21,11 @@
 
     <div class='standard-form-row'>
       <p><%= t(".select") %></p>
-      <ul>
+      <ul class="form-list">
       <% Report.categories_for(@report.issue.reportable).each do |c| %>
         <li>
           <%= radio_button :report, :category, c, :required => true %>
-          <%= label_tag "report_category_#{c}", t(".categories.#{@report.issue.reportable.class.name.underscore}.#{c}_label") %> <br />
+          <%= label_tag "report_category_#{c}", t(".categories.#{@report.issue.reportable.class.name.underscore}.#{c}_label") %>
         </li>
       <% end %>
       </ul>

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -8,20 +8,20 @@
 
 <div id='edit-trace-form' class='standard-form'>
   <fieldset>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class='standard-label'><%= t ".filename" %></label>
       <p class='deemphasize'><%= @trace.name %> (<%= link_to t(".download"), trace_data_path(@trace) %>)</p>
     </div>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class='standard-label'><%= t ".uploaded_at" %></label>
       <p class='deemphasize'><%= l @trace.timestamp, :format => :friendly %></p>
     </div>
   <% if @trace.inserted? %>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class='standard-label'><%= t ".points" %></label>
       <p class='deemphasize'><%= @trace.size.to_s.gsub(/(\d)(?=(\d{3})+$)/, '\1,') %></p>
     </div>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class='standard-label'><%= t ".start_coord" %></label>
     </div>
     <div class="geo">
@@ -30,19 +30,19 @@
     </div>
     (<%= link_to t(".map"), :controller => "site", :action => "index", :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%= link_to t(".edit"), :controller => "site", :action => "edit", :gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)
   <% end %>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class='standard-label'><%= t ".owner" %></label>
       <p class='deemphasize'><%= link_to h(@trace.user.display_name), user_path(@trace.user) %></p>
     </div>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class='standard-label'><%= t ".description" %></label>
       <%= f.text_field :description %>
     </div>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class='standard-label'><%= t ".tags" %></label>
       <%= f.text_field :tagstring %> (<%= t ".tags_help" %>)
     </div>
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class='standard-label'><%= t ".visibility" %></label>
       <%= f.select :visibility, [[t("traces.visibility.private"), "private"], [t("traces.visibility.public"), "public"], [t("traces.visibility.trackable"), "trackable"], [t("traces.visibility.identifiable"), "identifiable"]] %> (<a href="<%= t ".visibility_help_url" %>"><%= t ".visibility_help" %></a>)
     </div>

--- a/app/views/traces/new.html.erb
+++ b/app/views/traces/new.html.erb
@@ -7,20 +7,20 @@
 <%= form_for @trace, :url => { :action => "create" }, :html => { :multipart => true } do |f| %>
   <div class="standard-form">
     <fieldset>
-      <div class='form-row'>
+      <div class='standard-form-row'>
         <label for="trace_gpx_file" class="standard-label"><%= t ".upload_gpx" %></label>
         <%= f.file_field :gpx_file %>
       </div>
-      <div class='form-row'>
+      <div class='standard-form-row'>
         <label class="standard-label"><%= t ".description" %></label>
         <%= f.text_field :description %>
       </div>
-      <div class='form-row'>
+      <div class='standard-form-row'>
         <label class="standard-label"><%= t ".tags" %></label>
         <%= f.text_field :tagstring %>
         <span class="form-help deemphasize">(<%= t ".tags_help" %>)</span>
       </div>
-      <div class='form-row'>
+      <div class='standard-form-row'>
         <label class="standard-label"><%= t ".visibility" %></label>
         <%= f.select :visibility, [[t("traces.visibility.private"), "private"], [t("traces.visibility.public"), "public"], [t("traces.visibility.trackable"), "trackable"], [t("traces.visibility.identifiable"), "identifiable"]] %>
         <span class="form-help deemphasize">(<a href="<%= t ".visibility_help_url" %>"><%= t ".visibility_help" %></a>)</span>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -13,20 +13,20 @@
 <%= error_messages_for current_user %>
 <%= form_for current_user, :url => { :action => :account }, :method => :post, :html => { :multipart => true, :id => "accountForm", :class => "standard-form", :autocomplete => :off } do |f| %>
   <fieldset>
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t "users.new.display name" %></label>
       <%= f.text_field :display_name %>
     </div>
   </fieldset>
 
   <fieldset>
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t ".current email address" %></label>
       <input type="email" disabled value="<%= current_user.email %>" />
       <span class="form-help deemphasize"><%= t ".email never displayed publicly" %></span>
     </div>
 
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t ".new email address" %></label>
       <%= f.email_field :new_email, :autocomplete => :off %>
       <span class="form-help deemphasize"><%= t ".email never displayed publicly" %></span>
@@ -34,19 +34,19 @@
   </fieldset>
 
   <fieldset>
-    <div class="form-row">
+    <div class="standard-form-row">
         <label class="standard-label"><%= t "users.new.password" %></label>
       <%= f.password_field :pass_crypt, :value => "", :autocomplete => :off %>
     </div>
 
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t "users.new.confirm password" %></label>
       <%= f.password_field :pass_crypt_confirmation, :value => "", :autocomplete => :off %>
     </div>
   </fieldset>
 
   <fieldset>
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t ".external auth" %></label>
       <%= f.select :auth_provider, Auth::PROVIDERS %>
       <%= f.text_field :auth_uid %>
@@ -55,7 +55,7 @@
   </fieldset>
 
   <fieldset class="form-divider">
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t ".public editing.heading" %></label>
       <span class="form-help deemphasize">
         <% if current_user.data_public? %>
@@ -68,7 +68,7 @@
       </span>
     </div>
 
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t ".contributor terms.heading" %></label>
       <span class="form-help deemphasize">
         <% if current_user.terms_agreed? %>
@@ -83,24 +83,24 @@
         <% end %>
       </span>
     </div>
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t ".preferred editor" %></label>
       <%= f.select :preferred_editor, [[t("editor.default", :name => t("editor.#{Settings.default_editor}.name")), "default"]] + Editors::ALL_EDITORS.collect { |e| [t("editor.#{e}.description"), e] } %>
     </div>
   </fieldset>
 
   <fieldset class="form-divider">
-    <div class='form-row'>
+    <div class='standard-form-row'>
       <label class="standard-label"><%= t ".profile description" %></label>
       <%= richtext_area :user, :description, :object => current_user, :cols => 80, :rows => 20 %>
     </div>
 
-    <div class="form-row">
+    <div class="standard-form-row">
       <label class="standard-label"><%= t ".preferred languages" %></label>
       <%= f.text_field :languages %>
     </div>
 
-    <div class='form-row accountImage'>
+    <div class='standard-form-row accountImage'>
       <label class="standard-label"><%= t ".image" %></label>
         <%= user_image current_user %>
         <ul class='form-list accountImage-options'>
@@ -147,7 +147,7 @@
   </fieldset>
 
   <fieldset class="form-divider">
-    <div class='form-row location clearfix'>
+    <div class='standard-form-row location clearfix'>
     <label class="standard-label"><%= t ".home location" %></label>
     <div id="homerow" <% unless current_user.home_lat and current_user.home_lon %> class="nohome"<% end %>>
       <p class="message form-help deemphasize"><%= t ".no home location" %></p>
@@ -162,7 +162,7 @@
       </div>
     </div>
 
-    <div class="form-row">
+    <div class="standard-form-row">
       <input type="checkbox" name="updatehome" value="1" <% unless current_user.home_lat and current_user.home_lon %> checked="checked" <% end %> id="updatehome" />
       <label class="standard-label" for="updatehome"><%= t ".update home location on click" %></label>
     </div>

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -15,13 +15,13 @@
     <div id="loginForm" class="standard-form">
 
       <fieldset>
-        <div class="form-row">
+        <div class="standard-form-row">
           <label for="username" class="standard-label">
             <%= t ".email or username" %>
           </label>
           <%= text_field_tag "username", params[:username], :tabindex => 1 %>
         </div>
-        <div class="form-row">
+        <div class="standard-form-row">
           <label for="password" class="standard-label">
             <%= t ".password" %>
           </label>
@@ -73,7 +73,7 @@
           <li><%= auth_button "aol", "openid", :openid_url => "aol.com" %></li>
         </ul>
 
-        <div id='login_openid_url' class='form-row'>
+        <div id='login_openid_url' class='standard-form-row'>
           <label for='openid_url' class="standard-label"><%= t ".openid_html", :logo => openid_logo %></label>
           <%= hidden_field_tag("openid_referer", params[:referer]) if params[:referer] %>
           <%= text_field_tag("openid_url", "", :tabindex => 3, :class => "openid_url") %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,14 +19,14 @@
       <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
 
       <fieldset>
-        <div class="form-row">
+        <div class="standard-form-row">
           <label for="email" class="standard-label">
             <%= t ".email address" %>
           </label>
           <%= f.email_field(:email, :tabindex => 1) %>
           <%= f.error_message_on(:email) %>
         </div>
-        <div class="form-row">
+        <div class="standard-form-row">
           <label for="email_confirmation" class="standard-label">
             <%= t ".confirm email address" %>
           </label>
@@ -37,7 +37,7 @@
       </fieldset>
 
       <fieldset>
-        <div class="form-row">
+        <div class="standard-form-row">
           <label for="display_name" class="standard-label">
             <%= t ".display name" %>
           </label>
@@ -48,7 +48,7 @@
       </fieldset>
 
       <fieldset class="form-divider" id="auth_field">
-        <div class="form-row">
+        <div class="standard-form-row">
           <label for="openid_url" class="standard-label">
             <%= t ".external auth" %>
           </label>
@@ -60,14 +60,14 @@
       </fieldset>
 
       <fieldset>
-        <div class="form-row">
+        <div class="standard-form-row">
           <label for='user[pass_crypt]' class="standard-label">
             <%= t ".password" %>
           </label>
           <%= f.password_field(:pass_crypt, :tabindex => 6) %>
           <%= f.error_message_on(:pass_crypt) %>
         </div>
-        <div class="form-row">
+        <div class="standard-form-row">
           <label class="standard-label">
             <%= t ".confirm password" %>
           </label>
@@ -76,7 +76,7 @@
         </div>
       </fieldset>
 
-      <div id="auth_prompt" class="form-row">
+      <div id="auth_prompt" class="standard-form-row">
         <%= link_to t(".use external auth"), "#", :id => "auth_enable" %>
       </div>
 

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -13,14 +13,14 @@
   <h4>
     <%= t ".heading_ct" %>
   </h4>
-  <div class='form-row horizontal-list clearfix'>
+  <div class='standard-form-row horizontal-list clearfix'>
     <p class="deemphasize"><%= t ".contributor_terms_explain" %></p>
     <label class="standard-label">
       <%= t ".legale_select" %>
     </label>
 
     <% [%w[france FR], %w[italy IT], %w[rest_of_world GB]].each do |name, legale| %>
-      <div class="form-row">
+      <div class="standard-form-row">
         <label for="legale_<%= legale %>">
           <%= radio_button_tag "legale", legale, @legale == legale, :data => { :url => url_for(:legale => legale) } %>
           <%= t(".legale_names." + name) %>
@@ -40,7 +40,7 @@
             :translations => "https://www.osmfoundation.org/wiki/License/Contributor_Terms/Informal_Translations" %>
     </p>
   </div>
-  <div class="form-row">
+  <div class="standard-form-row">
     <label for="read_ct">
       <%= check_box_tag "read_ct" %>
       <%= t ".read_ct" %>
@@ -51,7 +51,7 @@
     <%= t "layouts.tou" %>
   </h4>
   <p class="deemphasize"><%= t ".tou_explain_html", :tou_link => link_to(t("layouts.tou"), "https://wiki.osmfoundation.org/wiki/Terms_of_Use", :target => :new) %></p>
-  <div class="form-row">
+  <div class="standard-form-row">
     <label for="read_tou">
       <%= check_box_tag "read_tou" %>
       <%= t ".read_tou" %>
@@ -59,7 +59,7 @@
 
     <%= hidden_field_tag("referer", h(params[:referer])) unless params[:referer].nil? %>
 
-    <div class="buttons form-row py-3 clearfix">
+    <div class="buttons standard-form-row py-3 clearfix">
       <%= submit_tag("Continue", :name => "continue", :id => "continue", :disabled => true) %>
       <%= submit_tag("Cancel", :name => "decline", :id => "decline") %>
     </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -248,7 +248,7 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.form-row > input.field_with_errors#user_email"
+    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_email"
   end
 
   def test_new_duplicate_email_uppercase
@@ -265,7 +265,7 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.form-row > input.field_with_errors#user_email"
+    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_email"
   end
 
   def test_new_duplicate_name
@@ -282,7 +282,7 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.form-row > input.field_with_errors#user_display_name"
+    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_display_name"
   end
 
   def test_new_duplicate_name_uppercase
@@ -299,7 +299,7 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.form-row > input.field_with_errors#user_display_name"
+    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_display_name"
   end
 
   def test_new_blocked_domain
@@ -832,7 +832,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select "div#errorExplanation", false
     assert_select ".notice", /^User information updated successfully/
-    assert_select "form#accountForm > fieldset > div.form-row > div#user_description_container > div#user_description_content > textarea#user_description", user.description
+    assert_select "form#accountForm > fieldset > div.standard-form-row > div#user_description_container > div#user_description_content > textarea#user_description", user.description
 
     # Changing to a invalid editor should fail
     user.preferred_editor = "unknown"
@@ -841,7 +841,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select ".notice", false
     assert_select "div#errorExplanation"
-    assert_select "form#accountForm > fieldset > div.form-row > select#user_preferred_editor > option[selected]", false
+    assert_select "form#accountForm > fieldset > div.standard-form-row > select#user_preferred_editor > option[selected]", false
 
     # Changing to a valid editor should work
     user.preferred_editor = "potlatch2"
@@ -850,7 +850,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select "div#errorExplanation", false
     assert_select ".notice", /^User information updated successfully/
-    assert_select "form#accountForm > fieldset > div.form-row > select#user_preferred_editor > option[selected][value=?]", "potlatch2"
+    assert_select "form#accountForm > fieldset > div.standard-form-row > select#user_preferred_editor > option[selected][value=?]", "potlatch2"
 
     # Changing to the default editor should work
     user.preferred_editor = "default"
@@ -859,7 +859,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select "div#errorExplanation", false
     assert_select ".notice", /^User information updated successfully/
-    assert_select "form#accountForm > fieldset > div.form-row > select#user_preferred_editor > option[selected]", false
+    assert_select "form#accountForm > fieldset > div.standard-form-row > select#user_preferred_editor > option[selected]", false
 
     # Changing to an uploaded image should work
     image = Rack::Test::UploadedFile.new("test/gpx/fixtures/a.gif", "image/gif")
@@ -868,7 +868,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select "div#errorExplanation", false
     assert_select ".notice", /^User information updated successfully/
-    assert_select "form#accountForm > fieldset > div.form-row.accountImage input[name=avatar_action][checked][value=?]", "keep"
+    assert_select "form#accountForm > fieldset > div.standard-form-row.accountImage input[name=avatar_action][checked][value=?]", "keep"
 
     # Changing to a gravatar image should work
     post :account, :params => { :display_name => user.display_name, :avatar_action => "gravatar", :user => user.attributes }, :session => { :user => user }
@@ -876,7 +876,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select "div#errorExplanation", false
     assert_select ".notice", /^User information updated successfully/
-    assert_select "form#accountForm > fieldset > div.form-row.accountImage input[name=avatar_action][checked][value=?]", "gravatar"
+    assert_select "form#accountForm > fieldset > div.standard-form-row.accountImage input[name=avatar_action][checked][value=?]", "gravatar"
 
     # Removing the image should work
     post :account, :params => { :display_name => user.display_name, :avatar_action => "delete", :user => user.attributes }, :session => { :user => user }
@@ -884,7 +884,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select "div#errorExplanation", false
     assert_select ".notice", /^User information updated successfully/
-    assert_select "form#accountForm > fieldset > div.form-row.accountImage input[name=avatar_action][checked]", false
+    assert_select "form#accountForm > fieldset > div.standard-form-row.accountImage input[name=avatar_action][checked]", false
 
     # Adding external authentication should redirect to the auth provider
     post :account, :params => { :display_name => user.display_name, :user => user.attributes.merge(:auth_provider => "openid", :auth_uid => "gmail.com") }, :session => { :user => user }
@@ -898,7 +898,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select ".notice", false
     assert_select "div#errorExplanation"
-    assert_select "form#accountForm > fieldset > div.form-row > input.field_with_errors#user_display_name"
+    assert_select "form#accountForm > fieldset > div.standard-form-row > input.field_with_errors#user_display_name"
 
     # Changing name to one that exists should fail, regardless of case
     new_attributes = user.attributes.dup.merge(:display_name => create(:user).display_name.upcase)
@@ -907,7 +907,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select ".notice", false
     assert_select "div#errorExplanation"
-    assert_select "form#accountForm > fieldset > div.form-row > input.field_with_errors#user_display_name"
+    assert_select "form#accountForm > fieldset > div.standard-form-row > input.field_with_errors#user_display_name"
 
     # Changing name to one that doesn't exist should work
     new_attributes = user.attributes.dup.merge(:display_name => "new tester")
@@ -916,7 +916,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select "div#errorExplanation", false
     assert_select ".notice", /^User information updated successfully/
-    assert_select "form#accountForm > fieldset > div.form-row > input#user_display_name[value=?]", "new tester"
+    assert_select "form#accountForm > fieldset > div.standard-form-row > input#user_display_name[value=?]", "new tester"
 
     # Record the change of name
     user.display_name = "new tester"
@@ -932,7 +932,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select ".notice", false
     assert_select "div#errorExplanation"
-    assert_select "form#accountForm > fieldset > div.form-row > input.field_with_errors#user_new_email"
+    assert_select "form#accountForm > fieldset > div.standard-form-row > input.field_with_errors#user_new_email"
 
     # Changing email to one that exists should fail, regardless of case
     user.new_email = create(:user).email.upcase
@@ -945,7 +945,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select ".notice", false
     assert_select "div#errorExplanation"
-    assert_select "form#accountForm > fieldset > div.form-row > input.field_with_errors#user_new_email"
+    assert_select "form#accountForm > fieldset > div.standard-form-row > input.field_with_errors#user_new_email"
 
     # Changing email to one that doesn't exist should work
     user.new_email = "new_tester@example.com"
@@ -958,7 +958,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_template :account
     assert_select "div#errorExplanation", false
     assert_select ".notice", /^User information updated successfully/
-    assert_select "form#accountForm > fieldset > div.form-row > input#user_new_email[value=?]", user.new_email
+    assert_select "form#accountForm > fieldset > div.standard-form-row > input#user_new_email[value=?]", user.new_email
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal user.new_email, email.to.first

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -51,7 +51,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_template "users/new"
       assert_equal locale.to_s, response.headers["Content-Language"] unless locale == :root
-      assert_select "form > fieldset > div.form-row > input.field_with_errors#user_email"
+      assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_email"
       assert_no_missing_translations
     end
   end
@@ -75,7 +75,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       end
       assert_response :success
       assert_template "users/new"
-      assert_select "form > fieldset > div.form-row > input.field_with_errors#user_display_name"
+      assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_display_name"
       assert_no_missing_translations
     end
   end


### PR DESCRIPTION
This PR contains some changes that clean up our custom CSS rules.

* Rename form-row to standard-form-row, since form-row clashes with a class in the bootstrap forms component (and so things go badly awry when enabling the forms component).
* Rework lists to assume that they have margin+discs by default. It's easier to override them in the few cases that we don't want that to happen (e.g. forms, nav links) and the number of overrides is likely to decrease anyway as we use more bootstrap components
* Remove the custom reset code. Bootstrap contains its own reset, so there's nothing to be gained by resetting things again.