### PR TITLE
More bootstrap forms

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1282,11 +1282,6 @@ tr.turn:hover {
     display: none;
     margin-bottom: $lineheight;
   }
-  #newcomment {
-    border-top: 1px solid $grey;
-    padding-top: $lineheight;
-    margin-top: $lineheight/2;
-  }
   .comments {
     max-width: 740px;
   }
@@ -1314,13 +1309,6 @@ tr.turn:hover {
 
 .diary_entries-show img.user_thumbnail {
   float: left;
-}
-
-
-.diary-subscribe-buttons {
-  position: relative;
-  top: -30px;
-  left: 130px;
 }
 
 /* Rules for the log in page */

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -13,20 +13,20 @@
 <%= render :partial => "diary_comment", :collection => @comments %>
 </div>
 
-<div class="standard-form">
+<hr>
+
+<div>
   <% if current_user %>
     <h3 id="newcomment"><%= t ".leave_a_comment" %></h3>
 
-    <%= error_messages_for "diary_comment" %>
-
-    <%= form_for @entry.comments.new, :url => { :action => "comment" } do |f| %>
-      <%= richtext_area :diary_comment, :body, :cols => 80, :rows => 15 %>
-      <%= f.submit %>
-    <% end %>
-    <% if @entry.subscribers.exists?(current_user.id) %>
-      <div class="diary-subscribe-buttons"><%= link_to t("javascripts.changesets.show.unsubscribe"), diary_entry_unsubscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => :button %></div>
-    <% else %>
-      <div class="diary-subscribe-buttons"><%= link_to t("javascripts.changesets.show.subscribe"), diary_entry_subscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => :button %></div>
+    <%= bootstrap_form_for @entry.comments.new, :url => { :action => "comment" } do |f| %>
+      <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
+      <%= f.primary %>
+      <% if @entry.subscribers.exists?(current_user.id) %>
+        <%= link_to t("javascripts.changesets.show.unsubscribe"), diary_entry_unsubscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => "btn btn-light" %>
+      <% else %>
+        <%= link_to t("javascripts.changesets.show.subscribe"), diary_entry_subscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => "btn btn-light" %>
+      <% end %>
     <% end %>
   <% else %>
     <h3 id="newcomment"><%= t(".login_to_leave_a_comment_html", :login_link => link_to(t(".login"), :controller => "users", :action => "login", :referer => request.fullpath)) %></h3>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -2,22 +2,11 @@
   <h2><%= t(".send_message_to_html", :name => link_to(@message.recipient.display_name, user_path(@message.recipient))) %></h2>
 <% end %>
 
-<%= error_messages_for "message" %>
-
-<%= form_for @message, :html => { :class => "standard-form" } do |f| %>
+<%= bootstrap_form_for @message do |f| %>
   <%= hidden_field_tag :display_name, @message.recipient.display_name %>
-  <fieldset>
-    <div class='standard-form-row'>
-      <label class="standard-label" for="message_title"><%= t ".subject" %></label>
-      <%= f.text_field :title, :size => 60, :class => "richtext_title" %>
-    </div>
-    <div class='standard-form-row'>
-      <label class="standard-label" for="message_body"><%= t ".body" %></label>
-      <%= richtext_area :message, :body, :cols => 80, :rows => 20 %>
-    </div>
-    <div class='buttons'>
-      <%= f.submit %>
-      <%= link_to t(".back_to_inbox"), inbox_messages_path, :class => "deemphasize button" %>
-    </div>
-  </fieldset>
+  <%= f.text_field :title %>
+  <%= f.richtext_field :body, :cols => 80, :rows => 20 %>
+
+  <%= f.primary %>
+  <%= link_to t(".back_to_inbox"), inbox_messages_path, :class => "btn btn-link" %>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -15,72 +15,31 @@
   </div>
 
   <div class="col-sm">
-    <%= form_for current_user, :url => { :action => "create" }, :html => { :class => "standard-form" } do |f| %>
+    <%= bootstrap_form_for current_user, :url => { :action => "create" } do |f| %>
       <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
 
-      <fieldset>
-        <div class="standard-form-row">
-          <label for="email" class="standard-label">
-            <%= t ".email address" %>
-          </label>
-          <%= f.email_field(:email, :tabindex => 1) %>
-          <%= f.error_message_on(:email) %>
+      <%= f.email_field :email, :label => t(".email address"), :tabindex => 1 %>
+      <%= f.email_field :email_confirmation, :label => t(".confirm email address"), :help => t(".not_displayed_publicly_html"), :tabindex => 2 %>
+
+      <%= f.text_field :display_name, :label => t(".display name"), :help => t(".display name description"), :tabindex => 3 %>
+
+      <fieldset class="form-group" id="auth_field">
+        <label for="user_auth_provider"><%= t(".external auth") %></label>
+        <div class="form-row">
+          <%= f.select(:auth_provider, Auth.providers, :default => "", :hide_label => "true", :wrapper => { :class => "col-auto mb-0" }, :tabindex => 4) %>
+          <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }, :tabindex => 5) %>
         </div>
