### PR TITLE
Mailer refactoring

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -83,7 +83,7 @@ class UserMailer < ApplicationMailer
 
       mail :from => from_address(message.sender.display_name, "m", message.id, message.digest),
            :to => message.recipient.email,
-           :subject => I18n.t("user_mailer.message_notification.subject_header", :subject => message.title)
+           :subject => t(".subject", :message_title => message.title)
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,7 +17,7 @@ class UserMailer < ApplicationMailer
                      :confirm_string => token.token)
 
       mail :to => user.email,
-           :subject => I18n.t("user_mailer.signup_confirm.subject")
+           :subject => t(".subject")
     end
   end
 
@@ -28,7 +28,7 @@ class UserMailer < ApplicationMailer
                      :confirm_string => token.token)
 
       mail :to => user.new_email,
-           :subject => I18n.t("user_mailer.email_confirm.subject")
+           :subject => t(".subject")
     end
   end
 
@@ -38,7 +38,7 @@ class UserMailer < ApplicationMailer
                      :token => token.token)
 
       mail :to => user.email,
-           :subject => I18n.t("user_mailer.lost_password.subject")
+           :subject => t(".subject")
     end
   end
 
@@ -52,7 +52,7 @@ class UserMailer < ApplicationMailer
       @possible_points = possible_points
 
       mail :to => trace.user.email,
-           :subject => I18n.t("user_mailer.gpx_success.subject")
+           :subject => t(".subject")
     end
   end
 
@@ -65,7 +65,7 @@ class UserMailer < ApplicationMailer
       @error = error
 
       mail :to => trace.user.email,
-           :subject => I18n.t("user_mailer.gpx_failure.subject")
+           :subject => t(".subject")
     end
   end
 
@@ -104,7 +104,7 @@ class UserMailer < ApplicationMailer
 
       mail :from => from_address(comment.user.display_name, "c", comment.id, comment.digest, recipient.id),
            :to => recipient.email,
-           :subject => I18n.t("user_mailer.diary_comment_notification.subject", :user => comment.user.display_name)
+           :subject => t(".subject", :user => comment.user.display_name)
     end
   end
 
@@ -117,7 +117,7 @@ class UserMailer < ApplicationMailer
 
       attach_user_avatar(@friendship.befriender)
       mail :to => friendship.befriendee.email,
-           :subject => I18n.t("user_mailer.friendship_notification.subject", :user => friendship.befriender.display_name)
+           :subject => t(".subject", :user => friendship.befriender.display_name)
     end
   end
 
@@ -132,7 +132,7 @@ class UserMailer < ApplicationMailer
       @commenter = if comment.author
                      comment.author.display_name
                    else
-                     I18n.t("user_mailer.note_comment_notification.anonymous")
+                     t(".anonymous")
                    end
 
       @author = @commenter
@@ -141,9 +141,9 @@ class UserMailer < ApplicationMailer
       set_references("note", comment.note)
 
       subject = if @owner
-                  I18n.t("user_mailer.note_comment_notification.#{@event}.subject_own", :commenter => @commenter)
+                  t(".#{@event}.subject_own", :commenter => @commenter)
                 else
-                  I18n.t("user_mailer.note_comment_notification.#{@event}.subject_other", :commenter => @commenter)
+                  t(".#{@event}.subject_other", :commenter => @commenter)
                 end
 
       mail :to => recipient.email, :subject => subject
@@ -163,9 +163,9 @@ class UserMailer < ApplicationMailer
       @author = @commenter
 
       subject = if @owner
-                  I18n.t("user_mailer.changeset_comment_notification.commented.subject_own", :commenter => @commenter)
+                  t(".commented.subject_own", :commenter => @commenter)
                 else
-                  I18n.t("user_mailer.changeset_comment_notification.commented.subject_other", :commenter => @commenter)
+                  t(".commented.subject_other", :commenter => @commenter)
                 end
 
       attach_user_avatar(comment.author)

--- a/app/views/user_mailer/changeset_comment_notification.html.erb
+++ b/app/views/user_mailer/changeset_comment_notification.html.erb
@@ -3,12 +3,12 @@
 </p>
 <p>
   <% if @owner %>
-    <%= raw t ".commented.your_changeset", :commenter => link_to_user(@commenter), :time => @time %>
+    <%= t ".commented.your_changeset_html", :commenter => link_to_user(@commenter), :time => @time %>
   <% else %>
