### PR TITLE
Bootstrap forms

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,5 +1,14 @@
+require "ostruct"
+
 module ReportsHelper
   def report_link(name, reportable)
     link_to name, new_report_url(:reportable_id => reportable.id, :reportable_type => reportable.class.name)
+  end
+
+  # Convert a list of strings into objects with methods that the collection_radio_buttons helper expects
+  def report_categories(reportable)
+    Report.categories_for(reportable).map do |c|
+      OpenStruct.new(:id => c, :label => t(".categories.#{reportable.class.name.underscore}.#{c}_label"))
+    end
   end
 end

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -2,13 +2,41 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
-<%= form_tag(issues_path, :method => :get, :class => "standard-form") do %>
 <p><%= t ".search_guidance" %></p>
-<%= select_tag :status, options_for_select(Issue.aasm.states.map(&:name).map { |state| [t(".states.#{state}"), state] }, params[:status]), :include_blank => t(".select_status"), :data => { :behavior => "category_dropdown" } %>
-<%= select_tag :issue_type, options_for_select(@issue_types, params[:issue_type]), :include_blank => t(".select_type"), :data => { :behavior => "category_dropdown" } %>
-<%= text_field_tag :search_by_user, params[:search_by_user], :placeholder => t(".reported_user") %>
-<%= select_tag :last_updated_by, options_for_select(@users.all.collect { |f| [f.display_name, f.id] } << [t(".not_updated"), "nil"], params[:last_updated_by]), :include_blank => t(".select_last_updated_by"), :data => { :behavior => "category_dropdown" } %>
-<%= submit_tag t(".search"), :name => nil %>
+
+<%= form_tag(issues_path, :method => :get) do %>
+  <div class="form-row">
+    <div class="form-group col-md-auto">
+      <%= select_tag :status,
+                     options_for_select(Issue.aasm.states.map(&:name).map { |state| [t(".states.#{state}"), state] }, params[:status]),
+                     :include_blank => t(".select_status"),
+                     :data => { :behavior => "category_dropdown" },
+                     :class => "form-control custom-select" %>
+    </div>
+    <div class="form-group col-md-auto">
+      <%= select_tag :issue_type,
+                     options_for_select(@issue_types, params[:issue_type]),
+                     :include_blank => t(".select_type"),
+                     :data => { :behavior => "category_dropdown" },
+                     :class => "form-control custom-select" %>
+    </div>
+    <div class="form-group col-md">
+      <%= text_field_tag :search_by_user,
+                         params[:search_by_user],
+                         :placeholder => t(".reported_user"),
+                         :class => "form-control" %>
+    </div>
+    <div class="form-group col-md-auto">
+      <%= select_tag :last_updated_by,
+                     options_for_select(@users.all.collect { |f| [f.display_name, f.id] } << [t(".not_updated"), "nil"], params[:last_updated_by]),
+                     :include_blank => t(".select_last_updated_by"),
+                     :data => { :behavior => "category_dropdown" },
+                     :class => "form-control custom-select" %>
+    </div>
+    <div class="form-group col-md-auto">
+      <%= submit_tag t(".search"), :name => nil, :class => "btn btn-primary" %>
+    </div>
+  </div>
 <% end %>
 <br />
 

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -38,42 +38,39 @@
     </div>
   </div>
 <% end %>
-<br />
 
 <% if @issues.length == 0 %>
   <p><%= t ".issues_not_found" %></p>
-<% end %>
-
-<br />
-
-<table class="table table-sm">
-  <thead>
-    <tr>
-      <th><%= t ".status" %></th>
-      <th><%= t ".reports" %></th>
-      <th><%= t ".reported_item" %></th>
-      <th><%= t ".reported_user" %></th>
-      <th><%= t ".last_updated" %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @issues.each do |issue| %>
+<% else %>
+  <table class="table table-sm">
+    <thead>
       <tr>
