### PR TITLE
Add noindex meta tag to diary index pages

### DIFF
--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :head, tag(:meta, :name => :robots, :content => :noindex) %>
 <% content_for :heading do %>
   <div <% if @user %> id="userinformation"<% end %>>
     <% if @user %>


### PR DESCRIPTION
Google (and other search engines) should follow all links on this page, but only index the actual diary_entry#show and not the #index. This meta tag tells google to do just that (https://developers.google.com/search/docs/advanced/crawling/block-indexing?hl=en).

Part of https://github.com/openstreetmap/openstreetmap-website/issues/2851