### PR TITLE
Add authorship check for config/locales

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,41 @@
-dist: bionic
-language: ruby
-rvm:
-  - 2.5.3
-cache:
-  - bundler
-addons:
-  postgresql: 9.5
-  apt:
-    packages:
-      - firefox-geckodriver
-      - libarchive-dev
-      - libgd-dev
-      - libffi-dev
-      - libbz2-dev
-services:
-  - memcached
-before_script:
-  - sed -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.expected
-  - psql -U postgres -c "CREATE DATABASE openstreetmap"
-  - psql -U postgres -c "CREATE EXTENSION btree_gist" openstreetmap
-  - psql -U postgres -f db/functions/functions.sql openstreetmap
-  - cp config/travis.database.yml config/database.yml
-  - cp config/example.storage.yml config/storage.yml
-  - touch config/settings.local.yml
-  - echo -e "---\nmemcache_servers:\n  - 127.0.0.1" > config/settings/test.local.yml
-  - bundle exec rake db:migrate
-  - bundle exec rake i18n:js:export
-  - bundle exec rake yarn:install
-script:
-  - bundle exec rubocop -f fuubar
-  - bundle exec rake eslint
-  - bundle exec erblint .
-  - bundle exec brakeman -q
-  - bundle exec rake db:structure:dump
-  - sed -e "/idle_in_transaction_session_timeout/d" -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.actual
-  - diff -uw db/structure.expected db/structure.actual
-  - bundle exec rake test:db
+jobs:
+  include:
+  - name: "Website Code"
+    dist: bionic
+    language: ruby
+    rvm:
+      - 2.5.3
+    cache:
+      - bundler
+    addons:
+      postgresql: 9.5
+      apt:
+        packages:
+          - firefox-geckodriver
+          - libarchive-dev
+          - libgd-dev
+          - libffi-dev
+          - libbz2-dev
+    services:
+      - memcached
+    before_script:
+      - sed -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.expected
+      - psql -U postgres -c "CREATE DATABASE openstreetmap"
+      - psql -U postgres -c "CREATE EXTENSION btree_gist" openstreetmap
+      - psql -U postgres -f db/functions/functions.sql openstreetmap
+      - cp config/travis.database.yml config/database.yml
+      - cp config/example.storage.yml config/storage.yml
+      - touch config/settings.local.yml
+      - echo -e "---\nmemcache_servers:\n  - 127.0.0.1" > config/settings/test.local.yml
+      - bundle exec rake db:migrate
+      - bundle exec rake i18n:js:export
+      - bundle exec rake yarn:install
+    script:
+      - bundle exec rubocop -f fuubar
+      - bundle exec rake eslint
+      - bundle exec erblint .
+      - bundle exec brakeman -q
+      - bundle exec rake db:structure:dump
+      - sed -e "/idle_in_transaction_session_timeout/d" -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.actual
+      - diff -uw db/structure.expected db/structure.actual
+      - bundle exec rake test:db

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 jobs:
   include:
+  - name: "Locales"
+    install: skip
+    script:
+      - echo "TRAVIS_COMMIT_RANGE:" $TRAVIS_COMMIT_RANGE
   - name: "Website Code"
     dist: bionic
     language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 jobs:
   include:
-  - name: "Locales"
+  - name: "Locale Authorship"
     install: skip
     script:
