### PR TITLE
Traces#index: Introduce tab navigation, fix tag-filter

### DIFF
--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -67,7 +67,6 @@ class TracesController < ApplicationController
 
     # final helper vars for view
     @target_user = target_user
-    @display_name = target_user.display_name if target_user
   end
 
   def mine

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -5,7 +5,7 @@
     <%= render :partial => "layouts/flash", :locals => { :flash => flash } %>
     <% if content_for? :heading %>
       <div class="content-heading">
-        <div class="content-inner">
+        <div class="content-inner <%= yield :heading_class %>">
           <%= yield :heading %>
         </div>
       </div>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -1,25 +1,61 @@
+<% content_for :heading_class, 'pb-0' %>
 <% content_for :heading do %>
   <h1><%= @title %></h1>
-  <ul class='secondary-actions clearfix'>
-    <li><%= t(".description") %></li>
-    <li><%= rss_link_to :action => "georss", :display_name => @display_name, :tag => @tag %></li>
-    <li><%= link_to t(".upload_trace"), new_trace_path %></li>
-    <% if @tag %>
-      <li><%= link_to t(".see_all_traces"), :controller => "traces", :action => "index", :display_name => nil, :tag => nil, :page => nil %></li>
-      <li><%= link_to t(".see_my_traces"), :action => "mine", :tag => nil, :page => nil %></li>
-    <% else %>
-      <% if @display_name %>
-        <li><%= link_to t(".see_all_traces"), :controller => "traces", :action => "index", :display_name => nil, :tag => nil, :page => nil %></li>
-      <% end %>
-      <% if current_user && current_user != @target_user %>
-        <li><%= link_to t(".see_my_traces"), :action => "mine", :tag => nil, :page => nil %></li>
-      <% end %>
+  <p>
+    <%= t(".description") %>
+    <% if params[:tag] %>
+      <%= link_to t(".remove_tag_filter", :tag => params[:tag]), {:controller => "traces", :action => "index", :display_name => nil, :tag => nil, :page => nil}, {:class => "border-left ml-2 pl-2"} %>
     <% end %>
+  </p>
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <% if @target_user.blank? %>
+        <!-- public traces -->
+        <% if current_user %>
+          <li class="nav-item">
+            <%= link_to t(".see_my_traces"), {:action => "mine", :page => nil}, {:class => "nav-link"} %>
+          </li>
+        <% end %>
+        <li class="nav-item">
+          <%= link_to t(".see_all_traces"), {:controller => "traces", :action => "index", :display_name => nil, :page => nil}, {:class => "nav-link active"} %>
+        </li>
+      <% elsif current_user && current_user == @target_user %>
+        <!-- my traces -->
+        <li class="nav-item">
+          <%= link_to t(".see_my_traces"), {:action => "mine", :page => nil}, {:class => "nav-link active"} %>
+        </li>
+        <li class="nav-item">
+          <%= link_to t(".see_all_traces"), {:controller => "traces", :action => "index", :display_name => nil, :page => nil}, {:class => "nav-link"} %>
+        </li>
+      <% else %>
+        <!-- public_traces_from @target_user -->
+        <li class="nav-item">
+          <%= link_to t(".see_public_traces_from", :user => @target_user&.display_name), {:action => "mine", :page => nil}, {:class => "nav-link active"} %>
+        </li>
+        <% if current_user && current_user != @target_user %>
+          <li class="nav-item">
+            <%= link_to t(".see_my_traces"), {:action => "mine", :page => nil}, {:class => "nav-link"} %>
+          </li>
+        <% end %>
+        <li class="nav-item">
+          <%= link_to t(".see_all_traces"), {:controller => "traces", :action => "index", :display_name => nil, :page => nil}, {:class => "nav-link"} %>
+        </li>
+      <% end %>
+    </li>
+
+    <li class="nav-item ml-auto pt-1">
+      <%= link_to({:action => :georss, :display_name => @target_user&.display_name, :tag => params[:tag]}, {:class => "btn btn-secondary btn-sm px-1 py-0"}) do %>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16">
+          <path d="M5.5 12a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm-3-8.5a1 1 0 0 1 1-1c5.523 0 10 4.477 10 10a1 1 0 1 1-2 0 8 8 0 0 0-8-8 1 1 0 0 1-1-1zm0 4a1 1 0 0 1 1-1 6 6 0 0 1 6 6 1 1 0 1 1-2 0 4 4 0 0 0-4-4 1 1 0 0 1-1-1z"/>
+        </svg>
+      <% end -%>
+      <%= link_to t(".upload_trace"), new_trace_path, :class => "btn btn-secondary btn-sm px-1 py-0" %>
+    </li>
   </ul>
 <% end %>
 
 <% content_for :auto_discovery_link_tag do %>
