### PR TITLE
Added historic=rune_stone to en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -819,6 +819,7 @@ en:
           railway: "Historic Railway"
           roman_road: "Roman Road"
           ruins: "Ruins"
+          rune_stone: "Rune Stone"
           stone: "Stone"
           tomb: "Tomb"
           tower: "Tower"


### PR DESCRIPTION
Added key-value pair to allow TranslateWiki translation of labels in Nominatim.

https://wiki.openstreetmap.org/wiki/Tag:historic%3Drune_stone

See #3124 and #3142.