### PR TITLE
Rework user images and thumbnails to use flex grid

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1117,10 +1117,6 @@ tr.turn:hover {
     margin-top: 0 0 0 60px;
     font-size: 12px;
   }
-  img.user_thumbnail {
-    float: left;
-    margin: 0 $lineheight/2 0 0;
-  }
 }
 
 /* Rules for the user list */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1421,25 +1421,9 @@ img.user_image {
   max-width: 100px;
   max-height: 100px;
   border: 1px solid $grey;
-  margin-bottom: $lineheight;
-  float: left;
-  margin-right: $lineheight;
-}
-
-img.user_image_no_margins {
-  max-width: 100px;
-  max-height: 100px;
-  border: 1px solid $grey;
 }
 
 img.user_thumbnail {
-  max-width: 50px;
-  max-height: 50px;
-  border: 1px solid $grey;
-  margin-right: $lineheight;
-}
-
-img.user_thumbnail_no_margins {
   max-width: 50px;
   max-height: 50px;
   border: 1px solid $grey;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1612,10 +1612,6 @@ dl.dl-inline {
   }
 }
 
-.comments .richtext {
-  margin-left: 70px;
-}
-
 /* Rules for the user notes list */
 
 .note_list {

--- a/app/assets/stylesheets/leaflet-all.scss
+++ b/app/assets/stylesheets/leaflet-all.scss
@@ -15,9 +15,6 @@ div.leaflet-marker-icon.location-filter.move-marker {
 
 /* Override some conflicting styles.
    https://github.com/openstreetmap/openstreetmap-website/pull/121#issuecomment-10206946 */
-.leaflet-popup-content img.user_thumbnail {
-  max-width: 50px !important;
-}
 
 .user_popup p {
   margin: 0 !important;

--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -6,7 +6,7 @@
    } %>
 <%= tag.div :class => "contact-activity clearfix row", :data => { :user => user_data } do %>
   <div class="col-auto">
-    <%= user_thumbnail contact, :class => "user_thumbnail_no_margins" %>
+    <%= user_thumbnail contact %>
   </div>
   <div class="col">
     <p class='text-muted mb-0'>

--- a/app/views/dashboards/_popup.html.erb
+++ b/app/views/dashboards/_popup.html.erb
@@ -1,6 +1,6 @@
 <div class="user_popup row no-gutters mx-1">
   <div class="col-auto mx-1">
-    <%= user_thumbnail popup, :class => "user_thumbnail_no_margins" %>
+    <%= user_thumbnail popup %>
   </div>
   <div class="col mx-1">
     <p><%= t(".#{type}") %></p>

--- a/app/views/dashboards/_popup.html.erb
+++ b/app/views/dashboards/_popup.html.erb
@@ -1,5 +1,9 @@
-<div class="user_popup">
-  <%= user_thumbnail popup %>
-  <p><%= t(".#{type}") %></p>
-  <p><%= link_to popup.display_name, user_path(popup) %></p>
+<div class="user_popup row no-gutters mx-1">
+  <div class="col-auto mx-1">
+    <%= user_thumbnail popup, :class => "user_thumbnail_no_margins" %>
+  </div>
+  <div class="col mx-1">
+    <p><%= t(".#{type}") %></p>
+    <p><%= link_to popup.display_name, user_path(popup) %></p>
+  </div>
 </div>

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -1,19 +1,23 @@
-<div class="clearfix diary-comment<%= " text-muted deleted" unless diary_comment.visible? %>">
-  <%= user_thumbnail diary_comment.user %>
-  <p class="text-muted comment-heading" id="comment<%= diary_comment.id %>"><%= t(".comment_from_html", :link_user => (link_to diary_comment.user.display_name, user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}")) %>
-    <% if current_user and diary_comment.user.id != current_user.id %>
-      | <%= report_link(t(".report"), diary_comment) %>
-    <% end %>
-  </p>
-
-  <div class="richtext text-break"><%= diary_comment.body.to_html %></div>
-  <% if can? :hidecomment, DiaryEntry %>
-    <span>
-      <% if diary_comment.visible? %>
-        <%= link_to t(".hide_link"), hide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data => { :confirm => t(".confirm") } %>
-      <% else %>
-        <%= link_to t(".unhide_link"), unhide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+<div class="row diary-comment<%= " text-muted deleted" unless diary_comment.visible? %>">
+  <div class="col-auto">
+    <%= user_thumbnail diary_comment.user, :class => "user_thumbnail_no_margins" %>
+  </div>
+  <div class="col">
+    <p class="text-muted comment-heading" id="comment<%= diary_comment.id %>"><%= t(".comment_from_html", :link_user => (link_to diary_comment.user.display_name, user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}")) %>
+      <% if current_user and diary_comment.user.id != current_user.id %>
+        | <%= report_link(t(".report"), diary_comment) %>
       <% end %>
-    </span>
-  <% end %>
+    </p>
+
+    <div class="richtext text-break"><%= diary_comment.body.to_html %></div>
+    <% if can? :hidecomment, DiaryEntry %>
+      <span>
+        <% if diary_comment.visible? %>
+          <%= link_to t(".hide_link"), hide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+        <% else %>
+          <%= link_to t(".unhide_link"), unhide_diary_comment_path(:display_name => diary_comment.diary_entry.user.display_name, :id => diary_comment.diary_entry.id, :comment => diary_comment.id), :method => :post, :data => { :confirm => t(".confirm") } %>
+        <% end %>
+      </span>
+    <% end %>
+  </div>
 </div>

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="row diary-comment<%= " text-muted deleted" unless diary_comment.visible? %>">
   <div class="col-auto">
-    <%= user_thumbnail diary_comment.user, :class => "user_thumbnail_no_margins" %>
+    <%= user_thumbnail diary_comment.user %>
   </div>
   <div class="col">
     <p class="text-muted comment-heading" id="comment<%= diary_comment.id %>"><%= t(".comment_from_html", :link_user => (link_to diary_comment.user.display_name, user_path(diary_comment.user)), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}")) %>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -1,10 +1,17 @@
 <div class='diary_post<%= " text-muted px-3 deleted" unless diary_entry.visible %> user_<%= diary_entry.user.id %>'>
-  <div class='post_heading clearfix'>
-    <% if !@user %>
-      <%= user_thumbnail diary_entry.user %>
+  <div class='post_heading'>
+    <% if @user %>
+      <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>
+    <% else %>
+      <div class="row">
+        <div class="col-auto">
+          <%= user_thumbnail diary_entry.user, :class => "user_thumbnail_no_margins" %>
+        </div>
+        <div class="col">
+          <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>
+        </div>
+      </div>
     <% end %>
-
-    <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>
 
     <small class='text-muted'>
       <%= t(".posted_by_html", :link_user => (link_to diary_entry.user.display_name, user_path(diary_entry.user)), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to diary_entry.language.name, :controller => "diary_entries", :action => "index", :display_name => nil, :language => diary_entry.language_code)) %>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -5,7 +5,7 @@
     <% else %>
       <div class="row">
         <div class="col-auto">
-          <%= user_thumbnail diary_entry.user, :class => "user_thumbnail_no_margins" %>
+          <%= user_thumbnail diary_entry.user %>
         </div>
         <div class="col">
           <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -1,26 +1,31 @@
 <% content_for :head, tag(:meta, :name => :robots, :content => :noindex) %>
 <% content_for :heading do %>
-  <div <% if @user %> id="userinformation"<% end %>>
+  <div <% if @user %> id="userinformation"<% end %> class="row">
     <% if @user %>
-      <%= user_image @user %>
+        <div class="col-auto">
+          <%= user_image @user, :class => "user_image_no_margins" %>
+        </div>
     <% end %>
-    <h1><%= @title %></h1>
 
-    <nav class="secondary-actions">
-      <ul class="clearfix">
-        <% unless params[:friends] or params[:nearby] -%>
-          <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>
-          <% end -%>
+    <div class="col">
+      <h1><%= @title %></h1>
 
-          <% if @user && @user == current_user || !@user && current_user %>
-            <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
-          <% end %>
+      <nav class="secondary-actions">
+        <ul class="clearfix">
+          <% unless params[:friends] or params[:nearby] -%>
+            <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>
+            <% end -%>
 
-          <% if !@user && current_user %>
-            <li><%= link_to t(".my_diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %></li>
-          <% end %>
-      </ul>
-    </nav>
+            <% if @user && @user == current_user || !@user && current_user %>
+              <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
+            <% end %>
+
+            <% if !@user && current_user %>
+              <li><%= link_to t(".my_diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %></li>
+            <% end %>
+        </ul>
+      </nav>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -3,7 +3,7 @@
   <div <% if @user %> id="userinformation"<% end %> class="row">
     <% if @user %>
         <div class="col-auto">
-          <%= user_image @user, :class => "user_image_no_margins" %>
+          <%= user_image @user %>
         </div>
     <% end %>
 

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :heading do %>
   <div id="userinformation" class="row">
     <div class="col-sm-auto">
-      <%= user_image @entry.user, :class => "user_image_no_margins" %>
+      <%= user_image @entry.user %>
     </div>
     <div class="col">
       <h2><%= link_to t(".user_title", :user => @entry.user.display_name), :action => :index %></h2>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -1,8 +1,12 @@
 <% content_for :heading do %>
-  <div id="userinformation">
-    <%= user_image @entry.user %>
-    <h2><%= link_to t(".user_title", :user => @entry.user.display_name), :action => :index %></h2>
-    <p><%= rss_link_to :action => :rss, :display_name => @entry.user.display_name %></p>
+  <div id="userinformation" class="row">
+    <div class="col-sm-auto">
+      <%= user_image @entry.user, :class => "user_image_no_margins" %>
+    </div>
+    <div class="col">
+      <h2><%= link_to t(".user_title", :user => @entry.user.display_name), :action => :index %></h2>
+      <p><%= rss_link_to :action => :rss, :display_name => @entry.user.display_name %></p>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -2,7 +2,7 @@
   <% comments.each do |comment| %>
     <div class="row">
       <div class="col-auto">
-        <%= link_to user_thumbnail(comment.user, :class => "user_image_no_margins"), user_path(comment.user) %>
+        <%= link_to user_thumbnail(comment.user), user_path(comment.user) %>
       </div>
       <div class="col">
         <p class="text-muted mb-0">

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -1,14 +1,16 @@
 <div>
   <% comments.each do |comment| %>
-    <div class="comment">
-      <div class="float-left">
-        <%= link_to user_thumbnail(comment.user), user_path(comment.user) %>
+    <div class="row">
+      <div class="col-auto">
+        <%= link_to user_thumbnail(comment.user, :class => "user_image_no_margins"), user_path(comment.user) %>
       </div>
-      <p class="text-muted mb-0">
-        <%= t ".comment_from_html", :user_link => link_to(comment.user.display_name, user_path(comment.user)),
-                                    :comment_created_at => l(comment.created_at.to_datetime, :format => :friendly) %>
-      </p>
-      <p><%= comment.body %></p>
+      <div class="col">
+        <p class="text-muted mb-0">
+          <%= t ".comment_from_html", :user_link => link_to(comment.user.display_name, user_path(comment.user)),
+                                      :comment_created_at => l(comment.created_at.to_datetime, :format => :friendly) %>
+        </p>
+        <p><%= comment.body %></p>
+      </div>
     </div>
     <hr>
   <% end %>

--- a/app/views/issues/_reports.html.erb
+++ b/app/views/issues/_reports.html.erb
@@ -1,7 +1,7 @@
 <% reports.each do |report| %>
   <div class="row">
     <div class="col-auto">
-      <%= link_to user_thumbnail(report.user, :class => "user_thumbnail_no_margins"), user_path(report.user) %>
+      <%= link_to user_thumbnail(report.user), user_path(report.user) %>
     </div>
     <div class="col">
       <p class="text-muted mb-0">

--- a/app/views/issues/_reports.html.erb
+++ b/app/views/issues/_reports.html.erb
@@ -1,14 +1,16 @@
 <% reports.each do |report| %>
-  <div class="report">
-    <div class="float-left">
-      <%= link_to user_thumbnail(report.user), user_path(report.user) %>
+  <div class="row">
+    <div class="col-auto">
+      <%= link_to user_thumbnail(report.user, :class => "user_thumbnail_no_margins"), user_path(report.user) %>
     </div>
-    <p class="text-muted mb-0">
-      <%= t ".reported_by_html", :category => report.category,
-                                 :user => link_to(report.user.display_name, user_path(report.user)),
-                                 :updated_at => l(report.updated_at.to_datetime, :format => :friendly) %>
-    </p>
-    <p><%= report.details %></p>
+    <div class="col">
+      <p class="text-muted mb-0">
+        <%= t ".reported_by_html", :category => report.category,
+                                   :user => link_to(report.user.display_name, user_path(report.user)),
+                                   :updated_at => l(report.updated_at.to_datetime, :format => :friendly) %>
+      </p>
+      <p><%= report.details %></p>
+    </div>
   </div>
   <hr>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :heading do %>
   <div id="userinformation" class="row">
     <div class="col-sm-auto">
-      <%= user_image @user, :class => "user_image_no_margins" %>
+      <%= user_image @user %>
     </div>
     <div class="col">
       <h1><%= @user.display_name %> <%= role_icons(@user) %></h1>


### PR DESCRIPTION
This PR continues work started in 9aa17258fcccf5b1f292e1190bd9a2968822274e and 31e247c1e223145a6ac8ce9012fe5eb586f1aaea to refactor the `user_image` and `user_thumbnail` css rules. Instead of using floats and margins, we now prefer to use the flex grid to control the layout.

The commits in this PR refactor each use of these helpers to use the temporary `_no_margins` rules, before refactoring the old rules and removing the class overrides at the end.