### PR TITLE
Add button styles to edit-diary-entry-button

### DIFF
--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -23,7 +23,7 @@
     <%= render :partial => "location", :object => diary_entry %>
   <% end %>
 
-  <ul class='secondary-actions clearfix'>
+  <ul class='secondary-actions clearfix pt-3'>
     <% if params[:action] == 'index' %>
       <li><%= link_to t(".comment_link"), diary_entry_path(diary_entry.user, diary_entry, :anchor => "newcomment") %></li>
       <li><%= link_to t(".reply_link"), new_message_path(diary_entry.user, :message => { :title => "Re: #{diary_entry.title}" }) %></li>
@@ -31,7 +31,7 @@
     <% end %>
 
     <% if current_user && current_user == diary_entry.user %>
-      <li><%= link_to t(".edit_link"), :action => "edit", :display_name => diary_entry.user.display_name, :id => diary_entry.id %></li>
+      <li><%= link_to t(".edit_link"), { :action => "edit", :display_name => diary_entry.user.display_name, :id => diary_entry.id }, { :class => "btn btn-primary mt-3" } %></li>
     <% end %>
 
     <% if current_user and diary_entry.user != current_user %>


### PR DESCRIPTION
This adds a button style and also a bit of spacing.

Before:

![Bildschirmfoto 2020-12-27 um 14 26 21 Kopie](https://user-images.githubusercontent.com/111561/103172182-f0891a80-4851-11eb-8cba-b22bec0b0cd6.jpg)


After:

![Bildschirmfoto 2020-12-27 um 14 26 11 Kopie](https://user-images.githubusercontent.com/111561/103172184-f7179200-4851-11eb-9401-0e736b997884.jpg)

Disclaimer: I did not run the code since my setup is not operational ATM.

The style looks different from the comments-buttons (example https://www.openstreetmap.org/user/tordans/diary/395215) but it uses the default bootstrap style so I guess we are moving everything to this style step by step, right?
