### PR TITLE
Use flexbox instead of floating to position the comment icon

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -791,7 +791,6 @@ tr.turn:hover {
   }
 
   .comments {
-    float: right;
     color: $darkgrey;
   }
 

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -16,13 +16,15 @@
       <%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %>
     </a>
   </p>
-  <div class="comments comments-<%= changeset.comments.length %>">
-    <%= changeset.comments.length %>
-    <span class="icon note grey"></span>
-  </div>
-  <div class="details">
-    <%= changeset_details(changeset) %>
-    &middot;
-    #<%= changeset.id %>
+  <div class="row">
+    <div class="col">
+      <%= changeset_details(changeset) %>
+      &middot;
+      #<%= changeset.id %>
+    </div>
+    <div class="col-auto comments comments-<%= changeset.comments.length %>">
+      <%= changeset.comments.length %>
+      <span class="icon note grey"></span>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
This ensures both components get appropriate padding. Fixes #3305