### PR TITLE
Remove ineffective query cache disable initializer

### DIFF
--- a/config/initializers/query_cache.rb
+++ b/config/initializers/query_cache.rb
@@ -1,1 +1,0 @@
-Rails.configuration.middleware.delete ActiveRecord::QueryCache


### PR DESCRIPTION
I don't know why the query cache was originally intended to be disabled, since the [original commit](0d8e4b4337e9b94b6a9ed85095005a779f69583c) doesn't give any reason or links to tickets.

However, this initializer seems to be ineffective, since queries are being successfully cached on my local machine, and as far as I can tell, there's no middleware with that name any longer. Perhaps this is all just historical stuff?

So this PR just removes the initializer.