### PR TITLE
Change tile licence (pls merge 2020.7.1)

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -44,12 +44,13 @@
 <%= tag.div :lang => @locale, :dir => t("html.dir", :locale => @locale) do %>
   <p><%= t ".legal_babble.intro_1_html", :locale => @locale %></p>
   <p><%= t ".legal_babble.intro_2_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.intro_3_html", :locale => @locale %></p>
+  <p><%= t ".legal_babble.intro_3_1_html", :locale => @locale %></p>
 
   <h3><%= t ".legal_babble.credit_title_html", :locale => @locale %></h3>
   <p><%= t ".legal_babble.credit_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.credit_2_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.credit_3_html", :locale => @locale %></p>
+  <p><%= t ".legal_babble.credit_2_1_html", :locale => @locale %></p>
+  <p><%= t ".legal_babble.credit_3_1_html", :locale => @locale %></p>
+  <p><%= t ".legal_babble.credit_4_html", :locale => @locale %></p>
   <p><%= image_tag("attribution_example.png",
                    :alt => t(".legal_babble.attribution_example.alt"),
                    :border => 0,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1419,26 +1419,30 @@ en:
           may distribute the result only under the same licence. The
           full <a href="https://opendatacommons.org/licenses/odbl/1.0/">legal
           code</a> explains your rights and responsibilities.
-        intro_3_html: |
-          The cartography in our map tiles, and our documentation, are
-          licensed under the <a href="https://creativecommons.org/licenses/by-sa/2.0/">Creative
-          Commons Attribution-ShareAlike 2.0</a> license (CC BY-SA).
+        intro_3_1_html: |
+          Our documentation is licensed under the 
+          <a href="https://creativecommons.org/licenses/by-sa/2.0/">Creative
+          Commons Attribution-ShareAlike 2.0</a> license (CC BY-SA 2.0).
         credit_title_html: How to credit OpenStreetMap
         credit_1_html: |
           We require that you use the credit &ldquo;&copy; OpenStreetMap
           contributors&rdquo;.
-        credit_2_html: |
+        credit_2_1_html: |
           You must also make it clear that the data is available under the Open
-          Database License, and if using our map tiles, that the cartography is
-          licensed as CC BY-SA. You may do this by linking to
+          Database License. You may do this by linking to
           <a href="https://www.openstreetmap.org/copyright">this copyright page</a>.
           Alternatively, and as a requirement if you are distributing OSM in a
           data form, you can name and link directly to the license(s). In media
           where links are not possible (e.g. printed works), we suggest you
           direct your readers to openstreetmap.org (perhaps by expanding
-          'OpenStreetMap' to this full address), to opendatacommons.org, and
-          if relevant, to creativecommons.org.
-        credit_3_html: |
+          'OpenStreetMap' to this full address) and to opendatacommons.org.
+        credit_3_1_html: |
+          The map tiles in the &ldquo;standard style&rdquo; at www.openstreetmap.org are a 
+          Produced Work by the OpenStreetMap Foundation using OpenStreetMap data 
+          under the Open Database License. If you are using these tiles please use 
+          the following attribution: 
+          &ldquo;Base map and data from OpenStreetMap and OpenStreetMap Foundation&rdquo;. 
+        credit_4_html: |
           For a browsable electronic map, the credit should appear in the corner of the map.
           For example:
         attribution_example:


### PR DESCRIPTION
This changes the text describing the tile licence as per decision of the OSMF board starting July 1st 2020. 

There might be a bit of fine tuning before this is finalised, in any case it should not go live before July 1st.