### PR TITLE
Avoid lego translations for coordinates

### DIFF
--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -24,7 +24,10 @@
 <% if @type == "node" and common_details.visible? %>
 <div class="details geo">
   <%= t "browse.location" %>
-  <%= link_to(tag.span(number_with_delimiter(common_details.lat), :class => "latitude") + ", " + tag.span(number_with_delimiter(common_details.lon), :class => "longitude"), root_path(:anchor => "map=18/#{common_details.lat}/#{common_details.lon}")) %>
+  <%= link_to(t(".coordinates_html",
+                :latitude => tag.span(number_with_delimiter(common_details.lat), :class => "latitude"),
+                :longitude => tag.span(number_with_delimiter(common_details.lon), :class => "longitude")),
+              root_path(:anchor => "map=18/#{common_details.lat}/#{common_details.lon}")) %>
 </div>
 <% end %>
 

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -19,7 +19,10 @@
       <% end %>
       <li>
         <%= t "browse.location" %>
-        <%= link_to(tag.span(number_with_delimiter(@note.lat), :class => "latitude") + ", " + tag.span(number_with_delimiter(@note.lon), :class => "longitude"), root_path(:anchor => "map=18/#{@note.lat}/#{@note.lon}")) %>
+        <%= link_to(t(".coordinates_html",
+                      :latitude => tag.span(number_with_delimiter(@note.lat), :class => "latitude"),
+                      :longitude => tag.span(number_with_delimiter(@note.lon), :class => "longitude")),
+                    root_path(:anchor => "map=18/#{@note.lat}/#{@note.lon}")) %>
       </li>
     </ul>
   </div>

--- a/app/views/diary_entries/_location.html.erb
+++ b/app/views/diary_entries/_location.html.erb
@@ -1,7 +1,7 @@
 <%= t ".location" %>
 
 <a href="<%= url_for :controller => "site", :action => "index", :anchor => "map=14/#{location.latitude}/#{location.longitude}" %>">
-<abbr class="geo" title="<%= number_with_precision(location.latitude, :precision => 4) %>; <%= number_with_precision(location.longitude, :precision => 4) %>">
+<abbr class="geo" title="<%= t ".coordinates", :latitude => number_with_precision(location.latitude, :precision => 4), :longitude => number_with_precision(location.longitude, :precision => 4) %>">
 <%= describe_location location.latitude, location.longitude, 14, location.language_code %>
 </abbr>
 </a>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -25,7 +25,13 @@
     <td><%= number_with_delimiter(@trace.size) %></td></tr>
   <tr>
     <td><%= t ".start_coordinates" %></td>
-    <td><div class="d-inline"><span class="latitude"><%= @trace.latitude %></span>; <span class="longitude"><%= @trace.longitude %></span></div> (<%= link_to t(".map"), :controller => "site", :action => "index", :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%= link_to t(".edit"), :controller => "site", :action => "edit", :gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
+    <td>
+      <div class="d-inline">
+        <%= t ".coordinates_html",
+              :latitude => tag.span(number_with_delimiter(@trace.latitude), :class => "latitude"),
+              :longitude => tag.span(number_with_delimiter(@trace.longitude), :class => "longitude") %>
+      </div>
+      (<%= link_to t(".map"), :controller => "site", :action => "index", :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%= link_to t(".edit"), :controller => "site", :action => "edit", :gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
   </tr>
   <% end %>
   <tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,8 @@ en:
     view_history: "View History"
     view_details: "View Details"
     location: "Location:"
+    common_details:
+      coordinates_html: "%{latitude}, %{longitude}"
     changeset:
       title: "Changeset: %{id}"
       belongs_to: "Author"
@@ -318,6 +320,7 @@ en:
       reopened_by_anonymous: "Reactivated by anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
       hidden_by: "Hidden by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
       report: Report this note
+      coordinates_html: "%{latitude}, %{longitude}"
     query:
       title: "Query Features"
       introduction: "Click on the map to find nearby features."
@@ -423,6 +426,7 @@ en:
       location: "Location:"
       view: "View"
       edit: "Edit"
+      coordinates: "%{latitude}; %{longitude}"
     feed:
       user:
         title: "OpenStreetMap diary entries for %{user}"
@@ -2043,6 +2047,7 @@ en:
       uploaded: "Uploaded:"
       points: "Points:"
       start_coordinates: "Start coordinate:"
+      coordinates_html: "%{latitude}; %{longitude}"
       map: "map"
       edit: "edit"
       owner: "Owner:"


### PR DESCRIPTION
Use the i18n system for joining coordinate values together, while avoiding making any changes or standardisation involving the exact symbol used in each situation.

Refs #2732

This was mentioned in passing in the linked issue, so I thought I could at least fix that minor point. It doesn't change anything wrt decimal separators, and it's worth noting that we've been inconsistent in the past with `,` vs `;` within pairs of coordinates and this PR deliberately doesn't change either option, just moves them into the i18n files.