### PR TITLE
Rename the notes#mine action to index

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -17,7 +17,7 @@ class Ability
       can [:index, :feed], Changeset
       can :index, ChangesetComment
       can [:index, :rss, :show, :comments], DiaryEntry
-      can [:mine], Note
+      can [:index], Note
       can [:index, :show], Redaction
       can [:index, :show, :data, :georss, :picture, :icon], Trace
       can [:terms, :login, :logout, :new, :create, :save, :confirm, :confirm_resend, :confirm_email, :lost_password, :reset_password, :show, :auth_success, :auth_failure], User

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,5 +1,5 @@
 class NotesController < ApplicationController
-  layout "site", :only => [:mine]
+  layout "site"
 
   before_action :check_api_readable
   before_action :authorize_web
@@ -11,11 +11,11 @@ class NotesController < ApplicationController
 
   ##
   # Display a list of notes by a specified user
-  def mine
+  def index
     if params[:display_name]
       if @user = User.active.find_by(:display_name => params[:display_name])
         @params = params.permit(:display_name)
-        @title = t "notes.mine.title", :user => @user.display_name
+        @title = t ".title", :user => @user.display_name
         @page = (params[:page] || 1).to_i
         @page_size = 10
         @notes = @user.notes

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :heading do %>
-  <h2><%= t "notes.mine.heading", :user => @user.display_name %></h2>
-  <p><%= t "notes.mine.subheading_html", :user => link_to(@user.display_name, user_path(@user)) %></p>
+  <h2><%= t ".heading", :user => @user.display_name %></h2>
+  <p><%= t ".subheading_html", :user => link_to(@user.display_name, user_path(@user)) %></p>
 <% end %>
 
 <%= render :partial => "notes_paging_nav" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
             <span class='count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
           </li>
           <li>
-            <%= link_to t(".my notes"), :controller => "notes", :action => "mine" %>
+            <%= link_to t(".my notes"), user_notes_path(@user) %>
           </li>
           <li>
             <%= link_to t(".my traces"), :controller => "traces", :action => "mine" %>
@@ -53,7 +53,7 @@
             <span class='count-number'><%= number_with_delimiter(@user.changesets.size) %></span>
           </li>
           <li>
-            <%= link_to t(".notes"), :controller => "notes", :action => "mine" %>
+            <%= link_to t(".notes"), user_notes_path(@user) %>
           </li>
           <li>
             <%= link_to t(".traces"), :controller => "traces", :action => "index", :display_name => @user.display_name %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2448,7 +2448,7 @@ en:
       next: "Next »"
       previous: "« Previous"
   notes:
-    mine:
+    index:
       title: "Notes submitted or commented on by %{user}"
       heading: "%{user}'s notes"
       subheading_html: "Notes submitted or commented on by %{user}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ OpenStreetMap::Application.routes.draw do
   get "/note/new" => "browse#new_note"
   get "/user/:display_name/history" => "changesets#index"
   get "/user/:display_name/history/feed" => "changesets#feed", :defaults => { :format => :atom }
-  get "/user/:display_name/notes" => "notes#mine", :as => :my_notes
+  get "/user/:display_name/notes" => "notes#index", :as => :user_notes
   get "/history/friends" => "changesets#index", :friends => true, :as => "friend_changesets", :defaults => { :format => :html }
   get "/history/nearby" => "changesets#index", :nearby => true, :as => "nearby_changesets", :defaults => { :format => :html }
 

--- a/test/abilities/abilities_test.rb
+++ b/test/abilities/abilities_test.rb
@@ -29,7 +29,7 @@ class GuestAbilityTest < AbilityTest
   test "note permissions for a guest" do
     ability = Ability.new nil
 
-    [:mine].each do |action|
+    [:index].each do |action|
       assert ability.can?(action, Note), "should be able to #{action} Notes"
     end
   end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -13,11 +13,11 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
   def test_routes
     assert_routing(
       { :path => "/user/username/notes", :method => :get },
-      { :controller => "notes", :action => "mine", :display_name => "username" }
+      { :controller => "notes", :action => "index", :display_name => "username" }
     )
   end
 
-  def test_mine_success
+  def test_index_success
     first_user = create(:user)
     second_user = create(:user)
     moderator_user = create(:moderator_user)
@@ -33,43 +33,43 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Note that the table rows include a header row
-    get my_notes_path(:display_name => first_user.display_name)
+    get user_notes_path(:display_name => first_user.display_name)
     assert_response :success
     assert_select "table.note_list tr", :count => 2
 
-    get my_notes_path(:display_name => second_user.display_name)
+    get user_notes_path(:display_name => second_user.display_name)
     assert_response :success
     assert_select "table.note_list tr", :count => 2
 
-    get my_notes_path(:display_name => "non-existent")
+    get user_notes_path(:display_name => "non-existent")
     assert_response :not_found
 
     session_for(moderator_user)
 
-    get my_notes_path(:display_name => first_user.display_name)
+    get user_notes_path(:display_name => first_user.display_name)
     assert_response :success
     assert_select "table.note_list tr", :count => 2
 
-    get my_notes_path(:display_name => second_user.display_name)
+    get user_notes_path(:display_name => second_user.display_name)
     assert_response :success
     assert_select "table.note_list tr", :count => 3
 
-    get my_notes_path(:display_name => "non-existent")
+    get user_notes_path(:display_name => "non-existent")
     assert_response :not_found
   end
 
-  def test_mine_paged
+  def test_index_paged
     user = create(:user)
 
     create_list(:note, 50) do |note|
       create(:note_comment, :note => note, :author => user)
     end
 
-    get my_notes_path(:display_name => user.display_name)
+    get user_notes_path(:display_name => user.display_name)
     assert_response :success
     assert_select "table.note_list tr", :count => 11
 
-    get my_notes_path(:display_name => user.display_name, :page => 2)
+    get user_notes_path(:display_name => user.display_name, :page => 2)
     assert_response :success
     assert_select "table.note_list tr", :count => 11
   end


### PR DESCRIPTION
This is a simple renaming to use a more resourceful action name. The "user" part of "user_notes_path" is what it would be if we refactored the routes to use nested resources, so it's a bit of future proofing.