### PR TITLE
Show mailto: links for email values in browse

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
 
+Metrics/ModuleLength:
+  Max: 150
+
 Naming/FileName:
   Exclude:
     - 'script/deliver-message'

--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -21,6 +21,12 @@ module BrowseTagsHelper
       link_to h(wmc[:title]), wmc[:url], :title => t("browse.tag_details.wikimedia_commons_link", :page => wmc[:title])
     elsif url = wiki_link("tag", "#{key}=#{value}")
       link_to h(value), url, :title => t("browse.tag_details.wiki_link.tag", :key => key, :value => value)
+    elsif emails = email_links(key, value)
+      # similarly, email_links() returns an array of emails
+      emails = emails.map do |e|
+        link_to(h(e[:email]), e[:url], :title => t("browse.tag_details.email_link", :email => e[:email]))
+      end
+      safe_join(emails, "; ")
     elsif phones = telephone_links(key, value)
       # similarly, telephone_links() returns an array of phone numbers
       phones = phones.map do |p|
@@ -119,6 +125,27 @@ module BrowseTagsHelper
         :url => "//commons.wikimedia.org/wiki/#{value}?uselang=#{I18n.locale}",
         :title => value
       }
+    end
+    nil
+  end
+
+  def email_links(_key, value)
+    # Does value look like an email? eg "someone@domain.tld"
+    # or a list of alternate emails separated by ;
+
+    # Uses WHATWG implementation of email validation, which follows RFC 1123
+    # but is a willful violation of RFC 5322.
+    #  (see: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)
+    if value.match?(%r{^\s*[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\s*
+                      (;\s*[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\s*)*$
+                    }x)
+      return value.split(";").map do |email|
+        # remove any leading or trailing whitespace if present
+        email = email.strip
+
+        # add 'mailto:'' prefix
+        { :email => email, :url => "mailto:#{email}" }
+      end
     end
     nil
   end

--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -136,8 +136,10 @@ module BrowseTagsHelper
     # Uses WHATWG implementation of email validation, which follows RFC 1123
     # but is a willful violation of RFC 5322.
     #  (see: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)
-    if value.match?(%r{^\s*[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\s*
-                      (;\s*[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\s*)*$
+    if value.match?(%r{^\s*[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+
+                          @[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\s*
+                      (;\s*[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+
+                          @[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\s*)*$
                     }x)
       return value.split(";").map do |email|
         # remove any leading or trailing whitespace if present

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -221,6 +221,78 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_nil link
   end
 
+  def test_email_links
+    links = email_links("foo", "Test")
+    assert_nil links
+
+    links = email_links("email", "123")
+    assert_nil links
+
+    links = email_links("email", "Abc.example.com")
+    assert_nil links
+
+    links = email_links("email", "a@b@c.com")
+    assert_nil links
+
+    links = email_links("email", "123 abcdefg@space.com")
+    assert_nil links
+
+    links = email_links("email", "test@ abc")
+    assert_nil links
+
+    links = email_links("email", "just\"not\"right@example.com")
+    assert_nil links
+
+    # If multiple emails are listed, all must be valid
+    links = email_links("email", "very.common@test.com; a@b@c.com")
+    assert_nil links
+
+    links = email_links("email", "x@example.com")
+    assert_equal 1, links.length
+    assert_equal "x@example.com", links[0][:email]
+    assert_equal "mailto:x@example.com", links[0][:url]
+
+    links = email_links("email", "other.email-with-hyphen@example.com")
+    assert_equal 1, links.length
+    assert_equal "other.email-with-hyphen@example.com", links[0][:email]
+    assert_equal "mailto:other.email-with-hyphen@example.com", links[0][:url]
+
+    links = email_links("email", "user.name+tag+sorting@example.com")
+    assert_equal 1, links.length
+    assert_equal "user.name+tag+sorting@example.com", links[0][:email]
+    assert_equal "mailto:user.name+tag+sorting@example.com", links[0][:url]
+
+    links = email_links("email", "dash-in@both-parts.com")
+    assert_equal 1, links.length
+    assert_equal "dash-in@both-parts.com", links[0][:email]
+    assert_equal "mailto:dash-in@both-parts.com", links[0][:url]
+
+    links = email_links("email", "   test@email.com	")
+    assert_equal 1, links.length
+    assert_equal "test@email.com", links[0][:email]
+    assert_equal "mailto:test@email.com", links[0][:url]
+
+    links = email_links("email", "example@s.example")
+    assert_equal 1, links.length
+    assert_equal "example@s.example", links[0][:email]
+    assert_equal "mailto:example@s.example", links[0][:url]
+
+    # Multiple valid phone numbers separated by ;
+    links = email_links("email", "test@email.com; example@s.example")
+    assert_equal 2, links.length
+    assert_equal "test@email.com", links[0][:email]
+    assert_equal "mailto:test@email.com", links[0][:url]
+    assert_equal "example@s.example", links[1][:email]
+    assert_equal "mailto:example@s.example", links[1][:url]
+
+    links = email_links("email", "x@example.com ;  dash-in@both-parts.com ")
+    assert_equal 2, links.length
+    assert_equal "x@example.com", links[0][:email]
+    assert_equal "mailto:x@example.com", links[0][:url]
+    assert_equal "dash-in@both-parts.com", links[1][:email]
+    assert_equal "mailto:dash-in@both-parts.com", links[1][:url]
+  end
+
   def test_telephone_links
     links = telephone_links("foo", "Test")
     assert_nil links

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -221,76 +221,55 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_nil link
   end
 
-  def test_email_links
-    links = email_links("foo", "Test")
-    assert_nil links
+  def test_email_link
+    email = email_link("foo", "Test")
+    assert_nil email
 
-    links = email_links("email", "123")
-    assert_nil links
+    email = email_link("email", "123")
+    assert_nil email
 
-    links = email_links("email", "Abc.example.com")
-    assert_nil links
+    email = email_link("email", "Abc.example.com")
+    assert_nil email
 
-    links = email_links("email", "a@b@c.com")
-    assert_nil links
+    email = email_link("email", "a@b@c.com")
+    assert_nil email
 
-    links = email_links("email", "123 abcdefg@space.com")
-    assert_nil links
+    email = email_link("email", "just\"not\"right@example.com")
+    assert_nil email
 
-    links = email_links("email", "test@ abc")
-    assert_nil links
+    email = email_link("email", "123 abcdefg@space.com")
+    assert_nil email
 
-    links = email_links("email", "just\"not\"right@example.com")
-    assert_nil links
+    email = email_link("email", "test@ abc")
+    assert_nil email
 
-    # If multiple emails are listed, all must be valid
-    links = email_links("email", "very.common@test.com; a@b@c.com")
-    assert_nil links
+    email = email_link("email", "using;semicolon@test.com")
+    assert_nil email
 
-    links = email_links("email", "x@example.com")
-    assert_equal 1, links.length
-    assert_equal "x@example.com", links[0][:email]
-    assert_equal "mailto:x@example.com", links[0][:url]
+    email = email_link("email", "x@example.com")
+    assert_equal "x@example.com", email[:email]
+    assert_equal "mailto:x@example.com", email[:url]
 
-    links = email_links("email", "other.email-with-hyphen@example.com")
-    assert_equal 1, links.length
-    assert_equal "other.email-with-hyphen@example.com", links[0][:email]
-    assert_equal "mailto:other.email-with-hyphen@example.com", links[0][:url]
+    email = email_link("email", "other.email-with-hyphen@example.com")
+    assert_equal "other.email-with-hyphen@example.com", email[:email]
+    assert_equal "mailto:other.email-with-hyphen@example.com", email[:url]
 
-    links = email_links("email", "user.name+tag+sorting@example.com")
-    assert_equal 1, links.length
-    assert_equal "user.name+tag+sorting@example.com", links[0][:email]
-    assert_equal "mailto:user.name+tag+sorting@example.com", links[0][:url]
+    email = email_link("email", "user.name+tag+sorting@example.com")
+    assert_equal "user.name+tag+sorting@example.com", email[:email]
+    assert_equal "mailto:user.name+tag+sorting@example.com", email[:url]
 
-    links = email_links("email", "dash-in@both-parts.com")
-    assert_equal 1, links.length
-    assert_equal "dash-in@both-parts.com", links[0][:email]
-    assert_equal "mailto:dash-in@both-parts.com", links[0][:url]
+    email = email_link("email", "dash-in@both-parts.com")
+    assert_equal "dash-in@both-parts.com", email[:email]
+    assert_equal "mailto:dash-in@both-parts.com", email[:url]
 
-    links = email_links("email", "   test@email.com	")
-    assert_equal 1, links.length
-    assert_equal "test@email.com", links[0][:email]
-    assert_equal "mailto:test@email.com", links[0][:url]
+    email = email_link("email", "example@s.example")
+    assert_equal "example@s.example", email[:email]
+    assert_equal "mailto:example@s.example", email[:url]
 
-    links = email_links("email", "example@s.example")
-    assert_equal 1, links.length
-    assert_equal "example@s.example", links[0][:email]
-    assert_equal "mailto:example@s.example", links[0][:url]
-
-    # Multiple valid phone numbers separated by ;
-    links = email_links("email", "test@email.com; example@s.example")
-    assert_equal 2, links.length
-    assert_equal "test@email.com", links[0][:email]
-    assert_equal "mailto:test@email.com", links[0][:url]
-    assert_equal "example@s.example", links[1][:email]
-    assert_equal "mailto:example@s.example", links[1][:url]
-
-    links = email_links("email", "x@example.com ;  dash-in@both-parts.com ")
-    assert_equal 2, links.length
-    assert_equal "x@example.com", links[0][:email]
-    assert_equal "mailto:x@example.com", links[0][:url]
-    assert_equal "dash-in@both-parts.com", links[1][:email]
-    assert_equal "mailto:dash-in@both-parts.com", links[1][:url]
+    # Strips whitespace at ends
+    email = email_link("email", " test@email.com ")
+    assert_equal "test@email.com", email[:email]
+    assert_equal "mailto:test@email.com", email[:url]
   end
 
   def test_telephone_links


### PR DESCRIPTION
Resolves #1689.
This will recognize most, but not all, valid email values and create mailto: links for them.
First used a regex suggested by the [W3C HTML spec](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address) directly,  but changed to using the built-in `URI::MailTo::EMAIL_REGEXP` in 5d7b09e3bd0a072835d992abc4a5229c3fcb10f1.

A subset of valid emails containing comments, whitespace characters, and quoted strings may not be recognized.