### PR TITLE
Avoid various uses of html_safe

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -167,8 +167,6 @@ Rails/OutputSafety:
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/changesets_helper.rb'
     - 'app/helpers/geocoder_helper.rb'
-    - 'app/helpers/note_helper.rb'
-    - 'app/helpers/open_graph_helper.rb'
     - 'app/helpers/user_blocks_helper.rb'
     - 'lib/rich_text.rb'
     - 'test/helpers/application_helper_test.rb'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -344,7 +344,7 @@ class UsersController < ApplicationController
       flash[:error] = t "users.confirm_resend.failure", :name => params[:display_name]
     else
       UserMailer.signup_confirm(user, user.tokens.create).deliver_later
-      flash[:notice] = t("users.confirm_resend.success", :email => user.email, :sender => Settings.support_email).html_safe
+      flash[:notice] = t "users.confirm_resend.success_html", :email => user.email, :sender => Settings.support_email
     end
 
     redirect_to :action => "login"

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -1,14 +1,16 @@
 module NoteHelper
+  include ActionView::Helpers::TranslationHelper
+
   def note_event(event, at, by)
     if by.nil?
-      I18n.t("browse.note." + event + "_by_anonymous",
-             :when => friendly_date_ago(at),
-             :exact_time => l(at)).html_safe
+      t("browse.note." + event + "_by_anonymous_html",
+        :when => friendly_date_ago(at),
+        :exact_time => l(at))
     else
-      I18n.t("browse.note." + event + "_by",
-             :when => friendly_date_ago(at),
-             :exact_time => l(at),
-             :user => note_author(by)).html_safe
+      t("browse.note." + event + "_by_html",
+        :when => friendly_date_ago(at),
+        :exact_time => l(at),
+        :user => note_author(by))
     end
   end
 

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -10,8 +10,8 @@ module OpenGraphHelper
       "og:description" => t("layouts.intro_text")
     }
 
-    tags.map do |property, content|
+    safe_join(tags.map do |property, content|
       tag(:meta, :property => property, :content => content)
-    end.join("").html_safe
+    end, "\n")
   end
 end

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -37,10 +37,10 @@
             <% if comment.visible %>
               <li id="c<%= comment.id %>">
                 <small class='text-muted'>
-                  <%= t(".commented_by",
+                  <%= t(".commented_by_html",
                         :when => friendly_date_ago(comment.created_at),
                         :exact_time => l(comment.created_at),
-                        :user => link_to(comment.author.display_name, user_path(comment.author))).html_safe %>
+                        :user => link_to(comment.author.display_name, user_path(comment.author))) %>
                   <% if current_user and current_user.moderator? %>
                     — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_hide_url(comment.id) %>"><%= t("javascripts.changesets.show.hide_comment") %></span>
                   <% end %>
@@ -50,10 +50,10 @@
             <% elsif current_user and current_user.moderator? %>
               <li id="c<%= comment.id %>">
                 <small class='text-muted'>
-                  <%= t(".hidden_commented_by",
+                  <%= t(".hidden_commented_by_html",
                         :when => friendly_date_ago(comment.created_at),
                         :exact_time => l(comment.created_at),
-                        :user => link_to(comment.author.display_name, user_path(comment.author))).html_safe %>
+                        :user => link_to(comment.author.display_name, user_path(comment.author))) %>
                   — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_unhide_url(comment.id) %>"><%= t("javascripts.changesets.show.unhide_comment") %></span>
                  </small>
                 <%= comment.body.to_html %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,8 +254,8 @@ en:
       relation: "Relations (%{count})"
       relation_paginated: "Relations (%{x}-%{y} of %{count})"
       comment: "Comments (%{count})"
-      hidden_commented_by: "Hidden comment from %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
-      commented_by: "Comment from %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
+      hidden_commented_by_html: "Hidden comment from %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
+      commented_by_html: "Comment from %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
       changesetxml: "Changeset XML"
       osmchangexml: "osmChange XML"
       feed:
@@ -337,15 +337,15 @@ en:
       open_title: "Unresolved note #%{note_name}"
       closed_title: "Resolved note #%{note_name}"
       hidden_title: "Hidden note #%{note_name}"
-      opened_by: "Created by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
-      opened_by_anonymous: "Created by anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
-      commented_by: "Comment from %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
-      commented_by_anonymous: "Comment from anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
-      closed_by: "Resolved by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
-      closed_by_anonymous: "Resolved by anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
-      reopened_by: "Reactivated by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
-      reopened_by_anonymous: "Reactivated by anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
-      hidden_by: "Hidden by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
+      opened_by_html: "Created by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
+      opened_by_anonymous_html: "Created by anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
+      commented_by_html: "Comment from %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
+      commented_by_anonymous_html: "Comment from anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
+      closed_by_html: "Resolved by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
+      closed_by_anonymous_html: "Resolved by anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
+      reopened_by_html: "Reactivated by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
+      reopened_by_anonymous_html: "Reactivated by anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
+      hidden_by_html: "Hidden by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
       report: Report this note
       coordinates_html: "%{latitude}, %{longitude}"
     query:
@@ -2458,7 +2458,7 @@ en:
       unknown token: "That confirmation code has expired or does not exist."
       reconfirm_html: "If you need us to resend the confirmation email, <a href=\"%{reconfirm}\">click here</a>."
     confirm_resend:
-      success: "We've sent a new confirmation note to %{email} and as soon as you confirm your account you'll be able to get mapping.<br /><br />If you use an antispam system which sends confirmation requests then please make sure you whitelist %{sender} as we are unable to reply to any confirmation requests."
+      success_html: "We've sent a new confirmation note to %{email} and as soon as you confirm your account you'll be able to get mapping.<br /><br />If you use an antispam system which sends confirmation requests then please make sure you whitelist %{sender} as we are unable to reply to any confirmation requests."
       failure: "User %{name} not found."
     confirm_email:
       heading: Confirm a change of email address


### PR DESCRIPTION
We can avoid using `html_safe` in various circumstances, through alternative approaches like i18n keys ending in `_html` or using `safe_join` to avoid converting via unsafe string types.

The `_html` keys approach only work for ActionView helper version of `t`, not the base `I18n.t` method.