### PR TITLE
Ensure that urls are only valid if the entire string is a url

### DIFF
--- a/app/models/client_application.rb
+++ b/app/models/client_application.rb
@@ -39,9 +39,9 @@ class ClientApplication < ApplicationRecord
 
   validates :key, :presence => true, :uniqueness => true
   validates :name, :url, :secret, :presence => true
-  validates :url, :format => %r{\Ahttp(s?)://(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(/|/([\w#!:.?+=&%@!\-/]))?}i
-  validates :support_url, :allow_blank => true, :format => %r{\Ahttp(s?)://(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(/|/([\w#!:.?+=&%@!\-/]))?}i
-  validates :callback_url, :allow_blank => true, :format => %r{\A[a-z][a-z0-9.+-]*://(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(/|/([\w#!:.?+=&%@!\-/]))?}i
+  validates :url, :format => /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
+  validates :support_url, :allow_blank => true, :format => /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
+  validates :callback_url, :allow_blank => true, :format => /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
 
   before_validation :generate_keys, :on => :create
 

--- a/test/models/client_application_test.rb
+++ b/test/models/client_application_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ClientApplicationTest < ActiveSupport::TestCase
   def test_url_valid
     ok = ["http://example.com/test", "https://example.com/test"]
-    bad = ["", "ftp://example.com/test", "myapp://somewhere"]
+    bad = ["", "ftp://example.com/test", "myapp://somewhere", "http://example.com\nhttp://example.net"]
 
     ok.each do |url|
       app = build(:client_application)
@@ -20,7 +20,7 @@ class ClientApplicationTest < ActiveSupport::TestCase
 
   def test_support_url_valid
     ok = ["", "http://example.com/test", "https://example.com/test"]
-    bad = ["ftp://example.com/test", "myapp://somewhere", "gibberish"]
+    bad = ["ftp://example.com/test", "myapp://somewhere", "gibberish", "http://example.com\nhttp://example.net"]
 
     ok.each do |url|
       app = build(:client_application)
@@ -37,7 +37,7 @@ class ClientApplicationTest < ActiveSupport::TestCase
 
   def test_callback_url_valid
     ok = ["", "http://example.com/test", "https://example.com/test", "ftp://example.com/test", "myapp://somewhere"]
-    bad = ["gibberish"]
+    bad = ["gibberish", "http://example.com\nhttp://example.net"]
 
     ok.each do |url|
       app = build(:client_application)


### PR DESCRIPTION
Replacement PR for #2570 and #2578 

This replaces our homegrown regexps (that didn't quite work) with ruby built-in regexps, and uses the termination anchor to ensure that the entire string, not just the first part, is validated.