### PR TITLE
Use the db:seed task to load languages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,6 @@ Metrics/ModuleLength:
 Naming/FileName:
   Exclude:
     - 'script/deliver-message'
-    - 'script/locale/reload-languages'
     - 'script/update-spam-blocks'
 
 Naming/MethodParameterName:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Language.load(Rails.root.join("config/languages.yml"))

--- a/script/locale/reload-languages
+++ b/script/locale/reload-languages
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-require File.dirname(__FILE__) + "/../../config/environment"
-
-Language.load(RAILS_ROOT + "/config/languages.yml")


### PR DESCRIPTION
This is seed data that should reasonably be loaded into every database, even those that are otherwise empty (e.g. no geo data). Using the seeds process means that it will often be loaded by default (depending on exactly which db tasks are run), and is easier to find for existing rails developers.

Replaces #309