### PR TITLE
Remove some unused translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2278,7 +2278,6 @@ en:
           <p>Unlike other maps, OpenStreetMap is completely created by people like you,
           and it's free for anyone to fix, update, download and use.</p>
           <p>Sign up to get started contributing. We'll send an email to confirm your account.</p>
-      license_agreement: 'When you confirm your account you will need to agree to the <a href="https://www.osmfoundation.org/wiki/License/Contributor_Terms">contributor terms</a>.'
       email address: "Email Address:"
       confirm email address: "Confirm Email Address:"
       not_displayed_publicly_html: 'Your address is not displayed publicly, see our <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" title="OSMF privacy policy including section on email addresses">privacy policy</a> for more information'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1248,10 +1248,6 @@ en:
         level8: "City Boundary"
         level9: "Village Boundary"
         level10: "Suburb Boundary"
-    description:
-      title:
-        osm_nominatim: 'Location from <a href="https://nominatim.openstreetmap.org/">OpenStreetMap Nominatim</a>'
-        geonames: 'Location from <a href="http://www.geonames.org/">GeoNames</a>'
       types:
         cities: Cities
         towns: Towns


### PR DESCRIPTION
I believe these translations are currently unused, unless the keys are generated using some kind of programmatic trickery. Each commit shows where the usage was removed from the codebase.