### PR TITLE
Refactor site controller tests to inherit from ActionDispatch::IntegrationTest

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,7 +180,7 @@ OpenStreetMap::Application.routes.draw do
   match "/auth/:provider" => "users#auth", :via => [:get, :post], :as => :auth
 
   # permalink
-  get "/go/:code" => "site#permalink", :code => /[a-zA-Z0-9_@~]+[=-]*/
+  get "/go/:code" => "site#permalink", :code => /[a-zA-Z0-9_@~]+[=-]*/, :as => :permalink
 
   # rich text preview
   post "/preview/:type" => "site#preview", :as => :preview

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -185,6 +185,11 @@ module ActiveSupport
       click_on "Login", :match => :first
     end
 
+    def session_for(user)
+      post login_path, :params => { :username => user.display_name, :password => "test" }
+      follow_redirect!
+    end
+
     def xml_for_node(node)
       doc = OSM::API.new.get_xml_doc
       doc.root << xml_node_for_node(node)


### PR DESCRIPTION
This is the modern way of writing controller tests, since it uses the rails middleware (among other things) and leads to more realistic tests.

Refs #2563

If we're all happy with this, then I can refactor all the remaining controller tests in order to unblock #2563 