-        <td><%= t ".states.#{issue.status}" %></td>
-        <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
-        <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
-        <td><%= link_to issue.reported_user.display_name, user_path(issue.reported_user) if issue.reported_user %></td>
-        <td>
-          <% if issue.user_updated %>
-            <%= t ".last_updated_time_user_html", :user => link_to(issue.user_updated.display_name, user_path(issue.user_updated)),
-                                                  :time => time_ago_in_words(issue.updated_at, :scope => :'datetime.distance_in_words_ago'),
-                                                  :title => l(issue.updated_at) %>
-          <% else %>
-            <%= t ".last_updated_time_html", :time => time_ago_in_words(issue.updated_at, :scope => :'datetime.distance_in_words_ago'),
-                                             :title => l(issue.updated_at) %>
-          <% end %>
-        </td>
+        <th><%= t ".status" %></th>
+        <th><%= t ".reports" %></th>
+        <th><%= t ".reported_item" %></th>
+        <th><%= t ".reported_user" %></th>
+        <th><%= t ".last_updated" %></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @issues.each do |issue| %>
+        <tr>
+          <td><%= t ".states.#{issue.status}" %></td>
+          <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
+          <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
+          <td><%= link_to issue.reported_user.display_name, user_path(issue.reported_user) if issue.reported_user %></td>
+          <td>
+            <% if issue.user_updated %>
+              <%= t ".last_updated_time_user_html", :user => link_to(issue.user_updated.display_name, user_path(issue.user_updated)),
+                                                    :time => time_ago_in_words(issue.updated_at, :scope => :'datetime.distance_in_words_ago'),
+                                                    :title => l(issue.updated_at) %>
+            <% else %>
+              <%= t ".last_updated_time_html", :time => time_ago_in_words(issue.updated_at, :scope => :'datetime.distance_in_words_ago'),
+                                               :title => l(issue.updated_at) %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/oauth_clients/_form.html.erb
+++ b/app/views/oauth_clients/_form.html.erb
@@ -1,29 +1,11 @@
-<div class='standard-form'>
-  <fieldset>
-    <div class="standard-form-row">
-      <label class='standard-label' for="client_application_name"><%= t ".name" %> (<%= t ".required" %>)</label>
-      <%= f.text_field :name %>
-    </div>
-    <div class="standard-form-row">
-      <label class='standard-label' for="client_application_url"><%= t ".url" %> (<%= t ".required" %>)</label>
-      <%= f.text_field :url %>
-    </div>
-    <div class="standard-form-row">
-      <label class='standard-label' for="client_application_callback_url"><%= t ".callback_url" %></label>
-      <%= f.text_field :callback_url %>
-    </div>
-    <div class="standard-form-row">
-      <label class='standard-label' for="client_application_support_url"><%= t ".support_url" %></label>
-      <%= f.text_field :support_url %>
-    </div>
-  </fieldset>
-  <fieldset class='form-divider'>
-      <p><%= t ".requests" %></p>
-      <% ClientApplication.all_permissions.each do |perm| %>
-        <div class="standard-form-row">
-          <%= f.check_box perm %>
-          <label class='standard-label' for="client_application_<%= perm.to_s %>"><%= t("." + perm.to_s) %></label>
-        </div>
-      <% end %>
-  </fieldset>
+<%= f.text_field :name %>
+<%= f.text_field :url %>
+<%= f.text_field :callback_url %>
+<%= f.text_field :support_url %>
+<div class='form-group'>
+  <p><%= t ".requests" %></p>
+  <% ClientApplication.all_permissions.each do |perm| %>
+    <%= f.check_box perm %>
+  <% end %>
 </div>
+<%= f.primary %>

--- a/app/views/oauth_clients/edit.html.erb
+++ b/app/views/oauth_clients/edit.html.erb
@@ -2,7 +2,6 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
-<%= form_for @client_application, :url => oauth_client_path(@client_application.user.display_name, @client_application), :html => { :method => :put, :class => "standard-form" } do |f| %>
+<%= bootstrap_form_for @client_application, :url => oauth_client_path(@client_application.user.display_name, @client_application), :html => { :method => :put } do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
-  <%= f.submit %>
 <% end %>

