### PR TITLE
Add rubocop-rake

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
   - rubocop-minitest
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rake
 
 AllCops:
   TargetRubyVersion: 2.5

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,6 +12,7 @@ require:
   - rubocop-minitest
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rake
 
 # Offense count: 544
 # Cop supports --auto-correct.
@@ -167,6 +168,20 @@ Rails/OutputSafety:
 # SupportedStyles: strict, flexible
 Rails/TimeZone:
   Enabled: false
+
+# Offense count: 8
+Rake/Desc:
+  Exclude:
+    - 'lib/tasks/auto_annotate_models.rake'
+    - 'lib/tasks/eslint.rake'
+    - 'lib/tasks/subscribe_diary_authors.rake'
+    - 'lib/tasks/subscribe_old_changesets.rake'
+    - 'lib/tasks/testing.rake'
+
+# Offense count: 3
+Rake/MethodDefinitionInTask:
+  Exclude:
+    - 'lib/tasks/eslint.rake'
 
 # Offense count: 558
 # Cop supports --auto-correct.

--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,7 @@ group :test do
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rails"
+  gem "rubocop-rake"
   gem "selenium-webdriver"
   gem "simplecov", :require => false
   gem "simplecov-lcov", :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,6 +408,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
+    rubocop-rake (0.5.1)
+      rubocop
     ruby-openid (2.9.2)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
@@ -540,6 +542,7 @@ DEPENDENCIES
   rubocop-minitest
   rubocop-performance
   rubocop-rails
+  rubocop-rake
   sanitize
   sassc-rails
   secure_headers


### PR DESCRIPTION
This checks the coding standards in our rake files. I haven't fixed any of the current warnings, but at least it will avoid any more problems in the future.