### PR TITLE
Update to Omniauth 2.x

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ require:
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Layout/LineLength:
-  Max: 248
+  Max: 254
 
 # Offense count: 36
 # Configuration parameters: AllowSafeAssignment.

--- a/Gemfile
+++ b/Gemfile
@@ -61,12 +61,13 @@ gem "quad_tile", "~> 1.0.1"
 gem "rack-uri_sanitizer"
 
 # Omniauth for authentication
-gem "omniauth", "~> 1.9.1"
+gem "omniauth", "~> 2.0.2"
 gem "omniauth-facebook"
 gem "omniauth-github"
 gem "omniauth-google-oauth2", ">= 0.6.0"
 gem "omniauth-mediawiki", ">= 0.0.4"
 gem "omniauth-openid"
+gem "omniauth-rails_csrf_protection", "~> 1.0"
 gem "omniauth-windowslive"
 
 # Markdown formatting support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,14 +287,15 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.9.1)
+    omniauth (2.0.2)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
+      rack-protection
     omniauth-facebook (8.0.0)
       omniauth-oauth2 (~> 1.2)
-    omniauth-github (1.4.0)
-      omniauth (~> 1.5)
-      omniauth-oauth2 (>= 1.4.0, < 2.0)
+    omniauth-github (2.0.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.7.1)
     omniauth-google-oauth2 (0.8.1)
       jwt (>= 2.0)
       oauth2 (~> 1.1)
@@ -312,6 +313,9 @@ GEM
     omniauth-openid (2.0.1)
       omniauth (>= 1.0, < 3.0)
       rack-openid (~> 1.4.0)
+    omniauth-rails_csrf_protection (1.0.0)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     omniauth-windowslive (0.0.12)
       multi_json (~> 1.12)
       omniauth-oauth2 (~> 1.4)
@@ -334,6 +338,8 @@ GEM
     rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack-uri_sanitizer (0.0.2)
@@ -510,12 +516,13 @@ DEPENDENCIES
   mini_magick
   minitest (~> 5.1)
   oauth-plugin (>= 0.5.1)
-  omniauth (~> 1.9.1)
+  omniauth (~> 2.0.2)
   omniauth-facebook
   omniauth-github
   omniauth-google-oauth2 (>= 0.6.0)
   omniauth-mediawiki (>= 0.0.4)
   omniauth-openid
+  omniauth-rails_csrf_protection (~> 1.0)
   omniauth-windowslive
   openstreetmap-deadlock_retry (>= 1.3.0)
   pg

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -260,7 +260,7 @@ class UsersController < ApplicationController
       elsif current_user.auth_provider.present?
         # Verify external authenticator before moving on
         session[:new_user] = current_user
-        redirect_to auth_url(current_user.auth_provider, current_user.auth_uid)
+        redirect_to auth_url(current_user.auth_provider, current_user.auth_uid), :status => :temporary_redirect
       else
         # Save the user record
         session[:new_user] = current_user

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -60,6 +60,7 @@ module UserHelper
     link_to(
       image_tag("#{name}.svg", :alt => t("users.login.auth_providers.#{name}.alt"), :class => "rounded-lg"),
       auth_path(options.merge(:provider => provider)),
+      :method => :post,
       :class => "auth_button",
       :title => t("users.login.auth_providers.#{name}.title")
     )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,7 +173,7 @@ OpenStreetMap::Application.routes.draw do
   # omniauth
   get "/auth/failure" => "users#auth_failure"
   match "/auth/:provider/callback" => "users#auth_success", :via => [:get, :post], :as => :auth_success
-  match "/auth/:provider" => "users#auth", :via => [:get, :post], :as => :auth
+  post "/auth/:provider" => "users#auth", :as => :auth
 
   # permalink
   get "/go/:code" => "site#permalink", :code => /[a-zA-Z0-9_@~]+[=-]*/, :as => :permalink

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -73,10 +73,10 @@ class UserHelperTest < ActionView::TestCase
 
   def test_auth_button
     button = auth_button("google", "google")
