### PR TITLE
Traces: Migrate pagination to bootstrap

### DIFF
--- a/app/views/traces/_trace_paging_nav.html.erb
+++ b/app/views/traces/_trace_paging_nav.html.erb
@@ -1,18 +1,27 @@
-<p>
+<nav>
+  <ul class="pagination my-3 py-0">
+    <% if page > 1 %>
+      <li class="page-item">
+        <%= link_to t(".newer"), params.merge(:page => page - 1), :class => "page-link" %>
+      </li>
+    <% else %>
+      <li class="page-item disabled">
+        <span class="page-link"><%= t(".newer") %></span>
+      </li>
+    <% end %>
 
-<% if @traces.size > 1 %>
-<% if @page > 1 %>
-<%= link_to t(".newer"), @params.merge(:page => @page - 1) %>
-<% else %>
-<%= t(".newer") %>
-<% end %>
+    <li class="page-item disabled">
+      <span class="page-link"><%= t(".showing_page", :page => page) %></span>
+    </li>
 
-| <%= t(".showing_page", :page => @page) %> |
-
-<% if @traces.size < @page_size %>
-<%= t(".older") %>
-<% else %>
-<%= link_to t(".older"), @params.merge(:page => @page + 1) %>
-<% end %>
-<% end %>
-</p>
+    <% if traces.size < page_size %>
+      <li class="page-item disabled">
+        <span class="page-link"><%= t(".older") %></span>
+      </li>
+    <% else %>
+      <li class="page-item">
+        <%= link_to t(".older"), params.merge(:page => page + 1), :class => "page-link" %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -23,15 +23,15 @@
 <% end %>
 
 <% if @traces.size > 0 %>
-  <%= render :partial => "trace_paging_nav" %>
+  <%= render "trace_paging_nav", :page => @page, :page_size => @page_size, :traces => @traces, :params => @params %>
 
-  <table id="trace_list" class="table table-borderless table-striped">
+  <table id="trace_list" class="table table-borderless table-striped mb-0">
     <tbody>
       <%= render @traces unless @traces.nil? %>
     </tbody>
   </table>
 
-  <%= render :partial => "trace_paging_nav" %>
+  <%= render "trace_paging_nav", :page => @page, :page_size => @page_size, :traces => @traces, :params => @params %>
 <% else %>
   <h4><%= t ".empty_html", :upload_link => new_trace_path %></h4>
 <% end %>


### PR DESCRIPTION
- Change pagination to use bootstrap default styles
- … but with empty span-tags instead of non-active a-tags
- refactor partial to not use @-variables but get the variables via
the render-call, simplify render-call-syntax
- remove the additional `if @traces.size > 1` inside the pagination
partial since that caused the pagination to disappear on the last page.
The partial will be visible with inactive links.
- Add bootstrap spacer-classes to overwrite commons-css so removing. Eg.
commons also has a pagination class same as bootstrap.
