### PR TITLE
Add bootstrap classes to markdown tables

### DIFF
--- a/config/initializers/sanitize.rb
+++ b/config/initializers/sanitize.rb
@@ -3,3 +3,6 @@ Sanitize::Config::OSM = Sanitize::Config::RELAXED.dup
 Sanitize::Config::OSM[:elements] -= %w[div style]
 Sanitize::Config::OSM[:add_attributes] = { "a" => { "rel" => "nofollow noopener noreferrer" } }
 Sanitize::Config::OSM[:remove_contents] = %w[script style]
+Sanitize::Config::OSM[:transformers] = lambda do |env|
+  env[:node].add_class("table table-sm w-auto") if env[:node_name] == "table"
+end


### PR DESCRIPTION
This is an alternative implementation of #2959 that overrides the kramdown converter to add the classes instead of trying edit the generated HTML with a search and replace.