### PR TITLE
Diary entries #index: Migrate to bootstrap pagination

### DIFF
--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -28,21 +28,29 @@
 
   <%= render @entries %>
 
-  <div class="pagination">
-    <% if @entries.size < @page_size -%>
-      <%= t(".older_entries") %>
-    <% else -%>
-      <%= link_to t(".older_entries"), @params.merge(:page => @page + 1) %>
-    <% end -%>
+  <nav>
+    <ul class='pagination'>
+      <% if @entries.size >= @page_size -%>
+        <li class='page-item'>
+          <%= link_to t('.older_entries'), @params.merge(:page => @page + 1), :class => 'page-link' %>
+        </li>
+      <% else -%>
+        <li class='page-item disabled'>
+          <%= link_to t('.older_entries'), '#', :class => 'page-link', :tabindex => '-1', :'aria-disabled' => true %>
+        </li>
+      <% end -%>
 
-    |
-
-    <% if @page > 1 -%>
-      <%= link_to t(".newer_entries"), @params.merge(:page => @page - 1) %>
-    <% else -%>
-      <%= t(".newer_entries") %>
-    <% end -%>
-  </div>
+      <% if @page > 1 -%>
+        <li class='page-item'>
+          <%= link_to_if @page > 1, t(".newer_entries"), @params.merge(:page => @page - 1), :class => 'page-link' %>
+        </li>
+      <% else -%>
+        <li class='page-item disabled'>
+          <%= link_to t('.newer_entries'), '#', :class => 'page-link', :tabindex => '-1', :'aria-disabled' => true %>
+        </li>
+      <% end -%>
+    </ul>
+  </nav>
 <% end %>
 
 <% unless params[:friends] or params[:nearby] -%>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -5,7 +5,7 @@
     <% end %>
     <h1><%= @title %></h1>
 
-    <ul class='secondary-actions clearfix'>
+    <ul class="secondary-actions clearfix">
       <% unless params[:friends] or params[:nearby] -%>
         <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>
       <% end -%>
@@ -29,24 +29,24 @@
   <%= render @entries %>
 
   <nav>
-    <ul class='pagination'>
+    <ul class="pagination">
       <% if @entries.size >= @page_size -%>
-        <li class='page-item'>
-          <%= link_to t('.older_entries'), @params.merge(:page => @page + 1), :class => 'page-link' %>
+        <li class="page-item">
+          <%= link_to t(".older_entries"), @params.merge(:page => @page + 1), :class => "page-link" %>
         </li>
       <% else -%>
-        <li class='page-item disabled'>
-          <%= link_to t('.older_entries'), '#', :class => 'page-link', :tabindex => '-1', :'aria-disabled' => true %>
+        <li class="page-item disabled">
+          <span class="page-link"><%= t(".older_entries") %></span>
         </li>
       <% end -%>
 
       <% if @page > 1 -%>
-        <li class='page-item'>
-          <%= link_to_if @page > 1, t(".newer_entries"), @params.merge(:page => @page - 1), :class => 'page-link' %>
+        <li class="page-item">
+          <%= link_to_if @page > 1, t(".newer_entries"), @params.merge(:page => @page - 1), :class => "page-link" %>
         </li>
       <% else -%>
-        <li class='page-item disabled'>
-          <%= link_to t('.newer_entries'), '#', :class => 'page-link', :tabindex => '-1', :'aria-disabled' => true %>
+        <li class="page-item disabled">
+          <span class="page-link"><%= t(".newer_entries") %></span>
         </li>
       <% end -%>
     </ul>


### PR DESCRIPTION
Use https://getbootstrap.com/docs/4.5/components/pagination/ for the pagination.

Side note: I tried using link_to_if but this does not work well in this case since multiple changes need to happen for the disabled state.

The pagination css class cannot be removed, yet, since there is quite a bit more custom pagination in the codebase that will be a lot harder to migrate. Maybe for those, using a pagination gem that also uses bootstrap would be the better approach.

# Screenshots

Before

<img width="883" alt="Bildschirmfoto 2020-12-30 um 14 20 37" src="https://user-images.githubusercontent.com/111561/103353882-4952f000-4aaa-11eb-8132-b9ee8f01ed90.png">


After 

<img width="872" alt="Bildschirmfoto 2020-12-30 um 14 20 45" src="https://user-images.githubusercontent.com/111561/103353890-4c4de080-4aaa-11eb-94f0-48572ba0f32e.png">
