### PR TITLE
turn_costs=true only for car

### DIFF
--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -28,7 +28,7 @@ function GraphHopperEngine(id, vehicleType) {
           key: "LijBPDQGfu7Iiq80w3HzwB4RUDJbMbhs6BU0dEnn",
           elevation: false,
           instructions: true,
-          turn_costs: true,
+          turn_costs: vehicleType === "car",
           point: points.map(function (p) { return p.lat + "," + p.lng; })
         },
         traditional: true,


### PR DESCRIPTION
I know there was a bit forth and back in #2695 and my last recommendation was to use turn_costs=true. This was not intended for bike and foot - they are currently broken :( ... which this PR fixes.

Sorry for this.