-    assert_equal("<a class=\"auth_button\" title=\"Login with Google\" href=\"/auth/google\"><img alt=\"Login with a Google OpenID\" class=\"rounded-lg\" src=\"/images/google.svg\" /></a>", button)
+    assert_equal("<a class=\"auth_button\" title=\"Login with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\"><img alt=\"Login with a Google OpenID\" class=\"rounded-lg\" src=\"/images/google.svg\" /></a>", button)
 
     button = auth_button("yahoo", "openid", :openid_url => "yahoo.com")
-    assert_equal("<a class=\"auth_button\" title=\"Login with Yahoo\" href=\"/auth/openid?openid_url=yahoo\.com\"><img alt=\"Login with a Yahoo OpenID\" class=\"rounded-lg\" src=\"/images/yahoo.svg\" /></a>", button)
+    assert_equal("<a class=\"auth_button\" title=\"Login with Yahoo\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/openid?openid_url=yahoo\.com\"><img alt=\"Login with a Yahoo OpenID\" class=\"rounded-lg\" src=\"/images/yahoo.svg\" /></a>", button)
   end
 
   private

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -243,7 +243,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
@@ -289,7 +289,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
@@ -328,7 +328,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                             :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
@@ -397,7 +397,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "google")
           follow_redirect!
@@ -442,7 +442,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "google")
           follow_redirect!
@@ -482,7 +482,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                             :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "google")
           follow_redirect!
@@ -549,7 +549,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "facebook")
           follow_redirect!
@@ -594,7 +594,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "facebook")
           follow_redirect!
@@ -632,7 +632,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                             :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "facebook")
           follow_redirect!
@@ -699,7 +699,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "windowslive")
           follow_redirect!
@@ -744,7 +744,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "windowslive")
           follow_redirect!
@@ -782,7 +782,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                             :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "windowslive", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "windowslive")
           follow_redirect!
@@ -849,7 +849,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "github")
           follow_redirect!
@@ -895,7 +895,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "github")
           follow_redirect!
@@ -933,7 +933,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                             :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "github")
           follow_redirect!
@@ -1001,7 +1001,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
@@ -1047,7 +1047,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => "" } }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
@@ -1085,7 +1085,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                             :referer => referer }
           assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
-          follow_redirect!
+          post response.location
           assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -359,7 +359,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
@@ -380,7 +380,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
@@ -405,7 +405,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
@@ -429,7 +429,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "openid", :openid_url => "http://localhost:1123/fred.bloggs", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "openid", :openid_url => "http://localhost:1123/fred.bloggs", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/fred.bloggs", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
@@ -452,7 +452,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
@@ -472,7 +472,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
@@ -496,7 +496,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
@@ -522,7 +522,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
@@ -545,7 +545,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
@@ -570,7 +570,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
@@ -590,7 +590,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
@@ -614,7 +614,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
@@ -638,7 +638,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
@@ -659,7 +659,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "windowslive", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "windowslive", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "windowslive")
     follow_redirect!
@@ -679,7 +679,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "windowslive", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "windowslive", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "windowslive")
     follow_redirect!
@@ -703,7 +703,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "windowslive", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "windowslive", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "windowslive")
     follow_redirect!
@@ -727,7 +727,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "windowslive", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "windowslive", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "windowslive")
     follow_redirect!
@@ -748,7 +748,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
@@ -768,7 +768,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
@@ -792,7 +792,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
@@ -816,7 +816,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
@@ -837,7 +837,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
@@ -857,7 +857,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
@@ -881,7 +881,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
@@ -905,7 +905,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "users/login"
-    get auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
+    post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!


### PR DESCRIPTION
This requires converting all use of the /auth endpoints to use the POST method as GET is no longer supported.

Unfortunately I had to change all the `follow_redirect!` calls in the tests as in rails 6.0 that always uses GET regardless of the response status - in rails 6.1 that has actually been fixed but we can't move to that yet.