### PR TITLE
Remove tempfile patch for trace data

### DIFF
--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -215,25 +215,23 @@ class Trace < ApplicationRecord
     tarred = filetype =~ /tar archive/
 
     if gzipped || bzipped || zipped || tarred
-      tmpfile = Tempfile.new("trace.#{id}")
+      file = Tempfile.new("trace.#{id}")
 
       if tarred && gzipped
-        system("tar -zxOf #{trace_name} > #{tmpfile.path}")
+        system("tar -zxOf #{trace_name} > #{file.path}")
       elsif tarred && bzipped
-        system("tar -jxOf #{trace_name} > #{tmpfile.path}")
+        system("tar -jxOf #{trace_name} > #{file.path}")
       elsif tarred
-        system("tar -xOf #{trace_name} > #{tmpfile.path}")
+        system("tar -xOf #{trace_name} > #{file.path}")
       elsif gzipped
-        system("gunzip -c #{trace_name} > #{tmpfile.path}")
+        system("gunzip -c #{trace_name} > #{file.path}")
       elsif bzipped
-        system("bunzip2 -c #{trace_name} > #{tmpfile.path}")
+        system("bunzip2 -c #{trace_name} > #{file.path}")
       elsif zipped
-        system("unzip -p #{trace_name} -x '__MACOSX/*' > #{tmpfile.path} 2> /dev/null")
+        system("unzip -p #{trace_name} -x '__MACOSX/*' > #{file.path} 2> /dev/null")
       end
 
-      tmpfile.unlink
-
-      file = tmpfile.file
+      file.unlink
     else
       file = File.open(trace_name)
     end

--- a/config/initializers/tempfile.rb
+++ b/config/initializers/tempfile.rb
@@ -1,7 +1,0 @@
-# Hack TempFile to let us get at the underlying File object as ruby
-# does a half assed job of making TempFile act as a File
-class Tempfile
-  def file
-    @tmpfile
-  end
-end


### PR DESCRIPTION
Effectively reverts c0d2ad40c30e5a0837b6012d7b9067d69ce41dd0

This patch is no longer required, since we only use send_data in combination with Tempfile.read and that all works fine. 

And going by the original commit message, it might not have been needed after we upgraded from ruby 1.8.4