### PR TITLE
Avoid using raw html in translations for links.

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -191,7 +191,7 @@
     <div class="col-md order-md-last">
       <% if @user.home_lat.nil? or @user.home_lon.nil? %>
         <div id="map" class="content_map">
-          <p id="no_home_location"><%= t(".set_location_html", :edit_profile_url => edit_profile_path) %></p>
+          <p id="no_home_location"><%= t(".no_home_location_html", :edit_profile_link => link_to(t(".edit_your_profile"), edit_profile_path)) %></p>
         </div>
       <% else %>
         <% content_for :head do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2505,7 +2505,8 @@ en:
       spam score: "Spam Score:"
       description: Description
       user location: User location
-      set_location_html: "<a href=\"%{edit_profile_url}\">Edit your profile</a> and set your home location to see nearby users."
+      no_home_location_html: "%{edit_profile_link} and set your home location to see nearby users."
+      edit_your_profile: Edit your profile
       my friends: My friends
       no friends: You have not added any friends yet.
       km away: "%{count}km away"


### PR DESCRIPTION
This is a followup to 26698d6 which introduced the html. It's better to use interpolation for links, since this avoids the translations introducing any html syntax errors.

I had to change the translation key, since changing the interpolation variables alone would lead to breakages.