### PR TITLE
Sync more hash-url-params for iD

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -20,6 +20,8 @@ $(document).ready(function () {
       params.map = (mapParams.zoom || 17) + '/' + mapParams.lat + '/' + mapParams.lon;
     }
 
+    console.table(hashParams);
+
     if (hashParams.background) params.background = hashParams.background;
     if (hashParams.comment) params.comment = hashParams.comment;
     if (hashParams.disable_features) params.disable_features = hashParams.disable_features;
@@ -40,6 +42,8 @@ $(document).ready(function () {
     } else if (hashParams.gpx) {
       params.gpx = hashParams.gpx;
     }
+
+    console.table(params);
 
     id.attr("src", id.data("url") + "#" + Qs.stringify(params));
   } else {

--- a/app/assets/javascripts/id.js
+++ b/app/assets/javascripts/id.js
@@ -11,6 +11,8 @@ document.addEventListener("DOMContentLoaded", function () {
       "Please upgrade your browser or use Potlatch 2 to edit the map.";
     container.className = "unsupported";
   } else {
+    console.log(parent.location.hash)
+
     var id = iD.coreContext()
       .embed(true)
       .assetPath("iD/")
@@ -29,16 +31,41 @@ document.addEventListener("DOMContentLoaded", function () {
     id.map().on("move.embed", parent.$.throttle(250, function () {
       if (id.inIntro()) return;
       var zoom = ~~id.map().zoom(),
-          center = id.map().center(),
-          llz = { lon: center[0], lat: center[1], zoom: zoom };
+        center = id.map().center(),
+        hashParams = parent.OSM.params(location.hash.substring(1)),
+        llz = { lon: center[0], lat: center[1], zoom: zoom };
+
+      console.log('location.hash', location.hash)
+      console.log('parent.location.hash', parent.location.hash)
+      console.log('hashParams', parent.OSM.params(parent.location.hash.substring(1)))
+      console.log('mapParams', parent.OSM.mapParams())
 
       parent.updateLinks(llz, zoom);
 
       // Manually resolve URL to avoid iframe JS context weirdness.
       // http://bl.ocks.org/jfirebaugh/5439412
       var hash = parent.OSM.formatHash(llz);
+
+      if (hashParams.background) hash += '&background=' + hashParams.background;
+      if (hashParams.comment) hash += '&comment=' + hashParams.comment;
+      if (hashParams.disable_features) hash += '&disable_features=' + hashParams.disable_features;
+      if (hashParams.hashtags) hash += '&hashtags=' + hashParams.hashtags;
+      if (hashParams.locale) hash += '&locale=' + hashParams.locale;
+      if (hashParams.maprules) hash += '&maprules=' + hashParams.maprules;
+      if (hashParams.offset) hash += '&offset=' + hashParams.offset;
+      if (hashParams.offset) hash += '&offset=' + hashParams.offset;
+      if (hashParams.photo) hash += '&photo=' + hashParams.photo;
+      if (hashParams.photo_dates) hash += '&photo_dates=' + hashParams.photo_dates;
+      if (hashParams.photo_overlay) hash += '&photo_overlay=' + hashParams.photo_overlay;
+      if (hashParams.photo_username) hash += '&photo_username=' + hashParams.photo_username;
+      if (hashParams.presets) hash += '&presets=' + hashParams.presets;
+      if (hashParams.source) hash += '&source=' + hashParams.source;
+      if (hashParams.walkthrough) hash += '&walkthrough=' + hashParams.walkthrough;
+
       if (hash !== parent.location.hash) {
         parent.location.replace(parent.location.href.replace(/(#.*|$)/, hash));
+        console.log(parent.location);
+        console.log(hash);
       }
     }));
 


### PR DESCRIPTION
This commit includes a few console.logs since it is still WIP.

It solved part of the issue described in https://github.com/openstreetmap/openstreetmap-website/issues/3031:

Whenever I pan the map in iD, the osm-hash-params get updated with the current iD-in-iframe-configuration.
However, click actions in the iD iframe (eg changing the map layer) don't trigger this update until I also pan the map afterwards.

This is all I could contribute with my limited knowledge of the code. I am pretty sure there is a more elegant solution to this. However, I also think this would already be a bit better than what we have right now …