### PR TITLE
Traces: Migrate list to bootstrap

### DIFF
--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -1,35 +1,47 @@
-<tr>
-  <td>
-    <% if Settings.status != "gpx_offline" %>
+<li class="media mb-1 p-2 <%= cycle('', ' bg-light') %>">
+  <% if Settings.status != "gpx_offline" %>
+    <% if trace.inserted %>
+      <a href="<%= url_for :controller => "traces", :action => "show", :id => trace.id, :display_name => trace.user.display_name %>">
+        <img src="<%= url_for :controller => "traces", :action => "icon", :id => trace.id, :display_name => trace.user.display_name %>" alt="" class="img-thumbnail mr-3" />
+      </a>
+    <% else %>
+      <div style="width: 60px; height: 60px" class="img-thumbnail bg-white mr-3"></div>
+    <% end %>
+  <% end %>
+
+  <div class="media-body">
+    <% if trace.inserted %>
+      <p class="float-right">
+        <%= link_to t(".view_map"), { :controller => "site", :action => "index", :mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}" }, { :class => "mr-2 border-right pr-2" } %>
+        <%= link_to t(".edit_map"), { :controller => "site", :action => "edit", :gpx => trace.id } %>
+      </p>
+    <% end %>
+
+    <p class="mb-0">
+      <strong class="mr-2">
+        <%= link_to trace.name, :controller => "traces", :action => "show", :display_name => trace.user.display_name, :id => trace.id %>
+      </strong>
       <% if trace.inserted %>
-        <a href="<%= url_for :controller => "traces", :action => "show", :id => trace.id, :display_name => trace.user.display_name %>"><img src="<%= url_for :controller => "traces", :action => "icon", :id => trace.id, :display_name => trace.user.display_name %>" border="0" alt="" /></a>
+        <%= t ".count_points", :count => trace.size %>
       <% else %>
-        <span class="text-danger"><%= t ".pending" %></span>
+        <span class="text-warning"><%= t ".pending" %></span>
       <% end %>
-    <% end %>
-  </td>
-  <td><%= link_to trace.name, :controller => "traces", :action => "show", :display_name => trace.user.display_name, :id => trace.id %>
-    <span class="text-muted" title="<%= trace.timestamp %>"> ...
-      <% if trace.inserted %>
-        (<%= t ".count_points", :count => trace.size %>)
-      <% end %>
-      ... <%= time_ago_in_words(trace.timestamp, :scope => :'datetime.distance_in_words_ago') %></span>
-      <%= link_to_if trace.inserted?, t(".map"), { :controller => "site", :action => "index", :mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}" }, { :title => t(".view_map") } %> /
-      <%= link_to t(".edit"), { :controller => "site", :action => "edit", :gpx => trace.id }, { :title => t(".edit_map") } %>
-
       <% badge_class = case trace.visibility
-                       when "public", "identifiable" then "success"
-                       else "danger"
-                       end %>
-      <span class="badge badge-<%= badge_class %> text-white"><%= t(".#{trace.visibility}") %></span>
+                        when "public", "identifiable" then "success"
+                        else "danger"
+                        end %>
+      <span class="ml-2 badge badge-<%= badge_class %> text-white"><%= t(".#{trace.visibility}") %></span>
+    </p>
 
-      <br />
-      <%= trace.description %>
-    <br />
-    <%= t ".by" %> <%= link_to trace.user.display_name, user_path(trace.user) %>
-    <% if !trace.tags.empty? %>
-      <%= t ".in" %>
-      <%= safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>
-    <% end %>
-  </td>
-</tr>
+    <p class="mb-0 text-muted" title="<%= trace.timestamp %>">
+      <%= time_ago_in_words(trace.timestamp, :scope => :'datetime.distance_in_words_ago') %>
+      <%= t ".by" %> <%= link_to trace.user.display_name, user_path(trace.user) %>
+      <% if trace.tags.present? %>
+        <%= t ".in" %>
+        <%= safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>
+      <% end %>
+    </p>
+
+    <p class="font-italic my-1"><%= trace.description %></p>
+  </div>
+</li>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -25,11 +25,9 @@
 <% if @traces.size > 0 %>
   <%= render :partial => "trace_paging_nav" %>
 
-  <table id="trace_list" class="table table-borderless table-striped">
-    <tbody>
-      <%= render @traces unless @traces.nil? %>
-    </tbody>
-  </table>
+  <ul id="trace_list" class="list-unstyled">
+    <%= render @traces %>
+  </ul>
 
   <%= render :partial => "trace_paging_nav" %>
 <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2117,7 +2117,6 @@ en:
       more: "more"
       trace_details: "View Trace Details"
       view_map: "View Map"
-      edit: "edit"
       edit_map: "Edit Map"
       public: "PUBLIC"
       identifiable: "IDENTIFIABLE"
@@ -2125,7 +2124,6 @@ en:
       trackable: "TRACKABLE"
       by: "by"
       in: "in"
-      map: "map"
     index:
       public_traces: "Public GPS traces"
       my_traces: "My GPS traces"


### PR DESCRIPTION
Changes:

- switch from tables to bootstrap media since it makes the spacing around the image easier and also its not a table in a semantic way
- remove the unless in #index since it is covered by the if-size>0 above

refactor the list
- reorder elements
- make the pending-image a blank square and move the pending notice to the first line
- move the actions to the right and use the previous title-text as link-text since those explain a lot better what the links actually do (I thought "edit" would edit the trace-db-entry, not open the map-editor)
- remove the two translations that are not used anymore from en.yml
- use if-present for tags-link-list since its easier to read
- use the same styling for the trace description as on the changeset description (italic text)

I will wait for a first review of this.

Still to do:

- [ ]  Check specs
- [ ]  Add translations for the two new strings (hint about how to this is welcome)

### Screenshots

BEFORE
<img width="875" alt="traces-before" src="https://user-images.githubusercontent.com/111561/103489011-7805f900-4e11-11eb-8d5f-7f8e745658a0.png">

AFTER 

<img width="882" alt="traces-after" src="https://user-images.githubusercontent.com/111561/103489008-776d6280-4e11-11eb-8f76-daef52c9d348.png">

AFTER / PENDING
<img width="1133" alt="traces-pending" src="https://user-images.githubusercontent.com/111561/103489006-75a39f00-4e11-11eb-880f-cf0732160261.png">
