### PR TITLE
Return the centre of the image if the bbox has no extent

### DIFF
--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -378,12 +378,17 @@ module OSM
     end
 
     # and these two will give you the right points on your image. all the constants can be reduced to speed things up. FIXME
+    # If the bbox has no extent, return the centre of the image to avoid dividing by zero.
 
     def y(lat)
+      return @height / 2 if (@by - @ty).zero?
+
       @height - ((ysheet(lat) - @ty) / (@by - @ty) * @height)
     end
 
     def x(lon)
+      return @width / 2 if (@bx - @tx).zero?
+
       ((xsheet(lon) - @tx) / (@bx - @tx) * @width)
     end
   end

--- a/test/lib/osm_test.rb
+++ b/test/lib/osm_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class OsmTest < ActiveSupport::TestCase
+  def test_mercator
+    proj = OSM::Mercator.new(0, 0, 1, 1, 100, 200)
+    assert_in_delta(50, proj.x(0.5), 0.01)
+    assert_in_delta(100, proj.y(0.5), 0.01)
+  end
+
+  def test_mercator_collapsed_bbox
+    proj = OSM::Mercator.new(0, 0, 0, 0, 100, 200)
+    assert_in_delta(50, proj.x(0), 0.01)
+    assert_in_delta(100, proj.y(0), 0.01)
+  end
+end


### PR DESCRIPTION
Fixes #3007. 

If all the provided points in the gpx file have the same lat/lon, then an image where they are all at the centre seems plausible.
