### PR TITLE
Remove GL and SH cantonal WMS servers from black list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,9 +95,6 @@ imagery_blacklist:
   - "http://xdworld\\.vworld\\.kr:8080/.*"
   # Blacklist here
   - ".*\\.here\\.com[/:].*"
-  # Blacklist Kanton SH and GL
-  - ".*wms.geo.sh.ch.*Luftbild_201[06].*"
-  - ".*wms.geo.gl.ch.*ch.gl.imagery.orthofoto201[357].*"
 # URL of Overpass instance to use for feature queries
 overpass_url: "https://overpass-api.de/api/interpreter"
 # Routing endpoints


### PR DESCRIPTION
The previously restrictively licensed material is now available on relatively open terms directly from swisstopo per 1. March 2021, so these entries can be removed.