### PR TITLE
Use list-inline to achieve spacing between elements on a line

### DIFF
--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -9,24 +9,26 @@
     <% end %>
   </td>
   <td>
-    <span class="mr-2">
-      <%= link_to trace.name, :controller => "traces", :action => "show", :display_name => trace.user.display_name, :id => trace.id %>
-    </span>
+    <ul class="list-inline mb-0">
+      <li class="list-inline-item">
+        <%= link_to trace.name, :controller => "traces", :action => "show", :display_name => trace.user.display_name, :id => trace.id %>
+      </li>
 
-    <% if trace.inserted? %>
-      <span class="mr-2">
-        <%= t ".count_points", :count => trace.size %>
-      </span>
-    <% end %>
+      <% if trace.inserted? %>
+        <li class="list-inline-item">
+          <%= t ".count_points", :count => trace.size %>
+        </li>
+      <% end %>
 
-    <% badge_class = case trace.visibility
-                     when "public", "identifiable" then "success"
-                     else "danger"
-                     end %>
-    <span class="badge badge-<%= badge_class %> text-white"><%= t(".#{trace.visibility}") %></span>
-
-    <br />
-    <span class="text-muted">
+      <li class="list-inline-item">
+        <% badge_class = case trace.visibility
+                         when "public", "identifiable" then "success"
+                         else "danger"
+                         end %>
+        <span class="badge badge-<%= badge_class %> text-white"><%= t(".#{trace.visibility}") %></span>
+      </li>
+    </ul>
+    <p class="text-muted mb-0">
       <span title="<%= trace.timestamp %>">
         <%= time_ago_in_words(trace.timestamp, :scope => :'datetime.distance_in_words_ago') %>
       </span>
@@ -35,9 +37,8 @@
         <%= t ".in" %>
         <%= safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>
       <% end %>
-    </span>
-    <br />
-    <p class="font-italic my-1">
+    </p>
+    <p class="font-italic mb-0">
       <%= trace.description %>
     </p>
   </td>

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -768,7 +768,7 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
         assert_select "tr", :count => traces.length do |rows|
           traces.zip(rows).each do |trace, row|
             assert_select row, "a", Regexp.new(Regexp.escape(trace.name))
-            assert_select row, "span", Regexp.new(Regexp.escape("#{trace.size} points")) if trace.inserted?
+            assert_select row, "li", Regexp.new(Regexp.escape("#{trace.size} points")) if trace.inserted?
             assert_select row, "td", Regexp.new(Regexp.escape(trace.description))
             assert_select row, "td", Regexp.new(Regexp.escape("by #{trace.user.display_name}"))
           end


### PR DESCRIPTION
This is a better solution than spans and margins. Additionally, rework to use `mb-*` instead of `my-*` (bootstrap advises against using margin-top) and get rid of `<br>`s by using paragraphs instead.

My apologies for two PRs on the same topic in quick succession, but I discovered the `list-inline` while reviewing another PR and so I thought I should go back and improve this.