### PR TITLE
Break long URLs in blog post show

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
     tag.div(:id => "#{id}_container", :class => "richtext_container") do
       output_buffer << tag.div(:id => "#{id}_content", :class => "richtext_content") do
         output_buffer << text_area(object_name, method, options.merge("data-preview-url" => preview_url(:type => type)))
-        output_buffer << tag.div("", :id => "#{id}_preview", :class => "richtext_preview richtext")
+        output_buffer << tag.div("", :id => "#{id}_preview", :class => "richtext_preview richtext text-break")
       end
 
       output_buffer << tag.div(:id => "#{id}_help", :class => "richtext_help") do

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -6,7 +6,7 @@
     <% end %>
   </p>
 
-  <div class="richtext"><%= diary_comment.body.to_html %></div>
+  <div class="richtext text-break"><%= diary_comment.body.to_html %></div>
   <% if can? :hidecomment, DiaryEntry %>
     <span>
       <% if diary_comment.visible? %>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -15,7 +15,7 @@
 
   </div>
 
-  <div class="richtext" xml:lang="<%= diary_entry.language_code %>" lang="<%= diary_entry.language_code %>">
+  <div class="richtext text-break" xml:lang="<%= diary_entry.language_code %>" lang="<%= diary_entry.language_code %>">
     <%= diary_entry.body.to_html %>
   </div>
 

--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -14,7 +14,7 @@
   <tr class="<%= "deemphasize" unless comment.visible? %>">
     <td width="25%"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
     <td width="25%"><span title="<%= l comment.created_at, :format => :friendly %>"><%= time_ago_in_words(comment.created_at, :scope => :'datetime.distance_in_words_ago') %></span></td>
-    <td width="50%" class="richtext"><%= comment.body.to_html %></td>
+    <td width="50%" class="richtext text-break"><%= comment.body.to_html %></td>
   </tr>
   <% end -%>
 </table>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -32,7 +32,7 @@
     </div>
   </div>
 
-  <div class="richtext"><%= @message.body.to_html %></div>
+  <div class="richtext text-break"><%= @message.body.to_html %></div>
 
   <div>
     <%= link_to t(".back"), outbox_messages_path, :class => "btn btn-link" %>

--- a/app/views/redactions/show.html.erb
+++ b/app/views/redactions/show.html.erb
@@ -7,7 +7,7 @@
   <b><%= t ".user" %></b>
   <%= link_to(@redaction.user.display_name, user_path(@redaction.user)) %>
 </p>
-<div class="richtext">
+<div class="richtext text-break">
   <b><%= t ".description" %></b>
   <%= @redaction.description.to_html %>
 </div>

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -3,7 +3,7 @@
   <div id="<%= id %>_container" class="form-row richtext_container">
     <div id="<%= id %>_content" class="col-sm-8 mb-3 richtext_content">
       <%= builder.text_area(attribute, options.merge(:wrapper => false, "data-preview-url" => preview_url(:type => type))) %>
-      <div id="<%= id %>_preview" class="richtext_preview richtext"></div>
+      <div id="<%= id %>_preview" class="richtext_preview richtext text-break"></div>
     </div>
     <div id="<%= id %>_help" class="col-sm-4 richtext_help">
       <div class="card bg-light">

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -33,4 +33,4 @@
 <p><b><%= t ".status" %></b>: <%= block_status(@user_block) %></p>
 
 <p><b><%= t ".reason" %></b></p>
-<div class="richtext"><%= @user_block.reason.to_html %></div>
+<div class="richtext text-break"><%= @user_block.reason.to_html %></div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -15,7 +15,7 @@
               :date => l(user.creation_time, :format => :friendly) %>
       <% end %>
     </p>
-    <div class="richtext"><%= user.description.to_html %></div>
+    <div class="richtext text-break"><%= user.description.to_html %></div>
   </td>
   <td>
     <%= check_box_tag "user_#{user.id}", "", false, :name => "user[#{user.id}]" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -163,7 +163,7 @@
       </p>
     </div>
 
-    <div class="user-description richtext"><%= @user.description.to_html %></div>
+    <div class="user-description richtext text-break"><%= @user.description.to_html %></div>
 
   </div>
 


### PR DESCRIPTION
This uses https://getbootstrap.com/docs/4.4/utilities/text/#word-break to break long URLs on the blog post show view.

Example case: https://www.openstreetmap.org/user/tordans/diary/395215

Screenshot before:

![Bildschirmfoto 2020-12-27 um 14 16 15 Kopie](https://user-images.githubusercontent.com/111561/103171702-a0f51f80-484e-11eb-9e27-0612ebb2fe66.jpg)

Screenshot after:

![Bildschirmfoto 2020-12-27 um 14 20 40 Kopie](https://user-images.githubusercontent.com/111561/103171716-be29ee00-484e-11eb-91c7-180c3260fb5c.jpg)

An alternativ solution would be this custom CSS:

```
.diary_post .richtext {
    margin-top: $lineheight;
    // Prevent long URLs from breaking out of the container
    // https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
    overflow-wrap: break-word;
    word-wrap: break-word;
    word-break: break-word;  
  }
```