### PR TITLE
Turn on turn restriction support for graphhopper

### DIFF
--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -29,6 +29,7 @@ function GraphHopperEngine(id, vehicleType) {
           "ch.disable": vehicleType === "car",
           "elevation": false,
           "instructions": true,
+          "turn_costs": true,
           "point": points.map(function (p) { return p.lat + "," + p.lng; })
         },
         traditional: true,


### PR DESCRIPTION
No way of actually testing if this works, but it is based on https://docs.graphhopper.com/#operation/getRoute/parameters/point and https://www.graphhopper.com/blog/2020/07/08/turn-restriction-support-for-graphhoppers-directions-api/