### PR TITLE
Added natural=coastline and natural=peninsula to i18n file

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -969,6 +969,7 @@ en:
           cape: "Cape"
           cave_entrance: "Cave Entrance"
           cliff: "Cliff"
+          coastline: "Coastline"
           crater: "Crater"
           dune: "Dune"
           fell: "Fell"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -987,6 +987,7 @@ en:
           moor: "Moor"
           mud: "Mud"
           peak: "Peak"
+          peninsula: "Peninsula"
           point: "Point"
           reef: "Reef"
           ridge: "Ridge"


### PR DESCRIPTION
It turns out that neither `natural=peninsula` or `natural=coastline` are available for translation using [Translatewiki](https://translatewiki.net/wiki/Translating:OpenStreetMap).

https://wiki.openstreetmap.org/wiki/Tag:natural%3Dpeninsula

https://wiki.openstreetmap.org/wiki/Coastline

Let me know if this is the way to add it so that it will be available in Translatewiki.