### PR TITLE
Improve guessing of labels for Nominatim results

### DIFF
--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -149,10 +149,10 @@ class GeocoderController < ApplicationController
                       t "geocoder.search_osm_nominatim.prefix.#{klass}.#{type}", :default => type.tr("_", " ").capitalize
                     end
       if klass == "boundary" && type == "administrative"
-        rank = (place.attributes["place_rank"].to_i + 1) / 2
+        rank = (place.attributes["address_rank"].to_i + 1) / 2
         prefix_name = t "geocoder.search_osm_nominatim.admin_levels.level#{rank}", :default => prefix_name
         place.elements["extratags"].elements.each("tag") do |extratag|
-          prefix_name = t "geocoder.search_osm_nominatim.prefix.place.#{extratag.attributes['value']}", :default => prefix_name if extratag.attributes["key"] == "place"
+          prefix_name = t "geocoder.search_osm_nominatim.prefix.place.#{extratag.attributes['value']}", :default => prefix_name if extratag.attributes["key"] == "linked_place" || extratag.attributes["key"] == "place"
         end
       end
       prefix = t "geocoder.search_osm_nominatim.prefix_format", :name => prefix_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1244,12 +1244,15 @@ en:
           "yes": "Waterway"
       admin_levels:
         level2: "Country Boundary"
+        level3: "Region Boundary"
         level4: "State Boundary"
         level5: "Region Boundary"
         level6: "County Boundary"
+        level7: "Municipality Boundary"
         level8: "City Boundary"
         level9: "Village Boundary"
         level10: "Suburb Boundary"
+        level11: "Neighbourhood Boundary"
       types:
         cities: Cities
         towns: Towns


### PR DESCRIPTION
This adapts to two changes in place handling by Nominatim:

* Place links that are computed by Nominatim are now found in extratags['linked_places']. Keep the check for extratags['place']
  as this may contain an explicitly mapped place label.
* Use address rank for guessing the boundary type. This gets normalised by Nominatim with respect to country-specific use of admin_level.

Also adds additional labels for admin levels, so that we now have complete coverage for all levels that are in use in OSM.

I would have liked to avoid the long line but rubocop insisted on using a modifier if.