### PR TITLE
Remove the userinformation ids from headings

### DIFF
--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :head, tag.meta(:name => :robots, :content => :noindex) %>
 <% content_for :heading do %>
-  <div <% if @user %> id="userinformation"<% end %> class="row">
+  <div class="row">
     <% if @user %>
         <div class="col-auto">
           <%= user_image @user %>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <div id="userinformation" class="row">
+  <div class="row">
     <div class="col-sm-auto">
       <%= user_image @entry.user %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <div id="userinformation" class="row">
+  <div class="row">
     <div class="col-sm-auto">
       <%= user_image @user %>
     </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -560,7 +560,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     get user_path(user)
     assert_response :success
-    assert_select "div#userinformation" do
+    assert_select "div.content-heading" do
       assert_select "a[href^='/user/#{ERB::Util.u(user.display_name)}/history']", 1
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/traces']", 1
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/diary']", 1
@@ -579,7 +579,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     create(:user_block, :user => blocked_user)
     get user_path(blocked_user)
     assert_response :success
-    assert_select "div#userinformation" do
+    assert_select "div.content-heading" do
       assert_select "a[href^='/user/#{ERB::Util.u(blocked_user.display_name)}/history']", 1
       assert_select "a[href='/user/#{ERB::Util.u(blocked_user.display_name)}/traces']", 1
       assert_select "a[href='/user/#{ERB::Util.u(blocked_user.display_name)}/diary']", 1
@@ -595,7 +595,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     create(:user_block, :creator => moderator_user)
     get user_path(moderator_user)
     assert_response :success
-    assert_select "div#userinformation" do
+    assert_select "div.content-heading" do
       assert_select "a[href^='/user/#{ERB::Util.u(moderator_user.display_name)}/history']", 1
       assert_select "a[href='/user/#{ERB::Util.u(moderator_user.display_name)}/traces']", 1
       assert_select "a[href='/user/#{ERB::Util.u(moderator_user.display_name)}/diary']", 1
@@ -612,7 +612,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     # Test the normal user
     get user_path(user)
     assert_response :success
-    assert_select "div#userinformation" do
+    assert_select "div.content-heading" do
       assert_select "a[href^='/user/#{ERB::Util.u(user.display_name)}/history']", 1
       assert_select "a[href='/traces/mine']", 1
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/diary']", 1
@@ -629,7 +629,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     # Test the normal user
     get user_path(user)
     assert_response :success
-    assert_select "div#userinformation" do
+    assert_select "div.content-heading" do
       assert_select "a[href^='/user/#{ERB::Util.u(user.display_name)}/history']", 1
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/traces']", 1
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/diary']", 1
@@ -649,21 +649,21 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     get user_path(agreed_user)
     assert_response :success
-    assert_select "div#userinformation" do
+    assert_select "div.content-heading" do
       assert_select "dt", :count => 0, :text => /Contributor terms/
     end
 
     get user_path(seen_user)
     assert_response :success
     # put @response.body
-    assert_select "div#userinformation" do
+    assert_select "div.content-heading" do
       assert_select "dt", :count => 1, :text => /Contributor terms/
       assert_select "dd", /Declined/
     end
 
     get user_path(not_seen_user)
     assert_response :success
-    assert_select "div#userinformation" do
+    assert_select "div.content-heading" do
       assert_select "dt", :count => 1, :text => /Contributor terms/
       assert_select "dd", /Undecided/
     end


### PR DESCRIPTION
The style rule was removed in 3f8cf322723750aa4c8d062d4a727f9107ceccb4 and they were otherwise only used in the tests.