### PR TITLE
Rephrase the 'used_by' text on the about page.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1355,7 +1355,7 @@ en:
     about:
       next: Next
       copyright_html: <span>&copy;</span>OpenStreetMap<br>contributors
-      used_by_html: "%{name} powers map data on thousands of web sites, mobile apps, and hardware devices"
+      used_by_html: "%{name} provides map data for thousands of web sites, mobile apps, and hardware devices"
       lede_text: |
         OpenStreetMap is built by a community of mappers that contribute and maintain data
         about roads, trails, cafés, railway stations, and much more, all over the world.


### PR DESCRIPTION
In an effort to resolve the long-outstanding #1632, I'm proposing this slight change to the about text. This is based on [my suggestion](https://github.com/openstreetmap/openstreetmap-website/pull/1632#issuecomment-367891236) adapted with [the feedback to stick with the word 'map'](https://github.com/openstreetmap/openstreetmap-website/pull/1632#issuecomment-368039431). 

Thanks to @klumbumbus for the original suggestion.
