### PR TITLE
More bootstrap forms

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -448,25 +448,10 @@ body.compact-nav {
 
   .welcome {
     display: none;
-    padding-bottom: 5px;
 
     p {
-      padding: $lineheight/2 $lineheight $lineheight;
       font-size: 110%;
       font-weight: 300;
-    }
-
-    .button {
-      width: 50%;
-      float: left;
-      margin: 0;
-      border-radius: 0;
-      font-weight: normal;
-      padding: .6em;
-
-      &.learn-more {
-        border-right: 1px solid #fff;
-      }
     }
   }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1005,9 +1005,8 @@ tr.turn:hover {
   .export_area_inputs {
     margin-bottom: $lineheight/2;
     input[type="text"] {
-      width: 80px;
+      width: 100px;
       text-align: center;
-      margin-bottom: 5px;
     }
   }
 
@@ -1025,16 +1024,11 @@ tr.turn:hover {
       float: right;
       /* no-r2 */ margin-right: -1px;
     }
-    #minlat { margin-bottom: 0; }
+    #minlat { margin-bottom: -1px; }
   }
 
   .export_bound {
     margin: $lineheight/4;
-  }
-
-  .export_button {
-    margin-top: $lineheight;
-    margin-bottom: $lineheight;
   }
 
   dl {

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -41,15 +41,21 @@
     <% unless current_user %>
       <div class="welcome">
         <%= render "sidebar_header", :title => t("layouts.intro_header") %>
-        <p><%= t "layouts.intro_text" %></p>
-        <p><%= t "layouts.hosting_partners_html",
-                 :ucl => link_to(t("layouts.partners_ucl"), "https://www.ucl.ac.uk"),
-                 :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
-                 :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
-        </p>
-        <div class="standard-form">
-          <a class="button learn-more" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
-          <a class="button sign-up" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+        <div class="px-3 pb-3">
+          <p><%= t "layouts.intro_text" %></p>
+          <p><%= t "layouts.hosting_partners_html",
+                   :ucl => link_to(t("layouts.partners_ucl"), "https://www.ucl.ac.uk"),
+                   :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
+                   :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
+          </p>
+          <div class="d-flex mx-n1">
+            <div class="w-50 px-1">
+              <a class="btn btn-primary w-100" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
+            </div>
+            <div class="w-50 px-1">
+              <a class="btn btn-primary w-100" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+            </div>
+          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -1,8 +1,8 @@
-<tr id="inbox-<%= message_summary.id %>" class="standard-form inbox-row<%= "-unread" unless message_summary.message_read? %>">
+<tr id="inbox-<%= message_summary.id %>" class="inbox-row<%= "-unread" unless message_summary.message_read? %>">
   <td class="inbox-sender"><%= link_to message_summary.sender.display_name, user_path(message_summary.sender) %></td>
   <td class="inbox-subject"><%= link_to message_summary.title, message_path(message_summary) %></td>
   <td class="inbox-sent"><%= l message_summary.sent_on, :format => :friendly %></td>
-  <td class="inbox-mark-unread"><%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true %></td>
-  <td class="inbox-mark-read"><%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true %></td>
-  <td class="inbox-destroy"><%= button_to t(".destroy_button"), message_path(message_summary, :referer => request.fullpath), :method => :delete, :remote => true %></td>
+  <td class="inbox-mark-unread"><%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary" %></td>
+  <td class="inbox-mark-read"><%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true, :class => "btn btn-sm btn-primary" %></td>
+  <td class="inbox-destroy"><%= button_to t(".destroy_button"), message_path(message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger" %></td>
 </tr>

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -2,5 +2,5 @@
   <td class="inbox-sender"><%= link_to sent_message_summary.recipient.display_name, user_path(sent_message_summary.recipient) %></td>
   <td class="inbox-subject"><%= link_to sent_message_summary.title, message_path(sent_message_summary) %></td>
   <td class="inbox-sent"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
-  <td class="inbox-destroy"><%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true %></td>
+  <td class="inbox-destroy"><%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger" %></td>
 </tr>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -18,9 +18,9 @@
       <td><%= link_to token.client_application.name, token.client_application.url %></td>
       <td><%= token.authorized_at %></td>
       <td>
-        <%= form_tag({ :controller => "oauth", :action => "revoke" }, { :class => "standard-form" }) do %>
+        <%= form_tag({ :controller => "oauth", :action => "revoke" }) do %>
           <%= hidden_field_tag "token", token.token %>
-          <%= submit_tag t(".revoke") %>
+          <%= submit_tag t(".revoke"), :class => "btn btn-sm btn-primary" %>
         <% end %>
       </td>
     </tr>

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -2,17 +2,17 @@
 
 <%= render "sidebar_header", :title => t(".title") %>
 
-<%= form_tag({ :controller => "export", :action => "finish" }, { :class => "export_form standard-form" }) do %>
+<%= form_tag({ :controller => "export", :action => "finish" }, { :class => "export_form" }) do %>
   <%= hidden_field_tag "format", "osm" %>
 
   <div class='export_area_inputs'>
     <div class='export_boxy'>
-      <%= text_field_tag("maxlat", nil, :size => 10, :class => "export_bound") %>
-      <br />
-      <%= text_field_tag("minlon", nil, :size => 10, :class => "export_bound") %>
-      <%= text_field_tag("maxlon", nil, :size => 10, :class => "export_bound") %>
-      <br /><br />
-      <%= text_field_tag("minlat", nil, :size => 10, :class => "export_bound") %>
+      <%= text_field_tag("maxlat", nil, :size => 10, :class => "export_bound form-control mx-auto") %>
+      <div class="clearfix">
+        <%= text_field_tag("minlon", nil, :size => 10, :class => "export_bound form-control") %>
+        <%= text_field_tag("maxlon", nil, :size => 10, :class => "export_bound form-control") %>
+      </div>
+      <%= text_field_tag("minlat", nil, :size => 10, :class => "export_bound form-control mx-auto") %>
       </div>
     <a id='drag_box' href="#"><%= t ".manually_select" %></a>
   </div>
@@ -27,8 +27,8 @@
   </div>
 
   <div id="export_commit">
-    <div class="export_button">
-      <%= submit_tag t(".export_button") %>
+    <div class="form-group d-flex">
+      <%= submit_tag t(".export_button"), :class => "btn btn-primary mx-auto" %>
     </div>
 
     <p><%= t ".too_large.advice" %></p>

--- a/app/views/user_blocks/revoke.html.erb
+++ b/app/views/user_blocks/revoke.html.erb
@@ -11,23 +11,23 @@
 <% end %>
 
 <% if @user_block.ends_at > Time.now %>
-<p><b>
-  <%= t(".time_future", :time => distance_of_time_in_words_to_now(@user_block.ends_at)) %>
-</b></p>
+  <p>
+    <%= t(".time_future", :time => distance_of_time_in_words_to_now(@user_block.ends_at)) %>
+  </p>
 
-<%= form_for :revoke, :url => { :action => "revoke" }, :html => { :class => "standard-form" } do |f| %>
-  <%= f.error_messages %>
-<p>
-  <%= check_box_tag "confirm", "yes" %>
-  <%= label_tag "confirm", t(".confirm") %>
-</p>
-<p>
-  <%= submit_tag t(".revoke") %>
-</p>
-<% end %>
+  <%= bootstrap_form_for :revoke, :url => { :action => "revoke" } do |f| %>
+    <div class="form-group">
+      <div class="form-check">
+        <%= check_box_tag "confirm", "yes", false, { :class => "form-check-input" } %>
+        <%= label_tag "confirm", t(".confirm"), { :class => "form-check-label" } %>
+      </div>
+    </div>
+
+    <%= f.primary t(".revoke") %>
+  <% end %>
 
 <% else %>
-<p>
-  <%= t(".past", :time => time_ago_in_words(@user_block.ends_at, :scope => :'datetime.distance_in_words_ago')) %>
-</p>
+  <p>
+    <%= t(".past", :time => time_ago_in_words(@user_block.ends_at, :scope => :'datetime.distance_in_words_ago')) %>
+  </p>
 <% end %>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -100,9 +100,9 @@
         <%= f.text_field :home_lon, :wrapper_class => "col-sm-4", :id => "home_lon" %>
       </div>
     </div>
-    <div class="standard-form-row">
-      <input type="checkbox" name="updatehome" value="1" <% unless current_user.home_lat and current_user.home_lon %> checked="checked" <% end %> id="updatehome" />
-      <label class="standard-label" for="updatehome"><%= t ".update home location on click" %></label>
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.home_lat and current_user.home_lon %> checked="checked" <% end %> id="updatehome" />
+      <label class="form-check-label" for="updatehome"><%= t ".update home location on click" %></label>
     </div>
     <%= tag.div "", :id => "map", :class => "content_map set_location" %>
   </fieldset>


### PR DESCRIPTION
This PR refactors a few more forms to use bootstrap, namely:

* Checkbox on the accounts page that I previously overlooked
* User Blocks revoke form
* Message list action buttons
* OAuth client action buttons
* Export form
* Buttons on the welcome message
