### PR TITLE
Prefer keyword arguments when method has optional boolean arguments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -185,9 +185,6 @@ Style/OptionalBooleanParameter:
     - 'app/models/trace.rb'
     - 'app/models/tracepoint.rb'
     - 'app/models/way.rb'
-    - 'test/models/diary_entry_test.rb'
-    - 'test/models/trace_test.rb'
-    - 'test/models/tracetag_test.rb'
 
 # Offense count: 28
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -176,9 +176,6 @@ Style/NumericLiterals:
 # Offense count: 20
 Style/OptionalBooleanParameter:
   Exclude:
-    - 'app/controllers/api/notes_controller.rb'
-    - 'app/controllers/application_controller.rb'
-    - 'app/helpers/browse_helper.rb'
     - 'app/models/changeset.rb'
     - 'app/models/node.rb'
     - 'app/models/relation.rb'

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -240,7 +240,7 @@ module Api
         @note.status = "hidden"
         @note.save
 
-        add_comment(@note, comment, "hidden", false)
+        add_comment(@note, comment, "hidden", :notify => false)
       end
 
       # Return a copy of the updated note
@@ -369,7 +369,7 @@ module Api
 
     ##
     # Add a comment to a note
-    def add_comment(note, text, event, notify = true)
+    def add_comment(note, text, event, notify: true)
       attributes = { :visible => true, :event => event, :body => text }
 
       if current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def check_database_readable(need_api = false)
+  def check_database_readable(need_api: false)
     if Settings.status == "database_offline" || (need_api && Settings.status == "api_offline")
       if request.xhr?
         report_error "Database offline for maintenance", :service_unavailable
@@ -94,7 +94,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def check_database_writable(need_api = false)
+  def check_database_writable(need_api: false)
     if Settings.status == "database_offline" || Settings.status == "database_readonly" ||
        (need_api && (Settings.status == "api_offline" || Settings.status == "api_readonly"))
       if request.xhr?
@@ -171,7 +171,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def preferred_languages(reset = false)
+  def preferred_languages(reset: false)
     @preferred_languages = nil if reset
     @preferred_languages ||= if params[:locale]
                                Locale.list(params[:locale])
@@ -184,13 +184,13 @@ class ApplicationController < ActionController::Base
 
   helper_method :preferred_languages
 
-  def set_locale(reset = false)
+  def set_locale(reset: false)
     if current_user&.languages&.empty? && !http_accept_language.user_preferred_languages.empty?
       current_user.languages = http_accept_language.user_preferred_languages
       current_user.save
     end
 
-    I18n.locale = Locale.available.preferred(preferred_languages(reset))
+    I18n.locale = Locale.available.preferred(preferred_languages(:reset => reset))
 
     response.headers["Vary"] = "Accept-Language"
     response.headers["Content-Language"] = I18n.locale.to_s

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -3,7 +3,7 @@ class BrowseController < ApplicationController
 
   before_action :authorize_web
   before_action :set_locale
-  before_action -> { check_database_readable(true) }
+  before_action -> { check_database_readable(:need_api => true) }
   before_action :require_oauth
   around_action :web_timeout
   authorize_resource :class => false

--- a/app/controllers/changeset_comments_controller.rb
+++ b/app/controllers/changeset_comments_controller.rb
@@ -4,7 +4,7 @@ class ChangesetCommentsController < ApplicationController
 
   authorize_resource
 
-  before_action -> { check_database_readable(true) }
+  before_action -> { check_database_readable(:need_api => true) }
   around_action :web_timeout
 
   ##

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -6,7 +6,7 @@ class ChangesetsController < ApplicationController
 
   before_action :authorize_web
   before_action :set_locale
-  before_action -> { check_database_readable(true) }, :only => [:index, :feed]
+  before_action -> { check_database_readable(:need_api => true) }, :only => [:index, :feed]
 
   authorize_resource
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -652,7 +652,7 @@ class UsersController < ApplicationController
     if user.save
       session[:fingerprint] = user.fingerprint
 
-      set_locale(true)
+      set_locale(:reset => true)
 
       if user.new_email.blank? || user.new_email == user.email
         flash.now[:notice] = t "users.account.flash update success"

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -1,5 +1,5 @@
 module BrowseHelper
