### PR TITLE
Make image non-blocking for pointer inputs

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1063,6 +1063,7 @@ tr.turn:hover {
     background-image: image-url("sign-up-illustration-arm.png");
     position: absolute;
     z-index: 100;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
Currently the arm of the planet on https://www.openstreetmap.org/user/new is blocking pointer inputs on about a third of the email input field. This is solved by adding `pointer-events: none;` to the image.