### PR TITLE
Make layer naming more consistent and indicative

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2499,10 +2499,10 @@ en:
           other: You are within %{count} feet of this point
       base:
         standard: Standard
-        cycle_map: Cycle Map
-        transport_map: Transport Map
+        cycle_map: Cycle
+        transport_map: Transport (TF)
         hot: Humanitarian
-        opnvkarte: ÖPNVKarte
+        opnvkarte: Transport (ÖPNV)
       layers:
         header: Map Layers
         notes: Map Notes


### PR DESCRIPTION
* Use "Transport" for both layers showing public transport cartographies
* Indicate cartography name of transport layers in parenthesis to distinguish
* Also eliminate "map" in layer names, which seems redundant

This is a follow-up to a comment regarding naming on blog post
https://blog.openstreetmap.org/2020/07/10/opnvkarte-a-new-featured-layer-on-www-openstreetmap-org/
(still unmoderated as of this commit).