-<%= auto_discovery_link_tag :rss, :action => "georss", :display_name => @display_name, :tag => @tag %>
+  <%= auto_discovery_link_tag :rss, :action => "georss", :display_name => @target_user&.display_name, :tag => params[:tag] %>
 <% end %>
 
 <% if @traces.size > 0 %>


### PR DESCRIPTION
- introduce bootstrap tabs to switch the views
- introduce `content_for :heading_class` to remove the padding below the bootstrap tabs
- update the rss-image to use a svg, adopted from https://icons.getbootstrap.com/icons/rss/ (without the outer border)
- move rss- and new-button away from the view-switching actions
- the `@tag` logic was broken. introduce new link to remove the tag-filter; the tabs keep the filter once given
- use `&.` syntax nil-safety so we can remove `@display_name`

I will wait for a first review of this.

Still to do:

- [ ] Double Check the usage of `params[:tag]` in the views. Did I introduce a security problem here? If so, what is the smartest way to solve it? – Will need to look into this; but maybe someone already has the answer …
- [ ] Check specs
- [ ] Add translations for the two new strings (hint about how to this is welcome – just add it to en.yml and the other translations will come automatically?)

The remove-tag-feature is not ideal IMO, but on the other hand it was broken ATM and nobody noticed so it was probably not that important and IMO not worth adding even more complexity.

## Screenshots
**gps – logged-in – someone-else**
<img width="1054" alt="gps--logged-in--someone-else" src="https://user-images.githubusercontent.com/111561/103467062-4cb8d680-4d4b-11eb-8e67-bd607fa40cf3.png">

**gps – logged-in – all**
<img width="1034" alt="gps--logged-in--all" src="https://user-images.githubusercontent.com/111561/103467063-4d516d00-4d4b-11eb-91f5-432cf3155727.png">

**gps – logged-in – my**
<img width="1038" alt="gps--logged-in--my" src="https://user-images.githubusercontent.com/111561/103467064-4dea0380-4d4b-11eb-9610-520bec86bdf9.png">

**gps – logged-out – someone-else**
<img width="1043" alt="gps--logged-out--someone-else" src="https://user-images.githubusercontent.com/111561/103467054-488cb900-4d4b-11eb-8ca7-afd9ef0807b8.png">

**gps – logged-out – all**
<img width="1058" alt="gps--logged-out--all" src="https://user-images.githubusercontent.com/111561/103467055-4a567c80-4d4b-11eb-8144-95d4947cec36.png">

**gps – logged-in – someone-else – tag filter active**
<img width="1044" alt="gps--logged-in--someone-else--tag" src="https://user-images.githubusercontent.com/111561/103467058-4b87a980-4d4b-11eb-8fe6-95940dacfd49.png">

**gps – logged-in – all – tag filter active**
<img width="1045" alt="gps--logged-in--all--tag" src="https://user-images.githubusercontent.com/111561/103467059-4c204000-4d4b-11eb-946d-b97d3a0ab657.png">

**gps – logged-in – my – tag filter active**
<img width="1039" alt="gps--logged-in--my--tag" src="https://user-images.githubusercontent.com/111561/103467060-4cb8d680-4d4b-11eb-9381-71404f215a84.png">

**gps – logged-out – someone-else – tag filter active**
<img width="1065" alt="gps--logged-out--someone-else--tag" src="https://user-images.githubusercontent.com/111561/103467057-4aef1300-4d4b-11eb-8183-cf699a6716c4.png">

**gps – logged-out – all – tag filter active**
<img width="1045" alt="gps--logged-out--all--tag" src="https://user-images.githubusercontent.com/111561/103467056-4a567c80-4d4b-11eb-84ed-038a4b7ba93c.png">
