### PR TITLE
Style changeset descriptions with italics on browse pages

### DIFF
--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,21 +1,21 @@
-<h4>
+<h4 class="details">
+  <%= t "browse.version" %>
+  #<%= common_details.version %>
+</h4>
+
+<p class="font-italic">
   <% if common_details.changeset.tags['comment'].present? %>
     <%= linkify(common_details.changeset.tags["comment"]) %>
   <% else %>
     <%= t "browse.no_comment" %>
   <% end %>
-</h4>
+</p>
 
 <div class="details">
   <%= t "browse.#{common_details.visible? ? :edited : :deleted}_by_html",
         :time => time_ago_in_words(common_details.timestamp, :scope => :'datetime.distance_in_words_ago'),
         :user => changeset_user_link(common_details.changeset),
         :title => l(common_details.timestamp) %>
-</div>
-
-<div class="details">
-  <%= t "browse.version" %>
-  #<%= common_details.version %>
   &middot;
   <%= t "browse.in_changeset" %>
   #<%= link_to common_details.changeset_id, :action => :changeset, :id => common_details.changeset_id %>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -6,7 +6,9 @@
 </h2>
 
 <div class="browse-section">
-  <h6><%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %></h6>
+  <p class="font-italic">
+    <%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %>
+  </p>
   <div class="details"><%= changeset_details(@changeset) %></div>
 
   <%= render :partial => "tag_details", :object => @changeset.tags.except("comment") %>

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -11,11 +11,11 @@
    end %>
 
 <%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item" do %>
-  <h6>
+  <p class="font-italic">
     <a class="changeset_id text-dark" href="<%= changeset_path(changeset) %>">
       <%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %>
     </a>
-  </h6>
+  </p>
   <div class="comments comments-<%= changeset.comments.length %>">
     <%= changeset.comments.length %>
     <span class="icon note grey"></span>

--- a/app/views/users/_contact.html.erb
+++ b/app/views/users/_contact.html.erb
@@ -23,9 +23,9 @@
       <% if changeset %>
         <%= t("users.show.latest edit", :ago => time_ago_in_words(changeset.created_at, :scope => :'datetime.distance_in_words_ago')) %>
         <% comment = changeset.tags["comment"].to_s != "" ? changeset.tags["comment"] : t("browse.no_comment") %>
-        "<%= link_to(comment,
-                     { :controller => "browse", :action => "changeset", :id => changeset.id },
-                     { :title => t("changesets.changeset.view_changeset_details") }) %>"
+        <q><%= link_to(comment,
+                       { :controller => "browse", :action => "changeset", :id => changeset.id },
+                       { :title => t("changesets.changeset.view_changeset_details") }) %></q>
       <% else %>
        <%= t "changesets.changeset.no_edits" %>
       <% end %>


### PR DESCRIPTION
Alternative to #580

This reworks changeset descriptions to use italics instead of header elements, in order to make them look more like quotes.

I've always found it strange that they were headers, particularly on the node/way/relation pages, since they are more similar to a text paragraph or a quote than a description of the element being viewed. But it turns out to be quite tricky to refactor, since the descriptions appear in multiple contexts, and the partials are repeated in history pages and look strange unless the first item is a header.

So this is my proposed solution, feedback welcome.

![Screenshot from 2020-09-16 18-14-59](https://user-images.githubusercontent.com/360803/93364821-4d376b00-f849-11ea-84e2-8423f55fb5d2.png) ![Screenshot from 2020-09-16 18-15-31](https://user-images.githubusercontent.com/360803/93364824-4e689800-f849-11ea-9a8a-0edc91df45f8.png) ![Screenshot from 2020-09-16 18-13-57](https://user-images.githubusercontent.com/360803/93364825-4f012e80-f849-11ea-8141-779fa43dcc9c.png)

