### PR TITLE
Fix buttons

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -709,8 +709,7 @@ body.compact-nav {
     margin: $lineheight auto;
   }
 
-  .loader,
-  .load_more {
+  .loader {
     text-align: center;
     margin: auto;
     width: 40px;

--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -3,8 +3,8 @@
     <%= render @changesets %>
   </ol>
 <% if @changesets.size == 20 -%>
-  <div class="changeset_more">
-    <%= link_to t(".load_more"), url_for(@params.merge(:max_id => @changesets.last.id - 1)), :class => "button load_more" %>
+  <div class="changeset_more text-center">
+    <%= link_to t(".load_more"), url_for(@params.merge(:max_id => @changesets.last.id - 1)), :class => "btn btn-primary" %>
     <div class="loader"><%= image_tag "searching.gif" %></div>
   </div>
 <% end -%>

--- a/app/views/geocoder/results.html.erb
+++ b/app/views/geocoder/results.html.erb
@@ -11,8 +11,8 @@
     <% end %>
   </ul>
   <% if @more_params %>
-    <div class="search_more">
-      <%= link_to t(".more_results"), url_for(@more_params), :class => "button load_more" %>
+    <div class="search_more text-center">
+      <%= link_to t(".more_results"), url_for(@more_params), :class => "btn btn-primary" %>
       <div class="loader"><%= image_tag "searching.gif" %></div>
     </div>
   <% end %>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -48,8 +48,10 @@
                  :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
                  :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
         </p>
-        <a class="button learn-more" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
-        <a class="button sign-up" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+        <div class="standard-form">
+          <a class="button learn-more" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
+          <a class="button sign-up" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -17,7 +17,7 @@
       <h5><%= t ".how_to_help.join_the_community.title" %></h5>
       <p><%= t ".how_to_help.join_the_community.explanation_html" %></p>
       <p class='text-center'>
-        <a class="button sign-up" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+        <a class="btn btn-primary" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
       </p>
     </div>
     <div class='col-sm'>


### PR DESCRIPTION
Fixes #2774 

I also found one more unstyled button on the fixthemap page. 

The preferred option is to use bootstrap buttons, but in one case I used the `standard-form` class as a temporary workaround. After refactoring, the `load_more` class was no longer necessary.