### PR TITLE
Switch to Argon2 for password hashing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem "autoprefixer-rails"
 # Use image_optim to optimise images
 gem "image_optim_rails"
 
+# Use argon2 for password hashing
+gem "argon2"
+
 # Load rails plugins
 gem "actionpack-page_caching", ">= 1.2.0"
 gem "activerecord-import"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
+    argon2 (2.1.1)
+      ffi (~> 1.14)
+      ffi-compiler (~> 1.0)
     ast (2.4.2)
     autoprefixer-rails (10.3.3.0)
       execjs (~> 2)
@@ -225,6 +228,9 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     ffi (1.15.4)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     ffi-libarchive (1.1.3)
       ffi (~> 1.0)
     fspath (3.1.2)
@@ -498,6 +504,7 @@ DEPENDENCIES
   active_record_union
   activerecord-import
   annotate
+  argon2
   autoprefixer-rails
   aws-sdk-s3
   better_errors

--- a/lib/password_hash.rb
+++ b/lib/password_hash.rb
@@ -1,51 +1,44 @@
-require "securerandom"
-require "openssl"
+require "argon2"
 require "base64"
 require "digest/md5"
+require "openssl"
+require "securerandom"
 
 module PasswordHash
-  SALT_BYTE_SIZE = 32
-  HASH_BYTE_SIZE = 32
-  PBKDF2_ITERATIONS = 10000
-  DIGEST_ALGORITHM = "sha512".freeze
+  FORMAT = Argon2::HashFormat.new(Argon2::Password.create(""))
 
   def self.create(password)
-    salt = SecureRandom.base64(SALT_BYTE_SIZE)
-    hash = self.hash(password, salt, PBKDF2_ITERATIONS, HASH_BYTE_SIZE, DIGEST_ALGORITHM)
-    [hash, [DIGEST_ALGORITHM, PBKDF2_ITERATIONS, salt].join("!")]
+    hash = Argon2::Password.create(password)
+    [hash, nil]
   end
 
   def self.check(hash, salt, candidate)
-    if salt.nil?
-      candidate = Digest::MD5.hexdigest(candidate)
+    if Argon2::HashFormat.valid_hash?(hash)
+      Argon2::Password.verify_password(candidate, hash)
+    elsif salt.nil?
+      hash == Digest::MD5.hexdigest(candidate)
     elsif salt.include?("!")
       algorithm, iterations, salt = salt.split("!")
       size = Base64.strict_decode64(hash).length
-      candidate = self.hash(candidate, salt, iterations.to_i, size, algorithm)
+      hash == pbkdf2(candidate, salt, iterations.to_i, size, algorithm)
     else
-      candidate = Digest::MD5.hexdigest(salt + candidate)
+      hash == Digest::MD5.hexdigest(salt + candidate)
     end
-
-    hash == candidate
   end
 
-  def self.upgrade?(hash, salt)
-    if salt.nil?
-      return true
-    elsif salt.include?("!")
-      algorithm, iterations, salt = salt.split("!")
-      return true if Base64.strict_decode64(salt).length != SALT_BYTE_SIZE
-      return true if Base64.strict_decode64(hash).length != HASH_BYTE_SIZE
-      return true if iterations.to_i != PBKDF2_ITERATIONS
-      return true if algorithm != DIGEST_ALGORITHM
-    else
-      return true
-    end
+  def self.upgrade?(hash, _salt)
+    format = Argon2::HashFormat.new(hash)
 
-    false
+    format.variant != FORMAT.variant ||
+      format.version != FORMAT.version ||
+      format.t_cost != FORMAT.t_cost ||
+      format.m_cost != FORMAT.m_cost ||
+      format.p_cost != FORMAT.p_cost
+  rescue Argon2::ArgonHashFail
+    true
   end
 
-  def self.hash(password, salt, iterations, size, algorithm)
+  def self.pbkdf2(password, salt, iterations, size, algorithm)
     digest = OpenSSL::Digest.new(algorithm)
     pbkdf2 = OpenSSL::PKCS5.pbkdf2_hmac(password, salt, iterations, size, digest)
     Base64.strict_encode64(pbkdf2)


### PR DESCRIPTION
It's been five years since we last updated our password hashing and things have moved on - the [current OWASP recommendation](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) is to use Argon2.

Argon2 takes care of recording the salt and hash parameters as part of the password so the separate salt is no longer needed except for legacy passwords.

We're using the default parameters (64Mb memory, 2 iterations, 1 degree of parallelism) which exceeds the OWASP recommended values and upgrading will be automatic as the defaults change over time.

There is also support for an optional "pepper" which means that a leak of hashed passwords would be useless without the pepper (a shared secret included in the hashes) which is not present in the database or on the database servers.