### PR TITLE
Remove unnecessary h() calls on model attributes

### DIFF
--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,6 +1,6 @@
 <h4>
   <% if common_details.changeset.tags['comment'].present? %>
-    <%= linkify(h(common_details.changeset.tags["comment"])) %>
+    <%= linkify(common_details.changeset.tags["comment"]) %>
   <% else %>
     <%= t "browse.no_comment" %>
   <% end %>
@@ -15,7 +15,7 @@
 
 <div class="details">
   <%= t "browse.version" %>
-  #<%= h(common_details.version) %>
+  #<%= common_details.version %>
   &middot;
   <%= t "browse.in_changeset" %>
   #<%= link_to common_details.changeset_id, :action => :changeset, :id => common_details.changeset_id %>

--- a/app/views/browse/_containing_relation.html.erb
+++ b/app/views/browse/_containing_relation.html.erb
@@ -1,7 +1,7 @@
-<li><%= linked_name = link_to h(printable_name(containing_relation.relation)), :action => "relation", :id => containing_relation.relation.id.to_s
+<li><%= linked_name = link_to printable_name(containing_relation.relation), :action => "relation", :id => containing_relation.relation.id.to_s
         if containing_relation.member_role.blank?
           t ".entry_html", :relation_name => linked_name
         else
-          t ".entry_role_html", :relation_name => linked_name, :relation_role => h(containing_relation.member_role)
+          t ".entry_role_html", :relation_name => linked_name, :relation_role => containing_relation.member_role
         end %>
 </li>

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -5,6 +5,6 @@
   <%= if relation_member.member_role.blank?
         t ".entry_html", :type => type_str, :name => linked_name
       else
-        t ".entry_role_html", :type => type_str, :name => linked_name, :role => h(relation_member.member_role)
+        t ".entry_role_html", :type => type_str, :name => linked_name, :role => relation_member.member_role
       end %>
 </li>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -6,7 +6,7 @@
 </h2>
 
 <div class="browse-section">
-  <h6><%= linkify(h(@changeset.tags["comment"].to_s.presence || t("browse.no_comment"))) %></h6>
+  <h6><%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %></h6>
   <div class="details"><%= changeset_details(@changeset) %></div>
 
   <%= render :partial => "tag_details", :object => @changeset.tags.except("comment") %>
@@ -38,7 +38,7 @@
                   <%= t(".commented_by",
                         :when => friendly_date_ago(comment.created_at),
                         :exact_time => l(comment.created_at),
-                        :user => link_to(h(comment.author.display_name), user_path(comment.author))).html_safe %>
+                        :user => link_to(comment.author.display_name, user_path(comment.author))).html_safe %>
                   <% if current_user and current_user.moderator? %>
                     — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_hide_url(comment.id) %>"><%= t("javascripts.changesets.show.hide_comment") %></span>
                   <% end %>
@@ -51,7 +51,7 @@
                   <%= t(".hidden_commented_by",
                         :when => friendly_date_ago(comment.created_at),
                         :exact_time => l(comment.created_at),
-                        :user => link_to(h(comment.author.display_name), user_path(comment.author))).html_safe %>
+                        :user => link_to(comment.author.display_name, user_path(comment.author))).html_safe %>
                   — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_unhide_url(comment.id) %>"><%= t("javascripts.changesets.show.unhide_comment") %></span>
                  </small>
                 <%= comment.body.to_html %>

--- a/app/views/changesets/index.atom.builder
+++ b/app/views/changesets/index.atom.builder
@@ -24,9 +24,9 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
                  :type => "application/osmChange+xml"
 
       if !changeset.tags.empty? && changeset.tags.key?("comment")
-        entry.title t("browse.changeset.feed.title_comment", :id => h(changeset.id), :comment => h(changeset.tags["comment"])), :type => "html"
+        entry.title t("browse.changeset.feed.title_comment", :id => changeset.id, :comment => changeset.tags["comment"]), :type => "html"
       else
-        entry.title t("browse.changeset.feed.title", :id => h(changeset.id))
+        entry.title t("browse.changeset.feed.title", :id => changeset.id)
       end
 
       if changeset.user.data_public?
@@ -51,7 +51,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
             table.tr do |tr|
               tr.th t("browse.changeset.belongs_to")
               tr.td do |td|
-                td.a h(changeset.user.display_name), :href => user_url(changeset.user, :only_path => false)
+                td.a changeset.user.display_name, :href => user_url(changeset.user, :only_path => false)
               end
             end
           end
@@ -62,7 +62,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
                 td.table :cellpadding => "0" do |tag_table|
                   changeset.tags.sort.each do |tag|
                     tag_table.tr do |tag_tr|
-                      tag_tr.td << "#{h(tag[0])} = #{linkify(h(tag[1]))}"
+                      tag_tr.td << "#{tag[0]} = #{linkify(tag[1])}"
                     end
                   end
                 end

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="clearfix diary-comment<%= " deemphasize" unless diary_comment.visible? %>">
   <%= user_thumbnail diary_comment.user %>
