### PR TITLE
Upload profile picture with standard image formats

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,7 @@ class User < ApplicationRecord
 
   validates_email_format_of :email, :if => proc { |u| u.email_changed? }
   validates_email_format_of :new_email, :allow_blank => true, :if => proc { |u| u.new_email_changed? }
+  validates :image, allow_blank: true, format: { with: %r{.(gif|jpg|png|jpeg)\Z}i, message: 'must be a URL for GIF, JPG ,PNG or JPEG image.' }
 
   after_initialize :set_defaults
   before_save :encrypt_password


### PR DESCRIPTION
I have made profile pictures to be uploaded only with PNG, JPG, GIF, and JPEG formats, before which images can be uploaded with any extension such as .rb, .pdf, etc. 