### PR TITLE
Switch to using selenium for system tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   postgresql: 9.5
   apt:
     packages:
+      - firefox-geckodriver
       - libarchive-dev
       - libgd-dev
       - libffi-dev

--- a/Gemfile
+++ b/Gemfile
@@ -143,7 +143,6 @@ group :test do
   gem "erb_lint", :require => false
   gem "factory_bot_rails"
   gem "minitest", "~> 5.1"
-  gem "poltergeist"
   gem "puma", "~> 3.11"
   gem "rails-controller-testing"
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    cliver (0.3.2)
     coderay (1.1.2)
     composite_primary_keys (12.0.1)
       activerecord (~> 6.0.0)
@@ -325,10 +324,6 @@ GEM
     parser (2.7.1.1)
       ast (~> 2.4.0)
     pg (1.2.3)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     popper_js (1.16.0)
     progress (3.5.2)
     psych (3.1.0)
@@ -527,7 +522,6 @@ DEPENDENCIES
   omniauth-windowslive
   openstreetmap-deadlock_retry (>= 1.3.0)
   pg
-  poltergeist
   psych
   puma (~> 3.11)
   quad_tile (~> 1.0.1)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,7 @@ These can be installed on Ubuntu 18.04 or later with:
 sudo apt-get update
 sudo apt-get install ruby2.5 libruby2.5 ruby2.5-dev bundler \
                      libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
-                     apache2 apache2-dev build-essential git-core phantomjs \
+                     apache2 apache2-dev build-essential git-core firefox-geckodriver \
                      postgresql postgresql-contrib libpq-dev libsasl2-dev \
                      imagemagick libffi-dev libgd-dev libarchive-dev libbz2-dev
 sudo gem2.5 install bundler
@@ -95,11 +95,11 @@ You will need to tell `bundler` that `libxml2` is installed in a Homebrew locati
 bundle config build.libxml-ruby --with-xml2-config=/usr/local/opt/libxml2/bin/xml2-config
 ```
 
-If you want to run the tests, you need `phantomjs` as well:
+If you want to run the tests, you need `geckodriver` as well:
 
 ```
 brew tap homebrew/cask
-brew cask install phantomjs
+brew cask install geckodriver
 ```
 
 Note that OS X does not have a /home directory by default, so if you are using the GPX functions, you will need to change the directories specified in config/application.yml.

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,21 +1,13 @@
 require "test_helper"
-require "capybara/poltergeist"
 
-# Work around weird debian/ubuntu phantomjs
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=817277
-# https://github.com/ariya/phantomjs/issues/14376
-ENV["QT_QPA_PLATFORM"] = "offscreen" if IO.popen(["phantomjs", "--version"], :err => :close).read.empty?
+ENV.delete("http_proxy")
 
 ActiveSupport.on_load(:action_dispatch_system_test_case) do
   ActionDispatch::SystemTesting::Server.silence_puma = true
 end
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :poltergeist, :screen_size => [1400, 1400], :options => { :timeout => 120 }
-
-  # Phantomjs can pick up browser Accept-Language preferences from your desktop environment.
-  # We don't want this to happen during the tests!
-  setup do
-    page.driver.add_headers("Accept-Language" => "en")
+  driven_by :selenium, :using => :headless_firefox do |options|
+    options.add_preference("intl.accept_languages", "en")
   end
 end


### PR DESCRIPTION
This switches to using selenium with a headless firefox to run system tests. I would have preferred to use chrome (possibly running firefox as well in travis at least) but https://bugs.chromium.org/p/chromium/issues/detail?id=775911 means that headless chrome is a pain as we can't control `Accept-Language` fully.