### PR TITLE
Avoid list markers for the richtext help text

### DIFF
--- a/app/views/site/_markdown_help.html.erb
+++ b/app/views/site/_markdown_help.html.erb
@@ -1,5 +1,5 @@
 <h4 class='heading'><%= t ".title_html" %></h4>
-<ul>
+<ul class='list-unstyled'>
   <li>
     <h4><%= t ".headings" %></h4>
     <p># <%= t ".heading" %><br>


### PR DESCRIPTION
I missed this ban in January during https://github.com/openstreetmap/openstreetmap-website/pull/2508