### PR TITLE
Added missing dependency for fedora installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,7 +50,7 @@ For Fedora, you can install the minimum requirements with:
 sudo dnf install ruby ruby-devel rubygem-rdoc rubygem-bundler rubygems \
                  libxml2-devel js \
                  gcc gcc-c++ git \
-                 postgresql postgresql-server postgresql-contrib \
+                 postgresql postgresql-server postgresql-contrib libpq-devel \
                  perl-podlators ImageMagick libffi-devel gd-devel libarchive-devel \
                  bzip2-devel nodejs-yarn
 ```


### PR DESCRIPTION
libpq-dev is required for `gem install pg` (this is also included in the ubuntu install guide). Note that on fedora the package is named libpq-devel