### PR TITLE
VAGRANT.md: add a note about maintenance status

### DIFF
--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -1,3 +1,7 @@
+# Currently unmaintaned 
+
+The Vagrant setup is currently unmaintaned. See https://github.com/openstreetmap/openstreetmap-website/issues/2344 for more.
+
 # Installing Vagrant
 
 On Ubuntu, it should be as simple as:


### PR DESCRIPTION
This adds a note about maintenance status by linking to https://github.com/openstreetmap/openstreetmap-website/issues/2344

I just tried to use this setup but it failed. I then searched and found the reason for it in https://github.com/openstreetmap/openstreetmap-website/issues/2344.

This link on the page would have helped, so here it is …