### PR TITLE
Update en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1838,9 +1838,8 @@ en:
         credit_3_1_html: |
           The map tiles in the &ldquo;standard style&rdquo; at www.openstreetmap.org are a
           Produced Work by the OpenStreetMap Foundation using OpenStreetMap data
-          under the Open Database License. If you are using these tiles please use
-          the following attribution:
-          &ldquo;Base map and data from OpenStreetMap and OpenStreetMap Foundation&rdquo;.
+          under the Open Database License. When using this map style, the same attribution is
+          required as for the map data.
         credit_4_html: |
           For a browsable electronic map, the credit should appear in the corner of the map.
           For example:


### PR DESCRIPTION
Updated (simplified) map tile attribution requirement to be the same as for any use of OSM data (based on request to LWG)