-    <%= raw t ".commented.commented_changeset", :commenter => link_to_user(@commenter), :time => @time, :changeset_author => @changeset_author %>
+    <%= t ".commented.commented_changeset_html", :commenter => link_to_user(@commenter), :time => @time, :changeset_author => @changeset_author %>
   <% end %>
   <% if @changeset_comment %>
-    <%= raw t ".commented.partial_changeset_with_comment", :changeset_comment => tag.em(@changeset_comment) %>
+    <%= t ".commented.partial_changeset_with_comment_html", :changeset_comment => tag.em(@changeset_comment) %>
   <% else %>
     <%= t ".commented.partial_changeset_without_comment" %>
   <% end %>
@@ -19,11 +19,11 @@
 <% end %>
 
 <p>
-  <%= raw t ".details", :url => link_to(@changeset_url, @changeset_url) %>
+  <%= t ".details_html", :url => link_to(@changeset_url, @changeset_url) %>
 </p>
 
 <% content_for :footer do %>
   <p>
-    <%= raw t ".unsubscribe", :url => link_to(@changeset_url, @changeset_url, :style => "color: #222") %>
+    <%= t ".unsubscribe_html", :url => link_to(@changeset_url, @changeset_url, :style => "color: #222") %>
   </p>
 <% end %>

--- a/app/views/user_mailer/diary_comment_notification.html.erb
+++ b/app/views/user_mailer/diary_comment_notification.html.erb
@@ -2,7 +2,7 @@
   <%= t ".hi", :to_user => @to_user %>
 </p>
 <p>
-  <%= raw t ".header", :from_user => link_to_user(@from_user), :subject => tag.em(@title) %>
+  <%= t ".header_html", :from_user => link_to_user(@from_user), :subject => tag.em(@title) %>
 </p>
 
 <%= message_body do %>
@@ -10,9 +10,9 @@
 <% end %>
 
 <% content_for :footer do %>
-  <p><%= raw t ".footer",
-               :readurl => link_to(@readurl, @readurl) + tag(:br),
-               :commenturl => link_to(@commenturl, @commenturl) + tag(:br),
-               :replyurl => link_to(@replyurl, @replyurl) %>
+  <p><%= t ".footer_html",
+           :readurl => link_to(@readurl, @readurl) + tag(:br),
+           :commenturl => link_to(@commenturl, @commenturl) + tag(:br),
+           :replyurl => link_to(@replyurl, @replyurl) %>
   </p>
 <% end %>

--- a/app/views/user_mailer/diary_comment_notification.text.erb
+++ b/app/views/user_mailer/diary_comment_notification.text.erb
@@ -3,7 +3,7 @@
 <%= t '.header', :from_user => @from_user, :subject => @title %>
 
 ==
-<%= raw @text.to_text %>
+<%= @text.to_text %>
 ==
 
 <%= t '.footer', :readurl => @readurl, :commenturl => @commenturl, :replyurl => @replyurl %>

--- a/app/views/user_mailer/email_confirm.html.erb
+++ b/app/views/user_mailer/email_confirm.html.erb
@@ -1,7 +1,7 @@
-<p><%= t "user_mailer.email_confirm_html.greeting" %></p>
+<p><%= t ".greeting" %></p>
 
-<p><%= t "user_mailer.email_confirm_html.hopefully_you", :server_url => Settings.server_url, :new_address => @address %></p>
+<p><%= t ".hopefully_you", :server_url => Settings.server_url, :new_address => @address %></p>
 
-<p><%= t "user_mailer.email_confirm_html.click_the_link" %></p>
+<p><%= t ".click_the_link" %></p>
 
 <p><a href="<%= @url %>"><%= @url %></a></p>

--- a/app/views/user_mailer/email_confirm.text.erb
+++ b/app/views/user_mailer/email_confirm.text.erb
@@ -1,7 +1,7 @@
-<%= t 'user_mailer.email_confirm_plain.greeting' %>
+<%= t '.greeting' %>
 
-<%= word_wrap(t 'user_mailer.email_confirm_plain.hopefully_you', :server_url => Settings.server_url, :new_address => @address) %>
+<%= word_wrap(t '.hopefully_you', :server_url => Settings.server_url, :new_address => @address) %>
 
