### PR TITLE
Use more named paths

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -93,10 +93,10 @@ class ConfirmationsController < ApplicationController
         current_user.tokens.delete_all
         session[:user] = current_user.id
         session[:fingerprint] = current_user.fingerprint
-        redirect_to :controller => :users, :action => :account, :display_name => current_user.display_name
+        redirect_to user_account_path(current_user)
       elsif token
         flash[:error] = t "confirmations.confirm_email.failure"
-        redirect_to :controller => :users, :action => :account, :display_name => token.user.display_name
+        redirect_to user_account_path(token.user)
       else
         flash[:error] = t "confirmations.confirm_email.unknown_token"
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
 
       if current_user&.terms_agreed?
         # Already agreed to terms, so just show settings
-        redirect_to :action => :account, :display_name => current_user.display_name
+        redirect_to user_account_path(current_user)
       elsif current_user.nil? && session[:new_user].nil?
         redirect_to login_path(:referer => request.fullpath)
       end
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
         if params[:referer]
           redirect_to safe_referer(params[:referer])
         else
-          redirect_to :action => :account, :display_name => current_user.display_name
+          redirect_to user_account_path(current_user)
         end
       elsif params[:decline]
         redirect_to t("users.terms.declined")
@@ -67,7 +67,7 @@ class UsersController < ApplicationController
       if params[:referer]
         redirect_to safe_referer(params[:referer])
       else
-        redirect_to :action => :account, :display_name => current_user.display_name
+        redirect_to user_account_path(current_user)
       end
     else
       self.current_user = session.delete(:new_user)
@@ -147,7 +147,7 @@ class UsersController < ApplicationController
     current_user.data_public = true
     current_user.save
     flash[:notice] = t "users.go_public.flash success"
-    redirect_to :action => "account", :display_name => current_user.display_name
+    redirect_to user_account_path(current_user)
   end
 
   def new
@@ -297,7 +297,7 @@ class UsersController < ApplicationController
 
       session[:user_errors] = current_user.errors.as_json
 
-      redirect_to :action => "account", :display_name => current_user.display_name
+      redirect_to user_account_path(current_user)
     elsif session[:new_user]
       session[:new_user].auth_provider = provider
       session[:new_user].auth_uid = uid

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -95,7 +95,7 @@
             <span class='count-number'><%= number_with_delimiter(current_user.new_messages.size) %></span>
           <% end %>
           <%= link_to t("users.show.my profile"), user_path(current_user), :class => "dropdown-item" %>
-          <%= link_to t("users.show.my settings"), { :controller => "users", :action => "account", :display_name => current_user.display_name }, { :class => "dropdown-item" } %>
+          <%= link_to t("users.show.my settings"), user_account_path(current_user), :class => "dropdown-item" %>
           <%= link_to t("users.show.my_preferences"), preferences_path, :class => "dropdown-item" %>
           <div class="dropdown-divider"></div>
           <%= yield :greeting %>

--- a/app/views/site/edit.html.erb
+++ b/app/views/site/edit.html.erb
@@ -5,7 +5,7 @@
     <p><%= t "layouts.osm_read_only" %></p>
   <% elsif !current_user.data_public? %>
     <p><%= t ".not_public" %></p>
-    <p><%= t ".not_public_description_html", :user_page => (link_to t(".user_page_link"), :controller => "users", :action => "account", :display_name => current_user.display_name, :anchor => "public") %></p>
+    <p><%= t ".not_public_description_html", :user_page => (link_to t(".user_page_link"), user_account_path(current_user, :anchor => "public")) %></p>
     <p><%= t ".anon_edits_html", :link => link_to(t(".anon_edits_link_text"), t(".anon_edits_link")) %></p>
   <% else %>
     <%= render :partial => preferred_editor %>

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -17,6 +17,6 @@
   <td><%= link_to t(".show"), block %></td>
   <td><% if current_user and current_user.id == block.creator_id and block.active? %><%= link_to t(".edit"), edit_user_block_path(block) %><% end %></td>
   <% if show_revoke_link %>
