### PR TITLE
Add a user link to the heading of the diary comments page

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -235,6 +235,8 @@ class DiaryEntriesController < ApplicationController
   end
 
   def comments
+    @title = t ".title", :user => @user.display_name
+
     conditions = { :user_id => @user }
 
     conditions[:visible] = true unless can? :unhidecomment, DiaryEntry

--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -1,5 +1,6 @@
 <% content_for :heading do %>
-  <h1><%= t(".has_commented_on", :display_name => @user.display_name) %></h1>
+  <h1><%= t ".heading", :user => @user.display_name %></h1>
+  <p><%= t ".subheading_html", :user => link_to(@user.display_name, user_path(@user)) %></p>
 <% end %>
 
 <% if @comments.empty? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -504,7 +504,9 @@ en:
         title: "OpenStreetMap diary entries"
         description: "Recent diary entries from users of OpenStreetMap"
     comments:
-      has_commented_on: "%{display_name} has commented on the following diary entries"
+      title: "Diary Comments added by %{user}"
+      heading: "%{user}'s Diary Comments"
+      subheading_html: "Diary Comments added by %{user}"
       no_comments: "No diary comments"
       post: Post
       when: When


### PR DESCRIPTION
Fixes #3369

This makes the heading match the layout of the user's Notes page,
which also has a short heading and a subheading with a link.

Additionally, add a page title, again for consistency