### PR TITLE
Improve capitalisation of page titles

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -423,10 +423,10 @@ en:
       location: Location
       use_map_link: Use Map
     index:
-      title: "Users' diaries"
-      title_friends: "Friends' diaries"
-      title_nearby: "Nearby Users' diaries"
-      user_title: "%{user}'s diary"
+      title: "Users' Diaries"
+      title_friends: "Friends' Diaries"
+      title_nearby: "Nearby Users' Diaries"
+      user_title: "%{user}'s Diary"
       in_language_title: "Diary Entries in %{language}"
       new: New Diary Entry
       new_title: Compose a new entry in my user diary
@@ -439,8 +439,8 @@ en:
       title: Edit Diary Entry
       marker_text: Diary entry location
     show:
-      title: "%{user}'s diary | %{title}"
-      user_title: "%{user}'s diary"
+      title: "%{user}'s Diary | %{title}"
+      user_title: "%{user}'s Diary"
       leave_a_comment: "Leave a comment"
       login_to_leave_a_comment_html: "%{login_link} to leave a comment"
       login: "Login"
@@ -2218,8 +2218,8 @@ en:
         other: "You have %{count} traces waiting for upload. Please consider waiting for these to finish before uploading any more, so as not to block the queue for other users."
     edit:
       cancel: Cancel
-      title: "Editing trace %{name}"
-      heading: "Editing trace %{name}"
+      title: "Editing Trace %{name}"
+      heading: "Editing Trace %{name}"
       visibility_help: "what does this mean?"
       visibility_help_url: "https://wiki.openstreetmap.org/wiki/Visibility_of_GPS_traces"
     update:
@@ -2227,8 +2227,8 @@ en:
     trace_optionals:
       tags: "Tags"
     show:
-      title: "Viewing trace %{name}"
-      heading: "Viewing trace %{name}"
+      title: "Viewing Trace %{name}"
+      heading: "Viewing Trace %{name}"
       pending: "PENDING"
       filename: "Filename:"
       download: "download"
@@ -2267,9 +2267,9 @@ en:
       by: "by"
       in: "in"
     index:
-      public_traces: "Public GPS traces"
-      my_traces: "My GPS traces"
-      public_traces_from: "Public GPS traces from %{user}"
+      public_traces: "Public GPS Traces"
+      my_traces: "My GPS Traces"
+      public_traces_from: "Public GPS Traces from %{user}"
       description: "Browse recent GPS trace uploads"
       tagged_with: " tagged with %{tags}"
       empty_html: "Nothing here yet. <a href='%{upload_link}'>Upload a new trace</a> or learn more about GPS tracing on the <a href='https://wiki.openstreetmap.org/wiki/Beginners_Guide_1.2'>wiki page</a>."
@@ -2378,7 +2378,7 @@ en:
       flash: "Destroyed the client application registration"
   oauth2_applications:
     index:
-      title: "My client applications"
+      title: "My Client Applications"
       no_applications_html: "Do you have an application you would like to register for use with us using the %{oauth2} standard? You must register your application before it can make OAuth requests to this service."
       oauth_2: "OAuth 2"
       new: "Register new application"
@@ -2405,7 +2405,7 @@ en:
       sorry: "Sorry, that application could not be found."
   oauth2_authorizations:
     new:
-      title: "Authorization required"
+      title: "Authorization Required"
       introduction: "Authorize %{application} to access your account with the following permissions?"
       authorize: "Authorize"
       deny: "Deny"
@@ -2415,7 +2415,7 @@ en:
       title: "Authorization code"
   oauth2_authorized_applications:
     index:
-      title: "My authorized applications"
+      title: "My Authorized Applications"
       application: "Application"
       permissions: "Permissions"
       no_applications_html: "You have not yet authorized any %{oauth2} applications."
@@ -2544,7 +2544,7 @@ en:
       friend: "Friend"
     account:
       title: "Edit account"
-      my settings: My settings
+      my settings: My Settings
       current email address: "Current Email Address"
       external auth: "External Authentication"
       openid:
