### PR TITLE
Skip intermediate lengths when testing tag validity

### DIFF
--- a/test/models/changeset_tag_test.rb
+++ b/test/models/changeset_tag_test.rb
@@ -5,7 +5,7 @@ class ChangesetTagTest < ActiveSupport::TestCase
     changeset = create(:changeset)
 
     key = "k"
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag = ChangesetTag.new
       tag.changeset_id = changeset.id
       tag.k = key * i
@@ -18,7 +18,7 @@ class ChangesetTagTest < ActiveSupport::TestCase
     changeset = create(:changeset)
 
     val = "v"
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag = ChangesetTag.new
       tag.changeset_id = changeset.id
       tag.k = "k"

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -32,7 +32,7 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   def test_utf8_roundtrip
-    (1..255).each do |i|
+    [1, 255].each do |i|
       assert_message_ok("c", i)
       assert_message_ok(EURO, i)
     end

--- a/test/models/node_tag_test.rb
+++ b/test/models/node_tag_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class NodeTagTest < ActiveSupport::TestCase
   def test_length_key_valid
     tag = create(:node_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.k = "k" * i
       assert tag.valid?
     end
@@ -11,7 +11,7 @@ class NodeTagTest < ActiveSupport::TestCase
 
   def test_length_value_valid
     tag = create(:node_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.v = "v" * i
       assert tag.valid?
     end

--- a/test/models/old_node_tag_test.rb
+++ b/test/models/old_node_tag_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class OldNodeTagTest < ActiveSupport::TestCase
   def test_length_key_valid
     tag = create(:old_node_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.k = "k" * i
       assert tag.valid?
     end
@@ -11,7 +11,7 @@ class OldNodeTagTest < ActiveSupport::TestCase
 
   def test_length_value_valid
     tag = create(:old_node_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.v = "v" * i
       assert tag.valid?
     end

--- a/test/models/old_relation_tag_test.rb
+++ b/test/models/old_relation_tag_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class OldRelationTagTest < ActiveSupport::TestCase
   def test_length_key_valid
     tag = create(:old_relation_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.k = "k" * i
       assert tag.valid?
     end
@@ -11,7 +11,7 @@ class OldRelationTagTest < ActiveSupport::TestCase
 
   def test_length_value_valid
     tag = create(:old_relation_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.v = "v" * i
       assert tag.valid?
     end

--- a/test/models/old_way_tag_test.rb
+++ b/test/models/old_way_tag_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class OldWayTagTest < ActiveSupport::TestCase
   def test_length_key_valid
     tag = create(:old_way_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.k = "k" * i
       assert tag.valid?
     end
@@ -11,7 +11,7 @@ class OldWayTagTest < ActiveSupport::TestCase
 
   def test_length_value_valid
     tag = create(:old_way_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.v = "v" * i
       assert tag.valid?
     end

--- a/test/models/relation_tag_test.rb
+++ b/test/models/relation_tag_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class RelationTagTest < ActiveSupport::TestCase
   def test_length_key_valid
     tag = create(:relation_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.k = "k" * i
       assert tag.valid?
     end
@@ -11,7 +11,7 @@ class RelationTagTest < ActiveSupport::TestCase
 
   def test_length_value_valid
     tag = create(:relation_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.v = "v" * i
       assert tag.valid?
     end

--- a/test/models/user_preference_test.rb
+++ b/test/models/user_preference_test.rb
@@ -15,7 +15,7 @@ class UserPreferenceTest < ActiveSupport::TestCase
   def test_check_valid_length
     key = "k"
     val = "v"
-    (1..255).each do |i|
+    [1, 255].each do |i|
       up = UserPreference.new
       up.user = create(:user)
       up.k = key * i

--- a/test/models/way_tag_test.rb
+++ b/test/models/way_tag_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class WayTagTest < ActiveSupport::TestCase
   def test_length_key_valid
     tag = create(:way_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.k = "k" * i
       assert tag.valid?
     end
@@ -11,7 +11,7 @@ class WayTagTest < ActiveSupport::TestCase
 
   def test_length_value_valid
     tag = create(:way_tag)
-    (0..255).each do |i|
+    [0, 255].each do |i|
       tag.v = "v" * i
       assert tag.valid?
     end


### PR DESCRIPTION
It's really the upper and lower boundaries that we want to check, and it's reasonable to assume all the intermediate values will work fine if the boundary values are tested.

This also saves about 75% of the time taken and almost 85% of the assertions when running all the model tests.

Rough notes from my laptop when running `bundle exec rails test test/models/`:

Before:

```
Finished in 21.187886s, 11.1384 runs/s, 314.2362 assertions/s.
236 runs, 6658 assertions, 0 failures, 0 errors, 0 skips
```

After:

```
Finished in 6.723931s, 35.0985 runs/s, 160.3229 assertions/s.
236 runs, 1078 assertions, 0 failures, 0 errors, 0 skips
```