### PR TITLE
Prevent exceptions while reversing directions

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -145,10 +145,10 @@ OSM.Directions = function (map) {
         to = endpoints[1].latlng,
         routeFrom = "",
         routeTo = "";
-    if(from){
+    if (from){
       routeFrom = from.lat + "," + from.lng;
     }
-    if(to){
+    if (to){
       routeTo = to.lat + "," + to.lng;
     }
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -142,12 +142,20 @@ OSM.Directions = function (map) {
 
   $(".directions_form .reverse_directions").on("click", function () {
     var from = endpoints[0].latlng,
-        to = endpoints[1].latlng;
+        to = endpoints[1].latlng,
+        routeFrom = "",
+        routeTo = "";
+    if(from){
+      routeFrom = from.lat + "," + from.lng;
+    }
+    if(to){
+      routeTo = to.lat + "," + to.lng;
+    }
 
     OSM.router.route("/directions?" + querystring.stringify({
       from: $("#route_to").val(),
       to: $("#route_from").val(),
-      route: to.lat + "," + to.lng + ";" + from.lat + "," + from.lng
+      route: routeTo + ";" + routeFrom
     }));
   });
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -145,10 +145,10 @@ OSM.Directions = function (map) {
         to = endpoints[1].latlng,
         routeFrom = "",
         routeTo = "";
-    if (from){
+    if (from) {
       routeFrom = from.lat + "," + from.lng;
     }
-    if (to){
+    if (to) {
       routeTo = to.lat + "," + to.lng;
     }
 


### PR DESCRIPTION
When reversing a route with full or partial empty `to` and `from` inputs, we get an exception.

Steps to reproduce.

- open directions, 
- enter something in `to` input.
- hit reverse directions
- the variable `to` is undefined, but the properties `lat` and `lng` are accessed.

![image](https://user-images.githubusercontent.com/2410353/73133630-d7695f80-402b-11ea-957c-82e76b2a375a.png)
