### PR TITLE
Display message when the there are no notes/comments to display

### DIFF
--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -2,24 +2,30 @@
   <h1><%= t(".has_commented_on", :display_name => @user.display_name) %></h1>
 <% end %>
 
-<table class="table table-striped" width="100%">
-  <thead>
-    <tr>
-      <th width="25%"><%= t ".post" %></th>
-      <th width="25%"><%= t ".when" %></th>
-      <th width="50%"><%= t ".comment" %></th>
-    </tr>
-  </thead>
-  <% @comments.each do |comment| -%>
-  <tr class="<%= "text-muted" unless comment.visible? %>">
-    <td width="25%"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
-    <td width="25%"><span title="<%= l comment.created_at, :format => :friendly %>"><%= time_ago_in_words(comment.created_at, :scope => :'datetime.distance_in_words_ago') %></span></td>
-    <td width="50%" class="richtext text-break"><%= comment.body.to_html %></td>
-  </tr>
-  <% end -%>
-</table>
+<% if @comments.empty? %>
+  <h4><%= t ".no_comments" %></h4>
 
-<div class='secondary-actions clearfix'>
-  <span><%= link_to t(".older_comments"), :page => @comment_pages.current.next if @comment_pages.current.next %>
-  <%= link_to t(".newer_comments"), :page => @comment_pages.current.previous if @comment_pages.current.previous %></span>
-</div>
+<% else %>
+  <table class="table table-striped" width="100%">
+    <thead>
+      <tr>
+        <th width="25%"><%= t ".post" %></th>
+        <th width="25%"><%= t ".when" %></th>
+        <th width="50%"><%= t ".comment" %></th>
+      </tr>
+    </thead>
+    <% @comments.each do |comment| -%>
+    <tr class="<%= "text-muted" unless comment.visible? %>">
+      <td width="25%"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
+      <td width="25%"><span title="<%= l comment.created_at, :format => :friendly %>"><%= time_ago_in_words(comment.created_at, :scope => :'datetime.distance_in_words_ago') %></span></td>
+      <td width="50%" class="richtext text-break"><%= comment.body.to_html %></td>
+    </tr>
+    <% end -%>
+  </table>
+
+  <div class='secondary-actions clearfix'>
+    <span><%= link_to t(".older_comments"), :page => @comment_pages.current.next if @comment_pages.current.next %>
+    <%= link_to t(".newer_comments"), :page => @comment_pages.current.previous if @comment_pages.current.previous %></span>
+  </div>
+
+<% end -%>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -3,35 +3,41 @@
   <p><%= t ".subheading_html", :user => link_to(@user.display_name, user_path(@user)) %></p>
 <% end %>
 
-<%= render :partial => "notes_paging_nav" %>
+<% if @notes.empty? %>
+  <h4><%= t ".no_notes" %></h4>
 
-<table class="table table-sm note_list">
-  <thead>
-    <tr>
-      <th></th>
-      <th><%= t ".id" %></th>
-      <th><%= t ".creator" %></th>
-      <th><%= t ".description" %></th>
-      <th><%= t ".created_at" %></th>
-      <th><%= t ".last_changed" %></th>
+<% else %>
+  <%= render :partial => "notes_paging_nav" %>
+
+  <table class="table table-sm note_list">
+    <thead>
+      <tr>
+        <th></th>
+        <th><%= t ".id" %></th>
+        <th><%= t ".creator" %></th>
+        <th><%= t ".description" %></th>
+        <th><%= t ".created_at" %></th>
+        <th><%= t ".last_changed" %></th>
+      </tr>
+    </thead>
+  <% @notes.each do |note| -%>
+    <tr<% if note.author == @user %> class="creator"<% end %>>
+      <td>
+        <% if note.closed? %>
+          <%= image_tag("closed_note_marker.png", :alt => "closed", :size => "25x40") %>
+        <% else %>
+          <%= image_tag("open_note_marker.png", :alt => "open", :size => "25x40") %>
+        <% end %>
+      </td>
+      <td><%= link_to note.id, browse_note_path(note) %></td>
+      <td><%= note_author(note.author) %></td>
+      <td><%= note.comments.first.body.to_html %></td>
+      <td><%= friendly_date_ago(note.created_at) %></td>
+      <td><%= friendly_date_ago(note.updated_at) %></td>
     </tr>
-  </thead>
-<% @notes.each do |note| -%>
-  <tr<% if note.author == @user %> class="creator"<% end %>>
-    <td>
-      <% if note.closed? %>
-        <%= image_tag("closed_note_marker.png", :alt => "closed", :size => "25x40") %>
-      <% else %>
-        <%= image_tag("open_note_marker.png", :alt => "open", :size => "25x40") %>
-      <% end %>
-    </td>
-    <td><%= link_to note.id, browse_note_path(note) %></td>
-    <td><%= note_author(note.author) %></td>
-    <td><%= note.comments.first.body.to_html %></td>
-    <td><%= friendly_date_ago(note.created_at) %></td>
-    <td><%= friendly_date_ago(note.updated_at) %></td>
-  </tr>
-<% end -%>
-</table>
+  <% end -%>
+  </table>
 
-<%= render :partial => "notes_paging_nav" %>
+  <%= render :partial => "notes_paging_nav" %>
+
+<% end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2638,6 +2638,7 @@ en:
       title: "Notes submitted or commented on by %{user}"
       heading: "%{user}'s notes"
       subheading_html: "Notes submitted or commented on by %{user}"
+      no_notes: No notes
       id: "Id"
       creator: "Creator"
       description: "Description"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -474,6 +474,7 @@ en:
         description: "Recent diary entries from users of OpenStreetMap"
     comments:
       has_commented_on: "%{display_name} has commented on the following diary entries"
+      no_comments: "No diary comments"
       post: Post
       when: When
       comment: Comment

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -848,9 +848,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     get diary_comments_path(:display_name => user.display_name)
     assert_response :success
     assert_template :comments
-    assert_select "table.table-striped" do
-      assert_select "tr", :count => 1 # header, no comments
-    end
+    assert_select "h4", :html => "No diary comments"
 
     # Test a user with a comment
     create(:diary_comment, :user => other_user)

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -73,4 +73,11 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "table.note_list tr", :count => 11
   end
+
+  def test_empty_page
+    user = create(:user)
+    get user_notes_path(:display_name => user.display_name)
+    assert_response :success
+    assert_select "h4", :html => "No notes"
+  end
 end


### PR DESCRIPTION
Display more specific/friendly message when the there are no notes/comments to display, rather than empty tables.