### PR TITLE
Reduce usage of margin-top for layout

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1118,15 +1118,6 @@ tr.turn:hover {
 
 #user_list {
   width: 100%;
-
-  tr {
-    vertical-align: middle;
-  }
-}
-
-#user_list_actions {
-  float: right;
-  margin-top: $lineheight/2;
 }
 
 /* Rules for the diary list page */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -370,8 +370,6 @@ body.compact-nav {
     }
 
     h3, h4 {
-      margin-top: $lineheight;
-      margin-bottom: $lineheight/2;
       font-size: 1.25rem;
     }
 
@@ -813,7 +811,6 @@ tr.turn:hover {
     border-bottom: 1px solid $grey;
 
     h4:first-child {
-      margin-top: 0;
       word-wrap: break-word;
     }
   }
@@ -858,6 +855,7 @@ tr.turn:hover {
     border-collapse: separate;
     border-spacing: 0;
     width: 100%;
+    margin-bottom: $spacer;
 
     th, td {
       border-bottom: 1px solid $grey;
@@ -910,7 +908,7 @@ tr.turn:hover {
 
   .subscribe-buttons {
     float: left;
-    margin: 18px 10px 10px;
+    margin: 0 10px;
     min-width: 80px;
   }
 
@@ -966,7 +964,7 @@ tr.turn:hover {
   }
 
   .export_area_inputs {
-    margin-bottom: $lineheight/2;
+    margin-bottom: $spacer;
     input[type="text"] {
       width: 100px;
       text-align: center;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1092,13 +1092,6 @@ tr.turn:hover {
   }
 }
 
-/* Rules for the user profile page */
-
-.contact-activity {
-  margin-top: $lineheight;
-  width: 100%;
-}
-
 /* Rules for the user map */
 
 .content_map .leaflet-popup-content {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1122,11 +1122,6 @@ tr.turn:hover {
   tr {
     vertical-align: middle;
   }
-
-  p {
-    margin-top: 0px;
-    margin-bottom: 0px;
-  }
 }
 
 #user_list_actions {

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 </p>
 
-<div class="details">
+<p class="details">
   <%= t "browse.#{common_details.visible? ? :edited : :deleted}_by_html",
         :time => time_ago_in_words(common_details.timestamp, :scope => :"datetime.distance_in_words_ago"),
         :user => changeset_user_link(common_details.changeset),
@@ -19,7 +19,7 @@
   &middot;
   <%= t "browse.in_changeset" %>
   #<%= link_to common_details.changeset_id, :action => :changeset, :id => common_details.changeset_id %>
-</div>
+</p>
 
 <% if @type == "node" and common_details.visible? %>
 <div class="details geo">

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -6,7 +6,7 @@
   <p class="font-italic">
     <%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %>
   </p>
-  <div class="details"><%= changeset_details(@changeset) %></div>
+  <p class="details"><%= changeset_details(@changeset) %></p>
 
   <%= render :partial => "tag_details", :object => @changeset.tags.except("comment") %>
 
@@ -63,14 +63,14 @@
   <% end %>
 
   <% unless current_user %>
-    <div class="notice">
+    <p class="notice">
       <%= link_to(t(".join_discussion"), login_path(:referer => request.fullpath)) %>
-    </div>
+    </p>
   <% end %>
 
   <% if current_user %>
     <% unless @changeset.is_open? %>
-      <form action="#">
+      <form action="#" class="mb-3">
         <div class="form-group">
           <textarea class="form-control" name="text" cols="40" rows="5"></textarea>
         </div>
@@ -79,9 +79,9 @@
         </div>
       </form>
     <% else %>
-      <div class="notice">
-      <%= t(".still_open") %>
-      </div>
+      <p class="notice">
+        <%= t(".still_open") %>
+      </p>
     <% end %>
   <% end %>
 

--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -4,7 +4,7 @@
      :icon => image_path(type == "friend" ? "marker-blue.png" : "marker-green.png"),
      :description => render(:partial => "popup", :object => contact, :locals => { :type => type })
    } %>
-<%= tag.div :class => "contact-activity clearfix row", :data => { :user => user_data } do %>
+<%= tag.div :class => "clearfix row", :data => { :user => user_data } do %>
   <div class="col-auto">
     <%= user_thumbnail contact, :class => "user_thumbnail_no_margins" %>
   </div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -32,7 +32,7 @@
       <% if friends.empty? %>
         <%= t ".no friends" %>
       <% else %>
-        <nav class='secondary-actions'>
+        <nav class='secondary-actions mb-3'>
           <ul class='clearfix'>
             <li><%= link_to t(".friends_changesets"), friend_changesets_path %></li>
             <li><%= link_to t(".friends_diaries"), friends_diary_entries_path %></li>
@@ -50,7 +50,7 @@
       <% if nearby.empty? %>
         <%= t ".no nearby users" %>
       <% else %>
-        <nav class='secondary-actions'>
+        <nav class='secondary-actions mb-3'>
           <ul class='clearfix'>
             <li><%= link_to t(".nearby_changesets"), nearby_changesets_path %></li>
             <li><%= link_to t(".nearby_diaries"), nearby_diary_entries_path %></li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -36,8 +36,8 @@
     </table>
 
     <div id="user_list_actions buttons">
-      <%= submit_tag t(".confirm"), :name => "confirm" %>
-      <%= submit_tag t(".hide"), :name => "hide" %>
+      <%= submit_tag t(".confirm"), :name => "confirm", :class => "btn btn-primary" %>
+      <%= submit_tag t(".hide"), :name => "hide", :class => "btn btn-primary" %>
     </div>
   <% end %>
 <% else %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -35,7 +35,7 @@
       <%= render @users %>
     </table>
 
-    <div id="user_list_actions buttons">
+    <div>
       <%= submit_tag t(".confirm"), :name => "confirm", :class => "btn btn-primary" %>
       <%= submit_tag t(".hide"), :name => "hide", :class => "btn btn-primary" %>
     </div>

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -28,7 +28,9 @@ class DashboardsControllerTest < ActionDispatch::IntegrationTest
 
     # Friends should be visible as we're now logged in
     assert_select "div#friends-container" do
-      assert_select "div.contact-activity", :count => 1
+      assert_select "div" do
+        assert_select "a[href='/user/#{ERB::Util.u(friend_user.display_name)}']", :count => 1
+      end
     end
   end
 end

--- a/test/integration/user_changeset_comments_test.rb
+++ b/test/integration/user_changeset_comments_test.rb
@@ -12,7 +12,7 @@ class UserChangesetCommentsTest < ActionDispatch::IntegrationTest
       assert_select "div#sidebar" do
         assert_select "div#sidebar_content" do
           assert_select "div" do
-            assert_select "div.notice" do
+            assert_select "p.notice" do
               assert_select "a[href='/login?referer=%2Fchangeset%2F#{changeset.id}']", :text => I18n.t("browse.changeset.join_discussion"), :count => 1
             end
           end


### PR DESCRIPTION
This PR reduces the usage of margin-top for controlling layouts. Bootstrap [tries to avoid margin-top](https://getbootstrap.com/docs/4.0/content/reboot/) since they collapse into preceding margin-bottoms, so it's easier to be consistent and just use margin-bottoms instead. Since they are applied to most elements (like tables, lists, paragraphs) by default, some refactoring of plain text-in-div to text-in-paragraph solved the spacing problems, otherwise I used the bootstrap margin utilities.