### PR TITLE
Black list 2010 and 2016 imagery for the Canton Schaffhauen

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -97,6 +97,8 @@ imagery_blacklist:
   - "http://xdworld\\.vworld\\.kr:8080/.*"
   # Blacklist here
   - ".*\\.here\\.com[/:].*"
+  # Blacklist Kanton SH
+  - ".*wms.geo.sh.ch.*Luftbild_201[06].*"
 # URL of Overpass instance to use for feature queries
 overpass_url: "https://overpass-api.de/api/interpreter"
 # Routing endpoints


### PR DESCRIPTION
Sorry that this is necessary but as iD is currently dead in the water this seems to be the only expedient way of stopping people to use these two layers, which are not available on OSM compatible terms. Hopefully in the long term this can be removed again. 

PS: tested locally with iD.