### PR TITLE
Remove incorrectly spelled helper_method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,6 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user
   helper_method :oauth_token
-  helper_method :preferred_langauges
 
   private
 


### PR DESCRIPTION
The spelling of language is wrong here, and the correct version is already there further down at the preferred_language method definition itself.