### PR TITLE
Even more bootstrap forms

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -4,8 +4,6 @@
 
 /* Styles common to large and small screens */
 
-.fillL { background-color: white; }
-
 /* Default rules for the body of every page */
 
 body {
@@ -1317,13 +1315,6 @@ tr.turn:hover {
 
     ol ol {
       list-style-type: lower-alpha;
-    }
-  }
-
-  #decline {
-    background: $lightblue;
-    &:hover {
-      background: darken($lightblue, $hovercolor);
     }
   }
 }

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -14,11 +14,11 @@
 
   <% if current_user %>
     <div class="buttons clearfix subscribe-buttons">
-      <form action="#" class="standard-form">
+      <form action="#">
         <% if @changeset.subscribers.exists?(current_user.id) %>
-          <input class="action-button" type="submit" name="unsubscribe" value="<%= t("javascripts.changesets.show.unsubscribe") %>" data-method="POST" data-url="<%= changeset_unsubscribe_url(@changeset) %>" />
+          <input class="action-button btn btn-sm btn-primary" type="submit" name="unsubscribe" value="<%= t("javascripts.changesets.show.unsubscribe") %>" data-method="POST" data-url="<%= changeset_unsubscribe_url(@changeset) %>" />
         <% else %>
-          <input class="action-button" type="submit" name="subscribe" value="<%= t("javascripts.changesets.show.subscribe") %>" data-method="POST" data-url="<%= changeset_subscribe_url(@changeset) %>" />
+          <input class="action-button btn btn-sm btn-primary" type="submit" name="subscribe" value="<%= t("javascripts.changesets.show.subscribe") %>" data-method="POST" data-url="<%= changeset_subscribe_url(@changeset) %>" />
         <% end %>
       </form>
     </div>
@@ -28,7 +28,7 @@
 
   <% if @comments.length > 0 %>
     <div class='changeset-comments'>
-      <form action="#" class="standard-form">
+      <form action="#">
         <ul class="list-unstyled">
           <% @comments.each do |comment| %>
             <% if comment.visible %>
@@ -39,7 +39,7 @@
                         :exact_time => l(comment.created_at),
                         :user => link_to(comment.author.display_name, user_path(comment.author))) %>
                   <% if current_user and current_user.moderator? %>
-                    — <span class="action-button deemphasize" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_hide_url(comment.id) %>"><%= t("javascripts.changesets.show.hide_comment") %></span>
+                    — <span class="action-button" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_hide_url(comment.id) %>"><%= t("javascripts.changesets.show.hide_comment") %></span>
                   <% end %>
                 </small>
                 <%= comment.body.to_html %>
@@ -70,10 +70,12 @@
 
   <% if current_user %>
     <% unless @changeset.is_open? %>
-      <form action="#" class="standard-form">
-        <textarea class="comment" name="text" cols="40" rows="5"></textarea>
+      <form action="#">
+        <div class="form-group">
+          <textarea class="form-control" name="text" cols="40" rows="5"></textarea>
+        </div>
         <div class="buttons clearfix">
-          <input type="submit" name="comment" value="<%= t("javascripts.changesets.show.comment") %>" data-changeset-id="<%= @changeset.id %>" data-method="POST" data-url="<%= changeset_comment_url(@changeset) %>" disabled="1" />
+          <input type="submit" name="comment" value="<%= t("javascripts.changesets.show.comment") %>" data-changeset-id="<%= @changeset.id %>" data-method="POST" data-url="<%= changeset_comment_url(@changeset) %>" disabled="1" class="btn btn-sm btn-primary" />
         </div>
       </form>
     <% else %>

--- a/app/views/browse/new_note.html.erb
+++ b/app/views/browse/new_note.html.erb
@@ -4,12 +4,14 @@
 
 <div class="note browse-section">
   <p class="alert alert-info"><%= t("javascripts.notes.new.intro") %></p>
-  <form action="#" class="standard-form">
+  <form action="#">
     <input type="hidden" name="lon">
     <input type="hidden" name="lat">
-    <textarea class="comment" name="text" cols="40" rows="10" maxlength="2000" placeholder="<%= t("javascripts.notes.new.advice") %>"></textarea>
+    <div class="form-group">
+      <textarea class="form-control" name="text" cols="40" rows="10" maxlength="2000" placeholder="<%= t("javascripts.notes.new.advice") %>"></textarea>
+    </div>
     <div class="buttons clearfix">
-      <input type="submit" name="add" value="<%= t("javascripts.notes.new.add") %>" disabled="1">
+      <input type="submit" name="add" value="<%= t("javascripts.notes.new.add") %>" disabled="1" class="btn btn-primary">
     </div>
   </form>
 </div>

--- a/app/views/users/login.html.erb
+++ b/app/views/users/login.html.erb
@@ -21,11 +21,11 @@
     <%= f.primary t(".login_button"), :tabindex => 4 %>
   <% end %>
 
-  <div id="loginForm" class="standard-form">
+  <hr>
 
-    <fieldset class='form-divider'>
-
-      <p class='standard-label'><%= t ".with external" %></p>
+  <div id="loginForm">
+    <div class="form-group">
+      <label><%= t ".with external" %></label>
 
       <ul class='list-unstyled' id="login_auth_buttons">
         <li><%= link_to image_tag("openid.png", :alt => t(".auth_providers.openid.title")), "#", :id => "openid_open_url", :title => t(".auth_providers.openid.title") %></li>
@@ -50,18 +50,15 @@
       </ul>
 
       <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
