### PR TITLE
More CSS cleanups

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -81,11 +81,11 @@ $(document).ready(function () {
     var windowWidth = $(window).width();
 
     if (windowWidth < compactWidth) {
-      $("body").removeClass("compact").addClass("small");
+      $("body").removeClass("compact-nav").addClass("small-nav");
     } else if (windowWidth < headerWidth) {
-      $("body").addClass("compact").removeClass("small");
+      $("body").addClass("compact-nav").removeClass("small-nav");
     } else {
-      $("body").removeClass("compact").removeClass("small");
+      $("body").removeClass("compact-nav").removeClass("small-nav");
     }
   }
 
@@ -100,13 +100,13 @@ $(document).ready(function () {
       headerWidth = headerWidth + $(e).outerWidth();
     });
 
-    $("body").addClass("compact");
+    $("body").addClass("compact-nav");
 
     $("header").children(":visible").each(function (i, e) {
       compactWidth = compactWidth + $(e).outerWidth();
     });
 
-    $("body").removeClass("compact");
+    $("body").removeClass("compact-nav");
 
     updateHeader();
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2211,9 +2211,15 @@ input.richtext_title[type="text"] {
       display: block;
       color: white;
       font-weight: 300;
-      font-size: 34px;
+      font-size: 28px;
       span {
         color: $vibrant-green;
+      }
+    }
+
+    @include media-breakpoint-up(sm) {
+      h1 {
+        font-size: 34px;
       }
     }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -270,7 +270,7 @@ nav.primary, nav.secondary {
   display: none;
 }
 
-body.compact {
+body.compact-nav {
   #compact-secondary-nav {
     display: inline-block;
   }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -80,7 +80,6 @@ small, aside {
 a {
   color: #24d;
   text-decoration: none;
-  -webkit-appearance: none;
   outline: 0;
   &:hover {
     text-decoration: underline;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -35,8 +35,6 @@ small, aside {
   margin-right: $lineheight/4;
 }
 
-.piwik { border: 0; }
-
 [dir=rtl] { /* no-r2 */ text-align: right; }
 
 [dir=ltr] { /* no-r2 */ text-align: left; }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -35,8 +35,6 @@ small, aside {
   margin-right: $lineheight/4;
 }
 
-.red { color: $red; }
-
 .piwik { border: 0; }
 
 [dir=rtl] { /* no-r2 */ text-align: right; }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2297,8 +2297,3 @@ input.richtext_title[type="text"] {
     display: none;
   }
 }
-
-.read-reports {
-  background: $lightgrey;
-  opacity: 0.7;
-}

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1511,13 +1511,6 @@ tr.turn:hover {
 
 /* Rules for the account settings page */
 
-#accountForm .user_map {
-  position: relative;
-  width: 500px;
-  height: 400px;
-  border: 1px solid $grey;
-}
-
 #accountForm .user_image {
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -120,11 +120,6 @@ body.small {
   #login_openid_buttons td {
     padding: 2px;
   }
-
-  &.site-about #content .attr h1 {
-    font-size: 28px;
-  }
-
 }
 
 @media (max-width: 767.98px) {

--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -93,27 +93,6 @@ body.small {
   .leaflet-top.leaflet-right {
     top: 10px !important;
   }
-
-  /* Rules for the login form */
-
-  #login_login input#user_email {
-    width: 100%;
-    max-width: 18em;
-  }
-
-  #login_login input#user_password {
-    width: 100%;
-    max-width: 18em;
-  }
-
-  #login_login input#openid_url {
-    width: 100%;
-    max-width: 18em;
-  }
-
-  #login_openid_buttons td {
-    padding: 2px;
-  }
 }
 
 @media (max-width: 767.98px) {
@@ -143,5 +122,28 @@ body.small {
       width: 100%;
       overflow-y: scroll;
     }
+  }
+}
+
+@media (max-width: 575.98px) {
+  /* Rules for the login form */
+
+  #login_login input#user_email {
+    width: 100%;
+    max-width: 18em;
+  }
+
+  #login_login input#user_password {
+    width: 100%;
+    max-width: 18em;
+  }
+
+  #login_login input#openid_url {
+    width: 100%;
+    max-width: 18em;
+  }
+
+  #login_openid_buttons td {
+    padding: 2px;
   }
 }

--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -2,7 +2,7 @@
 
 /* Styles specific to a small screen, such as iPhone, Android, etc... */
 
-body.small {
+body.small-nav {
   #menu-icon {
     display: inline-block !important;
   }

--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -121,13 +121,6 @@ body.small {
     padding: 2px;
   }
 
-  /* Rules for the user view */
-
-  .user_map {
-    width: 100% !important;
-    height: 300px !important;
-  }
-
   &.site-about #content .attr h1 {
     font-size: 28px;
   }

--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -3,12 +3,6 @@
 /* Styles specific to a small screen, such as iPhone, Android, etc... */
 
 body.small {
-
-  input[type="submit"],
-  input[type="text"] {
-    -webkit-appearance: none;
-  }
-
   #menu-icon {
     display: inline-block !important;
   }

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -24,14 +24,14 @@
     <h3><%= t ".reports_of_this_issue" %></h3>
 
     <% if @read_reports.present? %>
-    <div class="read-reports">
+    <div class="bg-light text-muted">
       <h4><%= t ".read_reports" %></h4>
       <%= render "reports", :reports => @read_reports %>
     </div>
     <% end %>
 
     <% if @unread_reports.any? %>
-    <div class="unread-reports">
+    <div>
       <h4><%= t ".new_reports" %></h4>
       <%= render "reports", :reports => @unread_reports %>
     </div>


### PR DESCRIPTION
This PR contains several CSS cleanups. 

The main theme is continuing the work of disentangling the small screen stuff (which should be done with media breakpoints or builtin bootstrap functionality) from the navigation bar changes (which is based on the length of the text in the menus, not on the screen size).

Various other changes were found during this work too.