### PR TITLE
Move banner close icon so we can see it

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -394,14 +394,14 @@ body.compact-nav {
       position: absolute;
       top: 0;
       right: 0;
-      width: 60px;
-      height: 60px;
+      width: 26px;
+      height: 26px;
 
       .icon.close {
         pointer-events: none;
         position: absolute;
-        right: 20px;
-        top: 20px;
+        right: 3px;
+        top: 3px;
       }
     }
 


### PR DESCRIPTION
We sometimes have banner graphics (like the current "community_survey" image) which uses space quite far into the top right. This can make the close "x" icon hard to see. Move it towards the corner where it is less likely to overlap with banner graphic text.

**Before and after:**

<img width="802" alt="Screenshot 2021-01-24 at 00 58 53" src="https://user-images.githubusercontent.com/227525/105618512-eec65e80-5ddf-11eb-81a3-006635ec2998.png">
