### PR TITLE
Refactoring for to_xml

### DIFF
--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -33,7 +33,7 @@ module Api
       # get all the points
       ordered_points = Tracepoint.bbox(bbox).joins(:trace).where(:gpx_files => { :visibility => %w[trackable identifiable] }).order("gpx_id DESC, trackid ASC, timestamp ASC")
       unordered_points = Tracepoint.bbox(bbox).joins(:trace).where(:gpx_files => { :visibility => %w[public private] }).order("gps_points.latitude", "gps_points.longitude", "gps_points.timestamp")
-      points = ordered_points.union_all(unordered_points).offset(offset).limit(Settings.tracepoints_per_page)
+      points = ordered_points.union_all(unordered_points).offset(offset).limit(Settings.tracepoints_per_page).preload(:trace)
 
       doc = XML::Document.new
       doc.encoding = XML::Encoding::UTF_8

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -53,24 +53,22 @@ module Api
       trkseg = nil
       anon_track = nil
       anon_trkseg = nil
-      gpx_file = nil
       timestamps = false
 
       points.each do |point|
         if gpx_id != point.gpx_id
           gpx_id = point.gpx_id
           trackid = -1
-          gpx_file = Trace.find(gpx_id)
 
-          if gpx_file.trackable?
+          if point.trace.trackable?
             track = XML::Node.new "trk"
             doc.root << track
             timestamps = true
 
-            if gpx_file.identifiable?
-              track << (XML::Node.new("name") << gpx_file.name)
-              track << (XML::Node.new("desc") << gpx_file.description)
-              track << (XML::Node.new("url") << url_for(:controller => "/traces", :action => "show", :display_name => gpx_file.user.display_name, :id => gpx_file.id))
+            if point.trace.identifiable?
+              track << (XML::Node.new("name") << point.trace.name)
+              track << (XML::Node.new("desc") << point.trace.description)
+              track << (XML::Node.new("url") << url_for(:controller => "/traces", :action => "show", :display_name => point.trace.user.display_name, :id => point.trace.id))
             end
           else
             # use the anonymous track segment if the user hasn't allowed
@@ -85,7 +83,7 @@ module Api
         end
 
         if trackid != point.trackid
-          if gpx_file.trackable?
+          if point.trace.trackable?
             trkseg = XML::Node.new "trkseg"
             track << trkseg
             trackid = point.trackid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,26 +153,6 @@ class User < ApplicationRecord
     user
   end
 
-  def to_xml
-    doc = OSM::API.new.get_xml_doc
-    doc.root << to_xml_node
-    doc
-  end
-
-  def to_xml_node
-    el1 = XML::Node.new "user"
-    el1["display_name"] = display_name.to_s
-    el1["account_created"] = creation_time.xmlschema
-    if home_lat && home_lon
-      home = XML::Node.new "home"
-      home["lat"] = home_lat.to_s
-      home["lon"] = home_lon.to_s
-      home["zoom"] = home_zoom.to_s
-      el1 << home
-    end
-    el1
-  end
-
   def description
     RichText.new(self[:description_format], self[:description])
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -268,24 +268,4 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.visible?
     assert_not user.active?
   end
-
-  def test_to_xml
-    user = build(:user, :with_home_location)
-    xml = user.to_xml
-    assert_select Nokogiri::XML::Document.parse(xml.to_s), "user" do
-      assert_select "[display_name=?]", user.display_name
-      assert_select "[account_created=?]", user.creation_time.xmlschema
-      assert_select "home[lat=?][lon=?][zoom=?]", user.home_lat.to_s, user.home_lon.to_s, user.home_zoom.to_s
-    end
-  end
-
-  def test_to_xml_node
-    user = build(:user, :with_home_location)
-    xml = user.to_xml_node
-    assert_select Nokogiri::XML::DocumentFragment.parse(xml.to_s), "user" do
-      assert_select "[display_name=?]", user.display_name
-      assert_select "[account_created=?]", user.creation_time.xmlschema
-      assert_select "home[lat=?][lon=?][zoom=?]", user.home_lat.to_s, user.home_lon.to_s, user.home_zoom.to_s
-    end
-  end
 end


### PR DESCRIPTION
This was originally going to involve getting rid of the to_xml for tracepoints, and move to a builder view for that, but I got bogged down in the gpx file building stuff and had to abandon that.

So this PR is some stand-alone work that was going to be in that PR but may as well be used separately.