### PR TITLE
Show linked features as collapsable detail panels on feature browse pages

### DIFF
--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -12,12 +12,24 @@
 
     <% unless node.ways.empty? and node.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
-      <ul class="list-unstyled">
-        <% node.ways.uniq.each do |way| %>
-          <li><%= link_to printable_name(way), { :action => "way", :id => way.id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
-        <% end %>
-        <%= render :partial => "containing_relation", :collection => node.containing_relation_members.uniq %>
-      </ul>
+      <% unless node.ways.empty? %>
+        <details <%= 'open' if node.ways.count < 10 %>>
+          <summary><%= t 'browse.part_of_ways', :count => node.ways.count %></summary>
+          <ul class="list-unstyled">
+            <% node.ways.uniq.each do |way| %>
+              <li><%= link_to printable_name(way), { :action => "way", :id => way.id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
+            <% end %>
+          </ul>
+        </details>
+      <% end %>
+      <% unless node.containing_relation_members.empty? %>
+        <details <%= 'open' if node.containing_relation_members.count < 10 %>>
+          <summary><%= t 'browse.part_of_relations', :count => node.containing_relation_members.count %></summary>
+          <ul class="list-unstyled">
+            <%= render :partial => "containing_relation", :collection => node.containing_relation_members.uniq %>
+          </ul>
+        </details>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -12,12 +12,22 @@
 
     <% unless relation.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
-      <ul class="list-unstyled"><%= render :partial => "containing_relation", :collection => relation.containing_relation_members.uniq %></ul>
+      <details <%= 'open' if relation.containing_relation_members.count < 10 %>>
+        <summary><%= t 'browse.part_of_relations', :count => relation.containing_relation_members.count %></summary>
+        <ul class="list-unstyled">
+          <%= render :partial => "containing_relation", :collection => relation.containing_relation_members.uniq %>
+        </ul>
+      </details>
     <% end %>
 
     <% unless relation.relation_members.empty? %>
       <h4><%= t ".members" %></h4>
-      <ul class="list-unstyled"><%= render :partial => "relation_member", :collection => relation.relation_members %></ul>
+      <details <%= 'open' if relation.relation_members.count < 10 %>>
+        <summary><%= t '.members_count', :count => relation.relation_members.count %></summary>
+        <ul class="list-unstyled">
+          <%= render :partial => "relation_member", :collection => relation.relation_members %>
+        </ul>
+      </details>
     <% end %>
   </div>
 <% end %>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -12,24 +12,30 @@
 
     <% unless way.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
-      <ul class="list-unstyled">
-        <%= render :partial => "containing_relation", :collection => way.containing_relation_members.uniq %>
-      </ul>
+      <details <%= 'open' if way.containing_relation_members.count < 10 %>>
+        <summary><%= t 'browse.part_of_relations', :count => way.containing_relation_members.count %></summary>
+        <ul class="list-unstyled">
+          <%= render :partial => "containing_relation", :collection => way.containing_relation_members.uniq %>
+        </ul>
+      </details>
     <% end %>
 
     <% unless way.way_nodes.empty? %>
       <h4><%= t ".nodes" %></h4>
-      <ul class="list-unstyled">
-        <% way.way_nodes.each do |wn| %>
-          <li>
-            <%= link_to printable_name(wn.node), { :action => "node", :id => wn.node_id.to_s }, { :class => link_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>
-            <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
-            <% if related_ways.size > 0 then %>
-              (<%= t ".also_part_of_html", :count => related_ways.size, :related_ways => to_sentence(related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, { :class => link_class("way", w), :title => link_title(w) }) }) %>)
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
+      <details <%= 'open' if way.way_nodes.count < 10 %>>
+        <summary><%= t '.nodes_count', :count => way.way_nodes.count %></summary>
+        <ul class="list-unstyled">
+          <% way.way_nodes.each do |wn| %>
+            <li>
+              <%= link_to printable_name(wn.node), { :action => "node", :id => wn.node_id.to_s }, { :class => link_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>
+              <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
+              <% if related_ways.size > 0 then %>
+                (<%= t ".also_part_of_html", :count => related_ways.size, :related_ways => to_sentence(related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, { :class => link_class("way", w), :title => link_title(w) }) }) %>)
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      </details>
     <% end %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,6 +232,12 @@ en:
     anonymous: "anonymous"
     no_comment: "(no comment)"
     part_of: "Part of"
+    part_of_relations:
+      one: 1 relation
+      other: "%{count} relations"
+    part_of_ways:
+      one: 1 way
+      other: "%{count} ways"
     download_xml: "Download XML"
     view_history: "View History"
     view_details: "View Details"
@@ -265,6 +271,8 @@ en:
       title_html: "Way: %{name}"
       history_title_html: "Way History: %{name}"
       nodes: "Nodes"
+      nodes_count:
+        other: "%{count} nodes"
       also_part_of_html:
         one: "part of way %{related_ways}"
         other: "part of ways %{related_ways}"
@@ -272,6 +280,9 @@ en:
       title_html: "Relation: %{name}"
       history_title_html: "Relation History: %{name}"
       members: "Members"
+      members_count:
+        one: 1 member
+        other: "%{count} members"
     relation_member:
       entry_html: "%{type} %{name}"
       entry_role_html: "%{type} %{name} as %{role}"


### PR DESCRIPTION
Fixes #2823

The panels are collapsed by default, when there is a long list of features, but open on short lists to save on clicks. 10 items is arbitrary but seemed reasonable.

![Screenshot from 2020-09-16 15-29-19](https://user-images.githubusercontent.com/360803/93344084-9085df80-f831-11ea-979b-42d66143c8dd.png)

This is one of those "how hard can it be", "oh wait that took longer than expected" kinds of thing. Thanks to @tordans for the pure-html suggestion, I think it looks reasonable. But I think a proper designer could do better. I'm not 100% happy with the duplication between the `<h4>` section titles and the `<summary>` labels, but putting titles in the summaries breaks the layout and I think this PR is at least a little better than the previous situation. Similarly, I went back and forth on whether small lists should be handled differently, whether small lists should even have the summaries, and trying to balance consistent behaviour vs excess clicking etc.

Feedback welcome, and I'm happy to change things in future too.