-<%= t 'user_mailer.email_confirm_plain.click_the_link' %>
+<%= t '.click_the_link' %>
 
 <%= @url %>

--- a/app/views/user_mailer/friendship_notification.html.erb
+++ b/app/views/user_mailer/friendship_notification.html.erb
@@ -1,9 +1,9 @@
 <p><%= t ".had_added_you", :user => @friendship.befriender.display_name %></p>
 
 <%= message_body do %>
-  <p><%= raw t ".see_their_profile", :userurl => link_to(@viewurl, @viewurl) %></p>
+  <p><%= t ".see_their_profile_html", :userurl => link_to(@viewurl, @viewurl) %></p>
 
   <% unless @friendship.befriendee.is_friends_with?(@friendship.befriender) -%>
-  <p><%= raw t ".befriend_them", :befriendurl => link_to(@friendurl, @friendurl) %></p>
+  <p><%= t ".befriend_them_html", :befriendurl => link_to(@friendurl, @friendurl) %></p>
   <% end -%>
 <% end %>

--- a/app/views/user_mailer/lost_password.html.erb
+++ b/app/views/user_mailer/lost_password.html.erb
@@ -1,7 +1,7 @@
-<p><%= t "user_mailer.lost_password_html.greeting" %></p>
+<p><%= t ".greeting" %></p>
 
-<p><%= t "user_mailer.lost_password_html.hopefully_you" %></p>
+<p><%= t ".hopefully_you" %></p>
 
-<p><%= t "user_mailer.lost_password_html.click_the_link" %></p>
+<p><%= t ".click_the_link" %></p>
 
 <p><a href="<%= @url %>"><%= @url %></a></p>

--- a/app/views/user_mailer/lost_password.text.erb
+++ b/app/views/user_mailer/lost_password.text.erb
@@ -1,7 +1,7 @@
-<%= t 'user_mailer.lost_password_plain.greeting' %>
+<%= t '.greeting' %>
 
-<%= word_wrap(t 'user_mailer.lost_password_plain.hopefully_you') %>
+<%= word_wrap(t '.hopefully_you') %>
 
-<%= t 'user_mailer.lost_password_plain.click_the_link' %>
+<%= t '.click_the_link' %>
 
 <%= @url %>

--- a/app/views/user_mailer/message_notification.html.erb
+++ b/app/views/user_mailer/message_notification.html.erb
@@ -2,9 +2,9 @@
   <%= t ".hi", :to_user => @to_user %>
 </p>
 <p>
-  <%= raw t ".header",
-            :from_user => link_to_user(@from_user),
-            :subject => tag.em(@title) %>
+  <%= t ".header",
+        :from_user => link_to_user(@from_user),
+        :subject => tag.em(@title) %>
 </p>
 
 <%= message_body do %>

--- a/app/views/user_mailer/message_notification.text.erb
+++ b/app/views/user_mailer/message_notification.text.erb
@@ -1,9 +1,9 @@
-<%= raw t '.hi', :to_user => @to_user %>
+<%= t '.hi', :to_user => @to_user %>
 
-<%= raw t '.header', :from_user => @from_user, :subject => @title %>
+<%= t '.header', :from_user => @from_user, :subject => @title %>
 
 ==
-<%= raw @text.to_text %>
+<%= @text.to_text %>
 ==
 
 <%= word_wrap(t '.footer_html', :readurl => @readurl, :replyurl => @replyurl) %>

--- a/app/views/user_mailer/message_notification.text.erb
+++ b/app/views/user_mailer/message_notification.text.erb
@@ -6,4 +6,4 @@
 <%= @text.to_text %>
 ==
 
-<%= word_wrap(t '.footer_html', :readurl => @readurl, :replyurl => @replyurl) %>
+<%= word_wrap(t '.footer', :readurl => @readurl, :replyurl => @replyurl) %>

--- a/app/views/user_mailer/note_comment_notification.html.erb
+++ b/app/views/user_mailer/note_comment_notification.html.erb
@@ -1,9 +1,9 @@
 <p><%= t ".greeting" %></p>
 
 <% if @owner %>
-  <p><%= raw t ".#{@event}.your_note", :commenter => link_to_user(@commenter), :place => @place %></p>
+  <p><%= t ".#{@event}.your_note_html", :commenter => link_to_user(@commenter), :place => @place %></p>
 <% else %>
