### PR TITLE
Ensure heading text appears above the header illustration

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1035,13 +1035,8 @@ tr.turn:hover {
 
 /* Overrides for pages that use new layout conventions */
 
-.users-new,
-.users-create,
-.users-terms,
-.users-confirm {
-  .content-heading .content-inner {
-    height: 200px;
-  }
+.header-illustration-heading {
+  height: 200px;
 }
 
 .header-illustration {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1035,15 +1035,11 @@ tr.turn:hover {
 
 /* Overrides for pages that use new layout conventions */
 
-.header-illustration-heading {
-  height: 200px;
-}
-
 .header-illustration {
   background-position: 0 0;
   background-repeat: no-repeat;
-  position: absolute;
-  height: 200px;
+  position: relative;
+  min-height: 200px;
   width: 100%;
   left: 0;
   bottom: 0;
@@ -1063,9 +1059,10 @@ tr.turn:hover {
   &.new-user-arm {
     height: 110px;
     width: 130px;
-    left: 260px;
-    top: 160px;
+    left: 280px;
+    top: 180px;
     background-image: image-url("sign-up-illustration-arm.png");
+    position: absolute;
     z-index: 100;
   }
 }

--- a/app/views/confirmations/confirm.html.erb
+++ b/app/views/confirmations/confirm.html.erb
@@ -1,7 +1,8 @@
-<% content_for :heading_class, "header-illustration-heading" %>
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
-  <h1><%= t ".heading" %></h1>
-  <div class='header-illustration confirm-main'></div>
+  <div class='header-illustration confirm-main'>
+    <h1><%= t ".heading" %></h1>
+  </div>
 <% end %>
 
 <% if params[:confirm_string] %>

--- a/app/views/confirmations/confirm.html.erb
+++ b/app/views/confirmations/confirm.html.erb
@@ -1,3 +1,4 @@
+<% content_for :heading_class, "header-illustration-heading" %>
 <% content_for :heading do %>
   <h1><%= t ".heading" %></h1>
   <div class='header-illustration confirm-main'></div>

--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -1,7 +1,8 @@
-<% content_for :heading_class, "header-illustration-heading" %>
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
-  <h1><%= t "users.new.title" %></h1>
-  <div class='header-illustration new-user-main'></div>
+  <div class='header-illustration new-user-main'>
+    <h1><%= t "users.new.title" %></h1>
+  </div>
   <div class='header-illustration new-user-arm'></div>
 <% end %>
 

--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -1,3 +1,4 @@
+<% content_for :heading_class, "header-illustration-heading" %>
 <% content_for :heading do %>
   <h1><%= t "users.new.title" %></h1>
   <div class='header-illustration new-user-main'></div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,7 @@
   <%= javascript_include_tag "user" %>
 <% end %>
 
+<% content_for :heading_class, "header-illustration-heading" %>
 <% content_for :heading do %>
   <h1><%= t ".title" %></h1>
   <div class='header-illustration new-user-main'></div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,10 +2,11 @@
   <%= javascript_include_tag "user" %>
 <% end %>
 
-<% content_for :heading_class, "header-illustration-heading" %>
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
-  <h1><%= t ".title" %></h1>
-  <div class='header-illustration new-user-main'></div>
+  <div class='header-illustration new-user-main'>
+    <h1><%= t ".title" %></h1>
+  </div>
   <div class='header-illustration new-user-arm'></div>
 <% end %>
 

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -2,6 +2,7 @@
   <%= javascript_include_tag "user" %>
 <% end %>
 
+<% content_for :heading_class, "header-illustration-heading" %>
 <% content_for :heading do %>
   <h1><%= t ".heading" %></h1>
   <div class='header-illustration new-user-terms'></div>

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -2,10 +2,11 @@
   <%= javascript_include_tag "user" %>
 <% end %>
 
-<% content_for :heading_class, "header-illustration-heading" %>
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
-  <h1><%= t ".heading" %></h1>
-  <div class='header-illustration new-user-terms'></div>
+  <div class='header-illustration new-user-terms'>
+    <h1><%= t ".heading" %></h1>
+  </div>
 <% end %>
 
 <%= form_tag({ :action => "save" }) do %>


### PR DESCRIPTION
Fixes #3259 

The first problem was that there was a missing class there, since the CSS rule applied only to a certain list of classes and those class names are based on the controller. So this was inadvertantly broken in #3165.

The main problem is that the text appeared behind the background illustration. This predates any of our recent CSS work, but was probably less noticed back then since the titles were in a much smaller font. Here's a screenshot from early 2019 codebase. The titles need to be very long before being overlapped by the illustration.

![Screenshot from 2021-07-21 12-10-13](https://user-images.githubusercontent.com/360803/126503768-18f8a10c-3f46-4794-93d4-8ed708d4f2a5.png)

So in this PR I've refactored the heading, so that the titles are a child of the div that has the background illustration, and this means the text naturally appears over the top.

![Screenshot from 2021-07-21 15-04-48](https://user-images.githubusercontent.com/360803/126504048-64c95b39-ff05-4fbc-89b5-8c3a9848e27d.png)

I've also tweaked the div to be `min-height` instead of `height`, so that even with very long texts and very narrow windows, the title stays within the header rather than overlapping the rest of the content. This is probably unimportant in the real world.
