### PR TITLE
Fix broken `libpgosm.so`

### DIFF
--- a/.github/workflows/tests-libpgosm.yml
+++ b/.github/workflows/tests-libpgosm.yml
@@ -1,0 +1,107 @@
+---
+name: Tests (libpgosm.so)
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Ubuntu ${{ matrix.ubuntu }}, Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ubuntu: [18.04, 20.04]
+        ruby: [2.7, 3.0]
+    runs-on: ubuntu-${{ matrix.ubuntu }}
+    env:
+      RAILS_ENV: test
+      OPENSTREETMAP_MEMCACHE_SERVERS: 127.0.0.1
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2.3.4
+      - name: Setup ruby
+        uses: actions/setup-ruby@v1.1.3
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Cache gems
+        uses: actions/cache@v2.1.6
+        with:
+          path: vendor/bundle
+          key: bundle-ubuntu-${{ matrix.ubuntu }}-ruby-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            bundle-ubuntu-${{ matrix.ubuntu }}-ruby-${{ matrix.ruby }}-
+      - name: Cache node modules
+        uses: actions/cache@v2.1.6
+        with:
+          path: node_modules
+          key: yarn-ubuntu-${{ matrix.ubuntu }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-ubuntu-${{ matrix.ubuntu }}-
+      - name: Install packages
+        run: |
+          sudo apt-get -yqq update
+          sudo apt-get -yqq install memcached
+      - name: Install gems
+        run: |
+          gem install bundler
+          bundle config set deployment true
+          bundle install --jobs 4 --retry 3
+      - name: Install libpgosm.so build dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          KEY_URL: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          REPO_URL: https://apt.postgresql.org/pub/repos/apt/
+        run: |
+          wget -qnv ${KEY_URL} -O /tmp/PGDG.key
+          sudo apt-key add /tmp/PGDG.key
+          echo "deb ${REPO_URL} `lsb_release -cs`-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get -yqq update
+          sudo apt-get -yqq install postgresql-server-dev-all
+          sudo rm /etc/apt/sources.list.d/pgdg.list
+      - name: Build libpgosm.so
+        working-directory: db/functions
+        run: |
+          make libpgosm.so
+      - name: Create database
+        run: |
+          sudo systemctl start postgresql
+          sudo -u postgres createuser -s $(id -un)
+          createdb openstreetmap
+      - name: Create database extension
+        run: |
+          psql -c "CREATE EXTENSION btree_gist" openstreetmap
+      - name: Create database functions
+        run: |
+          psql -c "CREATE FUNCTION tile_for_point(int4, int4) RETURNS int8 AS '`pwd`/db/functions/libpgosm', 'tile_for_point' LANGUAGE C STRICT" openstreetmap
+      - name: Configure rails
+        run: |
+          cp config/github.database.yml config/database.yml
+          cp config/example.storage.yml config/storage.yml
+          touch config/settings.local.yml
+      - name: Populate database
+        run: |
+          bundle exec rake db:migrate
+      - name: Export javascript strings
+        run: bundle exec rake i18n:js:export
+      - name: Install node modules
+        run: bundle exec rake yarn:install
+      - name: Run tests
+        run: bundle exec rails test:all
+      - name: Report completion to Coveralls
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: ubuntu-${{ matrix.ubuntu }}-ruby-${{ matrix.ruby }}
+          parallel: true
+
+  finish:
+    name: Finalise
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report completion to Coveralls
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,18 +1,14 @@
----
 name: Tests
-
 on:
   - push
   - pull_request
-
 jobs:
   test:
-    name: Ubuntu ${{ matrix.ubuntu }}, Ruby ${{ matrix.ruby }} (${{ matrix.db_funcs }})
+    name: Ubuntu ${{ matrix.ubuntu }}, Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
         ubuntu: [18.04, 20.04]
         ruby: [2.7, 3.0]
-        db_funcs: ['libpgosm.so', 'Pure SQL']
     runs-on: ubuntu-${{ matrix.ubuntu }}
     env:
       RAILS_ENV: test
@@ -47,57 +43,22 @@ jobs:
         gem install bundler
         bundle config set deployment true
         bundle install --jobs 4 --retry 3
-    - name: Install libpgosm.so build dependencies
-      if: ${{ matrix.db_funcs == 'libpgosm.so' }}
-      env:
-        DEBIAN_FRONTEND: noninteractive
-        KEY_URL: https://www.postgresql.org/media/keys/ACCC4CF8.asc
-        REPO_URL: https://apt.postgresql.org/pub/repos/apt/
-      run: |
-        wget -qnv ${KEY_URL} -O /tmp/PGDG.key
-        sudo apt-key add /tmp/PGDG.key
-        echo "deb ${REPO_URL} `lsb_release -cs`-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
-        sudo apt-get -yqq update
-        sudo apt-get -yqq install postgresql-server-dev-all
-        sudo rm /etc/apt/sources.list.d/pgdg.list
-    - name: Build libpgosm.so
-      if: ${{ matrix.db_funcs == 'libpgosm.so' }}
-      working-directory: db/functions
-      run: |
-        make libpgosm.so
     - name: Create database
       run: |
         sudo systemctl start postgresql
         sudo -u postgres createuser -s $(id -un)
         createdb openstreetmap
-    - name: Create database extension
-      run: |
         psql -c "CREATE EXTENSION btree_gist" openstreetmap
-
-    - name: Create database functions (Pure SQL)
-      if: ${{ matrix.db_funcs == 'Pure SQL' }}
-      run: |
         psql -f db/functions/functions.sql openstreetmap
-
-    - name: Create database functions (libpgosm.so)
-      if: ${{ matrix.db_funcs == 'libpgosm.so' }}
-      run: |
-        psql -c "CREATE FUNCTION tile_for_point(int4, int4) RETURNS int8 AS '`pwd`/db/functions/libpgosm', 'tile_for_point' LANGUAGE C STRICT" openstreetmap
     - name: Configure rails
       run: |
         cp config/github.database.yml config/database.yml
         cp config/example.storage.yml config/storage.yml
         touch config/settings.local.yml
-    - name: Create `db/structure.expected` (Pure SQL)
-      if: ${{ matrix.db_funcs == 'Pure SQL' }}
-      run: |
-        sed -f script/normalise-structure db/structure.sql > db/structure.expected
     - name: Populate database
       run: |
+        sed -f script/normalise-structure db/structure.sql > db/structure.expected
         bundle exec rake db:migrate
-    - name: Verify `db/structure.expected` (Pure SQL)
-      if: ${{ matrix.db_funcs == 'Pure SQL' }}
-      run: |
         sed -f script/normalise-structure db/structure.sql > db/structure.actual
         diff -uw db/structure.expected db/structure.actual
     - name: Export javascript strings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,18 @@
+---
 name: Tests
+
 on:
   - push
   - pull_request
+
 jobs:
   test:
-    name: Ubuntu ${{ matrix.ubuntu }}, Ruby ${{ matrix.ruby }}
+    name: Ubuntu ${{ matrix.ubuntu }}, Ruby ${{ matrix.ruby }} (${{ matrix.db_funcs }})
     strategy:
       matrix:
         ubuntu: [18.04, 20.04]
         ruby: [2.7, 3.0]
+        db_funcs: ['libpgosm.so', 'Pure SQL']
     runs-on: ubuntu-${{ matrix.ubuntu }}
     env:
       RAILS_ENV: test
@@ -43,22 +47,57 @@ jobs:
         gem install bundler
         bundle config set deployment true
         bundle install --jobs 4 --retry 3
+    - name: Install libpgosm.so build dependencies
+      if: ${{ matrix.db_funcs == 'libpgosm.so' }}
+      env:
+        DEBIAN_FRONTEND: noninteractive
+        KEY_URL: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+        REPO_URL: https://apt.postgresql.org/pub/repos/apt/
+      run: |
+        wget -qnv ${KEY_URL} -O /tmp/PGDG.key
+        sudo apt-key add /tmp/PGDG.key
+        echo "deb ${REPO_URL} `lsb_release -cs`-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+        sudo apt-get -yqq update
+        sudo apt-get -yqq install postgresql-server-dev-all
+        sudo rm /etc/apt/sources.list.d/pgdg.list
+    - name: Build libpgosm.so
+      if: ${{ matrix.db_funcs == 'libpgosm.so' }}
+      working-directory: db/functions
+      run: |
+        make libpgosm.so
     - name: Create database
       run: |
         sudo systemctl start postgresql
         sudo -u postgres createuser -s $(id -un)
         createdb openstreetmap
+    - name: Create database extension
+      run: |
         psql -c "CREATE EXTENSION btree_gist" openstreetmap
+
+    - name: Create database functions (Pure SQL)
+      if: ${{ matrix.db_funcs == 'Pure SQL' }}
+      run: |
         psql -f db/functions/functions.sql openstreetmap
+
+    - name: Create database functions (libpgosm.so)
+      if: ${{ matrix.db_funcs == 'libpgosm.so' }}
+      run: |
+        psql -c "CREATE FUNCTION tile_for_point(int4, int4) RETURNS int8 AS '`pwd`/db/functions/libpgosm', 'tile_for_point' LANGUAGE C STRICT" openstreetmap
     - name: Configure rails
       run: |
         cp config/github.database.yml config/database.yml
         cp config/example.storage.yml config/storage.yml
         touch config/settings.local.yml
-    - name: Populate database
+    - name: Create `db/structure.expected` (Pure SQL)
+      if: ${{ matrix.db_funcs == 'Pure SQL' }}
       run: |
         sed -f script/normalise-structure db/structure.sql > db/structure.expected
+    - name: Populate database
+      run: |
         bundle exec rake db:migrate
+    - name: Verify `db/structure.expected` (Pure SQL)
+      if: ${{ matrix.db_funcs == 'Pure SQL' }}
+      run: |
         sed -f script/normalise-structure db/structure.sql > db/structure.actual
         diff -uw db/structure.expected db/structure.actual
     - name: Export javascript strings

--- a/db/functions/Makefile
+++ b/db/functions/Makefile
@@ -16,7 +16,7 @@ all: ${DESTDIR}/libpgosm.so
 clean:
 	$(RM) ${DESTDIR}/*.so ${DESTDIR}/*.o
 
-${DESTDIR}/libpgosm.so: ${DESTDIR}/quadtile.o
+${DESTDIR}/libpgosm.so: ${DESTDIR}/pg_module_magic.o ${DESTDIR}/quadtile.o
 	cc ${LDFLAGS} -o $@ $^
 
 ${DESTDIR}/%.o: %.c

--- a/db/functions/pg_module_magic.c
+++ b/db/functions/pg_module_magic.c
@@ -1,0 +1,6 @@
+#include <postgres.h>
+#include <fmgr.h>
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif


### PR DESCRIPTION
After the removal of [db/functions/maptile.c](https://github.com/openstreetmap/openstreetmap-website/commit/4e6d729529c94486a50cf135dfbbdcf841790200#diff-c3f52ef93a4aaf1f148e626e39ec31e4de87ce44154fbb7f5ea6e321c4e195a4L34-L36) in 4e6d729529c94486a50cf135dfbbdcf841790200, the `PG_MODULE_MAGIC` macro no longer gets called and therefore causes the compiled shared library to no longer be compatible. Resolved by creating a new `.c`/`.o` file whose only function is to call `PG_MODULE_MAGIC`.

Also:
  * Added `libpgosm.so` build to new `Tests (libpgosm.so)` workflow, here are links the relevant jobs:
    * Before:
      https://github.com/hummeltech/openstreetmap-website/runs/3256812366?check_suite_focus=true
    * After:
      https://github.com/hummeltech/openstreetmap-website/actions/runs/1103419155
      