### PR TITLE
fixed nodejs package name for fedora

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ For Fedora, you can install the minimum requirements with:
 
 ```
 sudo dnf install ruby ruby-devel rubygem-rdoc rubygem-bundler rubygems \
-                 libxml2-devel js \
+                 libxml2-devel nodejs \
                  gcc gcc-c++ git \
                  postgresql postgresql-server postgresql-contrib \
                  perl-podlators ImageMagick libffi-devel gd-devel libarchive-devel \


### PR DESCRIPTION
There is no "js" package, so this is probably a typo and should be "nodejs" (https://nodejs.org/en/download/package-manager/#centos-fedora-and-red-hat-enterprise-linux)