### PR TITLE
Add OPNVKarte

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -35,6 +35,8 @@ window.onload = function () {
     new L.OSM.CycleMap(thunderforestOptions).addTo(map);
   } else if (args.layer === "transportmap") {
     new L.OSM.TransportMap(thunderforestOptions).addTo(map);
+  } else if (args.layer === "opnvkarte") {
+    new L.OSM.OPNVKarte().addTo(map);
   } else if (args.layer === "hot") {
     new L.OSM.HOT().addTo(map);
   }

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -19,6 +19,7 @@ L.OSM.Map = L.Map.extend({
     var donate = I18n.t("javascripts.map.donate_link_text", { donate_url: "https://donate.openstreetmap.org" });
     var terms = I18n.t("javascripts.map.terms", { terms_url: "https://wiki.osmfoundation.org/wiki/Terms_of_Use" });
     var thunderforest = I18n.t("javascripts.map.thunderforest", { thunderforest_url: "https://www.thunderforest.com/" });
+    var memomaps = I18n.t("javascripts.map.opnvkarte", { memomaps_url: "https://memomaps.de/" });
     var hotosm = I18n.t("javascripts.map.hotosm", { hotosm_url: "https://www.hotosm.org/", osmfrance_url: "https://openstreetmap.fr/" });
 
     this.baseLayers = [];
@@ -47,6 +48,13 @@ L.OSM.Map = L.Map.extend({
         name: I18n.t("javascripts.map.base.transport_map")
       }));
     }
+
+    this.baseLayers.push(new L.OSM.OPNVKarte ({
+      attribution: copyright + ". " + memomaps + ". " + terms,
+      code: "O",
+      keyid: "opnvkarte",
+      name: I18n.t("javascripts.map.base.opnvkarte")
+    }));
 
     this.baseLayers.push(new L.OSM.HOT({
       attribution: copyright + ". " + hotosm + ". " + terms,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2498,6 +2498,7 @@ en:
         cycle_map: Cycle Map
         transport_map: Transport Map
         hot: Humanitarian
+        opnvkarte: ÖPNVKarte
       layers:
         header: Map Layers
         notes: Map Notes
@@ -2509,6 +2510,7 @@ en:
       donate_link_text: "<a class='donate-attr' href='%{donate_url}'>Make a Donation</a>"
       terms: "<a href='%{terms_url}' target='_blank'>Website and API terms</a>"
       thunderforest: "Tiles courtesy of <a href='%{thunderforest_url}' target='_blank'>Andy Allan</a>"
+      opnvkarte: "Tiles courtesy of <a href='%{memomaps_url}' target='_blank'>MeMoMaps</a>"
       hotosm: "Tiles style by <a href='%{hotosm_url}' target='_blank'>Humanitarian OpenStreetMap Team</a> hosted by <a href='%{osmfrance_url}' target='_blank'>OpenStreetMap France</a>"
     site:
       edit_tooltip: Edit the map

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -35,6 +35,14 @@ L.OSM.TransportMap = L.OSM.TileLayer.extend({
   }
 });
 
+L.OSM.OPNVKarte = L.OSM.TileLayer.extend({
+  options: {
+    url: 'https://tileserver.memomaps.de/tilegen/{z}/{x}/{y}.png',
+    maxZoom: 18,
+    attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors. Tiles courtesy of <a href="http://memomaps.de/" target="_blank">MeMoMaps</a>'
+  }
+});
+
 L.OSM.HOT = L.OSM.TileLayer.extend({
   options: {
     url: 'https://tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png',


### PR DESCRIPTION
The layer has been approved by the OWG, I just took longer than expected to add it.

![image](https://user-images.githubusercontent.com/1190866/85818357-5242bd80-b725-11ea-91ba-1397077a679f.png)

There was some discussion with @gravitystorm about naming in IRC a few weeks back. I think this naming is consistent with what we've done with other layers, using the layer name rather than a description. We've used that for MapQuest, HOT, Transport, and close to that to OpenCycleMap.