### PR TITLE
Use the worldCopyJump option for leaflet overlays

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -30,7 +30,8 @@ $(document).ready(function () {
   var map = new L.OSM.Map("map", {
     zoomControl: false,
     layerControl: false,
-    contextmenu: true
+    contextmenu: true,
+    worldCopyJump: true
   });
 
   OSM.loadSidebarContent = function (path, callback) {


### PR DESCRIPTION
This means that if you pan to a 'copy' of the world, the overlays reappear on that copy.

https://leafletjs.com/reference-1.6.0.html#map-worldcopyjump

Fixes #2040