### PR TITLE
Add Fastly as top three donor

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -45,6 +45,7 @@
           <p><%= t "layouts.intro_text" %></p>
           <p><%= t "layouts.hosting_partners_html",
                    :ucl => link_to(t("layouts.partners_ucl"), "https://www.ucl.ac.uk"),
+                   :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
                    :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
                    :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
           </p>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -40,6 +40,7 @@
       <h2><div class='icon partners'></div><%= t ".partners_title", :locale => @locale %></h2>
       <p><%= t "layouts.hosting_partners_html", :locale => @locale,
                                                 :ucl => link_to(t("layouts.partners_ucl", :locale => @locale), "https://www.ucl.ac.uk"),
+                                                :fastly => link_to(t("layouts.partners_fastly", :locale => @locale), "https://www.fastly.com/"),
                                                 :bytemark => link_to(t("layouts.partners_bytemark", :locale => @locale), "https://www.bytemark.co.uk"),
                                                 :partners => link_to(t("layouts.partners_partners", :locale => @locale), "https://hardware.openstreetmap.org/thanks/") %>
       </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1420,8 +1420,9 @@ en:
     intro_header: Welcome to OpenStreetMap!
     intro_text: OpenStreetMap is a map of the world, created by people like you and free to use under an open license.
     intro_2_create_account: "Create a user account"
-    hosting_partners_html: "Hosting is supported by %{ucl}, %{bytemark}, and other %{partners}."
+    hosting_partners_html: "Hosting is supported by %{ucl}, %{fastly}, %{bytemark}, and other %{partners}."
     partners_ucl: "UCL"
+    partners_fastly: "Fastly"
     partners_bytemark: "Bytemark Hosting"
     partners_partners: "partners"
     tou: "Terms of Use"


### PR DESCRIPTION
As discussed in the ops meeting, they meet the criteria for listing as a top three donor.