-      - git log $TRAVIS_COMMIT_RANGE
+      # Locale files (in config/locales) are updated via Translatewiki.
+      # Look for other authors and fail this test if any are found.
       - config/locales/check-authors.sh $TRAVIS_COMMIT_RANGE
   - name: "Website Code"
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,41 @@
-jobs:
-  include:
-  - name: "Locale Authorship"
-    install: skip
-    script:
-      # Locale files (in config/locales) are updated via Translatewiki.
-      # Look for other authors and fail this test if any are found.
-      - config/locales/check-authors.sh $TRAVIS_COMMIT_RANGE
-  - name: "Website Code"
-    dist: bionic
-    language: ruby
-    rvm:
-      - 2.5.3
-    cache:
-      - bundler
-    addons:
-      postgresql: 9.5
-      apt:
-        packages:
-          - firefox-geckodriver
-          - libarchive-dev
-          - libgd-dev
-          - libffi-dev
-          - libbz2-dev
-    services:
-      - memcached
-    before_script:
-      - sed -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.expected
-      - psql -U postgres -c "CREATE DATABASE openstreetmap"
-      - psql -U postgres -c "CREATE EXTENSION btree_gist" openstreetmap
-      - psql -U postgres -f db/functions/functions.sql openstreetmap
-      - cp config/travis.database.yml config/database.yml
-      - cp config/example.storage.yml config/storage.yml
-      - touch config/settings.local.yml
-      - echo -e "---\nmemcache_servers:\n  - 127.0.0.1" > config/settings/test.local.yml
-      - bundle exec rake db:migrate
-      - bundle exec rake i18n:js:export
-      - bundle exec rake yarn:install
-    script:
-      - bundle exec rubocop -f fuubar
-      - bundle exec rake eslint
-      - bundle exec erblint .
-      - bundle exec brakeman -q
-      - bundle exec rake db:structure:dump
-      - sed -e "/idle_in_transaction_session_timeout/d" -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.actual
-      - diff -uw db/structure.expected db/structure.actual
-      - bundle exec rake test:db
+dist: bionic
+language: ruby
+rvm:
+  - 2.5.3
+cache:
+  - bundler
+addons:
+  postgresql: 9.5
+  apt:
+    packages:
+      - firefox-geckodriver
+      - libarchive-dev
+      - libgd-dev
+      - libffi-dev
+      - libbz2-dev
+services:
+  - memcached
+before_script:
+  - sed -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.expected
+  - psql -U postgres -c "CREATE DATABASE openstreetmap"
+  - psql -U postgres -c "CREATE EXTENSION btree_gist" openstreetmap
+  - psql -U postgres -f db/functions/functions.sql openstreetmap
+  - cp config/travis.database.yml config/database.yml
+  - cp config/example.storage.yml config/storage.yml
+  - touch config/settings.local.yml
+  - echo -e "---\nmemcache_servers:\n  - 127.0.0.1" > config/settings/test.local.yml
+  - bundle exec rake db:migrate
+  - bundle exec rake i18n:js:export
+  - bundle exec rake yarn:install
+script:
+  - bundle exec rubocop -f fuubar
+  - bundle exec rake eslint
+  - bundle exec erblint .
+  # Locale files (in config/locales) are updated via Translatewiki.
+  # Look for other authors and fail this test if any are found.
+  - config/locales/check-authors.sh $TRAVIS_COMMIT_RANGE
+  - bundle exec brakeman -q
+  - bundle exec rake db:structure:dump
+  - sed -e "/idle_in_transaction_session_timeout/d" -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.actual
+  - diff -uw db/structure.expected db/structure.actual
+  - bundle exec rake test:db

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,11 @@ script:
   - bundle exec rubocop -f fuubar
   - bundle exec rake eslint
   - bundle exec erblint .
-  # Locale files (in config/locales) are updated via Translatewiki.
-  # Look for other authors and fail this test if any are found.
-  - config/locales/check-authors.sh $TRAVIS_COMMIT_RANGE
   - bundle exec brakeman -q
   - bundle exec rake db:structure:dump
   - sed -e "/idle_in_transaction_session_timeout/d" -e 's/ IMMUTABLE / /' -e "/^--/d" db/structure.sql > db/structure.actual
   - diff -uw db/structure.expected db/structure.actual
   - bundle exec rake test:db
+  # Locale files (in config/locales) are updated via Translatewiki.
+  # Look for other authors and fail this test if any are found.
+  - config/locales/check-authors.sh $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ script:
   - bundle exec rake test:db
   # Locale files (in config/locales) are updated via Translatewiki.
   # Look for other authors and fail this test if any are found.
-  - config/locales/check-authors.sh $TRAVIS_COMMIT_RANGE
+  - config/locales/check-authors.sh $TRAVIS_PULL_REQUEST $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jobs:
   - name: "Locales"
     install: skip
     script:
-      - echo "TRAVIS_COMMIT_RANGE:" $TRAVIS_COMMIT_RANGE
+      - config/locales/check-authors.sh $TRAVIS_COMMIT_RANGE
   - name: "Website Code"
     dist: bionic
     language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jobs:
   - name: "Locales"
     install: skip
     script:
+      - git log $TRAVIS_COMMIT_RANGE
       - config/locales/check-authors.sh $TRAVIS_COMMIT_RANGE
   - name: "Website Code"
     dist: bionic

--- a/config/locales/check-authors.sh
+++ b/config/locales/check-authors.sh
@@ -18,8 +18,11 @@ STATUS=0
 
 # Check nothing if we're not in a PR
 if [ "$PULL_REQUEST" = "false" ]; then
-    echo "Not checking locale authorship outside a pull request"
+    echo "--> Not checking locale authorship outside a pull request."
     exit $STATUS;
+else
+    echo "--> Checking locale authorship for PR ${PULL_REQUEST} commit range ${COMMIT_RANGE}"
+    echo "    See CONTRIBUTING.md, i18n section"
 fi
 
 for FILE in *.yml; do
