### PR TITLE
Make the back button not look disabled

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1640,17 +1640,6 @@ tr.turn:hover {
   display: none;
 }
 
-.messages-show .message-buttons {
-  margin-top: $lineheight;
-  margin-bottom: $lineheight * 1.5;
-  padding-top: $lineheight;
-  border-top: 1px solid $lightgrey;
-}
-
-.messages-show .buttons .mark-unread-button {
-  border-radius: 0;
-}
-
 /* Rules for "flash" notice boxes shown at the top of the content area */
 
 .flash {

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -13,11 +13,11 @@
 
   <div class="richtext"><%= @message.body.to_html %></div>
 
-  <div class='message-buttons buttons'>
-    <%= button_to t(".reply_button"), message_reply_path(@message), :class => "reply-button" %>
-    <%= button_to t(".unread_button"), message_mark_path(@message, :mark => "unread"), :class => "mark-unread-button" %>
-    <%= button_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "destroy-button" %>
-    <%= link_to t(".back"), inbox_messages_path, :class => "button deemphasize" %>
+  <div>
+    <%= link_to t(".reply_button"), message_reply_path(@message), :class => "btn btn-primary" %>
+    <%= link_to t(".unread_button"), message_mark_path(@message, :mark => "unread"), :method => "post", :class => "btn btn-primary" %>
+    <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-primary" %>
+    <%= link_to t(".back"), inbox_messages_path, :class => "btn btn-link" %>
   </div>
 
 <% else %>
@@ -34,8 +34,8 @@
 
   <div class="richtext"><%= @message.body.to_html %></div>
 
-  <div class='message-buttons buttons'>
-    <%= link_to t(".back"), outbox_messages_path, :class => "button deemphasize" %>
+  <div>
+    <%= link_to t(".back"), outbox_messages_path, :class => "btn btn-link" %>
   </div>
 
 <% end %>


### PR DESCRIPTION
This switches the message buttons to use bootstrap, so that we can have a back button that looks clickable.

Alternative implementation of #2386