### PR TITLE
Add missing root attributes to User#show and User#index json responses

### DIFF
--- a/app/views/api/users/index.json.jbuilder
+++ b/app/views/api/users/index.json.jbuilder
@@ -1,3 +1,5 @@
+json.partial! "api/root_attributes"
+
 json.users(@users) do |user|
   json.partial! user
 end

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -1,1 +1,3 @@
+json.partial! "api/root_attributes"
+
 json.partial! @user


### PR DESCRIPTION
During review for another PR, I released that the root attributes (copyright, generator etc) were missing from the User json responses.