-  <p class="deemphasize comment-heading" id="comment<%= diary_comment.id %>"><%= t(".comment_from_html", :link_user => (link_to h(diary_comment.user.display_name), user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}")) %>
+  <p class="deemphasize comment-heading" id="comment<%= diary_comment.id %>"><%= t(".comment_from_html", :link_user => (link_to diary_comment.user.display_name, user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}")) %>
     <% if current_user and diary_comment.user.id != current_user.id %>
       | <%= report_link(t(".report"), diary_comment) %>
     <% end %>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -4,10 +4,10 @@
       <%= user_thumbnail diary_entry.user %>
     <% end %>
 
-    <h2><%= link_to h(diary_entry.title), diary_entry_path(diary_entry.user, diary_entry) %></h2>
+    <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>
 
     <small class='deemphasize'>
-      <%= t(".posted_by_html", :link_user => (link_to h(diary_entry.user.display_name), user_path(diary_entry.user)), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to diary_entry.language.name, :controller => "diary_entries", :action => "index", :display_name => nil, :language => diary_entry.language_code)) %>
+      <%= t(".posted_by_html", :link_user => (link_to diary_entry.user.display_name, user_path(diary_entry.user)), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to diary_entry.language.name, :controller => "diary_entries", :action => "index", :display_name => nil, :language => diary_entry.language_code)) %>
     </small>
 
   </div>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -3,7 +3,7 @@
     <% if @user %>
       <%= user_image @user %>
     <% end %>
-    <h1><%= h(@title) %></h1>
+    <h1><%= @title %></h1>
 
     <ul class='secondary-actions clearfix'>
       <% unless params[:friends] or params[:nearby] -%>

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -1,6 +1,6 @@
 <tr id="inbox-<%= message_summary.id %>" class="inbox-row<%= "-unread" unless message_summary.message_read? %>">
-  <td class="inbox-sender"><%= link_to h(message_summary.sender.display_name), user_path(message_summary.sender) %></td>
-  <td class="inbox-subject"><%= link_to h(message_summary.title), message_path(message_summary) %></td>
+  <td class="inbox-sender"><%= link_to message_summary.sender.display_name, user_path(message_summary.sender) %></td>
+  <td class="inbox-subject"><%= link_to message_summary.title, message_path(message_summary) %></td>
   <td class="inbox-sent"><%= l message_summary.sent_on, :format => :friendly %></td>
   <td class="inbox-mark-unread"><%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true %></td>
   <td class="inbox-mark-read"><%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true %></td>

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -1,6 +1,6 @@
 <tr class="inbox-row">
-  <td class="inbox-sender"><%= link_to h(sent_message_summary.recipient.display_name), user_path(sent_message_summary.recipient) %></td>
-  <td class="inbox-subject"><%= link_to h(sent_message_summary.title), message_path(sent_message_summary) %></td>
+  <td class="inbox-sender"><%= link_to sent_message_summary.recipient.display_name, user_path(sent_message_summary.recipient) %></td>
+  <td class="inbox-subject"><%= link_to sent_message_summary.title, message_path(sent_message_summary) %></td>
   <td class="inbox-sent"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
   <td class="inbox-destroy"><%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true %></td>
 </tr>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,11 +1,11 @@
 <% if current_user == @message.recipient %>
   <% content_for :heading do %>
-    <h2><%= h(@message.title) %></h2>
+    <h2><%= @message.title %></h2>
   <% end %>
 
   <div class='info-line clearfix'>
     <%= user_thumbnail_tiny @message.sender %>
-    <%= link_to h(@message.sender.display_name), user_path(@message.sender) %></td>
+    <%= link_to @message.sender.display_name, user_path(@message.sender) %></td>
     <div class='right'>
       <%= l @message.sent_on, :format => :friendly %>
     </div>
@@ -22,11 +22,11 @@
 
 <% else %>
 
-  <h2><%= h(@message.title) %></h2>
+  <h2><%= @message.title %></h2>
 
   <div class='info-line clearfix'>
     <%= user_thumbnail_tiny @message.recipient %>
-    <%= link_to h(@message.recipient.display_name), user_path(@message.recipient) %></td>
+    <%= link_to @message.recipient.display_name, user_path(@message.recipient) %></td>
     <div class='right'>
       <%= l @message.sent_on, :format => :friendly %>
     </div>

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -26,7 +26,7 @@
       <br />
       <%= trace.description %>
     <br />
-    <%= t ".by" %> <%= link_to h(trace.user.display_name), user_path(trace.user) %>
+    <%= t ".by" %> <%= link_to trace.user.display_name, user_path(trace.user) %>
     <% if !trace.tags.empty? %>
       <%= t ".in" %>
       <%= safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t ".heading", :name => h(@trace.name) %></h2>
+  <h2><%= t ".heading", :name => @trace.name %></h2>
 <% end %>
 
 <img src="<%= url_for :controller => "traces", :action => "picture", :id => @trace.id, :display_name => @trace.user.display_name %>">
@@ -32,7 +32,7 @@
   <% end %>
     <div class='standard-form-row'>
       <label class='standard-label'><%= t ".owner" %></label>
