### PR TITLE
Fix help page, grid card layout on mobile

### DIFF
--- a/app/views/site/help.html.erb
+++ b/app/views/site/help.html.erb
@@ -10,7 +10,7 @@
 <% sites.in_groups_of(3, false) do |group| %>
   <div class="card-deck mb-4">
     <% group.each do |site| %>
-      <div class='<%= site %> help-item card w-25'>
+      <div class='<%= site %> help-item card'>
         <div class='card-body'>
           <h6 class='card-title'>
             <a href='<%= t ".#{site}.url" %>'>


### PR DESCRIPTION
before: 
![image](https://user-images.githubusercontent.com/518939/74434850-f3626300-4e6b-11ea-8a56-702f8a1dc5a6.png)
 
after: 
![image](https://user-images.githubusercontent.com/518939/74434806-d9288500-4e6b-11ea-9440-2757e5df1b4e.png)
