### PR TITLE
Minor improvements to messages

### DIFF
--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -2,8 +2,10 @@
   <%= javascript_include_tag "messages" %>
 <% end %>
 
+<% content_for :heading_class, "pb-0" %>
+
 <% content_for :heading do %>
-  <ul class="nav nav-pills">
+  <ul class="nav nav-tabs">
     <li class="nav-item">
       <a class="nav-link active"><%= t ".my_inbox" %></a>
     </li>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -5,6 +5,7 @@
 <% content_for :heading_class, "pb-0" %>
 
 <% content_for :heading do %>
+  <h1><%= t("users.show.my messages") %></h1>
   <ul class="nav nav-tabs">
     <li class="nav-item">
       <a class="nav-link active"><%= t ".my_inbox" %></a>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -5,6 +5,8 @@
 <% content_for :heading_class, "pb-0" %>
 
 <% content_for :heading do %>
+  <h1><%= t("users.show.my messages") %></h1>
+
   <ul class="nav nav-tabs">
     <li class="nav-item">
       <%= link_to t(".my_inbox"), inbox_messages_path, :class => "nav-link" %>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -2,8 +2,10 @@
   <%= javascript_include_tag "messages" %>
 <% end %>
 
+<% content_for :heading_class, "pb-0" %>
+
 <% content_for :heading do %>
-  <ul class="nav nav-pills">
+  <ul class="nav nav-tabs">
     <li class="nav-item">
       <%= link_to t(".my_inbox"), inbox_messages_path, :class => "nav-link" %>
     </li>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -16,7 +16,7 @@
   <div>
     <%= link_to t(".reply_button"), message_reply_path(@message), :class => "btn btn-primary" %>
     <%= link_to t(".unread_button"), message_mark_path(@message, :mark => "unread"), :method => "post", :class => "btn btn-primary" %>
-    <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-primary" %>
+    <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>
     <%= link_to t(".back"), inbox_messages_path, :class => "btn btn-link" %>
   </div>
 <% else %>
@@ -31,6 +31,7 @@
   <div class="richtext text-break"><%= @message.body.to_html %></div>
 
   <div>
+    <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>
     <%= link_to t(".back"), outbox_messages_path, :class => "btn btn-link" %>
   </div>
 <% end %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,8 +1,8 @@
-<% if current_user == @message.recipient %>
-  <% content_for :heading do %>
-    <h2><%= @message.title %></h2>
-  <% end %>
+<% content_for :heading do %>
+  <h2><%= @message.title %></h2>
+<% end %>
 
+<% if current_user == @message.recipient %>
   <div class='info-line clearfix'>
     <%= user_thumbnail_tiny @message.sender %>
     <%= link_to @message.sender.display_name, user_path(@message.sender) %></td>
@@ -11,7 +11,7 @@
     </div>
   </div>
 
-  <div class="richtext"><%= @message.body.to_html %></div>
+  <div class="richtext text-break"><%= @message.body.to_html %></div>
 
   <div>
     <%= link_to t(".reply_button"), message_reply_path(@message), :class => "btn btn-primary" %>
@@ -19,11 +19,7 @@
     <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-primary" %>
     <%= link_to t(".back"), inbox_messages_path, :class => "btn btn-link" %>
   </div>
-
 <% else %>
-
-  <h2><%= @message.title %></h2>
-
   <div class='info-line clearfix'>
     <%= user_thumbnail_tiny @message.recipient %>
     <%= link_to @message.recipient.display_name, user_path(@message.recipient) %></td>
@@ -37,5 +33,4 @@
   <div>
     <%= link_to t(".back"), outbox_messages_path, :class => "btn btn-link" %>
   </div>
-
 <% end %>


### PR DESCRIPTION
This PR contains a few minor improvements to the messages pages, namely

* Converting the inbox and outbox lines to tabs, in line with the tabs on the traces pages
* Adding a title to the header, since tabs alone looked a bit weird
* Putting the message title into the heading for sent messages, for consistency
* Making the delete message button red when viewing messages (for consistency with the similar buttons on inbox/outbox) and adding the button to the sent message view page (already shown on the outbox page)