### PR TITLE
Fix border-radius for search query input field

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -764,10 +764,6 @@ header .search_forms,
     overflow: hidden;
     border-radius: 2px 0 0 2px;
   }
-  
-  input#query {
-    border-radius: 3px 0px 0px 3px;
-  }
 
   input[type=text] {
     width: 100%;
@@ -777,6 +773,7 @@ header .search_forms,
 
   input[type=text].overflow {
     border-right: none;
+    border-radius: 3px 0px 0px 3px;
   }
 
   input:focus {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -764,6 +764,10 @@ header .search_forms,
     overflow: hidden;
     border-radius: 2px 0 0 2px;
   }
+  
+  input#query {
+    border-radius: 3px 0px 0px 3px;
+  }
 
   input[type=text] {
     width: 100%;


### PR DESCRIPTION
With this PR, I fixed a minor visual bug with the search query input field. The border-radius caused the field to not touch the neighbouring button at its corners, which looked weird in my opinion.

**Before**
![Searchbar Before](https://user-images.githubusercontent.com/31667811/76684075-30f01280-6609-11ea-9b2d-8e4b13b12d30.PNG)
**After**
![Searchbar After](https://user-images.githubusercontent.com/31667811/76684456-7c57f000-660c-11ea-8d38-86abfdf7ae40.PNG)
