### PR TITLE
Temporary pin on rubocop-rails until next bugfix release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ group :test do
   gem "rubocop"
   gem "rubocop-minitest"
   gem "rubocop-performance"
-  gem "rubocop-rails"
+  gem "rubocop-rails", "~> 2.11.3" # Bug in 2.12.0, fixed in master after 2.12.2
   gem "rubocop-rake"
   gem "selenium-webdriver"
   gem "simplecov", :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,7 @@ GEM
     rubocop-performance (1.11.5)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.12.2)
+    rubocop-rails (2.11.3)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
@@ -560,7 +560,7 @@ DEPENDENCIES
   rubocop
   rubocop-minitest
   rubocop-performance
-  rubocop-rails
+  rubocop-rails (~> 2.11.3)
   rubocop-rake
   sanitize
   sassc-rails


### PR DESCRIPTION
There is a bug in the Rails/ContentTag cop that causes rubocop to crash. The bug has already been fixed and so should be available in the next release.

See https://github.com/rubocop/rubocop-rails/issues/543