### PR TITLE
Convert remaining heading titles to use h1

### DIFF
--- a/app/views/diary_entries/no_such_entry.html.erb
+++ b/app/views/diary_entries/no_such_entry.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t ".heading", :id => h(params[:id]) %></h2>
+  <h1><%= t ".heading", :id => h(params[:id]) %></h1>
 <% end %>
 
 <p><%= t ".body", :id => h(params[:id]) %></p>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -4,7 +4,7 @@
       <%= user_image @entry.user %>
     </div>
     <div class="col">
-      <h2><%= link_to t(".user_title", :user => @entry.user.display_name), :action => :index %></h2>
+      <h1><%= link_to t(".user_title", :user => @entry.user.display_name), :action => :index %></h1>
       <p><%= rss_link_to :action => :rss, :display_name => @entry.user.display_name %></p>
     </div>
   </div>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-<h2><%= t ".title", :status => @issue.status.humanize, :issue_id => @issue.id %></h2>
+<h1><%= t ".title", :status => @issue.status.humanize, :issue_id => @issue.id %></h1>
 <p><%= @issue.reportable.model_name.human %> : <%= link_to reportable_title(@issue.reportable), reportable_url(@issue.reportable) %></p>
 <p class="text-muted">
   <small>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t(".send_message_to_html", :name => link_to(@message.recipient.display_name, user_path(@message.recipient))) %></h2>
+  <h1><%= t(".send_message_to_html", :name => link_to(@message.recipient.display_name, user_path(@message.recipient))) %></h1>
 <% end %>
 
 <%= bootstrap_form_for @message do |f| %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= @message.title %></h2>
+  <h1><%= @message.title %></h1>
 <% end %>
 
 <% if current_user == @message.recipient %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t ".heading", :user => @user.display_name %></h2>
+  <h1><%= t ".heading", :user => @user.display_name %></h1>
   <p><%= t ".subheading_html", :user => link_to(@user.display_name, user_path(@user)) %></p>
 <% end %>
 

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t ".heading", :name => @trace.name %></h2>
+  <h1><%= t ".heading", :name => @trace.name %></h1>
 <% end %>
 
 <img src="<%= url_for :controller => "traces", :action => "picture", :id => @trace.id, :display_name => @trace.user.display_name %>">

--- a/app/views/traces/offline.html.erb
+++ b/app/views/traces/offline.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-<h2><%= t ".heading" %></h2>
+  <h1><%= t ".heading" %></h1>
 <% end %>
 
 <p><%= t ".message" %></p>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h2><%= t ".heading", :name => @trace.name %></h2>
+  <h1><%= t ".heading", :name => @trace.name %></h1>
 <% end %>
 
 <% if Settings.status != "gpx_offline" %>

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -273,7 +273,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     get edit_diary_entry_path(:display_name => entry.user.display_name, :id => 9999)
     assert_response :not_found
     assert_select "div.content-heading", :count => 1 do
-      assert_select "h2", :text => "No entry with the id: 9999", :count => 1
+      assert_select "h1", :text => "No entry with the id: 9999", :count => 1
     end
 
     # Now pass the id, and check that you can edit it, when using the same
@@ -316,7 +316,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_template "show"
     assert_select "title", :text => /Users' Diaries | /, :count => 1
     assert_select "div.content-heading", :count => 1 do
-      assert_select "h2", :text => /#{entry.user.display_name}'s Diary/, :count => 1
+      assert_select "h1", :text => /#{entry.user.display_name}'s Diary/, :count => 1
     end
     assert_select "div#content", :count => 1 do
       assert_select "div.post_heading", :text => /#{new_title}/, :count => 1
@@ -336,7 +336,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_template "show"
     assert_select "title", :text => /Users' Diaries | /, :count => 1
     assert_select "div.content-heading", :count => 1 do
-      assert_select "h2", :text => /#{entry.user.display_name}'s Diary/, :count => 1
+      assert_select "h1", :text => /#{entry.user.display_name}'s Diary/, :count => 1
     end
     assert_select "div#content", :count => 1 do
       assert_select "div.post_heading", :text => /#{new_title}/, :count => 1
@@ -374,7 +374,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     post comment_diary_entry_path(:display_name => entry.user.display_name, :id => 9999)
     assert_response :not_found
     assert_select "div.content-heading", :count => 1 do
-      assert_select "h2", :text => "No entry with the id: 9999", :count => 1
+      assert_select "h1", :text => "No entry with the id: 9999", :count => 1
     end
 
     # Now try an invalid comment with an empty body


### PR DESCRIPTION
This makes them consistent with all the other pages that use `h1` in the `content_for :heading` sections