### PR TITLE
Refactor more controller tests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,13 +10,13 @@ OpenStreetMap::Application.routes.draw do
     get "permissions" => "api/permissions#show"
 
     put "changeset/create" => "api/changesets#create"
-    post "changeset/:id/upload" => "api/changesets#upload", :id => /\d+/
+    post "changeset/:id/upload" => "api/changesets#upload", :as => :changeset_upload, :id => /\d+/
     get "changeset/:id/download" => "api/changesets#download", :as => :changeset_download, :id => /\d+/
     get "changeset/:id" => "api/changesets#show", :as => :changeset_show, :id => /\d+/
     post "changeset/:id/subscribe" => "api/changesets#subscribe", :as => :changeset_subscribe, :id => /\d+/
     post "changeset/:id/unsubscribe" => "api/changesets#unsubscribe", :as => :changeset_unsubscribe, :id => /\d+/
     put "changeset/:id" => "api/changesets#update", :id => /\d+/
-    put "changeset/:id/close" => "api/changesets#close", :id => /\d+/
+    put "changeset/:id/close" => "api/changesets#close", :as => :changeset_close, :id => /\d+/
     get "changesets" => "api/changesets#query"
     post "changeset/:id/comment" => "api/changeset_comments#create", :as => :changeset_comment, :id => /\d+/
     post "changeset/comment/:id/hide" => "api/changeset_comments#destroy", :as => :changeset_comment_hide, :id => /\d+/
@@ -28,7 +28,7 @@ OpenStreetMap::Application.routes.draw do
     get "node/:id/history" => "api/old_nodes#history", :id => /\d+/
     post "node/:id/:version/redact" => "api/old_nodes#redact", :version => /\d+/, :id => /\d+/
     get "node/:id/:version" => "api/old_nodes#version", :id => /\d+/, :version => /\d+/
-    get "node/:id" => "api/nodes#show", :id => /\d+/
+    get "node/:id" => "api/nodes#show", :as => :api_node, :id => /\d+/
     put "node/:id" => "api/nodes#update", :id => /\d+/
     delete "node/:id" => "api/nodes#delete", :id => /\d+/
     get "nodes" => "api/nodes#index"
@@ -39,7 +39,7 @@ OpenStreetMap::Application.routes.draw do
     get "way/:id/relations" => "api/relations#relations_for_way", :id => /\d+/
     post "way/:id/:version/redact" => "api/old_ways#redact", :version => /\d+/, :id => /\d+/
     get "way/:id/:version" => "api/old_ways#version", :id => /\d+/, :version => /\d+/
-    get "way/:id" => "api/ways#show", :id => /\d+/
+    get "way/:id" => "api/ways#show", :as => :api_way, :id => /\d+/
     put "way/:id" => "api/ways#update", :id => /\d+/
     delete "way/:id" => "api/ways#delete", :id => /\d+/
     get "ways" => "api/ways#index"

--- a/test/controllers/api/capabilities_controller_test.rb
+++ b/test/controllers/api/capabilities_controller_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 module Api
-  class CapabilitiesControllerTest < ActionController::TestCase
+  class CapabilitiesControllerTest < ActionDispatch::IntegrationTest
     ##
     # test all routes which lead to this controller
     def test_routes
@@ -16,7 +16,7 @@ module Api
     end
 
     def test_capabilities
-      get :show
+      get api_capabilities_path
       assert_response :success
       assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
         assert_select "api", :count => 1 do

--- a/test/controllers/api/changes_controller_test.rb
+++ b/test/controllers/api/changes_controller_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 module Api
-  class ChangesControllerTest < ActionController::TestCase
+  class ChangesControllerTest < ActionDispatch::IntegrationTest
     ##
     # test all routes which lead to this controller
     def test_routes
@@ -28,7 +28,7 @@ module Api
       create(:node, :timestamp => Time.utc(2008, 1, 1, 0, 0, 0), :lat => 7, :lon => 7)
 
       travel_to Time.utc(2010, 4, 3, 10, 55, 0) do
-        get :index
+        get changes_path
         assert_response :success
         now = Time.now.getutc
         hourago = now - 1.hour
@@ -40,7 +40,7 @@ module Api
       end
 
       travel_to Time.utc(2007, 1, 1, 0, 30, 0) do
-        get :index
+        get changes_path
         assert_response :success
         # print @response.body
         # As we have loaded the fixtures, we can assume that there are some
@@ -58,7 +58,7 @@ module Api
     def test_changes_zoom_invalid
       zoom_to_test = %w[p -1 0 17 one two]
       zoom_to_test.each do |zoom|
-        get :index, :params => { :zoom => zoom }
+        get changes_path(:zoom => zoom)
         assert_response :bad_request
         assert_equal @response.body, "Requested zoom is invalid, or the supplied start is after the end time, or the start duration is more than 24 hours"
       end
@@ -66,7 +66,7 @@ module Api
 
     def test_changes_zoom_valid
       1.upto(16) do |zoom|
-        get :index, :params => { :zoom => zoom }
+        get changes_path(:zoom => zoom)
         assert_response :success
         # NOTE: there was a test here for the timing, but it was too sensitive to be a good test
         # and it was annoying.
@@ -79,7 +79,7 @@ module Api
     def test_changes_hours_invalid
       invalid = %w[-21 335 -1 0 25 26 100 one two three ping pong :]
       invalid.each do |hour|
-        get :index, :params => { :hours => hour }
+        get changes_path(:hours => hour)
         assert_response :bad_request, "Problem with the hour: #{hour}"
         assert_equal @response.body, "Requested zoom is invalid, or the supplied start is after the end time, or the start duration is more than 24 hours", "Problem with the hour: #{hour}."
       end
@@ -87,19 +87,19 @@ module Api
 
     def test_changes_hours_valid
       1.upto(24) do |hour|
-        get :index, :params => { :hours => hour }
+        get changes_path(:hours => hour)
         assert_response :success
       end
     end
 
     def test_changes_start_end_invalid
-      get :index, :params => { :start => "2010-04-03 10:55:00", :end => "2010-04-03 09:55:00" }
+      get changes_path(:start => "2010-04-03 10:55:00", :end => "2010-04-03 09:55:00")
       assert_response :bad_request
       assert_equal @response.body, "Requested zoom is invalid, or the supplied start is after the end time, or the start duration is more than 24 hours"
     end
 
     def test_changes_start_end_valid
-      get :index, :params => { :start => "2010-04-03 09:55:00", :end => "2010-04-03 10:55:00" }
+      get changes_path(:start => "2010-04-03 09:55:00", :end => "2010-04-03 10:55:00")
       assert_response :success
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,6 +119,12 @@ module ActiveSupport
     end
 
     ##
+    # return request header for HTTP Basic Authorization
+    def basic_authorization_header(user, pass)
+      { "Authorization" => format("Basic %{auth}", :auth => Base64.encode64("#{user}:#{pass}")) }
+    end
+
+    ##
     # set request header for HTTP Accept
     def http_accept_format(format)
       @request.env["HTTP_ACCEPT"] = format
@@ -128,6 +134,10 @@ module ActiveSupport
     # set request readers to ask for a particular error format
     def error_format(format)
       @request.env["HTTP_X_ERROR_FORMAT"] = format
+    end
+
+    def error_format_header(f)
+      { "X-Error-Format" => f }
     end
 
     ##


### PR DESCRIPTION
For the changesets_controller_test, I introduced a few more route aliases. I'm not super keen on some of them (like api_node) but that's to distinguish them from the non-api method that already has the name. Refactoring the routes is left for the future.

The two new helper methods will replace the existing ones, we only need both sets during the transition.