### PR TITLE
Remove SystemTimer and use stdlib Timeout directly

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,7 +58,7 @@ Metrics/BlockNesting:
 # Offense count: 25
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 643
+  Max: 644
 
 # Offense count: 68
 # Configuration parameters: IgnoredMethods.

--- a/Gemfile
+++ b/Gemfile
@@ -88,9 +88,6 @@ gem "libxml-ruby", ">= 2.0.5", :require => "libxml"
 gem "htmlentities"
 gem "sanitize"
 
-# Load SystemTimer for implementing request timeouts
-gem "SystemTimer", ">= 1.1.3", :require => "system_timer", :platforms => :ruby_18
-
 # Load faraday for mockable HTTP client
 gem "faraday"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    SystemTimer (1.2.3)
     aasm (5.1.1)
       concurrent-ruby (~> 1.0)
     actioncable (6.0.3.4)
@@ -468,7 +467,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  SystemTimer (>= 1.1.3)
   aasm
   actionpack-page_caching (>= 1.2.0)
   active_record_union

--- a/app/controllers/api/amf_controller.rb
+++ b/app/controllers/api/amf_controller.rb
@@ -37,6 +37,8 @@
 
 module Api
   class AmfController < ApiController
+    require "timeout"
+
     include Potlatch
 
     before_action :check_api_writable
@@ -130,7 +132,7 @@ module Api
 
     def amf_handle_error_with_timeout(call, rootobj, rootid, &block)
       amf_handle_error(call, rootobj, rootid) do
-        OSM::Timer.timeout(Settings.api_timeout, OSM::APITimeoutError, &block)
+        Timeout.timeout(Settings.api_timeout, OSM::APITimeoutError, &block)
       end
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  require "timeout"
+
   include SessionPersistence
 
   protect_from_forgery :with => :exception
@@ -229,7 +231,7 @@ class ApplicationController < ActionController::Base
   ##
   # wrap an api call in a timeout
   def api_call_timeout(&block)
-    OSM::Timer.timeout(Settings.api_timeout, Timeout::Error, &block)
+    Timeout.timeout(Settings.api_timeout, Timeout::Error, &block)
   rescue Timeout::Error
     raise OSM::APITimeoutError
   end
@@ -237,7 +239,7 @@ class ApplicationController < ActionController::Base
   ##
   # wrap a web page in a timeout
   def web_timeout(&block)
-    OSM::Timer.timeout(Settings.web_timeout, Timeout::Error, &block)
+    Timeout.timeout(Settings.web_timeout, Timeout::Error, &block)
   rescue ActionView::Template::Error => e
     e = e.cause
 

--- a/lib/nominatim.rb
+++ b/lib/nominatim.rb
@@ -1,4 +1,6 @@
 module Nominatim
+  require "timeout"
+
   extend ActionView::Helpers::NumberHelper
 
   def self.describe_location(lat, lon, zoom = nil, language = nil)
@@ -9,7 +11,7 @@ module Nominatim
       url = "https://nominatim.openstreetmap.org/reverse?lat=#{lat}&lon=#{lon}&zoom=#{zoom}&accept-language=#{language}"
 
       begin
-        response = OSM::Timer.timeout(4) do
+        response = Timeout.timeout(4) do
           REXML::Document.new(Net::HTTP.get(URI.parse(url)))
         end
       rescue StandardError

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -5,13 +5,6 @@ module OSM
   require "rexml/text"
   require "xml/libxml"
 
-  if defined?(SystemTimer)
-    Timer = SystemTimer
-  else
-    require "timeout"
-    Timer = Timeout
-  end
-
   # The base class for API Errors.
   class APIError < RuntimeError
     def initialize(message = "Generic API Error")


### PR DESCRIPTION
SystemTimer was only needed on ruby 1.8, and we dropped support for that a long time ago.

https://web.archive.org/web/20110820091021/http://ph7spot.com/musings/system-timer shows the creator of SystemTimer saying not to use it on other versions of ruby.