### PR TITLE
Remove CSS overrides for the login page at small screen sizes

### DIFF
--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -124,26 +124,3 @@ body.small-nav {
     }
   }
 }
-
-@media (max-width: 575.98px) {
-  /* Rules for the login form */
-
-  #login_login input#user_email {
-    width: 100%;
-    max-width: 18em;
-  }
-
-  #login_login input#user_password {
-    width: 100%;
-    max-width: 18em;
-  }
-
-  #login_login input#openid_url {
-    width: 100%;
-    max-width: 18em;
-  }
-
-  #login_openid_buttons td {
-    padding: 2px;
-  }
-}


### PR DESCRIPTION
Some of these selectors no longer apply, and the one that did just made the behaviour worse, so they are all no longer required.