### PR TITLE
Update wikidata URL in wikidata_links

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -110,7 +110,7 @@ module BrowseTagsHelper
           value =~ /^[Qq][1-9][0-9]*(\s*;\s*[Qq][1-9][0-9]*)*$/
       # Splitting at every semicolon to get a separate hash for each wikidata-ID
       return value.split(";").map do |id|
-        { :title => id, :url => "//www.wikidata.org/entity/#{id.strip}?uselang=#{I18n.locale}" }
+        { :title => id, :url => "//www.wikidata.org/wiki/#{id.strip}?uselang=#{I18n.locale}" }
       end
     end
     nil


### PR DESCRIPTION
This prevents the redirect from eg https://www.wikidata.org/entity/Q23059690?uselang=de to https://www.wikidata.org/wiki/Q23059690?uselang=de

However, I am not 100 % sure this is the right thing to do. When I use the /entity/ URL in my browser, the redirect happens like this. However, I cannot reproduce it via httpie/curl.

Please feel free to close this, in case I misinterpreted the wikidata URL behaviour.

httpie-result:

```
$ http https://www.wikidata.org/entity/Q23059690?uselang=de
HTTP/1.1 303 See Other
Age: 0
Connection: keep-alive
Content-Length: 276
Content-Type: text/html; charset=iso-8859-1
Date: Sat, 05 Sep 2020 20:34:50 GMT
Location: https://www.wikidata.org/wiki/Special:EntityData/Q23059690?uselang=de
Server: mw2315.codfw.wmnet
Server-Timing: cache;desc="pass"
Set-Cookie: WMF-Last-Access=05-Sep-2020;Path=/;HttpOnly;secure;Expires=Wed, 07 Oct 2020 12:00:00 GMT
Set-Cookie: WMF-Last-Access-Global=05-Sep-2020;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Wed, 07 Oct 2020 12:00:00 GMT
Set-Cookie: GeoIP=DE:HE:Frankfurt_am_Main:50.12:8.68:v4; Path=/; secure; Domain=.wikidata.org
Strict-Transport-Security: max-age=106384710; includeSubDomains; preload
X-Cache: cp3062 miss, cp3056 pass
X-Cache-Status: pass
X-Client-IP: 37.61.220.43

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>303 See Other</title>
</head><body>
<h1>See Other</h1>
<p>The answer to your request is located <a href="https://www.wikidata.org/wiki/Special:EntityData/Q23059690?uselang=de">here</a>.</p>
</body></html>

$ http https://www.wikidata.org/wiki/Special:EntityData/Q23059690?uselang=de
HTTP/1.1 303 See Other
Access-Control-Allow-Origin: *
Age: 0
Cache-Control: private, s-maxage=0, max-age=0, must-revalidate
Connection: keep-alive
Content-Length: 0
Content-Type: text/html; charset=utf-8
Date: Sat, 05 Sep 2020 20:35:11 GMT
Expires: Sat, 05 Sep 2020 20:35:11 GMT
Last-Modified: Sat, 05 Sep 2020 20:35:11 GMT
Location: https://www.wikidata.org/wiki/Special:EntityData/Q23059690.json
P3p: CP="See https://www.wikidata.org/wiki/Special:CentralAutoLogin/P3P for more info."
Server: mw2367.codfw.wmnet
Server-Timing: cache;desc="pass"
Set-Cookie: WMF-Last-Access=05-Sep-2020;Path=/;HttpOnly;secure;Expires=Wed, 07 Oct 2020 12:00:00 GMT
Set-Cookie: WMF-Last-Access-Global=05-Sep-2020;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Wed, 07 Oct 2020 12:00:00 GMT
Set-Cookie: GeoIP=DE:HE:Frankfurt_am_Main:50.12:8.68:v4; Path=/; secure; Domain=.wikidata.org
Strict-Transport-Security: max-age=106384710; includeSubDomains; preload
Vary: Accept-Encoding,X-Forwarded-Proto,Cookie,Authorization
X-Cache: cp3060 miss, cp3056 pass
X-Cache-Status: pass
X-Client-IP: 37.61.220.43
X-Content-Type-Options: nosniff
X-Request-Id: cd842742-7c47-4246-a2ba-6fd3a431f426

http https://www.wikidata.org/wiki/Special:EntityData/Q23059690.json
HTTP/1.1 200 OK
Accept-Ranges: bytes
Access-Control-Allow-Origin: *
Age: 0
Cache-Control: private, s-maxage=0, max-age=0, must-revalidate
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json; charset=UTF-8
Date: Sat, 05 Sep 2020 20:39:15 GMT
Last-Modified: Sun, 22 Mar 2020 09:56:47 GMT
P3p: CP="See https://www.wikidata.org/wiki/Special:CentralAutoLogin/P3P for more info."
Server: mw2316.codfw.wmnet
Server-Timing: cache;desc="pass"
Set-Cookie: WMF-Last-Access=05-Sep-2020;Path=/;HttpOnly;secure;Expires=Wed, 07 Oct 2020 12:00:00 GMT
Set-Cookie: WMF-Last-Access-Global=05-Sep-2020;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Wed, 07 Oct 2020 12:00:00 GMT
Set-Cookie: GeoIP=DE:HE:Frankfurt_am_Main:50.12:8.68:v4; Path=/; secure; Domain=.wikidata.org
Strict-Transport-Security: max-age=106384710; includeSubDomains; preload
Transfer-Encoding: chunked
Vary: Accept-Encoding
X-Cache: cp3056 miss, cp3056 pass
X-Cache-Status: pass
X-Client-IP: 37.61.220.43
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Request-Id: f6bd49bd-c41e-4e09-8ab9-4408eaf43592

{
    "entities": {
        "Q23059690": {
            "aliases": {},
            "claims": {
                "P106": [
…
```