-  <td><% if block.active? %><%= link_to t(".revoke"), :controller => "user_blocks", :action => "revoke", :id => block.id %><% end %></td>
+  <td><% if block.active? %><%= link_to t(".revoke"), revoke_user_block_path(block) %><% end %></td>
   <% end %>
 </tr>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -14,7 +14,7 @@
       <li><%= link_to t(".edit"), edit_user_block_path(@user_block) %></li>
     <% end %>
     <% if can?(:revoke, UserBlock) %>
-      <li><%= link_to(t(".revoke"), :controller => "user_blocks", :action => "revoke", :id => @user_block.id) %></li>
+      <li><%= link_to t(".revoke"), revoke_user_block_path(@user_block) %></li>
     <% end %>
   <% end %>
   <li><%= link_to t(".back"), user_blocks_path %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,7 @@
             <span class='count-number'><%= number_with_delimiter(current_user.diary_entries.size) %></span>
           </li>
           <li>
-            <%= link_to t(".my comments"), :controller => "diary_entries", :action => "comments", :display_name => current_user.display_name %>
+            <%= link_to t(".my comments"), diary_comments_path(current_user) %>
           </li>
           <li>
             <%= link_to t(".my settings"), user_account_path(current_user) %>
@@ -70,7 +70,7 @@
             <span class='count-number'><%= number_with_delimiter(@user.diary_entries.size) %></span>
           </li>
           <li>
-            <%= link_to t(".comments"), :controller => "diary_entries", :action => "comments", :display_name => @user.display_name %>
+            <%= link_to t(".comments"), diary_comments_path(@user) %>
           </li>
           <li>
             <% if current_user and current_user.is_friends_with?(@user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,14 +30,14 @@
 
           <% if current_user.blocks.exists? %>
             <li>
-              <%= link_to t(".blocks on me"), :controller => "user_blocks", :action => "blocks_on", :display_name => current_user.display_name %>
+              <%= link_to t(".blocks on me"), user_blocks_on_path(current_user) %>
               <span class='count-number'><%= number_with_delimiter(current_user.blocks.active.size) %></span>
             </li>
           <% end %>
 
           <% if can?(:create, UserBlock) and current_user.blocks_created.exists? %>
             <li>
-              <%= link_to t(".blocks by me"), :controller => "user_blocks", :action => "blocks_by", :display_name => current_user.display_name %>
+              <%= link_to t(".blocks by me"), user_blocks_by_path(current_user) %>
               <span class='count-number'><%= number_with_delimiter(current_user.blocks_created.active.size) %></span>
             </li>
           <% end %>
@@ -84,21 +84,21 @@
 
           <% if @user.blocks.exists? %>
             <li>
-              <%= link_to t(".block_history"), :controller => "user_blocks", :action => "blocks_on", :display_name => @user.display_name %>
+              <%= link_to t(".block_history"), user_blocks_on_path(@user) %>
               <span class='count-number'><%= number_with_delimiter(@user.blocks.active.size) %></span>
             </li>
           <% end %>
 
           <% if @user.moderator? and @user.blocks_created.exists? %>
             <li>
-              <%= link_to t(".moderator_history"), :controller => "user_blocks", :action => "blocks_by", :display_name => @user.display_name %>
+              <%= link_to t(".moderator_history"), user_blocks_by_path(@user) %>
               <span class='count-number'><%= number_with_delimiter(@user.blocks_created.active.size) %></span>
             </li>
           <% end %>
 
           <% if can?(:create, UserBlock) %>
             <li>
-            <%= link_to t(".create_block"), :controller => "user_blocks", :action => "new", :display_name => @user.display_name %>
+            <%= link_to t(".create_block"), new_user_block_path(@user) %>
             </li>
           <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,7 @@
             <%= link_to t(".my comments"), :controller => "diary_entries", :action => "comments", :display_name => current_user.display_name %>
           </li>
           <li>
-            <%= link_to t(".my settings"), :controller => "users", :action => "account", :display_name => current_user.display_name %>
+            <%= link_to t(".my settings"), user_account_path(current_user) %>
           </li>
 
           <% if current_user.blocks.exists? %>


### PR DESCRIPTION
This PR refactors various links to use named paths, rather than the `controller => ... action => ...` alternative. This makes them easier to read, particularly when dealing with `display_name` parameters.