### PR TITLE
WIP: Use database replicas for read requests

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -115,7 +115,10 @@ class ApiController < ApplicationController
                           elsif username == "token"
                             User.authenticate(:token => passwd) # preferred - random token for user from db, passed in basic auth
                           else
-                            User.authenticate(:username => username, :password => passwd) # basic auth
+                            # User.authenticate might try to update the saved password
+                            ActiveRecord::Base.connected_to(:role => :writing) do
+                              User.authenticate(:username => username, :password => passwd) # basic auth
+                            end
                           end
       # log if we have authenticated using basic auth
       logger.info "Authenticated as user #{current_user.id} using basic authentication" if current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -186,8 +186,10 @@ class ApplicationController < ActionController::Base
 
   def set_locale
     if current_user&.languages&.empty? && !http_accept_language.user_preferred_languages.empty?
-      current_user.languages = http_accept_language.user_preferred_languages
-      current_user.save
+      ActiveRecord::Base.connected_to(:role => :writing) do
+        current_user.languages = http_accept_language.user_preferred_languages
+        current_user.save
+      end
     end
 
     I18n.locale = Locale.available.preferred(preferred_languages)

--- a/app/controllers/concerns/session_methods.rb
+++ b/app/controllers/concerns/session_methods.rb
@@ -62,7 +62,9 @@ module SessionMethods
   ##
   #
   def unconfirmed_login(user)
-    session[:token] = user.tokens.create.token
+    ActiveRecord::Base.connected_to(:role => :writing) do
+      session[:token] = user.tokens.create.token
+    end
 
     redirect_to :controller => "confirmations", :action => "confirm", :display_name => user.display_name
 

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -65,7 +65,9 @@ class ConfirmationsController < ApplicationController
     if user.nil? || token.nil? || token.user != user
       flash[:error] = t ".failure", :name => params[:display_name]
     else
-      UserMailer.signup_confirm(user, user.tokens.create).deliver_later
+      ActiveRecord::Base.connected_to(:role => :writing) do
+        UserMailer.signup_confirm(user, user.tokens.create).deliver_later
+      end
       flash[:notice] = { :partial => "confirmations/resend_success_flash", :locals => { :email => user.email, :sender => Settings.email_from } }
     end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -17,8 +17,10 @@ class MessagesController < ApplicationController
     @message = Message.find(params[:id])
 
     if @message.recipient == current_user || @message.sender == current_user
-      @message.message_read = true if @message.recipient == current_user
-      @message.save
+      ActiveRecord::Base.connected_to(:role => :writing) do
+        @message.message_read = true if @message.recipient == current_user
+        @message.save
+      end
     else
       flash[:notice] = t ".wrong_user", :user => current_user.display_name
       redirect_to login_path(:referer => request.fullpath)
@@ -75,7 +77,9 @@ class MessagesController < ApplicationController
     message = Message.find(params[:message_id])
 
     if message.recipient == current_user