--- a/app/views/oauth_clients/new.html.erb
+++ b/app/views/oauth_clients/new.html.erb
@@ -2,9 +2,6 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
-<div class='standard-form'>
-  <%= form_for @client_application, :url => { :action => :create } do |f| %>
-    <%= render :partial => "form", :locals => { :f => f } %>
-    <%= f.submit %>
-  <% end %>
-</div>
+<%= bootstrap_form_for @client_application, :url => { :action => :create } do |f| %>
+  <%= render :partial => "form", :locals => { :f => f } %>
+<% end %>

--- a/app/views/oauth_clients/show.html.erb
+++ b/app/views/oauth_clients/show.html.erb
@@ -1,33 +1,31 @@
 <% content_for :heading do %>
   <h1><%= t(".title", :app_name => @client_application.name) %></h1>
 <% end %>
-<div class='prose'>
-  <p>
-    <strong><%= t ".key" %></strong> <%= @client_application.key %>
-  </p>
-  <p>
-    <strong><%= t ".secret" %></strong> <%= @client_application.secret %>
-  </p>
-  <p>
-    <strong><%= t ".url" %></strong> http<%= "s" if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.request_token_path %>
-  </p>
-  <p>
-    <strong><%= t ".access_url" %></strong> http<%= "s" if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.access_token_path %>
-  </p>
-  <p>
-    <strong><%= t ".authorize_url" %></strong> http<%= "s" if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.authorize_path %>
-  </p>
 
+<dl class="row">
+  <dt class="col-sm-3"><%= t ".key" %></dt>
+  <dd class="col-sm-9"><%= @client_application.key %></dt>
+  <dt class="col-sm-3"><%= t ".secret" %></dt>
+  <dd class="col-sm-9"><%= @client_application.secret %></dd>
+  <dt class="col-sm-3"><%= t ".url" %></dt>
+  <dd class="col-sm-9">http<%= "s" if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.request_token_path %></dd>
+  <dt class="col-sm-3"><%= t ".access_url" %></dt>
+  <dd class="col-sm-9">http<%= "s" if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.access_token_path %></dd>
+  <dt class="col-sm-3"><%= t ".authorize_url" %></dt>
+  <dd class="col-sm-9">http<%= "s" if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.authorize_path %></dd>
+</dl>
+
+<div>
   <p><%= t ".requests" %></p>
-  <ul><% @client_application.permissions.each do |perm| %>
-  <div class="field">
-    <li><%= t("oauth_clients.form." + perm.to_s) %></li>
-  </div>
-  <% end %></ul>
-
+  <ul>
+    <% @client_application.permissions.each do |perm| %>
+      <li><%= t("activerecord.attributes.client_application." + perm.to_s) %></li>
+    <% end %>
+  </ul>
   <p><%= t ".support_notice" %></p>
 </div>
-<div class="buttons standard-form">
-  <%= button_to t(".edit"), edit_oauth_client_path(@client_application.user.display_name, @client_application), :method => :get, :class => "oauth-edit" %>
-  <%= button_to t(".delete"), oauth_client_path(@client_application.user.display_name, @client_application), :method => :delete, :data => { :confirm => t(".confirm") }, :class => "oauth-delete deemphasize" %>
+
+<div>
+  <%= link_to t(".edit"), edit_oauth_client_path(@client_application.user.display_name, @client_application), :method => :get, :class => "btn btn-outline-primary" %>
+  <%= link_to t(".delete"), oauth_client_path(@client_application.user.display_name, @client_application), :method => :delete, :data => { :confirm => t(".confirm") }, :class => "btn btn-outline-danger" %>
 </div>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -11,32 +11,13 @@
   </ul>
 </div>
 
-<%= form_for(@report) do |f| %>
-  <%= f.error_messages %>
-  <fieldset class="standard-form">
-    <%= f.fields_for @report.issue do |issue_form| %>
-      <%= issue_form.hidden_field :reportable_id %>
-      <%= issue_form.hidden_field :reportable_type %>
-    <% end %>
+<%= bootstrap_form_for(@report) do |f| %>
+  <%= f.fields_for @report.issue do |issue_form| %>
+    <%= issue_form.hidden_field :reportable_id %>
+    <%= issue_form.hidden_field :reportable_type %>
+  <% end %>
 
