### PR TITLE
Add species to wikidata_links helper

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -105,7 +105,7 @@ module BrowseTagsHelper
         :title => value
       }]
     # Key has to be one of the accepted wikidata-tags
-    elsif key =~ /(architect|artist|brand|name:etymology|network|operator|subject):wikidata/ &&
+    elsif key =~ /(architect|artist|brand|name:etymology|network|operator|species|subject):wikidata/ &&
           # Value has to be a semicolon-separated list of wikidata-IDs (whitespaces allowed before and after semicolons)
           value =~ /^[Qq][1-9][0-9]*(\s*;\s*[Qq][1-9][0-9]*)*$/
       # Splitting at every semicolon to get a separate hash for each wikidata-ID


### PR DESCRIPTION
I propose to add the key https://wiki.openstreetmap.org/wiki/Key:species:wikidata to the wikidata_links helper, so it may be linked on osm.org as well.

The key status is "Status: de facto" with ~9k uses.