@@ -2702,11 +2702,11 @@ en:
           other: "%{count} years"
     blocks_on:
       title: "Blocks on %{name}"
-      heading_html: "List of blocks on %{name}"
+      heading_html: "List of Blocks on %{name}"
       empty: "%{name} has not been blocked yet."
     blocks_by:
       title: "Blocks by %{name}"
-      heading_html: "List of blocks by %{name}"
+      heading_html: "List of Blocks by %{name}"
       empty: "%{name} has not made any blocks yet."
     show:
       title: "%{block_on} blocked by %{block_by}"
@@ -2739,7 +2739,7 @@ en:
   notes:
     index:
       title: "Notes submitted or commented on by %{user}"
-      heading: "%{user}'s notes"
+      heading: "%{user}'s Notes"
       subheading_html: "Notes submitted or commented on by %{user}"
       no_notes: No notes
       id: "Id"
@@ -2935,19 +2935,19 @@ en:
       centre_map: Centre map here
   redactions:
     edit:
-      heading: "Edit redaction"
-      title: "Edit redaction"
+      heading: "Edit Redaction"
+      title: "Edit Redaction"
     index:
       empty: "No redactions to show."
-      heading: "List of redactions"
-      title: "List of redactions"
+      heading: "List of Redactions"
+      title: "List of Redactions"
     new:
-      heading: "Enter information for new redaction"
-      title: "Creating new redaction"
+      heading: "Enter Information for New Redaction"
+      title: "Creating New Redaction"
     show:
       description: "Description:"
-      heading: "Showing redaction \"%{title}\""
-      title: "Showing redaction"
+      heading: "Showing Redaction \"%{title}\""
+      title: "Showing Redaction"
       user: "Creator:"
       edit: "Edit this redaction"
       destroy: "Remove this redaction"

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -314,9 +314,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     get diary_entry_path(:display_name => entry.user.display_name, :id => entry)
     assert_response :success
     assert_template "show"
-    assert_select "title", :text => /Users' diaries | /, :count => 1
+    assert_select "title", :text => /Users' Diaries | /, :count => 1
     assert_select "div.content-heading", :count => 1 do
-      assert_select "h2", :text => /#{entry.user.display_name}'s diary/, :count => 1
+      assert_select "h2", :text => /#{entry.user.display_name}'s Diary/, :count => 1
     end
     assert_select "div#content", :count => 1 do
       assert_select "div.post_heading", :text => /#{new_title}/, :count => 1
@@ -334,9 +334,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     get diary_entry_path(:display_name => entry.user.display_name, :id => entry)
     assert_response :success
     assert_template "show"
-    assert_select "title", :text => /Users' diaries | /, :count => 1
+    assert_select "title", :text => /Users' Diaries | /, :count => 1
     assert_select "div.content-heading", :count => 1 do
-      assert_select "h2", :text => /#{entry.user.display_name}'s diary/, :count => 1
+      assert_select "h2", :text => /#{entry.user.display_name}'s Diary/, :count => 1
     end
     assert_select "div#content", :count => 1 do
       assert_select "div.post_heading", :text => /#{new_title}/, :count => 1

--- a/test/system/user_logout_test.rb
+++ b/test/system/user_logout_test.rb
@@ -20,7 +20,7 @@ class UserLogoutTest < ApplicationSystemTestCase
     click_on user.display_name
     click_on "Log Out"
     assert page.has_content? "Log In"
-    assert page.has_content? "Public GPS traces"
+    assert page.has_content? "Public GPS Traces"
   end
 
   test "Sign out via fallback page" do
@@ -43,6 +43,6 @@ class UserLogoutTest < ApplicationSystemTestCase
 
     click_button "Logout"
     assert page.has_content? "Log In"
-    assert page.has_content? "Public GPS traces"
+    assert page.has_content? "Public GPS Traces"
   end
 end


### PR DESCRIPTION
As discussed in the #3257 review our page titles are somewhat inconsistent in their use of capitalisation and this is an attempt to improve that situation.

That said, some of our headings are quite long sentences and I'm not sure how well they work in full titlecase...