### PR TITLE
Automatically enable the btree_gist extension

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,6 @@ jobs:
         sudo systemctl start postgresql
         sudo -u postgres createuser -s $(id -un)
         createdb openstreetmap
-        psql -c "CREATE EXTENSION btree_gist" openstreetmap
         psql -f db/functions/functions.sql openstreetmap
     - name: Configure rails
       run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -190,14 +190,6 @@ To create the three databases - for development, testing and production - run:
 bundle exec rake db:create
 ```
 
-### PostgreSQL Btree-gist Extension
-
-We need to load the `btree-gist` extension, which is needed for showing changesets on the history tab.
-
-```
-psql -d openstreetmap -c "CREATE EXTENSION btree_gist"
-```
-
 ### PostgreSQL Functions
 
 We need to install some special functions into the PostgreSQL database:

--- a/db/migrate/028_add_more_changeset_indexes.rb
+++ b/db/migrate/028_add_more_changeset_indexes.rb
@@ -1,5 +1,7 @@
 class AddMoreChangesetIndexes < ActiveRecord::Migration[4.2]
   def self.up
+    enable_extension "btree_gist"
+
     add_index "changesets", ["created_at"], :name => "changesets_created_at_idx"
     add_index "changesets", ["closed_at"], :name => "changesets_closed_at_idx"
     add_index "changesets", %w[min_lat max_lat min_lon max_lon], :name => "changesets_bbox_idx", :using => "GIST"
@@ -9,5 +11,7 @@ class AddMoreChangesetIndexes < ActiveRecord::Migration[4.2]
     remove_index "changesets", :name => "changesets_bbox_idx"
     remove_index "changesets", :name => "changesets_closed_at_idx"
     remove_index "changesets", :name => "changesets_created_at_idx"
+
+    disable_extension "btree_gist"
   end
 end

--- a/docker/postgres/openstreetmap-postgres-init.sh
+++ b/docker/postgres/openstreetmap-postgres-init.sh
@@ -8,8 +8,5 @@ psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" <<-EOSQL
     GRANT ALL PRIVILEGES ON DATABASE openstreetmap TO openstreetmap;
 EOSQL
 
-# Create btree_gist extensions
-psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -c "CREATE EXTENSION btree_gist" openstreetmap
-
 # Define custom functions
 psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -f "/usr/local/share/osm-db-functions.sql" openstreetmap

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -36,9 +36,6 @@ if [ "$db_user_exists" != "1" ]; then
     sudo -u postgres createuser -s vagrant
     sudo -u vagrant createdb -E UTF-8 -O vagrant openstreetmap
     sudo -u vagrant createdb -E UTF-8 -O vagrant osm_test
-    # add btree_gist extension
-    sudo -u vagrant psql -c "create extension btree_gist" openstreetmap
-    sudo -u vagrant psql -c "create extension btree_gist" osm_test
 fi
 
 


### PR DESCRIPTION
This simplifies the install instructions. Loading from structure.sql is already handled.

The more I thought about what I wrote in #3110 the more I realised it was worth doing anyway.