### PR TITLE
Use Bootstrap nav tabs for inbox/outbox header navigation

### DIFF
--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -8,7 +8,7 @@
       <a class="nav-link active"><%= t ".my_inbox" %></a>
     </li>
     <li class="nav-item">
-      <%= link_to t(".my_outbox"), outbox_messages_path, class: "nav-link" %>
+      <%= link_to t(".my_outbox"), outbox_messages_path, class => "nav-link" %>
     </li>
   </ul>
 <% end %>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -8,7 +8,7 @@
       <a class="nav-link active"><%= t ".my_inbox" %></a>
     </li>
     <li class="nav-item">
-      <%= link_to t(".my_outbox"), outbox_messages_path, class => "nav-link" %>
+      <%= link_to t(".my_outbox"), outbox_messages_path, :class => "nav-link" %>
     </li>
   </ul>
 <% end %>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -3,7 +3,14 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h2><%= t ".my_inbox" %>/<%= link_to t(".outbox"), outbox_messages_path %></h2>
+  <ul class="nav nav-pills">
+    <li class="nav-item">
+      <a class="nav-link active"><%= t ".my_inbox" %></a>
+    </li>
+    <li class="nav-item">
+      <%= link_to t(".my_outbox"), outbox_messages_path, class: "nav-link" %>
+    </li>
+  </ul>
 <% end %>
 
   <h4><%= render :partial => "message_count" %></h4>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -5,7 +5,7 @@
 <% content_for :heading do %>
   <ul class="nav nav-pills">
     <li class="nav-item">
-      <%= link_to t(".my_inbox"), inbox_messages_path, class: "nav-link" %>
+      <%= link_to t(".my_inbox"), inbox_messages_path, class => "nav-link" %>
     </li>
     <li class="nav-item">
       <a class="nav-link active"><%= t ".my_outbox" %></a>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -3,7 +3,14 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h2><%= t(".my_inbox_html", :inbox_link => link_to(t(".inbox"), inbox_messages_path)) %>/<%= t ".outbox" %></h2>
+  <ul class="nav nav-pills">
+    <li class="nav-item">
+      <%= link_to t(".my_inbox"), inbox_messages_path, class: "nav-link" %>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link active"><%= t ".my_outbox" %></a>
+    </li>
+  </ul>
 <% end %>
 
 <h4><%= t ".messages", :count => current_user.sent_messages.size %></h4>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -5,7 +5,7 @@
 <% content_for :heading do %>
   <ul class="nav nav-pills">
     <li class="nav-item">
-      <%= link_to t(".my_inbox"), inbox_messages_path, class => "nav-link" %>
+      <%= link_to t(".my_inbox"), inbox_messages_path, :class => "nav-link" %>
     </li>
     <li class="nav-item">
       <a class="nav-link active"><%= t ".my_outbox" %></a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1520,6 +1520,7 @@ en:
       title: "Inbox"
       my_inbox: "My Inbox"
       outbox: "outbox"
+      my_outbox: "My Outbox"
       messages: "You have %{new_messages} and %{old_messages}"
       new_messages:
         one: "%{count} new message"
@@ -1552,9 +1553,10 @@ en:
       body: "Sorry there is no message with that id."
     outbox:
       title: "Outbox"
-      my_inbox_html: "My %{inbox_link}"
       inbox: "inbox"
       outbox: "outbox"
+      my_inbox: "My Inbox"
+      my_outbox: "My Outbox"
       messages:
         one: "You have %{count} sent message"
         other: "You have %{count} sent messages"


### PR DESCRIPTION
Per https://github.com/openstreetmap/openstreetmap-website/issues/2962#issuecomment-768985393, improve visual appearance of inbox/outbox headers.

# This change

<img width="823" alt="OSM Inbox" src="https://user-images.githubusercontent.com/58730/109376244-16459680-7878-11eb-8aaa-cdc2e8d358f8.png">

<img width="823" alt="OSM Outbox" src="https://user-images.githubusercontent.com/58730/109376246-18a7f080-7878-11eb-8011-bc7f296e5e6d.png">

# Current appearance

<img width="823" alt="Old Inbox" src="https://user-images.githubusercontent.com/58730/109376257-252c4900-7878-11eb-8ac0-e8f9bcd275df.png">

<img width="823" alt="Old Outbox" src="https://user-images.githubusercontent.com/58730/109376259-278ea300-7878-11eb-881e-1594dbe59282.png">


Closes #2962
