### PR TITLE
Avoid some (more) uses of html_safe

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -165,9 +165,6 @@ Rails/OutputSafety:
   Exclude:
     - 'app/controllers/users_controller.rb'
     - 'app/helpers/application_helper.rb'
-    - 'app/helpers/changesets_helper.rb'
-    - 'app/helpers/geocoder_helper.rb'
-    - 'app/helpers/user_blocks_helper.rb'
     - 'lib/rich_text.rb'
     - 'test/helpers/application_helper_test.rb'
 

--- a/app/helpers/changesets_helper.rb
+++ b/app/helpers/changesets_helper.rb
@@ -17,7 +17,7 @@ module ChangesetsHelper
     else
       action = :closed
       time = time_ago_in_words(changeset.closed_at, :scope => :'datetime.distance_in_words_ago')
-      title = "#{t('browse.created')}: #{l(changeset.created_at)}&#10;#{t('browse.closed')}: #{l(changeset.closed_at)}".html_safe
+      title = safe_join([t("browse.created"), ": ", l(changeset.created_at), "&#10;".html_safe, t("browse.closed"), ": ", l(changeset.closed_at)])
     end
 
     if params.key?(:display_name)

--- a/app/helpers/geocoder_helper.rb
+++ b/app/helpers/geocoder_helper.rb
@@ -14,13 +14,13 @@ module GeocoderHelper
       html_options[:data][key.to_s.tr("_", "-")] = value
     end
 
-    html = ""
+    html = []
     html << result[:prefix] if result[:prefix]
     html << " " if result[:prefix] && result[:name]
     html << link_to(result[:name], url, html_options) if result[:name]
     html << " " if result[:suffix] && result[:name]
     html << result[:suffix] if result[:suffix]
-    html.html_safe
+    safe_join(html)
   end
 
   def describe_location(lat, lon, zoom = nil, language = nil)

--- a/app/helpers/user_blocks_helper.rb
+++ b/app/helpers/user_blocks_helper.rb
@@ -1,4 +1,6 @@
 module UserBlocksHelper
+  include ActionView::Helpers::TranslationHelper
+
   ##
   # returns a translated string representing the status of the
   # user block (i.e: whether it's active, what the expiry time is)
@@ -7,34 +9,34 @@ module UserBlocksHelper
       # if the block hasn't expired yet show the date, if the user just needs to login show that
       if block.needs_view?
         if block.ends_at > Time.now.getutc
-          I18n.t("user_blocks.helper.time_future_and_until_login", :time => friendly_date(block.ends_at)).html_safe
+          t("user_blocks.helper.time_future_and_until_login_html", :time => friendly_date(block.ends_at))
         else
-          I18n.t("user_blocks.helper.until_login")
+          t("user_blocks.helper.until_login")
         end
       else
-        I18n.t("user_blocks.helper.time_future", :time => friendly_date(block.ends_at)).html_safe
+        t("user_blocks.helper.time_future_html", :time => friendly_date(block.ends_at))
       end
     else
       # the max of the last update time or the ends_at time is when this block finished
       # either because the user viewed the block (updated_at) or it expired or was
       # revoked (ends_at)
       last_time = [block.ends_at, block.updated_at].max
-      I18n.t("user_blocks.helper.time_past", :time => friendly_date_ago(last_time)).html_safe
+      t("user_blocks.helper.time_past_html", :time => friendly_date_ago(last_time))
     end
   end
 
   def block_duration_in_words(duration)
     parts = ActiveSupport::Duration.build(duration).parts
     if duration < 1.day
-      I18n.t("user_blocks.helper.block_duration.hours", :count => parts[:hours])
+      t("user_blocks.helper.block_duration.hours", :count => parts[:hours])
     elsif duration < 1.week
-      I18n.t("user_blocks.helper.block_duration.days", :count => parts[:days])
+      t("user_blocks.helper.block_duration.days", :count => parts[:days])
     elsif duration < 1.month
-      I18n.t("user_blocks.helper.block_duration.weeks", :count => parts[:weeks])
+      t("user_blocks.helper.block_duration.weeks", :count => parts[:weeks])
     elsif duration < 1.year
-      I18n.t("user_blocks.helper.block_duration.months", :count => parts[:months])
+      t("user_blocks.helper.block_duration.months", :count => parts[:months])
     else
-      I18n.t("user_blocks.helper.block_duration.years", :count => parts[:years])
+      t("user_blocks.helper.block_duration.years", :count => parts[:years])
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2572,10 +2572,10 @@ en:
       revoke: "Revoke!"
       flash: "This block has been revoked."
     helper:
-      time_future: "Ends in %{time}."
+      time_future_html: "Ends in %{time}."
       until_login: "Active until the user logs in."
-      time_future_and_until_login: "Ends in %{time} and after the user has logged in."
-      time_past: "Ended %{time}."
+      time_future_and_until_login_html: "Ends in %{time} and after the user has logged in."
+      time_past_html: "Ended %{time}."
       block_duration:
         hours:
           one: "1 hour"


### PR DESCRIPTION
We can use `html_safe` on non-interpolated strings, since that's trusted content.