### PR TITLE
Added natural=atoll and place=archipelago to en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1036,6 +1036,7 @@ en:
           "yes": "Office"
         place:
           allotments: "Allotments"
+          archipelago: "Archipelago"
           city: "City"
           city_block: "City Block"
           country: "Country"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -963,6 +963,7 @@ en:
         mountain_pass:
           "yes" : "Mountain Pass"
         natural:
+          atoll: "Atoll"
           bare_rock: "Bare Rock"
           bay: "Bay"
           beach: "Beach"


### PR DESCRIPTION
Added key-value pairs to allow TranslateWiki translation of labels in Nominatum (a follow-up to #3124 )

https://wiki.openstreetmap.org/wiki/Tag:natural%3Datoll

https://wiki.openstreetmap.org/wiki/Tag:place%3Darchipelago