### PR TITLE
Added JSON support to user preferences

### DIFF
--- a/app/controllers/api/user_preferences_controller.rb
+++ b/app/controllers/api/user_preferences_controller.rb
@@ -7,12 +7,17 @@ module Api
 
     around_action :api_call_handle_error
 
+    before_action :set_request_formats
+
     ##
     # return all the preferences as an XML document
     def index
       @user_preferences = current_user.preferences
 
-      render :formats => [:xml]
+      respond_to do |format|
+        format.xml
+        format.json
+      end
     end
 
     ##

--- a/app/views/api/user_preferences/_user_preference.json.jbuilder
+++ b/app/views/api/user_preferences/_user_preference.json.jbuilder
@@ -1,0 +1,6 @@
+attrs = {
+  "k" => user_preference.k,
+  "v" => user_preference.v
+}
+
+json.preference(attrs)

--- a/app/views/api/user_preferences/_user_preference.json.jbuilder
+++ b/app/views/api/user_preferences/_user_preference.json.jbuilder
@@ -1,6 +1,5 @@
 attrs = {
-  "k" => user_preference.k,
-  "v" => user_preference.v
+  user_preference.k => user_preference.v
 }
 
 json.preference(attrs)

--- a/app/views/api/user_preferences/_user_preference.json.jbuilder
+++ b/app/views/api/user_preferences/_user_preference.json.jbuilder
@@ -1,5 +1,0 @@
-attrs = {
-  user_preference.k => user_preference.v
-}
-
-json.preference(attrs)

--- a/app/views/api/user_preferences/index.json.jbuilder
+++ b/app/views/api/user_preferences/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! @user_preferences

--- a/app/views/api/user_preferences/index.json.jbuilder
+++ b/app/views/api/user_preferences/index.json.jbuilder
@@ -1,1 +1,3 @@
-json.partial! @user_preferences
+json.partial! "api/root_attributes"
+
+json.preferences @user_preferences.map { |pref| [pref.k, pref.v] }.to_h

--- a/test/controllers/api/user_preferences_controller_test.rb
+++ b/test/controllers/api/user_preferences_controller_test.rb
@@ -62,6 +62,15 @@ module Api
           assert_select "preference[k=\"#{user_preference2.k}\"][v=\"#{user_preference2.v}\"]", :count => 1
         end
       end
+
+      # Test json
+      get user_preferences_path(:format => "json"), :headers => auth_header
+      assert_response :success
+      assert_equal "application/json", @response.media_type
+
+      js = ActiveSupport::JSON.decode(@response.body)
+      assert_not_nil js
+      assert_equal 2, js["preferences"].count
     end
 
     ##


### PR DESCRIPTION
I’m unsure about this, because I haven’t seen an example with more than one preference.

Test plan:

```
GET /api/0.6/user/preferences?format=json

{"preference":{"k":"diary.default_language","v":"en"}}
```

```
GET /api/0.6/user/preferences?format=xml

<osm version="0.6" generator="OpenStreetMap server" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright"license="http://opendatacommons.org/licenses/odbl/1-0/">
<preferences>
<preference k="diary.default_language" v="en"/>
</preferences>
</osm>
```

Closes https://github.com/openstreetmap/openstreetmap-website/issues/3160