### PR TITLE
Refactor trace notifications to reduce lego translations

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -44,6 +44,7 @@ class UserMailer < ApplicationMailer
 
   def gpx_success(trace, possible_points)
     with_recipient_locale trace.user do
+      @to_user = trace.user.display_name
       @trace_name = trace.name
       @trace_points = trace.size
       @trace_description = trace.description
@@ -51,19 +52,20 @@ class UserMailer < ApplicationMailer
       @possible_points = possible_points
 
       mail :to => trace.user.email,
-           :subject => I18n.t("user_mailer.gpx_notification.success.subject")
+           :subject => I18n.t("user_mailer.gpx_success.subject")
     end
   end
 
   def gpx_failure(trace, error)
     with_recipient_locale trace.user do
+      @to_user = trace.user.display_name
       @trace_name = trace.name
       @trace_description = trace.description
       @trace_tags = trace.tags
       @error = error
 
       mail :to => trace.user.email,
-           :subject => I18n.t("user_mailer.gpx_notification.failure.subject")
+           :subject => I18n.t("user_mailer.gpx_failure.subject")
     end
   end
 

--- a/app/views/user_mailer/_gpx_description.html.erb
+++ b/app/views/user_mailer/_gpx_description.html.erb
@@ -1,7 +1,7 @@
 <% trace_name = tag.strong(@trace_name) %>
 <% trace_description = tag.em(@trace_description) %>
 <% if @trace_tags.length > 0 %>
-  <% tags = @trace_tags.map { tag.tag.rstrip.join(" ") } %>
+  <% tags = @trace_tags.map(&:tag).join(" ") %>
   <%= t ".description_with_tags_html", :trace_name => trace_name, :trace_description => trace_description, :tags => tags %>
 <% else %>
   <%= t ".description_with_no_tags_html", :trace_name => trace_name, :trace_description => trace_description %>

--- a/app/views/user_mailer/_gpx_description.html.erb
+++ b/app/views/user_mailer/_gpx_description.html.erb
@@ -1,12 +1,8 @@
-<%= t "user_mailer.gpx_notification.your_gpx_file" %>
-<strong><%= @trace_name %></strong>
-<%= t "user_mailer.gpx_notification.with_description" %>
-<em><%= @trace_description %></em>
-<% if @trace_tags.length>0 %>
-  <%= t "user_mailer.gpx_notification.and_the_tags" %>
-  <em><% @trace_tags.each do |tag| %>
-    <%= tag.tag.rstrip %>
-  <% end %></em>
+<% trace_name = tag.strong(@trace_name) %>
+<% trace_description = tag.em(@trace_description) %>
+<% if @trace_tags.length > 0 %>
+  <% tags = @trace_tags.map { tag.tag.rstrip.join(" ") } %>
+  <%= t ".description_with_tags_html", :trace_name => trace_name, :trace_description => trace_description, :tags => tags %>
 <% else %>
-  <%= t "user_mailer.gpx_notification.and_no_tags" %>
+  <%= t ".description_with_no_tags_html", :trace_name => trace_name, :trace_description => trace_description %>
 <% end %>

--- a/app/views/user_mailer/gpx_failure.html.erb
+++ b/app/views/user_mailer/gpx_failure.html.erb
@@ -1,8 +1,8 @@
-<p><%= t "user_mailer.gpx_notification.greeting" %></p>
+<p><%= t ".hi", :to_user => @to_user %></p>
 
 <p>
   <%= render :partial => "gpx_description" %>
-  <%= t "user_mailer.gpx_notification.failure.failed_to_import" %>
+  <%= t ".failed_to_import" %>
 </p>
 
 <blockquote>
@@ -10,7 +10,5 @@
 </blockquote>
 
 <p>
-  <%= t "user_mailer.gpx_notification.failure.more_info_1" %>
-  <%= t "user_mailer.gpx_notification.failure.more_info_2" %>
-  <%= t "user_mailer.gpx_notification.failure.import_failures_url" %>
+  <%= t ".more_info_html", :url => link_to(t(".import_failures_url"), t(".import_failures_url")) %>
 </p>

--- a/app/views/user_mailer/gpx_success.html.erb
+++ b/app/views/user_mailer/gpx_success.html.erb
@@ -1,7 +1,7 @@
-<p><%= t "user_mailer.gpx_notification.greeting" %></p>
+<p><%= t ".hi", :to_user => @to_user %></p>
 
 <p>
   <%= render :partial => "gpx_description" %>
-  <%= t("user_mailer.gpx_notification.success.loaded_successfully",
+  <%= t(".loaded_successfully",
         :trace_points => @trace_points, :possible_points => @possible_points, :count => @possible_points) %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1426,23 +1426,21 @@ en:
       had_added_you: "%{user} has added you as a friend on OpenStreetMap."
       see_their_profile: "You can see their profile at %{userurl}."
       befriend_them: "You can also add them as a friend at %{befriendurl}."
-    gpx_notification:
-      greeting: "Hi,"
-      your_gpx_file: "It looks like your GPX file"
-      with_description: "with the description"
-      and_the_tags: "and the following tags:"
-      and_no_tags: "and no tags."
-      failure:
-        subject: "[OpenStreetMap] GPX Import failure"
-        failed_to_import: "failed to import. Here is the error:"
-        more_info_1: "More information about GPX import failures and how to avoid"
-        more_info_2: "them can be found at:"
-        import_failures_url: "https://wiki.openstreetmap.org/wiki/GPX_Import_Failures"
-      success:
-        subject: "[OpenStreetMap] GPX Import success"
-        loaded_successfully:
-          one: loaded successfully with %{trace_points} out of a possible 1 point.
-          other: loaded successfully with %{trace_points} out of a possible %{possible_points} points.
+    gpx_description:
+      description_with_tags_html: "It looks like your GPX file %{trace_name} with the description %{trace_description} and the following tags: %{tags}"
+      description_with_no_tags_html: "It looks like your GPX file %{trace_name} with the description %{trace_description} and no tags"
+    gpx_failure:
+      hi: "Hi %{to_user},"
+      failed_to_import: "failed to import. Here is the error:"
+      more_info_html: "More information about GPX import failures and how to avoid them can be found at %{url}."
+      import_failures_url: "https://wiki.openstreetmap.org/wiki/GPX_Import_Failures"
+      subject: "[OpenStreetMap] GPX Import failure"
+    gpx_success:
+      hi: "Hi %{to_user},"
+      loaded_successfully:
+        one: loaded successfully with %{trace_points} out of a possible 1 point.
+        other: loaded successfully with %{trace_points} out of a possible %{possible_points} points.
+      subject: "[OpenStreetMap] GPX Import success"
     signup_confirm:
       subject: "[OpenStreetMap] Welcome to OpenStreetMap"
       greeting: "Hi there!"

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -6,4 +6,15 @@ class UserMailerTest < ActionMailer::TestCase
 
     assert_match(/<html lang=/, email.html_part.body.to_s)
   end
+
+  def test_gpx_description_tags
+    trace = create(:trace) do |t|
+      create(:tracetag, :trace => t, :tag => "one")
+      create(:tracetag, :trace => t, :tag => "two")
+      create(:tracetag, :trace => t, :tag => "three")
+    end
+    email = UserMailer.gpx_success(trace, 100)
+
+    assert_match(/one two three/, email.html_part.body.to_s)
+  end
 end


### PR DESCRIPTION
Fixes #2268.

Unfortunately there's still a lego translation when both halves of the sentence are joined together, but this at least reduces the number of combinations to translate.