### PR TITLE
Add table borders for legibility in richtext diary posts

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1965,53 +1965,6 @@ div.secondary-actions {
     margin: 0;
     color: $darkgrey;
   }
-
-  /* Default table appearance: no background color, thin gray borders, narrow padding */
-
-  table tr td,
-  table tr th
-  {
-    border: none;
-    border-top: 1px solid #ccc;
-    border-left: 1px solid #ccc;
-    padding: .25em .5em;
-  }
-
-  /* Use thicker borders at start of tbody and tfoot table sections */
-
-  table tbody tr:first-child td,
-  table tfoot tr:first-child td
-  {
-    border-top-width: 3px;
-  }
-
-  /* Remove all outside table borders */
-
-  table *:first-child tr:first-child td,
-  table *:first-child tr:first-child th
-  {
-    border-top: none;
-    padding-top: 0;
-  }
-
-  table * tr td:first-child,
-  table * tr th:first-child
-  {
-    border-left: none;
-    padding-left: .25em;
-  }
-
-  table *:last-child tr:last-child td,
-  table *:last-child tr:last-child th
-  {
-    padding-bottom: 0;
-  }
-
-  table * tr td:last-child,
-  table * tr th:last-child
-  {
-    padding-right: .25em;
-  }
 }
 
 .diary_post .richtext {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1965,6 +1965,53 @@ div.secondary-actions {
     margin: 0;
     color: $darkgrey;
   }
+
+  /* Default table appearance: no background color, thin gray borders, narrow padding */
+
+  table tr td,
+  table tr th
+  {
+    border: none;
+    border-top: 1px solid #ccc;
+    border-left: 1px solid #ccc;
+    padding: .25em .5em;
+  }
+
+  /* Use thicker borders at start of tbody and tfoot table sections */
+
+  table tbody tr:first-child td,
+  table tfoot tr:first-child td
+  {
+    border-top-width: 3px;
+  }
+
+  /* Remove all outside table borders */
+
+  table *:first-child tr:first-child td,
+  table *:first-child tr:first-child th
+  {
+    border-top: none;
+    padding-top: 0;
+  }
+
+  table * tr td:first-child,
+  table * tr th:first-child
+  {
+    border-left: none;
+    padding-left: .25em;
+  }
+
+  table *:last-child tr:last-child td,
+  table *:last-child tr:last-child th
+  {
+    padding-bottom: 0;
+  }
+
+  table * tr td:last-child,
+  table * tr th:last-child
+  {
+    padding-right: .25em;
+  }
 }
 
 .diary_post .richtext {

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -80,7 +80,9 @@ module RichText
 
   class Markdown < Base
     def to_html
-      linkify(sanitize(Kramdown::Document.new(self).to_html), :all)
+      html1 = Kramdown::Document.new(self).to_html
+      html2 = html1.gsub(/<table\b/, '<table class="table table-sm w-auto"')
+      linkify(sanitize(html2), :all)
     end
 
     def to_text


### PR DESCRIPTION
Introduce new table border treatment for richtext areas in diary entries. In diary entries with tables like [*Calculating label points with PostGIS*](https://www.openstreetmap.org/user/pnorman/diary/394676), [*2020 Editor Usage*](https://www.openstreetmap.org/user/Glassman/diary/394740), and [*Querying OpenStreetMap Changesets with Amazon Athena*](https://www.openstreetmap.org/user/Jennings%20Anderson/diary/394762) table elements appear squashed and hard to read.

This change slightly expands padding within table cell elements and adds thin, light-gray lines between rows and cells to make wider and more complex tables easier to read. Screenshots below are from Firefox 82.

## Current Site

Table elements are pressed together and rows & columns can be difficult to see easily.

<img width="454" alt="Screen Shot 2020-11-13 at 3 59 31 PM" src="https://user-images.githubusercontent.com/58730/99131892-399a4d80-25c9-11eb-985a-a65ae04abb97.png">

## This Change

Table elements are spaced further apart and rows & columns are easy to follow visually.

<img width="440" alt="Screen Shot 2020-11-13 at 4 00 03 PM" src="https://user-images.githubusercontent.com/58730/99131923-4c148700-25c9-11eb-8a71-a7d136d7e42f.png">
