### PR TITLE
Use a view to render tracepoints

### DIFF
--- a/app/models/tracepoint.rb
+++ b/app/models/tracepoint.rb
@@ -31,12 +31,4 @@ class Tracepoint < ApplicationRecord
   validates :timestamp, :presence => true
 
   belongs_to :trace, :foreign_key => "gpx_id"
-
-  def to_xml_node(print_timestamp: false)
-    el1 = XML::Node.new "trkpt"
-    el1["lat"] = lat.to_s
-    el1["lon"] = lon.to_s
-    el1 << (XML::Node.new("time") << timestamp.xmlschema) if print_timestamp
-    el1
-  end
 end

--- a/app/views/api/tracepoints/index.gpx.builder
+++ b/app/views/api/tracepoints/index.gpx.builder
@@ -1,0 +1,79 @@
+xml.instruct!
+
+xml.gpx("version" => "1.0",
+        "creator" => "OpenStreetMap.org",
+        "xmlns" => "http://www.topografix.com/GPX/1/0") do
+  # initialise these variables outside of the loop so that they
+  # stay in scope and don't get free'd up by the GC during the
+  # loop.
+  gpx_id = -1
+  trackid = -1
+  tracks = []
+  track = nil
+  trkseg = nil
+  anon_track = nil
+  anon_trkseg = nil
+
+  @points.each do |point|
+    if gpx_id != point.gpx_id
+      gpx_id = point.gpx_id
+      trackid = -1
+
+      if point.trace.trackable?
+        track = {}
+        track["trksegs"] = []
+        tracks << track
+
+        if point.trace.identifiable?
+          track["name"] = point.trace.name
+          track["desc"] = point.trace.description
+          track["url"] = url_for(:controller => "/traces", :action => "show", :display_name => point.trace.user.display_name, :id => point.trace.id)
+        end
+      else
+        # use the anonymous track segment if the user hasn't allowed
+        # their GPX points to be tracked.
+        if anon_track.nil?
+          anon_track = {}
+          anon_track["trksegs"] = []
+          tracks << anon_track
+        end
+        track = anon_track
+      end
+    end
+
+    if trackid != point.trackid
+      if point.trace.trackable?
+        trkseg = []
+        track["trksegs"] << trkseg
+        trackid = point.trackid
+      else
+        if anon_trkseg.nil?
+          anon_trkseg = []
+          anon_track["trksegs"] << anon_trkseg
+        end
+        trkseg = anon_trkseg
+      end
+    end
+
+    trkseg << point
+  end
+
+  tracks.each do |trk|
+    xml.trk do
+      if trk.key?("name")
+        xml.name trk["name"]
+        xml.desc trk["desc"]
+        xml.url trk["url"]
+      end
+      trk["trksegs"].each do |trksg|
+        xml.trkseg do
+          trksg.each do |tracepoint|
+            xml.trkpt("lat" => tracepoint.lat.to_s, "lon" => tracepoint.lon.to_s) do
+              xml.time tracepoint.timestamp.xmlschema if tracepoint.trace.trackable?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/api/tracepoints_controller_test.rb
+++ b/test/controllers/api/tracepoints_controller_test.rb
@@ -148,5 +148,14 @@ module Api
         assert_equal "The minimum latitude must be less than the maximum latitude, but it wasn't", @response.body, "bbox: #{bbox}"
       end
     end
+
+    # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05
+    def test_lat_lon_xml_format
+      create(:tracepoint, :latitude => (0.00004 * GeoRecord::SCALE).to_i, :longitude => (0.00008 * GeoRecord::SCALE).to_i)
+
+      get trackpoints_path(:bbox => "0,0,0.1,0.1")
+      assert_match(/lat="0.0000400"/, response.body)
+      assert_match(/lon="0.0000800"/, response.body)
+    end
   end
 end

--- a/test/models/tracepoint_test.rb
+++ b/test/models/tracepoint_test.rb
@@ -7,12 +7,4 @@ class TracepointTest < ActiveSupport::TestCase
     tracepoint.timestamp = nil
     assert_not tracepoint.valid?
   end
-
-  # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05
-  def test_lat_lon_xml_format
-    tracepoint = build(:tracepoint, :latitude => 0.00004 * GeoRecord::SCALE, :longitude => 0.00008 * GeoRecord::SCALE)
-
-    assert_match(/lat="0.0000400"/, tracepoint.to_xml_node.to_s)
-    assert_match(/lon="0.0000800"/, tracepoint.to_xml_node.to_s)
-  end
 end


### PR DESCRIPTION
This PR moves the rendering of the tracepoints#index call to use a builder view, rather than creating the xml within the controller method. It then allows us to remove the `to_xml_node` method from the model.

I've had to refactor the code slightly, since the original involved going back to previously added XML nodes and adding more details to them (e.g. adding more points to the anon_trackseg). I couldn't find a way to do this "revisiting" approach with the xml builder, so instead I sort all the tracepoints into the tracksegs using hashes and arrays, and then iterate over those structures when writing out the end result as xml. The decisions on what goes where should (hopefully) be the same though, since that logic hasn't been changed.