### PR TITLE
Post-merge Docker Compose cleanup issues

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -71,6 +71,7 @@ You can now use Docker to load this extract into your local Docker-based OSM ins
     docker-compose run --rm web osmosis \
         -verbose    \
         --read-pbf district-of-columbia-latest.osm.pbf \
+        --log-progress \
         --write-apidb \
             host="db" \
             database="openstreetmap" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install system packages
+# Install system packages then clean up to minimize image size
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \
       build-essential \
@@ -30,7 +30,7 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# Install current Osmosis
+# Install compatible Osmosis to help users import sample data in a new instance
 RUN curl -OL https://github.com/openstreetmap/osmosis/releases/download/0.47.2/osmosis-0.47.2.tgz \
  && tar -C /usr/local -xzf osmosis-0.47.2.tgz
 
@@ -45,6 +45,7 @@ ADD Gemfile Gemfile.lock /app/
 RUN gem install bundler \
  && bundle install
 
-# Install NodeJS packages
+# Install NodeJS packages using yarnpkg
+# `bundle exec rake yarn:install` will not work
 ADD package.json yarn.lock /app/
 RUN yarnpkg install

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" if ENV.fetch("ENABLE_BOOTSNAP", "true") == "true" # Speed up boot time by caching expensive operations.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,6 @@ services:
       - web-images:/home/osm/images
     ports:
       - "3000:3000"
-    environment:
-      # https://github.com/Shopify/bootsnap/issues/262
-      ENABLE_BOOTSNAP: 'false'
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     depends_on:
       - db

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -4,4 +4,4 @@ FROM postgres:11
 ADD docker/postgres/openstreetmap-postgres-init.sh /docker-entrypoint-initdb.d/
 
 # Custom database functions are in a SQL file.
-ADD db/functions/functions.sql /usr/local/sbin/osm-db-functions.sql
+ADD db/functions/functions.sql /usr/local/share/osm-db-functions.sql

--- a/docker/postgres/openstreetmap-postgres-init.sh
+++ b/docker/postgres/openstreetmap-postgres-init.sh
@@ -11,4 +11,4 @@ EOSQL
 psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -c "CREATE EXTENSION btree_gist" openstreetmap
 
 # Define custom functions
-psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -f "/usr/local/sbin/osm-db-functions.sql" openstreetmap
+psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -f "/usr/local/share/osm-db-functions.sql" openstreetmap

--- a/docker/postgres/openstreetmap-postgres-init.sh
+++ b/docker/postgres/openstreetmap-postgres-init.sh
@@ -2,6 +2,7 @@
 set -ex
 
 # Create 'openstreetmap' user
+# Password and superuser privilege are needed to successfully run test suite
 psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" <<-EOSQL
     CREATE USER openstreetmap SUPERUSER PASSWORD 'openstreetmap';
     GRANT ALL PRIVILEGES ON DATABASE openstreetmap TO openstreetmap;


### PR DESCRIPTION
Follow up to Tom’s review comments in https://github.com/openstreetmap/openstreetmap-website/pull/2409#pullrequestreview-582662631:

- Checkout was updated to v2 upstream, so no need to do that in this PR
- After testing under a variety of platforms, we haven’t been able to reproduce last year’s bug so ENABLE_BOOTSTRAP is now gone.
- Moved DB functions to `/usr/local/share/` since they’re still necessary per https://github.com/openstreetmap/openstreetmap-website/pull/2409#discussion_r570115583
- DB password and superuser privilege are both still needed when even when using trust auth because the database is needed for setup, migrations, normal usage, and data imports
- `yarnpkg install` is still required since `bundle exec` will not work without additional app code present during Docker build step. The old option here was to leave the yarn step for the end-user after app installation, but I think it’s better more of the build process to be automated within the Dockerfile

Closes https://github.com/openstreetmap/openstreetmap-website/issues/3081