### PR TITLE
Increase memory given to the virtualbox vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb, override|
     override.vm.box = "ubuntu/focal64"
     override.vm.synced_folder ".", "/srv/openstreetmap-website"
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]
     vb.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
   end


### PR DESCRIPTION
Fixes #2972

Like others, I found that the previous setting caused OOM failures, and 4096 was sufficient. I suspect lower values will also work, but I don't have time or inclination to bisect a smaller value.