-      message.update(:message_read => true)
+      ActiveRecord::Base.connected_to(:role => :writing) do
+        message.update(:message_read => true)
+      end
 
       @message = Message.new(
         :recipient => message.sender,

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -22,8 +22,10 @@ class UserBlocksController < ApplicationController
 
   def show
     if current_user && current_user == @user_block.user
-      @user_block.needs_view = false
-      @user_block.save!
+      ActiveRecord::Base.connected_to(:role => :writing) do
+        @user_block.needs_view = false
+        @user_block.save!
+      end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -280,7 +280,9 @@ class UsersController < ApplicationController
       if user.nil? && provider == "google"
         openid_url = auth_info[:extra][:id_info]["openid_id"]
         user = User.find_by(:auth_provider => "openid", :auth_uid => openid_url) if openid_url
-        user&.update(:auth_provider => provider, :auth_uid => uid)
+        ActiveRecord::Base.connected_to(:role => :writing) do
+          user&.update(:auth_provider => provider, :auth_uid => uid)
+        end
       end
 
       if user

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  connects_to :database => { :writing => :primary, :reading => :primary_replica }
 end

--- a/app/models/client_application.rb
+++ b/app/models/client_application.rb
@@ -78,7 +78,9 @@ class ClientApplication < ApplicationRecord
     permissions.each do |p|
       params[p] = true
     end
-    RequestToken.create(params)
+    ActiveRecord::Base.connected_to(:role => :writing) do
+      RequestToken.create(params)
+    end
   end
 
   def access_token_for_user(user)

--- a/app/models/oauth_nonce.rb
+++ b/app/models/oauth_nonce.rb
@@ -23,7 +23,10 @@ class OauthNonce < ApplicationRecord
   def self.remember(nonce, timestamp)
     return false if Time.now.to_i - timestamp.to_i > 86400
 
-    oauth_nonce = OauthNonce.create(:nonce => nonce, :timestamp => timestamp.to_i)
+    oauth_nonce = nil
+    ActiveRecord::Base.connected_to(:role => :writing) do
+      oauth_nonce = OauthNonce.create(:nonce => nonce, :timestamp => timestamp.to_i)
+    end
     return false if oauth_nonce.new_record?
 
     oauth_nonce

--- a/app/views/site/id.html.erb
+++ b/app/views/site/id.html.erb
@@ -10,7 +10,10 @@
 <body>
 <% data = {}
    if Settings.key?(:id_application)
-     token = current_user.oauth_token(Settings.id_application)
+     token = nil
+     ActiveRecord::Base.connected_to(:role => :writing) do
+       token = current_user.oauth_token(Settings.id_application)
+     end
      data[:token] = token.token
    end
    data[:locale] = ID::LOCALES.preferred(preferred_languages).to_s

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,5 +57,9 @@ module OpenStreetMap
       config.logstasher.logger_path = Settings.logstash_path
       config.logstasher.log_controller_parameters = true
     end
+
+    config.active_record.database_selector = { :delay => 2.seconds }
+    config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
   end
 end

--- a/config/docker.database.yml
+++ b/config/docker.database.yml
@@ -1,20 +1,28 @@
 # This configuration is tailored for use with docker-compose. See DOCKER.md for more information.
 
 development:
-  adapter: postgresql
-  database: openstreetmap
-  username: openstreetmap
-  password: openstreetmap
-  host: db
-  encoding: utf8
+  primary: &development_db
+    adapter: postgresql
+    database: openstreetmap
+    username: openstreetmap
+    password: openstreetmap
+    host: db
+    encoding: utf8
+  primary_replica:
+    <<: *development_db
+    replica: true
 
 # Warning: The database defined as 'test' will be erased and
 # re-generated from your development database when you run 'rake'.
 # Do not set this db to the same as development or production.
 test:
-  adapter: postgresql
-  database: osm_test
-  username: openstreetmap
-  password: openstreetmap
-  host: db
-  encoding: utf8
+  primary: &test_db
+    adapter: postgresql
+    database: osm_test
+    username: openstreetmap
+    password: openstreetmap
+    host: db
+    encoding: utf8
+  primary_replica:
+    <<: *test_db
+    replica: true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,6 +98,27 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false unless Settings.status == "database_offline"
 
+  # Inserts middleware to perform automatic connection switching.
+  # The `database_selector` hash is used to pass options to the DatabaseSelector
+  # middleware. The `delay` is used to determine how long to wait after a write
+  # to send a subsequent read to the primary.
+  #
+  # The `database_resolver` class is used by the middleware to determine which
+  # database is appropriate to use based on the time delay.
+  #
+  # The `database_resolver_context` class is used by the middleware to set
+  # timestamps for the last write to the primary. The resolver uses the context
+  # class timestamps to determine how long to wait before reading from the
+  # replica.
+  #
+  # By default Rails will store a last write timestamp in the session. The
+  # DatabaseSelector middleware is designed as such you can define your own
+  # strategy for connection switching and pass that into the middleware through
+  # these configuration options.
+  # config.active_record.database_selector = { :delay => 2.seconds }
+  # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
   # Enable autoloading of dependencies.
   config.enable_dependency_loading = true
 

--- a/config/example.database.yml
+++ b/config/example.database.yml
@@ -2,28 +2,40 @@
 # See https://github.com/openstreetmap/openstreetmap-website/blob/master/INSTALL.md#database-setup for detailed setup instructions.
 #
 development:
-  adapter: postgresql
-  database: openstreetmap
-#  username: openstreetmap
-#  password: openstreetmap
-#  host: localhost
-  encoding: utf8
+  primary: &development_db
+    adapter: postgresql
+    database: openstreetmap
+    #  username: openstreetmap
+    #  password: openstreetmap
+    #  host: localhost
+    encoding: utf8
+  primary_replica:
+    <<: *development_db
+    replica: true
 
 # Warning: The database defined as 'test' will be erased and
 # re-generated from your development database when you run 'rake'.
 # Do not set this db to the same as development or production.
 test:
-  adapter: postgresql
-  database: osm_test
-#  username: osm_test
-#  password: osm_test
-#  host: localhost
-  encoding: utf8
+  primary: &test_db
+    adapter: postgresql
+    database: osm_test
+    #  username: osm_test
+    #  password: osm_test
+    #  host: localhost
+    encoding: utf8
+  primary_replica:
+    <<: *test_db
+    replica: true
 
 production:
-  adapter: postgresql
-  database: osm
-#  username: osm
-#  password: osm
-#  host: localhost
-  encoding: utf8
+  primary: &production_db
+    adapter: postgresql
+    database: osm
+    #  username: osm
+    #  password: osm
+    #  host: localhost
+    encoding: utf8
+  primary_replica:
+    <<: *production_db
+    replica: true

--- a/config/github.database.yml
+++ b/config/github.database.yml
@@ -1,4 +1,8 @@
 test:
-  adapter: postgresql
-  database: openstreetmap
-  encoding: utf8
+  primary: &test_db
+    adapter: postgresql
+    database: openstreetmap
+    encoding: utf8
+  primary_replica:
+    <<: *test_db
+    replica: true


### PR DESCRIPTION
Fixes #2634

The connection switching is managed using the standard Resolver, which chooses the connection based on the HTTP verb. In the small number of cases where we update the database during GET requests, we override the default choice of connections.

Additionally, after any write in a particular user session, the resolver will continue to use the same (write) connection for two seconds for subsequent reads. This gives time for the changes to be replicated before switching back.

Unfortunately [there's a bug in rails when running migrations](https://github.com/rails/rails/issues/41855) so we can't merge this yet, but I thought I would push this now for review and discussion anyway. It contains a lot fewer connection overrides than when I last looked at this, since there's been some refactoring in the meantime as we move more things to standard new/create/update/etc.