### PR TITLE
Add a browse map link to notes

### DIFF
--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -24,7 +24,7 @@
 <% if @type == "node" and common_details.visible? %>
 <div class="details geo">
   <%= t "browse.location" %>
-  <%= link_to(tag.span(number_with_delimiter(common_details.lat), :class => "latitude") + ", " + tag.span(number_with_delimiter(common_details.lon), :class => "longitude"), :controller => "site", :action => "index", :anchor => "map=18/#{common_details.lat}/#{common_details.lon}") %>
+  <%= link_to(tag.span(number_with_delimiter(common_details.lat), :class => "latitude") + ", " + tag.span(number_with_delimiter(common_details.lon), :class => "longitude"), root_path(:anchor => "map=18/#{common_details.lat}/#{common_details.lon}")) %>
 </div>
 <% end %>
 

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -12,10 +12,16 @@
   </div>
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">
-    <p><%= note_event("opened", @note.created_at, @note.author) %></p>
-    <% if @note.status == "closed" %>
-      <p><%= note_event(@note.status, @note.closed_at, @note.all_comments.last.author) %></p>
-    <% end %>
+    <ul class="list-unstyled">
+      <li><%= note_event("opened", @note.created_at, @note.author) %></li>
+      <% if @note.status == "closed" %>
+        <li><%= note_event(@note.status, @note.closed_at, @note.all_comments.last.author) %></li>
+      <% end %>
+      <li>
+        <%= t "browse.location" %>
+        <%= link_to(tag.span(number_with_delimiter(@note.lat), :class => "latitude") + ", " + tag.span(number_with_delimiter(@note.lon), :class => "longitude"), root_path(:anchor => "map=18/#{@note.lat}/#{@note.lon}")) %>
+      </li>
+    </ul>
   </div>
 
   <% if @note_comments.find { |comment| comment.author.nil? } -%>


### PR DESCRIPTION
This matches the one for nodes. Fixes #1355. Replacement for #1773.

An unstyled list works better for the details section, particularly when all three are shown.

The change to the named path in the nodes template is based on a review I gave in #1773.