-      <p class='deemphasize'><%= link_to h(@trace.user.display_name), user_path(@trace.user) %></p>
+      <p class='deemphasize'><%= link_to @trace.user.display_name, user_path(@trace.user) %></p>
     </div>
     <div class='standard-form-row'>
       <label class='standard-label'><%= t ".description" %></label>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= h(@title) %></h1>
+  <h1><%= @title %></h1>
   <ul class='secondary-actions clearfix'>
     <li><%= t(".description") %></li>
     <li><%= rss_link_to :action => "georss", :display_name => @display_name, :tag => @tag %></li>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t ".heading", :name => h(@trace.name) %></h2>
+  <h2><%= t ".heading", :name => @trace.name %></h2>
 <% end %>
 
 <% if Settings.status != "gpx_offline" %>
@@ -30,11 +30,11 @@
   <% end %>
   <tr>
     <td><%= t ".owner" %></td>
-    <td><%= link_to h(@trace.user.display_name), user_path(@trace.user) %></td>
+    <td><%= link_to @trace.user.display_name, user_path(@trace.user) %></td>
   </tr>
   <tr>
     <td><%= t ".description" %></td>
-    <td><%= h(@trace.description) %></td>
+    <td><%= @trace.description %></td>
   </tr>
   <tr>
     <td><%= t ".tags" %></td>

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -1,9 +1,9 @@
 <tr>
   <% if show_user_name %>
-  <td><%= link_to h(block.user.display_name), user_path(block.user) %></td>
+  <td><%= link_to block.user.display_name, user_path(block.user) %></td>
   <% end %>
   <% if show_creator_name %>
-  <td><%= link_to h(block.creator.display_name), user_path(block.creator) %></td>
+  <td><%= link_to block.creator.display_name, user_path(block.creator) %></td>
   <% end %>
   <td><%= h truncate(block.reason) %></td>
   <td><%= h block_status(block) %></td>
@@ -11,7 +11,7 @@
     <% if block.revoker_id.nil? %>
       <%= t(".not_revoked") %>
     <% else %>
-      <%= link_to h(block.revoker.display_name), user_path(block.revoker) %>
+      <%= link_to block.revoker.display_name, user_path(block.revoker) %>
     <% end %>
   </td>
   <td><%= link_to t(".show"), block %></td>

--- a/app/views/user_blocks/blocks_on.html.erb
+++ b/app/views/user_blocks/blocks_on.html.erb
@@ -5,5 +5,5 @@
 <% unless @user_blocks.empty? %>
 <%= render :partial => "blocks", :locals => { :show_revoke_link => can?(:revoke, UserBlock), :show_user_name => false, :show_creator_name => true } %>
 <% else %>
-<p><%= t ".empty", :name => h(@user.display_name) %></p>
+<p><%= t ".empty", :name => @user.display_name %></p>
 <% end %>

--- a/app/views/user_blocks/revoke.html.erb
+++ b/app/views/user_blocks/revoke.html.erb
@@ -1,6 +1,6 @@
 <% @title = t(".title",
-              :block_on => h(@user_block.user.display_name),
-              :block_by => h(@user_block.creator.display_name)) %>
+              :block_on => @user_block.user.display_name,
+              :block_by => @user_block.creator.display_name) %>
 
 <% content_for :heading do %>
   <h1><%= t(".heading_html",

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -24,7 +24,7 @@
 <% if @user_block.revoker %>
 <p>
   <b><%= t ".revoker" %></b>
-  <%= link_to h(@user_block.revoker.display_name), user_path(@user_block.revoker) %>
+  <%= link_to @user_block.revoker.display_name, user_path(@user_block.revoker) %>
 </p>
 <% end %>
 

--- a/app/views/users/_contact.html.erb
+++ b/app/views/users/_contact.html.erb
@@ -8,7 +8,7 @@
   <%= user_thumbnail contact %>
   <div class='activity-details'>
     <p class='deemphasize'>
-      <%= link_to h(contact.display_name), user_path(contact) %>
+      <%= link_to contact.display_name, user_path(contact) %>
       <% if @user.home_lon and @user.home_lat and contact.home_lon and contact.home_lat %>
         <% distance = @user.distance(contact) %>
         <% if distance < 1 %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -6,12 +6,12 @@
     <p>
       <% if user.creation_ip %>
         <%= t "users.index.summary_html",
-              :name => link_to(h(user.display_name), user_path(user)),
+              :name => link_to(user.display_name, user_path(user)),
               :ip_address => link_to(user.creation_ip, :ip => user.creation_ip),
               :date => l(user.creation_time, :format => :friendly) %>
       <% else %>
         <%= t "users.index.summary_no_ip_html",
-              :name => link_to(h(user.display_name), user_path(user)),
+              :name => link_to(user.display_name, user_path(user)),
               :date => l(user.creation_time, :format => :friendly) %>
       <% end %>
     </p>


### PR DESCRIPTION
These were necessary in the rails 2.x era, but not now. Expands on the situations fixed by #2500 