### PR TITLE
Add rubocop-minitest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-minitest
   - rubocop-performance
   - rubocop-rails
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,6 +89,40 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 25
 
+# Offense count: 2
+# Cop supports --auto-correct.
+Minitest/AssertEmpty:
+  Exclude:
+    - 'test/controllers/api/amf_controller_test.rb'
+
+# Offense count: 6
+# Cop supports --auto-correct.
+Minitest/AssertEqual:
+  Exclude:
+    - 'test/controllers/api/amf_controller_test.rb'
+
+# Offense count: 27
+# Cop supports --auto-correct.
+Minitest/AssertIncludes:
+  Exclude:
+    - 'test/controllers/api/amf_controller_test.rb'
+    - 'test/controllers/api/nodes_controller_test.rb'
+    - 'test/helpers/browse_helper_test.rb'
+    - 'test/lib/i18n_test.rb'
+    - 'test/models/node_test.rb'
+    - 'test/models/old_node_test.rb'
+    - 'test/models/user_test.rb'
+
+# Offense count: 104
+# Cop supports --auto-correct.
+Minitest/AssertTruthy:
+  Enabled: false
+
+# Offense count: 110
+# Cop supports --auto-correct.
+Minitest/RefuteFalse:
+  Enabled: false
+
 # Offense count: 6
 Naming/AccessorMethodName:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,7 @@ group :test do
   gem "minitest", "~> 5.1", :platforms => [:ruby_19, :ruby_20]
   gem "rails-controller-testing"
   gem "rubocop"
+  gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rails"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,6 +398,8 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-minitest (0.9.0)
+      rubocop (>= 0.74)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     rubocop-rails (2.5.1)
@@ -538,6 +540,7 @@ DEPENDENCIES
   rinku (>= 2.0.6)
   rotp
   rubocop
+  rubocop-minitest
   rubocop-performance
   rubocop-rails
   sanitize


### PR DESCRIPTION
I found this gem recently while investigating other things, and I think it makes sense to add it. I've updated the `rubocop_todo.yml` file with the currently failing tests, so this PR is just to add the gem. Changes to the test suite will be added in future PRs.