### PR TITLE
Add missing html suffix to translation key

### DIFF
--- a/app/views/user_mailer/message_notification.html.erb
+++ b/app/views/user_mailer/message_notification.html.erb
@@ -2,7 +2,7 @@
   <%= t ".hi", :to_user => @to_user %>
 </p>
 <p>
-  <%= t ".header",
+  <%= t ".header_html",
         :from_user => link_to_user(@from_user),
         :subject => tag.em(@title) %>
 </p>


### PR DESCRIPTION
The new key was added to the translations config file in #2993 

Thanks to @woodpeck for reporting at https://github.com/openstreetmap/openstreetmap-website/pull/2993#issuecomment-740623075