### PR TITLE
Ensure that urls are only valid if the entire string is a url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem "rack-cors"
 gem "rails-i18n", "~> 4.0.0"
 gem "rinku", ">= 2.0.6", :require => "rails_rinku"
 gem "strong_migrations"
+gem "validate_url", :git => "https://github.com/perfectline/validates_url"
 gem "validates_email_format_of", ">= 1.5.1"
 
 # Native OSM extensions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/perfectline/validates_url
+  revision: aae8b65e047c89afdaa2617b595eb181dccff6b0
+  specs:
+    validate_url (1.0.8)
+      activemodel (>= 3.0.0)
+      public_suffix
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -546,6 +554,7 @@ DEPENDENCIES
   selenium-webdriver
   strong_migrations
   uglifier (>= 1.3.0)
+  validate_url!
   validates_email_format_of (>= 1.5.1)
   vendorer
   webmock

--- a/app/models/client_application.rb
+++ b/app/models/client_application.rb
@@ -39,9 +39,10 @@ class ClientApplication < ApplicationRecord
 
   validates :key, :presence => true, :uniqueness => true
   validates :name, :url, :secret, :presence => true
-  validates :url, :format => %r{\Ahttp(s?)://(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(/|/([\w#!:.?+=&%@!\-/]))?}i
-  validates :support_url, :allow_blank => true, :format => %r{\Ahttp(s?)://(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(/|/([\w#!:.?+=&%@!\-/]))?}i
-  validates :callback_url, :allow_blank => true, :format => %r{\A[a-z][a-z0-9.+-]*://(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(/|/([\w#!:.?+=&%@!\-/]))?}i
+  validates :url, :url => true
+  validates :support_url, :url => { :allow_blank => true }
+  # validate_url doesn't support arbitrary schemes. Wrap the default URI regexp in string terminators.
+  validates :callback_url, :allow_blank => true, :format => /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
 
   before_validation :generate_keys, :on => :create
 

--- a/test/models/client_application_test.rb
+++ b/test/models/client_application_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ClientApplicationTest < ActiveSupport::TestCase
   def test_url_valid
     ok = ["http://example.com/test", "https://example.com/test"]
-    bad = ["", "ftp://example.com/test", "myapp://somewhere"]
+    bad = ["", "ftp://example.com/test", "myapp://somewhere", "http://example.com\nhttp://example.net"]
 
     ok.each do |url|
       app = build(:client_application)
@@ -20,7 +20,7 @@ class ClientApplicationTest < ActiveSupport::TestCase
 
   def test_support_url_valid
     ok = ["", "http://example.com/test", "https://example.com/test"]
-    bad = ["ftp://example.com/test", "myapp://somewhere", "gibberish"]
+    bad = ["ftp://example.com/test", "myapp://somewhere", "gibberish", "http://example.com\nhttp://example.net"]
 
     ok.each do |url|
       app = build(:client_application)
@@ -37,7 +37,7 @@ class ClientApplicationTest < ActiveSupport::TestCase
 
   def test_callback_url_valid
     ok = ["", "http://example.com/test", "https://example.com/test", "ftp://example.com/test", "myapp://somewhere"]
-    bad = ["gibberish"]
+    bad = ["gibberish", "http://example.com\nhttp://example.net"]
 
     ok.each do |url|
       app = build(:client_application)


### PR DESCRIPTION
Replacement PR for #2557 

The previous regexps only checked that the string started with a url, but would accept further input.

The validates_url gem works well, but only with the inclusion of https://github.com/perfectline/validates_url/pull/85 which is not yet in a release. I'm not sure if it's better to wait for a release, or go with the git link for the gem.

There's also the fact that validates_url doesn't appear to support arbitrary schemes (e.g. `myapp://`) so I've used the underlying regexp for that.

