### PR TITLE
Switch to html5-compatible fragment encoding for wikipedia URLs

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -85,7 +85,7 @@ module BrowseTagsHelper
       # Must break it up to correctly build the url
       value = Regexp.last_match(1)
       section = "##{Regexp.last_match(2)}"
-      encoded_section = "##{CGI.escape(Regexp.last_match(2).gsub(/ +/, '_')).tr('%', '.')}"
+      encoded_section = "##{CGI.escape(Regexp.last_match(2).gsub(/ +/, '_'))}"
     else
       section = ""
       encoded_section = ""

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -169,11 +169,11 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_equal "de:Englischer Garten (München)#Japanisches Teehaus", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Alte Brücke (Heidelberg)#Brückenaffe")
-    assert_equal "https://de.wikipedia.org/wiki/de:Alte Brücke (Heidelberg)?uselang=en#Br.C3.BCckenaffe", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/de:Alte Brücke (Heidelberg)?uselang=en#Br%C3%BCckenaffe", link[:url]
     assert_equal "de:Alte Brücke (Heidelberg)#Brückenaffe", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Liste der Baudenkmäler in Eichstätt#Brückenstraße 1, Ehemaliges Bauernhaus")
-    assert_equal "https://de.wikipedia.org/wiki/de:Liste der Baudenkmäler in Eichstätt?uselang=en#Br.C3.BCckenstra.C3.9Fe_1.2C_Ehemaliges_Bauernhaus", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/de:Liste der Baudenkmäler in Eichstätt?uselang=en#Br%C3%BCckenstra%C3%9Fe_1%2C_Ehemaliges_Bauernhaus", link[:url]
     assert_equal "de:Liste der Baudenkmäler in Eichstätt#Brückenstraße 1, Ehemaliges Bauernhaus", link[:title]
 
     I18n.with_locale "pt-BR" do


### PR DESCRIPTION
Fixes #3269

In the HTML4 days, fragments weren't allowed to have `%` signs, so mediawiki generated fragments with `%` replaced with a `.`

In HTML5, fragments can have % encoded characters, and so in 2017 wikipedia switched over to this for their automatically generated fragments, while keeping the "dot" versions available as a fallback.

However, we have been automatically converting all fragments, including manually specified anchors that do not have "dot"-encoded versions available. So we can now simplify everything by just using the HTML5 percent-encoded fragments.