### PR TITLE
Use btn-outline-secondary for cancel buttons

### DIFF
--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -8,5 +8,5 @@
   <%= f.richtext_field :body, :cols => 80, :rows => 20 %>
 
   <%= f.primary %>
-  <%= link_to t(".back_to_inbox"), inbox_messages_path, :class => "btn btn-link" %>
+  <%= link_to t(".back_to_inbox"), inbox_messages_path, :class => "btn btn-outline-secondary" %>
 <% end %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -17,7 +17,7 @@
     <%= link_to t(".reply_button"), message_reply_path(@message), :class => "btn btn-primary" %>
     <%= link_to t(".unread_button"), message_mark_path(@message, :mark => "unread"), :method => "post", :class => "btn btn-primary" %>
     <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>
-    <%= link_to t(".back"), inbox_messages_path, :class => "btn btn-link" %>
+    <%= link_to t(".back"), inbox_messages_path, :class => "btn btn-outline-secondary" %>
   </div>
 <% else %>
   <div class='info-line clearfix'>
@@ -32,6 +32,6 @@
 
   <div>
     <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>
-    <%= link_to t(".back"), outbox_messages_path, :class => "btn btn-link" %>
+    <%= link_to t(".back"), outbox_messages_path, :class => "btn btn-outline-secondary" %>
   </div>
 <% end %>

--- a/app/views/preferences/edit.html.erb
+++ b/app/views/preferences/edit.html.erb
@@ -8,5 +8,5 @@
   <%= f.text_field :languages %>
 
   <%= f.primary t(".save") %>
-  <%= link_to t(".cancel"), preferences_path, :class => "btn btn-link" %>
+  <%= link_to t(".cancel"), preferences_path, :class => "btn btn-outline-secondary" %>
 <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -57,5 +57,5 @@
   </fieldset>
 
   <%= f.primary t(".save") %>
-    <%= link_to t(".cancel"), user_path(current_user), :class => "btn btn-link" %>
+    <%= link_to t(".cancel"), user_path(current_user), :class => "btn btn-outline-secondary" %>
 <% end %>

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -15,5 +15,5 @@
                 [t("traces.visibility.identifiable"), "identifiable"]],
                :help => link_to(t(".visibility_help"), t(".visibility_help_url")) %>
   <%= f.primary %>
-  <%= link_to t(".cancel"), show_trace_path(@trace.user, @trace), :class => "btn btn-link" %>
+  <%= link_to t(".cancel"), show_trace_path(@trace.user, @trace), :class => "btn btn-outline-secondary" %>
 <% end %>

--- a/app/views/traces/new.html.erb
+++ b/app/views/traces/new.html.erb
@@ -13,5 +13,5 @@
                 [t("traces.visibility.identifiable"), "identifiable"]],
                :help => link_to(t(".visibility_help"), t(".visibility_help_url")) %>
   <%= f.primary %>
-  <%= link_to t(".help"), t(".help_url"), :class => "btn btn-link" %>
+  <%= link_to t(".help"), t(".help_url"), :class => "btn btn-outline-secondary" %>
 <% end %>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -18,5 +18,5 @@
   <% end %>
 
   <%= f.primary %>
-  <%= link_to t(".back"), user_blocks_path, :class => "btn btn-link" %>
+  <%= link_to t(".back"), user_blocks_path, :class => "btn btn-outline-secondary" %>
 <% end %>


### PR DESCRIPTION
As discussed in the #3257 review this changes all cancel buttons to use `btn-outline-secondary` instead of `btn-link` because to my mind at least having a row of buttons and then what looks like a link is quite odd.

In all cases the existing buttons are all non-outline so the cancel button retains a distinctive look by being an outline button.