-        <div class="standard-form-row">
-          <label for="email_confirmation" class="standard-label">
-            <%= t ".confirm email address" %>
-          </label>
-          <%= f.email_field(:email_confirmation, :tabindex => 2) %>
-          <%= f.error_message_on(:email_confirmation) %>
-        </div>
-        <span class="form-help deemphasize"><%= t(".not_displayed_publicly_html") %></span>
+        <small class="form-text text-muted"><%= t ".auth no password" %></small>
       </fieldset>
 
-      <fieldset>
-        <div class="standard-form-row">
-          <label for="display_name" class="standard-label">
-            <%= t ".display name" %>
-          </label>
-          <%= f.text_field(:display_name, :tabindex => 3) %>
-          <%= f.error_message_on(:display_name) %>
-        </div>
-        <span class="form-help deemphasize"><%= t ".display name description" %></span>
-      </fieldset>
+      <%= f.password_field :pass_crypt, :tabindex => 6 %>
+      <%= f.password_field :pass_crypt_confirmation, :tabindex => 7 %>
 
-      <fieldset class="form-divider" id="auth_field">
-        <div class="standard-form-row">
-          <label for="openid_url" class="standard-label">
-            <%= t ".external auth" %>
-          </label>
-          <%= f.select(:auth_provider, Auth.providers, :default => "", :tabindex => 4) %>
-          <%= f.text_field(:auth_uid, :tabindex => 5) %>
-          <%= f.error_message_on(:auth_uid) %>
-        </div>
-        <span class="form-help deemphasize"><%= t ".auth no password" %></span>
-      </fieldset>
-
-      <fieldset>
-        <div class="standard-form-row">
-          <label for='user[pass_crypt]' class="standard-label">
-            <%= t ".password" %>
-          </label>
-          <%= f.password_field(:pass_crypt, :tabindex => 6) %>
-          <%= f.error_message_on(:pass_crypt) %>
-        </div>
-        <div class="standard-form-row">
-          <label class="standard-label">
-            <%= t ".confirm password" %>
-          </label>
-          <%= f.password_field(:pass_crypt_confirmation, :tabindex => 7) %>
-          <%= f.error_message_on(:pass_crypt_confirmation) %>
-        </div>
-      </fieldset>
-
-      <div id="auth_prompt" class="standard-form-row">
-        <%= link_to t(".use external auth"), "#", :id => "auth_enable" %>
+      <div id="auth_prompt">
+        <p><%= link_to t(".use external auth"), "#", :id => "auth_enable" %></p>
       </div>
 
-      <%= submit_tag t(".continue"), :tabindex => 8 %>
+      <%= f.primary t(".continue"), :tabindex => 8 %>
     <% end %>
   </div>
 </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -233,7 +233,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_email"
+    assert_select "form > div.form-group > input.is-invalid#user_email"
   end
 
   def test_save_duplicate_email
@@ -262,7 +262,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_email"
+    assert_select "form > div.form-group > input.is-invalid#user_email"
   end
 
   def test_save_duplicate_email_uppercase
@@ -291,7 +291,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_email"
+    assert_select "form > div.form-group > input.is-invalid#user_email"
   end
 
   def test_save_duplicate_name
@@ -320,7 +320,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_display_name"
+    assert_select "form > div.form-group > input.is-invalid#user_display_name"
   end
 
   def test_save_duplicate_name_uppercase
@@ -349,7 +349,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_template "new"
-    assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_display_name"
+    assert_select "form > div.form-group > input.is-invalid#user_display_name"
   end
 
   def test_save_blocked_domain

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -51,7 +51,8 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_template "users/new"
       assert_equal locale.to_s, response.headers["Content-Language"]
-      assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_email"
+      assert_select "form"
+      assert_select "form > div.form-group > input.is-invalid#user_email"
       assert_no_missing_translations
     end
   end
@@ -75,7 +76,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
       end
       assert_response :success
       assert_template "users/new"
-      assert_select "form > fieldset > div.standard-form-row > input.field_with_errors#user_display_name"
+      assert_select "form > div.form-group > input.is-invalid#user_display_name"
       assert_no_missing_translations
     end
   end


### PR DESCRIPTION
This PR converts the message, user registration, and diary comment forms to use bootstrap.

The user registration third-party-auth section was a little fiddly, due to the appearing and disappearing form fields, but I wanted to keep the current behaviour for now.