### PR TITLE
Allow smtp settings to be configured through the settings system

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -1,9 +1,12 @@
 # Configure ActionMailer SMTP settings
 ActionMailer::Base.smtp_settings = {
-  :address => "localhost",
-  :port => 25,
-  :domain => "localhost",
-  :enable_starttls_auto => false
+  :address => Settings.smtp_address,
+  :port => Settings.smtp_port,
+  :domain => Settings.smtp_domain,
+  :enable_starttls_auto => Settings.smtp_enable_starttls_auto,
+  :authentication => Settings.smtp_authentication,
+  :user_name => Settings.smtp_user_name,
+  :password => Settings.smtp_password
 }
 
 # Set the host and protocol for all ActionMailer URLs

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -131,3 +131,11 @@ storage_service: "local"
 # storage_url:
 # URL for tile CDN
 #tile_cdn_url: ""
+# SMTP settings for outbound mail
+smtp_address: "localhost"
+smtp_port: 25
+smtp_domain: "localhost"
+smtp_enable_starttls_auto: false
+smtp_authentication: null
+smtp_user_name: null
+smtp_password: null


### PR DESCRIPTION
This allows easier configuration using the settings.local.yml files

Fixes #2571