@@ -28,10 +31,11 @@ for FILE in *.yml; do
     HUMAN_AUTHOR=`git log --format='%ae' $COMMIT_RANGE -- $FILE | grep -v @translatewiki.net | head -n1`
     if [ $HUMAN_AUTHOR ]; then
       # Mark for failure if changes were made by anyone other than translatewiki.net
-      echo "Unexpectedly found ${HUMAN_AUTHOR} in ${FILE} (see CONTRIBUTING.md, i18n)"
+      echo "    Unexpectedly found ${HUMAN_AUTHOR} in ${FILE}"
       STATUS=1
     fi
   fi
 done
 
+echo "    Done checking locale authorship."
 exit $STATUS

--- a/config/locales/check-authors.sh
+++ b/config/locales/check-authors.sh
@@ -19,7 +19,7 @@ for FILE in *.yml; do
     HUMAN_AUTHOR=`git log --format='%ae' $COMMIT_RANGE -- $FILE | grep -v @translatewiki.net | head -n1`
     if [ $HUMAN_AUTHOR ]; then
       # Mark for failure if changes were made by anyone other than translatewiki.net
-      echo Found $HUMAN_AUTHOR in $FILE
+      echo "Unexpectedly found ${HUMAN_AUTHOR} in ${FILE} (see CONTRIBUTING.md, i18n)"
       STATUS=1
     fi
   fi

--- a/config/locales/check-authors.sh
+++ b/config/locales/check-authors.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+cd `dirname $0`
+
+COMMIT_RANGE=$1
+STATUS=0
+
+for FILE in *.yml; do
+  if [ $FILE != en.yml ]; then
+    # Fail if changes were made by anyone other than translatewiki.net
+    HUMAN_AUTHOR=`git log --format='%ae' $COMMIT_RANGE -- $FILE | grep -v @translatewiki.net | head -n1`
+    if [ $HUMAN_AUTHOR ]; then
+      echo Found $HUMAN_AUTHOR in $FILE
+      STATUS=1
+    fi
+  fi
+done
+
+exit $STATUS

--- a/config/locales/check-authors.sh
+++ b/config/locales/check-authors.sh
@@ -7,11 +7,20 @@
 #
 cd `dirname $0`
 
+# Name of current pull request, otherwise "false"
+PULL_REQUEST=$1
+
 # Look at just a specific commit range, expressed as "SHA1...SHA2"
-COMMIT_RANGE=$1
+COMMIT_RANGE=$2
 
 # Assume everything will be fine
 STATUS=0
+
+# Check nothing if we're not in a PR
+if [ "$PULL_REQUEST" = "false" ]; then
+    echo "Not checking locale authorship outside a pull request"
+    exit $STATUS;
+fi
 
 for FILE in *.yml; do
   # Don't check authorship of en.yml

--- a/config/locales/check-authors.sh
+++ b/config/locales/check-authors.sh
@@ -1,14 +1,24 @@
 #!/bin/sh -e
+#
+# Note from CONTRIBUTING.md: If you make a change that involve the locale
+# files (in config/locales) then please only submit changes to the en.yml
+# file. The other files are updated via Translatewiki and should not be
+# included in your pull request.
+#
 cd `dirname $0`
 
+# Look at just a specific commit range, expressed as "SHA1...SHA2"
 COMMIT_RANGE=$1
+
+# Assume everything will be fine
 STATUS=0
 
 for FILE in *.yml; do
+  # Don't check authorship of en.yml
   if [ $FILE != en.yml ]; then
-    # Fail if changes were made by anyone other than translatewiki.net
     HUMAN_AUTHOR=`git log --format='%ae' $COMMIT_RANGE -- $FILE | grep -v @translatewiki.net | head -n1`
     if [ $HUMAN_AUTHOR ]; then
+      # Mark for failure if changes were made by anyone other than translatewiki.net
       echo Found $HUMAN_AUTHOR in $FILE
       STATUS=1
     fi


### PR DESCRIPTION
Andy [pointed out the contribution rules for locales](https://github.com/openstreetmap/openstreetmap-website/pull/2735#discussion_r461356191): only `en.yml` is meant to be changed in PRs while other locales are edited viw TranslateWiki.

This PR adds a parallel Travis test to look for cases where this contribution rule has been violated. It lets the primary unit tests run to completion but offers quick feedback on authorship. 

Some changes to locale files are structural and exempt from the restriction. A check failure would need to be ignored in that case, or somehow suppressed. Would core project contributors like Andy or Tom be included in the TranslateWiki exception? Maybe this would only apply to external PRs?