### PR TITLE
Avoid recommending installation of the Ubuntu bundler package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ These can be installed on Ubuntu 20.04 or later with:
 
 ```
 sudo apt-get update
-sudo apt-get install ruby2.7 libruby2.7 ruby2.7-dev bundler \
+sudo apt-get install ruby2.7 libruby2.7 ruby2.7-dev \
                      libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
                      apache2 apache2-dev build-essential git-core firefox-geckodriver \
                      postgresql postgresql-contrib libpq-dev libsasl2-dev \


### PR DESCRIPTION
Due to a problem with namespacing and vendoring, the Ubuntu package leads to namespace conflicts with Thor 1+

Fixes #3013