-    <div class='standard-form-row'>
-      <p><%= t(".select") %></p>
-      <ul class="form-list">
-      <% Report.categories_for(@report.issue.reportable).each do |c| %>
-        <li>
-          <%= radio_button :report, :category, c, :required => true %>
-          <%= label_tag "report_category_#{c}", t(".categories.#{@report.issue.reportable.class.name.underscore}.#{c}_label") %>
-        </li>
-      <% end %>
-      </ul>
-    </div>
-
-    <div class='standard-form-row'>
-      <%= text_area :report, :details, :cols => 20, :rows => 5, :placeholder => t(".details") %>
-    </div>
-
-    <div class='buttons'>
-      <%= f.submit %>
-    </div>
-  </fieldset>
+  <%= f.collection_radio_buttons :category, report_categories(@report.issue.reportable), :id, :label %>
+  <%= f.text_area :details, :rows => 5, :label_as_placeholder => true %>
+  <%= f.primary %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,9 @@ en:
         title: "Subject"
         body: "Body"
         recipient: "Recipient"
+      report:
+        category: Select a reason for your report
+        details: Please provide some more details about the problem (required).
       user:
         email: "Email"
         active: "Active"
@@ -1118,8 +1121,6 @@ en:
     new:
       title_html: "Report %{link}"
       missing_params: "Cannot create a new report"
-      details: Please provide some more details about the problem (required).
-      select: "Select a reason for your report:"
       disclaimer:
         intro: "Before sending your report to the site moderators, please ensure that:"
         not_just_mistake: You are certain that the problem is not just a mistake

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@ en:
         create: Send
       client_application:
         create: Register
-        update: Edit
+        update: Update
       redaction:
         create: Create redaction
         update: Save redaction
@@ -75,6 +75,18 @@ en:
     # Translates all the model attributes, which is used in error handling on the web site
     # Only the ones that are used on the web site are translated at the moment
     attributes:
+      client_application:
+        name: Name (Required)
+        url: Main Application URL (Required)
+        callback_url: Callback URL
+        support_url: Support URL
+        allow_read_prefs:  read their user preferences
+        allow_write_prefs: modify their user preferences
+        allow_write_diary: create diary entries, comments and make friends
+        allow_write_api:   modify the map
+        allow_read_gpx:    read their private GPS traces
+        allow_write_gpx:   upload GPS traces
+        allow_write_notes: modify notes
       diary_comment:
         body: "Body"
       diary_entry:
@@ -1973,13 +1985,6 @@ en:
       delete: "Delete Client"
       confirm: "Are you sure?"
       requests: "Requesting the following permissions from the user:"
-      allow_read_prefs:  "read their user preferences."
-      allow_write_prefs: "modify their user preferences."
-      allow_write_diary: "create diary entries, comments and make friends."
-      allow_write_api:   "modify the map."
-      allow_read_gpx:    "read their private GPS traces."
-      allow_write_gpx:   "upload GPS traces."
-      allow_write_notes: "modify notes."
     index:
       title: "My OAuth Details"
       my_tokens: "My Authorised Applications"
@@ -1993,19 +1998,7 @@ en:
       registered_apps: "You have the following client applications registered:"
       register_new: "Register your application"
     form:
-      name: "Name"
-      required: "Required"
-      url: "Main Application URL"
-      callback_url: "Callback URL"
-      support_url: "Support URL"
       requests: "Request the following permissions from the user:"
-      allow_read_prefs:  "read their user preferences."
-      allow_write_prefs: "modify their user preferences."
-      allow_write_diary: "create diary entries, comments and make friends."
-      allow_write_api:   "modify the map."
-      allow_read_gpx:    "read their private GPS traces."
-      allow_write_gpx:   "upload GPS traces."
-      allow_write_notes: "modify notes."
     not_found:
       sorry: "Sorry, that %{type} could not be found."
     create:


### PR DESCRIPTION
This refactors the reports, issues and client_application forms to use Bootstrap form components.

The bootstrap_form `collection_radio_buttons` helper expects a group of objects that respond to methods, so we can't use the array of report category strings directly. I think the helper method is the best approach to this, since it leaves the form itself easy to read.