### PR TITLE
Avoid testing against empty db queries

### DIFF
--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -64,29 +64,29 @@ module Api
     ##
     # check the "full" mode
     def test_full
-      Way.all.each do |way|
-        get way_full_path(way)
+      way = create(:way_with_nodes, :nodes_count => 3)
 
-        # full call should say "gone" for non-visible ways...
-        unless way.visible
-          assert_response :gone
-          next
-        end
+      get way_full_path(way)
 
-        # otherwise it should say success
-        assert_response :success
+      assert_response :success
 
-        # Check the way is correctly returned
-        assert_select "osm way[id='#{way.id}'][version='#{way.version}'][visible='#{way.visible}']", 1
+      # Check the way is correctly returned
+      assert_select "osm way[id='#{way.id}'][version='1'][visible='true']", 1
 
-        # check that each node in the way appears once in the output as a
-        # reference and as the node element.
-        way.nodes.each do |n|
-          count = (way.nodes - (way.nodes - [n])).length
-          assert_select "osm way nd[ref='#{n.id}']", count
-          assert_select "osm node[id='#{n.id}'][version='#{n.version}'][lat='#{format('%.7f', n.lat)}'][lon='#{format('%.7f', n.lon)}']", 1
-        end
+      # check that each node in the way appears once in the output as a
+      # reference and as the node element.
+      way.nodes.each do |n|
+        assert_select "osm way nd[ref='#{n.id}']", 1
+        assert_select "osm node[id='#{n.id}'][version='1'][lat='#{format('%.7f', n.lat)}'][lon='#{format('%.7f', n.lon)}']", 1
       end
+    end
+
+    def test_full_deleted
+      way = create(:way, :deleted)
+
+      get way_full_path(way)
+
+      assert_response :gone
     end
 
     ##

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -146,6 +146,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     private_user = create(:user, :data_public => true)
     friendship = create(:friendship, :befriender => private_user)
     changeset = create(:changeset, :user => friendship.befriendee, :num_changes => 1)
+    _changeset2 = create(:changeset, :user => create(:user), :num_changes => 1)
 
     get friend_changesets_path
     assert_response :redirect
@@ -169,7 +170,9 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
   def test_index_nearby
     private_user = create(:user, :data_public => false, :home_lat => 51.1, :home_lon => 1.0)
     user = create(:user, :home_lat => 51.0, :home_lon => 1.0)
+    far_away_user = create(:user, :home_lat => 51.0, :home_lon => 130)
     changeset = create(:changeset, :user => user, :num_changes => 1)
+    _changeset2 = create(:changeset, :user => far_away_user, :num_changes => 1)
 
     get nearby_changesets_path
     assert_response :redirect


### PR DESCRIPTION
This PR fixes #2614. Minor refactoring of tests to create relevant objects, and test against them. Previously these tests were asserting against empty database queries, since the fixtures were removed a few years ago.