-  def printable_name(object, version = false)
+  def printable_name(object, version: false)
     id = if object.id.is_a?(Array)
            object.id[0]
          else

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -90,7 +90,7 @@
     </h4>
     <ul class="list-unstyled">
       <% @ways.each do |way| %>
-        <li><%= link_to printable_name(way, true), { :action => "way", :id => way.way_id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
+        <li><%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
       <% end %>
     </ul>
   <% end %>
@@ -102,7 +102,7 @@
     </h4>
     <ul class="list-unstyled">
       <% @relations.each do |relation| %>
-        <li><%= link_to printable_name(relation, true), { :action => "relation", :id => relation.relation_id.to_s }, { :class => link_class("relation", relation), :title => link_title(relation) } %></li>
+        <li><%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :class => link_class("relation", relation), :title => link_title(relation) } %></li>
       <% end %>
     </ul>
   <% end %>
@@ -114,7 +114,7 @@
     </h4>
     <ul class="list-unstyled">
       <% @nodes.each do |node| %>
-        <li><%= link_to printable_name(node, true), { :action => "node", :id => node.node_id.to_s }, { :class => link_class("node", node), :title => link_title(node), :rel => link_follow(node) } %></li>
+        <li><%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :class => link_class("node", node), :title => link_title(node), :rel => link_follow(node) } %></li>
       <% end %>
     </ul>
   <% end %>

--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -31,8 +31,8 @@ class BrowseHelperTest < ActionView::TestCase
     assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node)
     assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node_v2)
     assert_dom_equal node.id.to_s, printable_name(node_v1)
-    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, true)
-    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, true)
+    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, :version => true)
+    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, :version => true)
     assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_name(node_with_ref_without_name)
 
     I18n.locale = "pt"
@@ -41,8 +41,8 @@ class BrowseHelperTest < ActionView::TestCase
     assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node)
     assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node_v2)
     assert_dom_equal node.id.to_s, printable_name(node_v1)
-    assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, true)
-    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, true)
+    assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, :version => true)
+    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, :version => true)
     assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_name(node_with_ref_without_name)
 
     I18n.locale = "pt-BR"
@@ -51,8 +51,8 @@ class BrowseHelperTest < ActionView::TestCase
     assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node)
     assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node_v2)
     assert_dom_equal node.id.to_s, printable_name(node_v1)
-    assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, true)
-    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, true)
+    assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, :version => true)
+    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, :version => true)
     assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_name(node_with_ref_without_name)
 
     I18n.locale = "de"
@@ -61,8 +61,8 @@ class BrowseHelperTest < ActionView::TestCase
     assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node)
     assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node_v2)
     assert_dom_equal node.id.to_s, printable_name(node_v1)
-    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, true)
-    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, true)
+    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, :version => true)
+    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, :version => true)
     assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_name(node_with_ref_without_name)
   end
 

--- a/test/models/diary_entry_test.rb
+++ b/test/models/diary_entry_test.rb
@@ -8,18 +8,18 @@ class DiaryEntryTest < ActiveSupport::TestCase
 
   def test_diary_entry_validations
     diary_entry_valid({})
-    diary_entry_valid({ :title => "" }, false)
+    diary_entry_valid({ :title => "" }, :valid => false)
     diary_entry_valid(:title => "a" * 255)
-    diary_entry_valid({ :title => "a" * 256 }, false)
-    diary_entry_valid({ :body => "" }, false)
+    diary_entry_valid({ :title => "a" * 256 }, :valid => false)
+    diary_entry_valid({ :body => "" }, :valid => false)
     diary_entry_valid(:latitude => 90)
-    diary_entry_valid({ :latitude => 90.00001 }, false)
+    diary_entry_valid({ :latitude => 90.00001 }, :valid => false)
     diary_entry_valid(:latitude => -90)
-    diary_entry_valid({ :latitude => -90.00001 }, false)
+    diary_entry_valid({ :latitude => -90.00001 }, :valid => false)
     diary_entry_valid(:longitude => 180)
-    diary_entry_valid({ :longitude => 180.00001 }, false)
+    diary_entry_valid({ :longitude => 180.00001 }, :valid => false)
     diary_entry_valid(:longitude => -180)
-    diary_entry_valid({ :longitude => -180.00001 }, false)
+    diary_entry_valid({ :longitude => -180.00001 }, :valid => false)
   end
 
   def test_diary_entry_visible
