### PR TITLE
Installer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -222,6 +222,8 @@ This test will take a few minutes, reporting tests run, assertions, and any erro
 
 The unit tests may output parser errors related to "Attribute lat redefined." These can be ignored.
 
+Also, some contributors have reported errors with test:db related to an improperly installed yarn application.  You may have to reinstall yarn manually to run
+test:db error free. 
 ### Starting the server
 
 Rails comes with a built-in webserver, so that you can test on your own machine without needing a server. Run

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -222,8 +222,6 @@ This test will take a few minutes, reporting tests run, assertions, and any erro
 
 The unit tests may output parser errors related to "Attribute lat redefined." These can be ignored.
 
-Also, db test errors have been reported that are caused byyarn not being properly installed.  
-You may have to reinstall yarn manually.
 ### Starting the server
 
 Rails comes with a built-in webserver, so that you can test on your own machine without needing a server. Run


### PR DESCRIPTION
There have been multiple users that ran into errors running the test:db command while going through the environment installation process described in INSTALL.md.  The errors were caused by an improper installation of the yarn application.  I propose that adding a couple of sentences to INSTALL.md telling users they may have to reinstall yarn manually would save future users time in setting up the project environment.  I have edited INSTALL.md to reflect the proposed change.  Please consider this PR.