### PR TITLE
rerun script/misc/update-wiki-pages

### DIFF
--- a/config/wiki_pages.yml
+++ b/config/wiki_pages.yml
@@ -6,6 +6,8 @@ ar:
   key:
     highway: Ar:Key:highway
     name: Ar:Key:name
+    natural: Ar:Key:natural
+    waterway: Ar:Key:waterway
   tag:
     amenity=school: Ar:Tag:amenity=school
     shop=bakery: Ar:Tag:shop=bakery
@@ -18,50 +20,105 @@ bg:
     building: Bg:Key:building
     lanes: Bg:Key:lanes
   tag:
+    barrier=guard_rail: Bg:Tag:barrier=guard rail
     building=chapel: Bg:Tag:building=chapel
     natural=heath: Bg:Tag:natural=heath
     railway=crossing: Bg:Tag:railway=crossing
     railway=level_crossing: Bg:Tag:railway=level crossing
-bn:
-  key:
-    highway: Bn:Key:highway
-  tag:
-    highway=residential: Bn:Tag:highway=residential
 br:
   key:
     highway: Br:Key:highway
 ca:
   key:
     amenity: Ca:Key:amenity
+    board:title: Ca:Key:board:title
     building: Ca:Key:building
+    contact:facebook: Ca:Key:contact:facebook
+    created_by: Ca:Key:created by
+    facebook: Ca:Key:facebook
     lgbtq: Ca:Key:lgbtq
     name: Ca:Key:name
+    openplaques:id: Ca:Key:openplaques:id
     operator:type: Ca:Key:operator:type
     phone: Ca:Key:phone
+    roller_coaster: Ca:Key:roller coaster
     roundtrip: Ca:Key:roundtrip
     wikidata: Ca:Key:wikidata
   tag:
+    abandoned:amenity=prison: Ca:Tag:abandoned:amenity=prison
     admin_level=2: Ca:Tag:admin level=2
+    advertising=screen: Ca:Tag:advertising=screen
+    advertising=tarp: Ca:Tag:advertising=tarp
     advertising=wall_painting: Ca:Tag:advertising=wall painting
+    aerialway=cable_car: Ca:Tag:aerialway=cable car
+    aerialway=canopy: Ca:Tag:aerialway=canopy
+    aerialway=chair_lift: Ca:Tag:aerialway=chair lift
+    aerialway=drag_lift: Ca:Tag:aerialway=drag lift
+    aerialway=gondola: Ca:Tag:aerialway=gondola
+    aerialway=goods: Ca:Tag:aerialway=goods
+    aerialway=j-bar: Ca:Tag:aerialway=j-bar
+    aerialway=magic_carpet: Ca:Tag:aerialway=magic carpet
+    aerialway=mixed_lift: Ca:Tag:aerialway=mixed lift
+    aerialway=platter: Ca:Tag:aerialway=platter
+    aerialway=rope_tow: Ca:Tag:aerialway=rope tow
+    aerialway=station: Ca:Tag:aerialway=station
+    aerialway=t-bar: Ca:Tag:aerialway=t-bar
+    aerialway=zip_line: Ca:Tag:aerialway=zip line
+    aeroway=apron: Ca:Tag:aeroway=apron
+    aeroway=gate: Ca:Tag:aeroway=gate
+    aeroway=helipad: Ca:Tag:aeroway=helipad
+    aeroway=heliport: Ca:Tag:aeroway=heliport
+    aeroway=holding_position: Ca:Tag:aeroway=holding position
+    aeroway=navigationaid: Ca:Tag:aeroway=navigationaid
+    aeroway=terminal: Ca:Tag:aeroway=terminal
+    aeroway=windsock: Ca:Tag:aeroway=windsock
+    airmark=beacon: Ca:Tag:airmark=beacon
+    amenity=bar: Ca:Tag:amenity=bar
+    amenity=bicycle_parking: Ca:Tag:amenity=bicycle parking
+    amenity=biergarten: Ca:Tag:amenity=biergarten
+    amenity=cafe: Ca:Tag:amenity=cafe
+    amenity=college: Ca:Tag:amenity=college
+    amenity=driving_school: Ca:Tag:amenity=driving school
+    amenity=exhibition_centre: Ca:Tag:amenity=exhibition centre
+    amenity=fast_food: Ca:Tag:amenity=fast food
+    amenity=food_court: Ca:Tag:amenity=food court
+    amenity=ice_cream: Ca:Tag:amenity=ice cream
+    amenity=kindergarten: Ca:Tag:amenity=kindergarten
+    amenity=language_school: Ca:Tag:amenity=language school
+    amenity=library: Ca:Tag:amenity=library
+    amenity=music_school: Ca:Tag:amenity=music school
+    amenity=nightclub: Ca:Tag:amenity=nightclub
+    amenity=outfitter: Ca:Tag:amenity=outfitter
     amenity=post_box: Ca:Tag:amenity=post box
+    amenity=pub: Ca:Tag:amenity=pub
+    amenity=restaurant: Ca:Tag:amenity=restaurant
+    amenity=toy_library: Ca:Tag:amenity=toy library
+    amenity=university: Ca:Tag:amenity=university
     barrier=cable_barrier: Ca:Tag:barrier=cable barrier
     barrier=kerb: Ca:Tag:barrier=kerb
     building=boathouse: Ca:Tag:building=boathouse
+    building=cathedral: Ca:Tag:building=cathedral
     building=hospital: Ca:Tag:building=hospital
     building=hut: Ca:Tag:building=hut
     craft=blacksmith: Ca:Tag:craft=blacksmith
+    craft=restoration: Ca:Tag:craft=restoration
     crossing=traffic_signals: Ca:Tag:crossing=traffic signals
+    cycleway=opposite: Ca:Tag:cycleway=opposite
+    highway=motorway: Ca:Tag:highway=motorway
     highway=residential: Ca:Tag:highway=residential
     landuse=farmland: Ca:Tag:landuse=farmland
+    landuse=traffic_island: Ca:Tag:landuse=traffic island
     leisure=swimming_pool: Ca:Tag:leisure=swimming pool
     leisure=tanning_salon: Ca:Tag:leisure=tanning salon
     man_made=gantry: Ca:Tag:man made=gantry
     name=Herfy: Ca:Tag:name=Herfy
     natural=cliff: Ca:Tag:natural=cliff
+    network=VE:T:PO: Ca:Tag:network=VE:T:PO
     office=notary: Ca:Tag:office=notary
     place=isolated_dwelling: Ca:Tag:place=isolated dwelling
     power=line: Ca:Tag:power=line
     shop=frozen_food: Ca:Tag:shop=frozen food
+    tactile_paving=no: Ca:Tag:tactile paving=no
     vending=books: Ca:Tag:vending=books
 cs:
   key:
@@ -527,7 +584,6 @@ cs:
     navigationaid: Cs:Key:navigationaid
     network: Cs:Key:network
     noexit: Cs:Key:noexit
-    noname: Cs:Key:noname
     noref: Cs:Key:noref
     note: Cs:Key:note
     nudism: Cs:Key:nudism
@@ -1541,6 +1597,7 @@ cs:
     leisure=water_park: Cs:Tag:leisure=water park
     leisure=wildlife_hide: Cs:Tag:leisure=wildlife hide
     level_crossing=traffic_signals: Cs:Tag:level crossing=traffic signals
+    lifeguard=tower: Cs:Tag:lifeguard=tower
     man_made=adit: Cs:Tag:man made=adit
     man_made=beacon: Cs:Tag:man made=beacon
     man_made=beehive: Cs:Tag:man made=beehive
@@ -1693,6 +1750,7 @@ cs:
     network=lwn: Cs:Tag:network=lwn
     network=nwn: Cs:Tag:network=nwn
     network=rwn: Cs:Tag:network=rwn
+    noname=yes: Cs:Tag:noname=yes
     office=accountant: Cs:Tag:office=accountant
     office=administrative: Cs:Tag:office=administrative
     office=adoption_agency: Cs:Tag:office=adoption agency
@@ -1850,6 +1908,7 @@ cs:
     route=running: Cs:Tag:route=running
     route=ski: Cs:Tag:route=ski
     route=subway: Cs:Tag:route=subway
+    route=tracks: Cs:Tag:route=tracks
     route=train: Cs:Tag:route=train
     route=tram: Cs:Tag:route=tram
     route=trolleybus: Cs:Tag:route=trolleybus
@@ -2322,6 +2381,7 @@ de:
     bath:type: DE:Key:bath:type
     bdouble: DE:Key:bdouble
     beacon:type: DE:Key:beacon:type
+    beauty: DE:Key:beauty
     beds: DE:Key:beds
     bench: DE:Key:bench
     bicycle: DE:Key:bicycle
@@ -2346,6 +2406,7 @@ de:
     bridge: DE:Key:bridge
     bridge:movable: DE:Key:bridge:movable
     bridge:structure: DE:Key:bridge:structure
+    bridge:support: DE:Key:bridge:support
     buiding: DE:Key:buiding
     building: DE:Key:building
     building:architecture: DE:Key:building:architecture
@@ -2414,6 +2475,7 @@ de:
     craft: DE:Key:craft
     crane:type: DE:Key:crane:type
     created_by: DE:Key:created by
+    crop: DE:Key:crop
     crossing: DE:Key:crossing
     crossing:activation: DE:Key:crossing:activation
     crossing:barrier: DE:Key:crossing:barrier
@@ -2433,12 +2495,16 @@ de:
     cycleway: DE:Key:cycleway
     cycleway:left: DE:Key:cycleway:left
     cycleway:right: DE:Key:cycleway:right
+    cycleway:right:oneway: DE:Key:cycleway:right:oneway
     cycleway:surface: DE:Key:cycleway:surface
+    dance:style: DE:Key:dance:style
+    dance:teaching: DE:Key:dance:teaching
     date: DE:Key:date
     de:amtlicher_gemeindeschluessel: DE:Key:de:amtlicher gemeindeschluessel
     de:regionalschluessel: DE:Key:de:regionalschluessel
     de:strassenschluessel: DE:Key:de:strassenschluessel
     delivery: DE:Key:delivery
+    'demolished:': 'DE:Key:demolished:'
     denomination: DE:Key:denomination
     denotation: DE:Key:denotation
     departures_board: DE:Key:departures board
@@ -2453,6 +2519,8 @@ de:
     destination:ref:to: DE:Key:destination:ref:to
     destination:symbol: DE:Key:destination:symbol
     destination:to: DE:Key:destination:to
+    destroyed: DE:Key:destroyed
+    'destroyed:': 'DE:Key:destroyed:'
     diameter: DE:Key:diameter
     diaper: DE:Key:diaper
     diet: DE:Key:diet
@@ -2469,6 +2537,7 @@ de:
     'disused:': 'DE:Key:disused:'
     disused:amenity: DE:Key:disused:amenity
     disused:railway: DE:Key:disused:railway
+    dog: DE:Key:dog
     door: DE:Key:door
     draft: DE:Key:draft
     drink: DE:Key:drink
@@ -2490,6 +2559,7 @@ de:
     fence_type: DE:Key:fence type
     ferry:cable: DE:Key:ferry:cable
     fetish: DE:Key:fetish
+    fire_boundary: DE:Key:fire boundary
     fire_hydrant: DE:Key:fire hydrant
     fireplace: DE:Key:fireplace
     fixme: DE:Key:fixme
@@ -2498,12 +2568,14 @@ de:
     foot: DE:Key:foot
     footway: DE:Key:footway
     ford: DE:Key:ford
+    forestry: DE:Key:forestry
     format: DE:Key:format
     fortification_type: DE:Key:fortification type
     forward: DE:Key:forward
     frequency: DE:Key:frequency
     fridge: DE:Key:fridge
     from: DE:Key:from
+    fruit: DE:Key:fruit
     fuel: DE:Key:fuel
     fuel:LH2: DE:Key:fuel:LH2
     garden:style: DE:Key:garden:style
@@ -2538,6 +2610,7 @@ de:
     hazmat:water: DE:Key:hazmat:water
     healthcare: DE:Key:healthcare
     healthcare:counselling: DE:Key:healthcare:counselling
+    healthcare:speciality: DE:Key:healthcare:speciality
     height: DE:Key:height
     heritage: DE:Key:heritage
     hgv: DE:Key:hgv
@@ -2557,6 +2630,7 @@ de:
     image: DE:Key:image
     importance: DE:Key:importance
     incline: DE:Key:incline
+    indoor: DE:Key:indoor
     indoor_seating: DE:Key:indoor seating
     industrial: DE:Key:industrial
     informal: DE:Key:informal
@@ -2565,6 +2639,7 @@ de:
     int_name: DE:Key:int name
     intermittent: DE:Key:intermittent
     internet_access: DE:Key:internet access
+    internet_access:fee: DE:Key:internet access:fee
     interval: DE:Key:interval
     is_in: DE:Key:is in
     is_in:continent: DE:Key:is in:continent
@@ -2572,6 +2647,7 @@ de:
     is_in:county: DE:Key:is in:county
     isced:level: DE:Key:isced:level
     junction: DE:Key:junction
+    kerb: DE:Key:kerb
     kids_area: DE:Key:kids area
     kms: DE:Key:kms
     kneipp_water_cure: DE:Key:kneipp water cure
@@ -2607,10 +2683,11 @@ de:
     lock_name: DE:Key:lock name
     lock_ref: DE:Key:lock ref
     lockable: DE:Key:lockable
-    lottery: DE:Key:lottery
+    locked: DE:Key:locked
     love_locks: DE:Key:love locks
     lunch: DE:Key:lunch
     man_made: DE:Key:man made
+    managed: DE:Key:managed
     manhole: DE:Key:manhole
     manufacturer: DE:Key:manufacturer
     manufacturer:type: DE:Key:manufacturer:type
@@ -2632,6 +2709,7 @@ de:
     maxweight: DE:Key:maxweight
     maxwidth: DE:Key:maxwidth
     maxwidth:physical: DE:Key:maxwidth:physical
+    meadow: DE:Key:meadow
     megalith_type: DE:Key:megalith type
     memorial: DE:Key:memorial
     memorial:type: DE:Key:memorial:type
@@ -2687,6 +2765,7 @@ de:
     noaddress: DE:Key:noaddress
     noexit: DE:Key:noexit
     noname: DE:Key:noname
+    noref: DE:Key:noref
     note: DE:Key:note
     nudism: DE:Key:nudism
     nursery: DE:Key:nursery
@@ -2698,6 +2777,7 @@ de:
     old_name: DE:Key:old name
     oneway: DE:Key:oneway
     oneway:bicycle: DE:Key:oneway:bicycle
+    oneway:bus: DE:Key:oneway:bus
     oneway:conditional: DE:Key:oneway:conditional
     oneway:moped: DE:Key:oneway:moped
     onkz: DE:Key:onkz
@@ -2710,6 +2790,7 @@ de:
     operator:MNC: DE:Key:operator:MNC
     operator:type: DE:Key:operator:type
     organic: DE:Key:organic
+    origin: DE:Key:origin
     osak: DE:Key:osak
     osmc:status: DE:Key:osmc:status
     osmc:symbol: DE:Key:osmc:symbol
@@ -2722,6 +2803,7 @@ de:
     parking:lane: DE:Key:parking:lane
     parking:lane:hgv: DE:Key:parking:lane:hgv
     passenger_information_display: DE:Key:passenger information display
+    passing_places: DE:Key:passing places
     payment: DE:Key:payment
     permanent_camping: DE:Key:permanent camping
     phone: DE:Key:phone
@@ -2742,7 +2824,6 @@ de:
     population: DE:Key:population
     post_box:type: DE:Key:post box:type
     post_office: DE:Key:post office
-    post_office:type: DE:Key:post office:type
     postal_code: DE:Key:postal code
     power: DE:Key:power
     power_rating: DE:Key:power rating
@@ -2766,6 +2847,9 @@ de:
     railway:lzb: DE:Key:railway:lzb
     railway:position: DE:Key:railway:position
     railway:preserved: DE:Key:railway:preserved
+    railway:signal:distant: DE:Key:railway:signal:distant
+    railway:signal:speed_limit: DE:Key:railway:signal:speed limit
+    railway:signal:speed_limit_distant: DE:Key:railway:signal:speed limit distant
     railway:track_ref: DE:Key:railway:track ref
     ramp: DE:Key:ramp
     'razed:': 'DE:Key:razed:'
@@ -2784,6 +2868,9 @@ de:
     reservoir_type: DE:Key:reservoir type
     resource: DE:Key:resource
     restaurant: DE:Key:restaurant
+    reusable_packaging: DE:Key:reusable packaging
+    reusable_packaging:accept: DE:Key:reusable packaging:accept
+    reusable_packaging:offer: DE:Key:reusable packaging:offer
     right: DE:Key:right
     roof:material: DE:Key:roof:material
     room: DE:Key:room
@@ -2791,6 +2878,7 @@ de:
     rotor:diameter: DE:Key:rotor:diameter
     roundtrip: DE:Key:roundtrip
     route: DE:Key:route
+    route_ref: DE:Key:route ref
     ruins: DE:Key:ruins
     sac_scale: DE:Key:sac scale
     salt: DE:Key:salt
@@ -2815,6 +2903,7 @@ de:
     short_protection_title: DE:Key:short protection title
     shower: DE:Key:shower
     sidewalk: DE:Key:sidewalk
+    sidewalk:both:bicycle: DE:Key:sidewalk:both:bicycle
     site_type: DE:Key:site type
     ski: DE:Key:ski
     smoking: DE:Key:smoking
@@ -2840,6 +2929,7 @@ de:
     substance: DE:Key:substance
     substation: DE:Key:substation
     summit:register: DE:Key:summit:register
+    supervised: DE:Key:supervised
     support: DE:Key:support
     surface: DE:Key:surface
     surveillance: DE:Key:surveillance
@@ -2847,6 +2937,7 @@ de:
     survey:date: DE:Key:survey:date
     swimming: DE:Key:swimming
     swimming_pool: DE:Key:swimming pool
+    switch: DE:Key:switch
     symbol: DE:Key:symbol
     tactile_paving: DE:Key:tactile paving
     tactile_writing: DE:Key:tactile writing
@@ -2891,6 +2982,7 @@ de:
     turn:lanes:backward: DE:Key:turn:lanes:backward
     turn:lanes:forward: DE:Key:turn:lanes:forward
     type: DE:Key:type
+    uic_name: DE:Key:uic name
     uic_ref: DE:Key:uic ref
     usage: DE:Key:usage
     utility: DE:Key:utility
@@ -2901,12 +2993,14 @@ de:
     verbindung: DE:Key:verbindung
     viewpoint: DE:Key:viewpoint
     visibility: DE:Key:visibility
+    volcano:status: DE:Key:volcano:status
     voltage: DE:Key:voltage
     voltage:primary: DE:Key:voltage:primary
     voltage:secondary: DE:Key:voltage:secondary
     waste: DE:Key:waste
     water: DE:Key:water
     water_characteristic: DE:Key:water characteristic
+    water_well: DE:Key:water well
     waterway: DE:Key:waterway
     website: DE:Key:website
     wetland: DE:Key:wetland
@@ -3033,6 +3127,8 @@ de:
     amenity=dentist: DE:Tag:amenity=dentist
     amenity=dive_centre: DE:Tag:amenity=dive centre
     amenity=doctors: DE:Tag:amenity=doctors
+    amenity=dog_toilet: DE:Tag:amenity=dog toilet
+    amenity=dressing_room: DE:Tag:amenity=dressing room
     amenity=drinking_water: DE:Tag:amenity=drinking water
     amenity=driving_school: DE:Tag:amenity=driving school
     amenity=embassy: DE:Tag:amenity=embassy
@@ -3048,9 +3144,11 @@ de:
     amenity=fountain: DE:Tag:amenity=fountain
     amenity=fridge: DE:Tag:amenity=fridge
     amenity=fuel: DE:Tag:amenity=fuel
+    amenity=funeral_hall: DE:Tag:amenity=funeral hall
     amenity=give_box: DE:Tag:amenity=give box
     amenity=grave_yard: DE:Tag:amenity=grave yard
     amenity=grit_bin: DE:Tag:amenity=grit bin
+    amenity=hitching_post: DE:Tag:amenity=hitching post
     amenity=hookah_lounge: DE:Tag:amenity=hookah lounge
     amenity=hospice: DE:Tag:amenity=hospice
     amenity=hospital: DE:Tag:amenity=hospital
@@ -3100,6 +3198,7 @@ de:
     amenity=research_institute: DE:Tag:amenity=research institute
     amenity=restaurant: DE:Tag:amenity=restaurant
     amenity=retirement_home: DE:Tag:amenity=retirement home
+    amenity=sailing_school: DE:Tag:amenity=sailing school
     amenity=sanitary_dump_station: DE:Tag:amenity=sanitary dump station
     amenity=school: DE:Tag:amenity=school
     amenity=shelter: DE:Tag:amenity=shelter
@@ -3158,6 +3257,7 @@ de:
     barrier=hedge: DE:Tag:barrier=hedge
     barrier=hedge_bank: DE:Tag:barrier=hedge bank
     barrier=height_restrictor: DE:Tag:barrier=height restrictor
+    barrier=horse_jump: DE:Tag:barrier=horse jump
     barrier=jersey_barrier: DE:Tag:barrier=jersey barrier
     barrier=kerb: DE:Tag:barrier=kerb
     barrier=kissing_gate: DE:Tag:barrier=kissing gate
@@ -3254,6 +3354,7 @@ de:
     building=office: DE:Tag:building=office
     building=parking: DE:Tag:building=parking
     building=pavilion: DE:Tag:building=pavilion
+    building=presbytery: DE:Tag:building=presbytery
     building=public: DE:Tag:building=public
     building=residential: DE:Tag:building=residential
     building=retail: DE:Tag:building=retail
@@ -3285,6 +3386,7 @@ de:
     bunker_type=munitions: DE:Tag:bunker type=munitions
     bunker_type=pillbox: DE:Tag:bunker type=pillbox
     by_night=only: DE:Tag:by night=only
+    canoe=portage: DE:Tag:canoe=portage
     castle_type=castrum: DE:Tag:castle type=castrum
     castle_type=defensive: DE:Tag:castle type=defensive
     castle_type=fortress: DE:Tag:castle type=fortress
@@ -3298,6 +3400,7 @@ de:
     club=scout: DE:Tag:club=scout
     club=sport: DE:Tag:club=sport
     communication=line: DE:Tag:communication=line
+    company=logistics: DE:Tag:company=logistics
     construction=yes: DE:Tag:construction=yes
     content=hot_water: DE:Tag:content=hot water
     craft=agricultural_engines: DE:Tag:craft=agricultural engines
@@ -3317,6 +3420,7 @@ de:
     craft=carpet_layer: DE:Tag:craft=carpet layer
     craft=caterer: DE:Tag:craft=caterer
     craft=chimney_sweeper: DE:Tag:craft=chimney sweeper
+    craft=cleaning: DE:Tag:craft=cleaning
     craft=clockmaker: DE:Tag:craft=clockmaker
     craft=confectionery: DE:Tag:craft=confectionery
     craft=cooper: DE:Tag:craft=cooper
@@ -3337,6 +3441,7 @@ de:
     craft=hvac: DE:Tag:craft=hvac
     craft=information_electronics: DE:Tag:craft=information electronics
     craft=insulation: DE:Tag:craft=insulation
+    craft=interior_work: DE:Tag:craft=interior work
     craft=joiner: DE:Tag:craft=joiner
     craft=key_cutter: DE:Tag:craft=key cutter
     craft=metal_construction: DE:Tag:craft=metal construction
@@ -3388,11 +3493,14 @@ de:
     cuisine=dessert: DE:Tag:cuisine=dessert
     cycleway:left=lane: DE:Tag:cycleway:left=lane
     cycleway:right=lane: DE:Tag:cycleway:right=lane
+    cycleway:right=share_busway: DE:Tag:cycleway:right=share busway
     cycleway:right=track: DE:Tag:cycleway:right=track
+    cycleway=asl: DE:Tag:cycleway=asl
     cycleway=lane: DE:Tag:cycleway=lane
     cycleway=opposite: DE:Tag:cycleway=opposite
     cycleway=opposite_lane: DE:Tag:cycleway=opposite lane
     cycleway=opposite_track: DE:Tag:cycleway=opposite track
+    cycleway=separate: DE:Tag:cycleway=separate
     cycleway=share_busway: DE:Tag:cycleway=share busway
     cycleway=track: DE:Tag:cycleway=track
     defensive=bergfried: DE:Tag:defensive=bergfried
@@ -3416,6 +3524,7 @@ de:
     emergency=ambulance_station: DE:Tag:emergency=ambulance station
     emergency=assembly_point: DE:Tag:emergency=assembly point
     emergency=defibrillator: DE:Tag:emergency=defibrillator
+    emergency=designated: DE:Tag:emergency=designated
     emergency=drinking_water: DE:Tag:emergency=drinking water
     emergency=dry_riser_inlet: DE:Tag:emergency=dry riser inlet
     emergency=emergency_ward_entrance: DE:Tag:emergency=emergency ward entrance
@@ -3430,6 +3539,7 @@ de:
     emergency=first_aid_kit: DE:Tag:emergency=first aid kit
     emergency=landing_site: DE:Tag:emergency=landing site
     emergency=life_ring: DE:Tag:emergency=life ring
+    emergency=lifeguard: DE:Tag:emergency=lifeguard
     emergency=lifeguard_base: DE:Tag:emergency=lifeguard base
     emergency=lifeguard_place: DE:Tag:emergency=lifeguard place
     emergency=lifeguard_platform: DE:Tag:emergency=lifeguard platform
@@ -3499,9 +3609,13 @@ de:
     generator:type=steam_generator: DE:Tag:generator:type=steam generator
     generator:type=steam_turbine: DE:Tag:generator:type=steam turbine
     generator:type=vertical_axis: DE:Tag:generator:type=vertical axis
+    geological=fault: DE:Tag:geological=fault
     geological=moraine: DE:Tag:geological=moraine
     geological=outcrop: DE:Tag:geological=outcrop
     geological=palaeontological_site: DE:Tag:geological=palaeontological site
+    geological=volcanic_caldera_rim: DE:Tag:geological=volcanic caldera rim
+    geological=volcanic_lava_field: DE:Tag:geological=volcanic lava field
+    geological=volcanic_vent: DE:Tag:geological=volcanic vent
     golf=bunker: DE:Tag:golf=bunker
     golf=driving_range: DE:Tag:golf=driving range
     golf=fairway: DE:Tag:golf=fairway
@@ -3525,12 +3639,14 @@ de:
     government=ministry: DE:Tag:government=ministry
     government=prosecutor: DE:Tag:government=prosecutor
     government=register_office: DE:Tag:government=register office
+    government=social_security: DE:Tag:government=social security
     government=statistics: DE:Tag:government=statistics
     government=tax: DE:Tag:government=tax
     government=youth_welfare_department: DE:Tag:government=youth welfare department
     hazard=animal_crossing: DE:Tag:hazard=animal crossing
     hazard=children: DE:Tag:hazard=children
     hazard=cyclists: DE:Tag:hazard=cyclists
+    hazard=dangerous_junction: DE:Tag:hazard=dangerous junction
     hazard=falling_rocks: DE:Tag:hazard=falling rocks
     hazard=minefield: DE:Tag:hazard=minefield
     hazard=queues_likely: DE:Tag:hazard=queues likely
@@ -3538,15 +3654,23 @@ de:
     hazard=side_winds: DE:Tag:hazard=side winds
     hazard=slippery: DE:Tag:hazard=slippery
     hazmat:water=permissive: DE:Tag:hazmat:water=permissive
+    healthcare:speciality=orthodontics: DE:Tag:healthcare:speciality=orthodontics
+    healthcare:speciality=otolaryngology: DE:Tag:healthcare:speciality=otolaryngology
+    healthcare=alternative: DE:Tag:healthcare=alternative
+    healthcare=audiologist: DE:Tag:healthcare=audiologist
     healthcare=birthing_center: DE:Tag:healthcare=birthing center
+    healthcare=blood_bank: DE:Tag:healthcare=blood bank
     healthcare=blood_donation: DE:Tag:healthcare=blood donation
     healthcare=clinic: DE:Tag:healthcare=clinic
+    healthcare=counselling: DE:Tag:healthcare=counselling
     healthcare=dentist: DE:Tag:healthcare=dentist
     healthcare=dialysis: DE:Tag:healthcare=dialysis
     healthcare=doctor: DE:Tag:healthcare=doctor
     healthcare=hospice: DE:Tag:healthcare=hospice
     healthcare=hospital: DE:Tag:healthcare=hospital
     healthcare=laboratory: DE:Tag:healthcare=laboratory
+    healthcare=midwife: DE:Tag:healthcare=midwife
+    healthcare=occupational_therapist: DE:Tag:healthcare=occupational therapist
     healthcare=physiotherapist: DE:Tag:healthcare=physiotherapist
     healthcare=speech_therapist: DE:Tag:healthcare=speech therapist
     highway=abandoned: DE:Tag:highway=abandoned
@@ -3554,7 +3678,9 @@ de:
     highway=bridleway: DE:Tag:highway=bridleway
     highway=bus_guideway: DE:Tag:highway=bus guideway
     highway=bus_stop: DE:Tag:highway=bus stop
+    highway=busway: DE:Tag:highway=busway
     highway=byway: DE:Tag:highway=byway
+    highway=construction: DE:Tag:highway=construction
     highway=corridor: DE:Tag:highway=corridor
     highway=crossing: DE:Tag:highway=crossing
     highway=cycleway: DE:Tag:highway=cycleway
@@ -3623,6 +3749,7 @@ de:
     historic=citywalls: DE:Tag:historic=citywalls
     historic=fort: DE:Tag:historic=fort
     historic=gallows: DE:Tag:historic=gallows
+    historic=highwater_mark: DE:Tag:historic=highwater mark
     historic=locomotive: DE:Tag:historic=locomotive
     historic=manor: DE:Tag:historic=manor
     historic=memorial: DE:Tag:historic=memorial
@@ -3643,7 +3770,9 @@ de:
     historic=wayside_shrine: DE:Tag:historic=wayside shrine
     historic=wreck: DE:Tag:historic=wreck
     horse=designated: DE:Tag:horse=designated
+    horse=dismount: DE:Tag:horse=dismount
     industrial=bakery: DE:Tag:industrial=bakery
+    industrial=communication: DE:Tag:industrial=communication
     industrial=scrap_yard: DE:Tag:industrial=scrap yard
     industrial=slaughterhouse: DE:Tag:industrial=slaughterhouse
     information=audioguide: DE:Tag:information=audioguide
@@ -3656,6 +3785,7 @@ de:
     information=terminal: DE:Tag:information=terminal
     information=visitor_centre: DE:Tag:information=visitor centre
     internet_access=wlan: DE:Tag:internet access=wlan
+    junction=circular: DE:Tag:junction=circular
     junction=roundabout: DE:Tag:junction=roundabout
     landuse=allotments: DE:Tag:landuse=allotments
     landuse=aquaculture: DE:Tag:landuse=aquaculture
@@ -3738,6 +3868,7 @@ de:
     leisure=playground: DE:Tag:leisure=playground
     leisure=resort: DE:Tag:leisure=resort
     leisure=sauna: DE:Tag:leisure=sauna
+    leisure=schoolyard: DE:Tag:leisure=schoolyard
     leisure=slipway: DE:Tag:leisure=slipway
     leisure=sports_centre: DE:Tag:leisure=sports centre
     leisure=sports_hall: DE:Tag:leisure=sports hall
@@ -3753,13 +3884,17 @@ de:
     level_crossing=automatic_barrier: DE:Tag:level crossing=automatic barrier
     level_crossing=traffic_signals: DE:Tag:level crossing=traffic signals
     level_crossing=uncontrolled: DE:Tag:level crossing=uncontrolled
+    lifeguard=base: DE:Tag:lifeguard=base
+    lifeguard=tower: DE:Tag:lifeguard=tower
     line=bay: DE:Tag:line=bay
     line=busbar: DE:Tag:line=busbar
     location:transition=yes: DE:Tag:location:transition=yes
     location=underground: DE:Tag:location=underground
+    lottery=yes: DE:Tag:lottery=yes
     man_made=MDF: DE:Tag:man made=MDF
     man_made=adit: DE:Tag:man made=adit
     man_made=antenna: DE:Tag:man made=antenna
+    man_made=architecture_line: DE:Tag:man made=architecture line
     man_made=beacon: DE:Tag:man made=beacon
     man_made=beehive: DE:Tag:man made=beehive
     man_made=breakwater: DE:Tag:man made=breakwater
@@ -3780,6 +3915,8 @@ de:
     man_made=goods_conveyor: DE:Tag:man made=goods conveyor
     man_made=graduation_tower: DE:Tag:man made=graduation tower
     man_made=groyne: DE:Tag:man made=groyne
+    man_made=guard_stone: DE:Tag:man made=guard stone
+    man_made=guy_wire: DE:Tag:man made=guy wire
     man_made=hot_water_tank: DE:Tag:man made=hot water tank
     man_made=insect_hotel: DE:Tag:man made=insect hotel
     man_made=kiln: DE:Tag:man made=kiln
@@ -3812,6 +3949,7 @@ de:
     man_made=survey_point: DE:Tag:man made=survey point
     man_made=telescope: DE:Tag:man made=telescope
     man_made=tower: DE:Tag:man made=tower
+    man_made=utility_pole: DE:Tag:man made=utility pole
     man_made=wastewater_plant: DE:Tag:man made=wastewater plant
     man_made=water_tank: DE:Tag:man made=water tank
     man_made=water_tap: DE:Tag:man made=water tap
@@ -3855,6 +3993,8 @@ de:
     military=nuclear_explosion_site: DE:Tag:military=nuclear explosion site
     military=range: DE:Tag:military=range
     military=training_area: DE:Tag:military=training area
+    mooring=cruise: DE:Tag:mooring=cruise
+    mooring=guest: DE:Tag:mooring=guest
     motorcycle:type=scooter: DE:Tag:motorcycle:type=scooter
     museum=archaeological: DE:Tag:museum=archaeological
     museum=children: DE:Tag:museum=children
@@ -3945,6 +4085,8 @@ de:
     office=energy_supplier: DE:Tag:office=energy supplier
     office=engineer: DE:Tag:office=engineer
     office=estate_agent: DE:Tag:office=estate agent
+    office=financial: DE:Tag:office=financial
+    office=financial_advisor: DE:Tag:office=financial advisor
     office=forestry: DE:Tag:office=forestry
     office=geodesist: DE:Tag:office=geodesist
     office=government: DE:Tag:office=government
@@ -3952,18 +4094,22 @@ de:
     office=guide: DE:Tag:office=guide
     office=insurance: DE:Tag:office=insurance
     office=lawyer: DE:Tag:office=lawyer
+    office=logistics: DE:Tag:office=logistics
     office=moving_company: DE:Tag:office=moving company
     office=newspaper: DE:Tag:office=newspaper
     office=ngo: DE:Tag:office=ngo
     office=parish: DE:Tag:office=parish
     office=political_party: DE:Tag:office=political party
+    office=property_management: DE:Tag:office=property management
     office=religion: DE:Tag:office=religion
     office=research: DE:Tag:office=research
+    office=security: DE:Tag:office=security
     office=surveyor: DE:Tag:office=surveyor
     office=tax_advisor: DE:Tag:office=tax advisor
     office=telecommunication: DE:Tag:office=telecommunication
     office=therapist: DE:Tag:office=therapist
     office=travel_agent: DE:Tag:office=travel agent
+    office=union: DE:Tag:office=union
     office=water_utility: DE:Tag:office=water utility
     oneway=-1: DE:Tag:oneway=-1
     oneway=alternating: DE:Tag:oneway=alternating
@@ -3981,6 +4127,7 @@ de:
     parking:lane:hgv=on_street: DE:Tag:parking:lane:hgv=on street
     parking=multi-storey: DE:Tag:parking=multi-storey
     parking=street_side: DE:Tag:parking=street side
+    parking=surface: DE:Tag:parking=surface
     parking=underground: DE:Tag:parking=underground
     pipeline=marker: DE:Tag:pipeline=marker
     pipeline=substation: DE:Tag:pipeline=substation
@@ -4020,6 +4167,7 @@ de:
     plant:source=wind: DE:Tag:plant:source=wind
     plant:type=combined_cycle: DE:Tag:plant:type=combined cycle
     plant:type=steam_turbine: DE:Tag:plant:type=steam turbine
+    playground=structure: DE:Tag:playground=structure
     police=academy: DE:Tag:police=academy
     police=barracks: DE:Tag:police=barracks
     police=car_pound: DE:Tag:police=car pound
@@ -4031,8 +4179,10 @@ de:
     police=storage: DE:Tag:police=storage
     police=training_area: DE:Tag:police=training area
     police=yes: DE:Tag:police=yes
+    post_office=post_partner: DE:Tag:post office=post partner
     power=cable: DE:Tag:power=cable
     power=cable_distribution_cabinet: DE:Tag:power=cable distribution cabinet
+    power=compensator: DE:Tag:power=compensator
     power=converter: DE:Tag:power=converter
     power=generator: DE:Tag:power=generator
     power=heliostat: DE:Tag:power=heliostat
@@ -4071,6 +4221,7 @@ de:
     railway=monorail: DE:Tag:railway=monorail
     railway=narrow_gauge: DE:Tag:railway=narrow gauge
     railway=platform: DE:Tag:railway=platform
+    railway=platform_edge: DE:Tag:railway=platform edge
     railway=preserved: DE:Tag:railway=preserved
     railway=rail: DE:Tag:railway=rail
     railway=rail_brake: DE:Tag:railway=rail brake
@@ -4084,6 +4235,7 @@ de:
     railway=subway_entrance: DE:Tag:railway=subway entrance
     railway=switch: DE:Tag:railway=switch
     railway=tram: DE:Tag:railway=tram
+    railway=tram_crossing: DE:Tag:railway=tram crossing
     railway=tram_level_crossing: DE:Tag:railway=tram level crossing
     railway=tram_stop: DE:Tag:railway=tram stop
     railway=traverser: DE:Tag:railway=traverser
@@ -4103,6 +4255,7 @@ de:
     rental=strandkorb: DE:Tag:rental=strandkorb
     repair=assisted_self_service: DE:Tag:repair=assisted self service
     residential=urban: DE:Tag:residential=urban
+    resource=aggregate: DE:Tag:resource=aggregate
     roller_coaster=track: DE:Tag:roller coaster=track
     route=bicycle: DE:Tag:route=bicycle
     route=bus: DE:Tag:route=bus
@@ -4122,6 +4275,7 @@ de:
     route=railway: DE:Tag:route=railway
     route=road: DE:Tag:route=road
     route=running: DE:Tag:route=running
+    route=share_taxi: DE:Tag:route=share taxi
     route=ski: DE:Tag:route=ski
     route=subway: DE:Tag:route=subway
     route=tracks: DE:Tag:route=tracks
@@ -4130,6 +4284,8 @@ de:
     route=trolleybus: DE:Tag:route=trolleybus
     seamark:type=mooring: DE:Tag:seamark:type=mooring
     seamark:type=rock: DE:Tag:seamark:type=rock
+    segregated=no: DE:Tag:segregated=no
+    segregated=yes: DE:Tag:segregated=yes
     service=aircraft_control: DE:Tag:service=aircraft control
     service=alley: DE:Tag:service=alley
     service=crossover: DE:Tag:service=crossover
@@ -4139,9 +4295,14 @@ de:
     service=siding: DE:Tag:service=siding
     service=spur: DE:Tag:service=spur
     service=yard: DE:Tag:service=yard
+    shelter_type=Wetterpilz: DE:Tag:shelter type=Wetterpilz
     shelter_type=basic_hut: DE:Tag:shelter type=basic hut
+    shelter_type=gazebo: DE:Tag:shelter type=gazebo
     shelter_type=lean_to: DE:Tag:shelter type=lean to
+    shelter_type=pavilion: DE:Tag:shelter type=pavilion
+    shelter_type=picnic_shelter: DE:Tag:shelter type=picnic shelter
     shelter_type=public_transport: DE:Tag:shelter type=public transport
+    shelter_type=weather_shelter: DE:Tag:shelter type=weather shelter
     shop=agrarian: DE:Tag:shop=agrarian
     shop=alcohol: DE:Tag:shop=alcohol
     shop=antiques: DE:Tag:shop=antiques
@@ -4277,6 +4438,7 @@ de:
     shop=ticket: DE:Tag:shop=ticket
     shop=tiles: DE:Tag:shop=tiles
     shop=tobacco: DE:Tag:shop=tobacco
+    shop=tool_hire: DE:Tag:shop=tool hire
     shop=toys: DE:Tag:shop=toys
     shop=trade: DE:Tag:shop=trade
     shop=travel_agency: DE:Tag:shop=travel agency
@@ -4311,6 +4473,7 @@ de:
     social_facility=group_home: DE:Tag:social facility=group home
     social_facility=hospice: DE:Tag:social facility=hospice
     social_facility=nursing_home: DE:Tag:social facility=nursing home
+    social_facility=shelter: DE:Tag:social facility=shelter
     social_facility=soup_kitchen: DE:Tag:social facility=soup kitchen
     social_facility=workshop: DE:Tag:social facility=workshop
     source=HiRes_aerial_imagery: DE:Tag:source=HiRes aerial imagery
@@ -4376,8 +4539,12 @@ de:
     sport=volleyball: DE:Tag:sport=volleyball
     station=light_rail: DE:Tag:station=light rail
     station=subway: DE:Tag:station=subway
+    studio=audio: DE:Tag:studio=audio
+    studio=radio: DE:Tag:studio=radio
+    studio=video: DE:Tag:studio=video
     substation=converter: DE:Tag:substation=converter
     substation=distribution: DE:Tag:substation=distribution
+    substation=generation: DE:Tag:substation=generation
     substation=minor_distribution: DE:Tag:substation=minor distribution
     substation=traction: DE:Tag:substation=traction
     substation=transmission: DE:Tag:substation=transmission
@@ -4386,8 +4553,14 @@ de:
     surface=asphalt: DE:Tag:surface=asphalt
     surface=clay: DE:Tag:surface=clay
     surface=cobblestone: DE:Tag:surface=cobblestone
+    surface=compacted: DE:Tag:surface=compacted
     surface=concrete: DE:Tag:surface=concrete
     surface=concrete:lanes: DE:Tag:surface=concrete:lanes
+    surface=concrete:plates: DE:Tag:surface=concrete:plates
+    surface=fine_gravel: DE:Tag:surface=fine gravel
+    surface=gravel: DE:Tag:surface=gravel
+    surface=ground: DE:Tag:surface=ground
+    surface=paved: DE:Tag:surface=paved
     surface=paving_stones: DE:Tag:surface=paving stones
     surface=sett: DE:Tag:surface=sett
     surface=tartan: DE:Tag:surface=tartan
@@ -4402,8 +4575,15 @@ de:
     theatre:type=amphi: DE:Tag:theatre:type=amphi
     theatre:type=open_air: DE:Tag:theatre:type=open air
     tomb=cenotaph: DE:Tag:tomb=cenotaph
+    tomb=columbarium: DE:Tag:tomb=columbarium
+    tomb=crypt: DE:Tag:tomb=crypt
+    tomb=hypogeum: DE:Tag:tomb=hypogeum
     tomb=mausoleum: DE:Tag:tomb=mausoleum
+    tomb=pyramid: DE:Tag:tomb=pyramid
+    tomb=rock-cut: DE:Tag:tomb=rock-cut
+    tomb=sarcophagus: DE:Tag:tomb=sarcophagus
     tomb=tumulus: DE:Tag:tomb=tumulus
+    tomb=vault: DE:Tag:tomb=vault
     tomb=war_grave: DE:Tag:tomb=war grave
     tourism=alpine_hut: DE:Tag:tourism=alpine hut
     tourism=apartment: DE:Tag:tourism=apartment
@@ -4422,6 +4602,7 @@ de:
     tourism=museum: DE:Tag:tourism=museum
     tourism=picnic_site: DE:Tag:tourism=picnic site
     tourism=theme_park: DE:Tag:tourism=theme park
+    tourism=trail_riding_rest: DE:Tag:tourism=trail riding rest
     tourism=trail_riding_station: DE:Tag:tourism=trail riding station
     tourism=viewpoint: DE:Tag:tourism=viewpoint
     tourism=wilderness_hut: DE:Tag:tourism=wilderness hut
@@ -4438,6 +4619,7 @@ de:
     tower:type=communication: DE:Tag:tower:type=communication
     tower:type=cooling: DE:Tag:tower:type=cooling
     tower:type=defensive: DE:Tag:tower:type=defensive
+    tower:type=diving: DE:Tag:tower:type=diving
     tower:type=donjon: DE:Tag:tower:type=donjon
     tower:type=hose: DE:Tag:tower:type=hose
     tower:type=intake: DE:Tag:tower:type=intake
@@ -4454,6 +4636,7 @@ de:
     'traffic_sign=DE:': 'DE:Tag:traffic sign=DE:'
     traffic_sign=DE:1022-10: DE:Tag:traffic sign=DE:1022-10
     traffic_sign=DE:124: DE:Tag:traffic sign=DE:124
+    traffic_sign=DE:133-10: DE:Tag:traffic sign=DE:133-10
     traffic_sign=DE:136-10: DE:Tag:traffic sign=DE:136-10
     traffic_sign=DE:142-10: DE:Tag:traffic sign=DE:142-10
     traffic_sign=DE:142.10: DE:Tag:traffic sign=DE:142.10
@@ -4484,6 +4667,7 @@ de:
     traffic_sign=DE:261: DE:Tag:traffic sign=DE:261
     traffic_sign=DE:267: DE:Tag:traffic sign=DE:267
     traffic_sign=DE:269: DE:Tag:traffic sign=DE:269
+    traffic_sign=DE:272: DE:Tag:traffic sign=DE:272
     traffic_sign=DE:274-10: DE:Tag:traffic sign=DE:274-10
     traffic_sign=DE:274-100: DE:Tag:traffic sign=DE:274-100
     traffic_sign=DE:274-120: DE:Tag:traffic sign=DE:274-120
@@ -4564,6 +4748,7 @@ de:
     vending_machine=fuel: DE:Tag:vending machine=fuel
     wall=castle_wall: DE:Tag:wall=castle wall
     wall=dry_stone: DE:Tag:wall=dry stone
+    wall=no: DE:Tag:wall=no
     wall=noise_barrier: DE:Tag:wall=noise barrier
     waste=dog_excrement: DE:Tag:waste=dog excrement
     water=basin: DE:Tag:water=basin
@@ -4589,7 +4774,9 @@ de:
     waterway=fuel: DE:Tag:waterway=fuel
     waterway=lock_gate: DE:Tag:waterway=lock gate
     waterway=milestone: DE:Tag:waterway=milestone
+    waterway=portage: DE:Tag:waterway=portage
     waterway=pressurised: DE:Tag:waterway=pressurised
+    waterway=rapids: DE:Tag:waterway=rapids
     waterway=river: DE:Tag:waterway=river
     waterway=riverbank: DE:Tag:waterway=riverbank
     waterway=stream: DE:Tag:waterway=stream
@@ -4656,9 +4843,12 @@ el:
     highway=track: El:Tag:highway=track
 en:
   key:
+    '*:conditional': Key:*:conditional
+    '*:lanes': Key:*:lanes
     3dmr: Key:3dmr
     3dr:type: Key:3dr:type
     4wd_only: Key:4wd only
+    :conditional: Key::conditional
     :lanes: Key::lanes
     AND_nosr_r: Key:AND nosr r
     AlpinRes_ID: Key:AlpinRes ID
@@ -4669,6 +4859,10 @@ en:
     EH_ref: Key:EH ref
     FIXME: Key:FIXME
     Finance_agent: Key:Finance agent
+    GNS: Key:GNS
+    'GNS:': 'Key:GNS:'
+    GNS:dsg_code: Key:GNS:dsg code
+    GNS:id: Key:GNS:id
     HE_ref: Key:HE ref
     HU:ed_direction: Key:HU:ed direction
     HU:hu-go:length: Key:HU:hu-go:length
@@ -4689,7 +4883,9 @@ en:
     LINZ:source_version: Key:LINZ:source version
     Lock_ref: Key:Lock ref
     Mapper: Key:Mapper
+    NHD:ReachCode: Key:NHD:ReachCode
     NHS: Key:NHS
+    NSIW: Key:NSIW
     PMSA_ref: Key:PMSA ref
     Power_supply:schedule: Key:Power supply:schedule
     RLIS:bicycle: Key:RLIS:bicycle
@@ -4711,6 +4907,7 @@ en:
     abandoned:*: Key:abandoned:*
     abandoned:amenity: Key:abandoned:amenity
     abandoned:building: Key:abandoned:building
+    abandoned:highway: Key:abandoned:highway
     abandoned:place: Key:abandoned:place
     abandoned:railway: Key:abandoned:railway
     abutters: Key:abutters
@@ -4721,6 +4918,7 @@ en:
     access:lhv: Key:access:lhv
     access:roadtrain: Key:access:roadtrain
     access:roadtrain:trailers: Key:access:roadtrain:trailers
+    active_traffic_management: Key:active traffic management
     actuator: Key:actuator
     addr: Key:addr
     addr:alternatenumber: Key:addr:alternatenumber
@@ -4754,6 +4952,7 @@ en:
     addr:housenumber:ar: Key:addr:housenumber:ar
     addr:inclusion: Key:addr:inclusion
     addr:interpolation: Key:addr:interpolation
+    addr:neighbourhood: Key:addr:neighbourhood
     addr:place: Key:addr:place
     addr:place:ar: Key:addr:place:ar
     addr:place:de: Key:addr:place:de
@@ -4781,6 +4980,7 @@ en:
     addr:subdistrict:ar: Key:addr:subdistrict:ar
     addr:subdistrict:en: Key:addr:subdistrict:en
     addr:suburb: Key:addr:suburb
+    addr:type: Key:addr:type
     addr:unit: Key:addr:unit
     admin_level: Key:admin level
     adr_les: Key:adr les
@@ -4797,22 +4997,29 @@ en:
     airconditioned: Key:airconditioned
     alt_name: Key:alt name
     alt_name:ar: Key:alt name:ar
+    alt_name:arc: Key:alt name:arc
     alt_name:azb: Key:alt name:azb
     alt_name:be: Key:alt name:be
     alt_name:ckb: Key:alt name:ckb
     alt_name:en: Key:alt name:en
     alt_name:fa: Key:alt name:fa
+    alt_name:fr: Key:alt name:fr
     alt_name:glk: Key:alt name:glk
+    alt_name:gr: Key:alt name:gr
+    alt_name:grc: Key:alt name:grc
+    alt_name:kab-Arab: Key:alt name:kab-Arab
     alt_name:ko: Key:alt name:ko
     alt_name:ks: Key:alt name:ks
     alt_name:lrc: Key:alt name:lrc
     alt_name:mg: Key:alt name:mg
+    alt_name:ms-Arab: Key:alt name:ms-Arab
     alt_name:mzn: Key:alt name:mzn
     alt_name:pl: Key:alt name:pl
     alt_name:pnb: Key:alt name:pnb
     alt_name:ps: Key:alt name:ps
     alt_name:ru: Key:alt name:ru
     alt_name:sd: Key:alt name:sd
+    alt_name:syc: Key:alt name:syc
     alt_name:th: Key:alt name:th
     alt_name:ug: Key:alt name:ug
     alt_name:ur: Key:alt name:ur
@@ -4829,7 +5036,6 @@ en:
     area: Key:area
     area:aeroway: Key:area:aeroway
     area:highway: Key:area:highway
-    artist: Key:artist
     artist:wikidata: Key:artist:wikidata
     artist_name: Key:artist name
     artwork_subject: Key:artwork subject
@@ -4844,6 +5050,7 @@ en:
     assembly_point:tsunami: Key:assembly point:tsunami
     asset_ref: Key:asset ref
     assisted_trail: Key:assisted trail
+    association: Key:association
     at_bev:addr_date: Key:at bev:addr date
     atmotorway: Key:atmotorway
     attraction: Key:attraction
@@ -4908,6 +5115,7 @@ en:
     bollard: Key:bollard
     booking: Key:booking
     books: Key:books
+    booth: Key:booth
     border_type: Key:border type
     bot: Key:bot
     both: Key:both
@@ -4936,7 +5144,6 @@ en:
     bridge:short_name: Key:bridge:short name
     bridge:structure: Key:bridge:structure
     bridge:support: Key:bridge:support
-    bridge_name: Key:bridge name
     building: Key:building
     building:age: Key:building:age
     building:architecture: Key:building:architecture
@@ -4948,6 +5155,7 @@ en:
     building:fireproof: Key:building:fireproof
     building:flats: Key:building:flats
     building:height: Key:building:height
+    building:level: Key:building:level
     building:level:1,2,3...: Key:building:level:1,2,3...
     building:levels: Key:building:levels
     building:levels:underground: Key:building:levels:underground
@@ -4959,7 +5167,6 @@ en:
     building:prefabricated: Key:building:prefabricated
     building:roof: Key:building:roof
     building:roof:colour: Key:building:roof:colour
-    building:roof:shape: Key:building:roof:shape
     building:ruian:type: Key:building:ruian:type
     building:soft_storey: Key:building:soft storey
     building:structure: Key:building:structure
@@ -4971,25 +5178,31 @@ en:
     building:walls: Key:building:walls
     bulk_purchase: Key:bulk purchase
     bunker_type: Key:bunker type
+    buried:wikidata: Key:buried:wikidata
     bus: Key:bus
     bus:lanes: Key:bus:lanes
+    bus:lanes:backward: Key:bus:lanes:backward
+    bus:lanes:forward: Key:bus:lanes:forward
     bus_bay: Key:bus bay
     busbar: Key:busbar
     busway: Key:busway
     busway:left: Key:busway:left
     busway:right: Key:busway:right
     button_operated: Key:button operated
+    bygningsnr: Key:bygningsnr
     cabin:rental: Key:cabin:rental
     cabins: Key:cabins
     cable_number: Key:cable number
     cables: Key:cables
+    cadc:2019: Key:cadc:2019
+    cadc:2020: Key:cadc:2020
     cafe: Key:cafe
     callsign: Key:callsign
     camp_site: Key:camp site
     camp_type: Key:camp type
     campers: Key:campers
     camping: Key:camping
-    camra: Key:camra
+    campwild: Key:campwild
     canal: Key:canal
     canoe: Key:canoe
     capacity: Key:capacity
@@ -5001,14 +5214,13 @@ en:
     capacity:women: Key:capacity:women
     capital: Key:capital
     capital_city: Key:capital city
-    car:sales: Key:car:sales
-    car:tyres: Key:car:tyres
     car_wash: Key:car wash
     caravan: Key:caravan
     caravans: Key:caravans
     cargo: Key:cargo
     cargo_bike: Key:cargo bike
     carpenter: Key:carpenter
+    carpool: Key:carpool
     carriage: Key:carriage
     carriageway_ref: Key:carriageway ref
     casemate: Key:casemate
@@ -5029,9 +5241,7 @@ en:
     cemetery: Key:cemetery
     cemt: Key:cemt
     census:population: Key:census:population
-    center_turn_lane: Key:center turn lane
     centralkey: Key:centralkey
-    centre_turn_lane: Key:centre turn lane
     change: Key:change
     changesets_count: Key:changesets count
     changing_table: Key:changing table
@@ -5040,8 +5250,12 @@ en:
     changing_table:location: Key:changing table:location
     charge: Key:charge
     charity: Key:charity
+    chchsid: Key:chchsid
     check_date: Key:check date
     checkpoint: Key:checkpoint
+    china_class: Key:china class
+    china_population: Key:china population
+    church:type: Key:church:type
     circuits: Key:circuits
     circumference: Key:circumference
     city_limit: Key:city limit
@@ -5061,6 +5275,7 @@ en:
     clli: Key:clli
     closed:note: Key:closed:note
     clothes: Key:clothes
+    clothes:for: Key:clothes:for
     club: Key:club
     club-mate: Key:club-mate
     coach: Key:coach
@@ -5137,9 +5352,12 @@ en:
     contact:xmpp: Key:contact:xmpp
     contact:youtube: Key:contact:youtube
     content: Key:content
+    converted_by: Key:converted by
     conveying: Key:conveying
     cooker: Key:cooker
+    cooling:method: Key:cooling:method
     country: Key:country
+    courts: Key:courts
     covered: Key:covered
     craft: Key:craft
     crane:type: Key:crane:type
@@ -5171,6 +5389,7 @@ en:
     cutting: Key:cutting
     cyclability: Key:cyclability
     cycle: Key:cycle
+    cycle_highway: Key:cycle highway
     cycle_network: Key:cycle network
     cyclestreet: Key:cyclestreet
     cyclestreets_id: Key:cyclestreets id
@@ -5190,6 +5409,8 @@ en:
     cycleway:surface: Key:cycleway:surface
     cycleway:width: Key:cycleway:width
     cycling_width: Key:cycling width
+    dance:style: Key:dance:style
+    dance:teaching: Key:dance:teaching
     date: Key:date
     date_off: Key:date off
     date_on: Key:date on
@@ -5200,6 +5421,7 @@ en:
     de:strassenschluessel: Key:de:strassenschluessel
     deanery: Key:deanery
     default_language: Key:default language
+    defensive_structure: Key:defensive structure
     dehoga: Key:dehoga
     delivery: Key:delivery
     delivery_point: Key:delivery point
@@ -5208,6 +5430,7 @@ en:
     demolished: Key:demolished
     'demolished:': 'Key:demolished:'
     demolished:building: Key:demolished:building
+    'demolition:': 'Key:demolition:'
     denomination: Key:denomination
     denotation: Key:denotation
     departures_board: Key:departures board
@@ -5251,6 +5474,8 @@ en:
     destination:street:lang:ar:forward: Key:destination:street:lang:ar:forward
     destination:symbol: Key:destination:symbol
     destination:to:lang:ar: Key:destination:to:lang:ar
+    destroyed: Key:destroyed
+    'destroyed:': 'Key:destroyed:'
     detour: Key:detour
     devices: Key:devices
     dewnr:park_id: Key:dewnr:park id
@@ -5300,6 +5525,7 @@ en:
     'disused:': 'Key:disused:'
     disused:amenity: Key:disused:amenity
     disused:building: Key:disused:building
+    disused:highway: Key:disused:highway
     disused:office: Key:disused:office
     disused:place: Key:disused:place
     disused:railway: Key:disused:railway
@@ -5314,11 +5540,13 @@ en:
     door: Key:door
     double_tracked_motor_vehicle: Key:double tracked motor vehicle
     draft: Key:draft
+    draisine: Key:draisine
     drink: Key:drink
     drink:afri-cola: Key:drink:afri-cola
     drink:beer: Key:drink:beer
     drink:club-mate: Key:drink:club-mate
     drink:coffee: Key:drink:coffee
+    drink:espresso: Key:drink:espresso
     drink:kräusen: Key:drink:kräusen
     drink:milk: Key:drink:milk
     drink:milk-raw: Key:drink:milk-raw
@@ -5345,7 +5573,9 @@ en:
     earthquake: Key:earthquake
     earthquake:damage: Key:earthquake:damage
     easy_overtaking: Key:easy overtaking
+    education: Key:education
     educational: Key:educational
+    ekatte: Key:ekatte
     ele: Key:ele
     ele:NHN: Key:ele:NHN
     ele:local: Key:ele:local
@@ -5360,19 +5590,21 @@ en:
     embedded_rails: Key:embedded rails
     embedded_rails:lanes: Key:embedded rails:lanes
     emergency: Key:emergency
+    'emergency:': 'Key:emergency:'
+    emergency:_prefix: 'Key:emergency: prefix'
     emergency:phone: Key:emergency:phone
     employee: Key:employee
     end_date: Key:end date
     enforcement: Key:enforcement
     engineer: Key:engineer
     entrance: Key:entrance
-    escalator: Key:escalator
     est_height: Key:est height
     est_length: Key:est length
     est_width: Key:est width
     etymology: Key:etymology
     european_cultural_path: Key:european cultural path
     evacuation_route: Key:evacuation route
+    excavation: Key:excavation
     exhibit: Key:exhibit
     exit: Key:exit
     exit_to: Key:exit to
@@ -5380,9 +5612,10 @@ en:
     expressway: Key:expressway
     facebook: Key:facebook
     faces: Key:faces
-    factory: Key:factory
     fair_trade: Key:fair trade
+    fallow: Key:fallow
     farming_system: Key:farming system
+    farmland: Key:farmland
     farmyard: Key:farmyard
     fast_food: Key:fast food
     fax: Key:fax
@@ -5392,7 +5625,9 @@ en:
     fee:conditional: Key:fee:conditional
     fee:disabled: Key:fee:disabled
     fee:disabled_assistant: Key:fee:disabled assistant
+    feeding:type: Key:feeding:type
     female: Key:female
+    female:conditional: Key:female:conditional
     fence_type: Key:fence type
     fenced: Key:fenced
     ferry: Key:ferry
@@ -5403,20 +5638,26 @@ en:
     fhrs:local_authority_id: Key:fhrs:local authority id
     field: Key:field
     finance_agent: Key:finance agent
+    fine: Key:fine
     fire: Key:fire
     fire_boundary: Key:fire boundary
     fire_hydrant: Key:fire hydrant
     fire_object:type: Key:fire object:type
     fire_operator: Key:fire operator
+    fire_path: Key:fire path
     fire_rank: Key:fire rank
+    fire_station:type: Key:fire station:type
     firearms: Key:firearms
     fireplace: Key:fireplace
     fishing: Key:fishing
     fitness_station: Key:fitness station
+    fix_guidepost: Key:fix guidepost
     fixme: Key:fixme
+    flag: Key:flag
     flag:name: Key:flag:name
     flag:type: Key:flag:type
     flag:wikidata: Key:flag:wikidata
+    flashing_lights: Key:flashing lights
     flat_steps: Key:flat steps
     flickr: Key:flickr
     floating: Key:floating
@@ -5475,12 +5716,14 @@ en:
     fuel:octane_98: Key:fuel:octane 98
     fuel:svo: Key:fuel:svo
     furniture: Key:furniture
+    fut_ref: Key:fut ref
     fvst:navnelbnr: Key:fvst:navnelbnr
     gambling: Key:gambling
     garden:style: Key:garden:style
     garden:type: Key:garden:type
     gauge: Key:gauge
     gay: Key:gay
+    gender: Key:gender
     gender_segregated: Key:gender segregated
     generator:method: Key:generator:method
     generator:output: Key:generator:output
@@ -5492,6 +5735,7 @@ en:
     generator:output:heat: Key:generator:output:heat
     generator:output:hot_air: Key:generator:output:hot air
     generator:output:hot_water: Key:generator:output:hot water
+    generator:output:hydrogen: Key:generator:output:hydrogen
     generator:output:steam: Key:generator:output:steam
     generator:output:vacuum: Key:generator:output:vacuum
     generator:place: Key:generator:place
@@ -5503,10 +5747,13 @@ en:
     genus:ar: Key:genus:ar
     genus:de: Key:genus:de
     genus:en: Key:genus:en
+    genus:it: Key:genus:it
     genus:ru: Key:genus:ru
+    genus:wikidata: Key:genus:wikidata
     geocodigo: Key:geocodigo
     geological: Key:geological
     geothermal: Key:geothermal
+    geyser:type: Key:geyser:type
     glacier:part: Key:glacier:part
     glacier:type: Key:glacier:type
     gluten_free: Key:gluten free
@@ -5539,6 +5786,7 @@ en:
     gun_emplacement_type: Key:gun emplacement type
     gun_turret: Key:gun turret
     gvr:code: Key:gvr:code
+    hand_cart: Key:hand cart
     handicap: Key:handicap
     handle: Key:handle
     handrail: Key:handrail
@@ -5560,9 +5808,11 @@ en:
     hazmat: Key:hazmat
     hazmat:water: Key:hazmat:water
     headframe: Key:headframe
+    health_facility:type: Key:health facility:type
     healthcare: Key:healthcare
     healthcare:counselling: Key:healthcare:counselling
     healthcare:speciality: Key:healthcare:speciality
+    heater: Key:heater
     heating: Key:heating
     height: Key:height
     height:hub: Key:height:hub
@@ -5584,18 +5834,19 @@ en:
     historic:civilization: Key:historic:civilization
     historic:era: Key:historic:era
     historic:period: Key:historic:period
-    historic_name: Key:historic name
     history: Key:history
     hoops: Key:hoops
     horse: Key:horse
     horse-drawn_carriage: Key:horse-drawn carriage
     horse_scale: Key:horse scale
+    hot_water: Key:hot water
     hour_off: Key:hour off
     hour_on: Key:hour on
     house: Key:house
     hov: Key:hov
     hov:lanes: Key:hov:lanes
     hunting: Key:hunting
+    hunting_stand: Key:hunting stand
     iata: Key:iata
     icao: Key:icao
     ice_cream: Key:ice cream
@@ -5662,6 +5913,7 @@ en:
     it:fvg:ctrn:code: Key:it:fvg:ctrn:code
     iucn_level: Key:iucn level
     jel: Key:jel
+    jetski: Key:jetski
     jetski:rental: Key:jetski:rental
     jetski:sales: Key:jetski:sales
     junction: Key:junction
@@ -5675,6 +5927,8 @@ en:
     kct_white: Key:kct white
     kct_yellow: Key:kct yellow
     kerb: Key:kerb
+    kerb:height: Key:kerb:height
+    kick_scooter: Key:kick scooter
     kids_area: Key:kids area
     kinky: Key:kinky
     kms: Key:kms
@@ -5692,6 +5946,7 @@ en:
     kneipp_water_cure: Key:kneipp water cure
     kp: Key:kp
     kudish: Key:kudish
+    kurb: Key:kurb
     lacounty:ain: Key:lacounty:ain
     lacounty:bld_id: Key:lacounty:bld id
     ladder: Key:ladder
@@ -5714,15 +5969,22 @@ en:
     language: Key:language
     language:LL: Key:language:LL
     language:ar: Key:language:ar
+    language:arc: Key:language:arc
     language:azb: Key:language:azb
     language:ckb: Key:language:ckb
+    language:de: Key:language:de
+    language:el: Key:language:el
     language:fa: Key:language:fa
     language:glk: Key:language:glk
+    language:gr: Key:language:gr
+    language:grc: Key:language:grc
     language:ks: Key:language:ks
     language:lrc: Key:language:lrc
     language:mzn: Key:language:mzn
+    language:pa: Key:language:pa
     language:ps: Key:language:ps
     language:sd: Key:language:sd
+    language:syc: Key:language:syc
     language:ug: Key:language:ug
     language:ur: Key:language:ur
     lawyer: Key:lawyer
@@ -5742,6 +6004,7 @@ en:
     lhv: Key:lhv
     liaison: Key:liaison
     license_classes: Key:license classes
+    lifeguard: Key:lifeguard
     light_rail: Key:light rail
     lighting:perceived: Key:lighting:perceived
     line: Key:line
@@ -5756,6 +6019,8 @@ en:
     loc_name: Key:loc name
     loc_name:ar: Key:loc name:ar
     loc_name:fa: Key:loc name:fa
+    loc_name:gr: Key:loc name:gr
+    loc_name:grc: Key:loc name:grc
     loc_name:ur: Key:loc name:ur
     loc_ref: Key:loc ref
     local_authority:FR: Key:local authority:FR
@@ -5806,6 +6071,7 @@ en:
     maxaxleload: Key:maxaxleload
     maxbogieweight: Key:maxbogieweight
     maxdraft: Key:maxdraft
+    maxdraught: Key:maxdraught
     maxheight: Key:maxheight
     maxheight:legal: Key:maxheight:legal
     maxheight:physical: Key:maxheight:physical
@@ -5828,6 +6094,7 @@ en:
     maxspeed:type: Key:maxspeed:type
     maxspeed:variable: Key:maxspeed:variable
     maxstay: Key:maxstay
+    maxstay:conditional: Key:maxstay:conditional
     maxtents: Key:maxtents
     maxweight: Key:maxweight
     maxweight:signed: Key:maxweight:signed
@@ -5840,16 +6107,20 @@ en:
     mdb_id: Key:mdb id
     meadow: Key:meadow
     measurement: Key:measurement
+    mechanical_coupling: Key:mechanical coupling
+    mechanical_driver: Key:mechanical driver
     medical_supply: Key:medical supply
     megalith_type: Key:megalith type
     membership: Key:membership
     memorial: Key:memorial
+    memorial:subject: Key:memorial:subject
     memorial:type: Key:memorial:type
     message: Key:message
     mhs:inscription_date: Key:mhs:inscription date
     microbrewery: Key:microbrewery
     milestone_type: Key:milestone type
     military: Key:military
+    military_service: Key:military service
     mimics: Key:mimics
     min_age: Key:min age
     min_height: Key:min height
@@ -5886,8 +6157,10 @@ en:
     mooring: Key:mooring
     moped: Key:moped
     motor_vehicle: Key:motor vehicle
+    motor_vehicle:conditional: Key:motor vehicle:conditional
     motorboat: Key:motorboat
     motorcar: Key:motorcar
+    motorcar:conditional: Key:motorcar:conditional
     motorcycle: Key:motorcycle
     motorcycle:clothes: Key:motorcycle:clothes
     motorcycle:conditional: Key:motorcycle:conditional
@@ -5905,6 +6178,7 @@ en:
     motorcycle:transport: Key:motorcycle:transport
     motorcycle:type: Key:motorcycle:type
     motorcycle:tyres: Key:motorcycle:tyres
+    motorcycles: Key:motorcycles
     motorhome: Key:motorhome
     motorroad: Key:motorroad
     motorway: Key:motorway
@@ -5919,15 +6193,19 @@ en:
     museum: Key:museum
     museum_type: Key:museum type
     musical_instrument: Key:musical instrument
+    musical_instrument:repair: Key:musical instrument:repair
     name: Key:name
     name:ar: Key:name:ar
     name:ar1: Key:name:ar1
+    name:arc: Key:name:arc
     name:ast: Key:name:ast
+    name:az-Arab: Key:name:az-Arab
     name:azb: Key:name:azb
     name:be: Key:name:be
     name:be-tarask: Key:name:be-tarask
     name:ber: Key:name:ber
     name:bn: Key:name:bn
+    name:bn-Arab: Key:name:bn-Arab
     name:botanical: Key:name:botanical
     name:br: Key:name:br
     name:ca: Key:name:ca
@@ -5957,6 +6235,8 @@ en:
     name:gem: Key:name:gem
     name:gl: Key:name:gl
     name:glk: Key:name:glk
+    name:gr: Key:name:gr
+    name:grc: Key:name:grc
     name:gsw: Key:name:gsw
     name:he: Key:name:he
     name:hi: Key:name:hi
@@ -5976,6 +6256,7 @@ en:
     name:kab-Arab: Key:name:kab-Arab
     name:kk: Key:name:kk
     name:kk-Arab: Key:name:kk-Arab
+    name:kmr: Key:name:kmr
     name:kn: Key:name:kn
     name:kn:iso15919: Key:name:kn:iso15919
     name:ko: Key:name:ko
@@ -5984,6 +6265,8 @@ en:
     name:ks: Key:name:ks
     name:ku: Key:name:ku
     name:ku-Arab: Key:name:ku-Arab
+    name:ky-Arab: Key:name:ky-Arab
+    name:language: Key:name:language
     name:left: Key:name:left
     name:left:ar: Key:name:left:ar
     name:left:fr: Key:name:left:fr
@@ -5995,6 +6278,7 @@ en:
     name:mk: Key:name:mk
     name:ml: Key:name:ml
     name:mr: Key:name:mr
+    name:ms-Arab: Key:name:ms-Arab
     name:my: Key:name:my
     name:mzn: Key:name:mzn
     name:nds: Key:name:nds
@@ -6003,7 +6287,9 @@ en:
     name:nn: Key:name:nn
     name:no: Key:name:no
     name:nov: Key:name:nov
+    name:oc: Key:name:oc
     name:ota: Key:name:ota
+    name:pa-Arab: Key:name:pa-Arab
     name:pl: Key:name:pl
     name:pnb: Key:name:pnb
     name:prefix: Key:name:prefix
@@ -6019,12 +6305,14 @@ en:
     name:sc: Key:name:sc
     name:sd: Key:name:sd
     name:sh: Key:name:sh
+    name:signed: Key:name:signed
     name:sk: Key:name:sk
     name:sl: Key:name:sl
     name:sr: Key:name:sr
     name:sr-Latn: Key:name:sr-Latn
     name:suffix: Key:name:suffix
     name:sv: Key:name:sv
+    name:syc: Key:name:syc
     name:ta: Key:name:ta
     name:te: Key:name:te
     name:th: Key:name:th
@@ -6037,6 +6325,7 @@ en:
     name:uk: Key:name:uk
     name:ur: Key:name:ur
     name:vi: Key:name:vi
+    name:vi-Hani: Key:name:vi-Hani
     name:vo: Key:name:vo
     name:wikipedia: Key:name:wikipedia
     name:xx: Key:name:xx
@@ -6045,6 +6334,7 @@ en:
     name:zh-sg: Key:name:zh-sg
     name_1: Key:name 1
     name_2: Key:name 2
+    naptan:AdministrativeAreaRef: Key:naptan:AdministrativeAreaRef
     naptan:AltCommonName: Key:naptan:AltCommonName
     naptan:AltCrossing: Key:naptan:AltCrossing
     naptan:AltIndicator: Key:naptan:AltIndicator
@@ -6056,12 +6346,15 @@ en:
     naptan:BusStopType: Key:naptan:BusStopType
     naptan:CommonName: Key:naptan:CommonName
     naptan:Crossing: Key:naptan:Crossing
+    naptan:Error: Key:naptan:Error
     naptan:Indicator: Key:naptan:Indicator
     naptan:Landmark: Key:naptan:Landmark
     naptan:NaptanCode: Key:naptan:NaptanCode
     naptan:Notes: Key:naptan:Notes
     naptan:PlusbusZoneRef: Key:naptan:PlusbusZoneRef
+    naptan:RevisionNumber: Key:naptan:RevisionNumber
     naptan:ShortCommonName: Key:naptan:ShortCommonName
+    naptan:Status: Key:naptan:Status
     naptan:StopAreaCode: Key:naptan:StopAreaCode
     naptan:StopAreaType: Key:naptan:StopAreaType
     naptan:Street: Key:naptan:Street
@@ -6093,6 +6386,7 @@ en:
     network:guid: Key:network:guid
     network:type: Key:network:type
     network:wikidata: Key:network:wikidata
+    next_check_date: Key:next check date
     nhd:com_id: Key:nhd:com id
     nhd:fcode: Key:nhd:fcode
     nhd:ftype: Key:nhd:ftype
@@ -6102,7 +6396,6 @@ en:
     noexit: Key:noexit
     nohousenumber: Key:nohousenumber
     non_existent_levels: Key:non existent levels
-    noname: Key:noname
     nonsquare: Key:nonsquare
     noref: Key:noref
     not: Key:not
@@ -6112,6 +6405,7 @@ en:
     not_accepted_import:leisure: Key:not accepted import:leisure
     not_served_by: Key:not served by
     note: Key:note
+    note:addr_place: Key:note:addr place
     note:ar: Key:note:ar
     note:deplacer4mE: Key:note:deplacer4mE
     note:depth: Key:note:depth
@@ -6121,6 +6415,7 @@ en:
     notes: Key:notes
     nuclear_explosion:country: Key:nuclear explosion:country
     nudism: Key:nudism
+    nudism:conditional: Key:nudism:conditional
     number_of_apartments: Key:number of apartments
     nursery: Key:nursery
     nvdb:date: Key:nvdb:date
@@ -6138,17 +6433,28 @@ en:
     office: Key:office
     official_name: Key:official name
     official_name:ar: Key:official name:ar
+    official_name:arc: Key:official name:arc
+    official_name:az-Arab: Key:official name:az-Arab
     official_name:azb: Key:official name:azb
     official_name:be: Key:official name:be
     official_name:ckb: Key:official name:ckb
+    official_name:en: Key:official name:en
     official_name:fa: Key:official name:fa
+    official_name:fr: Key:official name:fr
     official_name:glk: Key:official name:glk
+    official_name:gr: Key:official name:gr
+    official_name:grc: Key:official name:grc
+    official_name:kk-Arab: Key:official name:kk-Arab
+    official_name:kmr: Key:official name:kmr
     official_name:ks: Key:official name:ks
     official_name:lrc: Key:official name:lrc
     official_name:mzn: Key:official name:mzn
+    official_name:pl: Key:official name:pl
     official_name:pnb: Key:official name:pnb
     official_name:ps: Key:official name:ps
+    official_name:ru: Key:official name:ru
     official_name:sd: Key:official name:sd
+    official_name:syc: Key:official name:syc
     official_name:ug: Key:official name:ug
     official_name:ur: Key:official name:ur
     official_ref: Key:official ref
@@ -6166,7 +6472,10 @@ en:
     old_name:en: Key:old name:en
     old_name:etymology:wikidata: Key:old name:etymology:wikidata
     old_name:fa: Key:old name:fa
+    old_name:gr: Key:old name:gr
+    old_name:grc: Key:old name:grc
     old_name:ks: Key:old name:ks
+    old_name:ku-Arab: Key:old name:ku-Arab
     old_name:lrc: Key:old name:lrc
     old_name:pl: Key:old name:pl
     old_name:pnb: Key:old name:pnb
@@ -6184,10 +6493,12 @@ en:
     oneclass: Key:oneclass
     oneway: Key:oneway
     oneway:bicycle: Key:oneway:bicycle
+    oneway:bus: Key:oneway:bus
     oneway:conditional: Key:oneway:conditional
     oneway:foot: Key:oneway:foot
-    oneway:moped: Key:oneway:moped
+    oneway:motorcycle: Key:oneway:motorcycle
     oneway:psv: Key:oneway:psv
+    oneway:taxi: Key:oneway:taxi
     onkz: Key:onkz
     ons_code: Key:ons code
     open_air: Key:open air
@@ -6265,10 +6576,14 @@ en:
     parking:lane:both: Key:parking:lane:both
     parking:lane:hgv: Key:parking:lane:hgv
     parking:lane:left: Key:parking:lane:left
+    parking:lane:left:parallel: Key:parking:lane:left:parallel
     parking:lane:right: Key:parking:lane:right
+    parking:lane:right:parallel: Key:parking:lane:right:parallel
     parking:lane:side: Key:parking:lane:side
+    parking:lane:side:parallel: Key:parking:lane:side:parallel
     parking:orientation: Key:parking:orientation
     parking:street_side: Key:parking:street side
+    parking_space: Key:parking space
     parts: Key:parts
     passage_time: Key:passage time
     passenger: Key:passenger
@@ -6279,41 +6594,75 @@ en:
     paved:date: Key:paved:date
     payment: Key:payment
     payment:account_cards: Key:payment:account cards
+    payment:alipay: Key:payment:alipay
     payment:american_express: Key:payment:american express
+    payment:app: Key:payment:app
+    payment:apple_pay: Key:payment:apple pay
+    payment:bancomat: Key:payment:bancomat
+    payment:bitcoin: Key:payment:bitcoin
+    payment:bitcoincash: Key:payment:bitcoincash
+    payment:blik: Key:payment:blik
     payment:cards: Key:payment:cards
     payment:cash: Key:payment:cash
+    payment:cb: Key:payment:cb
+    payment:cheque: Key:payment:cheque
     payment:clipper: Key:payment:clipper
     payment:coins: Key:payment:coins
     payment:contactless: Key:payment:contactless
     payment:credit_cards: Key:payment:credit cards
+    payment:cryptocurrencies: Key:payment:cryptocurrencies
     payment:debit_cards: Key:payment:debit cards
+    payment:description: Key:payment:description
+    payment:diners_club: Key:payment:diners club
     payment:discover_card: Key:payment:discover card
+    payment:dkv: Key:payment:dkv
     payment:e_zpass: Key:payment:e zpass
+    payment:easycard: Key:payment:easycard
     payment:electronic_purses: Key:payment:electronic purses
+    payment:ep_easycard: Key:payment:ep easycard
+    payment:ep_geldkarte: Key:payment:ep geldkarte
+    payment:ep_ipass: Key:payment:ep ipass
     payment:fastrak: Key:payment:fastrak
     payment:foo: Key:payment:foo
     payment:girocard: Key:payment:girocard
     payment:good_to_go: Key:payment:good to go
+    payment:google_pay: Key:payment:google pay
     payment:i-pass: Key:payment:i-pass
+    payment:icsf: Key:payment:icsf
     payment:ipass: Key:payment:ipass
+    payment:jcb: Key:payment:jcb
     payment:k-tag: Key:payment:k-tag
     payment:maestro: Key:payment:maestro
     payment:mastercard: Key:payment:mastercard
+    payment:mastercard_contactless: Key:payment:mastercard contactless
+    payment:mastercard_debit: Key:payment:mastercard debit
     payment:mir: Key:payment:mir
+    payment:mobile_phone: Key:payment:mobile phone
     payment:nc_quick_pass: Key:payment:nc quick pass
     payment:none: Key:payment:none
     payment:notes: Key:payment:notes
+    payment:others: Key:payment:others
+    payment:paypal: Key:payment:paypal
     payment:peach_pass: Key:payment:peach pass
     payment:peachpass: Key:payment:peachpass
     payment:pikepass: Key:payment:pikepass
+    payment:prepaid_ticket: Key:payment:prepaid ticket
     payment:pro100: Key:payment:pro100
+    payment:stored_value_card: Key:payment:stored value card
     payment:sunpass: Key:payment:sunpass
+    payment:telephone_cards: Key:payment:telephone cards
+    payment:touchngo: Key:payment:touchngo
+    payment:twint: Key:payment:twint
     payment:u-key: Key:payment:u-key
+    payment:unionpay: Key:payment:unionpay
+    payment:uta: Key:payment:uta
+    payment:v_pay: Key:payment:v pay
     payment:visa: Key:payment:visa
     payment:visa_debit: Key:payment:visa debit
+    payment:visa_electron: Key:payment:visa electron
+    payment:wechat: Key:payment:wechat
+    payment:wire_transfer: Key:payment:wire transfer
     permanent_camping: Key:permanent camping
-    pet_allowed: Key:pet allowed
-    pets_allowed: Key:pets allowed
     phoenixbikeguide: Key:phoenixbikeguide
     phone: Key:phone
     photo: Key:photo
@@ -6360,7 +6709,9 @@ en:
     playground: Key:playground
     'playground:': 'Key:playground:'
     playground:theme: Key:playground:theme
+    pmfsefin:idedif: Key:pmfsefin:idedif
     point: Key:point
+    pole: Key:pole
     pole:type: Key:pole:type
     police: Key:police
     polling_station: Key:polling station
@@ -6370,9 +6721,11 @@ en:
     position: Key:position
     post_box:design: Key:post box:design
     post_box:type: Key:post box:type
-    post_office:type: Key:post office:type
+    post_office: Key:post office
+    post_office:parcel_pickup: Key:post office:parcel pickup
     postal_code: Key:postal code
     postcode: Key:postcode
+    potholes: Key:potholes
     power: Key:power
     power_output: Key:power output
     power_rating: Key:power rating
@@ -6401,6 +6754,8 @@ en:
     pruning: Key:pruning
     psv: Key:psv
     psv:lanes: Key:psv:lanes
+    psv:lanes:backward: Key:psv:lanes:backward
+    psv:lanes:forward: Key:psv:lanes:forward
     public_bookcase:type: Key:public bookcase:type
     public_transport: Key:public transport
     public_transport:version: Key:public transport:version
@@ -6449,7 +6804,11 @@ en:
     real_cider: Key:real cider
     real_fire: Key:real fire
     recording: Key:recording
+    recreation_ground: Key:recreation ground
+    recycling:PET: Key:recycling:PET
     recycling:fire_extinguishers: Key:recycling:fire extinguishers
+    recycling:pet_drink_bottles: Key:recycling:pet drink bottles
+    recycling:plastic_bottle_tops: Key:recycling:plastic bottle tops
     recycling_type: Key:recycling type
     red_turn:left: Key:red turn:left
     red_turn:right: Key:red turn:right
@@ -6463,6 +6822,7 @@ en:
     ref: Key:ref
     ref:AGESIC: Key:ref:AGESIC
     ref:CEF: Key:ref:CEF
+    ref:DK:cvr: Key:ref:DK:cvr
     ref:De_Lijn: Key:ref:De Lijn
     ref:ERDF:gdo: Key:ref:ERDF:gdo
     ref:EU:ENTSOE_EIC: Key:ref:EU:ENTSOE EIC
@@ -6483,8 +6843,10 @@ en:
     ref:FR:MemorialGenWeb: Key:ref:FR:MemorialGenWeb
     ref:FR:NAF: Key:ref:FR:NAF
     ref:FR:Orange: Key:ref:FR:Orange
+    ref:FR:Orange:NRO: Key:ref:FR:Orange:NRO
     ref:FR:Orange_mobile: Key:ref:FR:Orange mobile
     ref:FR:PTT: Key:ref:FR:PTT
+    ref:FR:PTT:NRA: Key:ref:FR:PTT:NRA
     ref:FR:RNA: Key:ref:FR:RNA
     ref:FR:RTE: Key:ref:FR:RTE
     ref:FR:RTE_nom: Key:ref:FR:RTE nom
@@ -6495,9 +6857,12 @@ en:
     ref:FR:gdo: Key:ref:FR:gdo
     ref:FR:museofile: Key:ref:FR:museofile
     ref:FR:prix-carburants: Key:ref:FR:prix-carburants
+    ref:GB:mpan: Key:ref:GB:mpan
+    ref:GB:nhs_ods: Key:ref:GB:nhs ods
     ref:GB:uprn: Key:ref:GB:uprn
     ref:HU:edid: Key:ref:HU:edid
     ref:IFOPT: Key:ref:IFOPT
+    ref:INEP: Key:ref:INEP
     ref:INSEE: Key:ref:INSEE
     ref:ISTAT: Key:ref:ISTAT
     ref:LILA: Key:ref:LILA
@@ -6506,6 +6871,7 @@ en:
     ref:NBd: Key:ref:NBd
     ref:NLPG:UPRN:1: Key:ref:NLPG:UPRN:1
     ref:NPLG:UPRN:1: Key:ref:NPLG:UPRN:1
+    ref:REI: Key:ref:REI
     ref:TECB: Key:ref:TECB
     ref:TECC: Key:ref:TECC
     ref:TECH: Key:ref:TECH
@@ -6525,7 +6891,11 @@ en:
     ref:bam.brno.cz: Key:ref:bam.brno.cz
     ref:bic: Key:ref:bic
     ref:bufa: Key:ref:bufa
+    ref:bygningsnr: Key:ref:bygningsnr
+    ref:cadc:2020: Key:ref:cadc:2020
     ref:cadw: Key:ref:cadw
+    ref:capad:pa_id: Key:ref:capad:pa id
+    ref:capad:uid: Key:ref:capad:uid
     ref:circuits: Key:ref:circuits
     ref:cobe: Key:ref:cobe
     ref:color: Key:ref:color
@@ -6534,10 +6904,13 @@ en:
     ref:crs: Key:ref:crs
     ref:ctb: Key:ref:ctb
     ref:deniirn: Key:ref:deniirn
+    ref:dew:park_id: Key:ref:dew:park id
     ref:dhis2: Key:ref:dhis2
+    ref:doc: Key:ref:doc
     ref:edubase: Key:ref:edubase
     ref:ef: Key:ref:ef
     ref:gnis: Key:ref:gnis
+    ref:gsi: Key:ref:gsi
     ref:gss: Key:ref:gss
     ref:gurs:hs_mid: Key:ref:gurs:hs mid
     ref:harbour: Key:ref:harbour
@@ -6546,6 +6919,8 @@ en:
     ref:industrial: Key:ref:industrial
     ref:isil: Key:ref:isil
     ref:kmb: Key:ref:kmb
+    ref:linz:address_id: Key:ref:linz:address id
+    ref:linz:building_id: Key:ref:linz:building id
     ref:lor: Key:ref:lor
     ref:mcrb: Key:ref:mcrb
     ref:mhs: Key:ref:mhs
@@ -6554,6 +6929,7 @@ en:
     ref:minvskaddress: Key:ref:minvskaddress
     ref:mise: Key:ref:mise
     ref:mobil-parken.de: Key:ref:mobil-parken.de
+    ref:nid: Key:ref:nid
     ref:nrhp: Key:ref:nrhp
     ref:ortsnetz: Key:ref:ortsnetz
     ref:oslo:tree: Key:ref:oslo:tree
@@ -6573,8 +6949,10 @@ en:
     ref:shop:num: Key:ref:shop:num
     ref:sitp: Key:ref:sitp
     ref:sr:maticni_broj: Key:ref:sr:maticni broj
+    ref:ssb_tettsted: Key:ref:ssb tettsted
     ref:statistical: Key:ref:statistical
     ref:taskey: Key:ref:taskey
+    ref:udir_nsr: Key:ref:udir nsr
     ref:vatin: Key:ref:vatin
     ref:vatin:hu: Key:ref:vatin:hu
     ref:vorwahl: Key:ref:vorwahl
@@ -6589,11 +6967,14 @@ en:
     reference_point: Key:reference point
     reg_name: Key:reg name
     reg_name:ar: Key:reg name:ar
+    reg_name:gr: Key:reg name:gr
+    reg_name:grc: Key:reg name:grc
     reg_ref: Key:reg ref
     regelbau: Key:regelbau
     region:type: Key:region:type
     related_law: Key:related law
     religion: Key:religion
+    remotely_controllable: Key:remotely controllable
     removed: Key:removed
     'removed:': 'Key:removed:'
     removed:amenity: Key:removed:amenity
@@ -6613,7 +6994,9 @@ en:
     restaurant: Key:restaurant
     restriction:conditional: Key:restriction:conditional
     retreat: Key:retreat
-    retroreflecting: Key:retroreflecting
+    reusable_packaging: Key:reusable packaging
+    reusable_packaging:accept: Key:reusable packaging:accept
+    reusable_packaging:offer: Key:reusable packaging:offer
     review_requested: Key:review requested
     rfr: Key:rfr
     rhn_ref: Key:rhn ref
@@ -6634,6 +7017,7 @@ en:
     room: Key:room
     rooms: Key:rooms
     rotor:diameter: Key:rotor:diameter
+    rotor:swept_area: Key:rotor:swept area
     roundtrip: Key:roundtrip
     route: Key:route
     route_availability: Key:route availability
@@ -6674,8 +7058,10 @@ en:
     sauna:water:description: Key:sauna:water:description
     scenic: Key:scenic
     school: Key:school
+    school:gender: Key:school:gender
     scuba_diving:courses: Key:scuba diving:courses
     scuba_diving:rental: Key:scuba diving:rental
+    sculpture_type: Key:sculpture type
     seamark: Key:seamark
     seamark:beacon_isolated_danger:shape: Key:seamark:beacon isolated danger:shape
     seamark:beacon_safe_water:colour: Key:seamark:beacon safe water:colour
@@ -6757,6 +7143,7 @@ en:
     service: Key:service
     service:bicycle:cleaning: Key:service:bicycle:cleaning
     service:bicycle:diy: Key:service:bicycle:diy
+    service:bicycle:ebike: Key:service:bicycle:ebike
     service:bicycle:pump: Key:service:bicycle:pump
     service:bicycle:rental: Key:service:bicycle:rental
     service:bicycle:repair: Key:service:bicycle:repair
@@ -6782,11 +7169,18 @@ en:
     short_name:ur: Key:short name:ur
     shoulder: Key:shoulder
     shower: Key:shower
+    shrine: Key:shrine
     side_road: Key:side road
     sides: Key:sides
     sidewalk: Key:sidewalk
+    sidewalk:both: Key:sidewalk:both
+    sidewalk:both:bicycle: Key:sidewalk:both:bicycle
     sidewalk:both:surface: Key:sidewalk:both:surface
+    sidewalk:left: Key:sidewalk:left
+    sidewalk:left:bicycle: Key:sidewalk:left:bicycle
     sidewalk:left:surface: Key:sidewalk:left:surface
+    sidewalk:right: Key:sidewalk:right
+    sidewalk:right:bicycle: Key:sidewalk:right:bicycle
     sidewalk:right:surface: Key:sidewalk:right:surface
     sidewalk:surface: Key:sidewalk:surface
     sidewalk_orientation: Key:sidewalk orientation
@@ -6801,6 +7195,8 @@ en:
     ski_tour_difficulty: Key:ski tour difficulty
     sl_realtime: Key:sl realtime
     sl_stop_id: Key:sl stop id
+    sloped_curb: Key:sloped curb
+    small_electric_vehicle: Key:small electric vehicle
     smokefree: Key:smokefree
     smoking: Key:smoking
     smoking:outside: Key:smoking:outside
@@ -6813,17 +7209,26 @@ en:
     social_facility: Key:social facility
     social_facility:for: Key:social facility:for
     socket: Key:socket
+    socket:chademo: Key:socket:chademo
     socket:schuko: Key:socket:schuko
     socket:type1: Key:socket:type1
     socket:type2: Key:socket:type2
+    socket:type3: Key:socket:type3
     socket:type3c: Key:socket:type3c
     socket:typee: Key:socket:typee
+    soliciting: Key:soliciting
     sorting_name: Key:sorting name
     sorting_name:ar: Key:sorting name:ar
+    sorting_name:arc: Key:sorting name:arc
     sorting_name:azb: Key:sorting name:azb
     sorting_name:be: Key:sorting name:be
     sorting_name:fa: Key:sorting name:fa
+    sorting_name:gr: Key:sorting name:gr
+    sorting_name:grc: Key:sorting name:grc
+    sorting_name:ks: Key:sorting name:ks
+    sorting_name:ota: Key:sorting name:ota
     sorting_name:ru: Key:sorting name:ru
+    sorting_name:syc: Key:sorting name:syc
     sorting_name:ur: Key:sorting name:ur
     source: Key:source
     source:ProRail: Key:source:ProRail
@@ -6872,6 +7277,7 @@ en:
     species:no: Key:species:no
     species:ru: Key:species:ru
     species:wikidata: Key:species:wikidata
+    species:wikipedia: Key:species:wikipedia
     speech_input: Key:speech input
     speech_input:lg: Key:speech input:lg
     speech_output: Key:speech output
@@ -6904,7 +7310,6 @@ en:
     stroller: Key:stroller
     structure: Key:structure
     studio: Key:studio
-    sub_sea: Key:sub sea
     subject: Key:subject
     subject:wikidata: Key:subject:wikidata
     subject:wikipedia: Key:subject:wikipedia
@@ -6923,6 +7328,9 @@ en:
     surveillance:type: Key:surveillance:type
     surveillance:zone: Key:surveillance:zone
     survey:date: Key:survey:date
+    survey_point:datum_aligned: Key:survey point:datum aligned
+    survey_point:purpose: Key:survey point:purpose
+    survey_point:structure: Key:survey point:structure
     sustrans_ref: Key:sustrans ref
     swimming: Key:swimming
     swimming_pool: Key:swimming pool
@@ -6955,6 +7363,7 @@ en:
     telecom:medium: Key:telecom:medium
     telescope:type: Key:telescope:type
     television: Key:television
+    temperature: Key:temperature
     temporary: Key:temporary
     tenant: Key:tenant
     tents: Key:tents
@@ -6972,6 +7381,7 @@ en:
     ticks: Key:ticks
     tidal: Key:tidal
     tiger: Key:tiger
+    'tiger:': 'Key:tiger:'
     tiger:CLASSFP: Key:tiger:CLASSFP
     tiger:CPI: Key:tiger:CPI
     tiger:FUNCSTAT: Key:tiger:FUNCSTAT
@@ -6992,11 +7402,13 @@ en:
     todo: Key:todo
     toilets: Key:toilets
     toilets:paper_supplied: Key:toilets:paper supplied
+    toilets:unisex: Key:toilets:unisex
     toilets:wheelchair: Key:toilets:wheelchair
     toll: Key:toll
     toll:hgv: Key:toll:hgv
     toll:motorcycle: Key:toll:motorcycle
     tomb: Key:tomb
+    topless: Key:topless
     topmark: Key:topmark
     topmark:colour: Key:topmark:colour
     touring: Key:touring
@@ -7028,6 +7440,7 @@ en:
     traffic_signals:vibration: Key:traffic signals:vibration
     trail_visibility: Key:trail visibility
     trailblazed: Key:trailblazed
+    trailblazed:visibility: Key:trailblazed:visibility
     trailer: Key:trailer
     trailer:rental: Key:trailer:rental
     train: Key:train
@@ -7037,6 +7450,7 @@ en:
     tree_lined: Key:tree lined
     trees: Key:trees
     trench: Key:trench
+    trolley:deposit: Key:trolley:deposit
     trolley_wire: Key:trolley wire
     trolleybus: Key:trolleybus
     truck_wash: Key:truck wash
@@ -7104,6 +7518,7 @@ en:
     voltage:primary: Key:voltage:primary
     voltage:secondary: Key:voltage:secondary
     walk-in: Key:walk-in
+    wall: Key:wall
     wall:material: Key:wall:material
     washing_machine: Key:washing machine
     waste: Key:waste
@@ -7113,6 +7528,7 @@ en:
     water_point: Key:water point
     water_source: Key:water source
     water_system: Key:water system
+    water_well: Key:water well
     waterway: Key:waterway
     weather_protection: Key:weather protection
     website: Key:website
@@ -7179,6 +7595,7 @@ en:
     works: Key:works
     workshop: Key:workshop
     worship: Key:worship
+    wreck:type: Key:wreck:type
     www.prezzibenzina.it: Key:www.prezzibenzina.it
     xmas:feature: Key:xmas:feature
     xmpp: Key:xmpp
@@ -7206,8 +7623,10 @@ en:
     access=customers: Tag:access=customers
     access=delivery: Tag:access=delivery
     access=designated: Tag:access=designated
+    access=destination: Tag:access=destination
     access=exclusion_zone: Tag:access=exclusion zone
     access=forestry: Tag:access=forestry
+    access=licence: Tag:access=licence
     access=license: Tag:access=license
     access=no: Tag:access=no
     access=official: Tag:access=official
@@ -7216,11 +7635,13 @@ en:
     access=private: Tag:access=private
     access=public: Tag:access=public
     access=restricted: Tag:access=restricted
+    access=unknown: Tag:access=unknown
     access=use_sidepath: Tag:access=use sidepath
     actuator=electric_motor: Tag:actuator=electric motor
     actuator=hydraulic_cylinder: Tag:actuator=hydraulic cylinder
     actuator=manual: Tag:actuator=manual
     actuator=pneumatic_cylinder: Tag:actuator=pneumatic cylinder
+    addr:type=water: Tag:addr:type=water
     admin_level=1: Tag:admin level=1
     admin_level=10: Tag:admin level=10
     admin_level=11: Tag:admin level=11
@@ -7270,6 +7691,7 @@ en:
     aeroway=aerodrome: Tag:aeroway=aerodrome
     aeroway=airport: Tag:aeroway=airport
     aeroway=airstrip: Tag:aeroway=airstrip
+    aeroway=airtanker_base: Tag:aeroway=airtanker base
     aeroway=apron: Tag:aeroway=apron
     aeroway=arresting_gear: Tag:aeroway=arresting gear
     aeroway=fuel: Tag:aeroway=fuel
@@ -7282,6 +7704,7 @@ en:
     aeroway=landingpad: Tag:aeroway=landingpad
     aeroway=launchpad: Tag:aeroway=launchpad
     aeroway=navigationaid: Tag:aeroway=navigationaid
+    aeroway=papi: Tag:aeroway=papi
     aeroway=parking_position: Tag:aeroway=parking position
     aeroway=runway: Tag:aeroway=runway
     aeroway=spaceport: Tag:aeroway=spaceport
@@ -7292,6 +7715,7 @@ en:
     airmark=beacon: Tag:airmark=beacon
     ale_supply=limited: Tag:ale supply=limited
     allotments=plot: Tag:allotments=plot
+    amenity=High_school: Tag:amenity=High school
     amenity=Kneippbecken: Tag:amenity=Kneippbecken
     amenity=administration: Tag:amenity=administration
     amenity=advertising: Tag:amenity=advertising
@@ -7312,6 +7736,7 @@ en:
     amenity=bank: Tag:amenity=bank
     amenity=bar: Tag:amenity=bar
     amenity=bbq: Tag:amenity=bbq
+    amenity=bear_box: Tag:amenity=bear box
     amenity=bench: Tag:amenity=bench
     amenity=bicycle_library: Tag:amenity=bicycle library
     amenity=bicycle_parking: Tag:amenity=bicycle parking
@@ -7342,6 +7767,8 @@ en:
     amenity=carpet_washing: Tag:amenity=carpet washing
     amenity=carwash: Tag:amenity=carwash
     amenity=casino: Tag:amenity=casino
+    amenity=chair: Tag:amenity=chair
+    amenity=changing_room: Tag:amenity=changing room
     amenity=charging_station: Tag:amenity=charging station
     amenity=childcare: Tag:amenity=childcare
     amenity=cinema: Tag:amenity=cinema
@@ -7351,6 +7778,7 @@ en:
     amenity=clock: Tag:amenity=clock
     amenity=clothes_dryer: Tag:amenity=clothes dryer
     amenity=club: Tag:amenity=club
+    amenity=clubhouse: Tag:amenity=clubhouse
     amenity=coast_guard: Tag:amenity=coast guard
     amenity=coast_radar_station: Tag:amenity=coast radar station
     amenity=college: Tag:amenity=college
@@ -7361,6 +7789,7 @@ en:
     amenity=concession_stand: Tag:amenity=concession stand
     amenity=conference_centre: Tag:amenity=conference centre
     amenity=consulate: Tag:amenity=consulate
+    amenity=convention_centre: Tag:amenity=convention centre
     amenity=courthouse: Tag:amenity=courthouse
     amenity=coworking_space: Tag:amenity=coworking space
     amenity=crematorium: Tag:amenity=crematorium
@@ -7377,6 +7806,7 @@ en:
     amenity=doctor: Tag:amenity=doctor
     amenity=doctors: Tag:amenity=doctors
     amenity=dog_bin: Tag:amenity=dog bin
+    amenity=dog_parking: Tag:amenity=dog parking
     amenity=dog_toilet: Tag:amenity=dog toilet
     amenity=dog_waste_bin: Tag:amenity=dog waste bin
     amenity=dojo: Tag:amenity=dojo
@@ -7390,6 +7820,7 @@ en:
     amenity=embassy: Tag:amenity=embassy
     amenity=emergency_phone: Tag:amenity=emergency phone
     amenity=ev_charging: Tag:amenity=ev charging
+    amenity=events_centre: Tag:amenity=events centre
     amenity=events_venue: Tag:amenity=events venue
     amenity=exercise_point: Tag:amenity=exercise point
     amenity=exhibition_centre: Tag:amenity=exhibition centre
@@ -7400,11 +7831,10 @@ en:
     amenity=financial_advice: Tag:amenity=financial advice
     amenity=fire_hydrant: Tag:amenity=fire hydrant
     amenity=fire_station: Tag:amenity=fire station
-    amenity=first_aid: Tag:amenity=first aid
-    amenity=firstaid: Tag:amenity=firstaid
     amenity=fish_spa: Tag:amenity=fish spa
     amenity=fitness_station: Tag:amenity=fitness station
     amenity=food_court: Tag:amenity=food court
+    amenity=food_sharing: Tag:amenity=food sharing
     amenity=fountain: Tag:amenity=fountain
     amenity=fridge: Tag:amenity=fridge
     amenity=fuel: Tag:amenity=fuel
@@ -7431,6 +7861,7 @@ en:
     amenity=jobcentre: Tag:amenity=jobcentre
     amenity=juice_bar: Tag:amenity=juice bar
     amenity=karaoke_box: Tag:amenity=karaoke box
+    amenity=kick-scooter_rental: Tag:amenity=kick-scooter rental
     amenity=kindergarten: Tag:amenity=kindergarten
     amenity=kiosk: Tag:amenity=kiosk
     amenity=kitchen: Tag:amenity=kitchen
@@ -7464,6 +7895,7 @@ en:
     amenity=nursery: Tag:amenity=nursery
     amenity=nursing_home: Tag:amenity=nursing home
     amenity=office: Tag:amenity=office
+    amenity=osmica: Tag:amenity=osmica
     amenity=outfitter: Tag:amenity=outfitter
     amenity=park: Tag:amenity=park
     amenity=parking: Tag:amenity=parking
@@ -7475,6 +7907,7 @@ en:
     amenity=pharmacy: Tag:amenity=pharmacy
     amenity=photo_booth: Tag:amenity=photo booth
     amenity=piano: Tag:amenity=piano
+    amenity=place_of_mourning: Tag:amenity=place of mourning
     amenity=place_of_worship: Tag:amenity=place of worship
     amenity=planetarium: Tag:amenity=planetarium
     amenity=police: Tag:amenity=police
@@ -7508,10 +7941,8 @@ en:
     amenity=sanatorium: Tag:amenity=sanatorium
     amenity=sanitary_dump_station: Tag:amenity=sanitary dump station
     amenity=sauna: Tag:amenity=sauna
-    amenity=sceptic_tank: Tag:amenity=sceptic tank
     amenity=school: Tag:amenity=school
     amenity=seat: Tag:amenity=seat
-    amenity=septic_tank: Tag:amenity=septic tank
     amenity=shelter: Tag:amenity=shelter
     amenity=shop: Tag:amenity=shop
     amenity=shower: Tag:amenity=shower
@@ -7530,6 +7961,8 @@ en:
     amenity=street_lamp: Tag:amenity=street lamp
     amenity=street_light: Tag:amenity=street light
     amenity=stripclub: Tag:amenity=stripclub
+    amenity=stroller_parking: Tag:amenity=stroller parking
+    amenity=student_accommodation: Tag:amenity=student accommodation
     amenity=studio: Tag:amenity=studio
     amenity=surf_school: Tag:amenity=surf school
     amenity=swimming_pool: Tag:amenity=swimming pool
@@ -7546,7 +7979,9 @@ en:
     amenity=tourist_bus_parking: Tag:amenity=tourist bus parking
     amenity=townhall: Tag:amenity=townhall
     amenity=toy_library: Tag:amenity=toy library
+    amenity=traffic_park: Tag:amenity=traffic park
     amenity=trailer_park: Tag:amenity=trailer park
+    amenity=training: Tag:amenity=training
     amenity=trolley_bay: Tag:amenity=trolley bay
     amenity=tuition: Tag:amenity=tuition
     amenity=university: Tag:amenity=university
@@ -7560,15 +7995,16 @@ en:
     amenity=washing_machine: Tag:amenity=washing machine
     amenity=waste_basket: Tag:amenity=waste basket
     amenity=waste_disposal: Tag:amenity=waste disposal
+    amenity=waste_dump_site: Tag:amenity=waste dump site
     amenity=waste_transfer_station: Tag:amenity=waste transfer station
     amenity=water: Tag:amenity=water
     amenity=water_point: Tag:amenity=water point
     amenity=watering_place: Tag:amenity=watering place
     amenity=weighbridge: Tag:amenity=weighbridge
     amenity=winery: Tag:amenity=winery
+    amenity=workshop: Tag:amenity=workshop
     amenity=yacht_club: Tag:amenity=yacht club
     amenity=youth_centre: Tag:amenity=youth centre
-    aminety=sceptic_tank: Tag:aminety=sceptic tank
     animal=horse_walker: Tag:animal=horse walker
     animal=school: Tag:animal=school
     animal_breeding=gamecock: Tag:animal breeding=gamecock
@@ -7580,6 +8016,9 @@ en:
     area:highway=footway: Tag:area:highway=footway
     area:highway=path: Tag:area:highway=path
     area:highway=pedestrian: Tag:area:highway=pedestrian
+    area:highway=steps: Tag:area:highway=steps
+    area:highway=trunk: Tag:area:highway=trunk
+    area:highway=trunk_link: Tag:area:highway=trunk link
     area:highway=turning_circle: Tag:area:highway=turning circle
     artwork_type=architecture: Tag:artwork type=architecture
     artwork_type=bust: Tag:artwork type=bust
@@ -7594,10 +8033,12 @@ en:
     assembly_point:landslide=yes: Tag:assembly point:landslide=yes
     assembly_point:tornado=yes: Tag:assembly point:tornado=yes
     assembly_point:tsunami=yes: Tag:assembly point:tsunami=yes
+    athletics=cross_country: Tag:athletics=cross country
     atm=no: Tag:atm=no
     atm=yes: Tag:atm=yes
     attraction=alpine_coaster: Tag:attraction=alpine coaster
     attraction=animal: Tag:attraction=animal
+    attraction=boat_ride: Tag:attraction=boat ride
     attraction=maze: Tag:attraction=maze
     attraction=roller_coaster: Tag:attraction=roller coaster
     attraction=summer_toboggan: Tag:attraction=summer toboggan
@@ -7606,6 +8047,7 @@ en:
     baby_hatch=yes: Tag:baby hatch=yes
     bakehouse: Tag:bakehouse
     baking_oven: Tag:baking oven
+    barrier=avalanche_protection: Tag:barrier=avalanche protection
     barrier=bar: Tag:barrier=bar
     barrier=berm: Tag:barrier=berm
     barrier=block: Tag:barrier=block
@@ -7630,6 +8072,7 @@ en:
     barrier=full-height_turnstile: Tag:barrier=full-height turnstile
     barrier=gate: Tag:barrier=gate
     barrier=guard_rail: Tag:barrier=guard rail
+    barrier=ha-ha: Tag:barrier=ha-ha
     barrier=haha: Tag:barrier=haha
     barrier=hampshire_gate: Tag:barrier=hampshire gate
     barrier=handrail: Tag:barrier=handrail
@@ -7640,12 +8083,13 @@ en:
     barrier=horse_stile: Tag:barrier=horse stile
     barrier=jersey_barrier: Tag:barrier=jersey barrier
     barrier=kent_carriage_gap: Tag:barrier=kent carriage gap
-    barrier=kent_carriage_gate: Tag:barrier=kent carriage gate
     barrier=kerb: Tag:barrier=kerb
     barrier=kissing_gate: Tag:barrier=kissing gate
     barrier=lift_gate: Tag:barrier=lift gate
     barrier=log: Tag:barrier=log
+    barrier=lych_gate: Tag:barrier=lych gate
     barrier=motorcycle_barrier: Tag:barrier=motorcycle barrier
+    barrier=planter: Tag:barrier=planter
     barrier=retaining_wall: Tag:barrier=retaining wall
     barrier=rope: Tag:barrier=rope
     barrier=sally_port: Tag:barrier=sally port
@@ -7667,6 +8111,7 @@ en:
     baseball=softball: Tag:baseball=softball
     basin=cooling: Tag:basin=cooling
     basin=detention: Tag:basin=detention
+    basin=evaporation: Tag:basin=evaporation
     basin=infiltration: Tag:basin=infiltration
     basin=retention: Tag:basin=retention
     bath:type=hammam: Tag:bath:type=hammam
@@ -7682,10 +8127,12 @@ en:
     beacon:type=VOR: Tag:beacon:type=VOR
     bicycle:backward=use_sidepath: Tag:bicycle:backward=use sidepath
     bicycle:forward=use_sidepath: Tag:bicycle:forward=use sidepath
+    bicycle:type=logistics: Tag:bicycle:type=logistics
     bicycle=designated: Tag:bicycle=designated
     bicycle=dismount: Tag:bicycle=dismount
     bicycle=no: Tag:bicycle=no
     bicycle=official: Tag:bicycle=official
+    bicycle=private: Tag:bicycle=private
     bicycle=use_sidepath: Tag:bicycle=use sidepath
     bicycle=yes: Tag:bicycle=yes
     biosphärenwirt=yes: Tag:biosphärenwirt=yes
@@ -7699,8 +8146,12 @@ en:
     boat:type=pedalo: Tag:boat:type=pedalo
     boat:type=rowing: Tag:boat:type=rowing
     boat:type=sailing: Tag:boat:type=sailing
-    border_type=fishery: Tag:border type=fishery
     border_type=harbour_limits: Tag:border type=harbour limits
+    boules=bocce: Tag:boules=bocce
+    boules=boule_de_fort: Tag:boules=boule de fort
+    boules=breton: Tag:boules=breton
+    boules=lyonnaise: Tag:boules=lyonnaise
+    boules=petanque: Tag:boules=petanque
     boundary=aboriginal_lands: Tag:boundary=aboriginal lands
     boundary=administrative: Tag:boundary=administrative
     boundary=census: Tag:boundary=census
@@ -7752,6 +8203,11 @@ en:
     bridge:structure=simple-suspension: Tag:bridge:structure=simple-suspension
     bridge:structure=suspension: Tag:bridge:structure=suspension
     bridge:structure=truss: Tag:bridge:structure=truss
+    bridge:support=abutment: Tag:bridge:support=abutment
+    bridge:support=lift_pier: Tag:bridge:support=lift pier
+    bridge:support=pier: Tag:bridge:support=pier
+    bridge:support=pivot_pier: Tag:bridge:support=pivot pier
+    bridge:support=pylon: Tag:bridge:support=pylon
     bridge=aqueduct: Tag:bridge=aqueduct
     bridge=boardwalk: Tag:bridge=boardwalk
     bridge=cantilever: Tag:bridge=cantilever
@@ -7793,6 +8249,7 @@ en:
     building=container: Tag:building=container
     building=convent: Tag:building=convent
     building=cowshed: Tag:building=cowshed
+    building=demountable: Tag:building=demountable
     building=detached: Tag:building=detached
     building=digester: Tag:building=digester
     building=disused: Tag:building=disused
@@ -7802,6 +8259,7 @@ en:
     building=factory: Tag:building=factory
     building=farm: Tag:building=farm
     building=farm_auxiliary: Tag:building=farm auxiliary
+    building=fire_lookout: Tag:building=fire lookout
     building=fire_station: Tag:building=fire station
     building=font: Tag:building=font
     building=fort: Tag:building=fort
@@ -7834,8 +8292,11 @@ en:
     building=palace: Tag:building=palace
     building=parking: Tag:building=parking
     building=pavilion: Tag:building=pavilion
+    building=planned: Tag:building=planned
+    building=presbytery: Tag:building=presbytery
     building=proposed: Tag:building=proposed
     building=public: Tag:building=public
+    building=quonset_hut: Tag:building=quonset hut
     building=religious: Tag:building=religious
     building=remote_digital_terminal: Tag:building=remote digital terminal
     building=residential: Tag:building=residential
@@ -7849,6 +8310,7 @@ en:
     building=semidetached_house: Tag:building=semidetached house
     building=service: Tag:building=service
     building=shed: Tag:building=shed
+    building=shepherd_shelter: Tag:building=shepherd shelter
     building=ship: Tag:building=ship
     building=shrine: Tag:building=shrine
     building=slurry_tank: Tag:building=slurry tank
@@ -7867,6 +8329,7 @@ en:
     building=tent: Tag:building=tent
     building=terrace: Tag:building=terrace
     building=toilets: Tag:building=toilets
+    building=townhall: Tag:building=townhall
     building=train_station: Tag:building=train station
     building=transformer_tower: Tag:building=transformer tower
     building=transportation: Tag:building=transportation
@@ -7880,6 +8343,7 @@ en:
     building=unknown: Tag:building=unknown
     building=warehouse: Tag:building=warehouse
     building=water_tower: Tag:building=water tower
+    building=wayside_shrine: Tag:building=wayside shrine
     building=yes: Tag:building=yes
     bunker_type=gun_emplacement: Tag:bunker type=gun emplacement
     bunker_type=hardened_aircraft_shelter: Tag:bunker type=hardened aircraft shelter
@@ -7889,6 +8353,7 @@ en:
     bunker_type=technical: Tag:bunker type=technical
     bus=minibus: Tag:bus=minibus
     bus=no: Tag:bus=no
+    bus=school: Tag:bus=school
     bus=yes: Tag:bus=yes
     busbar=flexible: Tag:busbar=flexible
     busbar=rigid: Tag:busbar=rigid
@@ -7905,7 +8370,9 @@ en:
     camp_site=deluxe: Tag:camp site=deluxe
     camp_site=serviced: Tag:camp site=serviced
     camp_site=standard: Tag:camp site=standard
+    camra=yes: Tag:camra=yes
     canal=qanat: Tag:canal=qanat
+    canoe=portage: Tag:canoe=portage
     capital=4: Tag:capital=4
     capital=5: Tag:capital=5
     capital=6: Tag:capital=6
@@ -7925,26 +8392,51 @@ en:
     cemetery=grave: Tag:cemetery=grave
     cemetery=sector: Tag:cemetery=sector
     cemetery=war_cemetery: Tag:cemetery=war cemetery
+    center_turn_lane=yes: Tag:center turn lane=yes
     clothes=fashion: Tag:clothes=fashion
+    clothes=luxury: Tag:clothes=luxury
     clothes=motorcycle: Tag:clothes=motorcycle
     clothes=sports: Tag:clothes=sports
+    clothes=swimwear: Tag:clothes=swimwear
     clothes=underwear: Tag:clothes=underwear
+    clothes=unisex: Tag:clothes=unisex
+    clothes=wedding: Tag:clothes=wedding
     clothes=women: Tag:clothes=women
     clothes=women;men: Tag:clothes=women;men
     clothes=women;men;children: Tag:clothes=women;men;children
     club=amateur_radio: Tag:club=amateur radio
     club=automobile: Tag:club=automobile
+    club=bicycle: Tag:club=bicycle
+    club=card_games: Tag:club=card games
+    club=chess: Tag:club=chess
     club=fan: Tag:club=fan
+    club=fishing: Tag:club=fishing
+    club=freemasonry: Tag:club=freemasonry
+    club=golf: Tag:club=golf
+    club=linux: Tag:club=linux
     club=motorcycle: Tag:club=motorcycle
+    club=music: Tag:club=music
+    club=nudism: Tag:club=nudism
+    club=sailing: Tag:club=sailing
     club=scout: Tag:club=scout
     club=scuba_diving: Tag:club=scuba diving
+    club=social: Tag:club=social
     club=sport: Tag:club=sport
+    club=tourism: Tag:club=tourism
+    club=youth_movement: Tag:club=youth movement
     coastline:survey_quality=complete: Tag:coastline:survey quality=complete
     coastline:survey_quality=inadequate: Tag:coastline:survey quality=inadequate
     collection_times:signed=no: Tag:collection times:signed=no
     communication=line: Tag:communication=line
     communication=mobile_phone: Tag:communication=mobile phone
+    community_centre=club_home: Tag:community centre=club home
+    community_centre=youth_centre: Tag:community centre=youth centre
     company=aerospace: Tag:company=aerospace
+    company=it: Tag:company=it
+    company=logistics: Tag:company=logistics
+    company=software_development: Tag:company=software development
+    construction:power=plant: Tag:construction:power=plant
+    construction=shed: Tag:construction=shed
     construction=yes: Tag:construction=yes
     consulate=consular_agency: Tag:consulate=consular agency
     consulate=consular_office: Tag:consulate=consular office
@@ -7952,6 +8444,8 @@ en:
     consulate=honorary_consul: Tag:consulate=honorary consul
     consulate=yes: Tag:consulate=yes
     content=hot_water: Tag:content=hot water
+    cooling:method=dry_cooling: Tag:cooling:method=dry cooling
+    cooling:method=mechanical_draft: Tag:cooling:method=mechanical draft
     craft=agricultural_engines: Tag:craft=agricultural engines
     craft=atelier: Tag:craft=atelier
     craft=bag_repair: Tag:craft=bag repair
@@ -7972,6 +8466,7 @@ en:
     craft=caterer: Tag:craft=caterer
     craft=cheese: Tag:craft=cheese
     craft=chimney_sweeper: Tag:craft=chimney sweeper
+    craft=cleaning: Tag:craft=cleaning
     craft=clockmaker: Tag:craft=clockmaker
     craft=confectionery: Tag:craft=confectionery
     craft=cooper: Tag:craft=cooper
@@ -7994,10 +8489,12 @@ en:
     craft=hvac: Tag:craft=hvac
     craft=information_electronics: Tag:craft=information electronics
     craft=insulation: Tag:craft=insulation
+    craft=interior_work: Tag:craft=interior work
     craft=jeweller: Tag:craft=jeweller
     craft=joiner: Tag:craft=joiner
     craft=key_cutter: Tag:craft=key cutter
     craft=lacquerer: Tag:craft=lacquerer
+    craft=lapidary: Tag:craft=lapidary
     craft=leather: Tag:craft=leather
     craft=locksmith: Tag:craft=locksmith
     craft=luthier: Tag:craft=luthier
@@ -8032,6 +8529,7 @@ en:
     craft=signmaker: Tag:craft=signmaker
     craft=stand_builder: Tag:craft=stand builder
     craft=stonemason: Tag:craft=stonemason
+    craft=stove_fitter: Tag:craft=stove fitter
     craft=sun_protection: Tag:craft=sun protection
     craft=sweep: Tag:craft=sweep
     craft=tailor: Tag:craft=tailor
@@ -8048,6 +8546,7 @@ en:
     crane:type=floor-mounted_crane: Tag:crane:type=floor-mounted crane
     crane:type=gantry_crane: Tag:crane:type=gantry crane
     crane:type=portal_crane: Tag:crane:type=portal crane
+    crane:type=tower_crane: Tag:crane:type=tower crane
     crane:type=travel_lift: Tag:crane:type=travel lift
     crop=asparagus: Tag:crop=asparagus
     crop=aspargus: Tag:crop=aspargus
@@ -8083,16 +8582,36 @@ en:
     crossing=unknown: Tag:crossing=unknown
     crossing=unmarked: Tag:crossing=unmarked
     crossing=zebra: Tag:crossing=zebra
+    crossing_ref=zebra: Tag:crossing ref=zebra
     cuisine=barbecue: Tag:cuisine=barbecue
     cuisine=brazilian: Tag:cuisine=brazilian
     cuisine=brunch: Tag:cuisine=brunch
     cuisine=bubble_tea: Tag:cuisine=bubble tea
+    cuisine=burger: Tag:cuisine=burger
+    cuisine=chicken: Tag:cuisine=chicken
     cuisine=coffee_shop: Tag:cuisine=coffee shop
     cuisine=dessert: Tag:cuisine=dessert
+    cuisine=donut: Tag:cuisine=donut
+    cuisine=dumplings: Tag:cuisine=dumplings
     cuisine=empanada: Tag:cuisine=empanada
     cuisine=fish_and_chips: Tag:cuisine=fish and chips
     cuisine=friture: Tag:cuisine=friture
+    cuisine=hot_dog: Tag:cuisine=hot dog
+    cuisine=ice_cream: Tag:cuisine=ice cream
+    cuisine=kebab: Tag:cuisine=kebab
+    cuisine=pasta: Tag:cuisine=pasta
+    cuisine=pizza: Tag:cuisine=pizza
+    cuisine=sandwich: Tag:cuisine=sandwich
+    cuisine=seafood: Tag:cuisine=seafood
+    cuisine=soup: Tag:cuisine=soup
+    cuisine=steak_house: Tag:cuisine=steak house
+    cuisine=strudel: Tag:cuisine=strudel
+    cuisine=sushi: Tag:cuisine=sushi
+    cuisine=tea_house: Tag:cuisine=tea house
     cuisine=tea_shop: Tag:cuisine=tea shop
+    cuisine=teahouse: Tag:cuisine=teahouse
+    cuisine=waffle: Tag:cuisine=waffle
+    cuisine=wings: Tag:cuisine=wings
     curve=hairpin: Tag:curve=hairpin
     curve=loop: Tag:curve=loop
     curves=extended: Tag:curves=extended
@@ -8109,39 +8628,56 @@ en:
     cycle_network=US:US: Tag:cycle network=US:US
     cycle_network=cycle_highway: Tag:cycle network=cycle highway
     cycleway:both=lane: Tag:cycleway:both=lane
+    cycleway:both=no: Tag:cycleway:both=no
+    cycleway:both=shared_lane: Tag:cycleway:both=shared lane
     cycleway:left=lane: Tag:cycleway:left=lane
+    cycleway:left=no: Tag:cycleway:left=no
     cycleway:left=opposite_lane: Tag:cycleway:left=opposite lane
     cycleway:left=opposite_track: Tag:cycleway:left=opposite track
+    cycleway:left=separate: Tag:cycleway:left=separate
+    cycleway:left=share_busway: Tag:cycleway:left=share busway
+    cycleway:left=shared_lane: Tag:cycleway:left=shared lane
     cycleway:left=track: Tag:cycleway:left=track
     cycleway:right=lane: Tag:cycleway:right=lane
+    cycleway:right=no: Tag:cycleway:right=no
     cycleway:right=opposite_lane: Tag:cycleway:right=opposite lane
     cycleway:right=opposite_track: Tag:cycleway:right=opposite track
+    cycleway:right=separate: Tag:cycleway:right=separate
+    cycleway:right=share_busway: Tag:cycleway:right=share busway
+    cycleway:right=shared_lane: Tag:cycleway:right=shared lane
     cycleway:right=track: Tag:cycleway:right=track
     cycleway=asl: Tag:cycleway=asl
     cycleway=bike_box: Tag:cycleway=bike box
     cycleway=crossing: Tag:cycleway=crossing
     cycleway=lane: Tag:cycleway=lane
+    cycleway=no: Tag:cycleway=no
     cycleway=opposite: Tag:cycleway=opposite
     cycleway=opposite_lane: Tag:cycleway=opposite lane
     cycleway=opposite_share_busway: Tag:cycleway=opposite share busway
     cycleway=opposite_shared_busway: Tag:cycleway=opposite shared busway
     cycleway=opposite_track: Tag:cycleway=opposite track
+    cycleway=separate: Tag:cycleway=separate
     cycleway=share_busway: Tag:cycleway=share busway
     cycleway=shared_busway: Tag:cycleway=shared busway
+    cycleway=shared_lane: Tag:cycleway=shared lane
     cycleway=sidepath: Tag:cycleway=sidepath
     cycleway=track: Tag:cycleway=track
     dataset=buildings: Tag:dataset=buildings
     defensive=bergfried: Tag:defensive=bergfried
     defensive=donjon: Tag:defensive=donjon
     defensive=keep: Tag:defensive=keep
+    delivery=shipment: Tag:delivery=shipment
     demolished=yes: Tag:demolished=yes
     dennert_fir_tree=yes: Tag:dennert fir tree=yes
     denomination=la_luz_del_mundo: Tag:denomination=la luz del mundo
     denomination=mormon: Tag:denomination=mormon
     denomination=reformed: Tag:denomination=reformed
     denotation=cluster: Tag:denotation=cluster
+    designation=byway_open_to_all_traffic: Tag:designation=byway open to all traffic
     designation=common: Tag:designation=common
     destroyed=yes: Tag:destroyed=yes
+    diet:kosher=only: Tag:diet:kosher=only
+    diet:kosher=yes: Tag:diet:kosher=yes
     diplomatic=ambassadors_residence: Tag:diplomatic=ambassadors residence
     diplomatic=consulate: Tag:diplomatic=consulate
     diplomatic=consulate_general: Tag:diplomatic=consulate general
@@ -8158,9 +8694,16 @@ en:
     dock=drydock: Tag:dock=drydock
     dock=floating: Tag:dock=floating
     dock=tidal: Tag:dock=tidal
+    dog=leashed: Tag:dog=leashed
+    dog=no: Tag:dog=no
+    dog=unleashed: Tag:dog=unleashed
+    dog=yes: Tag:dog=yes
     driveway=pipestem: Tag:driveway=pipestem
     dual_carriageway=no: Tag:dual carriageway=no
     dual_carriageway=yes: Tag:dual carriageway=yes
+    education=centre: Tag:education=centre
+    education=exercise_area: Tag:education=exercise area
+    education=school: Tag:education=school
     electrified=4th_rail: Tag:electrified=4th rail
     electrified=contact_line: Tag:electrified=contact line
     electrified=rail: Tag:electrified=rail
@@ -8182,18 +8725,22 @@ en:
     emergency=coast_guard: Tag:emergency=coast guard
     emergency=defibrilator: Tag:emergency=defibrilator
     emergency=defibrillator: Tag:emergency=defibrillator
+    emergency=designated: Tag:emergency=designated
     emergency=disaster_response: Tag:emergency=disaster response
     emergency=drinking_water: Tag:emergency=drinking water
     emergency=dry_riser: Tag:emergency=dry riser
     emergency=dry_riser_inlet: Tag:emergency=dry riser inlet
     emergency=emergency_ward_entrance: Tag:emergency=emergency ward entrance
     emergency=fire_alarm_box: Tag:emergency=fire alarm box
+    emergency=fire_equipment: Tag:emergency=fire equipment
     emergency=fire_extinguisher: Tag:emergency=fire extinguisher
     emergency=fire_flapper: Tag:emergency=fire flapper
     emergency=fire_hose: Tag:emergency=fire hose
     emergency=fire_hydrant: Tag:emergency=fire hydrant
+    emergency=fire_lookout: Tag:emergency=fire lookout
     emergency=fire_point_stand: Tag:emergency=fire point stand
     emergency=fire_sand_bin: Tag:emergency=fire sand bin
+    emergency=fire_station: Tag:emergency=fire station
     emergency=fire_water_pond: Tag:emergency=fire water pond
     emergency=first_aid: Tag:emergency=first aid
     emergency=first_aid_kit: Tag:emergency=first aid kit
@@ -8206,10 +8753,12 @@ en:
     emergency=lifeguard_platform: Tag:emergency=lifeguard platform
     emergency=lifeguard_tower: Tag:emergency=lifeguard tower
     emergency=marine_refuge: Tag:emergency=marine refuge
+    emergency=marine_rescue: Tag:emergency=marine rescue
     emergency=mountain_rescue: Tag:emergency=mountain rescue
     emergency=phone: Tag:emergency=phone
     emergency=rescue_box: Tag:emergency=rescue box
     emergency=ses_station: Tag:emergency=ses station
+    emergency=shower: Tag:emergency=shower
     emergency=siamese: Tag:emergency=siamese
     emergency=siren: Tag:emergency=siren
     emergency=slipway: Tag:emergency=slipway
@@ -8223,16 +8772,26 @@ en:
     emergency=yes: Tag:emergency=yes
     emergency_service=technical: Tag:emergency service=technical
     entrance=garage: Tag:entrance=garage
+    entrance=gate: Tag:entrance=gate
     entrance=main: Tag:entrance=main
     entrance=main_entrance: Tag:entrance=main entrance
+    entrance=secondary: Tag:entrance=secondary
     entrance=staircase: Tag:entrance=staircase
     entrance=yes: Tag:entrance=yes
     esperanto=esperanto: Tag:esperanto=esperanto
     esperanto=yes: Tag:esperanto=yes
     estuary=yes: Tag:estuary=yes
     faculty=aerospace: Tag:faculty=aerospace
+    farmland=arable: Tag:farmland=arable
+    farmland=pasture: Tag:farmland=pasture
+    farmyard=stockyard: Tag:farmyard=stockyard
     fast_food=cafeteria: Tag:fast food=cafeteria
+    fire_hydrant:type=pillar: Tag:fire hydrant:type=pillar
+    fire_hydrant:type=pipe: Tag:fire hydrant:type=pipe
+    fire_hydrant:type=underground: Tag:fire hydrant:type=underground
+    fire_hydrant:type=wall: Tag:fire hydrant:type=wall
     fixme=Position_estimated: Tag:fixme=Position estimated
+    fixme=position_estimated: Tag:fixme=position estimated
     flag:type=advertising: Tag:flag:type=advertising
     flag:type=athletic: Tag:flag:type=athletic
     flag:type=governmental: Tag:flag:type=governmental
@@ -8242,15 +8801,27 @@ en:
     flag:type=organisation: Tag:flag:type=organisation
     flag:type=regional: Tag:flag:type=regional
     flag:type=religious: Tag:flag:type=religious
+    floating=yes: Tag:floating=yes
     flood_mark=painting: Tag:flood mark=painting
     flood_mark=plaque: Tag:flood mark=plaque
+    floor:material=wood: Tag:floor:material=wood
     flow_direction=both: Tag:flow direction=both
     foot=designated: Tag:foot=designated
+    foot=no: Tag:foot=no
     foot=official: Tag:foot=official
+    foot=private: Tag:foot=private
     foot=use_sidepath: Tag:foot=use sidepath
+    foot=yes: Tag:foot=yes
     footway=access_aisle: Tag:footway=access aisle
+    footway=alley: Tag:footway=alley
+    footway=both: Tag:footway=both
     footway=crossing: Tag:footway=crossing
+    footway=left: Tag:footway=left
+    footway=none: Tag:footway=none
+    footway=right: Tag:footway=right
     footway=sidewalk: Tag:footway=sidewalk
+    footway=traffic_island: Tag:footway=traffic island
+    footway=yes: Tag:footway=yes
     ford=boat: Tag:ford=boat
     ford=stepping_stones: Tag:ford=stepping stones
     ford=yes: Tag:ford=yes
@@ -8263,6 +8834,8 @@ en:
     fountain=drinking: Tag:fountain=drinking
     fountain=nasone: Tag:fountain=nasone
     fountain=roman_wolf: Tag:fountain=roman wolf
+    fountain=stone_block: Tag:fountain=stone block
+    fountain=toret: Tag:fountain=toret
     garden:type=botanical: Tag:garden:type=botanical
     generator:method=anaerobic_digestion: Tag:generator:method=anaerobic digestion
     generator:method=barrage: Tag:generator:method=barrage
@@ -8314,9 +8887,13 @@ en:
     generator:type=steam_turbine: Tag:generator:type=steam turbine
     generator:type=vertical_axis: Tag:generator:type=vertical axis
     generator:type=zuppinger_water_wheel: Tag:generator:type=zuppinger water wheel
+    geological=fault: Tag:geological=fault
     geological=moraine: Tag:geological=moraine
     geological=outcrop: Tag:geological=outcrop
     geological=palaeontological_site: Tag:geological=palaeontological site
+    geological=volcanic_caldera_rim: Tag:geological=volcanic caldera rim
+    geological=volcanic_lava_field: Tag:geological=volcanic lava field
+    geological=volcanic_vent: Tag:geological=volcanic vent
     glacier:type=mountain: Tag:glacier:type=mountain
     glideslope=yes: Tag:glideslope=yes
     golf=bunker: Tag:golf=bunker
@@ -8337,11 +8914,13 @@ en:
     government=aerospace: Tag:government=aerospace
     government=archive: Tag:government=archive
     government=audit: Tag:government=audit
+    government=bailiff: Tag:government=bailiff
     government=border_control: Tag:government=border control
     government=cadaster: Tag:government=cadaster
     government=customs: Tag:government=customs
     government=data_protection: Tag:government=data protection
     government=healthcare: Tag:government=healthcare
+    government=it: Tag:government=it
     government=legislative: Tag:government=legislative
     government=ministry: Tag:government=ministry
     government=parliament: Tag:government=parliament
@@ -8353,6 +8932,7 @@ en:
     grass=amenity_grassland: Tag:grass=amenity grassland
     grit_bin: Tag:grit bin
     guidepost=simple: Tag:guidepost=simple
+    handle=crank: Tag:handle=crank
     handle=lever: Tag:handle=lever
     handle=wheel: Tag:handle=wheel
     harbour:category=RoRo: Tag:harbour:category=RoRo
@@ -8373,6 +8953,7 @@ en:
     harbour:category=yacht: Tag:harbour:category=yacht
     harbour=marina: Tag:harbour=marina
     hazard=animal_crossing: Tag:hazard=animal crossing
+    hazard=archery_range: Tag:hazard=archery range
     hazard=bump: Tag:hazard=bump
     hazard=children: Tag:hazard=children
     hazard=contamination: Tag:hazard=contamination
@@ -8386,12 +8967,14 @@ en:
     hazard=horse_riders: Tag:hazard=horse riders
     hazard=ice: Tag:hazard=ice
     hazard=landslide: Tag:hazard=landslide
+    hazard=leeches: Tag:hazard=leeches
     hazard=loose_gravel: Tag:hazard=loose gravel
     hazard=low_flying_aircraft: Tag:hazard=low flying aircraft
     hazard=minefield: Tag:hazard=minefield
     hazard=nuclear: Tag:hazard=nuclear
     hazard=pedestrians: Tag:hazard=pedestrians
     hazard=queues_likely: Tag:hazard=queues likely
+    hazard=quicksand: Tag:hazard=quicksand
     hazard=school_zone: Tag:hazard=school zone
     hazard=shooting_range: Tag:hazard=shooting range
     hazard=side_winds: Tag:hazard=side winds
@@ -8405,6 +8988,11 @@ en:
     hazard_type=landslide: Tag:hazard type=landslide
     hazmat:water=permissive: Tag:hazmat:water=permissive
     healthcare:speciality=abortion: Tag:healthcare:speciality=abortion
+    healthcare:speciality=maxillofacial_surgery: Tag:healthcare:speciality=maxillofacial
+      surgery
+    healthcare:speciality=orthodontics: Tag:healthcare:speciality=orthodontics
+    healthcare:speciality=otolaryngology: Tag:healthcare:speciality=otolaryngology
+    healthcare:speciality=psychiatry: Tag:healthcare:speciality=psychiatry
     healthcare:speciality=vaccination: Tag:healthcare:speciality=vaccination
     healthcare=alternative: Tag:healthcare=alternative
     healthcare=audiologist: Tag:healthcare=audiologist
@@ -8432,9 +9020,12 @@ en:
     healthcare=podiatrist: Tag:healthcare=podiatrist
     healthcare=psychotherapist: Tag:healthcare=psychotherapist
     healthcare=rehabilitation: Tag:healthcare=rehabilitation
+    healthcare=sample_collection: Tag:healthcare=sample collection
     healthcare=speech_therapist: Tag:healthcare=speech therapist
     healthcare=vaccination_centre: Tag:healthcare=vaccination centre
+    healthcare=yes: Tag:healthcare=yes
     hgv=discouraged: Tag:hgv=discouraged
+    hgv=yes: Tag:hgv=yes
     highway=Bus_guideway: Tag:highway=Bus guideway
     highway=abandoned: Tag:highway=abandoned
     highway=access: Tag:highway=access
@@ -8442,6 +9033,7 @@ en:
     highway=bridleway: Tag:highway=bridleway
     highway=bus_guideway: Tag:highway=bus guideway
     highway=bus_stop: Tag:highway=bus stop
+    highway=busway: Tag:highway=busway
     highway=byway: Tag:highway=byway
     highway=cattle_grid: Tag:highway=cattle grid
     highway=construction: Tag:highway=construction
@@ -8493,6 +9085,7 @@ en:
     highway=steps: Tag:highway=steps
     highway=stile: Tag:highway=stile
     highway=stop: Tag:highway=stop
+    highway=street: Tag:highway=street
     highway=street_lamp: Tag:highway=street lamp
     highway=tertiary: Tag:highway=tertiary
     highway=tertiary_link: Tag:highway=tertiary link
@@ -8524,6 +9117,7 @@ en:
     historic=cannon: Tag:historic=cannon
     historic=castle: Tag:historic=castle
     historic=castle_wall: Tag:historic=castle wall
+    historic=cemetery: Tag:historic=cemetery
     historic=charcoal_pile: Tag:historic=charcoal pile
     historic=church: Tag:historic=church
     historic=city_gate: Tag:historic=city gate
@@ -8546,6 +9140,7 @@ en:
     historic=mine_shaft: Tag:historic=mine shaft
     historic=monastery: Tag:historic=monastery
     historic=monument: Tag:historic=monument
+    historic=ogham_stone: Tag:historic=ogham stone
     historic=optical_telegraph: Tag:historic=optical telegraph
     historic=pa: Tag:historic=pa
     historic=paleontological_site: Tag:historic=paleontological site
@@ -8573,32 +9168,38 @@ en:
     holding_position=intermediate: Tag:holding position=intermediate
     holding_position=runway: Tag:holding position=runway
     horse=designated: Tag:horse=designated
+    horse=dismount: Tag:horse=dismount
     house=bungalow: Tag:house=bungalow
     house=detached: Tag:house=detached
     house=semi-detached: Tag:house=semi-detached
     house=terrace: Tag:house=terrace
     house=terraced: Tag:house=terraced
+    hov=yes: Tag:hov=yes
     hunting=raised_hide: Tag:hunting=raised hide
     indoor=area: Tag:indoor=area
     indoor=corridor: Tag:indoor=corridor
     indoor=door: Tag:indoor=door
     indoor=room: Tag:indoor=room
     indoor=wall: Tag:indoor=wall
+    indoor=yes: Tag:indoor=yes
     indoormark=beacon: Tag:indoormark=beacon
     industrial=aluminium_smelting: Tag:industrial=aluminium smelting
     industrial=auto_wrecker: Tag:industrial=auto wrecker
     industrial=bakery: Tag:industrial=bakery
     industrial=brewery: Tag:industrial=brewery
     industrial=brickyard: Tag:industrial=brickyard
+    industrial=communication: Tag:industrial=communication
     industrial=depot: Tag:industrial=depot
     industrial=distributor: Tag:industrial=distributor
     industrial=factory: Tag:industrial=factory
     industrial=fish_farm: Tag:industrial=fish farm
     industrial=food_industry: Tag:industrial=food industry
+    industrial=food_processing: Tag:industrial=food processing
     industrial=furniture: Tag:industrial=furniture
     industrial=grinding_mill: Tag:industrial=grinding mill
     industrial=heating_station: Tag:industrial=heating station
     industrial=ice_factory: Tag:industrial=ice factory
+    industrial=integrated_circuit: Tag:industrial=integrated circuit
     industrial=machine_shop: Tag:industrial=machine shop
     industrial=mine: Tag:industrial=mine
     industrial=mobile_equipment: Tag:industrial=mobile equipment
@@ -8702,16 +9303,20 @@ en:
     landuse=fishfarm: Tag:landuse=fishfarm
     landuse=flowerbed: Tag:landuse=flowerbed
     landuse=forest: Tag:landuse=forest
+    landuse=forestry: Tag:landuse=forestry
     landuse=garages: Tag:landuse=garages
     landuse=grass: Tag:landuse=grass
     landuse=grave_yard: Tag:landuse=grave yard
+    landuse=greenery: Tag:landuse=greenery
     landuse=greenfield: Tag:landuse=greenfield
     landuse=greenhouse_horticulture: Tag:landuse=greenhouse horticulture
     landuse=harbour: Tag:landuse=harbour
     landuse=highway: Tag:landuse=highway
+    landuse=house: Tag:landuse=house
     landuse=industrial: Tag:landuse=industrial
     landuse=institutional: Tag:landuse=institutional
     landuse=landfill: Tag:landuse=landfill
+    landuse=livestock: Tag:landuse=livestock
     landuse=logging: Tag:landuse=logging
     landuse=meadow: Tag:landuse=meadow
     landuse=meadow_orchard: Tag:landuse=meadow orchard
@@ -8734,6 +9339,8 @@ en:
     landuse=residential: Tag:landuse=residential
     landuse=retail: Tag:landuse=retail
     landuse=salt_pond: Tag:landuse=salt pond
+    landuse=school: Tag:landuse=school
+    landuse=shrubs: Tag:landuse=shrubs
     landuse=street: Tag:landuse=street
     landuse=traffic_island: Tag:landuse=traffic island
     landuse=trees: Tag:landuse=trees
@@ -8747,6 +9354,7 @@ en:
     landuse=winter_sports: Tag:landuse=winter sports
     landuse=wood: Tag:landuse=wood
     landuse=wood_(Don't_use): Tag:landuse=wood (Don't use)
+    landuse=yes: Tag:landuse=yes
     lane=buffered: Tag:lane=buffered
     lawyer=notary: Tag:lawyer=notary
     leaf_cycle=deciduous: Tag:leaf cycle=deciduous
@@ -8768,6 +9376,7 @@ en:
     leisure=bbq: Tag:leisure=bbq
     leisure=beach: Tag:leisure=beach
     leisure=beach_resort: Tag:leisure=beach resort
+    leisure=bingo_hall: Tag:leisure=bingo hall
     leisure=bird_hide: Tag:leisure=bird hide
     leisure=bleachers: Tag:leisure=bleachers
     leisure=bowling_alley: Tag:leisure=bowling alley
@@ -8790,6 +9399,7 @@ en:
     leisure=hackerspace: Tag:leisure=hackerspace
     leisure=horse_riding: Tag:leisure=horse riding
     leisure=hot_spring: Tag:leisure=hot spring
+    leisure=hot_tub: Tag:leisure=hot tub
     leisure=ice_rink: Tag:leisure=ice rink
     leisure=indoor_play: Tag:leisure=indoor play
     leisure=landscape_reserve: Tag:leisure=landscape reserve
@@ -8804,6 +9414,7 @@ en:
     leisure=picnic_table: Tag:leisure=picnic table
     leisure=pitch: Tag:leisure=pitch
     leisure=playground: Tag:leisure=playground
+    leisure=practice_pitch: Tag:leisure=practice pitch
     leisure=recreation_ground: Tag:leisure=recreation ground
     leisure=red_light_district: Tag:leisure=red light district
     leisure=resort: Tag:leisure=resort
@@ -8819,6 +9430,7 @@ en:
     leisure=sports_hall: Tag:leisure=sports hall
     leisure=stadium: Tag:leisure=stadium
     leisure=summer_camp: Tag:leisure=summer camp
+    leisure=sunbathing: Tag:leisure=sunbathing
     leisure=swimming_area: Tag:leisure=swimming area
     leisure=swimming_pool: Tag:leisure=swimming pool
     leisure=table_tennis_table: Tag:leisure=table tennis table
@@ -8836,6 +9448,8 @@ en:
     liaison=liaison_office: Tag:liaison=liaison office
     liaison=representative_office: Tag:liaison=representative office
     liaison=subnational: Tag:liaison=subnational
+    lifeguard=base: Tag:lifeguard=base
+    lifeguard=tower: Tag:lifeguard=tower
     line=bay: Tag:line=bay
     line=busbar: Tag:line=busbar
     line=substation: Tag:line=substation
@@ -8855,31 +9469,41 @@ en:
     locality=townland: Tag:locality=townland
     localizer=yes: Tag:localizer=yes
     location:transition=yes: Tag:location:transition=yes
+    location=indoor: Tag:location=indoor
+    location=outdoor: Tag:location=outdoor
     location=overground: Tag:location=overground
     location=overhead: Tag:location=overhead
     location=underground: Tag:location=underground
     location=underwater: Tag:location=underwater
+    lottery=yes: Tag:lottery=yes
     maintenance=gritting: Tag:maintenance=gritting
     man_made=MDF: Tag:man made=MDF
     man_made=adit: Tag:man made=adit
     man_made=animal_trap: Tag:man made=animal trap
     man_made=antenna: Tag:man made=antenna
     man_made=archimedes_screw: Tag:man made=archimedes screw
+    man_made=architecture_line: Tag:man made=architecture line
+    man_made=avalanche_protection: Tag:man made=avalanche protection
     man_made=beacon: Tag:man made=beacon
     man_made=beehive: Tag:man made=beehive
+    man_made=bioreactor: Tag:man made=bioreactor
     man_made=breakwater: Tag:man made=breakwater
     man_made=bridge: Tag:man made=bridge
     man_made=bunker_silo: Tag:man made=bunker silo
     man_made=cairn: Tag:man made=cairn
     man_made=campanile: Tag:man made=campanile
     man_made=carpet_hanger: Tag:man made=carpet hanger
+    man_made=cellar_entrance: Tag:man made=cellar entrance
     man_made=chiller: Tag:man made=chiller
     man_made=chimney: Tag:man made=chimney
     man_made=clearcut: Tag:man made=clearcut
     man_made=communications_tower: Tag:man made=communications tower
     man_made=compass_rose: Tag:man made=compass rose
+    man_made=cooling: Tag:man made=cooling
     man_made=cooling_tower: Tag:man made=cooling tower
+    man_made=courtyard: Tag:man made=courtyard
     man_made=crane: Tag:man made=crane
+    man_made=cricket_nets: Tag:man made=cricket nets
     man_made=cross: Tag:man made=cross
     man_made=cut_line: Tag:man made=cut line
     man_made=cutline: Tag:man made=cutline
@@ -8902,8 +9526,12 @@ en:
     man_made=goods_conveyor: Tag:man made=goods conveyor
     man_made=graduation_tower: Tag:man made=graduation tower
     man_made=groyne: Tag:man made=groyne
+    man_made=guard_stone: Tag:man made=guard stone
     man_made=guy: Tag:man made=guy
+    man_made=guy_wire: Tag:man made=guy wire
+    man_made=heap: Tag:man made=heap
     man_made=hot_water_tank: Tag:man made=hot water tank
+    man_made=hunting_stand: Tag:man made=hunting stand
     man_made=ice_house: Tag:man made=ice house
     man_made=insect_hotel: Tag:man made=insect hotel
     man_made=jetty: Tag:man made=jetty
@@ -8917,11 +9545,13 @@ en:
     man_made=measurement_station: Tag:man made=measurement station
     man_made=mineshaft: Tag:man made=mineshaft
     man_made=monitoring_station: Tag:man made=monitoring station
+    man_made=mounting_block: Tag:man made=mounting block
     man_made=nesting_site: Tag:man made=nesting site
     man_made=obelisk: Tag:man made=obelisk
     man_made=observatory: Tag:man made=observatory
     man_made=offshore_platform: Tag:man made=offshore platform
     man_made=oil_well: Tag:man made=oil well
+    man_made=outfall: Tag:man made=outfall
     man_made=petroleum_well: Tag:man made=petroleum well
     man_made=pier: Tag:man made=pier
     man_made=pillar: Tag:man made=pillar
@@ -8939,6 +9569,7 @@ en:
     man_made=satellite_dish: Tag:man made=satellite dish
     man_made=school_sentry: Tag:man made=school sentry
     man_made=septic_tank: Tag:man made=septic tank
+    man_made=sewage: Tag:man made=sewage
     man_made=silo: Tag:man made=silo
     man_made=ski_jump: Tag:man made=ski jump
     man_made=snow_cannon: Tag:man made=snow cannon
@@ -8948,16 +9579,20 @@ en:
     man_made=spring_box: Tag:man made=spring box
     man_made=storage_tank: Tag:man made=storage tank
     man_made=street_cabinet: Tag:man made=street cabinet
+    man_made=stupa: Tag:man made=stupa
     man_made=submarine_cable: Tag:man made=submarine cable
     man_made=summit_cross: Tag:man made=summit cross
     man_made=surveillance: Tag:man made=surveillance
     man_made=survey_point: Tag:man made=survey point
+    man_made=tailings_pond: Tag:man made=tailings pond
     man_made=telescope: Tag:man made=telescope
     man_made=tell: Tag:man made=tell
     man_made=threshing_floor: Tag:man made=threshing floor
+    man_made=tomb: Tag:man made=tomb
     man_made=tower: Tag:man made=tower
     man_made=tunnel: Tag:man made=tunnel
     man_made=utility_pole: Tag:man made=utility pole
+    man_made=wastewater_basin: Tag:man made=wastewater basin
     man_made=wastewater_plant: Tag:man made=wastewater plant
     man_made=water_tank: Tag:man made=water tank
     man_made=water_tap: Tag:man made=water tap
@@ -8984,6 +9619,11 @@ en:
     material=concrete: Tag:material=concrete
     maxheight=default: Tag:maxheight=default
     maxweight:signed=no: Tag:maxweight:signed=no
+    mechanical_driver=combustion_engine: Tag:mechanical driver=combustion engine
+    mechanical_driver=electric_motor: Tag:mechanical driver=electric motor
+    mechanical_driver=manual: Tag:mechanical driver=manual
+    mechanical_driver=reciprocating_solenoid: Tag:mechanical driver=reciprocating
+      solenoid
     medical=aed: Tag:medical=aed
     megalith_type=alignment: Tag:megalith type=alignment
     megalith_type=chamber: Tag:megalith type=chamber
@@ -9005,20 +9645,24 @@ en:
     memorial:type=stolperstein: Tag:memorial:type=stolperstein
     memorial=blue_plaque: Tag:memorial=blue plaque
     memorial=bust: Tag:memorial=bust
+    memorial=cenotaph: Tag:memorial=cenotaph
     memorial=cross: Tag:memorial=cross
     memorial=ghost_bike: Tag:memorial=ghost bike
     memorial=obelisk: Tag:memorial=obelisk
     memorial=plaque: Tag:memorial=plaque
+    memorial=sculpture: Tag:memorial=sculpture
     memorial=statue: Tag:memorial=statue
     memorial=stele: Tag:memorial=stele
     memorial=stolperstein: Tag:memorial=stolperstein
     memorial=stone: Tag:memorial=stone
     memorial=storm_surge_post: Tag:memorial=storm surge post
+    memorial=vehicle: Tag:memorial=vehicle
     memorial=war_memorial: Tag:memorial=war memorial
     microbrewery=yes: Tag:microbrewery=yes
     military=airfield: Tag:military=airfield
     military=ammunition: Tag:military=ammunition
     military=barracks: Tag:military=barracks
+    military=base: Tag:military=base
     military=bunker: Tag:military=bunker
     military=checkpoint: Tag:military=checkpoint
     military=danger_area: Tag:military=danger area
@@ -9031,6 +9675,10 @@ en:
     military=range: Tag:military=range
     military=training_area: Tag:military=training area
     military=trench: Tag:military=trench
+    military_service=air_force: Tag:military service=air force
+    military_service=army: Tag:military service=army
+    military_service=marines: Tag:military service=marines
+    military_service=navy: Tag:military service=navy
     mofa=use_sidepath: Tag:mofa=use sidepath
     mooring=commercial: Tag:mooring=commercial
     mooring=cruise: Tag:mooring=cruise
@@ -9045,6 +9693,9 @@ en:
     moped=use_sidepath: Tag:moped=use sidepath
     motorcycle:type=electric: Tag:motorcycle:type=electric
     motorcycle:type=sportbike: Tag:motorcycle:type=sportbike
+    motorcycle=no: Tag:motorcycle=no
+    motorcycle=yes: Tag:motorcycle=yes
+    motorroad=no: Tag:motorroad=no
     mountain_pass=yes: Tag:mountain pass=yes
     museum=aerospace: Tag:museum=aerospace
     museum=archaeological: Tag:museum=archaeological
@@ -9059,6 +9710,7 @@ en:
     museum=railway: Tag:museum=railway
     museum=technology: Tag:museum=technology
     museum=transport: Tag:museum=transport
+    name:signed=no: Tag:name:signed=no
     name=7-Eleven: Tag:name=7-Eleven
     name=BMO: Tag:name=BMO
     name=BMO_Bank_of_Montreal: Tag:name=BMO Bank of Montreal
@@ -9072,12 +9724,15 @@ en:
     name=Jollibee: Tag:name=Jollibee
     name=KFC: Tag:name=KFC
     name=McDonald's: Tag:name=McDonald's
+    name=NHS: Tag:name=NHS
     name=Subway: Tag:name=Subway
     name=The_Church_of_Jesus_Christ_of_Latter-day_Saints: Tag:name=The Church of Jesus
       Christ of Latter-day Saints
+    name=Tim_Hortons: Tag:name=Tim Hortons
     name=Walmart: Tag:name=Walmart
     name=Wendy's: Tag:name=Wendy's
     name=Продукты: Tag:name=Продукты
+    naptan:verified=no: Tag:naptan:verified=no
     natural=anthill: Tag:natural=anthill
     natural=arch: Tag:natural=arch
     natural=arete: Tag:natural=arete
@@ -9095,6 +9750,7 @@ en:
     natural=cloud: Tag:natural=cloud
     natural=coastline: Tag:natural=coastline
     natural=col: Tag:natural=col
+    natural=couloir: Tag:natural=couloir
     natural=crater: Tag:natural=crater
     natural=crevasse: Tag:natural=crevasse
     natural=desert: Tag:natural=desert
@@ -9109,6 +9765,7 @@ en:
     natural=geyser: Tag:natural=geyser
     natural=glacier: Tag:natural=glacier
     natural=gorge: Tag:natural=gorge
+    natural=grass: Tag:natural=grass
     natural=grassland: Tag:natural=grassland
     natural=gully: Tag:natural=gully
     natural=heath: Tag:natural=heath
@@ -9124,7 +9781,6 @@ en:
     natural=meadow: Tag:natural=meadow
     natural=moor: Tag:natural=moor
     natural=moraine: Tag:natural=moraine
-    natural=moss: Tag:natural=moss
     natural=mountain_range: Tag:natural=mountain range
     natural=mud: Tag:natural=mud
     natural=naled: Tag:natural=naled
@@ -9135,6 +9791,7 @@ en:
     natural=plateau: Tag:natural=plateau
     natural=reef: Tag:natural=reef
     natural=ridge: Tag:natural=ridge
+    natural=riverbank: Tag:natural=riverbank
     natural=riverbed: Tag:natural=riverbed
     natural=rock: Tag:natural=rock
     natural=rocks: Tag:natural=rocks
@@ -9145,6 +9802,7 @@ en:
     natural=shingle: Tag:natural=shingle
     natural=shoal: Tag:natural=shoal
     natural=shrub: Tag:natural=shrub
+    natural=shrubbery: Tag:natural=shrubbery
     natural=sinkhole: Tag:natural=sinkhole
     natural=spring: Tag:natural=spring
     natural=stone: Tag:natural=stone
@@ -9164,12 +9822,16 @@ en:
     navigationaid=papi: Tag:navigationaid=papi
     navigationaid=vasi: Tag:navigationaid=vasi
     nest_platform=yes: Tag:nest platform=yes
+    network:type=node_network: Tag:network:type=node network
     network=BR: Tag:network=BR
     network=BR:ES: Tag:network=BR:ES
     network=BR:MG: Tag:network=BR:MG
     network=BR:PB: Tag:network=BR:PB
+    network=Barrie_Transit: Tag:network=Barrie Transit
+    network=CA:ON:York: Tag:network=CA:ON:York
     network=CN:AH: Tag:network=CN:AH
     network=CN:JS: Tag:network=CN:JS
+    network=CN:expressway: Tag:network=CN:expressway
     network=CN:national: Tag:network=CN:national
     network=CR:national: Tag:network=CR:national
     network=Flinkster: Tag:network=Flinkster
@@ -9337,10 +9999,12 @@ en:
     network=US:TX:FM: Tag:network=US:TX:FM
     network=US:TX:Loop: Tag:network=US:TX:Loop
     network=US:TX:NASA: Tag:network=US:TX:NASA
+    network=US:TX:PA: Tag:network=US:TX:PA
     network=US:TX:Park: Tag:network=US:TX:Park
     network=US:TX:RM: Tag:network=US:TX:RM
     network=US:TX:Recreational: Tag:network=US:TX:Recreational
     network=US:TX:Spur: Tag:network=US:TX:Spur
+    network=US:TX:Van_Zandt: Tag:network=US:TX:Van Zandt
     network=US:TX:Wood: Tag:network=US:TX:Wood
     network=US:US: Tag:network=US:US
     network=US:UT: Tag:network=US:UT
@@ -9352,6 +10016,8 @@ en:
     network=US:WI: Tag:network=US:WI
     network=US:WV: Tag:network=US:WV
     network=US:WV:Berkeley: Tag:network=US:WV:Berkeley
+    network=US:WV:Gilmer: Tag:network=US:WV:Gilmer
+    network=US:WV:HARP: Tag:network=US:WV:HARP
     network=US:WV:McDowell: Tag:network=US:WV:McDowell
     network=US:WV:Mercer: Tag:network=US:WV:Mercer
     network=US:WY: Tag:network=US:WY
@@ -9359,6 +10025,8 @@ en:
     network=VE:R:PO: Tag:network=VE:R:PO
     network=VE:T:PO: Tag:network=VE:T:PO
     network=VE:ramal:portuguesa: Tag:network=VE:ramal:portuguesa
+    network=VIVA: Tag:network=VIVA
+    network=York_Region_Transit: Tag:network=York Region Transit
     network=call-a-bike: Tag:network=call-a-bike
     network=cambio/stadtmobil: Tag:network=cambio/stadtmobil
     network=cambio_stadtmobil: Tag:network=cambio stadtmobil
@@ -9383,6 +10051,8 @@ en:
     nhd:fcode=46003: Tag:nhd:fcode=46003
     nhd:ftype=StreamRiver: Tag:nhd:ftype=StreamRiver
     noexit=no: Tag:noexit=no
+    noname=yes: Tag:noname=yes
+    nonsquare=yes: Tag:nonsquare=yes
     observatory:type=astronomical: Tag:observatory:type=astronomical
     observatory:type=gravitational: Tag:observatory:type=gravitational
     observatory:type=meteorological: Tag:observatory:type=meteorological
@@ -9393,11 +10063,13 @@ en:
     office=adoption_agency: Tag:office=adoption agency
     office=advertising_agency: Tag:office=advertising agency
     office=architect: Tag:office=architect
+    office=archive: Tag:office=archive
     office=association: Tag:office=association
     office=bail_bond_agent: Tag:office=bail bond agent
     office=charity: Tag:office=charity
     office=company: Tag:office=company
     office=consulting: Tag:office=consulting
+    office=courier: Tag:office=courier
     office=coworking: Tag:office=coworking
     office=diplomatic: Tag:office=diplomatic
     office=educational_institution: Tag:office=educational institution
@@ -9406,12 +10078,14 @@ en:
     office=engineer: Tag:office=engineer
     office=estate_agent: Tag:office=estate agent
     office=financial: Tag:office=financial
+    office=financial_advisor: Tag:office=financial advisor
     office=forestry: Tag:office=forestry
     office=foundation: Tag:office=foundation
     office=geodesist: Tag:office=geodesist
     office=government: Tag:office=government
     office=graphic_design: Tag:office=graphic design
     office=guide: Tag:office=guide
+    office=harbour_master: Tag:office=harbour master
     office=healthcare: Tag:office=healthcare
     office=insurance: Tag:office=insurance
     office=international_organization: Tag:office=international organization
@@ -9429,6 +10103,7 @@ en:
     office=political_party: Tag:office=political party
     office=private_investigator: Tag:office=private investigator
     office=property_management: Tag:office=property management
+    office=publisher: Tag:office=publisher
     office=quango: Tag:office=quango
     office=real_estate_agent: Tag:office=real estate agent
     office=realtor: Tag:office=realtor
@@ -9444,22 +10119,32 @@ en:
     office=therapist: Tag:office=therapist
     office=tourist_accommodation: Tag:office=tourist accommodation
     office=travel_agent: Tag:office=travel agent
+    office=tutoring: Tag:office=tutoring
     office=union: Tag:office=union
     office=university: Tag:office=university
     office=visa: Tag:office=visa
     office=water_utility: Tag:office=water utility
     office=yes: Tag:office=yes
+    on_demand=yes: Tag:on demand=yes
     oneway:bicycle=yes: Tag:oneway:bicycle=yes
+    oneway:bus=no: Tag:oneway:bus=no
+    oneway:moped=no: Tag:oneway:moped=no
+    oneway:motorcycle=no: Tag:oneway:motorcycle=no
+    oneway:psv=no: Tag:oneway:psv=no
     oneway=-1: Tag:oneway=-1
     oneway=alternating: Tag:oneway=alternating
     oneway=reversible: Tag:oneway=reversible
     opening_hours:signed=no: Tag:opening hours:signed=no
+    opening_hours=24/7: Tag:opening hours=24/7
     operational_status=closed: Tag:operational status=closed
     operator=Cambio: Tag:operator=Cambio
     operator=CiteeCar: Tag:operator=CiteeCar
     operator=Drive_Carsharing: Tag:operator=Drive Carsharing
+    operator=Enedis: Tag:operator=Enedis
     operator=Flinkster: Tag:operator=Flinkster
     operator=GRDF: Tag:operator=GRDF
+    operator=Orange: Tag:operator=Orange
+    operator=RTE: Tag:operator=RTE
     operator=Stadtmobil: Tag:operator=Stadtmobil
     operator=book-n-drive: Tag:operator=book-n-drive
     operator=cambio: Tag:operator=cambio
@@ -9467,7 +10152,9 @@ en:
     operator=stadtmobil: Tag:operator=stadtmobil
     operator=teilAuto: Tag:operator=teilAuto
     orchard=meadow_orchard: Tag:orchard=meadow orchard
+    ownership=private: Tag:ownership=private
     parking:lane:hgv=on_street: Tag:parking:lane:hgv=on street
+    parking:orientation=perpendicular: Tag:parking:orientation=perpendicular
     parking=lane: Tag:parking=lane
     parking=layby: Tag:parking=layby
     parking=multi-storey: Tag:parking=multi-storey
@@ -9525,6 +10212,9 @@ en:
     place=suburb: Tag:place=suburb
     place=town: Tag:place=town
     place=village: Tag:place=village
+    place_of_mourning=yes: Tag:place of mourning=yes
+    place_of_worship=holy_well: Tag:place of worship=holy well
+    place_of_worship=mass_rock: Tag:place of worship=mass rock
     placement=right_of:1: Tag:placement=right of:1
     placement=transition: Tag:placement=transition
     plant:method=combustion: Tag:plant:method=combustion
@@ -9549,6 +10239,7 @@ en:
     plant:type=gas_turbine: Tag:plant:type=gas turbine
     plant:type=solar_photovoltaic_panel: Tag:plant:type=solar photovoltaic panel
     plant:type=steam_turbine: Tag:plant:type=steam turbine
+    playground=map: Tag:playground=map
     playground=slide: Tag:playground=slide
     playground=structure: Tag:playground=structure
     pole=transition: Tag:pole=transition
@@ -9564,6 +10255,7 @@ en:
     police=storage: Tag:police=storage
     police=training_area: Tag:police=training area
     police=yes: Tag:police=yes
+    post_office=post_partner: Tag:post office=post partner
     power=antenna_line: Tag:power=antenna line
     power=busbar: Tag:power=busbar
     power=cable: Tag:power=cable
@@ -9599,6 +10291,19 @@ en:
     prison_camp=concentration_camp: Tag:prison camp=concentration camp
     prison_camp=extermination_camp: Tag:prison camp=extermination camp
     private=employees: Tag:private=employees
+    product=beer: Tag:product=beer
+    product=bricks: Tag:product=bricks
+    product=concrete: Tag:product=concrete
+    product=electronics: Tag:product=electronics
+    product=food: Tag:product=food
+    product=furniture: Tag:product=furniture
+    product=machinery: Tag:product=machinery
+    product=oil: Tag:product=oil
+    product=packaging: Tag:product=packaging
+    product=rice: Tag:product=rice
+    product=steel: Tag:product=steel
+    product=sugar: Tag:product=sugar
+    protect_class=11: Tag:protect class=11
     protect_class=19: Tag:protect class=19
     protect_class=1a: Tag:protect class=1a
     protect_class=1b: Tag:protect class=1b
@@ -9611,6 +10316,8 @@ en:
     protected_area=nature_reserve: Tag:protected area=nature reserve
     pseudo=yes: Tag:pseudo=yes
     psv=designated: Tag:psv=designated
+    psv=no: Tag:psv=no
+    psv=yes: Tag:psv=yes
     public_transport=pay_scale_area: Tag:public transport=pay scale area
     public_transport=platform: Tag:public transport=platform
     public_transport=pole: Tag:public transport=pole
@@ -9620,6 +10327,19 @@ en:
     pump=manual: Tag:pump=manual
     pump=no: Tag:pump=no
     pump=powered: Tag:pump=powered
+    pump_mechanism=axial_flow: Tag:pump mechanism=axial flow
+    pump_mechanism=centrifugal: Tag:pump mechanism=centrifugal
+    pump_mechanism=diaphragm: Tag:pump mechanism=diaphragm
+    pump_mechanism=eductor_jet: Tag:pump mechanism=eductor jet
+    pump_mechanism=gear: Tag:pump mechanism=gear
+    pump_mechanism=peristaltic: Tag:pump mechanism=peristaltic
+    pump_mechanism=piston: Tag:pump mechanism=piston
+    pump_mechanism=progressive_cavity: Tag:pump mechanism=progressive cavity
+    pump_mechanism=pulser: Tag:pump mechanism=pulser
+    pump_mechanism=ram: Tag:pump mechanism=ram
+    pump_mechanism=rope: Tag:pump mechanism=rope
+    pump_mechanism=rotary_vane: Tag:pump mechanism=rotary vane
+    pump_mechanism=screw: Tag:pump mechanism=screw
     raba:id=1100: Tag:raba:id=1100
     raba:id=1160: Tag:raba:id=1160
     raba:id=1180: Tag:raba:id=1180
@@ -9683,8 +10403,10 @@ en:
     railway=wash: Tag:railway=wash
     railway=water_crane: Tag:railway=water crane
     railway=water_tower: Tag:railway=water tower
+    railway=workshop: Tag:railway=workshop
     railway=yard: Tag:railway=yard
     reclaimed=yes: Tag:reclaimed=yes
+    recreation_ground=showground: Tag:recreation ground=showground
     recycling_type=centre: Tag:recycling type=centre
     refitted=yes: Tag:refitted=yes
     refugee=yes: Tag:refugee=yes
@@ -9702,6 +10424,7 @@ en:
     religion=taoist: Tag:religion=taoist
     religion=zoroastrian: Tag:religion=zoroastrian
     rental=appliance: Tag:rental=appliance
+    rental=quadracycle: Tag:rental=quadracycle
     rental=ski: Tag:rental=ski
     rental=strandkorb: Tag:rental=strandkorb
     rental=trailer: Tag:rental=trailer
@@ -9711,12 +10434,12 @@ en:
     residential=apartments: Tag:residential=apartments
     residential=halting_site: Tag:residential=halting site
     residential=rural: Tag:residential=rural
+    residential=trailer_park: Tag:residential=trailer park
     residential=university: Tag:residential=university
     residential=urban: Tag:residential=urban
     resource=aggregate: Tag:resource=aggregate
     resource=gravel: Tag:resource=gravel
     resource=sand: Tag:resource=sand
-    rfr=yes: Tag:rfr=yes
     road_marking=solid_stop_line: Tag:road marking=solid stop line
     roller_coaster=track: Tag:roller coaster=track
     route=aqueduct: Tag:route=aqueduct
@@ -9759,6 +10482,9 @@ en:
     route=waterway: Tag:route=waterway
     route=worship: Tag:route=worship
     sailing:tours=yes: Tag:sailing:tours=yes
+    school:gender=female: Tag:school:gender=female
+    school:gender=male: Tag:school:gender=male
+    school:gender=mixed: Tag:school:gender=mixed
     seamark:beacon_cardinal:colour_pattern=horizontal: Tag:seamark:beacon cardinal:colour
       pattern=horizontal
     seamark:beacon_cardinal:shape=tower: Tag:seamark:beacon cardinal:shape=tower
@@ -10071,8 +10797,11 @@ en:
     seamark:type=signal_station_traffic: Tag:seamark:type=signal station traffic
     seamark:type=signal_station_warning: Tag:seamark:type=signal station warning
     seamark:type=small_craft_facility: Tag:seamark:type=small craft facility
+    seamark:type=virtual_aton: Tag:seamark:type=virtual aton
     seamark:type=wreck: Tag:seamark:type=wreck
     seamark=landmark: Tag:seamark=landmark
+    second_hand=only: Tag:second hand=only
+    second_hand=yes: Tag:second hand=yes
     segregated=no: Tag:segregated=no
     segregated=yes: Tag:segregated=yes
     service=aircraft_control: Tag:service=aircraft control
@@ -10091,15 +10820,22 @@ en:
     service=parts: Tag:service=parts
     service=repair: Tag:service=repair
     service=siding: Tag:service=siding
+    service=slipway: Tag:service=slipway
     service=spur: Tag:service=spur
     service=tyres: Tag:service=tyres
     service=yard: Tag:service=yard
+    sett:style=portuguese: Tag:sett:style=portuguese
+    shelter_type=Wetterpilz: Tag:shelter type=Wetterpilz
     shelter_type=basic_hut: Tag:shelter type=basic hut
+    shelter_type=changing_rooms: Tag:shelter type=changing rooms
     shelter_type=field_shelter: Tag:shelter type=field shelter
+    shelter_type=gazebo: Tag:shelter type=gazebo
     shelter_type=lean_to: Tag:shelter type=lean to
+    shelter_type=pavilion: Tag:shelter type=pavilion
     shelter_type=picnic_shelter: Tag:shelter type=picnic shelter
     shelter_type=public_transport: Tag:shelter type=public transport
     shelter_type=weather_shelter: Tag:shelter type=weather shelter
+    shelter_type=wildlife_hide: Tag:shelter type=wildlife hide
     shop=*: Tag:shop=*
     shop=3d_printing: Tag:shop=3d printing
     shop=Alko: Tag:shop=Alko
@@ -10120,6 +10856,7 @@ en:
     shop=bag: Tag:shop=bag
     shop=bakery: Tag:shop=bakery
     shop=bathroom_furnishing: Tag:shop=bathroom furnishing
+    shop=bbq: Tag:shop=bbq
     shop=beauty: Tag:shop=beauty
     shop=bed: Tag:shop=bed
     shop=betting: Tag:shop=betting
@@ -10127,6 +10864,8 @@ en:
     shop=bicycle: Tag:shop=bicycle
     shop=board: Tag:shop=board
     shop=boat: Tag:shop=boat
+    shop=boat_parts: Tag:shop=boat parts
+    shop=boat_repair: Tag:shop=boat repair
     shop=bookmaker: Tag:shop=bookmaker
     shop=books: Tag:shop=books
     shop=boutique: Tag:shop=boutique
@@ -10165,6 +10904,7 @@ en:
     shop=dairy: Tag:shop=dairy
     shop=deli: Tag:shop=deli
     shop=delicatessen: Tag:shop=delicatessen
+    shop=dentures: Tag:shop=dentures
     shop=department_store: Tag:shop=department store
     shop=discount: Tag:shop=discount
     shop=dive: Tag:shop=dive
@@ -10185,6 +10925,7 @@ en:
     shop=farm: Tag:shop=farm
     shop=fashion: Tag:shop=fashion
     shop=fashion_accessories: Tag:shop=fashion accessories
+    shop=fast_food: Tag:shop=fast food
     shop=firearms: Tag:shop=firearms
     shop=fireplace: Tag:shop=fireplace
     shop=fireworks: Tag:shop=fireworks
@@ -10239,6 +10980,7 @@ en:
     shop=houseware: Tag:shop=houseware
     shop=hunting: Tag:shop=hunting
     shop=hvac: Tag:shop=hvac
+    shop=hydroponics: Tag:shop=hydroponics
     shop=ice_cream: Tag:shop=ice cream
     shop=insurance: Tag:shop=insurance
     shop=interior_decoration: Tag:shop=interior decoration
@@ -10273,6 +11015,7 @@ en:
     shop=motorcycle_parts: Tag:shop=motorcycle parts
     shop=motorcycle_repair: Tag:shop=motorcycle repair
     shop=motorhome: Tag:shop=motorhome
+    shop=motorsports: Tag:shop=motorsports
     shop=music: Tag:shop=music
     shop=musical_instrument: Tag:shop=musical instrument
     shop=musical_instruments: Tag:shop=musical instruments
@@ -10309,6 +11052,7 @@ en:
     shop=recreational_vehicle: Tag:shop=recreational vehicle
     shop=religion: Tag:shop=religion
     shop=rental: Tag:shop=rental
+    shop=repair: Tag:shop=repair
     shop=rice: Tag:shop=rice
     shop=robot: Tag:shop=robot
     shop=scooter: Tag:shop=scooter
@@ -10323,6 +11067,7 @@ en:
     shop=shopping_centre: Tag:shop=shopping centre
     shop=skate: Tag:shop=skate
     shop=ski: Tag:shop=ski
+    shop=snack: Tag:shop=snack
     shop=snowmobile: Tag:shop=snowmobile
     shop=solarium: Tag:shop=solarium
     shop=souvenir: Tag:shop=souvenir
@@ -10364,6 +11109,7 @@ en:
     shop=video_games: Tag:shop=video games
     shop=watches: Tag:shop=watches
     shop=water: Tag:shop=water
+    shop=water_sports: Tag:shop=water sports
     shop=weapons: Tag:shop=weapons
     shop=wholesale: Tag:shop=wholesale
     shop=wigs: Tag:shop=wigs
@@ -10375,19 +11121,12 @@ en:
     shop=wool: Tag:shop=wool
     shop=yes: Tag:shop=yes
     signal_station=bridge: Tag:signal station=bridge
-    signal_station=control: Tag:signal station=control
-    signal_station=distress: Tag:signal station=distress
     signal_station=firing: Tag:signal station=firing
-    signal_station=ice: Tag:signal station=ice
     signal_station=international_port_traffic: Tag:signal station=international port
       traffic
     signal_station=lock: Tag:signal station=lock
-    signal_station=storm: Tag:signal station=storm
-    signal_station=stream: Tag:signal station=stream
-    signal_station=tide: Tag:signal station=tide
     signal_station=tide_gauge: Tag:signal station=tide gauge
     signal_station=tide_scale: Tag:signal station=tide scale
-    signal_station=time: Tag:signal station=time
     signal_station=traffic: Tag:signal station=traffic
     signal_station=weather: Tag:signal station=weather
     signpost=forestry_compartment: Tag:signpost=forestry compartment
@@ -10410,6 +11149,7 @@ en:
     site_type=roman_villa: Tag:site type=roman villa
     site_type=settlement: Tag:site type=settlement
     site_type=tumulus: Tag:site type=tumulus
+    social_facility:for=homeless: Tag:social facility:for=homeless
     social_facility=ambulatory_care: Tag:social facility=ambulatory care
     social_facility=assisted_living: Tag:social facility=assisted living
     social_facility=clothing_bank: Tag:social facility=clothing bank
@@ -10446,15 +11186,19 @@ en:
     source=DNT_Oslo_og_Omegn: Tag:source=DNT Oslo og Omegn
     source=GURS: Tag:source=GURS
     source=Gazetteer_of_Australia_2012: Tag:source=Gazetteer of Australia 2012
+    source=Google: Tag:source=Google
+    source=Google,_2010-01-21: Tag:source=Google, 2010-01-21
     source=HiRes_aerial_imagery: Tag:source=HiRes aerial imagery
     source=Isle_of_Man_Government_1:25000_map_(2007): Tag:source=Isle of Man Government
       1:25000 map (2007)
     source=Isle_of_Man_Government_aerial_imagery_(2001): Tag:source=Isle of Man Government
       aerial imagery (2001)
+    source=Kartverket: Tag:source=Kartverket
     source=LPI_NSW_Base_Map: Tag:source=LPI NSW Base Map
     source=LPI_NSW_Imagery: Tag:source=LPI NSW Imagery
     source=NAIP: Tag:source=NAIP
     source=NPWS_Estate: Tag:source=NPWS Estate
+    source=NSW_LPI_BaseMap: Tag:source=NSW LPI BaseMap
     source=NSW_LPI_Base_Map: Tag:source=NSW LPI Base Map
     source=NSW_LPI_Imagery: Tag:source=NSW LPI Imagery
     source=Naturbase: Tag:source=Naturbase
@@ -10475,6 +11219,7 @@ en:
     sport=BASE: Tag:sport=BASE
     sport=aikido: Tag:sport=aikido
     sport=american_football: Tag:sport=american football
+    sport=american_handball: Tag:sport=american handball
     sport=archery: Tag:sport=archery
     sport=association_football: Tag:sport=association football
     sport=athletics: Tag:sport=athletics
@@ -10510,6 +11255,8 @@ en:
     sport=croquet: Tag:sport=croquet
     sport=crossfit: Tag:sport=crossfit
     sport=curling: Tag:sport=curling
+    sport=cycle_ball: Tag:sport=cycle ball
+    sport=cycle_polo: Tag:sport=cycle polo
     sport=cycling: Tag:sport=cycling
     sport=dancing: Tag:sport=dancing
     sport=darts: Tag:sport=darts
@@ -10521,9 +11268,12 @@ en:
     sport=fencing: Tag:sport=fencing
     sport=field_hockey: Tag:sport=field hockey
     sport=fitness: Tag:sport=fitness
+    sport=five-a-side: Tag:sport=five-a-side
     sport=fives: Tag:sport=fives
     sport=floorball: Tag:sport=floorball
+    sport=football: Tag:sport=football
     sport=footballgolf: Tag:sport=footballgolf
+    sport=four_square: Tag:sport=four square
     sport=free_flying: Tag:sport=free flying
     sport=futsal: Tag:sport=futsal
     sport=gaelic_football: Tag:sport=gaelic football
@@ -10564,6 +11314,7 @@ en:
     sport=parachuting: Tag:sport=parachuting
     sport=paragliding: Tag:sport=paragliding
     sport=parkour: Tag:sport=parkour
+    sport=pedal_car_racing: Tag:sport=pedal car racing
     sport=pelota: Tag:sport=pelota
     sport=pesäpallo: Tag:sport=pesäpallo
     sport=petanque: Tag:sport=petanque
@@ -10581,6 +11332,7 @@ en:
     sport=rugby_league: Tag:sport=rugby league
     sport=rugby_union: Tag:sport=rugby union
     sport=running: Tag:sport=running
+    sport=safety_training: Tag:sport=safety training
     sport=sailing: Tag:sport=sailing
     sport=scuba_diving: Tag:sport=scuba diving
     sport=shooting: Tag:sport=shooting
@@ -10615,6 +11367,7 @@ en:
     sport=windsurfing: Tag:sport=windsurfing
     sport=wrestling: Tag:sport=wrestling
     sport=yoga: Tag:sport=yoga
+    sport=zurkhaneh_sport: Tag:sport=zurkhaneh sport
     sports=aikido: Tag:sports=aikido
     sports=athletics: Tag:sports=athletics
     spring:type=hot: Tag:spring:type=hot
@@ -10642,21 +11395,50 @@ en:
     surface=acrylic: Tag:surface=acrylic
     surface=artificial_turf: Tag:surface=artificial turf
     surface=asphalt: Tag:surface=asphalt
+    surface=chipseal: Tag:surface=chipseal
     surface=clay: Tag:surface=clay
     surface=cobblestone: Tag:surface=cobblestone
     surface=compacted: Tag:surface=compacted
     surface=concrete: Tag:surface=concrete
     surface=concrete:lanes: Tag:surface=concrete:lanes
     surface=concrete:plates: Tag:surface=concrete:plates
+    surface=dirt: Tag:surface=dirt
+    surface=earth: Tag:surface=earth
+    surface=fine_gravel: Tag:surface=fine gravel
+    surface=grass: Tag:surface=grass
+    surface=grass_paver: Tag:surface=grass paver
+    surface=gravel: Tag:surface=gravel
+    surface=ground: Tag:surface=ground
     surface=metal: Tag:surface=metal
+    surface=mud: Tag:surface=mud
     surface=paved: Tag:surface=paved
     surface=paving_stones: Tag:surface=paving stones
+    surface=pebblestone: Tag:surface=pebblestone
     surface=rock: Tag:surface=rock
+    surface=rocks: Tag:surface=rocks
+    surface=sand: Tag:surface=sand
     surface=sett: Tag:surface=sett
     surface=tartan: Tag:surface=tartan
     surface=unhewn_cobblestone: Tag:surface=unhewn cobblestone
     surface=unpaved: Tag:surface=unpaved
     surface=wood: Tag:surface=wood
+    surface=woodchips: Tag:surface=woodchips
+    survey_point:datum_aligned=no: Tag:survey point:datum aligned=no
+    survey_point:datum_aligned=yes: Tag:survey point:datum aligned=yes
+    survey_point:purpose=both: Tag:survey point:purpose=both
+    survey_point:purpose=horizontal: Tag:survey point:purpose=horizontal
+    survey_point:purpose=vertical: Tag:survey point:purpose=vertical
+    survey_point:structure=beacon: Tag:survey point:structure=beacon
+    survey_point:structure=block: Tag:survey point:structure=block
+    survey_point:structure=bracket: Tag:survey point:structure=bracket
+    survey_point:structure=cut: Tag:survey point:structure=cut
+    survey_point:structure=indented_pin: Tag:survey point:structure=indented pin
+    survey_point:structure=magnet: Tag:survey point:structure=magnet
+    survey_point:structure=medallion: Tag:survey point:structure=medallion
+    survey_point:structure=pillar: Tag:survey point:structure=pillar
+    survey_point:structure=pin: Tag:survey point:structure=pin
+    survey_point:structure=plaque: Tag:survey point:structure=plaque
+    survey_point:structure=pole: Tag:survey point:structure=pole
     swimming_pool=yes: Tag:swimming pool=yes
     switch=circuit_breaker: Tag:switch=circuit breaker
     switch=disconnector: Tag:switch=disconnector
@@ -10688,10 +11470,12 @@ en:
     theatre:type=open_air: Tag:theatre:type=open air
     theatre:type=opera_house: Tag:theatre:type=opera house
     tickets:public_transport_subscription=yes: Tag:tickets:public transport subscription=yes
+    toilets:access=customers: Tag:toilets:access=customers
     toll=yes: Tag:toll=yes
     tomb=cenotaph: Tag:tomb=cenotaph
     tomb=columbarium: Tag:tomb=columbarium
     tomb=crypt: Tag:tomb=crypt
+    tomb=dolmen: Tag:tomb=dolmen
     tomb=hypogeum: Tag:tomb=hypogeum
     tomb=mausoleum: Tag:tomb=mausoleum
     tomb=obelisk: Tag:tomb=obelisk
@@ -10725,6 +11509,7 @@ en:
     tourism=resort: Tag:tourism=resort
     tourism=theme_park: Tag:tourism=theme park
     tourism=tourism-attraction: Tag:tourism=tourism-attraction
+    tourism=trail_riding_rest: Tag:tourism=trail riding rest
     tourism=trail_riding_station: Tag:tourism=trail riding station
     tourism=viewpoint: Tag:tourism=viewpoint
     tourism=wilderness_hut: Tag:tourism=wilderness hut
@@ -10743,6 +11528,7 @@ en:
     tower:type=communication: Tag:tower:type=communication
     tower:type=cooling: Tag:tower:type=cooling
     tower:type=defensive: Tag:tower:type=defensive
+    tower:type=diving: Tag:tower:type=diving
     tower:type=donjon: Tag:tower:type=donjon
     tower:type=hose: Tag:tower:type=hose
     tower:type=intake: Tag:tower:type=intake
@@ -10752,6 +11538,7 @@ en:
     tower:type=monitoring: Tag:tower:type=monitoring
     tower:type=monument: Tag:tower:type=monument
     tower:type=observation: Tag:tower:type=observation
+    tower:type=popinjay: Tag:tower:type=popinjay
     tower:type=radar: Tag:tower:type=radar
     tower:type=siren: Tag:tower:type=siren
     tower:type=suspension: Tag:tower:type=suspension
@@ -10762,9 +11549,20 @@ en:
     traffic=regional: Tag:traffic=regional
     traffic=suburban: Tag:traffic=suburban
     traffic=urban: Tag:traffic=urban
+    traffic_calming=bump: Tag:traffic calming=bump
+    traffic_calming=chicane: Tag:traffic calming=chicane
+    traffic_calming=choked_island: Tag:traffic calming=choked island
+    traffic_calming=choked_table: Tag:traffic calming=choked table
+    traffic_calming=choker: Tag:traffic calming=choker
+    traffic_calming=cushion: Tag:traffic calming=cushion
+    traffic_calming=dip: Tag:traffic calming=dip
     traffic_calming=double_dip: Tag:traffic calming=double dip
     traffic_calming=dynamic_bump: Tag:traffic calming=dynamic bump
+    traffic_calming=hump: Tag:traffic calming=hump
     traffic_calming=island: Tag:traffic calming=island
+    traffic_calming=mini_bumps: Tag:traffic calming=mini bumps
+    traffic_calming=painted_island: Tag:traffic calming=painted island
+    traffic_calming=rumble_strip: Tag:traffic calming=rumble strip
     traffic_calming=table: Tag:traffic calming=table
     traffic_sign:backward=DE:325.1: Tag:traffic sign:backward=DE:325.1
     traffic_sign:backward=DE:325.2: Tag:traffic sign:backward=DE:325.2
@@ -10774,6 +11572,7 @@ en:
     traffic_sign=CH:2.59.5: Tag:traffic sign=CH:2.59.5
     traffic_sign=DE:1022-10: Tag:traffic sign=DE:1022-10
     traffic_sign=DE:124: Tag:traffic sign=DE:124
+    traffic_sign=DE:133-10: Tag:traffic sign=DE:133-10
     traffic_sign=DE:136-10: Tag:traffic sign=DE:136-10
     traffic_sign=DE:142-10: Tag:traffic sign=DE:142-10
     traffic_sign=DE:205: Tag:traffic sign=DE:205
@@ -10803,6 +11602,7 @@ en:
     traffic_sign=DE:261: Tag:traffic sign=DE:261
     traffic_sign=DE:267: Tag:traffic sign=DE:267
     traffic_sign=DE:269: Tag:traffic sign=DE:269
+    traffic_sign=DE:272: Tag:traffic sign=DE:272
     traffic_sign=DE:274-10: Tag:traffic sign=DE:274-10
     traffic_sign=DE:274-100: Tag:traffic sign=DE:274-100
     traffic_sign=DE:274-120: Tag:traffic sign=DE:274-120
@@ -10850,6 +11650,7 @@ en:
     traffic_sign=NL:G12a: Tag:traffic sign=NL:G12a
     traffic_sign=NL:G13: Tag:traffic sign=NL:G13
     traffic_sign=city_limit: Tag:traffic sign=city limit
+    traffic_sign=give_way: Tag:traffic sign=give way
     traffic_sign=stop: Tag:traffic sign=stop
     traffic_signals=tram_priority: Tag:traffic signals=tram priority
     trailer:type=motorcycle: Tag:trailer:type=motorcycle
@@ -10884,7 +11685,10 @@ en:
     tunnel=building_passage: Tag:tunnel=building passage
     tunnel=culvert: Tag:tunnel=culvert
     tunnel=flooded: Tag:tunnel=flooded
+    turn:lanes=slide_left: Tag:turn:lanes=slide left
+    turn:lanes=slide_right: Tag:turn:lanes=slide right
     two_sided=yes: Tag:two sided=yes
+    type=associatedStreet: Tag:type=associatedStreet
     type=benchmark: Tag:type=benchmark
     type=boundary: Tag:type=boundary
     type=destination_sign: Tag:type=destination sign
@@ -10922,6 +11726,7 @@ en:
     utility=gas: Tag:utility=gas
     utility=heating: Tag:utility=heating
     utility=hydrant: Tag:utility=hydrant
+    utility=loudspeaker: Tag:utility=loudspeaker
     utility=oil: Tag:utility=oil
     utility=power: Tag:utility=power
     utility=sewerage: Tag:utility=sewerage
@@ -10938,6 +11743,7 @@ en:
     valve=needle: Tag:valve=needle
     valve=plug: Tag:valve=plug
     valve=spool: Tag:valve=spool
+    vehicle=customers: Tag:vehicle=customers
     vending: Tag:vending
     vending=SIM-cards: Tag:vending=SIM-cards
     vending=SIM_cards: Tag:vending=SIM cards
@@ -10996,18 +11802,29 @@ en:
     vending=water: Tag:vending=water
     vending_machine: Tag:vending machine
     vending_machine=fuel: Tag:vending machine=fuel
+    wall=brick: Tag:wall=brick
     wall=castle_wall: Tag:wall=castle wall
     wall=dry_stone: Tag:wall=dry stone
     wall=no: Tag:wall=no
     wall=noise_barrier: Tag:wall=noise barrier
     wall=seawall: Tag:wall=seawall
+    wall=stone: Tag:wall=stone
+    wall=stone_wall: Tag:wall=stone wall
     wall=tire_barrier: Tag:wall=tire barrier
     wall=training_wall: Tag:wall=training wall
+    waste=cigarettes: Tag:waste=cigarettes
     waste=dog_excrement: Tag:waste=dog excrement
+    waste=drugs: Tag:waste=drugs
+    waste=oil: Tag:waste=oil
+    waste=organic: Tag:waste=organic
+    waste=rubble: Tag:waste=rubble
+    waste=sharps: Tag:waste=sharps
+    waste=trash: Tag:waste=trash
     water=basin: Tag:water=basin
     water=canal: Tag:water=canal
     water=ditch: Tag:water=ditch
     water=drain: Tag:water=drain
+    water=fish_pass: Tag:water=fish pass
     water=intermittent: Tag:water=intermittent
     water=lagoon: Tag:water=lagoon
     water=lake: Tag:water=lake
@@ -11015,6 +11832,7 @@ en:
     water=moat: Tag:water=moat
     water=oxbow: Tag:water=oxbow
     water=pond: Tag:water=pond
+    water=rapids: Tag:water=rapids
     water=reflecting_pool: Tag:water=reflecting pool
     water=reservoir: Tag:water=reservoir
     water=river: Tag:water=river
@@ -11056,6 +11874,7 @@ en:
     waterway=sanitary_dump_station: Tag:waterway=sanitary dump station
     waterway=seaway: Tag:waterway=seaway
     waterway=sluice_gate: Tag:waterway=sluice gate
+    waterway=soakhole: Tag:waterway=soakhole
     waterway=spillway: Tag:waterway=spillway
     waterway=stream: Tag:waterway=stream
     waterway=stream_end: Tag:waterway=stream end
@@ -11078,10 +11897,19 @@ en:
     wetland=swamp: Tag:wetland=swamp
     wetland=tidalflat: Tag:wetland=tidalflat
     wetland=wet_meadow: Tag:wetland=wet meadow
+    wood=coniferous: Tag:wood=coniferous
     wood=eucalypt: Tag:wood=eucalypt
     wood=evergreen: Tag:wood=evergreen
     wood=nipa_palm: Tag:wood=nipa palm
     worship=stations_of_the_cross: Tag:worship=stations of the cross
+    zone:traffic=BE-BRU:urban: Tag:zone:traffic=BE-BRU:urban
+    zone:traffic=BE-VLG:rural: Tag:zone:traffic=BE-VLG:rural
+    zone:traffic=BE-VLG:urban: Tag:zone:traffic=BE-VLG:urban
+    zone:traffic=BE-WAL:rural: Tag:zone:traffic=BE-WAL:rural
+    zone:traffic=BE-WAL:urban: Tag:zone:traffic=BE-WAL:urban
+    zone:traffic=DE:motorway: Tag:zone:traffic=DE:motorway
+    zone:traffic=DE:rural: Tag:zone:traffic=DE:rural
+    zone:traffic=DE:urban: Tag:zone:traffic=DE:urban
     zoo=aviary: Tag:zoo=aviary
     zoo=birds: Tag:zoo=birds
     zoo=butterfly: Tag:zoo=butterfly
@@ -11096,14 +11924,20 @@ eo:
     craft=tinsmith: Eo:Tag:craft=tinsmith
     esperanto=esperanto: Eo:Tag:esperanto=esperanto
     esperanto=yes: Eo:Tag:esperanto=yes
+    shop=bakery: Eo:Tag:shop=bakery
 es:
   key:
+    AlpinRes_ID: ES:Key:AlpinRes ID
     abandoned: ES:Key:abandoned
     'abandoned:': 'ES:Key:abandoned:'
     abandoned:place: ES:Key:abandoned:place
     abandoned:railway: ES:Key:abandoned:railway
     abutters: ES:Key:abutters
     access: ES:Key:access
+    access:bdouble: ES:Key:access:bdouble
+    access:lhv: ES:Key:access:lhv
+    access:roadtrain: ES:Key:access:roadtrain
+    access:roadtrain:trailers: ES:Key:access:roadtrain:trailers
     addr: ES:Key:addr
     addr:city: ES:Key:addr:city
     addr:country: ES:Key:addr:country
@@ -11127,6 +11961,8 @@ es:
     aerialway: ES:Key:aerialway
     aeroway: ES:Key:aeroway
     after_school: ES:Key:after school
+    agricultural: ES:Key:agricultural
+    alt_name: ES:Key:alt name
     amenity: ES:Key:amenity
     architect: ES:Key:architect
     area: ES:Key:area
@@ -11134,11 +11970,16 @@ es:
     artist_name: ES:Key:artist name
     artwork_subject: ES:Key:artwork subject
     artwork_type: ES:Key:artwork type
+    backrest: ES:Key:backrest
     barrier: ES:Key:barrier
+    bdouble: ES:Key:bdouble
+    beauty: ES:Key:beauty
     beds: ES:Key:beds
     bicycle_parking: ES:Key:bicycle parking
     bicycle_road: ES:Key:bicycle road
+    board:title: ES:Key:board:title
     books: ES:Key:books
+    border_type: ES:Key:border type
     branch: ES:Key:branch
     brand: ES:Key:brand
     brewery: ES:Key:brewery
@@ -11154,6 +11995,7 @@ es:
     building:part: ES:Key:building:part
     building:soft_storey: ES:Key:building:soft storey
     building:use: ES:Key:building:use
+    bus: ES:Key:bus
     bus_bay: ES:Key:bus bay
     busway: ES:Key:busway
     capital: ES:Key:capital
@@ -11164,6 +12006,7 @@ es:
     clothes: ES:Key:clothes
     club: ES:Key:club
     collection_times: ES:Key:collection times
+    colour: ES:Key:colour
     comment: ES:Key:comment
     communication:amateur_radio: ES:Key:communication:amateur radio
     communication:radio: ES:Key:communication:radio
@@ -11177,6 +12020,7 @@ es:
     contact:twitter: ES:Key:contact:twitter
     content: ES:Key:content
     conveying: ES:Key:conveying
+    country: ES:Key:country
     covered: ES:Key:covered
     craft: ES:Key:craft
     created_by: ES:Key:created by
@@ -11186,12 +12030,16 @@ es:
     cuisine: ES:Key:cuisine
     currency: ES:Key:currency
     cutting: ES:Key:cutting
+    cyclestreets_id: ES:Key:cyclestreets id
     cycleway: ES:Key:cycleway
     cycleway:both: ES:Key:cycleway:both
     cycleway:lane: ES:Key:cycleway:lane
     cycleway:left: ES:Key:cycleway:left
     cycleway:right: ES:Key:cycleway:right
+    cycleway:right:oneway: ES:Key:cycleway:right:oneway
+    cycleway:surface: ES:Key:cycleway:surface
     delivery: ES:Key:delivery
+    'demolished:': 'ES:Key:demolished:'
     denotation: ES:Key:denotation
     description: ES:Key:description
     destination: ES:Key:destination
@@ -11199,24 +12047,34 @@ es:
     diet: ES:Key:diet
     diet:*: ES:Key:diet:*
     diet:kosher: ES:Key:diet:kosher
+    diet:vegan: ES:Key:diet:vegan
+    diet:vegetarian: ES:Key:diet:vegetarian
+    direction: ES:Key:direction
     dispensing: ES:Key:dispensing
     distance: ES:Key:distance
     disused: ES:Key:disused
     'disused:': 'ES:Key:disused:'
     disused:railway: ES:Key:disused:railway
+    drive_in: ES:Key:drive in
+    drive_through: ES:Key:drive through
+    ele: ES:Key:ele
     email: ES:Key:email
     embankment: ES:Key:embankment
     emergency: ES:Key:emergency
+    emergency:phone: ES:Key:emergency:phone
     end_date: ES:Key:end date
+    enforcement: ES:Key:enforcement
     engineer: ES:Key:engineer
     entrance: ES:Key:entrance
     evacuation_route: ES:Key:evacuation route
     facebook: ES:Key:facebook
     fair_trade: ES:Key:fair trade
+    fax: ES:Key:fax
     fee: ES:Key:fee
     fence_type: ES:Key:fence type
     fishing: ES:Key:fishing
     fixme: ES:Key:fixme
+    flag:type: ES:Key:flag:type
     flood_prone: ES:Key:flood prone
     foot: ES:Key:foot
     foot:backward: ES:Key:foot:backward
@@ -11227,12 +12085,16 @@ es:
     garden:style: ES:Key:garden:style
     garden:type: ES:Key:garden:type
     gauge: ES:Key:gauge
+    generator:method: ES:Key:generator:method
     generator:output: ES:Key:generator:output
     generator:source: ES:Key:generator:source
+    generator:type: ES:Key:generator:type
     genus: ES:Key:genus
     geological: ES:Key:geological
+    goods: ES:Key:goods
     government: ES:Key:government
     grassland: ES:Key:grassland
+    handrail: ES:Key:handrail
     hazard_prone: ES:Key:hazard prone
     healthcare: ES:Key:healthcare
     healthcare:counselling: ES:Key:healthcare:counselling
@@ -11241,6 +12103,7 @@ es:
     highway: ES:Key:highway
     historic: ES:Key:historic
     historic:civilization: ES:Key:historic:civilization
+    house: ES:Key:house
     image: ES:Key:image
     imagery_used: ES:Key:imagery used
     incline: ES:Key:incline
@@ -11250,6 +12113,8 @@ es:
     information: ES:Key:information
     inscription: ES:Key:inscription
     intermittent: ES:Key:intermittent
+    internet_access: ES:Key:internet access
+    internet_access:fee: ES:Key:internet access:fee
     interval: ES:Key:interval
     irrigated: ES:Key:irrigated
     is_in: ES:Key:is in
@@ -11263,12 +12128,15 @@ es:
     lanes: ES:Key:lanes
     lanes:psv: ES:Key:lanes:psv
     lawyer: ES:Key:lawyer
+    layer: ES:Key:layer
     leaf_cycle: ES:Key:leaf cycle
     leaf_type: ES:Key:leaf type
     leisure: ES:Key:leisure
     length: ES:Key:length
     level: ES:Key:level
     lgbtq: ES:Key:lgbtq
+    lhv: ES:Key:lhv
+    lit:perceived: ES:Key:lit:perceived
     local_ref: ES:Key:local ref
     locale: ES:Key:locale
     location: ES:Key:location
@@ -11277,15 +12145,26 @@ es:
     manufacturer: ES:Key:manufacturer
     mapillary: ES:Key:mapillary
     material: ES:Key:material
+    max_age: ES:Key:max age
+    maxaxleload: ES:Key:maxaxleload
+    maxbogieweight: ES:Key:maxbogieweight
     maxheight: ES:Key:maxheight
     maxspeed: ES:Key:maxspeed
     maxspeed:advisory: ES:Key:maxspeed:advisory
     maxspeed:practical: ES:Key:maxspeed:practical
+    maxstay: ES:Key:maxstay
+    maxweight: ES:Key:maxweight
+    maxwidth: ES:Key:maxwidth
     memorial: ES:Key:memorial
+    min_age: ES:Key:min age
     min_height: ES:Key:min height
     monitoring:galileo: ES:Key:monitoring:galileo
     monitoring:glonass: ES:Key:monitoring:glonass
     monitoring:gps: ES:Key:monitoring:gps
+    moped: ES:Key:moped
+    motor_vehicle: ES:Key:motor vehicle
+    motorcar: ES:Key:motorcar
+    motorcycle: ES:Key:motorcycle
     motorcycle:clothes: ES:Key:motorcycle:clothes
     motorcycle:parts: ES:Key:motorcycle:parts
     motorcycle:rental: ES:Key:motorcycle:rental
@@ -11307,7 +12186,6 @@ es:
     noexit: ES:Key:noexit
     nohousenumber: ES:Key:nohousenumber
     non_existent_levels: ES:Key:non existent levels
-    noname: ES:Key:noname
     'not:': 'ES:Key:not:'
     note: ES:Key:note
     nudism: ES:Key:nudism
@@ -11315,9 +12193,12 @@ es:
     office: ES:Key:office
     old_name: ES:Key:old name
     oneway: ES:Key:oneway
+    oneway:bicycle: ES:Key:oneway:bicycle
     oneway:psv: ES:Key:oneway:psv
+    opening_date: ES:Key:opening date
     opening_hours: ES:Key:opening hours
     opening_hours:covid19: ES:Key:opening hours:covid19
+    openplaques:id: ES:Key:openplaques:id
     operator: ES:Key:operator
     operator:type: ES:Key:operator:type
     organic: ES:Key:organic
@@ -11328,7 +12209,9 @@ es:
     owner: ES:Key:owner
     ownership: ES:Key:ownership
     parking: ES:Key:parking
+    parking:condition: ES:Key:parking:condition
     parking:lane: ES:Key:parking:lane
+    parking:orientation: ES:Key:parking:orientation
     passenger: ES:Key:passenger
     payment: ES:Key:payment
     phone: ES:Key:phone
@@ -11354,6 +12237,7 @@ es:
     railway: ES:Key:railway
     railway:preserved: ES:Key:railway:preserved
     ramp: ES:Key:ramp
+    recycling_type: ES:Key:recycling type
     ref: ES:Key:ref
     ref:bic: ES:Key:ref:bic
     ref:color: ES:Key:ref:color
@@ -11382,8 +12266,13 @@ es:
     safety_rope: ES:Key:safety rope
     seasonal: ES:Key:seasonal
     seats: ES:Key:seats
+    second_hand: ES:Key:second hand
+    segregated: ES:Key:segregated
+    self_service: ES:Key:self service
     service:bicycle:diy: ES:Key:service:bicycle:diy
     shelter: ES:Key:shelter
+    shelter_type: ES:Key:shelter type
+    shooting: ES:Key:shooting
     shop: ES:Key:shop
     shoulder: ES:Key:shoulder
     sidewalk: ES:Key:sidewalk
@@ -11392,10 +12281,12 @@ es:
     social_facility:for: ES:Key:social facility:for
     source: ES:Key:source
     species: ES:Key:species
+    species:de: ES:Key:species:de
     sport: ES:Key:sport
     stars: ES:Key:stars
     start_date: ES:Key:start date
     stop: ES:Key:stop
+    substance: ES:Key:substance
     supervised: ES:Key:supervised
     support: ES:Key:support
     surface: ES:Key:surface
@@ -11403,6 +12294,7 @@ es:
     surveillance:type: ES:Key:surveillance:type
     surveillance:zone: ES:Key:surveillance:zone
     symbol: ES:Key:symbol
+    tactile_paving: ES:Key:tactile paving
     takeaway: ES:Key:takeaway
     taxi: ES:Key:taxi
     tents: ES:Key:tents
@@ -11420,6 +12312,8 @@ es:
     traffic_sign: ES:Key:traffic sign
     traffic_signals: ES:Key:traffic signals
     traffic_signals:direction: ES:Key:traffic signals:direction
+    train: ES:Key:train
+    transformer: ES:Key:transformer
     tree_lined: ES:Key:tree lined
     trolley_wire: ES:Key:trolley wire
     trolleybus: ES:Key:trolleybus
@@ -11431,30 +12325,50 @@ es:
     url: ES:Key:url
     vaccination: ES:Key:vaccination
     vehicle: ES:Key:vehicle
+    vending: ES:Key:vending
     via: ES:Key:via
     water: ES:Key:water
+    water_source: ES:Key:water source
     waterway: ES:Key:waterway
     website: ES:Key:website
     wetland: ES:Key:wetland
     wheelchair: ES:Key:wheelchair
     wheelchair:description: ES:Key:wheelchair:description
     wholesale: ES:Key:wholesale
+    width: ES:Key:width
     wikidata: ES:Key:wikidata
     wikimedia_commons: ES:Key:wikimedia commons
     wikipedia: ES:Key:wikipedia
   tag:
+    abandoned:amenity=prison: ES:Tag:abandoned:amenity=prison
     abandoned:amenity=prison_camp: ES:Tag:abandoned:amenity=prison camp
+    access=agricultural: ES:Tag:access=agricultural
     access=customers: ES:Tag:access=customers
+    access=delivery: ES:Tag:access=delivery
+    access=forestry: ES:Tag:access=forestry
     access=private: ES:Tag:access=private
     admin_level=2: ES:Tag:admin level=2
     advertising=board: ES:Tag:advertising=board
     advertising=column: ES:Tag:advertising=column
+    advertising=screen: ES:Tag:advertising=screen
+    advertising=tarp: ES:Tag:advertising=tarp
     advertising=totem: ES:Tag:advertising=totem
     advertising=wall_painting: ES:Tag:advertising=wall painting
     aerialway=cable_car: ES:Tag:aerialway=cable car
+    aerialway=canopy: ES:Tag:aerialway=canopy
+    aerialway=chair_lift: ES:Tag:aerialway=chair lift
+    aerialway=drag_lift: ES:Tag:aerialway=drag lift
     aerialway=gondola: ES:Tag:aerialway=gondola
+    aerialway=goods: ES:Tag:aerialway=goods
+    aerialway=j-bar: ES:Tag:aerialway=j-bar
+    aerialway=magic_carpet: ES:Tag:aerialway=magic carpet
+    aerialway=mixed_lift: ES:Tag:aerialway=mixed lift
+    aerialway=platter: ES:Tag:aerialway=platter
     aerialway=pylon: ES:Tag:aerialway=pylon
+    aerialway=rope_tow: ES:Tag:aerialway=rope tow
     aerialway=station: ES:Tag:aerialway=station
+    aerialway=t-bar: ES:Tag:aerialway=t-bar
+    aerialway=zip_line: ES:Tag:aerialway=zip line
     aerodrome:type=regional: ES:Tag:aerodrome:type=regional
     aeroway=aerodrome: ES:Tag:aeroway=aerodrome
     aeroway=apron: ES:Tag:aeroway=apron
@@ -11469,10 +12383,14 @@ es:
     aeroway=terminal: ES:Tag:aeroway=terminal
     aeroway=windsock: ES:Tag:aeroway=windsock
     airmark=beacon: ES:Tag:airmark=beacon
+    allotments=plot: ES:Tag:allotments=plot
+    amenity=animal_breeding: ES:Tag:amenity=animal breeding
     amenity=animal_shelter: ES:Tag:amenity=animal shelter
     amenity=archive: ES:Tag:amenity=archive
     amenity=arts_centre: ES:Tag:amenity=arts centre
     amenity=atm: ES:Tag:amenity=atm
+    amenity=audiologist: ES:Tag:amenity=audiologist
+    amenity=baby_hatch: ES:Tag:amenity=baby hatch
     amenity=baking_oven: ES:Tag:amenity=baking oven
     amenity=bank: ES:Tag:amenity=bank
     amenity=bar: ES:Tag:amenity=bar
@@ -11481,14 +12399,18 @@ es:
     amenity=bicycle_library: ES:Tag:amenity=bicycle library
     amenity=bicycle_parking: ES:Tag:amenity=bicycle parking
     amenity=bicycle_rental: ES:Tag:amenity=bicycle rental
+    amenity=bicycle_repair_station: ES:Tag:amenity=bicycle repair station
     amenity=biergarten: ES:Tag:amenity=biergarten
     amenity=boat_storage: ES:Tag:amenity=boat storage
     amenity=brothel: ES:Tag:amenity=brothel
+    amenity=bureau_de_change: ES:Tag:amenity=bureau de change
     amenity=bus_station: ES:Tag:amenity=bus station
     amenity=cafe: ES:Tag:amenity=cafe
     amenity=car_rental: ES:Tag:amenity=car rental
     amenity=car_wash: ES:Tag:amenity=car wash
+    amenity=casino: ES:Tag:amenity=casino
     amenity=childcare: ES:Tag:amenity=childcare
+    amenity=cinema: ES:Tag:amenity=cinema
     amenity=clinic: ES:Tag:amenity=clinic
     amenity=clock: ES:Tag:amenity=clock
     amenity=college: ES:Tag:amenity=college
@@ -11505,6 +12427,7 @@ es:
     amenity=doctors: ES:Tag:amenity=doctors
     amenity=drinking_water: ES:Tag:amenity=drinking water
     amenity=driving_school: ES:Tag:amenity=driving school
+    amenity=dryer: ES:Tag:amenity=dryer
     amenity=embassy: ES:Tag:amenity=embassy
     amenity=events_venue: ES:Tag:amenity=events venue
     amenity=exhibition_centre: ES:Tag:amenity=exhibition centre
@@ -11518,7 +12441,9 @@ es:
     amenity=gambling: ES:Tag:amenity=gambling
     amenity=give_box: ES:Tag:amenity=give box
     amenity=grave_yard: ES:Tag:amenity=grave yard
+    amenity=grit_bin: ES:Tag:amenity=grit bin
     amenity=harbourmaster: ES:Tag:amenity=harbourmaster
+    amenity=hitching_post: ES:Tag:amenity=hitching post
     amenity=hospital: ES:Tag:amenity=hospital
     amenity=ice_cream: ES:Tag:amenity=ice cream
     amenity=internet_cafe: ES:Tag:amenity=internet cafe
@@ -11529,15 +12454,20 @@ es:
     amenity=lavoir: ES:Tag:amenity=lavoir
     amenity=letter_box: ES:Tag:amenity=letter box
     amenity=library: ES:Tag:amenity=library
+    amenity=life_ring: ES:Tag:amenity=life ring
+    amenity=lost_property_office: ES:Tag:amenity=lost property office
     amenity=lounger: ES:Tag:amenity=lounger
     amenity=love_hotel: ES:Tag:amenity=love hotel
     amenity=marketplace: ES:Tag:amenity=marketplace
     amenity=mobile_library: ES:Tag:amenity=mobile library
+    amenity=mobile_money_agent: ES:Tag:amenity=mobile money agent
+    amenity=money_transfer: ES:Tag:amenity=money transfer
     amenity=mortuary: ES:Tag:amenity=mortuary
     amenity=motorcycle_parking: ES:Tag:amenity=motorcycle parking
     amenity=music_school: ES:Tag:amenity=music school
     amenity=nightclub: ES:Tag:amenity=nightclub
     amenity=nursing_home: ES:Tag:amenity=nursing home
+    amenity=outfitter: ES:Tag:amenity=outfitter
     amenity=parking: ES:Tag:amenity=parking
     amenity=parking_entrance: ES:Tag:amenity=parking entrance
     amenity=parking_space: ES:Tag:amenity=parking space
@@ -11545,6 +12475,8 @@ es:
     amenity=payment_terminal: ES:Tag:amenity=payment terminal
     amenity=pharmacy: ES:Tag:amenity=pharmacy
     amenity=photo_booth: ES:Tag:amenity=photo booth
+    amenity=piano: ES:Tag:amenity=piano
+    amenity=place_of_mourning: ES:Tag:amenity=place of mourning
     amenity=place_of_worship: ES:Tag:amenity=place of worship
     amenity=planetarium: ES:Tag:amenity=planetarium
     amenity=police: ES:Tag:amenity=police
@@ -11552,10 +12484,14 @@ es:
     amenity=post_depot: ES:Tag:amenity=post depot
     amenity=post_office: ES:Tag:amenity=post office
     amenity=prep_school: ES:Tag:amenity=prep school
+    amenity=printer: ES:Tag:amenity=printer
+    amenity=prison: ES:Tag:amenity=prison
     amenity=prison_camp: ES:Tag:amenity=prison camp
     amenity=pub: ES:Tag:amenity=pub
+    amenity=public_bath: ES:Tag:amenity=public bath
     amenity=public_bookcase: ES:Tag:amenity=public bookcase
     amenity=public_building: ES:Tag:amenity=public building
+    amenity=ranger_station: ES:Tag:amenity=ranger station
     amenity=recycling: ES:Tag:amenity=recycling
     amenity=refugee_housing: ES:Tag:amenity=refugee housing
     amenity=research_institute: ES:Tag:amenity=research institute
@@ -11573,15 +12509,19 @@ es:
     amenity=stripclub: ES:Tag:amenity=stripclub
     amenity=studio: ES:Tag:amenity=studio
     amenity=taxi: ES:Tag:amenity=taxi
+    amenity=telephone: ES:Tag:amenity=telephone
     amenity=television: ES:Tag:amenity=television
     amenity=theatre: ES:Tag:amenity=theatre
+    amenity=toilets: ES:Tag:amenity=toilets
     amenity=tourist_bus_parking: ES:Tag:amenity=tourist bus parking
     amenity=townhall: ES:Tag:amenity=townhall
     amenity=toy_library: ES:Tag:amenity=toy library
+    amenity=trolley_bay: ES:Tag:amenity=trolley bay
     amenity=university: ES:Tag:amenity=university
     amenity=vehicle_inspection: ES:Tag:amenity=vehicle inspection
     amenity=vending_machine: ES:Tag:amenity=vending machine
     amenity=veterinary: ES:Tag:amenity=veterinary
+    amenity=washing_machine: ES:Tag:amenity=washing machine
     amenity=waste_basket: ES:Tag:amenity=waste basket
     amenity=waste_disposal: ES:Tag:amenity=waste disposal
     amenity=water_point: ES:Tag:amenity=water point
@@ -11594,12 +12534,14 @@ es:
     area:highway=footway: ES:Tag:area:highway=footway
     area:highway=path: ES:Tag:area:highway=path
     area:highway=pedestrian: ES:Tag:area:highway=pedestrian
+    artwork_type=sculpture: ES:Tag:artwork type=sculpture
     attraction=roller_coaster: ES:Tag:attraction=roller coaster
     attraction=water_slide: ES:Tag:attraction=water slide
     barrier=block: ES:Tag:barrier=block
     barrier=bollard: ES:Tag:barrier=bollard
     barrier=border_control: ES:Tag:barrier=border control
     barrier=cable_barrier: ES:Tag:barrier=cable barrier
+    barrier=cattle_grid: ES:Tag:barrier=cattle grid
     barrier=chain: ES:Tag:barrier=chain
     barrier=city_wall: ES:Tag:barrier=city wall
     barrier=debris: ES:Tag:barrier=debris
@@ -11621,13 +12563,17 @@ es:
     barrier=toll_booth: ES:Tag:barrier=toll booth
     barrier=tyres: ES:Tag:barrier=tyres
     barrier=wall: ES:Tag:barrier=wall
+    bicycle=no: ES:Tag:bicycle=no
     bicycle=use_sidepath: ES:Tag:bicycle=use sidepath
+    bicycle=yes: ES:Tag:bicycle=yes
     boundary=administrative: ES:Tag:boundary=administrative
     boundary=national_park: ES:Tag:boundary=national park
     boundary=political: ES:Tag:boundary=political
     boundary=protected_area: ES:Tag:boundary=protected area
     boundary=regional_park: ES:Tag:boundary=regional park
+    bridge:structure=beam: ES:Tag:bridge:structure=beam
     bridge=aqueduct: ES:Tag:bridge=aqueduct
+    bridge=boardwalk: ES:Tag:bridge=boardwalk
     bridge=viaduct: ES:Tag:bridge=viaduct
     building=apartments: ES:Tag:building=apartments
     building=bakehouse: ES:Tag:building=bakehouse
@@ -11694,6 +12640,7 @@ es:
     building=stable: ES:Tag:building=stable
     building=stadium: ES:Tag:building=stadium
     building=static_caravan: ES:Tag:building=static caravan
+    building=storage_tank: ES:Tag:building=storage tank
     building=sty: ES:Tag:building=sty
     building=supermarket: ES:Tag:building=supermarket
     building=synagogue: ES:Tag:building=synagogue
@@ -11708,11 +12655,15 @@ es:
     building=university: ES:Tag:building=university
     building=warehouse: ES:Tag:building=warehouse
     building=water_tower: ES:Tag:building=water tower
+    building=yes: ES:Tag:building=yes
+    busway=lane: ES:Tag:busway=lane
     castle_type=manor: ES:Tag:castle type=manor
     cemetery=grave: ES:Tag:cemetery=grave
+    cemetery=sector: ES:Tag:cemetery=sector
     clothes=fashion: ES:Tag:clothes=fashion
     club=scout: ES:Tag:club=scout
     club=sport: ES:Tag:club=sport
+    company=logistics: ES:Tag:company=logistics
     craft=agricultural_engines: ES:Tag:craft=agricultural engines
     craft=bakery: ES:Tag:craft=bakery
     craft=basket_maker: ES:Tag:craft=basket maker
@@ -11729,6 +12680,7 @@ es:
     craft=confectionery: ES:Tag:craft=confectionery
     craft=dental_technician: ES:Tag:craft=dental technician
     craft=distillery: ES:Tag:craft=distillery
+    craft=dressmaker: ES:Tag:craft=dressmaker
     craft=electrician: ES:Tag:craft=electrician
     craft=electronics_repair: ES:Tag:craft=electronics repair
     craft=engraver: ES:Tag:craft=engraver
@@ -11744,24 +12696,40 @@ es:
     craft=oil_mill: ES:Tag:craft=oil mill
     craft=optician: ES:Tag:craft=optician
     craft=photographer: ES:Tag:craft=photographer
+    craft=photographic_laboratory: ES:Tag:craft=photographic laboratory
     craft=plumber: ES:Tag:craft=plumber
     craft=pottery: ES:Tag:craft=pottery
     craft=printer: ES:Tag:craft=printer
+    craft=restoration: ES:Tag:craft=restoration
     craft=shoemaker: ES:Tag:craft=shoemaker
+    craft=stand_builder: ES:Tag:craft=stand builder
     craft=tailor: ES:Tag:craft=tailor
     craft=tiler: ES:Tag:craft=tiler
     craft=upholsterer: ES:Tag:craft=upholsterer
     craft=watchmaker: ES:Tag:craft=watchmaker
+    craft=welder: ES:Tag:craft=welder
+    craft=winery: ES:Tag:craft=winery
     crossing=marked: ES:Tag:crossing=marked
     crossing=traffic_signals: ES:Tag:crossing=traffic signals
+    crossing=uncontrolled: ES:Tag:crossing=uncontrolled
     crossing=zebra: ES:Tag:crossing=zebra
+    cuisine=fish_and_chips: ES:Tag:cuisine=fish and chips
+    cycleway:both=lane: ES:Tag:cycleway:both=lane
+    cycleway:both=no: ES:Tag:cycleway:both=no
+    cycleway:left=track: ES:Tag:cycleway:left=track
     cycleway:right=lane: ES:Tag:cycleway:right=lane
     cycleway:right=track: ES:Tag:cycleway:right=track
+    cycleway=crossing: ES:Tag:cycleway=crossing
     cycleway=lane: ES:Tag:cycleway=lane
+    cycleway=no: ES:Tag:cycleway=no
+    cycleway=opposite: ES:Tag:cycleway=opposite
     cycleway=opposite_lane: ES:Tag:cycleway=opposite lane
     cycleway=opposite_track: ES:Tag:cycleway=opposite track
+    cycleway=separate: ES:Tag:cycleway=separate
     cycleway=share_busway: ES:Tag:cycleway=share busway
     cycleway=track: ES:Tag:cycleway=track
+    denomination=mormon: ES:Tag:denomination=mormon
+    disused=yes: ES:Tag:disused=yes
     emergency=ambulance_station: ES:Tag:emergency=ambulance station
     emergency=defibrillator: ES:Tag:emergency=defibrillator
     emergency=dry_riser: ES:Tag:emergency=dry riser
@@ -11770,15 +12738,20 @@ es:
     emergency=fire_hose: ES:Tag:emergency=fire hose
     emergency=fire_hydrant: ES:Tag:emergency=fire hydrant
     emergency=landing_site: ES:Tag:emergency=landing site
+    emergency=lifeguard: ES:Tag:emergency=lifeguard
+    emergency=lifeguard_tower: ES:Tag:emergency=lifeguard tower
     emergency=phone: ES:Tag:emergency=phone
     emergency=ses_station: ES:Tag:emergency=ses station
     emergency=yes: ES:Tag:emergency=yes
     flow_direction=both: ES:Tag:flow direction=both
+    foot=use_sidepath: ES:Tag:foot=use sidepath
+    footway=access_aisle: ES:Tag:footway=access aisle
     footway=crossing: ES:Tag:footway=crossing
     footway=sidewalk: ES:Tag:footway=sidewalk
     ford=stepping_stones: ES:Tag:ford=stepping stones
     ford=yes: ES:Tag:ford=yes
     garden:type=botanical: ES:Tag:garden:type=botanical
+    generator:method=combustion: ES:Tag:generator:method=combustion
     generator:method=photovoltaic: ES:Tag:generator:method=photovoltaic
     generator:method=thermal: ES:Tag:generator:method=thermal
     generator:method=wind_turbine: ES:Tag:generator:method=wind turbine
@@ -11817,29 +12790,43 @@ es:
     government=statistics: ES:Tag:government=statistics
     government=tax: ES:Tag:government=tax
     government=youth_welfare_department: ES:Tag:government=youth welfare department
+    hazard=animal_crossing: ES:Tag:hazard=animal crossing
+    hazard=contamination: ES:Tag:hazard=contamination
+    hazard=cyclists: ES:Tag:hazard=cyclists
+    hazard=dangerous_junction: ES:Tag:hazard=dangerous junction
+    hazard=horse_riders: ES:Tag:hazard=horse riders
+    hazard=queues_likely: ES:Tag:hazard=queues likely
+    hazard=slippery: ES:Tag:hazard=slippery
     healthcare:speciality=vaccination: ES:Tag:healthcare:speciality=vaccination
     healthcare=birthing_center: ES:Tag:healthcare=birthing center
+    healthcare=clinic: ES:Tag:healthcare=clinic
+    healthcare=dentist: ES:Tag:healthcare=dentist
     healthcare=doctor: ES:Tag:healthcare=doctor
     healthcare=hospital: ES:Tag:healthcare=hospital
     healthcare=laboratory: ES:Tag:healthcare=laboratory
     healthcare=midwife: ES:Tag:healthcare=midwife
     healthcare=podiatrist: ES:Tag:healthcare=podiatrist
+    healthcare=vaccination_centre: ES:Tag:healthcare=vaccination centre
     highway=bridleway: ES:Tag:highway=bridleway
     highway=bus_guideway: ES:Tag:highway=bus guideway
     highway=bus_stop: ES:Tag:highway=bus stop
+    highway=busway: ES:Tag:highway=busway
     highway=byway: ES:Tag:highway=byway
     highway=corridor: ES:Tag:highway=corridor
     highway=crossing: ES:Tag:highway=crossing
     highway=cycleway: ES:Tag:highway=cycleway
     highway=elevator: ES:Tag:highway=elevator
     highway=emergency_access_point: ES:Tag:highway=emergency access point
+    highway=emergency_bay: ES:Tag:highway=emergency bay
     highway=escape: ES:Tag:highway=escape
     highway=footway: ES:Tag:highway=footway
     highway=living_street: ES:Tag:highway=living street
     highway=milestone: ES:Tag:highway=milestone
+    highway=mini_roundabout: ES:Tag:highway=mini roundabout
     highway=motorway: ES:Tag:highway=motorway
     highway=motorway_junction: ES:Tag:highway=motorway junction
     highway=motorway_link: ES:Tag:highway=motorway link
+    highway=passing_place: ES:Tag:highway=passing place
     highway=path: ES:Tag:highway=path
     highway=pedestrian: ES:Tag:highway=pedestrian
     highway=platform: ES:Tag:highway=platform
@@ -11860,23 +12847,30 @@ es:
     highway=stop: ES:Tag:highway=stop
     highway=street_lamp: ES:Tag:highway=street lamp
     highway=tertiary: ES:Tag:highway=tertiary
+    highway=tertiary_link: ES:Tag:highway=tertiary link
     highway=track: ES:Tag:highway=track
     highway=traffic_signals: ES:Tag:highway=traffic signals
     highway=trailhead: ES:Tag:highway=trailhead
     highway=trunk: ES:Tag:highway=trunk
+    highway=trunk_link: ES:Tag:highway=trunk link
     highway=turning_circle: ES:Tag:highway=turning circle
     highway=turning_loop: ES:Tag:highway=turning loop
     highway=unclassified: ES:Tag:highway=unclassified
     historic=aqueduct: ES:Tag:historic=aqueduct
     historic=archaeological_site: ES:Tag:historic=archaeological site
     historic=boundary_stone: ES:Tag:historic=boundary stone
+    historic=castle: ES:Tag:historic=castle
+    historic=cemetery: ES:Tag:historic=cemetery
     historic=district: ES:Tag:historic=district
     historic=farm: ES:Tag:historic=farm
+    historic=fort: ES:Tag:historic=fort
     historic=heritage: ES:Tag:historic=heritage
     historic=manor: ES:Tag:historic=manor
     historic=memorial: ES:Tag:historic=memorial
     historic=milestone: ES:Tag:historic=milestone
     historic=mine: ES:Tag:historic=mine
+    historic=monastery: ES:Tag:historic=monastery
+    historic=monument: ES:Tag:historic=monument
     historic=pillory: ES:Tag:historic=pillory
     historic=ruins: ES:Tag:historic=ruins
     historic=tomb: ES:Tag:historic=tomb
@@ -11886,6 +12880,7 @@ es:
     industrial=auto_wrecker: ES:Tag:industrial=auto wrecker
     industrial=depot: ES:Tag:industrial=depot
     industrial=factory: ES:Tag:industrial=factory
+    industrial=mine: ES:Tag:industrial=mine
     industrial=scrap_yard: ES:Tag:industrial=scrap yard
     industrial=warehouse: ES:Tag:industrial=warehouse
     information=board: ES:Tag:information=board
@@ -11894,7 +12889,9 @@ es:
     information=office: ES:Tag:information=office
     information=tactile_map: ES:Tag:information=tactile map
     information=visitor_centre: ES:Tag:information=visitor centre
+    internet_access=no: ES:Tag:internet access=no
     internet_access=wlan: ES:Tag:internet access=wlan
+    internet_access=yes: ES:Tag:internet access=yes
     junction=circular: ES:Tag:junction=circular
     junction=roundabout: ES:Tag:junction=roundabout
     karst=yes: ES:Tag:karst=yes
@@ -11909,8 +12906,10 @@ es:
     landuse=commercial: ES:Tag:landuse=commercial
     landuse=construction: ES:Tag:landuse=construction
     landuse=depot: ES:Tag:landuse=depot
+    landuse=education: ES:Tag:landuse=education
     landuse=farmland: ES:Tag:landuse=farmland
     landuse=farmyard: ES:Tag:landuse=farmyard
+    landuse=flowerbed: ES:Tag:landuse=flowerbed
     landuse=forest: ES:Tag:landuse=forest
     landuse=garages: ES:Tag:landuse=garages
     landuse=grass: ES:Tag:landuse=grass
@@ -11920,6 +12919,7 @@ es:
     landuse=landfill: ES:Tag:landuse=landfill
     landuse=meadow: ES:Tag:landuse=meadow
     landuse=meadow_orchard: ES:Tag:landuse=meadow orchard
+    landuse=military: ES:Tag:landuse=military
     landuse=orchard: ES:Tag:landuse=orchard
     landuse=plant_nursery: ES:Tag:landuse=plant nursery
     landuse=quarry: ES:Tag:landuse=quarry
@@ -11930,6 +12930,7 @@ es:
     landuse=salt_pond: ES:Tag:landuse=salt pond
     landuse=traffic_island: ES:Tag:landuse=traffic island
     landuse=village_green: ES:Tag:landuse=village green
+    landuse=vineyard: ES:Tag:landuse=vineyard
     leaf_cycle=deciduous: ES:Tag:leaf cycle=deciduous
     leaf_cycle=evergreen: ES:Tag:leaf cycle=evergreen
     leaf_cycle=mixed: ES:Tag:leaf cycle=mixed
@@ -11939,11 +12940,15 @@ es:
     leaf_type=leafless: ES:Tag:leaf type=leafless
     leaf_type=mixed: ES:Tag:leaf type=mixed
     leaf_type=needleleaved: ES:Tag:leaf type=needleleaved
+    leisure=adult_gaming_centre: ES:Tag:leisure=adult gaming centre
+    leisure=amusement_arcade: ES:Tag:leisure=amusement arcade
     leisure=bandstand: ES:Tag:leisure=bandstand
+    leisure=barefoot: ES:Tag:leisure=barefoot
     leisure=bird_hide: ES:Tag:leisure=bird hide
     leisure=bleachers: ES:Tag:leisure=bleachers
     leisure=bowling_alley: ES:Tag:leisure=bowling alley
     leisure=common: ES:Tag:leisure=common
+    leisure=dance: ES:Tag:leisure=dance
     leisure=disc_golf_course: ES:Tag:leisure=disc golf course
     leisure=dog_park: ES:Tag:leisure=dog park
     leisure=escape_game: ES:Tag:leisure=escape game
@@ -11955,6 +12960,7 @@ es:
     leisure=golf_course: ES:Tag:leisure=golf course
     leisure=hackerspace: ES:Tag:leisure=hackerspace
     leisure=horse_riding: ES:Tag:leisure=horse riding
+    leisure=ice_rink: ES:Tag:leisure=ice rink
     leisure=marina: ES:Tag:leisure=marina
     leisure=miniature_golf: ES:Tag:leisure=miniature golf
     leisure=nature_reserve: ES:Tag:leisure=nature reserve
@@ -11963,16 +12969,20 @@ es:
     leisure=picnic_table: ES:Tag:leisure=picnic table
     leisure=pitch: ES:Tag:leisure=pitch
     leisure=playground: ES:Tag:leisure=playground
+    leisure=resort: ES:Tag:leisure=resort
     leisure=sauna: ES:Tag:leisure=sauna
     leisure=schoolyard: ES:Tag:leisure=schoolyard
     leisure=slipway: ES:Tag:leisure=slipway
     leisure=sports_centre: ES:Tag:leisure=sports centre
     leisure=sports_hall: ES:Tag:leisure=sports hall
     leisure=stadium: ES:Tag:leisure=stadium
+    leisure=swimming_area: ES:Tag:leisure=swimming area
     leisure=swimming_pool: ES:Tag:leisure=swimming pool
     leisure=tanning_salon: ES:Tag:leisure=tanning salon
     leisure=track: ES:Tag:leisure=track
     leisure=water_park: ES:Tag:leisure=water park
+    leisure=wildlife_hide: ES:Tag:leisure=wildlife hide
+    lifeguard=tower: ES:Tag:lifeguard=tower
     man_made=adit: ES:Tag:man made=adit
     man_made=archimedes_screw: ES:Tag:man made=archimedes screw
     man_made=beehive: ES:Tag:man made=beehive
@@ -11989,7 +12999,9 @@ es:
     man_made=flagpole: ES:Tag:man made=flagpole
     man_made=gantry: ES:Tag:man made=gantry
     man_made=geoglyph: ES:Tag:man made=geoglyph
+    man_made=manhole: ES:Tag:man made=manhole
     man_made=mast: ES:Tag:man made=mast
+    man_made=mineshaft: ES:Tag:man made=mineshaft
     man_made=monitoring_station: ES:Tag:man made=monitoring station
     man_made=nesting_site: ES:Tag:man made=nesting site
     man_made=observatory: ES:Tag:man made=observatory
@@ -12003,8 +13015,10 @@ es:
     man_made=street_cabinet: ES:Tag:man made=street cabinet
     man_made=surveillance: ES:Tag:man made=surveillance
     man_made=survey_point: ES:Tag:man made=survey point
+    man_made=tailings_pond: ES:Tag:man made=tailings pond
     man_made=telescope: ES:Tag:man made=telescope
     man_made=tell: ES:Tag:man made=tell
+    man_made=threshing_floor: ES:Tag:man made=threshing floor
     man_made=tower: ES:Tag:man made=tower
     man_made=wastewater_plant: ES:Tag:man made=wastewater plant
     man_made=water_tap: ES:Tag:man made=water tap
@@ -12012,10 +13026,12 @@ es:
     man_made=water_well: ES:Tag:man made=water well
     man_made=water_works: ES:Tag:man made=water works
     man_made=watermill: ES:Tag:man made=watermill
+    man_made=wildlife_crossing: ES:Tag:man made=wildlife crossing
     man_made=wildlife_opening: ES:Tag:man made=wildlife opening
     man_made=windpump: ES:Tag:man made=windpump
     man_made=works: ES:Tag:man made=works
     manhole=drain: ES:Tag:manhole=drain
+    memorial:type=stolperstein: ES:Tag:memorial:type=stolperstein
     memorial=blue_plaque: ES:Tag:memorial=blue plaque
     memorial=bust: ES:Tag:memorial=bust
     memorial=cross: ES:Tag:memorial=cross
@@ -12027,6 +13043,8 @@ es:
     memorial=stolperstein: ES:Tag:memorial=stolperstein
     memorial=stone: ES:Tag:memorial=stone
     memorial=war_memorial: ES:Tag:memorial=war memorial
+    military=barracks: ES:Tag:military=barracks
+    military=base: ES:Tag:military=base
     military=naval_base: ES:Tag:military=naval base
     military=training_area: ES:Tag:military=training area
     name=Dollarama: ES:Tag:name=Dollarama
@@ -12052,6 +13070,7 @@ es:
     natural=hill: ES:Tag:natural=hill
     natural=meadow: ES:Tag:natural=meadow
     natural=moor: ES:Tag:natural=moor
+    natural=mountain_range: ES:Tag:natural=mountain range
     natural=mud: ES:Tag:natural=mud
     natural=naled: ES:Tag:natural=naled
     natural=peak: ES:Tag:natural=peak
@@ -12063,6 +13082,8 @@ es:
     natural=scree: ES:Tag:natural=scree
     natural=scrub: ES:Tag:natural=scrub
     natural=shingle: ES:Tag:natural=shingle
+    natural=shoal: ES:Tag:natural=shoal
+    natural=shrub: ES:Tag:natural=shrub
     natural=sinkhole: ES:Tag:natural=sinkhole
     natural=spring: ES:Tag:natural=spring
     natural=stone: ES:Tag:natural=stone
@@ -12079,6 +13100,7 @@ es:
     network=VE:R:PO: ES:Tag:network=VE:R:PO
     network=VE:T:PO: ES:Tag:network=VE:T:PO
     network=VE:ramal:portuguesa: ES:Tag:network=VE:ramal:portuguesa
+    noname=yes: ES:Tag:noname=yes
     office=accountant: ES:Tag:office=accountant
     office=administrative: ES:Tag:office=administrative
     office=advertising_agency: ES:Tag:office=advertising agency
@@ -12120,12 +13142,17 @@ es:
     office=telecommunication: ES:Tag:office=telecommunication
     office=therapist: ES:Tag:office=therapist
     office=travel_agent: ES:Tag:office=travel agent
+    office=union: ES:Tag:office=union
     office=visa: ES:Tag:office=visa
     office=water_utility: ES:Tag:office=water utility
     office=yes: ES:Tag:office=yes
+    oneway:bicycle=yes: ES:Tag:oneway:bicycle=yes
     oneway=reversible: ES:Tag:oneway=reversible
     operator=GRDF: ES:Tag:operator=GRDF
+    parking=lane: ES:Tag:parking=lane
+    parking=multi-storey: ES:Tag:parking=multi-storey
     parking=street_side: ES:Tag:parking=street side
+    parking=underground: ES:Tag:parking=underground
     passenger=yes: ES:Tag:passenger=yes
     place=allotments: ES:Tag:place=allotments
     place=archipelago: ES:Tag:place=archipelago
@@ -12155,6 +13182,10 @@ es:
     place=suburb: ES:Tag:place=suburb
     place=town: ES:Tag:place=town
     place=village: ES:Tag:place=village
+    plant:method=photovoltaic: ES:Tag:plant:method=photovoltaic
+    plant:method=thermal: ES:Tag:plant:method=thermal
+    plant:source=solar: ES:Tag:plant:source=solar
+    playground=structure: ES:Tag:playground=structure
     police=barracks: ES:Tag:police=barracks
     police=car_pound: ES:Tag:police=car pound
     police=checkpoint: ES:Tag:police=checkpoint
@@ -12168,6 +13199,7 @@ es:
     power=generator: ES:Tag:power=generator
     power=heliostat: ES:Tag:power=heliostat
     power=line: ES:Tag:power=line
+    power=plant: ES:Tag:power=plant
     power=pole: ES:Tag:power=pole
     power=substation: ES:Tag:power=substation
     power=tower: ES:Tag:power=tower
@@ -12189,16 +13221,19 @@ es:
     railway=platform: ES:Tag:railway=platform
     railway=rail: ES:Tag:railway=rail
     railway=station: ES:Tag:railway=station
+    railway=stop: ES:Tag:railway=stop
     railway=subway: ES:Tag:railway=subway
     railway=subway_entrance: ES:Tag:railway=subway entrance
     railway=tram: ES:Tag:railway=tram
     railway=tram_stop: ES:Tag:railway=tram stop
     railway=yard: ES:Tag:railway=yard
+    recycling_type=centre: ES:Tag:recycling type=centre
     religion=christian: ES:Tag:religion=christian
     residential=university: ES:Tag:residential=university
     roller_coaster=track: ES:Tag:roller coaster=track
     route=bus: ES:Tag:route=bus
     route=ferry: ES:Tag:route=ferry
+    route=hiking: ES:Tag:route=hiking
     route=light_rail: ES:Tag:route=light rail
     route=monorail: ES:Tag:route=monorail
     route=railway: ES:Tag:route=railway
@@ -12211,6 +13246,7 @@ es:
     route=worship: ES:Tag:route=worship
     service=aircraft_control: ES:Tag:service=aircraft control
     service=alley: ES:Tag:service=alley
+    service=busway: ES:Tag:service=busway
     service=crossover: ES:Tag:service=crossover
     service=drive-through: ES:Tag:service=drive-through
     service=driveway: ES:Tag:service=driveway
@@ -12222,22 +13258,26 @@ es:
     shelter_type=public_transport: ES:Tag:shelter type=public transport
     shop=agrarian: ES:Tag:shop=agrarian
     shop=alcohol: ES:Tag:shop=alcohol
+    shop=anime: ES:Tag:shop=anime
     shop=appliance: ES:Tag:shop=appliance
     shop=art: ES:Tag:shop=art
     shop=baby_goods: ES:Tag:shop=baby goods
     shop=bakery: ES:Tag:shop=bakery
     shop=bathroom_furnishing: ES:Tag:shop=bathroom furnishing
+    shop=beauty: ES:Tag:shop=beauty
     shop=bed: ES:Tag:shop=bed
     shop=beverages: ES:Tag:shop=beverages
     shop=bicycle: ES:Tag:shop=bicycle
     shop=bookmaker: ES:Tag:shop=bookmaker
     shop=books: ES:Tag:shop=books
     shop=butcher: ES:Tag:shop=butcher
+    shop=cannabis: ES:Tag:shop=cannabis
     shop=car: ES:Tag:shop=car
     shop=car_parts: ES:Tag:shop=car parts
     shop=car_repair: ES:Tag:shop=car repair
     shop=carpet: ES:Tag:shop=carpet
     shop=charity: ES:Tag:shop=charity
+    shop=cheese: ES:Tag:shop=cheese
     shop=chemist: ES:Tag:shop=chemist
     shop=chocolate: ES:Tag:shop=chocolate
     shop=clothes: ES:Tag:shop=clothes
@@ -12247,15 +13287,19 @@ es:
     shop=convenience: ES:Tag:shop=convenience
     shop=copyshop: ES:Tag:shop=copyshop
     shop=craft: ES:Tag:shop=craft
+    shop=curtain: ES:Tag:shop=curtain
     shop=dairy: ES:Tag:shop=dairy
     shop=deli: ES:Tag:shop=deli
     shop=department_store: ES:Tag:shop=department store
     shop=doityourself: ES:Tag:shop=doityourself
+    shop=dry_cleaning: ES:Tag:shop=dry cleaning
     shop=electrical: ES:Tag:shop=electrical
     shop=electronics: ES:Tag:shop=electronics
     shop=energy: ES:Tag:shop=energy
     shop=erotic: ES:Tag:shop=erotic
+    shop=estate_agent: ES:Tag:shop=estate agent
     shop=fabric: ES:Tag:shop=fabric
+    shop=farm: ES:Tag:shop=farm
     shop=fashion_accessories: ES:Tag:shop=fashion accessories
     shop=fireplace: ES:Tag:shop=fireplace
     shop=fishing: ES:Tag:shop=fishing
@@ -12266,9 +13310,11 @@ es:
     shop=games: ES:Tag:shop=games
     shop=garden_centre: ES:Tag:shop=garden centre
     shop=gas: ES:Tag:shop=gas
+    shop=general: ES:Tag:shop=general
     shop=gift: ES:Tag:shop=gift
     shop=glaziery: ES:Tag:shop=glaziery
     shop=greengrocer: ES:Tag:shop=greengrocer
+    shop=grocery: ES:Tag:shop=grocery
     shop=hairdresser: ES:Tag:shop=hairdresser
     shop=hardware: ES:Tag:shop=hardware
     shop=health_food: ES:Tag:shop=health food
@@ -12286,14 +13332,18 @@ es:
     shop=locksmith: ES:Tag:shop=locksmith
     shop=lottery: ES:Tag:shop=lottery
     shop=mall: ES:Tag:shop=mall
+    shop=massage: ES:Tag:shop=massage
     shop=medical: ES:Tag:shop=medical
     shop=medical_supply: ES:Tag:shop=medical supply
     shop=mobile_phone: ES:Tag:shop=mobile phone
     shop=model: ES:Tag:shop=model
+    shop=money_lender: ES:Tag:shop=money lender
     shop=motorcycle: ES:Tag:shop=motorcycle
     shop=motorcycle_repair: ES:Tag:shop=motorcycle repair
     shop=music: ES:Tag:shop=music
     shop=musical_instrument: ES:Tag:shop=musical instrument
+    shop=newsagent: ES:Tag:shop=newsagent
+    shop=nutrition_supplements: ES:Tag:shop=nutrition supplements
     shop=nuts: ES:Tag:shop=nuts
     shop=optician: ES:Tag:shop=optician
     shop=outdoor: ES:Tag:shop=outdoor
@@ -12306,6 +13356,7 @@ es:
     shop=pet_grooming: ES:Tag:shop=pet grooming
     shop=photo: ES:Tag:shop=photo
     shop=pottery: ES:Tag:shop=pottery
+    shop=pyrotechnics: ES:Tag:shop=pyrotechnics
     shop=radiotechnics: ES:Tag:shop=radiotechnics
     shop=rental: ES:Tag:shop=rental
     shop=rice: ES:Tag:shop=rice
@@ -12319,6 +13370,8 @@ es:
     shop=stationery: ES:Tag:shop=stationery
     shop=storage_rental: ES:Tag:shop=storage rental
     shop=supermarket: ES:Tag:shop=supermarket
+    shop=surf: ES:Tag:shop=surf
+    shop=tailor: ES:Tag:shop=tailor
     shop=tattoo: ES:Tag:shop=tattoo
     shop=tea: ES:Tag:shop=tea
     shop=ticket: ES:Tag:shop=ticket
@@ -12335,20 +13388,33 @@ es:
     shop=weapons: ES:Tag:shop=weapons
     shop=wholesale: ES:Tag:shop=wholesale
     shop=window_blind: ES:Tag:shop=window blind
+    shop=wine: ES:Tag:shop=wine
     shop=yes: ES:Tag:shop=yes
     sinkhole=estavelle: ES:Tag:sinkhole=estavelle
+    site_type=petroglyph: ES:Tag:site type=petroglyph
+    site_type=settlement: ES:Tag:site type=settlement
+    social_facility=assisted_living: ES:Tag:social facility=assisted living
     social_facility=clothing_bank: ES:Tag:social facility=clothing bank
     social_facility=food_bank: ES:Tag:social facility=food bank
+    social_facility=group_home: ES:Tag:social facility=group home
     social_facility=nursing_home: ES:Tag:social facility=nursing home
+    social_facility=outreach: ES:Tag:social facility=outreach
     social_facility=soup_kitchen: ES:Tag:social facility=soup kitchen
     source:geometry=Bing: ES:Tag:source:geometry=Bing
+    sport=basketball: ES:Tag:sport=basketball
     sport=boules: ES:Tag:sport=boules
     sport=bullfighting: ES:Tag:sport=bullfighting
     sport=chess: ES:Tag:sport=chess
+    sport=climbing: ES:Tag:sport=climbing
+    sport=cockfighting: ES:Tag:sport=cockfighting
+    sport=cricket_nets: ES:Tag:sport=cricket nets
     sport=cycling: ES:Tag:sport=cycling
+    sport=dog_racing: ES:Tag:sport=dog racing
     sport=equestrian: ES:Tag:sport=equestrian
     sport=futsal: ES:Tag:sport=futsal
+    sport=golf: ES:Tag:sport=golf
     sport=handball: ES:Tag:sport=handball
+    sport=horse_racing: ES:Tag:sport=horse racing
     sport=model_aerodrome: ES:Tag:sport=model aerodrome
     sport=motocross: ES:Tag:sport=motocross
     sport=motor: ES:Tag:sport=motor
@@ -12360,19 +13426,30 @@ es:
     sport=pelota: ES:Tag:sport=pelota
     sport=shooting: ES:Tag:sport=shooting
     sport=soccer: ES:Tag:sport=soccer
+    sport=surfing: ES:Tag:sport=surfing
+    sport=swimming: ES:Tag:sport=swimming
     sport=table_tennis: ES:Tag:sport=table tennis
+    sport=tennis: ES:Tag:sport=tennis
+    sport=volleyball: ES:Tag:sport=volleyball
     sport=water_polo: ES:Tag:sport=water polo
+    sport=yoga: ES:Tag:sport=yoga
     station=subway: ES:Tag:station=subway
     street_vendor=yes: ES:Tag:street vendor=yes
+    substation=distribution: ES:Tag:substation=distribution
+    substation=minor_distribution: ES:Tag:substation=minor distribution
+    substation=transmission: ES:Tag:substation=transmission
     surface=asphalt: ES:Tag:surface=asphalt
     surface=compacted: ES:Tag:surface=compacted
     surface=concrete: ES:Tag:surface=concrete
+    surface=paved: ES:Tag:surface=paved
     surface=tartan: ES:Tag:surface=tartan
     surface=unpaved: ES:Tag:surface=unpaved
     switch=disconnector: ES:Tag:switch=disconnector
+    tactile_paving=no: ES:Tag:tactile paving=no
     telecom=connection_point: ES:Tag:telecom=connection point
     telecom=service_device: ES:Tag:telecom=service device
     theatre:type=open_air: ES:Tag:theatre:type=open air
+    toll=yes: ES:Tag:toll=yes
     tomb=cenotaph: ES:Tag:tomb=cenotaph
     tomb=columbarium: ES:Tag:tomb=columbarium
     tomb=mausoleum: ES:Tag:tomb=mausoleum
@@ -12394,6 +13471,7 @@ es:
     tourism=motel: ES:Tag:tourism=motel
     tourism=museum: ES:Tag:tourism=museum
     tourism=picnic_site: ES:Tag:tourism=picnic site
+    tourism=theme_park: ES:Tag:tourism=theme park
     tourism=trail_riding_station: ES:Tag:tourism=trail riding station
     tourism=viewpoint: ES:Tag:tourism=viewpoint
     tourism=wilderness_hut: ES:Tag:tourism=wilderness hut
@@ -12405,8 +13483,18 @@ es:
     tower:type=minaret: ES:Tag:tower:type=minaret
     tower:type=observation: ES:Tag:tower:type=observation
     tower:type=watchtower: ES:Tag:tower:type=watchtower
+    traffic_calming=bump: ES:Tag:traffic calming=bump
+    traffic_calming=cushion: ES:Tag:traffic calming=cushion
+    traffic_calming=dip: ES:Tag:traffic calming=dip
+    traffic_calming=hump: ES:Tag:traffic calming=hump
     traffic_calming=island: ES:Tag:traffic calming=island
+    traffic_calming=rumble_strip: ES:Tag:traffic calming=rumble strip
+    traffic_calming=table: ES:Tag:traffic calming=table
+    traffic_sign=city_limit: ES:Tag:traffic sign=city limit
+    transformer=distribution: ES:Tag:transformer=distribution
+    trees=apple_trees: ES:Tag:trees=apple trees
     trees=oil_palms: ES:Tag:trees=oil palms
+    trees=olive_trees: ES:Tag:trees=olive trees
     tunnel=building_passage: ES:Tag:tunnel=building passage
     tunnel=culvert: ES:Tag:tunnel=culvert
     type=public_transport: ES:Tag:type=public transport
@@ -12424,27 +13512,37 @@ es:
     vending=parcel_mail_in: ES:Tag:vending=parcel mail in
     vending=parcel_pickup: ES:Tag:vending=parcel pickup
     vending=parking_tickets: ES:Tag:vending=parking tickets
+    vending=public_transport_tickets: ES:Tag:vending=public transport tickets
     wall=dry_stone: ES:Tag:wall=dry stone
+    wall=noise_barrier: ES:Tag:wall=noise barrier
     wall=tire_barrier: ES:Tag:wall=tire barrier
+    water=canal: ES:Tag:water=canal
+    water=fish_pass: ES:Tag:water=fish pass
     water=lagoon: ES:Tag:water=lagoon
     water=lake: ES:Tag:water=lake
     water=pond: ES:Tag:water=pond
     water=reservoir: ES:Tag:water=reservoir
+    water=river: ES:Tag:water=river
+    water=wastewater: ES:Tag:water=wastewater
     waterway=canal: ES:Tag:waterway=canal
     waterway=dam: ES:Tag:waterway=dam
     waterway=ditch: ES:Tag:waterway=ditch
     waterway=dock: ES:Tag:waterway=dock
     waterway=drain: ES:Tag:waterway=drain
     waterway=milestone: ES:Tag:waterway=milestone
+    waterway=rapids: ES:Tag:waterway=rapids
     waterway=river: ES:Tag:waterway=river
     waterway=riverbank: ES:Tag:waterway=riverbank
     waterway=stream: ES:Tag:waterway=stream
     waterway=water_point: ES:Tag:waterway=water point
     waterway=weir: ES:Tag:waterway=weir
     wetland=bog: ES:Tag:wetland=bog
+    wetland=mangrove: ES:Tag:wetland=mangrove
+    wetland=reedbed: ES:Tag:wetland=reedbed
     wetland=tidalflat: ES:Tag:wetland=tidalflat
     wetland=wet_meadow: ES:Tag:wetland=wet meadow
     worship=stations_of_the_cross: ES:Tag:worship=stations of the cross
+    zoo=falconry: ES:Tag:zoo=falconry
 et:
   key:
     addr: Et:Key:addr
@@ -12480,8 +13578,10 @@ fa:
   tag:
     amenity=fountain: Fa:Tag:amenity=fountain
     amenity=fuel: Fa:Tag:amenity=fuel
+    amenity=vehicle_inspection: Fa:Tag:amenity=vehicle inspection
     barrier=block: Fa:Tag:barrier=block
     barrier=cable_barrier: Fa:Tag:barrier=cable barrier
+    canal=qanat: Fa:Tag:canal=qanat
     highway=footway: Fa:Tag:highway=footway
     highway=path: Fa:Tag:highway=path
     highway=residential: Fa:Tag:highway=residential
@@ -12494,10 +13594,12 @@ fa:
     highway=unclassified: Fa:Tag:highway=unclassified
     junction=yes: Fa:Tag:junction=yes
     man_made=qanat: Fa:Tag:man made=qanat
+    man_made=water_tower: Fa:Tag:man made=water tower
     natural=peak: Fa:Tag:natural=peak
     natural=ridge: Fa:Tag:natural=ridge
     office=quango: Fa:Tag:office=quango
     place=country: Fa:Tag:place=country
+    railway=level_crossing: Fa:Tag:railway=level crossing
     service=alley: Fa:Tag:service=alley
     shop=bookmaker: Fa:Tag:shop=bookmaker
     shop=garden_centre: Fa:Tag:shop=garden centre
@@ -12589,6 +13691,7 @@ fi:
     man_made=watermill: Fi:Tag:man made=watermill
     natural=tree: Fi:Tag:natural=tree
     natural=wetland: Fi:Tag:natural=wetland
+    place=village: Fi:Tag:place=village
     power=line: Fi:Tag:power=line
     power=minor_line: Fi:Tag:power=minor line
     power=pole: Fi:Tag:power=pole
@@ -12624,23 +13727,29 @@ fr:
     admin_level: FR:Key:admin level
     advertising: FR:Key:advertising
     aeroway: FR:Key:aeroway
+    agrarian: FR:Key:agrarian
+    agricultural: FR:Key:agricultural
     alt_name: FR:Key:alt name
     amenity: FR:Key:amenity
     animal: FR:Key:animal
     animated: FR:Key:animated
+    architect: FR:Key:architect
     area: FR:Key:area
     artist_name: FR:Key:artist name
     artwork_type: FR:Key:artwork type
     attraction: FR:Key:attraction
+    backcountry: FR:Key:backcountry
     backrest: FR:Key:backrest
     backward: FR:Key:backward
     barrier: FR:Key:barrier
     baseball: FR:Key:baseball
     basin: FR:Key:basin
     bench: FR:Key:bench
+    bench:type: FR:Key:bench:type
     bicycle: FR:Key:bicycle
     bicycle_parking: FR:Key:bicycle parking
     bicycle_road: FR:Key:bicycle road
+    bin: FR:Key:bin
     board_type: FR:Key:board type
     boat: FR:Key:boat
     bollard: FR:Key:bollard
@@ -12666,8 +13775,10 @@ fr:
     capacity: FR:Key:capacity
     capacity:disabled: FR:Key:capacity:disabled
     cargo: FR:Key:cargo
+    cargo_bike: FR:Key:cargo bike
     carpool: FR:Key:carpool
     cash_withdrawal: FR:Key:cash withdrawal
+    changesets_count: FR:Key:changesets count
     charge: FR:Key:charge
     check_date: FR:Key:check date
     class:bicycle:commute: FR:Key:class:bicycle:commute
@@ -12684,6 +13795,7 @@ fr:
     construction: FR:Key:construction
     contact: FR:Key:contact
     contact:email: FR:Key:contact:email
+    contact:facebook: FR:Key:contact:facebook
     contact:fax: FR:Key:contact:fax
     contact:phone: FR:Key:contact:phone
     contact:vhf: FR:Key:contact:vhf
@@ -12715,10 +13827,16 @@ fr:
     diet:kosher: FR:Key:diet:kosher
     diet:vegan: FR:Key:diet:vegan
     diet:vegetarian: FR:Key:diet:vegetarian
+    diocese: FR:Key:diocese
     diplomatic: FR:Key:diplomatic
     direction: FR:Key:direction
+    disabled: FR:Key:disabled
+    disc_golf: FR:Key:disc golf
     dispensing: FR:Key:dispensing
+    display: FR:Key:display
     distance: FR:Key:distance
+    divider: FR:Key:divider
+    dog: FR:Key:dog
     door: FR:Key:door
     drink: FR:Key:drink
     drinking_water: FR:Key:drinking water
@@ -12741,6 +13859,7 @@ fr:
     fee: FR:Key:fee
     female: FR:Key:female
     fence_type: FR:Key:fence type
+    fire_path: FR:Key:fire path
     fishing: FR:Key:fishing
     fixme: FR:Key:fixme
     floating: FR:Key:floating
@@ -12753,6 +13872,7 @@ fr:
     fuel: FR:Key:fuel
     garden:style: FR:Key:garden:style
     garden:type: FR:Key:garden:type
+    gay: FR:Key:gay
     generator:method: FR:Key:generator:method
     generator:output: FR:Key:generator:output
     generator:output:battery_charging: FR:Key:generator:output:battery charging
@@ -12771,7 +13891,9 @@ fr:
     government: FR:Key:government
     grande_circulation: FR:Key:grande circulation
     handle: FR:Key:handle
+    handrail: FR:Key:handrail
     happy_hours: FR:Key:happy hours
+    hazard: FR:Key:hazard
     healthcare: FR:Key:healthcare
     height: FR:Key:height
     heritage: FR:Key:heritage
@@ -12783,6 +13905,7 @@ fr:
     horse: FR:Key:horse
     hov: FR:Key:hov
     image: FR:Key:image
+    imagery_used: FR:Key:imagery used
     incline: FR:Key:incline
     indoor: FR:Key:indoor
     information: FR:Key:information
@@ -12796,6 +13919,7 @@ fr:
     ladder: FR:Key:ladder
     landfill:waste: FR:Key:landfill:waste
     landuse: FR:Key:landuse
+    lane_markings: FR:Key:lane markings
     lanes: FR:Key:lanes
     layer: FR:Key:layer
     leaf_type: FR:Key:leaf type
@@ -12805,6 +13929,7 @@ fr:
     length: FR:Key:length
     level: FR:Key:level
     lgbtq: FR:Key:lgbtq
+    lifeguard: FR:Key:lifeguard
     line_attachment: FR:Key:line attachment
     line_management: FR:Key:line management
     lit: FR:Key:lit
@@ -12833,6 +13958,9 @@ fr:
     maxstay: FR:Key:maxstay
     maxweight: FR:Key:maxweight
     maxwidth: FR:Key:maxwidth
+    mechanical_coupling: FR:Key:mechanical coupling
+    mechanical_driver: FR:Key:mechanical driver
+    medical_supply: FR:Key:medical supply
     memorial: FR:Key:memorial
     message: FR:Key:message
     microbrewery: FR:Key:microbrewery
@@ -12845,6 +13973,7 @@ fr:
     mooring: FR:Key:mooring
     motorboat: FR:Key:motorboat
     motorcycle:parking: FR:Key:motorcycle:parking
+    motorroad: FR:Key:motorroad
     mountain_pass: FR:Key:mountain pass
     mtb:scale: FR:Key:mtb:scale
     name: FR:Key:name
@@ -12857,7 +13986,6 @@ fr:
     network: FR:Key:network
     noexit: FR:Key:noexit
     non_existent_levels: FR:Key:non existent levels
-    noname: FR:Key:noname
     noref: FR:Key:noref
     note: FR:Key:note
     nudism: FR:Key:nudism
@@ -12879,9 +14007,11 @@ fr:
     outdoor_seating: FR:Key:outdoor seating
     overtaking: FR:Key:overtaking
     owner: FR:Key:owner
+    par: FR:Key:par
     parking: FR:Key:parking
     parking:condition: FR:Key:parking:condition
     parking:lane: FR:Key:parking:lane
+    parking_space: FR:Key:parking space
     paved:date: FR:Key:paved:date
     payment: FR:Key:payment
     payment:MoyenDePaiement: FR:Key:payment:MoyenDePaiement
@@ -12897,6 +14027,7 @@ fr:
     plant:output: FR:Key:plant:output
     playground: FR:Key:playground
     post_box:type: FR:Key:post box:type
+    post_office: FR:Key:post office
     post_office:type: FR:Key:post office:type
     power: FR:Key:power
     power_supply: FR:Key:power supply
@@ -12907,10 +14038,13 @@ fr:
     public_bookcase:type: FR:Key:public bookcase:type
     public_transport: FR:Key:public transport
     pump: FR:Key:pump
+    pump_mechanism: FR:Key:pump mechanism
     railway: FR:Key:railway
+    railway:preserved: FR:Key:railway:preserved
     railway:track_ref: FR:Key:railway:track ref
     ramp: FR:Key:ramp
     ref: FR:Key:ref
+    ref:CD:CNOP: FR:Key:ref:CD:CNOP
     ref:CEF: FR:Key:ref:CEF
     ref:ERDF:gdo: FR:Key:ref:ERDF:gdo
     ref:EU:EVSE: FR:Key:ref:EU:EVSE
@@ -12950,6 +14084,7 @@ fr:
     right: FR:Key:right
     roof:direction: FR:Key:roof:direction
     roof:material: FR:Key:roof:material
+    roof:shape: FR:Key:roof:shape
     room: FR:Key:room
     ruins: FR:Key:ruins
     sac_scale: FR:Key:sac scale
@@ -12959,6 +14094,7 @@ fr:
     seasonal: FR:Key:seasonal
     second_hand: FR:Key:second hand
     segregated: FR:Key:segregated
+    self_checkout: FR:Key:self checkout
     self_service: FR:Key:self service
     service: FR:Key:service
     service_times: FR:Key:service times
@@ -12981,6 +14117,7 @@ fr:
     source:name:br: FR:Key:source:name:br
     species: FR:Key:species
     species:fr: FR:Key:species:fr
+    species:wikidata: FR:Key:species:wikidata
     sport: FR:Key:sport
     stairs: FR:Key:stairs
     start_date: FR:Key:start date
@@ -12991,11 +14128,15 @@ fr:
     support: FR:Key:support
     surface: FR:Key:surface
     surveillance: FR:Key:surveillance
+    surveillance:type: FR:Key:surveillance:type
+    surveillance:zone: FR:Key:surveillance:zone
     survey:date: FR:Key:survey:date
     switch: FR:Key:switch
     symbol: FR:Key:symbol
     tactile_paving: FR:Key:tactile paving
+    tactile_writing: FR:Key:tactile writing
     takeaway: FR:Key:takeaway
+    taxi: FR:Key:taxi
     telecom: FR:Key:telecom
     telecom:medium: FR:Key:telecom:medium
     tickets:public_transport_subscription: FR:Key:tickets:public transport subscription
@@ -13030,27 +14171,35 @@ fr:
     vine_row_orientation: FR:Key:vine row orientation
     visibility: FR:Key:visibility
     voltage: FR:Key:voltage
+    voltage:primary: FR:Key:voltage:primary
+    voltage:secondary: FR:Key:voltage:secondary
     waste: FR:Key:waste
     water: FR:Key:water
+    water_source: FR:Key:water source
     waterway: FR:Key:waterway
     website: FR:Key:website
     wetland: FR:Key:wetland
     wheelchair: FR:Key:wheelchair
     wheelchair:description: FR:Key:wheelchair:description
     width: FR:Key:width
+    width:carriageway: FR:Key:width:carriageway
     wikidata: FR:Key:wikidata
     wikimedia_commons: FR:Key:wikimedia commons
     wikipedia: FR:Key:wikipedia
     windings: FR:Key:windings
     xmas:feature: FR:Key:xmas:feature
     year_of_construction: FR:Key:year of construction
+    zero_waste: FR:Key:zero waste
+    zoo: FR:Key:zoo
   tag:
     Bascule_publique: FR:Tag:Bascule publique
     FIXME=Position_estimated: FR:Tag:FIXME=Position estimated
+    abandoned:amenity=prison_camp: FR:Tag:abandoned:amenity=prison camp
     abandoned=yes: FR:Tag:abandoned=yes
     access=customers: FR:Tag:access=customers
     access=designated: FR:Tag:access=designated
     access=no: FR:Tag:access=no
+    access=permit: FR:Tag:access=permit
     access=private: FR:Tag:access=private
     actuator=electric_motor: FR:Tag:actuator=electric motor
     actuator=hydraulic_cylinder: FR:Tag:actuator=hydraulic cylinder
@@ -13070,6 +14219,7 @@ fr:
     aerialway=cable_car: FR:Tag:aerialway=cable car
     aerialway=chair_lift: FR:Tag:aerialway=chair lift
     aeroway=aerodrome: FR:Tag:aeroway=aerodrome
+    aeroway=airtanker_base: FR:Tag:aeroway=airtanker base
     aeroway=apron: FR:Tag:aeroway=apron
     aeroway=gate: FR:Tag:aeroway=gate
     aeroway=hangar: FR:Tag:aeroway=hangar
@@ -13078,6 +14228,7 @@ fr:
     aeroway=parking_position: FR:Tag:aeroway=parking position
     aeroway=runway: FR:Tag:aeroway=runway
     aeroway=taxiway: FR:Tag:aeroway=taxiway
+    aeroway=windsock: FR:Tag:aeroway=windsock
     amenity=animal_boarding: FR:Tag:amenity=animal boarding
     amenity=animal_breeding: FR:Tag:amenity=animal breeding
     amenity=animal_shelter: FR:Tag:amenity=animal shelter
@@ -13087,11 +14238,13 @@ fr:
     amenity=bar: FR:Tag:amenity=bar
     amenity=bbq: FR:Tag:amenity=bbq
     amenity=bench: FR:Tag:amenity=bench
+    amenity=bicycle_library: FR:Tag:amenity=bicycle library
     amenity=bicycle_parking: FR:Tag:amenity=bicycle parking
     amenity=bicycle_rental: FR:Tag:amenity=bicycle rental
     amenity=bicycle_repair_station: FR:Tag:amenity=bicycle repair station
     amenity=biergarten: FR:Tag:amenity=biergarten
     amenity=binoculars: FR:Tag:amenity=binoculars
+    amenity=bird_bath: FR:Tag:amenity=bird bath
     amenity=boat_rental: FR:Tag:amenity=boat rental
     amenity=boat_sharing: FR:Tag:amenity=boat sharing
     amenity=brothel: FR:Tag:amenity=brothel
@@ -13118,6 +14271,7 @@ fr:
     amenity=doctors: FR:Tag:amenity=doctors
     amenity=dog_toilet: FR:Tag:amenity=dog toilet
     amenity=drinking_water: FR:Tag:amenity=drinking water
+    amenity=driver_training: FR:Tag:amenity=driver training
     amenity=driving_school: FR:Tag:amenity=driving school
     amenity=dryer: FR:Tag:amenity=dryer
     amenity=embassy: FR:Tag:amenity=embassy
@@ -13129,6 +14283,7 @@ fr:
     amenity=fountain: FR:Tag:amenity=fountain
     amenity=fuel: FR:Tag:amenity=fuel
     amenity=funeral_hall: FR:Tag:amenity=funeral hall
+    amenity=game_feeding: FR:Tag:amenity=game feeding
     amenity=give_box: FR:Tag:amenity=give box
     amenity=grave_yard: FR:Tag:amenity=grave yard
     amenity=grit_bin: FR:Tag:amenity=grit bin
@@ -13142,6 +14297,7 @@ fr:
     amenity=letter_box: FR:Tag:amenity=letter box
     amenity=library: FR:Tag:amenity=library
     amenity=loading_dock: FR:Tag:amenity=loading dock
+    amenity=lounger: FR:Tag:amenity=lounger
     amenity=love_hotel: FR:Tag:amenity=love hotel
     amenity=marae: FR:Tag:amenity=marae
     amenity=marketplace: FR:Tag:amenity=marketplace
@@ -13156,6 +14312,7 @@ fr:
     amenity=parking_space: FR:Tag:amenity=parking space
     amenity=pharmacy: FR:Tag:amenity=pharmacy
     amenity=photo_booth: FR:Tag:amenity=photo booth
+    amenity=place_of_mourning: FR:Tag:amenity=place of mourning
     amenity=place_of_worship: FR:Tag:amenity=place of worship
     amenity=planetarium: FR:Tag:amenity=planetarium
     amenity=police: FR:Tag:amenity=police
@@ -13185,6 +14342,7 @@ fr:
     amenity=toilets: FR:Tag:amenity=toilets
     amenity=townhall: FR:Tag:amenity=townhall
     amenity=toy_library: FR:Tag:amenity=toy library
+    amenity=trolley_bay: FR:Tag:amenity=trolley bay
     amenity=university: FR:Tag:amenity=university
     amenity=vacuum_cleaner: FR:Tag:amenity=vacuum cleaner
     amenity=vehicle_inspection: FR:Tag:amenity=vehicle inspection
@@ -13266,7 +14424,9 @@ fr:
     building=commercial: FR:Tag:building=commercial
     building=construction: FR:Tag:building=construction
     building=detached: FR:Tag:building=detached
+    building=digester: FR:Tag:building=digester
     building=farm: FR:Tag:building=farm
+    building=fire_lookout: FR:Tag:building=fire lookout
     building=fire_station: FR:Tag:building=fire station
     building=garage: FR:Tag:building=garage
     building=garages: FR:Tag:building=garages
@@ -13289,13 +14449,16 @@ fr:
     building=ruins: FR:Tag:building=ruins
     building=semidetached_house: FR:Tag:building=semidetached house
     building=shed: FR:Tag:building=shed
+    building=slurry_tank: FR:Tag:building=slurry tank
     building=sports_hall: FR:Tag:building=sports hall
     building=stable: FR:Tag:building=stable
     building=stadium: FR:Tag:building=stadium
     building=sty: FR:Tag:building=sty
+    building=tent: FR:Tag:building=tent
     building=terrace: FR:Tag:building=terrace
     building=warehouse: FR:Tag:building=warehouse
     cafe=time-cafe: FR:Tag:cafe=time-cafe
+    cemetery=war_cemetery: FR:Tag:cemetery=war cemetery
     club=sport: FR:Tag:club=sport
     construction=yes: FR:Tag:construction=yes
     craft=agricultural_engines: FR:Tag:craft=agricultural engines
@@ -13379,6 +14542,7 @@ fr:
     craft=window_construction: FR:Tag:craft=window construction
     craft=winery: FR:Tag:craft=winery
     crossing=zebra: FR:Tag:crossing=zebra
+    crossing_ref=zebra: FR:Tag:crossing ref=zebra
     cuisine=coffee_shop: FR:Tag:cuisine=coffee shop
     cycleway:right=lane: FR:Tag:cycleway:right=lane
     cycleway=asl: FR:Tag:cycleway=asl
@@ -13398,6 +14562,7 @@ fr:
     emergency=fire_flapper: FR:Tag:emergency=fire flapper
     emergency=fire_hose: FR:Tag:emergency=fire hose
     emergency=fire_hydrant: FR:Tag:emergency=fire hydrant
+    emergency=fire_lookout: FR:Tag:emergency=fire lookout
     emergency=fire_sand_bin: FR:Tag:emergency=fire sand bin
     emergency=fire_water_pond: FR:Tag:emergency=fire water pond
     emergency=landing_site: FR:Tag:emergency=landing site
@@ -13411,6 +14576,7 @@ fr:
     emergency=water_rescue_station: FR:Tag:emergency=water rescue station
     emergency=water_tank: FR:Tag:emergency=water tank
     fast_food=cafeteria: FR:Tag:fast food=cafeteria
+    footway=access_aisle: FR:Tag:footway=access aisle
     footway=crossing: FR:Tag:footway=crossing
     footway=sidewalk: FR:Tag:footway=sidewalk
     generator:method=combustion: FR:Tag:generator:method=combustion
@@ -13423,20 +14589,27 @@ fr:
     generator:source=biogas: FR:Tag:generator:source=biogas
     generator:source=biomass: FR:Tag:generator:source=biomass
     generator:source=coal: FR:Tag:generator:source=coal
+    generator:source=diesel: FR:Tag:generator:source=diesel
     generator:source=gas: FR:Tag:generator:source=gas
     generator:source=hydro: FR:Tag:generator:source=hydro
     generator:source=nuclear: FR:Tag:generator:source=nuclear
     generator:source=oil: FR:Tag:generator:source=oil
     generator:source=solar: FR:Tag:generator:source=solar
     generator:source=tidal: FR:Tag:generator:source=tidal
+    generator:source=waste: FR:Tag:generator:source=waste
     generator:source=wind: FR:Tag:generator:source=wind
     government=ministry: FR:Tag:government=ministry
     government=register_office: FR:Tag:government=register office
     government=tax: FR:Tag:government=tax
+    handle=lever: FR:Tag:handle=lever
     handle=wheel: FR:Tag:handle=wheel
+    hazard=dangerous_junction: FR:Tag:hazard=dangerous junction
     healthcare=blood_donation: FR:Tag:healthcare=blood donation
+    healthcare=clinic: FR:Tag:healthcare=clinic
+    healthcare=doctor: FR:Tag:healthcare=doctor
     healthcare=laboratory: FR:Tag:healthcare=laboratory
     healthcare=physiotherapist: FR:Tag:healthcare=physiotherapist
+    healthcare=vaccination_centre: FR:Tag:healthcare=vaccination centre
     highway=bridleway: FR:Tag:highway=bridleway
     highway=bus_guideway: FR:Tag:highway=bus guideway
     highway=bus_stop: FR:Tag:highway=bus stop
@@ -13473,6 +14646,7 @@ fr:
     highway=track: FR:Tag:highway=track
     highway=traffic_mirror: FR:Tag:highway=traffic mirror
     highway=traffic_signals: FR:Tag:highway=traffic signals
+    highway=trailhead: FR:Tag:highway=trailhead
     highway=trunk: FR:Tag:highway=trunk
     highway=turning_circle: FR:Tag:highway=turning circle
     highway=unclassified: FR:Tag:highway=unclassified
@@ -13517,6 +14691,7 @@ fr:
     information=office: FR:Tag:information=office
     information=terminal: FR:Tag:information=terminal
     junction=roundabout: FR:Tag:junction=roundabout
+    junction=yes: FR:Tag:junction=yes
     landcover=grass: FR:Tag:landcover=grass
     landuse=allotments: FR:Tag:landuse=allotments
     landuse=animal_keeping: FR:Tag:landuse=animal keeping
@@ -13526,17 +14701,20 @@ fr:
     landuse=cemetery: FR:Tag:landuse=cemetery
     landuse=commercial: FR:Tag:landuse=commercial
     landuse=construction: FR:Tag:landuse=construction
+    landuse=education: FR:Tag:landuse=education
     landuse=farm: FR:Tag:landuse=farm
     landuse=farmland: FR:Tag:landuse=farmland
     landuse=farmyard: FR:Tag:landuse=farmyard
     landuse=flowerbed: FR:Tag:landuse=flowerbed
     landuse=forest: FR:Tag:landuse=forest
+    landuse=forestry: FR:Tag:landuse=forestry
     landuse=garages: FR:Tag:landuse=garages
     landuse=grass: FR:Tag:landuse=grass
     landuse=greenhouse_horticulture: FR:Tag:landuse=greenhouse horticulture
     landuse=industrial: FR:Tag:landuse=industrial
     landuse=landfill: FR:Tag:landuse=landfill
     landuse=meadow: FR:Tag:landuse=meadow
+    landuse=military: FR:Tag:landuse=military
     landuse=orchard: FR:Tag:landuse=orchard
     landuse=plant_nursery: FR:Tag:landuse=plant nursery
     landuse=pond: FR:Tag:landuse=pond
@@ -13547,6 +14725,7 @@ fr:
     landuse=salt_pond: FR:Tag:landuse=salt pond
     landuse=village_green: FR:Tag:landuse=village green
     leaf_cycle=deciduous: FR:Tag:leaf cycle=deciduous
+    leaf_type=needleleaved: FR:Tag:leaf type=needleleaved
     leisure=bandstand: FR:Tag:leisure=bandstand
     leisure=bird_hide: FR:Tag:leisure=bird hide
     leisure=bleachers: FR:Tag:leisure=bleachers
@@ -13562,13 +14741,16 @@ fr:
     leisure=golf_course: FR:Tag:leisure=golf course
     leisure=hackerspace: FR:Tag:leisure=hackerspace
     leisure=horse_riding: FR:Tag:leisure=horse riding
+    leisure=ice_rink: FR:Tag:leisure=ice rink
     leisure=miniature_golf: FR:Tag:leisure=miniature golf
+    leisure=outdoor_seating: FR:Tag:leisure=outdoor seating
     leisure=paddling_pool: FR:Tag:leisure=paddling pool
     leisure=park: FR:Tag:leisure=park
     leisure=picnic_table: FR:Tag:leisure=picnic table
     leisure=pitch: FR:Tag:leisure=pitch
     leisure=playground: FR:Tag:leisure=playground
     leisure=sauna: FR:Tag:leisure=sauna
+    leisure=schoolyard: FR:Tag:leisure=schoolyard
     leisure=slipway: FR:Tag:leisure=slipway
     leisure=sports_centre: FR:Tag:leisure=sports centre
     leisure=stadium: FR:Tag:leisure=stadium
@@ -13577,6 +14759,8 @@ fr:
     leisure=tanning_salon: FR:Tag:leisure=tanning salon
     leisure=track: FR:Tag:leisure=track
     leisure=water_park: FR:Tag:leisure=water park
+    lifeguard=base: FR:Tag:lifeguard=base
+    lifeguard=tower: FR:Tag:lifeguard=tower
     line_attachment=anchor: FR:Tag:line attachment=anchor
     line_attachment=pin: FR:Tag:line attachment=pin
     line_attachment=pulley: FR:Tag:line attachment=pulley
@@ -13584,11 +14768,14 @@ fr:
     line_management=branch: FR:Tag:line management=branch
     line_management=split: FR:Tag:line management=split
     man_made=adit: FR:Tag:man made=adit
+    man_made=architecture_line: FR:Tag:man made=architecture line
     man_made=beehive: FR:Tag:man made=beehive
     man_made=bridge: FR:Tag:man made=bridge
     man_made=carpet_hanger: FR:Tag:man made=carpet hanger
+    man_made=cellar_entrance: FR:Tag:man made=cellar entrance
     man_made=cutline: FR:Tag:man made=cutline
     man_made=dovecote: FR:Tag:man made=dovecote
+    man_made=embankment: FR:Tag:man made=embankment
     man_made=flagpole: FR:Tag:man made=flagpole
     man_made=flare: FR:Tag:man made=flare
     man_made=ice_house: FR:Tag:man made=ice house
@@ -13608,6 +14795,7 @@ fr:
     man_made=surveillance: FR:Tag:man made=surveillance
     man_made=survey_point: FR:Tag:man made=survey point
     man_made=tower: FR:Tag:man made=tower
+    man_made=utility_pole: FR:Tag:man made=utility pole
     man_made=wastewater_plant: FR:Tag:man made=wastewater plant
     man_made=water_tap: FR:Tag:man made=water tap
     man_made=water_tower: FR:Tag:man made=water tower
@@ -13653,6 +14841,8 @@ fr:
     natural=water: FR:Tag:natural=water
     natural=wetland: FR:Tag:natural=wetland
     natural=wood: FR:Tag:natural=wood
+    noname=no: FR:Tag:noname=no
+    noname=yes: FR:Tag:noname=yes
     office=advertising_agency: FR:Tag:office=advertising agency
     office=association: FR:Tag:office=association
     office=company: FR:Tag:office=company
@@ -13667,12 +14857,16 @@ fr:
     office=logistics: FR:Tag:office=logistics
     office=newspaper: FR:Tag:office=newspaper
     office=ngo: FR:Tag:office=ngo
+    office=parish: FR:Tag:office=parish
     office=political_party: FR:Tag:office=political party
     office=religion: FR:Tag:office=religion
+    office=supervised_injection_site: FR:Tag:office=supervised injection site
     operator=ERDF: FR:Tag:operator=ERDF
     operator=Enedis: FR:Tag:operator=Enedis
     operator=GRDF: FR:Tag:operator=GRDF
+    operator=RTE: FR:Tag:operator=RTE
     parking=street_side: FR:Tag:parking=street side
+    pipeline=substation: FR:Tag:pipeline=substation
     pipeline=valve: FR:Tag:pipeline=valve
     piste:type=nordic: FR:Tag:piste:type=nordic
     place=city: FR:Tag:place=city
@@ -13711,7 +14905,6 @@ fr:
     public_transport=stop_area: FR:Tag:public transport=stop area
     public_transport=stop_position: FR:Tag:public transport=stop position
     pump=powered: FR:Tag:pump=powered
-    railway=crossing: FR:Tag:railway=crossing
     railway=disused: FR:Tag:railway=disused
     railway=funicular: FR:Tag:railway=funicular
     railway=halt: FR:Tag:railway=halt
@@ -13727,6 +14920,7 @@ fr:
     railway=tram: FR:Tag:railway=tram
     railway=tram_stop: FR:Tag:railway=tram stop
     railway=water_crane: FR:Tag:railway=water crane
+    recycling_type=centre: FR:Tag:recycling type=centre
     religion=buddhist: FR:Tag:religion=buddhist
     religion=christian: FR:Tag:religion=christian
     religion=hindu: FR:Tag:religion=hindu
@@ -13739,11 +14933,15 @@ fr:
     religion=taoist: FR:Tag:religion=taoist
     religion=zoroastrian: FR:Tag:religion=zoroastrian
     repair=assisted_self_service: FR:Tag:repair=assisted self service
+    request_stop=yes: FR:Tag:request stop=yes
+    residential=halting_site: FR:Tag:residential=halting site
     route=bicycle: FR:Tag:route=bicycle
     route=bus: FR:Tag:route=bus
     route=coach: FR:Tag:route=coach
     route=ferry: FR:Tag:route=ferry
     route=fitness_trail: FR:Tag:route=fitness trail
+    route=foot: FR:Tag:route=foot
+    route=hiking: FR:Tag:route=hiking
     route=piste: FR:Tag:route=piste
     route=railway: FR:Tag:route=railway
     route=subway: FR:Tag:route=subway
@@ -13756,6 +14954,7 @@ fr:
     service=driveway: FR:Tag:service=driveway
     service=parking_aisle: FR:Tag:service=parking aisle
     shelter_type=basic_hut: FR:Tag:shelter type=basic hut
+    shelter_type=changing_rooms: FR:Tag:shelter type=changing rooms
     shelter_type=lean_to: FR:Tag:shelter type=lean to
     shop=agrarian: FR:Tag:shop=agrarian
     shop=alcohol: FR:Tag:shop=alcohol
@@ -13801,6 +15000,7 @@ fr:
     shop=furnace: FR:Tag:shop=furnace
     shop=furniture: FR:Tag:shop=furniture
     shop=garden_centre: FR:Tag:shop=garden centre
+    shop=general: FR:Tag:shop=general
     shop=gift: FR:Tag:shop=gift
     shop=greengrocer: FR:Tag:shop=greengrocer
     shop=haberdashery: FR:Tag:shop=haberdashery
@@ -13814,6 +15014,7 @@ fr:
     shop=kiosk: FR:Tag:shop=kiosk
     shop=kitchen: FR:Tag:shop=kitchen
     shop=laundry: FR:Tag:shop=laundry
+    shop=mall: FR:Tag:shop=mall
     shop=medical_supply: FR:Tag:shop=medical supply
     shop=military_surplus: FR:Tag:shop=military surplus
     shop=mobile_phone: FR:Tag:shop=mobile phone
@@ -13839,6 +15040,7 @@ fr:
     shop=variety_store: FR:Tag:shop=variety store
     shop=video: FR:Tag:shop=video
     shop=video_games: FR:Tag:shop=video games
+    shop=window_blind: FR:Tag:shop=window blind
     sinkhole=estavelle: FR:Tag:sinkhole=estavelle
     social_facility=ambulatory_care: FR:Tag:social facility=ambulatory care
     sport=8pin: FR:Tag:sport=8pin
@@ -13854,6 +15056,7 @@ fr:
     sport=free_flying: FR:Tag:sport=free flying
     sport=hockey: FR:Tag:sport=hockey
     sport=horse_racing: FR:Tag:sport=horse racing
+    sport=motocross: FR:Tag:sport=motocross
     sport=rugby_league: FR:Tag:sport=rugby league
     sport=rugby_union: FR:Tag:sport=rugby union
     sport=sailing: FR:Tag:sport=sailing
@@ -13903,11 +15106,25 @@ fr:
     tower:type=bell_tower: FR:Tag:tower:type=bell tower
     tower:type=communication: FR:Tag:tower:type=communication
     tower:type=hose: FR:Tag:tower:type=hose
+    traffic_calming=bump: FR:Tag:traffic calming=bump
+    traffic_calming=chicane: FR:Tag:traffic calming=chicane
+    traffic_calming=choked_island: FR:Tag:traffic calming=choked island
+    traffic_calming=choked_table: FR:Tag:traffic calming=choked table
+    traffic_calming=choker: FR:Tag:traffic calming=choker
+    traffic_calming=cushion: FR:Tag:traffic calming=cushion
+    traffic_calming=dip: FR:Tag:traffic calming=dip
+    traffic_calming=double_dip: FR:Tag:traffic calming=double dip
+    traffic_calming=dynamic_bump: FR:Tag:traffic calming=dynamic bump
+    traffic_calming=hump: FR:Tag:traffic calming=hump
+    traffic_calming=island: FR:Tag:traffic calming=island
+    traffic_calming=rumble_strip: FR:Tag:traffic calming=rumble strip
     traffic_calming=table: FR:Tag:traffic calming=table
     traffic_sign=city_limit: FR:Tag:traffic sign=city limit
     transformer=auxiliary: FR:Tag:transformer=auxiliary
+    transformer=converter: FR:Tag:transformer=converter
     transformer=distribution: FR:Tag:transformer=distribution
     transformer=generator: FR:Tag:transformer=generator
+    transformer=phase_angle_regulator: FR:Tag:transformer=phase angle regulator
     transformer=traction: FR:Tag:transformer=traction
     tunnel=culvert: FR:Tag:tunnel=culvert
     tunnel=flooded: FR:Tag:tunnel=flooded
@@ -13964,6 +15181,15 @@ fr:
     wetland=marsh: FR:Tag:wetland=marsh
     wetland=reedbed: FR:Tag:wetland=reedbed
     wetland=swamp: FR:Tag:wetland=swamp
+    zoo=aviary: FR:Tag:zoo=aviary
+    zoo=birds: FR:Tag:zoo=birds
+    zoo=butterfly: FR:Tag:zoo=butterfly
+    zoo=enclosure: FR:Tag:zoo=enclosure
+    zoo=falconry: FR:Tag:zoo=falconry
+    zoo=petting_zoo: FR:Tag:zoo=petting zoo
+    zoo=reptile: FR:Tag:zoo=reptile
+    zoo=safari_park: FR:Tag:zoo=safari park
+    zoo=wildlife_park: FR:Tag:zoo=wildlife park
 gl:
   key:
     contact:facebook: Gl:Key:contact:facebook
@@ -13990,6 +15216,8 @@ gl:
     emergency=emergency_ward_entrance: Gl:Tag:emergency=emergency ward entrance
     emergency=yes: Gl:Tag:emergency=yes
     leisure=outdoor_seating: Gl:Tag:leisure=outdoor seating
+    natural=bare_rock: Gl:Tag:natural=bare rock
+    natural=stone: Gl:Tag:natural=stone
     natural=tree_row: Gl:Tag:natural=tree row
     railway=tram: Gl:Tag:railway=tram
     shop=vacant: Gl:Tag:shop=vacant
@@ -14003,6 +15231,7 @@ he:
     fax: He:Key:fax
 hr:
   key:
+    addr: Hr:Key:addr
     amenity: Hr:Key:amenity
     historic: Hr:Key:historic
     leisure: Hr:Key:leisure
@@ -14052,6 +15281,7 @@ hu:
     railway: Hu:Key:railway
     ref:HU:edid: Hu:Key:ref:HU:edid
     shop: Hu:Key:shop
+    smoothness: Hu:Key:smoothness
     surface: Hu:Key:surface
     symbol: Hu:Key:symbol
     tourism: Hu:Key:tourism
@@ -14065,6 +15295,7 @@ hu:
     barrier=bollard: Hu:Tag:barrier=bollard
     boundary=administrative: Hu:Tag:boundary=administrative
     highway=street_lamp: Hu:Tag:highway=street lamp
+    highway=traffic_signals: Hu:Tag:highway=traffic signals
     leaf_cycle=deciduous: Hu:Tag:leaf cycle=deciduous
     leaf_cycle=evergreen: Hu:Tag:leaf cycle=evergreen
     leaf_type=needleleaved: Hu:Tag:leaf type=needleleaved
@@ -14092,8 +15323,10 @@ it:
     backrest: IT:Key:backrest
     barrier: IT:Key:barrier
     basin: IT:Key:basin
+    beauty: IT:Key:beauty
     bicycle: IT:Key:bicycle
     bicycle_parking: IT:Key:bicycle parking
+    bicycle_road: IT:Key:bicycle road
     books: IT:Key:books
     boundary: IT:Key:boundary
     brewery: IT:Key:brewery
@@ -14109,11 +15342,14 @@ it:
     communication:bos: IT:Key:communication:bos
     communication:mobile_phone: IT:Key:communication:mobile phone
     construction: IT:Key:construction
+    contact: IT:Key:contact
     contact:facebook: IT:Key:contact:facebook
     craft: IT:Key:craft
     crossing: IT:Key:crossing
     cutting: IT:Key:cutting
+    cyclestreet: IT:Key:cyclestreet
     cycleway: IT:Key:cycleway
+    delivery: IT:Key:delivery
     denomination: IT:Key:denomination
     description: IT:Key:description
     destination: IT:Key:destination
@@ -14121,14 +15357,17 @@ it:
     diet:*: IT:Key:diet:*
     diet:vegan: IT:Key:diet:vegan
     diet:vegetarian: IT:Key:diet:vegetarian
+    direction: IT:Key:direction
     'disused:': 'IT:Key:disused:'
     drink: IT:Key:drink
     ele: IT:Key:ele
     embankment: IT:Key:embankment
     enforcement: IT:Key:enforcement
+    est_width: IT:Key:est width
     fee: IT:Key:fee
     fence_type: IT:Key:fence type
     ford: IT:Key:ford
+    fruit: IT:Key:fruit
     fuel: IT:Key:fuel
     garden:type: IT:Key:garden:type
     generator:output: IT:Key:generator:output
@@ -14144,6 +15383,7 @@ it:
     landuse: IT:Key:landuse
     lanes:psv: IT:Key:lanes:psv
     leisure: IT:Key:leisure
+    length: IT:Key:length
     lock: IT:Key:lock
     man_made: IT:Key:man made
     manhole: IT:Key:manhole
@@ -14155,7 +15395,9 @@ it:
     maxweight: IT:Key:maxweight
     maxwidth: IT:Key:maxwidth
     military: IT:Key:military
+    mofa: IT:Key:mofa
     mooring: IT:Key:mooring
+    motorcycle: IT:Key:motorcycle
     motorcycle:clothes: IT:Key:motorcycle:clothes
     motorcycle:parts: IT:Key:motorcycle:parts
     motorcycle:rental: IT:Key:motorcycle:rental
@@ -14163,10 +15405,13 @@ it:
     motorcycle:sales: IT:Key:motorcycle:sales
     motorcycle:type: IT:Key:motorcycle:type
     motorcycle:tyres: IT:Key:motorcycle:tyres
+    motorroad: IT:Key:motorroad
     mountain_pass: IT:Key:mountain pass
     mtb:scale: IT:Key:mtb:scale
     mtb:scale:imba: IT:Key:mtb:scale:imba
     name: IT:Key:name
+    name:left: IT:Key:name:left
+    name:right: IT:Key:name:right
     natural: IT:Key:natural
     noexit: IT:Key:noexit
     nohousenumber: IT:Key:nohousenumber
@@ -14177,6 +15422,7 @@ it:
     operator: IT:Key:operator
     organic: IT:Key:organic
     osmc:symbol: IT:Key:osmc:symbol
+    oven: IT:Key:oven
     parking: IT:Key:parking
     parking:lane:both: IT:Key:parking:lane:both
     passing_places: IT:Key:passing places
@@ -14187,7 +15433,9 @@ it:
     proposed: IT:Key:proposed
     pump: IT:Key:pump
     railway: IT:Key:railway
+    recycling_type: IT:Key:recycling type
     ref: IT:Key:ref
+    ref:REI: IT:Key:ref:REI
     ref:catasto: IT:Key:ref:catasto
     ref:mise: IT:Key:ref:mise
     ref:msal: IT:Key:ref:msal
@@ -14213,6 +15461,7 @@ it:
     surface: IT:Key:surface
     surveillance: IT:Key:surveillance
     tank_trap: IT:Key:tank trap
+    taxi: IT:Key:taxi
     tourism: IT:Key:tourism
     tracktype: IT:Key:tracktype
     traffic_calming: IT:Key:traffic calming
@@ -14248,6 +15497,7 @@ it:
     amenity=animal_boarding: IT:Tag:amenity=animal boarding
     amenity=animal_breeding: IT:Tag:amenity=animal breeding
     amenity=animal_shelter: IT:Tag:amenity=animal shelter
+    amenity=atm: IT:Tag:amenity=atm
     amenity=bank: IT:Tag:amenity=bank
     amenity=bar: IT:Tag:amenity=bar
     amenity=bbq: IT:Tag:amenity=bbq
@@ -14258,6 +15508,7 @@ it:
     amenity=cinema: IT:Tag:amenity=cinema
     amenity=college: IT:Tag:amenity=college
     amenity=dentist: IT:Tag:amenity=dentist
+    amenity=dive_centre: IT:Tag:amenity=dive centre
     amenity=driving_school: IT:Tag:amenity=driving school
     amenity=fast_food: IT:Tag:amenity=fast food
     amenity=fire_station: IT:Tag:amenity=fire station
@@ -14269,6 +15520,7 @@ it:
     amenity=kindergarten: IT:Tag:amenity=kindergarten
     amenity=milk_dispenser: IT:Tag:amenity=milk dispenser
     amenity=parking: IT:Tag:amenity=parking
+    amenity=pharmacy: IT:Tag:amenity=pharmacy
     amenity=photo_booth: IT:Tag:amenity=photo booth
     amenity=place_of_worship: IT:Tag:amenity=place of worship
     amenity=police: IT:Tag:amenity=police
@@ -14323,8 +15575,10 @@ it:
     barrier=turnstile: IT:Tag:barrier=turnstile
     barrier=wall: IT:Tag:barrier=wall
     bridge=boardwalk: IT:Tag:bridge=boardwalk
+    building=hospital: IT:Tag:building=hospital
     building=residential: IT:Tag:building=residential
     building=retail: IT:Tag:building=retail
+    building=roof: IT:Tag:building=roof
     building=train_station: IT:Tag:building=train station
     craft=agricultural_engines: IT:Tag:craft=agricultural engines
     craft=bakery: IT:Tag:craft=bakery
@@ -14444,6 +15698,7 @@ it:
     junction=roundabout: IT:Tag:junction=roundabout
     junction=yes: IT:Tag:junction=yes
     landuse=cemetery: IT:Tag:landuse=cemetery
+    landuse=civic_admin: IT:Tag:landuse=civic admin
     landuse=construction: IT:Tag:landuse=construction
     landuse=flowerbed: IT:Tag:landuse=flowerbed
     landuse=greenhouse_horticulture: IT:Tag:landuse=greenhouse horticulture
@@ -14467,6 +15722,7 @@ it:
     natural=grassland: IT:Tag:natural=grassland
     natural=palaeontological_site: IT:Tag:natural=palaeontological site
     natural=scree: IT:Tag:natural=scree
+    natural=shrub: IT:Tag:natural=shrub
     natural=spring: IT:Tag:natural=spring
     natural=tree_row: IT:Tag:natural=tree row
     natural=wetland: IT:Tag:natural=wetland
@@ -14540,6 +15796,7 @@ it:
     shop=confectionery: IT:Tag:shop=confectionery
     shop=convenience: IT:Tag:shop=convenience
     shop=deli: IT:Tag:shop=deli
+    shop=dry_cleaning: IT:Tag:shop=dry cleaning
     shop=electrical: IT:Tag:shop=electrical
     shop=electronics: IT:Tag:shop=electronics
     shop=farm: IT:Tag:shop=farm
@@ -14558,12 +15815,14 @@ it:
     shop=radiotechnics: IT:Tag:shop=radiotechnics
     shop=robot: IT:Tag:shop=robot
     shop=seafood: IT:Tag:shop=seafood
+    shop=shoes: IT:Tag:shop=shoes
     shop=souvenir: IT:Tag:shop=souvenir
     shop=supermarket: IT:Tag:shop=supermarket
     shop=tea: IT:Tag:shop=tea
     shop=tobacco: IT:Tag:shop=tobacco
     shop=tyres: IT:Tag:shop=tyres
     shop=wine: IT:Tag:shop=wine
+    shop=yes: IT:Tag:shop=yes
     sport=balle_pelote: IT:Tag:sport=balle pelote
     sport=climbing: IT:Tag:sport=climbing
     sport=hockey: IT:Tag:sport=hockey
@@ -14656,6 +15915,7 @@ ja:
     bicycle_parking: JA:Key:bicycle parking
     bicycle_road: JA:Key:bicycle road
     bin: JA:Key:bin
+    biotic_reef:type: JA:Key:biotic reef:type
     board_type: JA:Key:board type
     boat: JA:Key:boat
     bollard: JA:Key:bollard
@@ -14679,7 +15939,6 @@ ja:
     bridge:short_name: JA:Key:bridge:short name
     bridge:structure: JA:Key:bridge:structure
     bridge:support: JA:Key:bridge:support
-    bridge_name: JA:Key:bridge name
     building: JA:Key:building
     building:architecture: JA:Key:building:architecture
     building:colour: JA:Key:building:colour
@@ -14759,6 +16018,7 @@ ja:
     cutting: JA:Key:cutting
     cycle_network: JA:Key:cycle network
     cycleway: JA:Key:cycleway
+    cycleway:both: JA:Key:cycleway:both
     cycleway:left: JA:Key:cycleway:left
     cycleway:right: JA:Key:cycleway:right
     cycleway=lane: JA:Key:cycleway=lane
@@ -14870,6 +16130,7 @@ ja:
     golf: JA:Key:golf
     goods: JA:Key:goods
     government: JA:Key:government
+    grape_variety: JA:Key:grape variety
     grassland: JA:Key:grassland
     group_only: JA:Key:group only
     guest_house: JA:Key:guest house
@@ -14898,6 +16159,7 @@ ja:
     hov: JA:Key:hov
     iata: JA:Key:iata
     icao: JA:Key:icao
+    ice_cream: JA:Key:ice cream
     ice_road: JA:Key:ice road
     ignore_for_routing: JA:Key:ignore for routing
     image: JA:Key:image
@@ -15030,7 +16292,6 @@ ja:
     network: JA:Key:network
     network:wikidata: JA:Key:network:wikidata
     noexit: JA:Key:noexit
-    noname: JA:Key:noname
     noref: JA:Key:noref
     note: JA:Key:note
     note:ja: JA:Key:note:ja
@@ -15189,6 +16450,7 @@ ja:
     stone_type: JA:Key:stone type
     stream: JA:Key:stream
     stroller: JA:Key:stroller
+    sub_sea: JA:Key:sub sea
     substance: JA:Key:substance
     subway: JA:Key:subway
     supervised: JA:Key:supervised
@@ -15268,6 +16530,7 @@ ja:
     winter_road: JA:Key:winter road
     wires: JA:Key:wires
     wood: JA:Key:wood
+    year_of_construction: JA:Key:year of construction
     yh:LINE_NAME: JA:Key:yh:LINE NAME
     yh:LINE_NUM: JA:Key:yh:LINE NUM
     yh:STRUCTURE: JA:Key:yh:STRUCTURE
@@ -15288,6 +16551,7 @@ ja:
     access=license: JA:Tag:access=license
     access=no: JA:Tag:access=no
     access=official: JA:Tag:access=official
+    access=permissive: JA:Tag:access=permissive
     access=private: JA:Tag:access=private
     access=unknown: JA:Tag:access=unknown
     admin_level=10: JA:Tag:admin level=10
@@ -15331,6 +16595,7 @@ ja:
     aeroway=hangar: JA:Tag:aeroway=hangar
     aeroway=helipad: JA:Tag:aeroway=helipad
     aeroway=heliport: JA:Tag:aeroway=heliport
+    aeroway=holding_position: JA:Tag:aeroway=holding position
     aeroway=parking_position: JA:Tag:aeroway=parking position
     aeroway=runway: JA:Tag:aeroway=runway
     aeroway=taxiway: JA:Tag:aeroway=taxiway
@@ -15370,12 +16635,15 @@ ja:
     amenity=clinic: JA:Tag:amenity=clinic
     amenity=clock: JA:Tag:amenity=clock
     amenity=college: JA:Tag:amenity=college
+    amenity=community_center: JA:Tag:amenity=community center
     amenity=community_centre: JA:Tag:amenity=community centre
     amenity=compressed_air: JA:Tag:amenity=compressed air
+    amenity=consulate: JA:Tag:amenity=consulate
     amenity=courthouse: JA:Tag:amenity=courthouse
     amenity=coworking_space: JA:Tag:amenity=coworking space
     amenity=crematorium: JA:Tag:amenity=crematorium
     amenity=crypt: JA:Tag:amenity=crypt
+    amenity=customs: JA:Tag:amenity=customs
     amenity=dentist: JA:Tag:amenity=dentist
     amenity=doctor: JA:Tag:amenity=doctor
     amenity=doctors: JA:Tag:amenity=doctors
@@ -15392,6 +16660,7 @@ ja:
     amenity=food_court: JA:Tag:amenity=food court
     amenity=fountain: JA:Tag:amenity=fountain
     amenity=fuel: JA:Tag:amenity=fuel
+    amenity=funeral_hall: JA:Tag:amenity=funeral hall
     amenity=gambling: JA:Tag:amenity=gambling
     amenity=game_feeding: JA:Tag:amenity=game feeding
     amenity=grave_yard: JA:Tag:amenity=grave yard
@@ -15402,6 +16671,7 @@ ja:
     amenity=internet_cafe: JA:Tag:amenity=internet cafe
     amenity=karaoke_box: JA:Tag:amenity=karaoke box
     amenity=kindergarten: JA:Tag:amenity=kindergarten
+    amenity=kiosk: JA:Tag:amenity=kiosk
     amenity=language_school: JA:Tag:amenity=language school
     amenity=letter_box: JA:Tag:amenity=letter box
     amenity=library: JA:Tag:amenity=library
@@ -15436,6 +16706,7 @@ ja:
     amenity=public_bookcase: JA:Tag:amenity=public bookcase
     amenity=public_building: JA:Tag:amenity=public building
     amenity=recycling: JA:Tag:amenity=recycling
+    amenity=refugee_site: JA:Tag:amenity=refugee site
     amenity=register_office: JA:Tag:amenity=register office
     amenity=research_institute: JA:Tag:amenity=research institute
     amenity=restaurant: JA:Tag:amenity=restaurant
@@ -15668,9 +16939,14 @@ ja:
     cuisine=brazilian: JA:Tag:cuisine=brazilian
     cuisine=coffee_shop: JA:Tag:cuisine=coffee shop
     cuisine=dessert: JA:Tag:cuisine=dessert
+    cycleway:both=no: JA:Tag:cycleway:both=no
+    cycleway:left=no: JA:Tag:cycleway:left=no
+    cycleway:right=no: JA:Tag:cycleway:right=no
     cycleway=lane: JA:Tag:cycleway=lane
+    cycleway=no: JA:Tag:cycleway=no
     cycleway=opposite_track: JA:Tag:cycleway=opposite track
     cycleway=share_busway: JA:Tag:cycleway=share busway
+    cycleway=shared_lane: JA:Tag:cycleway=shared lane
     cycleway=track: JA:Tag:cycleway=track
     denomination=jodo_shinshu: JA:Tag:denomination=jodo shinshu
     denomination=jodo_shu: JA:Tag:denomination=jodo shu
@@ -15757,6 +17033,7 @@ ja:
     government=tax: JA:Tag:government=tax
     guidepost=simple: JA:Tag:guidepost=simple
     healthcare=blood_donation: JA:Tag:healthcare=blood donation
+    healthcare=doctor: JA:Tag:healthcare=doctor
     hgv=designated: JA:Tag:hgv=designated
     hgv=destination: JA:Tag:hgv=destination
     highway=bridleway: JA:Tag:highway=bridleway
@@ -15796,6 +17073,7 @@ ja:
     highway=stop: JA:Tag:highway=stop
     highway=street_lamp: JA:Tag:highway=street lamp
     highway=tertiary: JA:Tag:highway=tertiary
+    highway=toll_gantry: JA:Tag:highway=toll gantry
     highway=track: JA:Tag:highway=track
     highway=traffic_mirror: JA:Tag:highway=traffic mirror
     highway=traffic_signals: JA:Tag:highway=traffic signals
@@ -15951,6 +17229,7 @@ ja:
     leisure=swimming_pool: JA:Tag:leisure=swimming pool
     leisure=track: JA:Tag:leisure=track
     leisure=water_park: JA:Tag:leisure=water park
+    lifeguard=tower: JA:Tag:lifeguard=tower
     line=bay: JA:Tag:line=bay
     line=busbar: JA:Tag:line=busbar
     man_made=adit: JA:Tag:man made=adit
@@ -15971,6 +17250,7 @@ ja:
     man_made=embankment: JA:Tag:man made=embankment
     man_made=flagpole: JA:Tag:man made=flagpole
     man_made=flare: JA:Tag:man made=flare
+    man_made=gantry: JA:Tag:man made=gantry
     man_made=gasometer: JA:Tag:man made=gasometer
     man_made=geoglyph: JA:Tag:man made=geoglyph
     man_made=groyne: JA:Tag:man made=groyne
@@ -16076,6 +17356,7 @@ ja:
     network=jp:prefectural:nagano: JA:Tag:network=jp:prefectural:nagano
     network=ncn: JA:Tag:network=ncn
     network=nwn: JA:Tag:network=nwn
+    noname=yes: JA:Tag:noname=yes
     office=accountant: JA:Tag:office=accountant
     office=administrative: JA:Tag:office=administrative
     office=architect: JA:Tag:office=architect
@@ -16135,6 +17416,7 @@ ja:
     power=switchgear: JA:Tag:power=switchgear
     power=tower: JA:Tag:power=tower
     power=transformer: JA:Tag:power=transformer
+    protect_class=2: JA:Tag:protect class=2
     public_transport=platform: JA:Tag:public transport=platform
     public_transport=station: JA:Tag:public transport=station
     public_transport=stop_area: JA:Tag:public transport=stop area
@@ -16177,6 +17459,7 @@ ja:
     religion=christian: JA:Tag:religion=christian
     religion=muslim: JA:Tag:religion=muslim
     religion=shinto: JA:Tag:religion=shinto
+    residential=apartments: JA:Tag:residential=apartments
     residential=rural: JA:Tag:residential=rural
     resource=sand: JA:Tag:resource=sand
     roller_coaster=track: JA:Tag:roller coaster=track
@@ -16511,6 +17794,7 @@ ko:
     amenity=taxi: Ko:Tag:amenity=taxi
     amenity=townhall: Ko:Tag:amenity=townhall
     barrier=kerb: Ko:Tag:barrier=kerb
+    building=abandoned: Ko:Tag:building=abandoned
     craft=tailor: Ko:Tag:craft=tailor
     ford=stepping_stones: Ko:Tag:ford=stepping stones
     highway=bus_stop: Ko:Tag:highway=bus stop
@@ -16543,6 +17827,7 @@ ko:
     shop=garden_centre: Ko:Tag:shop=garden centre
     shop=gift: Ko:Tag:shop=gift
     tourism=attraction: Ko:Tag:tourism=attraction
+    traffic_calming=island: Ko:Tag:traffic calming=island
     waterway=ditch: Ko:Tag:waterway=ditch
 lt:
   key:
@@ -16560,14 +17845,10 @@ ms:
     highway=tertiary: Ms:Tag:highway=tertiary
     highway=trunk: Ms:Tag:highway=trunk
     highway=unclassified: Ms:Tag:highway=unclassified
-my:
-  tag:
-    craft=agricultural_engines: My:Tag:craft=agricultural engines
 ne:
   key:
     tracktype: Ne:Key:tracktype
   tag:
-    landuse=meadow: Ne:Tag:landuse=meadow
     natural=scrub: Ne:Tag:natural=scrub
 nl:
   key:
@@ -16599,6 +17880,7 @@ nl:
     fence_type: NL:Key:fence type
     fenced: NL:Key:fenced
     from: NL:Key:from
+    historic: NL:Key:historic
     internet_access: NL:Key:internet access
     landuse: NL:Key:landuse
     leaf_cycle: NL:Key:leaf cycle
@@ -16611,6 +17893,7 @@ nl:
     network:type: NL:Key:network:type
     office: NL:Key:office
     place: NL:Key:place
+    playground: NL:Key:playground
     population: NL:Key:population
     power_supply:schedule: NL:Key:power supply:schedule
     public_transport: NL:Key:public transport
@@ -16627,6 +17910,8 @@ nl:
     turn:lanes: NL:Key:turn:lanes
     type: NL:Key:type
     waste: NL:Key:waste
+    water: NL:Key:water
+    waterway: NL:Key:waterway
     wheelchair: NL:Key:wheelchair
     xmas:feature: NL:Key:xmas:feature
   tag:
@@ -16659,6 +17944,7 @@ nl:
     landuse=grass: NL:Tag:landuse=grass
     landuse=industrial: NL:Tag:landuse=industrial
     leaf_cycle=deciduous: NL:Tag:leaf cycle=deciduous
+    leisure=playground: NL:Tag:leisure=playground
     man_made=windmill: NL:Tag:man made=windmill
     natural=tree: NL:Tag:natural=tree
     office=architect: NL:Tag:office=architect
@@ -16673,6 +17959,7 @@ nl:
     shop=motorcycle: NL:Tag:shop=motorcycle
     sport=floorball: NL:Tag:sport=floorball
     sport=miniature_golf: NL:Tag:sport=miniature golf
+    sport=scuba_diving: NL:Tag:sport=scuba diving
     sport=squash: NL:Tag:sport=squash
     tourism=chalet: NL:Tag:tourism=chalet
     traffic_sign=NL:A01-30-ZB: NL:Tag:traffic sign=NL:A01-30-ZB
@@ -16806,6 +18093,7 @@ pl:
     castle_type: Pl:Key:castle type
     cemetery: Pl:Key:cemetery
     check_date: Pl:Key:check date
+    church:type: Pl:Key:church:type
     circuits: Pl:Key:circuits
     circumference: Pl:Key:circumference
     clothes: Pl:Key:clothes
@@ -16835,6 +18123,7 @@ pl:
     currency: Pl:Key:currency
     cutting: Pl:Key:cutting
     cycleway: Pl:Key:cycleway
+    cycleway:surface: Pl:Key:cycleway:surface
     deanery: Pl:Key:deanery
     delivery: Pl:Key:delivery
     denomination: Pl:Key:denomination
@@ -16962,7 +18251,6 @@ pl:
     location: Pl:Key:location
     lock: Pl:Key:lock
     lock_name: Pl:Key:lock name
-    lottery: Pl:Key:lottery
     male: Pl:Key:male
     man_made: Pl:Key:man made
     manhole: Pl:Key:manhole
@@ -17027,6 +18315,7 @@ pl:
     passenger_information_display: Pl:Key:passenger information display
     passing_places: Pl:Key:passing places
     payment: Pl:Key:payment
+    phone: Pl:Key:phone
     pipeline: Pl:Key:pipeline
     place: Pl:Key:place
     place_name: Pl:Key:place name
@@ -17049,6 +18338,7 @@ pl:
     ramp: Pl:Key:ramp
     razed: Pl:Key:razed
     'razed:': 'Pl:Key:razed:'
+    recycling:plastic_bottle_tops: Pl:Key:recycling:plastic bottle tops
     recycling_type: Pl:Key:recycling type
     reef: Pl:Key:reef
     ref: Pl:Key:ref
@@ -17081,6 +18371,7 @@ pl:
     shelter_type: Pl:Key:shelter type
     shop: Pl:Key:shop
     shower: Pl:Key:shower
+    shrine: Pl:Key:shrine
     sidewalk: Pl:Key:sidewalk
     site_type: Pl:Key:site type
     size: Pl:Key:size
@@ -17325,6 +18616,8 @@ pl:
     amenity=toilets: Pl:Tag:amenity=toilets
     amenity=tourist_bus_parking: Pl:Tag:amenity=tourist bus parking
     amenity=townhall: Pl:Tag:amenity=townhall
+    amenity=traffic_park: Pl:Tag:amenity=traffic park
+    amenity=training: Pl:Tag:amenity=training
     amenity=trolley_bay: Pl:Tag:amenity=trolley bay
     amenity=university: Pl:Tag:amenity=university
     amenity=vacuum_cleaner: Pl:Tag:amenity=vacuum cleaner
@@ -17371,6 +18664,7 @@ pl:
     barrier=retaining_wall: Pl:Tag:barrier=retaining wall
     barrier=sally_port: Pl:Tag:barrier=sally port
     barrier=spikes: Pl:Tag:barrier=spikes
+    barrier=stile: Pl:Tag:barrier=stile
     barrier=toll_booth: Pl:Tag:barrier=toll booth
     barrier=turnstile: Pl:Tag:barrier=turnstile
     barrier=wall: Pl:Tag:barrier=wall
@@ -17456,6 +18750,7 @@ pl:
     building=office: Pl:Tag:building=office
     building=parking: Pl:Tag:building=parking
     building=pavilion: Pl:Tag:building=pavilion
+    building=presbytery: Pl:Tag:building=presbytery
     building=public: Pl:Tag:building=public
     building=residential: Pl:Tag:building=residential
     building=retail: Pl:Tag:building=retail
@@ -17486,6 +18781,7 @@ pl:
     building=university: Pl:Tag:building=university
     building=warehouse: Pl:Tag:building=warehouse
     building=water_tower: Pl:Tag:building=water tower
+    building=wayside_shrine: Pl:Tag:building=wayside shrine
     bunker_type=gun_emplacement: Pl:Tag:bunker type=gun emplacement
     bunker_type=technical: Pl:Tag:bunker type=technical
     busway=lane: Pl:Tag:busway=lane
@@ -17499,6 +18795,7 @@ pl:
     club=fan: Pl:Tag:club=fan
     club=scout: Pl:Tag:club=scout
     club=sport: Pl:Tag:club=sport
+    construction=footpath: Pl:Tag:construction=footpath
     craft=agricultural_engines: Pl:Tag:craft=agricultural engines
     craft=bakery: Pl:Tag:craft=bakery
     craft=basket_maker: Pl:Tag:craft=basket maker
@@ -17529,6 +18826,7 @@ pl:
     craft=information_electronics: Pl:Tag:craft=information electronics
     craft=jeweller: Pl:Tag:craft=jeweller
     craft=joiner: Pl:Tag:craft=joiner
+    craft=key_cutter: Pl:Tag:craft=key cutter
     craft=oil_mill: Pl:Tag:craft=oil mill
     craft=painter: Pl:Tag:craft=painter
     craft=pottery: Pl:Tag:craft=pottery
@@ -17542,6 +18840,7 @@ pl:
     craft=window_construction: Pl:Tag:craft=window construction
     craft=winery: Pl:Tag:craft=winery
     cuisine=coffee_shop: Pl:Tag:cuisine=coffee shop
+    cycleway=asl: Pl:Tag:cycleway=asl
     cycleway=lane: Pl:Tag:cycleway=lane
     cycleway=opposite: Pl:Tag:cycleway=opposite
     cycleway=opposite_lane: Pl:Tag:cycleway=opposite lane
@@ -17578,9 +18877,12 @@ pl:
     government=prosecutor: Pl:Tag:government=prosecutor
     healthcare=dentist: Pl:Tag:healthcare=dentist
     healthcare=dialysis: Pl:Tag:healthcare=dialysis
+    healthcare=doctor: Pl:Tag:healthcare=doctor
+    healthcare=hospice: Pl:Tag:healthcare=hospice
     healthcare=laboratory: Pl:Tag:healthcare=laboratory
     healthcare=nutrition_counselling: Pl:Tag:healthcare=nutrition counselling
     healthcare=physiotherapist: Pl:Tag:healthcare=physiotherapist
+    healthcare=sample_collection: Pl:Tag:healthcare=sample collection
     highway=abandoned: Pl:Tag:highway=abandoned
     highway=bridleway: Pl:Tag:highway=bridleway
     highway=bus_guideway: Pl:Tag:highway=bus guideway
@@ -17780,7 +19082,9 @@ pl:
     leisure=video_arcade: Pl:Tag:leisure=video arcade
     leisure=water_park: Pl:Tag:leisure=water park
     leisure=wildlife_hide: Pl:Tag:leisure=wildlife hide
+    lifeguard=tower: Pl:Tag:lifeguard=tower
     location:transition=yes: Pl:Tag:location:transition=yes
+    lottery=yes: Pl:Tag:lottery=yes
     man_made=adit: Pl:Tag:man made=adit
     man_made=antenna: Pl:Tag:man made=antenna
     man_made=beacon: Pl:Tag:man made=beacon
@@ -17866,6 +19170,7 @@ pl:
     memorial=bust: Pl:Tag:memorial=bust
     memorial=obelisk: Pl:Tag:memorial=obelisk
     memorial=plaque: Pl:Tag:memorial=plaque
+    memorial=sculpture: Pl:Tag:memorial=sculpture
     memorial=statue: Pl:Tag:memorial=statue
     memorial=stele: Pl:Tag:memorial=stele
     memorial=stolperstein: Pl:Tag:memorial=stolperstein
@@ -18077,10 +19382,12 @@ pl:
     residential=rural: Pl:Tag:residential=rural
     residential=university: Pl:Tag:residential=university
     residential=urban: Pl:Tag:residential=urban
+    route=bus: Pl:Tag:route=bus
     route=emergency_access: Pl:Tag:route=emergency access
     route=hiking: Pl:Tag:route=hiking
     route=horse: Pl:Tag:route=horse
     route=running: Pl:Tag:route=running
+    route=tram: Pl:Tag:route=tram
     service=alley: Pl:Tag:service=alley
     service=drive-through: Pl:Tag:service=drive-through
     service=driveway: Pl:Tag:service=driveway
@@ -18201,6 +19508,7 @@ pl:
     shop=musical_instrument: Pl:Tag:shop=musical instrument
     shop=newsagent: Pl:Tag:shop=newsagent
     shop=nutrition_supplements: Pl:Tag:shop=nutrition supplements
+    shop=nuts: Pl:Tag:shop=nuts
     shop=optician: Pl:Tag:shop=optician
     shop=outdoor: Pl:Tag:shop=outdoor
     shop=outpost: Pl:Tag:shop=outpost
@@ -18221,6 +19529,7 @@ pl:
     shop=scuba_diving: Pl:Tag:shop=scuba diving
     shop=seafood: Pl:Tag:shop=seafood
     shop=second_hand: Pl:Tag:shop=second hand
+    shop=security: Pl:Tag:shop=security
     shop=sewing: Pl:Tag:shop=sewing
     shop=shoe_repair: Pl:Tag:shop=shoe repair
     shop=shoes: Pl:Tag:shop=shoes
@@ -18276,6 +19585,7 @@ pl:
     sport=equestrian: Pl:Tag:sport=equestrian
     sport=ice_hockey: Pl:Tag:sport=ice hockey
     sport=soccer: Pl:Tag:sport=soccer
+    surface=asphalt: Pl:Tag:surface=asphalt
     surface=concrete:lanes: Pl:Tag:surface=concrete:lanes
     tourism=alpine_hut: Pl:Tag:tourism=alpine hut
     tourism=apartment: Pl:Tag:tourism=apartment
@@ -18394,6 +19704,9 @@ pl:
     zoo=falconry: Pl:Tag:zoo=falconry
     zoo=petting_zoo: Pl:Tag:zoo=petting zoo
     zoo=reptile: Pl:Tag:zoo=reptile
+proposed features/eo:
+  tag:
+    esperanto=esperanto: Proposed features/Eo:Tag:esperanto=esperanto
 pt:
   key:
     IBGE:CD_ADMINIS: Pt:Key:IBGE:CD ADMINIS
@@ -18476,10 +19789,12 @@ pt:
     ice_road: Pt:Key:ice road
     incline: Pt:Key:incline
     industrial: Pt:Key:industrial
+    inscription: Pt:Key:inscription
     intermittent: Pt:Key:intermittent
     internet_access: Pt:Key:internet access
     internet_access:ssid: Pt:Key:internet access:ssid
     is_in: Pt:Key:is in
+    isced:level: Pt:Key:isced:level
     jetski:sales: Pt:Key:jetski:sales
     junction: Pt:Key:junction
     landuse: Pt:Key:landuse
@@ -18491,6 +19806,7 @@ pt:
     lit: Pt:Key:lit
     lock: Pt:Key:lock
     man_made: Pt:Key:man made
+    manhole: Pt:Key:manhole
     material: Pt:Key:material
     maxdraught: Pt:Key:maxdraught
     maxheight: Pt:Key:maxheight
@@ -18514,7 +19830,7 @@ pt:
     name: Pt:Key:name
     natural: Pt:Key:natural
     noexit: Pt:Key:noexit
-    noname: Pt:Key:noname
+    nohousenumber: Pt:Key:nohousenumber
     note: Pt:Key:note
     office: Pt:Key:office
     oneway: Pt:Key:oneway
@@ -18526,6 +19842,7 @@ pt:
     passing_places: Pt:Key:passing places
     place: Pt:Key:place
     placement: Pt:Key:placement
+    pmfsefin:idedif: Pt:Key:pmfsefin:idedif
     police: Pt:Key:police
     population: Pt:Key:population
     postal_code: Pt:Key:postal code
@@ -18537,6 +19854,7 @@ pt:
     railway: Pt:Key:railway
     recording: Pt:Key:recording
     ref: Pt:Key:ref
+    ref:INEP: Pt:Key:ref:INEP
     ref:bag: Pt:Key:ref:bag
     ref:vatin: Pt:Key:ref:vatin
     religion: Pt:Key:religion
@@ -18550,6 +19868,7 @@ pt:
     segregated: Pt:Key:segregated
     service: Pt:Key:service
     service_times: Pt:Key:service times
+    sett:style=portuguese: Pt:Key:sett:style=portuguese
     shop: Pt:Key:shop
     sidewalk: Pt:Key:sidewalk
     ski: Pt:Key:ski
@@ -18579,6 +19898,7 @@ pt:
     waterway: Pt:Key:waterway
     wetland: Pt:Key:wetland
     wheelchair: Pt:Key:wheelchair
+    wiki:symbol: Pt:Key:wiki:symbol
     wikidata: Pt:Key:wikidata
     wikipedia: Pt:Key:wikipedia
     winter_road: Pt:Key:winter road
@@ -18765,6 +20085,7 @@ pt:
     building=chapel: Pt:Tag:building=chapel
     building=church: Pt:Tag:building=church
     building=commercial: Pt:Tag:building=commercial
+    building=conservatory: Pt:Tag:building=conservatory
     building=house: Pt:Tag:building=house
     building=residential: Pt:Tag:building=residential
     building=roof: Pt:Tag:building=roof
@@ -18832,17 +20153,22 @@ pt:
     emergency=phone: Pt:Tag:emergency=phone
     emergency=siren: Pt:Tag:emergency=siren
     footway=crossing: Pt:Tag:footway=crossing
+    generator:source=solar: Pt:Tag:generator:source=solar
     geological=palaeontological_site: Pt:Tag:geological=palaeontological site
     government=cadaster: Pt:Tag:government=cadaster
     healthcare=blood_donation: Pt:Tag:healthcare=blood donation
+    healthcare=doctor: Pt:Tag:healthcare=doctor
+    healthcare=vaccination_centre: Pt:Tag:healthcare=vaccination centre
     highway=bridleway: Pt:Tag:highway=bridleway
     highway=bus_guideway: Pt:Tag:highway=bus guideway
     highway=bus_stop: Pt:Tag:highway=bus stop
+    highway=busway: Pt:Tag:highway=busway
     highway=corridor: Pt:Tag:highway=corridor
     highway=crossing: Pt:Tag:highway=crossing
     highway=cycleway: Pt:Tag:highway=cycleway
     highway=elevator: Pt:Tag:highway=elevator
     highway=emergency_access_point: Pt:Tag:highway=emergency access point
+    highway=escape: Pt:Tag:highway=escape
     highway=footway: Pt:Tag:highway=footway
     highway=ford: Pt:Tag:highway=ford
     highway=give_way: Pt:Tag:highway=give way
@@ -18893,12 +20219,14 @@ pt:
     historic=wayside_cross: Pt:Tag:historic=wayside cross
     historic=wayside_shrine: Pt:Tag:historic=wayside shrine
     historic=wreck: Pt:Tag:historic=wreck
+    industrial=slaughterhouse: Pt:Tag:industrial=slaughterhouse
     junction=roundabout: Pt:Tag:junction=roundabout
     landuse=allotments: Pt:Tag:landuse=allotments
     landuse=basin: Pt:Tag:landuse=basin
     landuse=brownfield: Pt:Tag:landuse=brownfield
     landuse=cemetery: Pt:Tag:landuse=cemetery
     landuse=commercial: Pt:Tag:landuse=commercial
+    landuse=education: Pt:Tag:landuse=education
     landuse=farm: Pt:Tag:landuse=farm
     landuse=farmyard: Pt:Tag:landuse=farmyard
     landuse=forest: Pt:Tag:landuse=forest
@@ -18939,6 +20267,7 @@ pt:
     leisure=slipway: Pt:Tag:leisure=slipway
     leisure=sports_centre: Pt:Tag:leisure=sports centre
     leisure=stadium: Pt:Tag:leisure=stadium
+    leisure=swimming_area: Pt:Tag:leisure=swimming area
     leisure=swimming_pool: Pt:Tag:leisure=swimming pool
     leisure=track: Pt:Tag:leisure=track
     leisure=water_park: Pt:Tag:leisure=water park
@@ -18975,6 +20304,7 @@ pt:
     man_made=watermill: Pt:Tag:man made=watermill
     man_made=windmill: Pt:Tag:man made=windmill
     man_made=works: Pt:Tag:man made=works
+    manhole=drain: Pt:Tag:manhole=drain
     memorial=bust: Pt:Tag:memorial=bust
     military=airfield: Pt:Tag:military=airfield
     military=barracks: Pt:Tag:military=barracks
@@ -19009,9 +20339,11 @@ pt:
     natural=wetland: Pt:Tag:natural=wetland
     natural=wood: Pt:Tag:natural=wood
     noexit=no: Pt:Tag:noexit=no
+    noname=yes: Pt:Tag:noname=yes
     office=accountant: Pt:Tag:office=accountant
     office=administrative: Pt:Tag:office=administrative
     office=architect: Pt:Tag:office=architect
+    office=association: Pt:Tag:office=association
     office=company: Pt:Tag:office=company
     office=educational_institution: Pt:Tag:office=educational institution
     office=employment_agency: Pt:Tag:office=employment agency
@@ -19189,6 +20521,7 @@ pt:
     shop=scuba_diving: Pt:Tag:shop=scuba diving
     shop=seafood: Pt:Tag:shop=seafood
     shop=second_hand: Pt:Tag:shop=second hand
+    shop=sewing: Pt:Tag:shop=sewing
     shop=shoes: Pt:Tag:shop=shoes
     shop=spices: Pt:Tag:shop=spices
     shop=sports: Pt:Tag:shop=sports
@@ -19211,6 +20544,7 @@ pt:
     sport=9pin: Pt:Tag:sport=9pin
     sport=golf: Pt:Tag:sport=golf
     sport=soccer: Pt:Tag:sport=soccer
+    surface=sett: Pt:Tag:surface=sett
     tourism=alpine_hut: Pt:Tag:tourism=alpine hut
     tourism=artwork: Pt:Tag:tourism=artwork
     tourism=attraction: Pt:Tag:tourism=attraction
@@ -19367,7 +20701,6 @@ pt-br:
     nat_ref: Pt-br:Key:nat ref
     natural: Pt-br:Key:natural
     ncn_ref: Pt-br:Key:ncn ref
-    noname: Pt-br:Key:noname
     office: Pt-br:Key:office
     official_name: Pt-br:Key:official name
     old_name: Pt-br:Key:old name
@@ -19751,6 +21084,7 @@ pt-br:
     natural=water: Pt-br:Tag:natural=water
     natural=wetland: Pt-BR:Tag:natural=wetland
     natural=wood: Pt-br:Tag:natural=wood
+    noname=yes: Pt-br:Tag:noname=yes
     office=accountant: Pt-br:Tag:office=accountant
     office=administrative: Pt-br:Tag:office=administrative
     office=architect: Pt-br:Tag:office=architect
@@ -19961,6 +21295,7 @@ ro:
 ru:
   key:
     3dmr: RU:Key:3dmr
+    AlpinRes_ID: RU:Key:AlpinRes ID
     abandoned: RU:Key:abandoned
     'abandoned:': 'RU:Key:abandoned:'
     abandoned:place: RU:Key:abandoned:place
@@ -19969,52 +21304,76 @@ ru:
     abutters: RU:Key:abutters
     access: RU:Key:access
     access:bdouble: RU:Key:access:bdouble
+    access:lanes: RU:Key:access:lanes
     access:lhv: RU:Key:access:lhv
     access:roadtrain: RU:Key:access:roadtrain
     access:roadtrain:trailers: RU:Key:access:roadtrain:trailers
     addr: RU:Key:addr
+    addr:block: RU:Key:addr:block
     addr:city: RU:Key:addr:city
+    addr:conscriptionnumber: RU:Key:addr:conscriptionnumber
     addr:country: RU:Key:addr:country
+    addr:district: RU:Key:addr:district
+    addr:door: RU:Key:addr:door
     addr:flats: RU:Key:addr:flats
     addr:floor: RU:Key:addr:floor
+    addr:full: RU:Key:addr:full
+    addr:hamlet: RU:Key:addr:hamlet
     addr:housename: RU:Key:addr:housename
     addr:housenumber: RU:Key:addr:housenumber
+    addr:inclusion: RU:Key:addr:inclusion
     addr:interpolation: RU:Key:addr:interpolation
     addr:letter: RU:Key:addr:letter
     addr:place: RU:Key:addr:place
     addr:postcode: RU:Key:addr:postcode
+    addr:province: RU:Key:addr:province
+    addr:region: RU:Key:addr:region
+    addr:state: RU:Key:addr:state
     addr:street: RU:Key:addr:street
+    addr:streetnumber: RU:Key:addr:streetnumber
+    addr:subdistrict: RU:Key:addr:subdistrict
     addr:suburb: RU:Key:addr:suburb
+    addr:unit: RU:Key:addr:unit
     advertising: RU:Key:advertising
     aerialway: RU:Key:aerialway
     aeroway: RU:Key:aeroway
     agricultural: RU:Key:agricultural
     alt_name: RU:Key:alt name
     amenity: RU:Key:amenity
+    animal: RU:Key:animal
     architect: RU:Key:architect
     area: RU:Key:area
     area:highway: RU:Key:area:highway
     artist_name: RU:Key:artist name
     artwork_type: RU:Key:artwork type
+    association: RU:Key:association
     attraction: RU:Key:attraction
     attribution: RU:Key:attribution
     atv:sales: RU:Key:atv:sales
+    baby_feeding: RU:Key:baby feeding
     backcountry: RU:Key:backcountry
     backward: RU:Key:backward
+    balcony: RU:Key:balcony
     barrier: RU:Key:barrier
+    beds: RU:Key:beds
     bench: RU:Key:bench
     bicycle: RU:Key:bicycle
     bicycle_parking: RU:Key:bicycle parking
+    bike_ride: RU:Key:bike ride
     bin: RU:Key:bin
+    board:title: RU:Key:board:title
     board_type: RU:Key:board type
     boat: RU:Key:boat
+    booking: RU:Key:booking
     books: RU:Key:books
     border_type: RU:Key:border type
     both: RU:Key:both
     boundary: RU:Key:boundary
     brand: RU:Key:brand
     brand:wikidata: RU:Key:brand:wikidata
+    brewery: RU:Key:brewery
     bridge: RU:Key:bridge
+    bridge:movable: RU:Key:bridge:movable
     bridge:name: RU:Key:bridge:name
     bridge:structure: RU:Key:bridge:structure
     bridge:support: RU:Key:bridge:support
@@ -20039,23 +21398,35 @@ ru:
     building:use:pl: RU:Key:building:use:pl
     bunker_type: RU:Key:bunker type
     bus: RU:Key:bus
+    cabin:rental: RU:Key:cabin:rental
+    cabins: RU:Key:cabins
     cafe: RU:Key:cafe
     camp_site: RU:Key:camp site
+    camp_type: RU:Key:camp type
     capacity: RU:Key:capacity
+    capacity:charging: RU:Key:capacity:charging
+    capacity:disabled: RU:Key:capacity:disabled
     capital: RU:Key:capital
     caravan: RU:Key:caravan
     castle_type: RU:Key:castle type
     cemetery: RU:Key:cemetery
     check_date: RU:Key:check date
     checkpoint: RU:Key:checkpoint
+    church:type: RU:Key:church:type
+    city_limit: RU:Key:city limit
+    class:bicycle: RU:Key:class:bicycle
     clli: RU:Key:clli
     clothes: RU:Key:clothes
     club: RU:Key:club
     colour: RU:Key:colour
     comment: RU:Key:comment
+    communication:bos: RU:Key:communication:bos
     community_centre: RU:Key:community centre
+    company: RU:Key:company
+    compressed_air: RU:Key:compressed air
     condo: RU:Key:condo
     construction: RU:Key:construction
+    consulting: RU:Key:consulting
     contact: RU:Key:contact
     contact:facebook: RU:Key:contact:facebook
     contact:fax: RU:Key:contact:fax
@@ -20068,10 +21439,13 @@ ru:
     created_by: RU:Key:created by
     crop: RU:Key:crop
     crossing: RU:Key:crossing
+    crossing:island: RU:Key:crossing:island
     cuisine: RU:Key:cuisine
     currency: RU:Key:currency
     cutting: RU:Key:cutting
-    cycleway: RU:Key:cycleway
+    cyclestreets_id: RU:Key:cyclestreets id
+    cycleway:left:oneway: RU:Key:cycleway:left:oneway
+    cycleway:right:oneway: RU:Key:cycleway:right:oneway
     delivery: RU:Key:delivery
     denomination: RU:Key:denomination
     departures_board: RU:Key:departures board
@@ -20081,30 +21455,37 @@ ru:
     design:ref: RU:Key:design:ref
     designation: RU:Key:designation
     diaper: RU:Key:diaper
+    diplomatic: RU:Key:diplomatic
     direction: RU:Key:direction
     dispensing: RU:Key:dispensing
     disused: RU:Key:disused
     'disused:': 'RU:Key:disused:'
     disused:shop: RU:Key:disused:shop
     dog: RU:Key:dog
-    door: RU:Key:door
+    drink:beer: RU:Key:drink:beer
     drinking_water: RU:Key:drinking water
     drinking_water:legal: RU:Key:drinking water:legal
     drive_in: RU:Key:drive in
     drive_through: RU:Key:drive through
     driving_side: RU:Key:driving side
+    dryer: RU:Key:dryer
     ele: RU:Key:ele
+    electric_bicycle: RU:Key:electric bicycle
     electrified: RU:Key:electrified
     email: RU:Key:email
     embankment: RU:Key:embankment
     emergency: RU:Key:emergency
+    engineer: RU:Key:engineer
     entrance: RU:Key:entrance
     est_width: RU:Key:est width
+    exhibit: RU:Key:exhibit
     exit: RU:Key:exit
     fast_food: RU:Key:fast food
     fax: RU:Key:fax
     fee: RU:Key:fee
+    feeding:type: RU:Key:feeding:type
     fence_type: RU:Key:fence type
+    ferry: RU:Key:ferry
     fire_boundary: RU:Key:fire boundary
     fire_object:type: RU:Key:fire object:type
     fire_operator: RU:Key:fire operator
@@ -20120,31 +21501,43 @@ ru:
     fuel:lpg: RU:Key:fuel:lpg
     furniture: RU:Key:furniture
     garden:style: RU:Key:garden:style
+    garden:type: RU:Key:garden:type
     gas: RU:Key:gas
     gauge: RU:Key:gauge
     generator:output: RU:Key:generator:output
     generator:source: RU:Key:generator:source
     genus: RU:Key:genus
+    government: RU:Key:government
     grassland: RU:Key:grassland
+    group_only: RU:Key:group only
+    guidepost:hiking: RU:Key:guidepost:hiking
     gvr:code: RU:Key:gvr:code
     handrail: RU:Key:handrail
+    hazard: RU:Key:hazard
+    hazmat: RU:Key:hazmat
     healthcare: RU:Key:healthcare
     height: RU:Key:height
+    heritage: RU:Key:heritage
     hgv: RU:Key:hgv
     highway: RU:Key:highway
+    hiking: RU:Key:hiking
     historic: RU:Key:historic
     horse: RU:Key:horse
+    horse_scale: RU:Key:horse scale
     iata: RU:Key:iata
     ice_road: RU:Key:ice road
     image: RU:Key:image
     incline: RU:Key:incline
     indoor: RU:Key:indoor
     industrial: RU:Key:industrial
+    infant_bed: RU:Key:infant bed
     information: RU:Key:information
     inscription: RU:Key:inscription
     int_name: RU:Key:int name
     intermittent: RU:Key:intermittent
     internet_access: RU:Key:internet access
+    is_in: RU:Key:is in
+    jetski:rental: RU:Key:jetski:rental
     junction: RU:Key:junction
     karaoke: RU:Key:karaoke
     kerb: RU:Key:kerb
@@ -20161,6 +21554,7 @@ ru:
     leisure: RU:Key:leisure
     length: RU:Key:length
     level: RU:Key:level
+    level:ref: RU:Key:level:ref
     license_classes: RU:Key:license classes
     lit: RU:Key:lit
     living_street: RU:Key:living street
@@ -20171,6 +21565,7 @@ ru:
     man_made: RU:Key:man made
     managed: RU:Key:managed
     manhole: RU:Key:manhole
+    mapillary: RU:Key:mapillary
     material: RU:Key:material
     max_age: RU:Key:max age
     maxaxleload: RU:Key:maxaxleload
@@ -20182,7 +21577,11 @@ ru:
     maxstay: RU:Key:maxstay
     maxtents: RU:Key:maxtents
     maxweight: RU:Key:maxweight
+    maxweight:signed: RU:Key:maxweight:signed
     maxwidth: RU:Key:maxwidth
+    mcrb:criteria: RU:Key:mcrb:criteria
+    memorial: RU:Key:memorial
+    memorial:subject: RU:Key:memorial:subject
     memorial:type: RU:Key:memorial:type
     military: RU:Key:military
     min_height: RU:Key:min height
@@ -20190,6 +21589,9 @@ ru:
     moped: RU:Key:moped
     motor_vehicle: RU:Key:motor vehicle
     motorcycle: RU:Key:motorcycle
+    motorcycle:parking: RU:Key:motorcycle:parking
+    motorcycle:rental: RU:Key:motorcycle:rental
+    motorcycle:storage: RU:Key:motorcycle:storage
     motorroad: RU:Key:motorroad
     mountain_pass: RU:Key:mountain pass
     mtb:scale: RU:Key:mtb:scale
@@ -20199,38 +21601,52 @@ ru:
     nat_name: RU:Key:nat name
     nat_ref: RU:Key:nat ref
     natural: RU:Key:natural
+    ncn_milepost: RU:Key:ncn milepost
+    network: RU:Key:network
+    next_check_date: RU:Key:next check date
     noaddress: RU:Key:noaddress
     noexit: RU:Key:noexit
-    noname: RU:Key:noname
+    nohousenumber: RU:Key:nohousenumber
     note: RU:Key:note
     office: RU:Key:office
+    office/Обзор_офисов: RU:Key:office/Обзор офисов
     official_name: RU:Key:official name
     official_short_type: RU:Key:official short type
     old_name: RU:Key:old name
     old_ref: RU:Key:old ref
     oneway: RU:Key:oneway
+    oneway:bicycle: RU:Key:oneway:bicycle
     opening_date: RU:Key:opening date
     opening_hours: RU:Key:opening hours
     opening_hours:kitchen: RU:Key:opening hours:kitchen
     operator: RU:Key:operator
     operator:ref:inn: RU:Key:operator:ref:inn
     operator:type: RU:Key:operator:type
+    orientation: RU:Key:orientation
     origin: RU:Key:origin
     overtaking: RU:Key:overtaking
     owner: RU:Key:owner
     ownership: RU:Key:ownership
+    park_ride: RU:Key:park ride
     parking: RU:Key:parking
+    parking:condition: RU:Key:parking:condition
     parking:lane: RU:Key:parking:lane
     parking:lane:both: RU:Key:parking:lane:both
     parking:lane:left: RU:Key:parking:lane:left
+    parking:lane:left:parallel: RU:Key:parking:lane:left:parallel
     parking:lane:right: RU:Key:parking:lane:right
+    parking:lane:right:parallel: RU:Key:parking:lane:right:parallel
+    parking:orientation: RU:Key:parking:orientation
+    parking_space: RU:Key:parking space
     passenger_information_display: RU:Key:passenger information display
     passing_places: RU:Key:passing places
     paved:date: RU:Key:paved:date
     payment: RU:Key:payment
+    payment:coins: RU:Key:payment:coins
     payment:credit_cards: RU:Key:payment:credit cards
     payment:notes: RU:Key:payment:notes
     phone: RU:Key:phone
+    picnic_table: RU:Key:picnic table
     pipeline: RU:Key:pipeline
     piste:type: RU:Key:piste:type
     place: RU:Key:place
@@ -20246,22 +21662,31 @@ ru:
     previous:vehicle: RU:Key:previous:vehicle
     priority_road: RU:Key:priority road
     product: RU:Key:product
+    proposed: RU:Key:proposed
     psv: RU:Key:psv
     public_bookcase:type: RU:Key:public bookcase:type
     pump: RU:Key:pump
     railway: RU:Key:railway
     ramp: RU:Key:ramp
+    ramp:bicycle: RU:Key:ramp:bicycle
     recycling:fire_extinguishers: RU:Key:recycling:fire extinguishers
     recycling_type: RU:Key:recycling type
     ref: RU:Key:ref
+    ref:RS:nkd: RU:Key:ref:RS:nkd
+    ref:mobil-parken.de: RU:Key:ref:mobil-parken.de
     ref:ruian:building: RU:Key:ref:ruian:building
     reference: RU:Key:reference
     refitted: RU:Key:refitted
     reg_name: RU:Key:reg name
     reg_ref: RU:Key:reg ref
     religion: RU:Key:religion
+    rental: RU:Key:rental
+    research: RU:Key:research
+    reservoir_type: RU:Key:reservoir type
+    residential: RU:Key:residential
     resort: RU:Key:resort
     resource: RU:Key:resource
+    rhn_ref: RU:Key:rhn ref
     right: RU:Key:right
     roof:direction: RU:Key:roof:direction
     roof:material: RU:Key:roof:material
@@ -20297,13 +21722,18 @@ ru:
     source:maxspeed: RU:Key:source:maxspeed
     source:taxon: RU:Key:source:taxon
     species: RU:Key:species
+    speed_pedelec: RU:Key:speed pedelec
     sport: RU:Key:sport
     start_date: RU:Key:start date
     step_count: RU:Key:step count
     substance: RU:Key:substance
+    supervised: RU:Key:supervised
     surface: RU:Key:surface
     surveillance: RU:Key:surveillance
     survey:date: RU:Key:survey:date
+    sustrans_ref: RU:Key:sustrans ref
+    swimming: RU:Key:swimming
+    symbol: RU:Key:symbol
     tactile_paving: RU:Key:tactile paving
     taxon: RU:Key:taxon
     technology: RU:Key:technology
@@ -20318,17 +21748,25 @@ ru:
     traffic_sign: RU:Key:traffic sign
     traffic_signals: RU:Key:traffic signals
     trail_visibility: RU:Key:trail visibility
+    trailer:rental: RU:Key:trailer:rental
     tram: RU:Key:tram
+    trolley_wire: RU:Key:trolley wire
     trolleybus: RU:Key:trolleybus
     tunnel: RU:Key:tunnel
     turn: RU:Key:turn
     turn:lanes: RU:Key:turn:lanes
     type: RU:Key:type
+    url: RU:Key:url
     usage: RU:Key:usage
     vehicle: RU:Key:vehicle
+    vending: RU:Key:vending
+    visibility: RU:Key:visibility
     voltage: RU:Key:voltage
+    washing_machine: RU:Key:washing machine
     waste: RU:Key:waste
     water: RU:Key:water
+    water_source: RU:Key:water source
+    water_system: RU:Key:water system
     waterway: RU:Key:waterway
     website: RU:Key:website
     wheelchair: RU:Key:wheelchair
@@ -20340,6 +21778,7 @@ ru:
     winter_road: RU:Key:winter road
     wood: RU:Key:wood
     xmas:feature: RU:Key:xmas:feature
+    zone:traffic: RU:Key:zone:traffic
   tag:
     access=customers: RU:Tag:access=customers
     access=delivery: RU:Tag:access=delivery
@@ -20372,6 +21811,7 @@ ru:
     amenity=animal_boarding: RU:Tag:amenity=animal boarding
     amenity=animal_breeding: RU:Tag:amenity=animal breeding
     amenity=animal_shelter: RU:Tag:amenity=animal shelter
+    amenity=animal_training: RU:Tag:amenity=animal training
     amenity=arts_centre: RU:Tag:amenity=arts centre
     amenity=atm: RU:Tag:amenity=atm
     amenity=baby_hatch: RU:Tag:amenity=baby hatch
@@ -20379,10 +21819,14 @@ ru:
     amenity=bar: RU:Tag:amenity=bar
     amenity=bbq: RU:Tag:amenity=bbq
     amenity=bench: RU:Tag:amenity=bench
+    amenity=bicycle_library: RU:Tag:amenity=bicycle library
     amenity=bicycle_parking: RU:Tag:amenity=bicycle parking
     amenity=bicycle_rental: RU:Tag:amenity=bicycle rental
     amenity=bicycle_repair_station: RU:Tag:amenity=bicycle repair station
+    amenity=bicycle_trailer_sharing: RU:Tag:amenity=bicycle trailer sharing
     amenity=biergarten: RU:Tag:amenity=biergarten
+    amenity=binoculars: RU:Tag:amenity=binoculars
+    amenity=bird_bath: RU:Tag:amenity=bird bath
     amenity=boat_storage: RU:Tag:amenity=boat storage
     amenity=border_control: RU:Tag:amenity=border control
     amenity=brothel: RU:Tag:amenity=brothel
@@ -20393,6 +21837,7 @@ ru:
     amenity=car_sharing: RU:Tag:amenity=car sharing
     amenity=car_wash: RU:Tag:amenity=car wash
     amenity=casino: RU:Tag:amenity=casino
+    amenity=changing_room: RU:Tag:amenity=changing room
     amenity=charging_station: RU:Tag:amenity=charging station
     amenity=checkpoint: RU:Tag:amenity=checkpoint
     amenity=childcare: RU:Tag:amenity=childcare
@@ -20411,7 +21856,10 @@ ru:
     amenity=dentist: RU:Tag:amenity=dentist
     amenity=device_charging_station: RU:Tag:amenity=device charging station
     amenity=doctors: RU:Tag:amenity=doctors
+    amenity=dog_bin: RU:Tag:amenity=dog bin
+    amenity=dog_toilet: RU:Tag:amenity=dog toilet
     amenity=dojo: RU:Tag:amenity=dojo
+    amenity=dressing_room: RU:Tag:amenity=dressing room
     amenity=drinking_water: RU:Tag:amenity=drinking water
     amenity=driver_training: RU:Tag:amenity=driver training
     amenity=driving_school: RU:Tag:amenity=driving school
@@ -20426,14 +21874,18 @@ ru:
     amenity=fountain: RU:Tag:amenity=fountain
     amenity=fridge: RU:Tag:amenity=fridge
     amenity=fuel: RU:Tag:amenity=fuel
+    amenity=funeral_hall: RU:Tag:amenity=funeral hall
     amenity=game_feeding: RU:Tag:amenity=game feeding
     amenity=grave_yard: RU:Tag:amenity=grave yard
     amenity=grit_bin: RU:Tag:amenity=grit bin
     amenity=harbourmaster: RU:Tag:amenity=harbourmaster
+    amenity=hitching_post: RU:Tag:amenity=hitching post
     amenity=hookah_lounge: RU:Tag:amenity=hookah lounge
     amenity=hospice: RU:Tag:amenity=hospice
     amenity=hospital: RU:Tag:amenity=hospital
+    amenity=hunting_stand: RU:Tag:amenity=hunting stand
     amenity=ice_cream: RU:Tag:amenity=ice cream
+    amenity=kick-scooter_rental: RU:Tag:amenity=kick-scooter rental
     amenity=kindergarten: RU:Tag:amenity=kindergarten
     amenity=kitchen: RU:Tag:amenity=kitchen
     amenity=kneipp_water_cure: RU:Tag:amenity=kneipp water cure
@@ -20448,6 +21900,7 @@ ru:
     amenity=monastery: RU:Tag:amenity=monastery
     amenity=mortuary: RU:Tag:amenity=mortuary
     amenity=motorcycle_parking: RU:Tag:amenity=motorcycle parking
+    amenity=music_school: RU:Tag:amenity=music school
     amenity=nightclub: RU:Tag:amenity=nightclub
     amenity=nursing_home: RU:Tag:amenity=nursing home
     amenity=parking: RU:Tag:amenity=parking
@@ -20462,9 +21915,11 @@ ru:
     amenity=post_box: RU:Tag:amenity=post box
     amenity=post_office: RU:Tag:amenity=post office
     amenity=prison: RU:Tag:amenity=prison
+    amenity=prison_camp: RU:Tag:amenity=prison camp
     amenity=pub: RU:Tag:amenity=pub
     amenity=public_bookcase: RU:Tag:amenity=public bookcase
     amenity=public_building: RU:Tag:amenity=public building
+    amenity=ranger_station: RU:Tag:amenity=ranger station
     amenity=recycling: RU:Tag:amenity=recycling
     amenity=register_office: RU:Tag:amenity=register office
     amenity=rescue_station: RU:Tag:amenity=rescue station
@@ -20480,6 +21935,7 @@ ru:
     amenity=shower: RU:Tag:amenity=shower
     amenity=smoking_area: RU:Tag:amenity=smoking area
     amenity=social_facility: RU:Tag:amenity=social facility
+    amenity=stables: RU:Tag:amenity=stables
     amenity=stool: RU:Tag:amenity=stool
     amenity=stripclub: RU:Tag:amenity=stripclub
     amenity=studio: RU:Tag:amenity=studio
@@ -20490,7 +21946,9 @@ ru:
     amenity=television: RU:Tag:amenity=television
     amenity=theatre: RU:Tag:amenity=theatre
     amenity=toilets: RU:Tag:amenity=toilets
+    amenity=tourist_bus_parking: RU:Tag:amenity=tourist bus parking
     amenity=townhall: RU:Tag:amenity=townhall
+    amenity=training: RU:Tag:amenity=training
     amenity=trolley_bay: RU:Tag:amenity=trolley bay
     amenity=university: RU:Tag:amenity=university
     amenity=vacuum_cleaner: RU:Tag:amenity=vacuum cleaner
@@ -20499,19 +21957,30 @@ ru:
     amenity=vending_machine: RU:Tag:amenity=vending machine
     amenity=veterinary: RU:Tag:amenity=veterinary
     amenity=veterinary_pharmacy: RU:Tag:amenity=veterinary pharmacy
+    amenity=vivarium: RU:Tag:amenity=vivarium
     amenity=washing_machine: RU:Tag:amenity=washing machine
     amenity=waste_basket: RU:Tag:amenity=waste basket
     amenity=waste_disposal: RU:Tag:amenity=waste disposal
     amenity=water_point: RU:Tag:amenity=water point
     amenity=watering_place: RU:Tag:amenity=watering place
     amenity=weighbridge: RU:Tag:amenity=weighbridge
+    animal=horse_walker: RU:Tag:animal=horse walker
+    animal=school: RU:Tag:animal=school
     animated=trivision_blades: RU:Tag:animated=trivision blades
     animated=winding_posters: RU:Tag:animated=winding posters
     anthropogenic=yes: RU:Tag:anthropogenic=yes
+    artwork_type=architecture: RU:Tag:artwork type=architecture
+    artwork_type=bust: RU:Tag:artwork type=bust
+    artwork_type=mural: RU:Tag:artwork type=mural
+    artwork_type=relief: RU:Tag:artwork type=relief
     artwork_type=sculpture: RU:Tag:artwork type=sculpture
     artwork_type=statue: RU:Tag:artwork type=statue
+    artwork_type=stone: RU:Tag:artwork type=stone
     atm=yes: RU:Tag:atm=yes
+    attraction=alpine_coaster: RU:Tag:attraction=alpine coaster
     attraction=animal: RU:Tag:attraction=animal
+    attraction=maze: RU:Tag:attraction=maze
+    attraction=roller_coaster: RU:Tag:attraction=roller coaster
     attraction=summer_toboggan: RU:Tag:attraction=summer toboggan
     attraction=train: RU:Tag:attraction=train
     attraction=water_slide: RU:Tag:attraction=water slide
@@ -20525,6 +21994,7 @@ ru:
     barrier=chain: RU:Tag:barrier=chain
     barrier=chech_hedgehog: RU:Tag:barrier=chech hedgehog
     barrier=city_wall: RU:Tag:barrier=city wall
+    barrier=cycle_barrier: RU:Tag:barrier=cycle barrier
     barrier=czech_hedgehog: RU:Tag:barrier=czech hedgehog
     barrier=debris: RU:Tag:barrier=debris
     barrier=ditch: RU:Tag:barrier=ditch
@@ -20538,21 +22008,30 @@ ru:
     barrier=hedge: RU:Tag:barrier=hedge
     barrier=hedge_bank: RU:Tag:barrier=hedge bank
     barrier=height_restrictor: RU:Tag:barrier=height restrictor
+    barrier=horse_jump: RU:Tag:barrier=horse jump
+    barrier=horse_stile: RU:Tag:barrier=horse stile
     barrier=kerb: RU:Tag:barrier=kerb
     barrier=lift_gate: RU:Tag:barrier=lift gate
     barrier=log: RU:Tag:barrier=log
     barrier=retaining_wall: RU:Tag:barrier=retaining wall
     barrier=sally_port: RU:Tag:barrier=sally port
     barrier=sliding_gate: RU:Tag:barrier=sliding gate
+    barrier=stile: RU:Tag:barrier=stile
     barrier=swing_gate: RU:Tag:barrier=swing gate
     barrier=tank_trap: RU:Tag:barrier=tank trap
     barrier=toll_booth: RU:Tag:barrier=toll booth
     barrier=turnstile: RU:Tag:barrier=turnstile
     barrier=wall: RU:Tag:barrier=wall
+    barrier=wicket_gate: RU:Tag:barrier=wicket gate
+    barrier=yes: RU:Tag:barrier=yes
     bicycle=designated: RU:Tag:bicycle=designated
+    bicycle=yes: RU:Tag:bicycle=yes
+    board_type=board: RU:Tag:board type=board
+    boat:rental=yes: RU:Tag:boat:rental=yes
     boundary=administrative: RU:Tag:boundary=administrative
     boundary=forest_compartment: RU:Tag:boundary=forest compartment
     boundary=forestry_compartment: RU:Tag:boundary=forestry compartment
+    boundary=place: RU:Tag:boundary=place
     boundary=postal_code: RU:Tag:boundary=postal code
     boundary=protected_area: RU:Tag:boundary=protected area
     bridge:movable=bascule: RU:Tag:bridge:movable=bascule
@@ -20576,6 +22055,7 @@ ru:
     building=apartments: RU:Tag:building=apartments
     building=bakehouse: RU:Tag:building=bakehouse
     building=barn: RU:Tag:building=barn
+    building=barracks: RU:Tag:building=barracks
     building=boathouse: RU:Tag:building=boathouse
     building=brewery: RU:Tag:building=brewery
     building=bridge: RU:Tag:building=bridge
@@ -20583,6 +22063,7 @@ ru:
     building=bunker: RU:Tag:building=bunker
     building=cabin: RU:Tag:building=cabin
     building=carport: RU:Tag:building=carport
+    building=castle: RU:Tag:building=castle
     building=cathedral: RU:Tag:building=cathedral
     building=central_office: RU:Tag:building=central office
     building=chapel: RU:Tag:building=chapel
@@ -20593,24 +22074,29 @@ ru:
     building=commercial: RU:Tag:building=commercial
     building=condominium: RU:Tag:building=condominium
     building=conservatory: RU:Tag:building=conservatory
+    building=constructie: RU:Tag:building=constructie
     building=construction: RU:Tag:building=construction
     building=container: RU:Tag:building=container
     building=convent: RU:Tag:building=convent
     building=cowshed: RU:Tag:building=cowshed
+    building=demountable: RU:Tag:building=demountable
     building=detached: RU:Tag:building=detached
     building=digester: RU:Tag:building=digester
     building=disused: RU:Tag:building=disused
     building=dormitory: RU:Tag:building=dormitory
     building=entrance: RU:Tag:building=entrance
+    building=factory: RU:Tag:building=factory
     building=farm: RU:Tag:building=farm
     building=farm_auxiliary: RU:Tag:building=farm auxiliary
     building=fire_station: RU:Tag:building=fire station
     building=font: RU:Tag:building=font
+    building=fort: RU:Tag:building=fort
     building=funeral_hall: RU:Tag:building=funeral hall
     building=garage: RU:Tag:building=garage
     building=garages: RU:Tag:building=garages
     building=gatehouse: RU:Tag:building=gatehouse
     building=ger: RU:Tag:building=ger
+    building=glasshouse: RU:Tag:building=glasshouse
     building=government: RU:Tag:building=government
     building=grandstand: RU:Tag:building=grandstand
     building=greenhouse: RU:Tag:building=greenhouse
@@ -20626,12 +22112,16 @@ ru:
     building=kiosk: RU:Tag:building=kiosk
     building=manufacture: RU:Tag:building=manufacture
     building=marquee: RU:Tag:building=marquee
+    building=military: RU:Tag:building=military
     building=monastery: RU:Tag:building=monastery
     building=mosque: RU:Tag:building=mosque
     building=museum: RU:Tag:building=museum
     building=office: RU:Tag:building=office
+    building=palace: RU:Tag:building=palace
     building=parking: RU:Tag:building=parking
     building=pavilion: RU:Tag:building=pavilion
+    building=presbytery: RU:Tag:building=presbytery
+    building=proposed: RU:Tag:building=proposed
     building=public: RU:Tag:building=public
     building=religious: RU:Tag:building=religious
     building=residential: RU:Tag:building=residential
@@ -20675,10 +22165,15 @@ ru:
     building=unknown: RU:Tag:building=unknown
     building=warehouse: RU:Tag:building=warehouse
     building=water_tower: RU:Tag:building=water tower
+    building=wayside_shrine: RU:Tag:building=wayside shrine
     building=yes: RU:Tag:building=yes
     bunker_type=pillbox: RU:Tag:bunker type=pillbox
     cafe=time-cafe: RU:Tag:cafe=time-cafe
     cafe=time_cafe: RU:Tag:cafe=time cafe
+    camp_site=basic: RU:Tag:camp site=basic
+    camp_site=deluxe: RU:Tag:camp site=deluxe
+    camp_site=serviced: RU:Tag:camp site=serviced
+    camp_site=standard: RU:Tag:camp site=standard
     castle_type=defensive: RU:Tag:castle type=defensive
     castle_type=fortress: RU:Tag:castle type=fortress
     castle_type=kremlin: RU:Tag:castle type=kremlin
@@ -20687,7 +22182,14 @@ ru:
     castle_type=shiro: RU:Tag:castle type=shiro
     castle_type=stately: RU:Tag:castle type=stately
     cemetery=grave: RU:Tag:cemetery=grave
+    cemetery=sector: RU:Tag:cemetery=sector
+    club=social: RU:Tag:club=social
+    company=aerospace: RU:Tag:company=aerospace
+    company=it: RU:Tag:company=it
+    company=logistics: RU:Tag:company=logistics
+    company=software_development: RU:Tag:company=software development
     craft=agricultural_engines: RU:Tag:craft=agricultural engines
+    craft=bakery: RU:Tag:craft=bakery
     craft=basket_maker: RU:Tag:craft=basket maker
     craft=beekeeper: RU:Tag:craft=beekeeper
     craft=blacksmith: RU:Tag:craft=blacksmith
@@ -20698,10 +22200,12 @@ ru:
     craft=carpet_layer: RU:Tag:craft=carpet layer
     craft=caterer: RU:Tag:craft=caterer
     craft=clockmaker: RU:Tag:craft=clockmaker
+    craft=distillery: RU:Tag:craft=distillery
     craft=dressmaker: RU:Tag:craft=dressmaker
     craft=electrician: RU:Tag:craft=electrician
     craft=glaziery: RU:Tag:craft=glaziery
     craft=handicraft: RU:Tag:craft=handicraft
+    craft=hvac: RU:Tag:craft=hvac
     craft=key_cutter: RU:Tag:craft=key cutter
     craft=photographer: RU:Tag:craft=photographer
     craft=roofer: RU:Tag:craft=roofer
@@ -20709,9 +22213,19 @@ ru:
     craft=stonemason: RU:Tag:craft=stonemason
     craft=tailor: RU:Tag:craft=tailor
     craft=window_construction: RU:Tag:craft=window construction
+    craft=winery: RU:Tag:craft=winery
     crop=grape: RU:Tag:crop=grape
     crop=hop: RU:Tag:crop=hop
+    cycleway:left=lane: RU:Tag:cycleway:left=lane
+    cycleway:left=share_busway: RU:Tag:cycleway:left=share busway
+    cycleway:right=lane: RU:Tag:cycleway:right=lane
+    cycleway:right=share_busway: RU:Tag:cycleway:right=share busway
     cycleway=opposite_lane: RU:Tag:cycleway=opposite lane
+    cycleway=share_busway: RU:Tag:cycleway=share busway
+    dog=leashed: RU:Tag:dog=leashed
+    dog=no: RU:Tag:dog=no
+    dog=unleashed: RU:Tag:dog=unleashed
+    dog=yes: RU:Tag:dog=yes
     emergency=ambulance_station: RU:Tag:emergency=ambulance station
     emergency=fire_extinguisher: RU:Tag:emergency=fire extinguisher
     emergency=fire_hose: RU:Tag:emergency=fire hose
@@ -20720,18 +22234,43 @@ ru:
     emergency=phone: RU:Tag:emergency=phone
     emergency=suction_point: RU:Tag:emergency=suction point
     emergency=water_tank: RU:Tag:emergency=water tank
+    entrance=garage: RU:Tag:entrance=garage
     entrance=staircase: RU:Tag:entrance=staircase
     fast_food=cafeteria: RU:Tag:fast food=cafeteria
     foot=designated: RU:Tag:foot=designated
+    foot=yes: RU:Tag:foot=yes
+    footway=access_aisle: RU:Tag:footway=access aisle
     footway=crossing: RU:Tag:footway=crossing
     footway=sidewalk: RU:Tag:footway=sidewalk
+    footway=traffic_island: RU:Tag:footway=traffic island
+    ford=yes: RU:Tag:ford=yes
     generator:method=anaerobic_digestion: RU:Tag:generator:method=anaerobic digestion
     generator:source=hydro: RU:Tag:generator:source=hydro
     generator:type=boiler: RU:Tag:generator:type=boiler
     geological=palaeontological_site: RU:Tag:geological=palaeontological site
+    government=administrative: RU:Tag:government=administrative
+    government=aerospace: RU:Tag:government=aerospace
+    government=audit: RU:Tag:government=audit
+    government=bailiff: RU:Tag:government=bailiff
+    government=border_control: RU:Tag:government=border control
+    government=cadaster: RU:Tag:government=cadaster
     government=customs: RU:Tag:government=customs
+    government=education: RU:Tag:government=education
+    government=healthcare: RU:Tag:government=healthcare
+    government=it: RU:Tag:government=it
+    government=legislative: RU:Tag:government=legislative
+    government=ministry: RU:Tag:government=ministry
+    government=parliament: RU:Tag:government=parliament
+    government=prosecutor: RU:Tag:government=prosecutor
+    government=register_office: RU:Tag:government=register office
+    government=social_security: RU:Tag:government=social security
+    government=statistics: RU:Tag:government=statistics
+    government=tax: RU:Tag:government=tax
+    government=youth_welfare_department: RU:Tag:government=youth welfare department
     healthcare=blood_donation: RU:Tag:healthcare=blood donation
+    healthcare=doctor: RU:Tag:healthcare=doctor
     healthcare=laboratory: RU:Tag:healthcare=laboratory
+    healthcare=sample_collection: RU:Tag:healthcare=sample collection
     highway=bridleway: RU:Tag:highway=bridleway
     highway=bus_guideway: RU:Tag:highway=bus guideway
     highway=bus_stop: RU:Tag:highway=bus stop
@@ -20794,6 +22333,7 @@ ru:
     historic=gallows: RU:Tag:historic=gallows
     historic=heritage: RU:Tag:historic=heritage
     historic=highwater_mark: RU:Tag:historic=highwater mark
+    historic=house: RU:Tag:historic=house
     historic=locomotive: RU:Tag:historic=locomotive
     historic=manor: RU:Tag:historic=manor
     historic=memorial: RU:Tag:historic=memorial
@@ -20815,12 +22355,19 @@ ru:
     historic=wayside_shrine: RU:Tag:historic=wayside shrine
     historic=wreck: RU:Tag:historic=wreck
     horse=designated: RU:Tag:horse=designated
+    horse=dismount: RU:Tag:horse=dismount
     industrial=factory: RU:Tag:industrial=factory
     industrial=warehouse: RU:Tag:industrial=warehouse
     industrial=well_cluster: RU:Tag:industrial=well cluster
+    information=audioguide: RU:Tag:information=audioguide
     information=board: RU:Tag:information=board
     information=guidepost: RU:Tag:information=guidepost
+    information=map: RU:Tag:information=map
     information=office: RU:Tag:information=office
+    information=tactile_map: RU:Tag:information=tactile map
+    information=tactile_model: RU:Tag:information=tactile model
+    information=terminal: RU:Tag:information=terminal
+    information=visitor_centre: RU:Tag:information=visitor centre
     junction=roundabout: RU:Tag:junction=roundabout
     landuse=allotments: RU:Tag:landuse=allotments
     landuse=animal_keeping: RU:Tag:landuse=animal keeping
@@ -20831,6 +22378,7 @@ ru:
     landuse=construction: RU:Tag:landuse=construction
     landuse=depot: RU:Tag:landuse=depot
     landuse=farm: RU:Tag:landuse=farm
+    landuse=farmland: RU:Tag:landuse=farmland
     landuse=flowerbed: RU:Tag:landuse=flowerbed
     landuse=forest: RU:Tag:landuse=forest
     landuse=garages: RU:Tag:landuse=garages
@@ -20866,10 +22414,13 @@ ru:
     leaf_type=needleleaved: RU:Tag:leaf type=needleleaved
     leisure=bandstand: RU:Tag:leisure=bandstand
     leisure=beach_resort: RU:Tag:leisure=beach resort
+    leisure=bird_hide: RU:Tag:leisure=bird hide
     leisure=common: RU:Tag:leisure=common
     leisure=dance: RU:Tag:leisure=dance
+    leisure=dog_park: RU:Tag:leisure=dog park
     leisure=escape_game: RU:Tag:leisure=escape game
     leisure=firepit: RU:Tag:leisure=firepit
+    leisure=fishing: RU:Tag:leisure=fishing
     leisure=fitness_centre: RU:Tag:leisure=fitness centre
     leisure=fitness_station: RU:Tag:leisure=fitness station
     leisure=garden: RU:Tag:leisure=garden
@@ -20890,12 +22441,16 @@ ru:
     leisure=swimming_pool: RU:Tag:leisure=swimming pool
     leisure=track: RU:Tag:leisure=track
     leisure=water_park: RU:Tag:leisure=water park
+    leisure=wildlife_hide: RU:Tag:leisure=wildlife hide
     location=overground: RU:Tag:location=overground
     location=overhead: RU:Tag:location=overhead
     location=underground: RU:Tag:location=underground
     location=underwater: RU:Tag:location=underwater
     man_made=adit: RU:Tag:man made=adit
+    man_made=animal_trap: RU:Tag:man made=animal trap
+    man_made=architecture_line: RU:Tag:man made=architecture line
     man_made=beacon: RU:Tag:man made=beacon
+    man_made=beehive: RU:Tag:man made=beehive
     man_made=breakwater: RU:Tag:man made=breakwater
     man_made=bridge: RU:Tag:man made=bridge
     man_made=bunker_silo: RU:Tag:man made=bunker silo
@@ -20915,10 +22470,13 @@ ru:
     man_made=flagpole: RU:Tag:man made=flagpole
     man_made=flare: RU:Tag:man made=flare
     man_made=geoglyph: RU:Tag:man made=geoglyph
+    man_made=guard_stone: RU:Tag:man made=guard stone
     man_made=lighthouse: RU:Tag:man made=lighthouse
     man_made=mast: RU:Tag:man made=mast
     man_made=mineshaft: RU:Tag:man made=mineshaft
     man_made=monitoring_station: RU:Tag:man made=monitoring station
+    man_made=mounting_block: RU:Tag:man made=mounting block
+    man_made=nesting_site: RU:Tag:man made=nesting site
     man_made=obelisk: RU:Tag:man made=obelisk
     man_made=observatory: RU:Tag:man made=observatory
     man_made=petroleum_well: RU:Tag:man made=petroleum well
@@ -20928,6 +22486,7 @@ ru:
     man_made=pumping_station: RU:Tag:man made=pumping station
     man_made=reservoir_covered: RU:Tag:man made=reservoir covered
     man_made=silo: RU:Tag:man made=silo
+    man_made=spoil_heap: RU:Tag:man made=spoil heap
     man_made=storage_tank: RU:Tag:man made=storage tank
     man_made=street_cabinet: RU:Tag:man made=street cabinet
     man_made=surveillance: RU:Tag:man made=surveillance
@@ -20941,10 +22500,14 @@ ru:
     man_made=water_works: RU:Tag:man made=water works
     man_made=watermill: RU:Tag:man made=watermill
     man_made=wildlife_crossing: RU:Tag:man made=wildlife crossing
+    man_made=wildlife_opening: RU:Tag:man made=wildlife opening
     man_made=windmill: RU:Tag:man made=windmill
     man_made=works: RU:Tag:man made=works
     manhole=drain: RU:Tag:manhole=drain
+    maxweight:signed=no: RU:Tag:maxweight:signed=no
+    memorial=ghost_bike: RU:Tag:memorial=ghost bike
     memorial=stele: RU:Tag:memorial=stele
+    microbrewery=yes: RU:Tag:microbrewery=yes
     military=airfield: RU:Tag:military=airfield
     military=barracks: RU:Tag:military=barracks
     military=bunker: RU:Tag:military=bunker
@@ -20985,30 +22548,89 @@ ru:
     natural=water: RU:Tag:natural=water
     natural=wetland: RU:Tag:natural=wetland
     natural=wood: RU:Tag:natural=wood
+    network=lhn: RU:Tag:network=lhn
+    network=rhn: RU:Tag:network=rhn
+    noname=yes: RU:Tag:noname=yes
     office=accountant: RU:Tag:office=accountant
     office=administrative: RU:Tag:office=administrative
+    office=adoption_agency: RU:Tag:office=adoption agency
+    office=advertising_agency: RU:Tag:office=advertising agency
     office=architect: RU:Tag:office=architect
+    office=archive: RU:Tag:office=archive
+    office=association: RU:Tag:office=association
+    office=bail_bond_agent: RU:Tag:office=bail bond agent
+    office=chamber: RU:Tag:office=chamber
+    office=charity: RU:Tag:office=charity
     office=company: RU:Tag:office=company
+    office=consulting: RU:Tag:office=consulting
+    office=courier: RU:Tag:office=courier
+    office=coworking: RU:Tag:office=coworking
+    office=diplomatic: RU:Tag:office=diplomatic
     office=educational_institution: RU:Tag:office=educational institution
     office=employment_agency: RU:Tag:office=employment agency
+    office=energy_supplier: RU:Tag:office=energy supplier
+    office=engineer: RU:Tag:office=engineer
     office=estate_agent: RU:Tag:office=estate agent
+    office=financial: RU:Tag:office=financial
+    office=financial_advisor: RU:Tag:office=financial advisor
+    office=forestry: RU:Tag:office=forestry
+    office=foundation: RU:Tag:office=foundation
+    office=geodesist: RU:Tag:office=geodesist
     office=government: RU:Tag:office=government
+    office=graphic_design: RU:Tag:office=graphic design
+    office=guide: RU:Tag:office=guide
+    office=harbour_master: RU:Tag:office=harbour master
+    office=healthcare: RU:Tag:office=healthcare
     office=insurance: RU:Tag:office=insurance
+    office=international_organization: RU:Tag:office=international organization
     office=it: RU:Tag:office=it
     office=lawyer: RU:Tag:office=lawyer
     office=logistics: RU:Tag:office=logistics
+    office=medical: RU:Tag:office=medical
+    office=moving_company: RU:Tag:office=moving company
     office=newspaper: RU:Tag:office=newspaper
     office=ngo: RU:Tag:office=ngo
+    office=notary: RU:Tag:office=notary
+    office=occupational_safety: RU:Tag:office=occupational safety
+    office=parish: RU:Tag:office=parish
     office=political_party: RU:Tag:office=political party
+    office=private_investigator: RU:Tag:office=private investigator
+    office=property_management: RU:Tag:office=property management
+    office=publisher: RU:Tag:office=publisher
+    office=quango: RU:Tag:office=quango
+    office=real_estate_agent: RU:Tag:office=real estate agent
+    office=register: RU:Tag:office=register
+    office=religion: RU:Tag:office=religion
     office=research: RU:Tag:office=research
+    office=security: RU:Tag:office=security
+    office=supervised_injection_site: RU:Tag:office=supervised injection site
+    office=surveyor: RU:Tag:office=surveyor
+    office=tax: RU:Tag:office=tax
+    office=tax_advisor: RU:Tag:office=tax advisor
     office=telecommunication: RU:Tag:office=telecommunication
+    office=therapist: RU:Tag:office=therapist
+    office=tourist_accommodation: RU:Tag:office=tourist accommodation
     office=travel_agent: RU:Tag:office=travel agent
+    office=tutoring: RU:Tag:office=tutoring
+    office=union: RU:Tag:office=union
+    office=university: RU:Tag:office=university
+    office=visa: RU:Tag:office=visa
+    office=water_utility: RU:Tag:office=water utility
+    office=yes: RU:Tag:office=yes
+    oneway:moped=no: RU:Tag:oneway:moped=no
     opening_hours=24/7: RU:Tag:opening hours=24/7
     overtaking=backward: RU:Tag:overtaking=backward
     overtaking=both: RU:Tag:overtaking=both
     overtaking=forward: RU:Tag:overtaking=forward
     overtaking=no: RU:Tag:overtaking=no
     overtaking=yes: RU:Tag:overtaking=yes
+    parking:orientation=perpendicular: RU:Tag:parking:orientation=perpendicular
+    parking=lane: RU:Tag:parking=lane
+    parking=layby: RU:Tag:parking=layby
+    parking=multi-storey: RU:Tag:parking=multi-storey
+    parking=street_side: RU:Tag:parking=street side
+    parking=surface: RU:Tag:parking=surface
+    parking=underground: RU:Tag:parking=underground
     pipeline=marker: RU:Tag:pipeline=marker
     pipeline=substation: RU:Tag:pipeline=substation
     place=allotments: RU:Tag:place=allotments
@@ -21062,14 +22684,18 @@ ru:
     railway=turntable: RU:Tag:railway=turntable
     religion=pagan: RU:Tag:religion=pagan
     religion=zoroastrian: RU:Tag:religion=zoroastrian
+    request_stop=yes: RU:Tag:request stop=yes
     residential=apartments: RU:Tag:residential=apartments
     residential=rural: RU:Tag:residential=rural
     residential=urban: RU:Tag:residential=urban
     route=bus: RU:Tag:route=bus
     route=ferry: RU:Tag:route=ferry
+    route=horse: RU:Tag:route=horse
     route=railway: RU:Tag:route=railway
+    route=share_taxi: RU:Tag:route=share taxi
     route=train: RU:Tag:route=train
     route=tram: RU:Tag:route=tram
+    route=transhumance: RU:Tag:route=transhumance
     service=alley: RU:Tag:service=alley
     service=crossover: RU:Tag:service=crossover
     service=dealer: RU:Tag:service=dealer
@@ -21079,7 +22705,11 @@ ru:
     service=parts: RU:Tag:service=parts
     service=repair: RU:Tag:service=repair
     service=tyres: RU:Tag:service=tyres
+    shelter_type=basic_hut: RU:Tag:shelter type=basic hut
+    shelter_type=field_shelter: RU:Tag:shelter type=field shelter
+    shelter_type=lean_to: RU:Tag:shelter type=lean to
     shelter_type=public_transport: RU:Tag:shelter type=public transport
+    shop=3d_printing: RU:Tag:shop=3d printing
     shop=agrarian: RU:Tag:shop=agrarian
     shop=alcohol: RU:Tag:shop=alcohol
     shop=anime: RU:Tag:shop=anime
@@ -21093,8 +22723,10 @@ ru:
     shop=bed: RU:Tag:shop=bed
     shop=beverages: RU:Tag:shop=beverages
     shop=bicycle: RU:Tag:shop=bicycle
+    shop=boat: RU:Tag:shop=boat
     shop=books: RU:Tag:shop=books
     shop=boutique: RU:Tag:shop=boutique
+    shop=brewing_supplies: RU:Tag:shop=brewing supplies
     shop=butcher: RU:Tag:shop=butcher
     shop=car: RU:Tag:shop=car
     shop=car_parts: RU:Tag:shop=car parts
@@ -21147,7 +22779,9 @@ ru:
     shop=household_linen: RU:Tag:shop=household linen
     shop=houseware: RU:Tag:shop=houseware
     shop=hunting: RU:Tag:shop=hunting
+    shop=hvac: RU:Tag:shop=hvac
     shop=interior_decoration: RU:Tag:shop=interior decoration
+    shop=jetski: RU:Tag:shop=jetski
     shop=jewelry: RU:Tag:shop=jewelry
     shop=kiosk: RU:Tag:shop=kiosk
     shop=kitchen: RU:Tag:shop=kitchen
@@ -21167,13 +22801,16 @@ ru:
     shop=outdoor: RU:Tag:shop=outdoor
     shop=outpost: RU:Tag:shop=outpost
     shop=paint: RU:Tag:shop=paint
+    shop=pastry: RU:Tag:shop=pastry
     shop=pawnbroker: RU:Tag:shop=pawnbroker
     shop=pet: RU:Tag:shop=pet
     shop=pet_grooming: RU:Tag:shop=pet grooming
+    shop=photo: RU:Tag:shop=photo
     shop=power_tools: RU:Tag:shop=power tools
     shop=pyrotechnics: RU:Tag:shop=pyrotechnics
     shop=radiotechnics: RU:Tag:shop=radiotechnics
     shop=religion: RU:Tag:shop=religion
+    shop=rental: RU:Tag:shop=rental
     shop=seafood: RU:Tag:shop=seafood
     shop=second_hand: RU:Tag:shop=second hand
     shop=security: RU:Tag:shop=security
@@ -21199,11 +22836,15 @@ ru:
     shop=watches: RU:Tag:shop=watches
     shop=wholesale: RU:Tag:shop=wholesale
     shop=window_blind: RU:Tag:shop=window blind
+    shop=wine: RU:Tag:shop=wine
+    shop=winery: RU:Tag:shop=winery
     signpost=forestry_compartment: RU:Tag:signpost=forestry compartment
     sinkhole=bluehole: RU:Tag:sinkhole=bluehole
     site_type=fortification: RU:Tag:site type=fortification
     social_facility=group_home: RU:Tag:social facility=group home
     sport=archery: RU:Tag:sport=archery
+    sport=dog_racing: RU:Tag:sport=dog racing
+    sport=equestrian: RU:Tag:sport=equestrian
     sport=futsal: RU:Tag:sport=futsal
     sport=horse_racing: RU:Tag:sport=horse racing
     sport=motocross: RU:Tag:sport=motocross
@@ -21212,11 +22853,13 @@ ru:
     sport=shooting: RU:Tag:sport=shooting
     summit:cross=yes: RU:Tag:summit:cross=yes
     tank_trap=czech_hedgehog: RU:Tag:tank trap=czech hedgehog
+    tomb=cenotaph: RU:Tag:tomb=cenotaph
     tomb=war_grave: RU:Tag:tomb=war grave
     tourism=apartment: RU:Tag:tourism=apartment
     tourism=aquarium: RU:Tag:tourism=aquarium
     tourism=artwork: RU:Tag:tourism=artwork
     tourism=attraction: RU:Tag:tourism=attraction
+    tourism=camp_pitch: RU:Tag:tourism=camp pitch
     tourism=camp_site: RU:Tag:tourism=camp site
     tourism=caravan_site: RU:Tag:tourism=caravan site
     tourism=chalet: RU:Tag:tourism=chalet
@@ -21229,16 +22872,48 @@ ru:
     tourism=museum: RU:Tag:tourism=museum
     tourism=picnic_site: RU:Tag:tourism=picnic site
     tourism=theme_park: RU:Tag:tourism=theme park
+    tourism=trail_riding_rest: RU:Tag:tourism=trail riding rest
+    tourism=trail_riding_station: RU:Tag:tourism=trail riding station
     tourism=viewpoint: RU:Tag:tourism=viewpoint
+    tourism=wilderness_hut: RU:Tag:tourism=wilderness hut
+    tourism=yes: RU:Tag:tourism=yes
+    tourism=zoo: RU:Tag:tourism=zoo
     tower:type=bell_tower: RU:Tag:tower:type=bell tower
     tower:type=cooling: RU:Tag:tower:type=cooling
     tower:type=lighting: RU:Tag:tower:type=lighting
+    trade=wood: RU:Tag:trade=wood
+    traffic_calming=hump: RU:Tag:traffic calming=hump
     traffic_calming=table: RU:Tag:traffic calming=table
+    traffic_sign=city_limit: RU:Tag:traffic sign=city limit
+    tunnel=building_passage: RU:Tag:tunnel=building passage
     tunnel=culvert: RU:Tag:tunnel=culvert
     type=site: RU:Tag:type=site
     type=waterway: RU:Tag:type=waterway
+    vending=excrement_bags: RU:Tag:vending=excrement bags
     vending=parcel_pickup: RU:Tag:vending=parcel pickup
+    vending=parking_tickets: RU:Tag:vending=parking tickets
+    water=basin: RU:Tag:water=basin
+    water=canal: RU:Tag:water=canal
+    water=ditch: RU:Tag:water=ditch
+    water=drain: RU:Tag:water=drain
+    water=fish_pass: RU:Tag:water=fish pass
+    water=intermittent: RU:Tag:water=intermittent
+    water=lagoon: RU:Tag:water=lagoon
+    water=lake: RU:Tag:water=lake
+    water=lock: RU:Tag:water=lock
+    water=moat: RU:Tag:water=moat
+    water=oxbow: RU:Tag:water=oxbow
+    water=pond: RU:Tag:water=pond
+    water=rapids: RU:Tag:water=rapids
+    water=reflecting_pool: RU:Tag:water=reflecting pool
+    water=reservoir: RU:Tag:water=reservoir
     water=river: RU:Tag:water=river
+    water=stream: RU:Tag:water=stream
+    water=stream_pool: RU:Tag:water=stream pool
+    water=tidal: RU:Tag:water=tidal
+    water=wastewater: RU:Tag:water=wastewater
+    water_source=main: RU:Tag:water source=main
+    water_source=river: RU:Tag:water source=river
     waterway=boatyard: RU:Tag:waterway=boatyard
     waterway=brook: RU:Tag:waterway=brook
     waterway=canal: RU:Tag:waterway=canal
@@ -21247,18 +22922,25 @@ ru:
     waterway=dock: RU:Tag:waterway=dock
     waterway=drain: RU:Tag:waterway=drain
     waterway=drystream: RU:Tag:waterway=drystream
+    waterway=fish_pass: RU:Tag:waterway=fish pass
     waterway=lock_gate: RU:Tag:waterway=lock gate
     waterway=rapids: RU:Tag:waterway=rapids
     waterway=river: RU:Tag:waterway=river
     waterway=riverbank: RU:Tag:waterway=riverbank
     waterway=stream: RU:Tag:waterway=stream
     waterway=turning_point: RU:Tag:waterway=turning point
+    waterway=waterfall: RU:Tag:waterway=waterfall
     waterway=weir: RU:Tag:waterway=weir
     wood=coniferous: RU:Tag:wood=coniferous
     wood=mixed: RU:Tag:wood=mixed
+    zoo=enclosure: RU:Tag:zoo=enclosure
     zoo=petting_zoo: RU:Tag:zoo=petting zoo
+    zoo=reptile: RU:Tag:zoo=reptile
+    zoo=safari_park: RU:Tag:zoo=safari park
+    zoo=wildlife_park: RU:Tag:zoo=wildlife park
 sh:
   key:
+    addr: Sh:Key:addr
     tracktype: Sh:Key:tracktype
 sk:
   key:
@@ -21266,6 +22948,8 @@ sk:
     addr:streetnumber: Sk:Key:addr:streetnumber
     note: Sk:Key:note
     ref:minvskaddress: Sk:Key:ref:minvskaddress
+  tag:
+    refitted=yes: Sk:Tag:refitted=yes
 sq:
   key:
     highway: Sq:Key:highway
@@ -21331,6 +23015,9 @@ uk:
     addr:street: Uk:Key:addr:street
     addr:unit: Uk:Key:addr:unit
     admin_level: Uk:Key:admin level
+    aerialway: Uk:Key:aerialway
+    aerodrome:type: Uk:Key:aerodrome:type
+    aeroway: Uk:Key:aeroway
     alt_name: Uk:Key:alt name
     amenity: Uk:Key:amenity
     arcade: Uk:Key:arcade
@@ -21357,6 +23044,7 @@ uk:
     crossing: Uk:Key:crossing
     cutting: Uk:Key:cutting
     date: Uk:Key:date
+    denotation: Uk:Key:denotation
     description: Uk:Key:description
     destination: Uk:Key:destination
     embankment: Uk:Key:embankment
@@ -21369,8 +23057,12 @@ uk:
     forward: Uk:Key:forward
     government: Uk:Key:government
     height: Uk:Key:height
+    heritage: Uk:Key:heritage
     highway: Uk:Key:highway
     historic: Uk:Key:historic
+    iata: Uk:Key:iata
+    icao: Uk:Key:icao
+    informal: Uk:Key:informal
     inscription: Uk:Key:inscription
     inscription:url: Uk:Key:inscription:url
     int_name: Uk:Key:int name
@@ -21395,11 +23087,11 @@ uk:
     name:fr: Uk:Key:name:fr
     name:ja: Uk:Key:name:ja
     name:lg: Uk:Key:name:lg
+    name:pronunciation: Uk:Key:name:pronunciation
     name:ru: Uk:Key:name:ru
     name:uk: Uk:Key:name:uk
     nat_name: Uk:Key:nat name
     natural: Uk:Key:natural
-    noname: Uk:Key:noname
     note: Uk:Key:note
     office: Uk:Key:office
     official_name: Uk:Key:official name
@@ -21410,6 +23102,7 @@ uk:
     oneway:moped: Uk:Key:oneway:moped
     opening_hours: Uk:Key:opening hours
     opening_hours/Tutorial: Uk:Key:opening hours/Tutorial
+    operator: Uk:Key:operator
     park_ride: Uk:Key:park ride
     place: Uk:Key:place
     playground: Uk:Key:playground
@@ -21434,6 +23127,7 @@ uk:
     short_name: Uk:Key:short name
     short_name:ru: Uk:Key:short name:ru
     sidewalk: Uk:Key:sidewalk
+    smoothness: Uk:Key:smoothness
     sorting_name: Uk:Key:sorting name
     source: Uk:Key:source
     source:addr: Uk:Key:source:addr
@@ -21457,12 +23151,23 @@ uk:
     admin_level=2: Uk:Tag:admin level=2
     admin_level=4: Uk:Tag:admin level=4
     admin_level=6: Uk:Tag:admin level=6
+    aerialway=cable_car: Uk:Tag:aerialway=cable car
+    aerialway=chair_lift: Uk:Tag:aerialway=chair lift
+    aerialway=gondola: Uk:Tag:aerialway=gondola
+    aeroway=aerodrome: Uk:Tag:aeroway=aerodrome
+    aeroway=gate: Uk:Tag:aeroway=gate
+    aeroway=helipad: Uk:Tag:aeroway=helipad
+    aeroway=heliport: Uk:Tag:aeroway=heliport
+    aeroway=runway: Uk:Tag:aeroway=runway
+    aeroway=terminal: Uk:Tag:aeroway=terminal
     amenity=atm: Uk:Tag:amenity=atm
+    amenity=bank: Uk:Tag:amenity=bank
     amenity=bench: Uk:Tag:amenity=bench
     amenity=bicycle_parking: Uk:Tag:amenity=bicycle parking
     amenity=bicycle_rental: Uk:Tag:amenity=bicycle rental
     amenity=clinic: Uk:Tag:amenity=clinic
     amenity=drinking_water: Uk:Tag:amenity=drinking water
+    amenity=fountain: Uk:Tag:amenity=fountain
     amenity=fuel: Uk:Tag:amenity=fuel
     amenity=grave_yard: Uk:Tag:amenity=grave yard
     amenity=hospital: Uk:Tag:amenity=hospital
@@ -21477,10 +23182,13 @@ uk:
     amenity=school: Uk:Tag:amenity=school
     amenity=shelter: Uk:Tag:amenity=shelter
     amenity=university: Uk:Tag:amenity=university
+    barrier=gate: Uk:Tag:barrier=gate
     barrier=retaining_wall: Uk:Tag:barrier=retaining wall
+    barrier=wicket_gate: Uk:Tag:barrier=wicket gate
     boundary=administrative: Uk:Tag:boundary=administrative
     boundary=historic: Uk:Tag:boundary=historic
     boundary=postal_code: Uk:Tag:boundary=postal code
+    building=cabin: Uk:Tag:building=cabin
     building=church: Uk:Tag:building=church
     building=commercial: Uk:Tag:building=commercial
     building=hospital: Uk:Tag:building=hospital
@@ -21490,16 +23198,27 @@ uk:
     emergency=fire_water_pond: Uk:Tag:emergency=fire water pond
     emergency=suction_point: Uk:Tag:emergency=suction point
     emergency=water_tank: Uk:Tag:emergency=water tank
+    entrance=garage: Uk:Tag:entrance=garage
+    entrance=main: Uk:Tag:entrance=main
+    entrance=secondary: Uk:Tag:entrance=secondary
     entrance=staircase: Uk:Tag:entrance=staircase
+    entrance=yes: Uk:Tag:entrance=yes
     footway=crossing: Uk:Tag:footway=crossing
     footway=sidewalk: Uk:Tag:footway=sidewalk
+    generator:method=run-of-the-river: Uk:Tag:generator:method=run-of-the-river
+    generator:method=water-pumped-storage: Uk:Tag:generator:method=water-pumped-storage
+    generator:method=water-storage: Uk:Tag:generator:method=water-storage
+    generator:source=hydro: Uk:Tag:generator:source=hydro
     government=legislative: Uk:Tag:government=legislative
     government=ministry: Uk:Tag:government=ministry
     government=prosecutor: Uk:Tag:government=prosecutor
     government=tax: Uk:Tag:government=tax
     highway=bridleway: Uk:Tag:highway=bridleway
+    highway=bus_guideway: Uk:Tag:highway=bus guideway
+    highway=busway: Uk:Tag:highway=busway
     highway=construction: Uk:Tag:highway=construction
     highway=cycleway: Uk:Tag:highway=cycleway
+    highway=escape: Uk:Tag:highway=escape
     highway=footway: Uk:Tag:highway=footway
     highway=ford: Uk:Tag:highway=ford
     highway=living_street: Uk:Tag:highway=living street
@@ -21509,6 +23228,7 @@ uk:
     highway=path: Uk:Tag:highway=path
     highway=pedestrian: Uk:Tag:highway=pedestrian
     highway=primary: Uk:Tag:highway=primary
+    highway=raceway: Uk:Tag:highway=raceway
     highway=residential: Uk:Tag:highway=residential
     highway=road: Uk:Tag:highway=road
     highway=secondary: Uk:Tag:highway=secondary
@@ -21528,7 +23248,9 @@ uk:
     historic=vehicle: Uk:Tag:historic=vehicle
     historic=wayside_cross: Uk:Tag:historic=wayside cross
     industrial=bakery: Uk:Tag:industrial=bakery
+    landuse=allotments: Uk:Tag:landuse=allotments
     landuse=cemetery: Uk:Tag:landuse=cemetery
+    landuse=education: Uk:Tag:landuse=education
     landuse=flowerbed: Uk:Tag:landuse=flowerbed
     landuse=forest: Uk:Tag:landuse=forest
     landuse=hop_garden: Uk:Tag:landuse=hop garden
@@ -21555,6 +23277,7 @@ uk:
     natural=valley: Uk:Tag:natural=valley
     natural=water: Uk:Tag:natural=water
     natural=wood: Uk:Tag:natural=wood
+    noname=yes: Uk:Tag:noname=yes
     office=accountant: Uk:Tag:office=accountant
     office=architect: Uk:Tag:office=architect
     office=company: Uk:Tag:office=company
@@ -21567,6 +23290,7 @@ uk:
     office=newspaper: Uk:Tag:office=newspaper
     office=ngo: Uk:Tag:office=ngo
     office=quango: Uk:Tag:office=quango
+    office=real_estate_agent: Uk:Tag:office=real estate agent
     office=research: Uk:Tag:office=research
     office=telecommunication: Uk:Tag:office=telecommunication
     office=travel_agent: Uk:Tag:office=travel agent
@@ -21620,7 +23344,10 @@ uk:
     sport=swimming: Uk:Tag:sport=swimming
     type=boundary: Uk:Tag:type=boundary
     vending=bicycle_tube: Uk:Tag:vending=bicycle tube
+    water=river: Uk:Tag:water=river
+    waterway=dam: Uk:Tag:waterway=dam
     waterway=riverbank: Uk:Tag:waterway=riverbank
+    waterway=weir: Uk:Tag:waterway=weir
 vi:
   key:
     addr: Vi:Key:addr
@@ -21682,6 +23409,8 @@ zh-hans:
     amenity: Zh-hans:Key:amenity
     building: Zh-hans:Key:building
     building:part: Zh-hans:Key:building:part
+    china_class: Zh-hans:Key:china class
+    china_population: Zh-hans:Key:china population
     cuisine: Zh-hans:Key:cuisine
     ele: Zh-hans:Key:ele
     entrance: Zh-hans:Key:entrance
@@ -21697,6 +23426,7 @@ zh-hans:
     parking:lane: Zh-hans:Key:parking:lane
     place: Zh-hans:Key:place
     plant:method: Zh-hans:Key:plant:method
+    population: Zh-hans:Key:population
     railway: Zh-hans:Key:railway
     railway:etcs: Zh-hans:Key:railway:etcs
     railway:lzb: Zh-hans:Key:railway:lzb
@@ -21704,6 +23434,7 @@ zh-hans:
     residential: Zh-hans:Key:residential
     roof:direction: Zh-hans:Key:roof:direction
     roof:shape: Zh-hans:Key:roof:shape
+    substation: Zh-hans:Key:substation
     surface: Zh-hans:Key:surface
     toll: Zh-hans:Key:toll
     turn: Zh-hans:Key:turn
@@ -21715,8 +23446,10 @@ zh-hans:
     amenity=toilets: Zh-hans:Tag:amenity=toilets
     barrier=toll_booth: Zh-hans:Tag:barrier=toll booth
     barrier=wall: Zh-hans:Tag:barrier=wall
+    boundary=administrative: Zh-hans:Tag:boundary=administrative
     bridge:structure=humpback: Zh-hans:Tag:bridge:structure=humpback
     building=detached: Zh-hans:Tag:building=detached
+    emergency=emergency_ward_entrance: Zh-hans:Tag:emergency=emergency ward entrance
     generator:source=wind: Zh-hans:Tag:generator:source=wind
     highway=bus_stop: Zh-hans:Tag:highway=bus stop
     highway=footway: Zh-hans:Tag:highway=footway
@@ -21725,14 +23458,17 @@ zh-hans:
     highway=toll_gantry: Zh-hans:Tag:highway=toll gantry
     highway=traffic_signals: Zh-hans:Tag:highway=traffic signals
     historic=stone: Zh-hans:Tag:historic=stone
+    industrial=slaughterhouse: Zh-hans:Tag:industrial=slaughterhouse
     landuse=commercial: Zh-hans:Tag:landuse=commercial
     landuse=forest: Zh-hans:Tag:landuse=forest
     man_made=antenna: Zh-hans:Tag:man made=antenna
     man_made=dyke: Zh-hans:Tag:man made=dyke
+    man_made=flagpole: Zh-hans:Tag:man made=flagpole
     natural=sand: Zh-hans:Tag:natural=sand
     natural=wood: Zh-hans:Tag:natural=wood
     network=CN:AH: Zh-hans:Tag:network=CN:AH
     network=CN:JS: Zh-hans:Tag:network=CN:JS
+    network=CN:expressway: Zh-hans:Tag:network=CN:expressway
     network=CN:national: Zh-hans:Tag:network=CN:national
     office=government: Zh-hans:Tag:office=government
     place=hamlet: Zh-hans:Tag:place=hamlet
@@ -21747,10 +23483,12 @@ zh-hans:
     service=parking_aisle: Zh-hans:Tag:service=parking aisle
     station=light_rail: Zh-hans:Tag:station=light rail
     station=subway: Zh-hans:Tag:station=subway
+    substation=transmission: Zh-hans:Tag:substation=transmission
     surface=acrylic: Zh-hans:Tag:surface=acrylic
     surface=artificial_turf: Zh-hans:Tag:surface=artificial turf
     surface=tartan: Zh-hans:Tag:surface=tartan
     vending=ice_cream: Zh-hans:Tag:vending=ice cream
+    waterway=river: Zh-hans:Tag:waterway=river
     waterway=weir: Zh-hans:Tag:waterway=weir
 zh-hant:
   key:
@@ -21758,6 +23496,7 @@ zh-hant:
     aeroway: Zh-hant:Key:aeroway
     amenity: Zh-hant:Key:amenity
     bridge: Zh-hant:Key:bridge
+    building: Zh-hant:Key:building
     conveying: Zh-hant:Key:conveying
     covered: Zh-hant:Key:covered
     cutting: Zh-hant:Key:cutting


### PR DESCRIPTION
fixes #3197

edit after merging:

# How this was done (notes for others or future self)

This update is done by running https://github.com/openstreetmap/openstreetmap-website/blob/master/script/misc/update-wiki-pages

it will update https://github.com/openstreetmap/openstreetmap-website/commits/master/config/wiki_pages.yml

(0) use linux
(1) create/update fork of this repo (for me I have "sync fork" at https://github.com/matkoniecz/openstreetmap-website )
(2) fetch that repo into local drive (`git clone https://github.com/matkoniecz/openstreetmap-website.git` in my case), install perl and necessary libraries and run script

```
date
sudo apt install libcpanplus-perl
sudo cpanp i MediaWiki::API YAML::XS # can I do this before entering repo folder?
cd ~/Desktop/tmp
git clone https://github.com/matkoniecz/openstreetmap-website.git
cd openstreetmap-website
git remote add upstream https://github.com/openstreetmap/openstreetmap-website/
git fetch --all
git reset --hard upstream/master
git branch wiki_update 
git checkout wiki_update
script/misc/update-wiki-pages
git add config/wiki_pages.yml
git commit -m "rerun script/misc/update-wiki-pages"
git push
date
```

The script runs for a long time, this is normal. For PR #3294 in August 2021 it was running almost two hours, going through 11 826 key pages and 17 869 value pages.

`date` commands bracketing allows me to update lapsed time for future runs

(3) go to https://github.com/openstreetmap/openstreetmap-website/pulls and send PR
(4) wait, typically not for long as this is a relatively trivial change


2023: start koło 17:00

If it fails to complete successfully:

this Perl script relies on https://www.mediawiki.org/wiki/API:Embeddedin and run queries similar to https://wiki.openstreetmap.org/w/api.php?action=query&list=embeddedin&eititle=Template:KeyDescription&eilimit=500 (further pages may be request by passing eicontinue in &eicontinue= parameters),

At least sometimes wiki API failed to include page with a template that exists on it, so it is a wiki bug. I will try to clear Wiki cache by making edit to this page and rerun this script.

There is also https://wiki.openstreetmap.org/w/index.php?title=Special%3AWhatLinksHere&limit=500&target=Template%3AKeyDescription&namespace=0 that is probably using the same internal calls to display similar list and is easier to paginate for humans.

# TODO

See https://wiki.openstreetmap.org/wiki/Template_talk:Pl:KeyDescription#Is_this_template_still_needed%3F