### PR TITLE
Correct defninition of `Public` trace and make the definitions clearer.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2057,10 +2057,10 @@ en:
           by dragging. Add your message, then click save, and other mappers will investigate.
   traces:
     visibility:
-      private: "Private (only shared as anonymous, unordered points)"
-      public: "Public (shown in trace list and as anonymous, unordered points)"
-      trackable: "Trackable (only shared as anonymous, ordered points with timestamps)"
-      identifiable: "Identifiable (shown in trace list and as identifiable, ordered points with timestamps)"
+      private: "Private (Anonymous Points)  -  Shared as anonymous, unordered points."
+      public: "Public (Points)  -  Shared as identifiable, unordered points. Shown in trace lists."
+      trackable: "Trackable (Anonymous)  -  Shared as anonymous, ordered points (lines) with timestamps."
+      identifiable: "Identifiable (Normal)  -  Shared as identifiable, ordered points (lines) with timestamps. Shown in trace lists."
     new:
       upload_trace: "Upload GPS Trace"
       visibility_help: "what does this mean?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2060,7 +2060,7 @@ en:
       private: "Private  -  Shared as anonymous, unordered points."
       public: "Public (Historical)  -  Shared as anonymous, unordered points. Shown and linked to account in trace lists."
       trackable: "Trackable (Preferred over private)  -  Shared as anonymous, ordered points (lines) with timestamps."
-      identifiable: "Identifiable (Reccomended)  -  Shared as identifiable, ordered points (lines) with timestamps. Shown and linked to account in trace lists."
+      identifiable: "Identifiable (Recommended)  -  Shared as identifiable, ordered points (lines) with timestamps. Shown and linked to account in trace lists."
     new:
       upload_trace: "Upload GPS Trace"
       visibility_help: "what does this mean?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2058,9 +2058,9 @@ en:
   traces:
     visibility:
       private: "Private (Anonymous Points)  -  Shared as anonymous, unordered points."
-      public: "Public (Points)  -  Shared as identifiable, unordered points. Shown in trace lists."
+      public: "Public (Anonymous Points)  -  Shared as anonymous, unordered points. Shown and linked to account in trace lists."
       trackable: "Trackable (Anonymous)  -  Shared as anonymous, ordered points (lines) with timestamps."
-      identifiable: "Identifiable (Normal)  -  Shared as identifiable, ordered points (lines) with timestamps. Shown in trace lists."
+      identifiable: "Identifiable (Normal)  -  Shared as identifiable, ordered points (lines) with timestamps. Shown and linked to account in trace lists."
     new:
       upload_trace: "Upload GPS Trace"
       visibility_help: "what does this mean?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2057,10 +2057,10 @@ en:
           by dragging. Add your message, then click save, and other mappers will investigate.
   traces:
     visibility:
-      private: "Private (Anonymous Points)  -  Shared as anonymous, unordered points."
-      public: "Public (Anonymous Points)  -  Shared as anonymous, unordered points. Shown and linked to account in trace lists."
-      trackable: "Trackable (Anonymous)  -  Shared as anonymous, ordered points (lines) with timestamps."
-      identifiable: "Identifiable (Normal)  -  Shared as identifiable, ordered points (lines) with timestamps. Shown and linked to account in trace lists."
+      private: "Private  -  Shared as anonymous, unordered points."
+      public: "Public (Historical)  -  Shared as anonymous, unordered points. Shown and linked to account in trace lists."
+      trackable: "Trackable (Preferred over private)  -  Shared as anonymous, ordered points (lines) with timestamps."
+      identifiable: "Identifiable (Reccomended)  -  Shared as identifiable, ordered points (lines) with timestamps. Shown and linked to account in trace lists."
     new:
       upload_trace: "Upload GPS Trace"
       visibility_help: "what does this mean?"


### PR DESCRIPTION
I have made the definition of trace visibilities clearer and corrected the definition of a `Public` trace.
See #2308 