### PR TITLE
Use bootstrap defaults for body CSS

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -7,7 +7,6 @@
 /* Default rules for the body of every page */
 
 body {
-  font-family: 'Helvetica Neue',Arial,sans-serif;
   font-size: $typeheight;
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1028,7 +1028,7 @@ tr.turn:hover {
 
 .content-inner {
   position: relative;
-  max-width: 900px;
+  max-width: 960px;
   margin: auto;
   padding: $lineheight;
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -9,13 +9,6 @@
 body {
   font-family: 'Helvetica Neue',Arial,sans-serif;
   font-size: $typeheight;
-  line-height: 1.6666;
-  color: #222;
-  background-color: #fff;
-  margin: 0px;
-  padding: 0px;
-  text-align: left;
-  height: 100%;
 }
 
 p > img {


### PR DESCRIPTION
This PR removes some of our overrides of basic CSS, which is handled through bootstrap. This reduces our custom CSS without having much impact on the rendered results. For example:

* color: `#222` -> `#212529`
* line-height: `1.6666` -> `1.5`;
* font-family: `'Helvetica Neue',Arial,sans-serif;` -> `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;`

My plan with the body `font-size` is to tackle all of our font-size settings in one go as a separate PR.