### PR TITLE
Add --ignore-engines for yarn in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ RUN gem install bundler \
 # Install NodeJS packages using yarnpkg
 # `bundle exec rake yarn:install` will not work
 ADD package.json yarn.lock /app/
-RUN yarnpkg install
+RUN yarnpkg --ignore-engines install


### PR DESCRIPTION
Refs #3275

See also 102f3a6668665774f069a8116a251a28c3c5c0cc

This at least fixes the docker CI build while we discuss the best long-term approach in #3275