-        <div id='login_openid_url' class='standard-form-row'>
-          <label for='openid_url' class="standard-label"><%= t ".openid_html", :logo => openid_logo %></label>
+        <div id='login_openid_url' class="form-group">
+          <label for='openid_url'><%= t ".openid_html", :logo => openid_logo %></label>
           <%= hidden_field_tag("referer", params[:referer]) %>
-          <%= text_field_tag("openid_url", "", :tabindex => 3, :class => "openid_url") %>
-          <span class="minorNote">(<a href="<%= t "users.account.openid.link" %>" target="_new"><%= t "users.account.openid.link text" %></a>)</span>
+          <%= text_field_tag("openid_url", "", :tabindex => 3, :class => "openid_url form-control") %>
+          <span class="form-text text-muted">(<a href="<%= t "users.account.openid.link" %>" target="_new"><%= t "users.account.openid.link text" %></a>)</span>
         </div>
 
-        <%= submit_tag t(".login_button"), :tabindex => 6, :id => "login_openid_submit" %>
+        <%= submit_tag t(".login_button"), :tabindex => 6, :id => "login_openid_submit", :class => "btn btn-primary" %>
       <% end %>
-
-      </fieldset>
-
     </div>
-
+  </div>
 </div>

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -7,22 +7,21 @@
   <div class='header-illustration new-user-terms'></div>
 <% end %>
 
-<%= form_tag({ :action => "save" }, { :class => "standard-form fillL" }) do %>
+<%= form_tag({ :action => "save" }) do %>
   <!-- legale is <%= @legale %> -->
   <p class="text-muted"><%= t ".read and accept with tou" %></p>
   <h4>
     <%= t ".heading_ct" %>
   </h4>
-  <div class='standard-form-row horizontal-list clearfix'>
-    <p class="text-muted"><%= t ".contributor_terms_explain" %></p>
-    <label class="standard-label">
-      <%= t ".legale_select" %>
-    </label>
-
+  <p class="text-muted"><%= t ".contributor_terms_explain" %></p>
+  <label>
+    <%= t ".legale_select" %>
+  </label>
+  <div class="form-group">
     <% [%w[france FR], %w[italy IT], %w[rest_of_world GB]].each do |name, legale| %>
-      <div class="standard-form-row">
-        <label for="legale_<%= legale %>">
-          <%= radio_button_tag "legale", legale, @legale == legale, :data => { :url => url_for(:legale => legale) } %>
+      <div class="form-check form-check-inline">
+        <%= radio_button_tag "legale", legale, @legale == legale, :data => { :url => url_for(:legale => legale) }, :class => "form-check-input" %>
+        <label for="legale_<%= legale %>" class="form-check-label">
           <%= t(".legale_names.#{name}") %>
         </label>
       </div>
@@ -40,35 +39,42 @@
             :translations => "https://www.osmfoundation.org/wiki/License/Contributor_Terms/Informal_Translations" %>
     </p>
   </div>
-  <div class="standard-form-row">
-    <label for="read_ct">
-      <%= check_box_tag "read_ct" %>
-      <%= t ".read_ct" %>
-    </label>
+  <div class="form-group">
+    <div class="form-check">
+      <%= check_box_tag "read_ct", "1", false, :class => "form-check-input" %>
+      <label for="read_ct" class="form-check-label">
+        <%= t ".read_ct" %>
+      </label>
+    </div>
   </div>
 
   <h4>
     <%= t "layouts.tou" %>
   </h4>
   <p class="text-muted"><%= t ".tou_explain_html", :tou_link => link_to(t("layouts.tou"), "https://wiki.osmfoundation.org/wiki/Terms_of_Use", :target => :new) %></p>
-  <div class="standard-form-row">
-    <label for="read_tou">
-      <%= check_box_tag "read_tou" %>
-      <%= t ".read_tou" %>
-    </label>
 
-    <%= hidden_field_tag("referer", h(params[:referer])) unless params[:referer].nil? %>
-
-    <div class="buttons standard-form-row py-3 clearfix">
-      <%= submit_tag("Continue", :name => "continue", :id => "continue", :disabled => true) %>
-      <%= submit_tag("Cancel", :name => "decline", :id => "decline") %>
+  <div class="form-group">
+    <div class="form-check">
+      <%= check_box_tag "read_tou", "1", false, :class => "form-check-input" %>
+      <label for="read_tou" class="form-check-label">
+        <%= t ".read_tou" %>
+      </label>
     </div>
+  </div>
 
-    <label for="user_consider_pd">
-      <%= check_box("user", "consider_pd") %>
+  <%= hidden_field_tag("referer", h(params[:referer])) unless params[:referer].nil? %>
+
+  <div class="form-group">
+    <%= submit_tag("Continue", :name => "continue", :id => "continue", :disabled => true, :class => "btn btn-primary") %>
+    <%= submit_tag("Cancel", :name => "decline", :id => "decline", :class => "btn btn-outline-secondary") %>
+  </div>
+
+  <div class="form-group">
+    <div class="form-check">
+      <%= check_box("user", "consider_pd", :class => "form-check-input") %>
+    <label for="user_consider_pd" class="form-check-label">
       <%= t ".consider_pd" %>
     </label>
     <span class="minorNote">(<%= link_to(t(".consider_pd_why"), t(".consider_pd_why_url"), :target => :new) %>)</span>
-
   </div>
 <% end %>


### PR DESCRIPTION
This pull request refactors four more forms to use bootstrap, specifically changeset comments, new notes, user terms and the third-party login form.

After this, there are only three more forms remaining, and then we can remove all the custom standard-form CSS. I tried refactoring the search form / directions form today, but it's a bit of a nightmare!