-  <p><%= raw t ".#{@event}.commented_note", :commenter => link_to_user(@commenter), :place => @place %></p>
+  <p><%= t ".#{@event}.commented_note_html", :commenter => link_to_user(@commenter), :place => @place %></p>
 <% end %>
 
 <% unless @comment.empty? %>
@@ -12,4 +12,4 @@
   <% end %>
 <% end %>
 
-<p><%= raw t ".details", :url => link_to(@noteurl, @noteurl) %></p>
+<p><%= t ".details_html", :url => link_to(@noteurl, @noteurl) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1449,21 +1449,11 @@ en:
       welcome: "After you confirm your account, we'll provide you with some additional information to get you started."
     email_confirm:
       subject: "[OpenStreetMap] Confirm your email address"
-    email_confirm_plain:
-      greeting: "Hi,"
-      hopefully_you: "Someone (hopefully you) would like to change their email address over at %{server_url} to %{new_address}."
-      click_the_link: "If this is you, please click the link below to confirm the change."
-    email_confirm_html:
       greeting: "Hi,"
       hopefully_you: "Someone (hopefully you) would like to change their email address over at %{server_url} to %{new_address}."
       click_the_link: "If this is you, please click the link below to confirm the change."
     lost_password:
       subject: "[OpenStreetMap] Password reset request"
-    lost_password_plain:
-      greeting: "Hi,"
-      hopefully_you: "Someone (possibly you) has asked for the password to be reset on this email address's openstreetmap.org account."
-      click_the_link: "If this is you, please click the link below to reset your password."
-    lost_password_html:
       greeting: "Hi,"
       hopefully_you: "Someone (possibly you) has asked for the password to be reset on this email address's openstreetmap.org account."
       click_the_link: "If this is you, please click the link below to reset your password."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1414,18 +1414,24 @@ en:
       subject: "[OpenStreetMap] %{user} commented on a diary entry"
       hi: "Hi %{to_user},"
       header: "%{from_user} has commented on the OpenStreetMap diary entry with the subject %{subject}:"
+      header_html: "%{from_user} has commented on the OpenStreetMap diary entry with the subject %{subject}:"
       footer: "You can also read the comment at %{readurl} and you can comment at %{commenturl} or send a message to the author at %{replyurl}"
+      footer_html: "You can also read the comment at %{readurl} and you can comment at %{commenturl} or send a message to the author at %{replyurl}"
     message_notification:
       subject: "[OpenStreetMap] %{message_title}"
       hi: "Hi %{to_user},"
       header: "%{from_user} has sent you a message through OpenStreetMap with the subject %{subject}:"
+      header_html: "%{from_user} has sent you a message through OpenStreetMap with the subject %{subject}:"
+      footer: "You can also read the message at %{readurl} and you can send a message to the author at %{replyurl}"
       footer_html: "You can also read the message at %{readurl} and you can send a message to the author at %{replyurl}"
     friendship_notification:
       hi: "Hi %{to_user},"
       subject: "[OpenStreetMap] %{user} added you as a friend"
       had_added_you: "%{user} has added you as a friend on OpenStreetMap."
       see_their_profile: "You can see their profile at %{userurl}."
+      see_their_profile_html: "You can see their profile at %{userurl}."
       befriend_them: "You can also add them as a friend at %{befriendurl}."
+      befriend_them_html: "You can also add them as a friend at %{befriendurl}."
     gpx_description:
       description_with_tags_html: "It looks like your GPX file %{trace_name} with the description %{trace_description} and the following tags: %{tags}"
       description_with_no_tags_html: "It looks like your GPX file %{trace_name} with the description %{trace_description} and no tags"
@@ -1464,18 +1470,25 @@ en:
         subject_own: "[OpenStreetMap] %{commenter} has commented on one of your notes"
         subject_other: "[OpenStreetMap] %{commenter} has commented on a note you are interested in"
         your_note: "%{commenter} has left a comment on one of your map notes near %{place}."
+        your_note_html: "%{commenter} has left a comment on one of your map notes near %{place}."
         commented_note: "%{commenter} has left a comment on a map note you have commented on. The note is near %{place}."
+        commented_note_html: "%{commenter} has left a comment on a map note you have commented on. The note is near %{place}."
       closed:
         subject_own: "[OpenStreetMap] %{commenter} has resolved one of your notes"
         subject_other: "[OpenStreetMap] %{commenter} has resolved a note you are interested in"
         your_note: "%{commenter} has resolved one of your map notes near %{place}."
