### PR TITLE
Rework various warnings

### DIFF
--- a/app/assets/javascripts/index/browse.js
+++ b/app/assets/javascripts/index/browse.js
@@ -49,15 +49,20 @@ OSM.initializeBrowse = function (map) {
 
   function displayFeatureWarning(count, limit, add, cancel) {
     $("#browse_status").html(
-      $("<p class='warning'></p>")
-        .text(I18n.t("browse.start_rjs.feature_warning", { num_features: count, max_features: limit }))
-        .prepend(
-          $("<span class='icon close'></span>")
-            .click(cancel))
+      $("<div>")
         .append(
-          $("<input type='submit'>")
-            .val(I18n.t("browse.start_rjs.load_data"))
-            .click(add)));
+          $("<h2>")
+            .text(I18n.t("browse.start_rjs.load_data"))
+            .prepend($("<span class='icon close'></span>").click(cancel)))
+        .append(
+          $("<div class='inner12'>")
+            .append(
+              $("<p class='alert alert-warning clearfix'></p>")
+                .text(I18n.t("browse.start_rjs.feature_warning", { num_features: count, max_features: limit })))
+            .append(
+              $("<input type='submit'>")
+                .val(I18n.t("browse.start_rjs.load_data"))
+                .click(add))));
   }
 
   var dataLoader;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -699,10 +699,6 @@ body.compact {
 }
 
 #browse_status {
-  p {
-    padding: $lineheight;
-  }
-
   input {
     display: block;
     margin-left: auto;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1040,11 +1040,6 @@ tr.turn:hover {
     }
   }
 
-  .warning {
-    margin: 0 0 $lineheight/2 0;
-    padding: 0 $lineheight/2;
-  }
-
   .note-comments li, .changeset-comments li {
     margin: $lineheight/2 0;
 

--- a/app/views/browse/new_note.html.erb
+++ b/app/views/browse/new_note.html.erb
@@ -6,7 +6,7 @@
 </h2>
 
 <div class="note browse-section">
-  <p class="warning"><%= t("javascripts.notes.new.intro") %></p>
+  <p class="alert alert-info"><%= t("javascripts.notes.new.intro") %></p>
   <form action="#">
     <input type="hidden" name="lon">
     <input type="hidden" name="lat">

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -12,15 +12,14 @@
   </div>
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">
-    <%= note_event("opened", @note.created_at, @note.author) %>
+    <p><%= note_event("opened", @note.created_at, @note.author) %></p>
     <% if @note.status == "closed" %>
-      <br />
-      <%= note_event(@note.status, @note.closed_at, @note.all_comments.last.author) %>
+      <p><%= note_event(@note.status, @note.closed_at, @note.all_comments.last.author) %></p>
     <% end %>
   </div>
 
   <% if @note_comments.find { |comment| comment.author.nil? } -%>
-    <p class='warning'><%= t "javascripts.notes.show.anonymous_warning" %></p>
+    <p class='alert alert-warning'><%= t "javascripts.notes.show.anonymous_warning" %></p>
   <% end -%>
 
   <% if current_user && current_user != @note.author %>

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -24,7 +24,7 @@
   <p><%= t ".export_details_html" %></p>
 
   <div id="export_osm_too_large">
-    <p class="warning">
+    <p class="alert alert-warning">
       <%= t ".too_large.body" %>
     </p>
   </div>


### PR DESCRIPTION
This work is based on the ideas from #1773 but with bootstrap alerts.

Pictures tell a thousand words:

### 1 New Notes

![Screenshot from 2020-07-15 15-28-47](https://user-images.githubusercontent.com/360803/87576378-96483300-c6d1-11ea-99d7-316418d1e5c1.png)

### 2 Note Anonymous warning

![Screenshot from 2020-07-15 19-27-09](https://user-images.githubusercontent.com/360803/87576426-ac55f380-c6d1-11ea-85ad-a7bab7479e26.png)

### 3 Export too large

![Screenshot from 2020-07-15 15-37-31](https://user-images.githubusercontent.com/360803/87576459-b841b580-c6d1-11ea-9a3e-ec2eaf62b99a.png)

### 4 Data browser too many features

![Screenshot from 2020-07-15 16-10-29](https://user-images.githubusercontent.com/360803/87576501-ca235880-c6d1-11ea-94e8-6cf92e5d13da.png)

The last of these took some rearranging of the jquery-crafted html, so I can rework that bit if necessary. But other than that I think they are much better than the merely indented paragraphs that we had before.


