### PR TITLE
Fix redirect to terms path when not logged in

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
         # Already agreed to terms, so just show settings
         redirect_to :action => :account, :display_name => current_user.display_name
       elsif current_user.nil? && session[:new_user].nil?
-        redirect_to :action => :login, :referer => request.fullpath
+        redirect_to login_path(:referer => request.fullpath)
       end
     end
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -414,6 +414,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to :action => :terms, :referer => "/user/#{ERB::Util.u(user.display_name)}/account"
   end
 
+  def test_terms_not_logged_in
+    get user_terms_path
+
+    assert_redirected_to login_path(:referer => "/user/terms")
+  end
+
   def test_go_public
     user = create(:user, :data_public => false)
     session_for(user)


### PR DESCRIPTION
This was missed during #3147 since it wasn't covered by a test.