### PR TITLE
Convert account setting menu to tabs, and include on other pages

### DIFF
--- a/app/views/application/_settings_menu.html.erb
+++ b/app/views/application/_settings_menu.html.erb
@@ -1,0 +1,18 @@
+<% content_for :heading_class, "pb-0" %>
+
+<% content_for :heading do %>
+  <ul class="nav nav-tabs flex-column flex-sm-row">
+    <li class="nav-item">
+      <%= link_to t(".account_settings"), user_account_path(current_user), :class => "nav-link #{'active' if controller_name == 'users'}" %>
+    </li>
+    <li class="nav-item">
+      <%= link_to t(".oauth1_settings"), oauth_clients_path(current_user), :class => "nav-link #{'active' if controller_name == 'oauth_clients'}" %>
+    </li>
+    <li class="nav-item">
+      <%= link_to t(".oauth2_applications"), oauth_applications_path, :class => "nav-link #{'active' if controller_name == 'oauth2_applications'}" %>
+    </li>
+    <li class="nav-item">
+      <%= link_to t(".oauth2_authorizations"), oauth_authorized_applications_path, :class => "nav-link #{'active' if controller_name == 'oauth2_authorized_applications'}" %>
+    </li>
+  </ul>
+<% end %>

--- a/app/views/oauth2_applications/edit.html.erb
+++ b/app/views/oauth2_applications/edit.html.erb
@@ -2,6 +2,8 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <%= bootstrap_form_for @application, :url => oauth_application_path(@application), :html => { :method => :put } do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
 <% end %>

--- a/app/views/oauth2_applications/index.html.erb
+++ b/app/views/oauth2_applications/index.html.erb
@@ -2,6 +2,8 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <% if @applications.length > 0 %>
   <table class="table table-borderless table-striped">
     <thead>

--- a/app/views/oauth2_applications/new.html.erb
+++ b/app/views/oauth2_applications/new.html.erb
@@ -2,6 +2,8 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <%= bootstrap_form_for @application, :url => { :action => :create } do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
 <% end %>

--- a/app/views/oauth2_applications/show.html.erb
+++ b/app/views/oauth2_applications/show.html.erb
@@ -2,6 +2,8 @@
   <h1><%= @application.name %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <% secret = flash[:application_secret].presence || @application.plaintext_secret %>
 
 <table class="table table-borderless">

--- a/app/views/oauth2_authorized_applications/index.html.erb
+++ b/app/views/oauth2_authorized_applications/index.html.erb
@@ -2,6 +2,8 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <% if @applications.length > 0 %>
   <table class="table table-borderless table-striped">
     <thead>

--- a/app/views/oauth_clients/edit.html.erb
+++ b/app/views/oauth_clients/edit.html.erb
@@ -2,6 +2,8 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <%= bootstrap_form_for @client_application, :url => oauth_client_path(@client_application.user.display_name, @client_application), :html => { :method => :put } do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
 <% end %>

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -2,6 +2,8 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <% unless @tokens.empty? %>
 <h3><%= t ".my_tokens" %></h3>
 <p><%= t ".list_tokens" %></p>

--- a/app/views/oauth_clients/new.html.erb
+++ b/app/views/oauth_clients/new.html.erb
@@ -2,6 +2,8 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <%= bootstrap_form_for @client_application, :url => { :action => :create } do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
 <% end %>

--- a/app/views/oauth_clients/show.html.erb
+++ b/app/views/oauth_clients/show.html.erb
@@ -2,6 +2,8 @@
   <h1><%= t(".title", :app_name => @client_application.name) %></h1>
 <% end %>
 
+<%= render :partial => "settings_menu" %>
+
 <dl class="row">
   <dt class="col-sm-3"><%= t ".key" %></dt>
   <dd class="col-sm-9"><%= @client_application.key %></dt>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -4,13 +4,9 @@
 
 <% content_for :heading do %>
   <h1><%= t ".my settings" %></h1>
-  <ul class='secondary-actions clearfix'>
-    <li><%= link_to t(".return to profile"), user_path(current_user) %></li>
-    <li><%= link_to t(".oauth1 settings"), oauth_clients_path %></li>
-    <li><%= link_to t(".oauth2 applications"), oauth_applications_path %></li>
-    <li><%= link_to t(".oauth2 authorizations"), oauth_authorized_applications_path %></li>
-  </ul>
 <% end %>
+
+<%= render :partial => "settings_menu", :locals => { :selected => "account" } %>
 
 <%= bootstrap_form_for current_user, :url => { :action => :account }, :method => :post, :html => { :multipart => true, :id => "accountForm", :autocomplete => :off } do |f| %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2304,6 +2304,11 @@ en:
       blocked_zero_hour: "You have an urgent message on the OpenStreetMap web site. You need to read the message before you will be able to save your edits."
       blocked: "Your access to the API has been blocked. Please log-in to the web interface to find out more."
       need_to_see_terms: "Your access to the API is temporarily suspended. Please log-in to the web interface to view the Contributor Terms. You do not need to agree, but you must view them."
+    settings_menu:
+      account_settings: Account Settings
+      oauth1_settings: OAuth 1 settings
+      oauth2_applications: OAuth 2 applications
+      oauth2_authorizations: OAuth 2 authorizations
   oauth:
     authorize:
       title: "Authorize access to your account"
@@ -2570,10 +2575,6 @@ en:
         link text: "what is this?"
       save changes button: Save Changes
       make edits public button: Make all my edits public
-      return to profile: Return to profile
-      oauth1 settings: OAuth 1 settings
-      oauth2 applications: OAuth 2 applications
-      oauth2 authorizations: OAuth 2 authorizations
       flash update success confirm needed: "User information updated successfully. Check your email for a note to confirm your new email address."
       flash update success: "User information updated successfully."
     set_home:

--- a/test/integration/client_applications_test.rb
+++ b/test/integration/client_applications_test.rb
@@ -23,7 +23,7 @@ class ClientApplicationsTest < ActionDispatch::IntegrationTest
 
     # check that the form to allow new client application creations exists
     assert_in_heading do
-      assert_select "ul.secondary-actions li a[href='/user/#{ERB::Util.u(user.display_name)}/oauth_clients']"
+      assert_select "ul.nav.nav-tabs li.nav-item a[href='/user/#{ERB::Util.u(user.display_name)}/oauth_clients']"
     end
 
     # now we follow the link to the oauth client list


### PR DESCRIPTION
This makes it easier to navigate around these pages. Since each tab corresponds to a given controller, this makes the selection of active tabs straightforward.

![Screenshot from 2021-08-18 14-40-19](https://user-images.githubusercontent.com/360803/129909042-73191577-cf76-4997-b74d-05fab541fd17.png)

The tabs, like on the traces pages, also switch to a vertical list on small screen widths.

![Screenshot from 2021-08-18 14-41-04](https://user-images.githubusercontent.com/360803/129909039-b2c800dd-b0ae-473d-a0ce-9948cd3d6da7.png)

