### PR TITLE
Remove custom table styling

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -92,25 +92,6 @@ a {
   }
 }
 
-/* General styles for tables */
-
-table {
-  width: 100%;
-  margin-bottom: $lineheight;
-  th, td {
-    text-align: left;
-    padding: $lineheight/4;
-    line-height: $lineheight;
-  }
-  th {
-    font-weight: 600;
-    vertical-align: top;
-  }
-  td {
-    vertical-align: middle;
-  }
-}
-
 /* Utility for de-emphasizing content */
 
 .deemphasize {
@@ -873,9 +854,6 @@ header .search_forms,
     margin-left: auto;
     margin-right: auto;
   }
-  td {
-    padding: 0 $lineheight/4 $lineheight/4 $lineheight/4;
-  }
 }
 
 /* Rules for search sidebar */
@@ -1029,6 +1007,7 @@ tr.turn:hover {
     table-layout: fixed;
     border-collapse: separate;
     border-spacing: 0;
+    width: 100%;
 
     th, td {
       border-bottom: 1px solid $grey;
@@ -1298,18 +1277,6 @@ tr.turn:hover {
   border: 1px solid $grey;
   margin-bottom: $lineheight;
   float: right;
-}
-
-/* Rules for the trace list shown by the traces tab etc */
-
-#trace_list {
-  border-width: 0px;
-  text-align: right;
-
-  .trace_summary {
-    font-size: 12px;
-    color: gray;
-  }
 }
 
 /* Rules for the new trace form */
@@ -1624,14 +1591,8 @@ tr.turn:hover {
 /* Rules for messages pages */
 
 .messages {
-  width: 100%;
-  border: 1px solid $grey;
-
   input[type="submit"] {
     margin: auto;
-  }
-  tbody tr {
-    border-top: 1px solid $grey;
   }
 
   .inbox-row {
@@ -1639,27 +1600,11 @@ tr.turn:hover {
   }
 
   .inbox-row-unread {
-    background:#CBEEA7;
+    background: #CBEEA7;
   }
 
   .right {
     float: right;
-  }
-
-  tr td,
-  tr th {
-    padding: $lineheight/4;
-  }
-  p:last-child,
-  h2:last-child,
-  h3:last-child,
-  ol:last-child,
-  ul:last-child {
-    margin-bottom:0;
-  }
-  tr td {
-    height: 30px;
-    border-right: 1px solid $lightgrey;
   }
 }
 
@@ -2192,15 +2137,7 @@ input.richtext_title[type="text"] {
 
 .note_list {
   tr.creator {
-    background-color: $lightgrey;
-  }
-
-  td {
-    padding: 3px;
-  }
-
-  p {
-    margin-bottom: 0px;
+    background-color: $offwhite;
   }
 }
 
@@ -2407,10 +2344,4 @@ input.richtext_title[type="text"] {
 .read-reports {
   background: $lightgrey;
   opacity: 0.7;
-}
-
-.issues-list {
-  td:nth-child(2) {
-    white-space: nowrap;
-  }
 }

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -18,7 +18,7 @@
 
 <br />
 
-<table class="issues-list">
+<table class="table table-sm">
   <thead>
     <tr>
       <th><%= t ".status" %></th>
@@ -32,7 +32,7 @@
     <% @issues.each do |issue| %>
       <tr>
         <td><%= t ".states.#{issue.status}" %></td>
-        <td><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
+        <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
         <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
         <td><%= link_to issue.reported_user.display_name, user_path(issue.reported_user) if issue.reported_user %></td>
         <td>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -9,7 +9,7 @@
   <h4><%= render :partial => "message_count" %></h4>
 
 <% if current_user.messages.size > 0 %>
-  <table class="messages">
+  <table class="table table-sm">
     <thead>
       <tr>
         <th><%= t ".from" %></th>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -9,7 +9,7 @@
 <h4><%= t ".messages", :count => current_user.sent_messages.size %></h4>
 
 <% if current_user.sent_messages.size > 0 %>
-  <table class="messages">
+  <table class="table table-sm">
     <thead>
       <tr>
         <th><%= t ".to" %></th>

--- a/app/views/notes/mine.html.erb
+++ b/app/views/notes/mine.html.erb
@@ -5,7 +5,7 @@
 
 <%= render :partial => "notes_paging_nav" %>
 
-<table class="note_list">
+<table class="table table-sm note_list">
   <thead>
     <tr>
       <th></th>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -5,7 +5,7 @@
 <% unless @tokens.empty? %>
 <h3><%= t ".my_tokens" %></h3>
 <p><%= t ".list_tokens" %></p>
-<table>
+<table class="table table-sm">
   <thead>
     <tr>
       <th><%= t ".application" %></th>

--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -1,9 +1,9 @@
 <div id="mapkey">
-  <table class="mapkey-table">
+  <table class="table table-sm table-borderless mapkey-table">
     <% YAML.load_file(Rails.root.join("config/key.yml")).each do |name,data| %>
       <% data.each do |entry| %>
         <tr class="mapkey-table-entry" data-layer="<%= name %>" data-zoom-min="<%= entry["min_zoom"] %>" data-zoom-max="<%= entry["max_zoom"] %>">
-          <td class="mapkey-table-key">
+          <td class="mapkey-table-key align-middle">
             <%= image_tag "key/#{name}/#{entry['image']}" %>
           </td>
           <td class="mapkey-table-value">

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -9,7 +9,7 @@
     <% end %>
   </td>
   <td><%= link_to trace.name, :controller => "traces", :action => "show", :display_name => trace.user.display_name, :id => trace.id %>
-    <span class="trace_summary" title="<%= trace.timestamp %>"> ...
+    <span class="deemphasize" title="<%= trace.timestamp %>"> ...
       <% if trace.inserted %>
         (<%= t ".count_points", :count => trace.size %>)
       <% end %>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 <% end %>
 
-<table border="0">
+<table class="table table-borderless table-sm">
   <tr>
     <td><%= t ".filename" %></td>
     <td><%= @trace.name %> (<%= link_to t(".download"), trace_data_path(@trace) %>)</td>

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -344,7 +344,7 @@ class MessagesControllerTest < ActionController::TestCase
     get :inbox
     assert_response :success
     assert_template "inbox"
-    assert_select "table.messages", :count => 1 do
+    assert_select ".content-inner > table", :count => 1 do
       assert_select "tr", :count => 2
       assert_select "tr#inbox-#{read_message.id}.inbox-row", :count => 1
     end
@@ -367,7 +367,7 @@ class MessagesControllerTest < ActionController::TestCase
     get :outbox
     assert_response :success
     assert_template "outbox"
-    assert_select "table.messages", :count => 1 do
+    assert_select ".content-inner > table", :count => 1 do
       assert_select "tr", :count => 2
       assert_select "tr.inbox-row", :count => 1
     end

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -721,7 +721,7 @@ class TracesControllerTest < ActionController::TestCase
         assert_select "tr", :count => traces.length do |rows|
           traces.zip(rows).each do |trace, row|
             assert_select row, "a", Regexp.new(Regexp.escape(trace.name))
-            assert_select row, "span.trace_summary", Regexp.new(Regexp.escape("(#{trace.size} points)")) if trace.inserted?
+            assert_select row, "span", Regexp.new(Regexp.escape("(#{trace.size} points)")) if trace.inserted?
             assert_select row, "td", Regexp.new(Regexp.escape(trace.description))
             assert_select row, "td", Regexp.new(Regexp.escape("by #{trace.user.display_name}"))
           end


### PR DESCRIPTION
This removes the custom table styling code, and move to using bootstrap table styling for almost all remaining tables.