### PR TITLE
Use a list group for search results

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -228,12 +228,14 @@ OSM.Query = function (map) {
 
         if (results.remark) {
           $("<li>")
+            .addClass("query-result list-group-item")
             .text(I18n.t("javascripts.query.error", { server: url, error: results.remark }))
             .appendTo($ul);
         }
 
         if ($ul.find("li").length === 0) {
           $("<li>")
+            .addClass("query-result list-group-item")
             .text(I18n.t("javascripts.query.nothing_found"))
             .appendTo($ul);
         }
@@ -242,6 +244,7 @@ OSM.Query = function (map) {
         $section.find(".loader").stopTime("loading").hide();
 
         $("<li>")
+          .addClass("query-result list-group-item")
           .text(I18n.t("javascripts.query." + status, { server: url, error: error }))
           .appendTo($ul);
       }

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -45,9 +45,9 @@ OSM.Search = function (map) {
   $("#sidebar_content")
     .on("click", ".search_more a", clickSearchMore)
     .on("click", ".search_results_entry a.set_position", clickSearchResult)
-    .on("mouseover", "p.search_results_entry:has(a.set_position)", showSearchResult)
-    .on("mouseout", "p.search_results_entry:has(a.set_position)", hideSearchResult)
-    .on("mousedown", "p.search_results_entry:has(a.set_position)", function () {
+    .on("mouseover", "li.search_results_entry:has(a.set_position)", showSearchResult)
+    .on("mouseout", "li.search_results_entry:has(a.set_position)", hideSearchResult)
+    .on("mousedown", "li.search_results_entry:has(a.set_position)", function () {
       var moved = false;
       $(this).one("click", function (e) {
         if (!moved && !$(e.target).is("a")) {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -939,15 +939,8 @@ header .search_forms,
 /* Rules for search sidebar */
 
 #sidebar .search_results_entry {
-  ul {
-   padding: 0;
-  }
-
   ul li {
-    border-bottom: $keyline;
     cursor: pointer;
-    list-style-type: none;
-    &:first-child { border-top: $keyline; }
     &.selected { background: $list-highlight; }
   }
 

--- a/app/views/geocoder/results.html.erb
+++ b/app/views/geocoder/results.html.erb
@@ -1,9 +1,13 @@
 <% if @results.empty? %>
-  <p class="search_results_entry inner12"><%= t ".no_results" %></p>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">
+      <%= t ".no_results" %>
+    </li>
+  </ul>
 <% else %>
-  <ul class='results-list'>
+  <ul class='results-list list-group list-group-flush'>
     <% @results.each do |result| %>
-      <li><p class="inner12 search_results_entry clearfix"><%= result_to_html(result) %></p></li>
+      <li class="list-group-item search_results_entry"><%= result_to_html(result) %></li>
     <% end %>
   </ul>
   <% if @more_params %>

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -489,11 +489,11 @@ class GeocoderControllerTest < ActionController::TestCase
       assert_select "ul.results-list", 0
     else
       assert_select "ul.results-list", 1 do
-        assert_select "p.search_results_entry", results.count
+        assert_select "li.search_results_entry", results.count
 
         results.each do |result|
           attrs = result.collect { |k, v| "[data-#{k}='#{v}']" }.join("")
-          assert_select "p.search_results_entry a.set_position#{attrs}", result[:name]
+          assert_select "li.search_results_entry a.set_position#{attrs}", result[:name]
         end
       end
     end


### PR DESCRIPTION
As requested in #2497 , this PR changes the search results to use list-groups, which sorts out the extra margins on that page. I also spotted some fallback text in the query tool that needed the new list item classes, so I've added them too.