### PR TITLE
Use em rather than fixed pixels to offset the copyright symbol

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1745,8 +1745,8 @@ dl.dl-inline {
 
     .byosm span {
       display: inline-block;
-      width: 20px;
-      margin-left: -20px;
+      width: 1em;
+      margin-left: -1em;
     }
   }
 

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -3,7 +3,7 @@
     <div class='row'>
       <div class='col-sm-7 user-image'></div>
       <div class='col-sm-5 px-5 py-3 byosm'>
-        <h5 class='text-white text-nowrap'><%= t ".copyright_html", :locale => @locale %></h4>
+        <h5 class='text-white text-nowrap'><%= t ".copyright_html", :locale => @locale %></h5>
       </div>
     </div>
     <div class='row'>


### PR DESCRIPTION
Fixes #3302

Also fixes an error where the h5 tag was closed incorrectly.