### PR TITLE
Final controller test refactorings

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,7 +161,7 @@ OpenStreetMap::Application.routes.draw do
   post "/user/new" => "users#create"
   get "/user/terms" => "users#terms"
   post "/user/save" => "users#save"
-  get "/user/:display_name/confirm/resend" => "users#confirm_resend"
+  get "/user/:display_name/confirm/resend" => "users#confirm_resend", :as => :user_confirm_resend
   match "/user/:display_name/confirm" => "users#confirm", :via => [:get, :post]
   match "/user/confirm" => "users#confirm", :via => [:get, :post]
   match "/user/confirm-email" => "users#confirm_email", :via => [:get, :post]
@@ -238,7 +238,7 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name" => "users#show", :as => "user"
   match "/user/:display_name/make_friend" => "users#make_friend", :via => [:get, :post], :as => "make_friend"
   match "/user/:display_name/remove_friend" => "users#remove_friend", :via => [:get, :post], :as => "remove_friend"
-  match "/user/:display_name/account" => "users#account", :via => [:get, :post]
+  match "/user/:display_name/account" => "users#account", :via => [:get, :post], :as => "user_account"
   get "/user/:display_name/set_status" => "users#set_status", :as => :set_status_user
   get "/user/:display_name/delete" => "users#delete", :as => :delete_user
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,11 +73,11 @@ OpenStreetMap::Application.routes.draw do
     end
 
     post "gpx/create" => "api/traces#create"
-    get "gpx/:id" => "api/traces#show", :id => /\d+/
+    get "gpx/:id" => "api/traces#show", :as => :api_trace, :id => /\d+/
     put "gpx/:id" => "api/traces#update", :id => /\d+/
     delete "gpx/:id" => "api/traces#destroy", :id => /\d+/
     get "gpx/:id/details" => "api/traces#show", :id => /\d+/
-    get "gpx/:id/data" => "api/traces#data"
+    get "gpx/:id/data" => "api/traces#data", :as => :api_trace_data
 
     # AMF (ActionScript) API
     post "amf/read" => "api/amf#amf_read"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,12 +116,6 @@ module ActiveSupport
     end
 
     ##
-    # set request headers for HTTP basic authentication
-    def basic_authorization(user, pass)
-      @request.env["HTTP_AUTHORIZATION"] = format("Basic %{auth}", :auth => Base64.encode64("#{user}:#{pass}"))
-    end
-
-    ##
     # return request header for HTTP Basic Authorization
     def basic_authorization_header(user, pass)
       { "Authorization" => format("Basic %{auth}", :auth => Base64.encode64("#{user}:#{pass}")) }


### PR DESCRIPTION
This refactors api/traces_controller_test and user_controller_test. The latter was a bit tough, since a lot of the tests involved somewhat artificial setup involving direct access to the session. In many cases around the testing of the terms and confirmation pages, the approach I've taken is to work through the first half of the signup process, to get the session into the expected state.

I found a bunch of tests were misnamed, since they were called 'test_new_something' but were testing the save method. Some things like duplicate emails are tested both during the submission of the signup form, and again during the creation of the user record in the save method. So I've renamed the tests and kept them testing the second stage, since it's more important. I added one test for the first step just for belts and braces.