### PR TITLE
Use Brakeman for static code analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - bundle exec rubocop -f fuubar
   - bundle exec rake eslint
   - bundle exec erblint .
+  - bundle exec brakeman -q
   - bundle exec rake db:structure:dump
   - sed -e "/idle_in_transaction_session_timeout/d" -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.actual
   - diff -uw db/structure.expected db/structure.actual

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,14 @@ You can view test coverage statistics by browsing the `coverage` directory.
 The tests are automatically run on Pull Requests and other commits with the
 results shown on [Travis CI](https://travis-ci.org/openstreetmap/openstreetmap-website).
 
+## Static Analysis
+
+We also perform static analysis of our code. You can run the analysis yourself with:
+
+```
+bundle exec brakeman -q
+```
+
 ## Comments
 
 Sometimes it's not apparent from the code itself what it does, or,

--- a/Gemfile
+++ b/Gemfile
@@ -138,6 +138,7 @@ end
 
 # Gems needed for running tests
 group :test do
+  gem "brakeman"
   gem "capybara", ">= 2.15"
   gem "coveralls", :require => false
   gem "erb_lint", :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
+    brakeman (4.8.2)
     browser (4.2.0)
     builder (3.2.4)
     bzip2-ffi (1.0.0)
@@ -484,6 +485,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.4.2)
   bootstrap (~> 4.5.0)
+  brakeman
   browser
   bzip2-ffi
   cancancan

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,0 +1,9 @@
+:skip_checks:
+# These checks are skipped, but should be considered TODO
+- CheckCrossSiteScripting
+- CheckExecute
+- CheckFileAccess
+- CheckRedirect
+- CheckRender
+- CheckSendFile
+- CheckSQL


### PR DESCRIPTION
This is my preferred version of #2229 

I've also reviewed the currently ignored warnings. Many of them are in code that will soon be either removed (amf_controller) or refactored (trace file handling) so I'm not prioritising fixing them at the moment. But at least having Brakeman included will prevent other errors from being accidentally introduced.