### PR TITLE
Fix a small typo and tests that depend on it.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1281,7 +1281,7 @@ en:
         open: Open
         resolved: Resolved
     update:
-      new_report: Your report has been registered sucessfully
+      new_report: Your report has been registered successfully
       successful_update: Your report has been updated successfully
       provide_details: Please provide the required details
     show:
@@ -1352,7 +1352,7 @@ en:
           abusive_label: This note is abusive
           other_label: Other
     create:
-      successful_report: Your report has been registered sucessfully
+      successful_report: Your report has been registered successfully
       provide_details: Please provide the required details
   layouts:
     project_name:

--- a/test/system/report_diary_comment_test.rb
+++ b/test/system/report_diary_comment_test.rb
@@ -29,7 +29,7 @@ class ReportDiaryCommentTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered sucessfully"
+    assert page.has_content? "Your report has been registered successfully"
 
     assert_equal @comment, Issue.last.reportable
     assert_equal "administrator", Issue.last.assigned_role

--- a/test/system/report_diary_entry_test.rb
+++ b/test/system/report_diary_entry_test.rb
@@ -28,7 +28,7 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered sucessfully"
+    assert page.has_content? "Your report has been registered successfully"
 
     assert_equal @diary_entry, Issue.last.reportable
     assert_equal "administrator", Issue.last.assigned_role

--- a/test/system/report_note_test.rb
+++ b/test/system/report_note_test.rb
@@ -24,7 +24,7 @@ class ReportNoteTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered sucessfully"
+    assert page.has_content? "Your report has been registered successfully"
 
     assert_equal note, Issue.last.reportable
     assert_equal "moderator", Issue.last.assigned_role
@@ -45,7 +45,7 @@ class ReportNoteTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered sucessfully"
+    assert page.has_content? "Your report has been registered successfully"
 
     assert_equal note, Issue.last.reportable
     assert_equal "moderator", Issue.last.assigned_role

--- a/test/system/report_user_test.rb
+++ b/test/system/report_user_test.rb
@@ -24,7 +24,7 @@ class ReportUserTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered sucessfully"
+    assert page.has_content? "Your report has been registered successfully"
 
     assert_equal user, Issue.last.reportable
     assert_equal "moderator", Issue.last.assigned_role
@@ -45,7 +45,7 @@ class ReportUserTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered sucessfully"
+    assert page.has_content? "Your report has been registered successfully"
 
     assert_equal user, Issue.last.reportable
     assert_equal "moderator", Issue.last.assigned_role
@@ -62,7 +62,7 @@ class ReportUserTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered sucessfully"
+    assert page.has_content? "Your report has been registered successfully"
 
     assert_equal user, Issue.last.reportable
     assert_equal "administrator", Issue.last.assigned_role


### PR DESCRIPTION
"successfully" was accidentally written with a single "c" on report creation, and then a couple tests expect that misspelled message.