### PR TITLE
Updated About Page Community Knowledge section for en and en-GB locales

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1311,8 +1311,8 @@ en-GB:
         is accurate and up to date.
       community_driven_title: Community Driven
       community_driven_html: |-
-        OpenStreetMap's community is diverse, passionate, and growing every day. Our contributors include enthusiast mappers, GIS professionals, engineers running the OSM servers, humanitarians mapping disaster-affected areas, and many more.
-        To learn more about the community, see the <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>, <a href='%{diary_path}'>user diaries</a>, <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.
+        OpenStreetMap's community is diverse, passionate, and growing every day. Our contributors include people like you: enthusiast mappers, GIS professionals, engineers running the OSM servers, humanitarians mapping disaster-affected areas, and many more.
+        To learn more about the community, see <a href="https://wiki.openstreetmap.org/wiki/How_to_contribute">How To Contribute</a>, the <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>, <a href='%{diary_path}'>user diaries</a>, <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.
       open_data_title: Open Data
       open_data_html: |-
         OpenStreetMap is <i>open data</i>: you are free to use it for any purpose

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1311,8 +1311,8 @@ en-GB:
         is accurate and up to date.
       community_driven_title: Community Driven
       community_driven_html: |-
-        OpenStreetMap's community is diverse, passionate, and growing every day. Our contributors include people like you: enthusiast mappers, GIS professionals, engineers running the OSM servers, humanitarians mapping disaster-affected areas, and many more.
-        To learn more about the community, see the OpenStreetMap <a href='https://welcome.openstreetmap.org/'>Welcome Mat</a>, <a href='https://blog.openstreetmap.org'>Blog</a>, <a href='%{diary_path}'>user diaries</a>, <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.
+        OpenStreetMap's community is diverse, passionate, and growing every day. Our contributors include enthusiast mappers, GIS professionals, engineers running the OSM servers, humanitarians mapping disaster-affected areas, and many more.
+        To learn more about the community, see the <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>, <a href='%{diary_path}'>user diaries</a>, <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.
       open_data_title: Open Data
       open_data_html: |-
         OpenStreetMap is <i>open data</i>: you are free to use it for any purpose

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1312,7 +1312,7 @@ en-GB:
       community_driven_title: Community Driven
       community_driven_html: |-
         OpenStreetMap's community is diverse, passionate, and growing every day. Our contributors include people like you: enthusiast mappers, GIS professionals, engineers running the OSM servers, humanitarians mapping disaster-affected areas, and many more.
-        To learn more about the community, see <a href="https://wiki.openstreetmap.org/wiki/How_to_contribute">How To Contribute</a>, the <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>, <a href='%{diary_path}'>user diaries</a>, <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.
+        To learn more about the community, see the OpenStreetMap <a href='https://welcome.openstreetmap.org/'>Welcome Mat</a>, <a href='https://blog.openstreetmap.org'>Blog</a>, <a href='%{diary_path}'>user diaries</a>, <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.
       open_data_title: Open Data
       open_data_html: |-
         OpenStreetMap is <i>open data</i>: you are free to use it for any purpose

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1367,11 +1367,12 @@ en:
       community_driven_title: Community Driven
       community_driven_html: |
         OpenStreetMap's community is diverse, passionate, and growing every day.
-        Our contributors include enthusiast mappers, GIS professionals, engineers
+        Our contributors include people like you: enthusiast mappers, GIS professionals, engineers
         running the OSM servers, humanitarians mapping disaster-affected areas,
         and many more.
-        To learn more about the community, see the
-        <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>,
+        To learn more about the community, see
+        <a href="https://wiki.openstreetmap.org/wiki/How_to_contribute">How To Contribute</a>,
+        the <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>,
         <a href='%{diary_path}'>user diaries</a>,
         <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and
         the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1370,9 +1370,9 @@ en:
         Our contributors include people like you: enthusiast mappers, GIS professionals, engineers
         running the OSM servers, humanitarians mapping disaster-affected areas,
         and many more.
-        To learn more about the community, see
-        <a href="https://wiki.openstreetmap.org/wiki/How_to_contribute">How To Contribute</a>,
-        the <a href='https://blog.openstreetmap.org'>OpenStreetMap Blog</a>,
+        To learn more about the community, see the OpenStreetMap
+        <a href='https://welcome.openstreetmap.org/'>Welcome Mat</a>,
+        <a href='https://blog.openstreetmap.org'>Blog</a>,
         <a href='%{diary_path}'>user diaries</a>,
         <a href='https://blogs.openstreetmap.org/'>community blogs</a>, and
         the <a href='https://www.osmfoundation.org/'>OSM Foundation</a> website.


### PR DESCRIPTION
Implements [Martin Koppenhoefer’s suggestions for the _About Page_](https://lists.openstreetmap.org/pipermail/talk/2020-July/085163.html) for just `en` and `en-GB` locales.

Preview:

<img width="960" alt="Screen Shot 2020-07-27 at 1 15 39 PM" src="https://user-images.githubusercontent.com/58730/88587766-51929500-d00b-11ea-80da-0cd878cd40b4.png">
