### PR TITLE
WIP: Convert database config to support reading from replicas

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  connects_to :database => { :writing => :primary, :reading => :primary_replica }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,9 +113,9 @@ Rails.application.configure do
   # DatabaseSelector middleware is designed as such you can define your own
   # strategy for connection switching and pass that into the middleware through
   # these configuration options.
-  # config.active_record.database_selector = { delay: 2.seconds }
-  # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.active_record.database_selector = { :delay => 2.seconds }
+  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # Enable autoloading of dependencies.
   config.enable_dependency_loading = true

--- a/config/example.database.yml
+++ b/config/example.database.yml
@@ -2,28 +2,40 @@
 # See https://github.com/openstreetmap/openstreetmap-website/blob/master/INSTALL.md#database-setup for detailed setup instructions.
 #
 development:
-  adapter: postgresql
-  database: openstreetmap
-#  username: openstreetmap
-#  password: openstreetmap
-#  host: localhost
-  encoding: utf8
+  primary: &development_db
+    adapter: postgresql
+    database: openstreetmap
+    # username: openstreetmap
+    # password: openstreetmap
+    # host: localhost
+    encoding: utf8
+  primary_replica:
+    <<: *development_db
+    replica: true
 
 # Warning: The database defined as 'test' will be erased and
 # re-generated from your development database when you run 'rake'.
 # Do not set this db to the same as development or production.
 test:
-  adapter: postgresql
-  database: osm_test
-#  username: osm_test
-#  password: osm_test
-#  host: localhost
-  encoding: utf8
+  primary: &test_db
+    adapter: postgresql
+    database: osm_test
+    # username: osm_test
+    # password: osm_test
+    # host: localhost
+    encoding: utf8
+  primary_replica:
+    <<: *test_db
+    replica: true
 
 production:
-  adapter: postgresql
-  database: osm
-#  username: osm
-#  password: osm
-#  host: localhost
-  encoding: utf8
+  primary: &production_db
+    adapter: postgresql
+    database: osm
+    # username: osm
+    # password: osm
+    # host: localhost
+    encoding: utf8
+  primary_replica:
+    <<: *production_db
+    replica: true

--- a/config/travis.database.yml
+++ b/config/travis.database.yml
@@ -1,5 +1,9 @@
 test:
-  adapter: postgresql
-  database: openstreetmap
-  username: postgres
-  encoding: utf8
+  primary: &test_db
+    adapter: postgresql
+    database: openstreetmap
+    username: postgres
+    encoding: utf8
+  primary_replica:
+    <<: *test_db
+    replica: true


### PR DESCRIPTION
https://guides.rubyonrails.org/active_record_multiple_databases.html

To enable splitting reads and writes we need to convert the database config files. This will involve everyone having to make changes to their local database.yml file too.

I generally don't like using yaml anchors and aliases, but I think this is the easiest way to avoid new developers from getting confused if they change e.g. the hostname for `development -> primary -> database` and forget to make the same change to the `primary_replica` entry too.

For situations where there's no replication (e.g. local development) then the example configs are fine. If you have a replicated database setup, then you can change just the bits you need, for example:

```
  primary_replica:
    <<: *production_db
    host: read-replica.example.com
    user: osmreadonly
    replica: true
```

I made some local tests and it seemed to work out of the box. With this PR, all reads come from the replica, unless the same user session has written to the database in the last 2 seconds. I had a look at the [munin graphs](https://munin.openstreetmap.org/openstreetmap.org/katla.openstreetmap.org/postgres_replication_9_5_main.html) and 2 seconds seems fine to me.