### PR TITLE
Block Canton Glarus imagery too

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -97,8 +97,9 @@ imagery_blacklist:
   - "http://xdworld\\.vworld\\.kr:8080/.*"
   # Blacklist here
   - ".*\\.here\\.com[/:].*"
-  # Blacklist Kanton SH
+  # Blacklist Kanton SH and GL
   - ".*wms.geo.sh.ch.*Luftbild_201[06].*"
+  - ".*wms.geo.gl.ch.*ch.gl.imagery.orthofoto201[357].*"
 # URL of Overpass instance to use for feature queries
 overpass_url: "https://overpass-api.de/api/interpreter"
 # Routing endpoints


### PR DESCRIPTION
Sorry, didn't realize that the GL imagery was still available in iD too.