### PR TITLE
Remove unnecessary layout calls from api controllers

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -2,7 +2,6 @@
 
 module Api
   class ChangesetsController < ApiController
-    layout "site"
     require "xml/libxml"
 
     before_action :authorize, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class NotesController < ApiController
-    layout "site", :only => [:mine]
-
     before_action :check_api_readable
     before_action :setup_user_auth, :only => [:create, :comment, :show]
     before_action :authorize, :only => [:close, :reopen, :destroy, :comment]

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class TracesController < ApiController
-    layout "site", :except => :georss
-
     before_action :authorize_web
     before_action :set_locale
     before_action :authorize

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class UsersController < ApiController
-    layout "site", :except => [:api_details]
-
     before_action :disable_terms_redirect, :only => [:details]
     before_action :authorize, :only => [:details, :gpx_files]
 


### PR DESCRIPTION
These were left over from the refactoring of the controllers into api and non-api versions.

I'm pretty sure that none of the API calls output html, but I wouldn't bet on it!