### PR TITLE
Show the crafted duration of a block independent of the reading time

### DIFF
--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -28,7 +28,10 @@
 </p>
 <% end %>
 
-<p><b><%= t ".created" %></b>: <%= friendly_date_ago(@user_block.created_at) %></p>
+<p>
+  <b><%= t ".created" %></b>: <%= friendly_date_ago(@user_block.created_at) %>
+  (<%= block_duration_in_words(@user_block.ends_at - @user_block.created_at) %>)
+</p>
 
 <p><b><%= t ".status" %></b>: <%= block_status(@user_block) %></p>
 


### PR DESCRIPTION
Fixes #3143.
Not tested by myself. Treat like pseudocode, I don't speak Ruby.

Intends to append the "Created" line with the difference ```duration = (ends_at - created_at)```, so it would read e.g.
```Created: over 1 year ago (4 hours)``` avoiding a new text string