### PR TITLE
Bump copyright string version to force re-translation

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -48,7 +48,7 @@
 
   <h3><%= t ".legal_babble.credit_title_html", :locale => @locale %></h3>
   <p><%= t ".legal_babble.credit_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.credit_2_1_html", :locale => @locale %></p>
+  <p><%= t ".legal_babble.credit_2_2_html", :locale => @locale %></p>
   <p><%= t ".legal_babble.credit_3_1_html", :locale => @locale %></p>
   <p><%= t ".legal_babble.credit_4_html", :locale => @locale %></p>
   <p><%= image_tag("attribution_example.png",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1617,7 +1617,7 @@ en:
         credit_1_html: |
           We require that you use the credit &ldquo;&copy; OpenStreetMap
           contributors&rdquo;.
-        credit_2_1_html: |
+        credit_2_2_html: |
           You must also make it clear that the data is available under the Open
           Database License. You may do this by linking to
           <a href="https://www.openstreetmap.org/copyright">this copyright page</a>.


### PR DESCRIPTION
This should force re-translation of one section in the copyright page that didn't get its "version" bumped.