### PR TITLE
Sanitize classes from outputs

### DIFF
--- a/config/initializers/sanitize.rb
+++ b/config/initializers/sanitize.rb
@@ -4,6 +4,7 @@ Sanitize::Config::OSM = Sanitize::Config.merge(
   :add_attributes => { "a" => { "rel" => "nofollow noopener noreferrer" } },
   :remove_contents => %w[script style],
   :transformers => lambda do |env|
+    env[:node].remove_class
     env[:node].add_class("table table-sm w-auto") if env[:node_name] == "table"
   end
 )

--- a/config/initializers/sanitize.rb
+++ b/config/initializers/sanitize.rb
@@ -1,8 +1,9 @@
-Sanitize::Config::OSM = Sanitize::Config::RELAXED.dup
-
-Sanitize::Config::OSM[:elements] -= %w[div style]
-Sanitize::Config::OSM[:add_attributes] = { "a" => { "rel" => "nofollow noopener noreferrer" } }
-Sanitize::Config::OSM[:remove_contents] = %w[script style]
-Sanitize::Config::OSM[:transformers] = lambda do |env|
-  env[:node].add_class("table table-sm w-auto") if env[:node_name] == "table"
-end
+Sanitize::Config::OSM = Sanitize::Config.merge(
+  Sanitize::Config::RELAXED,
+  :elements => Sanitize::Config::RELAXED[:elements] - %w[div style],
+  :add_attributes => { "a" => { "rel" => "nofollow noopener noreferrer" } },
+  :remove_contents => %w[script style],
+  :transformers => lambda do |env|
+    env[:node].add_class("table table-sm w-auto") if env[:node_name] == "table"
+  end
+)

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -47,6 +47,11 @@ class RichTextTest < ActiveSupport::TestCase
       assert_select "style", false
       assert_select "p", /^foo *baz$/
     end
+
+    r = RichText.new("html", "<table><tr><td>column</td></tr></table>")
+    assert_html r do
+      assert_select "table[class='table table-sm w-auto']"
+    end
   end
 
   def test_html_to_text
@@ -144,6 +149,11 @@ class RichTextTest < ActiveSupport::TestCase
     r = RichText.new("markdown", "    foo bar baz")
     assert_html r do
       assert_select "pre", /^\s*foo bar baz\s*$/
+    end
+
+    r = RichText.new("markdown", "|column|column")
+    assert_html r do
+      assert_select "table[class='table table-sm w-auto']"
     end
   end
 

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -52,6 +52,12 @@ class RichTextTest < ActiveSupport::TestCase
     assert_html r do
       assert_select "table[class='table table-sm w-auto']"
     end
+
+    r = RichText.new("html", "<p class='btn btn-warning'>Click Me</p>")
+    assert_html r do
+      assert_select "p[class='btn btn-warning']", false
+      assert_select "p", /^Click Me$/
+    end
   end
 
   def test_html_to_text
@@ -154,6 +160,13 @@ class RichTextTest < ActiveSupport::TestCase
     r = RichText.new("markdown", "|column|column")
     assert_html r do
       assert_select "table[class='table table-sm w-auto']"
+    end
+
+    r = RichText.new("markdown", "Click Me\n{:.btn.btn-warning}")
+    # raise r.to_html
+    assert_html r do
+      assert_select "p[class='btn btn-warning']", false
+      assert_select "p", /^Click Me$/
     end
   end
 


### PR DESCRIPTION
There are an endless amount of shenanigans that you can get up to using CSS classes. Examples are available privately on request.

This PR makes a few related changes:

* Adds tests for adding classes to table elements
* Refactors the configuration setup for the sanitize gem (although it turned out not to be necessary for this particular task)
* Strip away all class attributes from the output, by extending our custom transformer, to prevent shenanigans.