### PR TITLE
Fix typo: change 'noreferer' to 'noreferrer'

### DIFF
--- a/config/initializers/sanitize.rb
+++ b/config/initializers/sanitize.rb
@@ -1,5 +1,5 @@
 Sanitize::Config::OSM = Sanitize::Config::RELAXED.dup
 
 Sanitize::Config::OSM[:elements] -= %w[div style]
-Sanitize::Config::OSM[:add_attributes] = { "a" => { "rel" => "nofollow noopener noreferer" } }
+Sanitize::Config::OSM[:add_attributes] = { "a" => { "rel" => "nofollow noopener noreferrer" } }
 Sanitize::Config::OSM[:remove_contents] = %w[script style]

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -61,9 +61,9 @@ module RichText
 
     def linkify(text, mode = :urls)
       if text.html_safe?
-        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow noopener noreferer")).html_safe
+        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow noopener noreferrer")).html_safe
       else
-        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow noopener noreferer"))
+        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow noopener noreferrer"))
       end
     end
   end

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -8,14 +8,14 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow noopener noreferer']", 1
+      assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
 
     r = RichText.new("html", "foo <a href='http://example.com/'>bar</a> baz")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow noopener noreferer']", 1
+      assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
 
     r = RichText.new("html", "foo example@example.com bar")
@@ -27,7 +27,7 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='mailto:example@example.com']", 1
-      assert_select "a[rel='nofollow noopener noreferer']", 1
+      assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
 
     r = RichText.new("html", "foo <div>bar</div> baz")
@@ -64,28 +64,28 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow noopener noreferer']", 1
+      assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
 
     r = RichText.new("markdown", "foo [bar](http://example.com/) baz")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow noopener noreferer']", 1
+      assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
 
     r = RichText.new("markdown", "foo example@example.com bar")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='mailto:example@example.com']", 1
-      assert_select "a[rel='nofollow noopener noreferer']", 1
+      assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
 
     r = RichText.new("markdown", "foo [bar](mailto:example@example.com) bar")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='mailto:example@example.com']", 1
-      assert_select "a[rel='nofollow noopener noreferer']", 1
+      assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
 
     r = RichText.new("markdown", "foo ![bar](http://example.com/example.png) bar")
@@ -162,7 +162,7 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow noopener noreferer']", 1
+      assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
 
     r = RichText.new("text", "foo example@example.com bar")


### PR DESCRIPTION
as the correct rel attribute in external links.