### PR TITLE
Fix unexpected spacing on note buttons when overflowed

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -977,6 +977,12 @@ tr.turn:hover {
   }
 }
 
+.btn-wrapper {
+  > .btn {
+    margin-bottom: $lineheight/4;
+  }
+}
+
 /* Rules for export sidebar */
 
 .export_form {

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -53,10 +53,10 @@
         </div>
         <div>
           <% if current_user.moderator? -%>
-            <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
+            <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light mb-2" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
           <% end -%>
-          <input type="submit" name="close" value="<%= t("javascripts.notes.show.resolve") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= close_note_url(@note, "json") %>">
-          <input type="submit" name="comment" value="<%= t("javascripts.notes.show.comment") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= comment_note_url(@note, "json") %>" disabled="1">
+          <input type="submit" name="close" value="<%= t("javascripts.notes.show.resolve") %>" class="btn btn-primary mb-2" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= close_note_url(@note, "json") %>">
+          <input type="submit" name="comment" value="<%= t("javascripts.notes.show.comment") %>" class="btn btn-primary mb-2" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= comment_note_url(@note, "json") %>" disabled="1">
         </div>
       </form>
     <% end -%>
@@ -65,10 +65,10 @@
       <input type="hidden" name="text" value="">
       <div>
         <% if current_user and current_user.moderator? -%>
-          <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
+          <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light mb-2" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
         <% end -%>
         <% if current_user -%>
-          <input type="submit" name="reopen" value="<%= t("javascripts.notes.show.reactivate") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= reopen_note_url(@note, "json") %>">
+          <input type="submit" name="reopen" value="<%= t("javascripts.notes.show.reactivate") %>" class="btn btn-primary mb-2" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= reopen_note_url(@note, "json") %>">
         <% end -%>
       </div>
     </form>

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -51,24 +51,24 @@
         <div class="form-group">
           <textarea class="form-control" name="text" cols="40" rows="5" maxlength="2000"></textarea>
         </div>
-        <div>
+        <div class="btn-wrapper">
           <% if current_user.moderator? -%>
-            <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light mb-2" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
+            <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
           <% end -%>
-          <input type="submit" name="close" value="<%= t("javascripts.notes.show.resolve") %>" class="btn btn-primary mb-2" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= close_note_url(@note, "json") %>">
-          <input type="submit" name="comment" value="<%= t("javascripts.notes.show.comment") %>" class="btn btn-primary mb-2" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= comment_note_url(@note, "json") %>" disabled="1">
+          <input type="submit" name="close" value="<%= t("javascripts.notes.show.resolve") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= close_note_url(@note, "json") %>">
+          <input type="submit" name="comment" value="<%= t("javascripts.notes.show.comment") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= comment_note_url(@note, "json") %>" disabled="1">
         </div>
       </form>
     <% end -%>
   <% else %>
     <form action="#">
       <input type="hidden" name="text" value="">
-      <div>
+      <div class="btn-wrapper">
         <% if current_user and current_user.moderator? -%>
-          <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light mb-2" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
+          <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
         <% end -%>
         <% if current_user -%>
-          <input type="submit" name="reopen" value="<%= t("javascripts.notes.show.reactivate") %>" class="btn btn-primary mb-2" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= reopen_note_url(@note, "json") %>">
+          <input type="submit" name="reopen" value="<%= t("javascripts.notes.show.reactivate") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= reopen_note_url(@note, "json") %>">
         <% end -%>
       </div>
     </form>


### PR DESCRIPTION
Resolves #3075

Depending on the current language, the buttons for closing and commenting on notes may overflow resulting in no spacing between the buttons. This change improves accessibility as it allows the user to easily distinguish between the two buttons and reduces accidental presses on the wrong button.

Example of the issue:
![before image](https://user-images.githubusercontent.com/57260466/106171418-ccdb2c00-6191-11eb-8636-e4b9de686745.png)

Example after the fix:
![after image](https://user-images.githubusercontent.com/32040254/107301376-3b40a980-6a30-11eb-9473-65a00de4420e.png)

May require additional testing.