@@ -48,8 +48,8 @@ class DiaryEntryTest < ActiveSupport::TestCase
 
   private
 
-  def diary_entry_valid(attrs, result = true)
+  def diary_entry_valid(attrs, valid: true)
     entry = build(:diary_entry, attrs)
-    assert_equal result, entry.valid?, "Expected #{attrs.inspect} to be #{result}"
+    assert_equal valid, entry.valid?, "Expected #{attrs.inspect} to be #{valid}"
   end
 end

--- a/test/models/trace_test.rb
+++ b/test/models/trace_test.rb
@@ -76,17 +76,17 @@ class TraceTest < ActiveSupport::TestCase
 
   def test_validations
     trace_valid({})
-    trace_valid({ :user_id => nil }, false)
+    trace_valid({ :user_id => nil }, :valid => false)
     trace_valid(:name => "a" * 255)
-    trace_valid({ :name => "a" * 256 }, false)
-    trace_valid({ :description => nil }, false)
+    trace_valid({ :name => "a" * 256 }, :valid => false)
+    trace_valid({ :description => nil }, :valid => false)
     trace_valid(:description => "a" * 255)
-    trace_valid({ :description => "a" * 256 }, false)
+    trace_valid({ :description => "a" * 256 }, :valid => false)
     trace_valid(:visibility => "private")
     trace_valid(:visibility => "public")
     trace_valid(:visibility => "trackable")
     trace_valid(:visibility => "identifiable")
-    trace_valid({ :visibility => "foo" }, false)
+    trace_valid({ :visibility => "foo" }, :valid => false)
   end
 
   def test_tagstring
@@ -319,9 +319,9 @@ class TraceTest < ActiveSupport::TestCase
     assert_equal md5sum, md5sum(create(:trace, :fixture => id).xml_file)
   end
 
-  def trace_valid(attrs, result = true)
+  def trace_valid(attrs, valid: true)
     entry = build(:trace, attrs)
-    assert_equal result, entry.valid?, "Expected #{attrs.inspect} to be #{result}"
+    assert_equal valid, entry.valid?, "Expected #{attrs.inspect} to be #{valid}"
   end
 
   def md5sum(io)

--- a/test/models/tracetag_test.rb
+++ b/test/models/tracetag_test.rb
@@ -3,23 +3,23 @@ require "test_helper"
 class TracetagTest < ActiveSupport::TestCase
   def test_validations
     tracetag_valid({})
-    tracetag_valid({ :tag => nil }, false)
-    tracetag_valid({ :tag => "" }, false)
+    tracetag_valid({ :tag => nil }, :valid => false)
+    tracetag_valid({ :tag => "" }, :valid => false)
     tracetag_valid(:tag => "a")
     tracetag_valid(:tag => "a" * 255)
-    tracetag_valid({ :tag => "a" * 256 }, false)
-    tracetag_valid({ :tag => "a/b" }, false)
-    tracetag_valid({ :tag => "a;b" }, false)
-    tracetag_valid({ :tag => "a.b" }, false)
-    tracetag_valid({ :tag => "a,b" }, false)
-    tracetag_valid({ :tag => "a?b" }, false)
+    tracetag_valid({ :tag => "a" * 256 }, :valid => false)
+    tracetag_valid({ :tag => "a/b" }, :valid => false)
+    tracetag_valid({ :tag => "a;b" }, :valid => false)
+    tracetag_valid({ :tag => "a.b" }, :valid => false)
+    tracetag_valid({ :tag => "a,b" }, :valid => false)
+    tracetag_valid({ :tag => "a?b" }, :valid => false)
   end
 
   private
 
-  def tracetag_valid(attrs, result = true)
+  def tracetag_valid(attrs, valid: true)
     entry = build(:tracetag)
     entry.assign_attributes(attrs)
-    assert_equal result, entry.valid?, "Expected #{attrs.inspect} to be #{result}"
+    assert_equal valid, entry.valid?, "Expected #{attrs.inspect} to be #{valid}"
   end
 end


### PR DESCRIPTION
This PR fixes some cases where we are using optional boolean parameters, to use keyword arguments instead.

 I think this is particularly useful where the method definition lies elsewhere, since it's not obvious what an isolated 'true' or 'false' means.

https://docs.rubocop.org/rubocop/1.0/cops_style.html#styleoptionalbooleanparameter