### PR TITLE
Format openstreetmap.org/stats/data_stats

### DIFF
--- a/script/statistics
+++ b/script/statistics
@@ -11,7 +11,8 @@ puts "<title>OpenStreetMap Statistics</title>"
 puts "<style>th { text-align: left }</style>"
 puts "</head>"
 puts "<body>"
-puts "<h2>OpenStreetMap stats report run at #{start_time}</h2>"
+puts "<h1>OpenStreetMap stats</h1>"
+puts "<h2>Report run at #{start_time}</h2>"
 
 begin
   ActiveRecord::Base.transaction do
@@ -29,7 +30,7 @@ begin
     puts "<tr><td>Number of relations</td><td>#{relation_count}</td></tr>"
     puts "</table>"
 
-    puts "<h2>Top 50 users for uploads of GPS data</h2>"
+    puts "<h2 id="top-traces">Top 50 users for uploads of GPS data</h2>"
     puts "<table>"
     puts "<tr><th>User</th><th>Number of Points</th></tr>"
 
@@ -40,7 +41,7 @@ begin
 
     puts "</table>"
 
-    puts "<h2>Number of users editing over the past...</h2>"
+    puts "<h2 id="number-of-editors">Number of users editing over the past...</h2>"
     puts "<table>"
     puts "<tr><th>Data Type</th><th>Day</th><th>Week</th><th>Month</th></tr>"
 
@@ -58,7 +59,7 @@ begin
 
     puts "</table>"
 
-    puts "<h2>Top users editing over the past...</h2>"
+    puts "<h2 id="top-editors">Top users editing over the past...</h2>"
     puts "<table>"
     puts "<tr><th>Day</th><th>Week</th><th>Month</th></tr>"
 

--- a/script/statistics
+++ b/script/statistics
@@ -30,7 +30,7 @@ begin
     puts "<tr><td>Number of relations</td><td>#{relation_count}</td></tr>"
     puts "</table>"
 
-    puts "<h2 id="top-traces">Top 50 users for uploads of GPS data</h2>"
+    puts '<h2 id="top-traces">Top 50 users for uploads of GPS data</h2>'
     puts "<table>"
     puts "<tr><th>User</th><th>Number of Points</th></tr>"
 
@@ -41,7 +41,7 @@ begin
 
     puts "</table>"
 
-    puts "<h2 id="number-of-editors">Number of users editing over the past...</h2>"
+    puts '<h2 id="number-of-editors">Number of users editing over the past...</h2>'
     puts "<table>"
     puts "<tr><th>Data Type</th><th>Day</th><th>Week</th><th>Month</th></tr>"
 
@@ -59,7 +59,7 @@ begin
 
     puts "</table>"
 
-    puts "<h2 id="top-editors">Top users editing over the past...</h2>"
+    puts '<h2 id="top-editors">Top users editing over the past...</h2>'
     puts "<table>"
     puts "<tr><th>Day</th><th>Week</th><th>Month</th></tr>"
 


### PR DESCRIPTION
It would be nice to be able to link to specific sections on the stats page on osm.org. 

If the headings would have the IDs proposed here one could link to them like `

```
https://www.openstreetmap.org/stats/data_stats.html#number-of-editors
```
I also 

- changed the topmost heading to be h1 instead of h2 since each page should have a h1
- Put `OpenStreetMap stats`on its own and on the next line `report run at 2021-02-16 23:00:05 +0000`

The final result looks like this 
![image](https://user-images.githubusercontent.com/70209145/108271220-5dd96d80-7168-11eb-925d-c85dbd38bbcb.png)
