### PR TITLE
Sidebar styling fixes

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -902,6 +902,7 @@ header .search_forms,
     padding: 5px 20px 10px 15px;
     width: 100%;
     border-collapse: separate;
+    border-spacing: 0;
 }
 
 div.direction {
@@ -1026,6 +1027,7 @@ tr.turn:hover {
     border-radius: 3px;
     table-layout: fixed;
     border-collapse: separate;
+    border-spacing: 0;
 
     th, td {
       border-bottom: 1px solid $grey;

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -12,7 +12,7 @@
 
     <% unless node.ways.empty? and node.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
-      <ul>
+      <ul class="list-unstyled">
         <% node.ways.uniq.each do |way| %>
           <li><%= link_to printable_name(way), { :action => "way", :id => way.id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
         <% end %>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -12,12 +12,12 @@
 
     <% unless relation.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
-      <ul><%= render :partial => "containing_relation", :collection => relation.containing_relation_members.uniq %></ul>
+      <ul class="list-unstyled"><%= render :partial => "containing_relation", :collection => relation.containing_relation_members.uniq %></ul>
     <% end %>
 
     <% unless relation.relation_members.empty? %>
       <h4><%= t ".members" %></h4>
-      <ul><%= render :partial => "relation_member", :collection => relation.relation_members %></ul>
+      <ul class="list-unstyled"><%= render :partial => "relation_member", :collection => relation.relation_members %></ul>
     <% end %>
   </div>
 <% end %>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -12,14 +12,14 @@
 
     <% unless way.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
-      <ul>
+      <ul class="list-unstyled">
         <%= render :partial => "containing_relation", :collection => way.containing_relation_members.uniq %>
       </ul>
     <% end %>
 
     <% unless way.way_nodes.empty? %>
       <h4><%= t ".nodes" %></h4>
-      <ul>
+      <ul class="list-unstyled">
         <% way.way_nodes.each do |wn| %>
           <li>
             <%= link_to printable_name(wn.node), { :action => "node", :id => wn.node_id.to_s }, { :class => link_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -30,7 +30,7 @@
   <% if @comments.length > 0 %>
     <div class='changeset-comments'>
       <form action="#">
-        <ul>
+        <ul class="list-unstyled">
           <% @comments.each do |comment| %>
             <% if comment.visible %>
               <li id="c<%= comment.id %>">

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -29,7 +29,7 @@
 
   <% if @note_comments.length > 1 %>
     <div class='note-comments'>
-      <ul>
+      <ul class="list-unstyled">
         <% @note_comments[1..-1].each do |comment| %>
           <li id="c<%= comment.id %>">
             <small class='deemphasize'><%= note_event(comment.event, comment.created_at, comment.author) %></small>


### PR DESCRIPTION
Here's a few styling fixes for parts of the sidebar. Thanks go to @mmd-osm for pointing some out!

* Re-add table border spacing rules for the tables where we use border-collapse: separate
* Remove list styling from various lists in the sidebar, like nodes in the browse way page