### PR TITLE
Improve the OAuth index page

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -67,8 +67,8 @@ For example, to use the Potlatch 2 editor you need to register it as an OAuth ap
 Do the following:
 * Log into your Rails Port instance - e.g. http://localhost:3000
 * Click on your user name to go to your user page
-* Click on "my settings" on the user page
-* Click on "oauth settings" on the My settings page
+* Click on "My settings" on the user page
+* Click on "OAuth details" on the My settings page
 * Click on 'Register your application'.
 * Unless you have set up alternatives, use Name: "Local Potlatch" and URL: "http://localhost:3000"
 * Check the 'modify the map' box.

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1393,7 +1393,7 @@ tr.turn:hover {
   display: inline !important;
 }
 
-/* Rules for the oauth settings page */
+/* Rules for the OAuth settings page */
 
 .oauth_clients .buttons .oauth-edit {
   border-radius: 2px 0 0 2px;

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -10,13 +10,15 @@
     <tr>
       <th><%= t ".application" %></th>
       <th><%= t ".issued_at" %></th>
+      <th><%= t ".valid_to" %></th>
       <th>&nbsp;</th>
     </tr>
   </thead>
   <% @tokens.each do |token| %>
     <tr>
-      <td><%= link_to token.client_application.name, token.client_application.url %></td>
+      <td><%= link_to token.client_application.name, token.client_application.url, target: "_blank" %></td>
       <td><%= token.authorized_at %></td>
+      <td><%= token.valid_to %></td>
       <td>
         <%= form_tag({ :controller => "oauth", :action => "revoke" }, { :class => "standard-form" }) do %>
           <%= hidden_field_tag "token", token.token %>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -10,7 +10,6 @@
     <tr>
       <th><%= t ".application" %></th>
       <th><%= t ".issued_at" %></th>
-      <th><%= t ".valid_to" %></th>
       <th>&nbsp;</th>
     </tr>
   </thead>
@@ -18,7 +17,6 @@
     <tr>
       <td><%= link_to token.client_application.name, token.client_application.url, target: "_blank" %></td>
       <td><%= token.authorized_at %></td>
-      <td><%= token.valid_to %></td>
       <td>
         <%= form_tag({ :controller => "oauth", :action => "revoke" }, { :class => "standard-form" }) do %>
           <%= hidden_field_tag "token", token.token %>
@@ -28,6 +26,7 @@
     </tr>
   <% end %>
 </table>
+<p><%= t ".valid_until_revoked" %></p>
 <% end %>
 <h3><%= t ".my_apps" %></h3>
 <% if @client_applications.empty? %>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -15,7 +15,7 @@
   </thead>
   <% @tokens.each do |token| %>
     <tr>
-      <td><%= link_to token.client_application.name, token.client_application.url, target: "_blank" %></td>
+      <td><%= link_to token.client_application.name, token.client_application.url, :target => "_blank", :rel => "noopener" %></td>
       <td><%= token.authorized_at %></td>
       <td>
         <%= form_tag({ :controller => "oauth", :action => "revoke" }, { :class => "standard-form" }) do %>

--- a/app/views/oauth_clients/show.html.erb
+++ b/app/views/oauth_clients/show.html.erb
@@ -4,9 +4,9 @@
 
 <dl class="row">
   <dt class="col-sm-3"><%= t ".key" %></dt>
-  <dd class="col-sm-9"><%= @client_application.key %></dt>
+  <dd class="col-sm-9 text-monospace"><%= @client_application.key %></dt>
   <dt class="col-sm-3"><%= t ".secret" %></dt>
-  <dd class="col-sm-9"><%= @client_application.secret %></dd>
+  <dd class="col-sm-9 text-monospace"><%= @client_application.secret %></dd>
   <dt class="col-sm-3"><%= t ".url" %></dt>
   <dd class="col-sm-9">http<%= "s" if request.ssl? %>://<%= request.host_with_port %><%= @client_application.oauth_server.request_token_path %></dd>
   <dt class="col-sm-3"><%= t ".access_url" %></dt>

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -2083,7 +2083,7 @@ en-GB:
       my profile: My Profile
       my settings: My Settings
       my comments: My Comments
-      oauth settings: oauth settings
+      oauth settings: OAuth settings
       blocks on me: Blocks on Me
       blocks by me: Blocks by Me
       send message: Send Message

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2195,6 +2195,7 @@ en:
       oauth: OAuth
       registered_apps: "You have the following client applications registered:"
       register_new: "Register your application"
+      valid_until_revoked: The tokens are valid until they are revoked.
     form:
       requests: "Request the following permissions from the user:"
     not_found:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2334,7 +2334,7 @@ en:
       my profile: My Profile
       my settings: My Settings
       my comments: My Comments
-      oauth settings: oauth settings
+      oauth settings: OAuth settings
       blocks on me: Blocks on Me
       blocks by me: Blocks by Me
       send message: Send Message


### PR DESCRIPTION
Some minor improvement for the OAuth token/application page:
- Open authorized application links in a new tab
- Make some English titles use `OAuth` instead of `oauth`.
- Add a line about the expiration of tokens.
- Use monospace for displaying OAuth tokens

~~It might be a good idea to hide (or even delete tokens) that are no longer valid.~~

Screenshot:

![image](https://user-images.githubusercontent.com/1073881/96349796-338c7c00-10b2-11eb-9c3c-1bae0baf7525.png)
