### PR TITLE
Link to English site for Memomaps (ÖPNV) attribution

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -19,7 +19,7 @@ L.OSM.Map = L.Map.extend({
     var donate = I18n.t("javascripts.map.donate_link_text", { donate_url: "https://donate.openstreetmap.org" });
     var terms = I18n.t("javascripts.map.terms", { terms_url: "https://wiki.osmfoundation.org/wiki/Terms_of_Use" });
     var thunderforest = I18n.t("javascripts.map.thunderforest", { thunderforest_url: "https://www.thunderforest.com/" });
-    var memomaps = I18n.t("javascripts.map.opnvkarte", { memomaps_url: "https://memomaps.de/" });
+    var memomaps = I18n.t("javascripts.map.opnvkarte", { memomaps_url: "https://memomaps.de/en/" });
     var hotosm = I18n.t("javascripts.map.hotosm", { hotosm_url: "https://www.hotosm.org/", osmfrance_url: "https://openstreetmap.fr/" });
 
     this.baseLayers = [];


### PR DESCRIPTION
This is a follow-up to a comment regarding this on blog post
https://blog.openstreetmap.org/2020/07/10/opnvkarte-a-new-featured-layer-on-www-openstreetmap-org/
(still unmoderated as of this commit).