+        your_note_html: "%{commenter} has resolved one of your map notes near %{place}."
         commented_note: "%{commenter} has resolved a map note you have commented on. The note is near %{place}."
+        commented_note_html: "%{commenter} has resolved a map note you have commented on. The note is near %{place}."
       reopened:
         subject_own: "[OpenStreetMap] %{commenter} has reactivated one of your notes"
         subject_other: "[OpenStreetMap] %{commenter} has reactivated a note you are interested in"
         your_note: "%{commenter} has reactivated one of your map notes near %{place}."
+        your_note_html: "%{commenter} has reactivated one of your map notes near %{place}."
         commented_note: "%{commenter} has reactivated a map note you have commented on. The note is near %{place}."
+        commented_note_html: "%{commenter} has reactivated a map note you have commented on. The note is near %{place}."
       details: "More details about the note can be found at %{url}."
+      details_html: "More details about the note can be found at %{url}."
     changeset_comment_notification:
       hi: "Hi %{to_user},"
       greeting: "Hi,"
@@ -1483,11 +1496,16 @@ en:
         subject_own: "[OpenStreetMap] %{commenter} has commented on one of your changesets"
         subject_other: "[OpenStreetMap] %{commenter} has commented on a changeset you are interested in"
         your_changeset: "%{commenter} left a comment at %{time} on one of your changesets"
+        your_changeset_html: "%{commenter} left a comment at %{time} on one of your changesets"
         commented_changeset: "%{commenter} left a comment at %{time} on a changeset you are watching created by %{changeset_author}"
+        commented_changeset_html: "%{commenter} left a comment at %{time} on a changeset you are watching created by %{changeset_author}"
         partial_changeset_with_comment: "with comment '%{changeset_comment}'"
+        partial_changeset_with_comment_html: "with comment '%{changeset_comment}'"
         partial_changeset_without_comment: "without comment"
       details: "More details about the changeset can be found at %{url}."
+      details_html: "More details about the changeset can be found at %{url}."
       unsubscribe: 'To unsubscribe from updates to this changeset, visit %{url} and click "Unsubscribe".'
+      unsubscribe_html: 'To unsubscribe from updates to this changeset, visit %{url} and click "Unsubscribe".'
   messages:
     inbox:
       title: "Inbox"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1416,7 +1416,7 @@ en:
       header: "%{from_user} has commented on the OpenStreetMap diary entry with the subject %{subject}:"
       footer: "You can also read the comment at %{readurl} and you can comment at %{commenturl} or send a message to the author at %{replyurl}"
     message_notification:
-      subject_header: "[OpenStreetMap] %{subject}"
+      subject: "[OpenStreetMap] %{message_title}"
       hi: "Hi %{to_user},"
       header: "%{from_user} has sent you a message through OpenStreetMap with the subject %{subject}:"
       footer_html: "You can also read the message at %{readurl} and you can send a message to the author at %{replyurl}"

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -17,4 +17,13 @@ class UserMailerTest < ActionMailer::TestCase
 
     assert_match(/one two three/, email.html_part.body.to_s)
   end
+
+  def test_html_encoding
+    user = create(:user, :display_name => "Jack & Jill <br>")
+    message = create(:message, :sender => user)
+    email = UserMailer.message_notification(message)
+
+    assert_match("Jack & Jill <br>", email.text_part.body.to_s)
+    assert_match("Jack &amp; Jill &lt;br&gt;", email.html_part.body.to_s)
+  end
 end


### PR DESCRIPTION
This PR contains some translation-related refactoring for the user_mailer.

It took me two attempts to get this right, since there's some subtleties about how the `_html` translations interact with plain text mail templates, and so I had to revisit and refactor some (unsubmitted) work that was done last week when I realised what was going on. But I've added a test that would have caught my mistake earlier.

In short, `_html` translations take the translation options (e.g. something like `t(".foo", :username => "Jack & Jill")`, html_escapes the options, interpolates them into the translation, and returns the whole thing as a SafeBuffer to avoid further html_escaping in the template. Putting that straight into an html template is fine, since it a) is already a safebuffer and b) is already escaped. But for plain text templates, we don't want any html_escaping of the input options, so we have to avoid using `_html` translation keys. Hence the duplication between the `_html` and non-`_html` keys.