### PR TITLE
Enable test for showing flash message in the new language

### DIFF
--- a/test/system/preferences_test.rb
+++ b/test/system/preferences_test.rb
@@ -17,7 +17,6 @@ class PreferencesTest < ApplicationSystemTestCase
     fill_in "Preferred Languages", :with => "fr"
     click_on "Update Preferences"
 
-    # TODO: enable with french translation when that's available
-    # assert page.has_content?("Préférences mises à jour") # rubocop:disable Style/AsciiComments
+    assert page.has_content?("Préférences mises à jour")
   end
 end


### PR DESCRIPTION
Now that the translations have been updated, we can enable this test. 

Followup from #3257.