### PR TITLE
Add some issue templates and links to other repositories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,45 @@
+name: A Bug
+description: Something has gone wrong when you were using the website.
+# title:
+# labels:
+# assignees:
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: Please share the URL where the issue can be seen.
+      placeholder: https://www.openstreetmap.org/...
+    validations:
+      required: false
+  - type: textarea
+    id: steps-reproduce
+    attributes:
+      label: How to reproduce the issue?
+      description: Please share the steps to reproduce the issue.
+      placeholder: 1. ..., 2. ..., 3. ...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Screenshot(s) or anything else?
+      description: Please add screenshots or additional information to help us understand your issue.
+      placeholder:
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Which browsers are you seeing this problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: There is an issue with the default map layer shown on the front page
+    url: https://github.com/gravitystorm/openstreetmap-carto
+    about: Please share your feedback with the OpenStreetMap-Carto team
+  - name: There is an issue with the iD editor used on the Edit tab
+    url: https://github.com/openstreetmap/iD
+    about: Please share your feedback with the iD team
+  - name: There is an issue with the search results
+    url: https://github.com/osm-search/Nominatim
+    about: Please share your feedback with the Nominatim team

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: 'Feature, Idea, Question'
+description: You want to request a feature, share an idea or have a question.
+# title:
+# labels:
+# assignees:
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: Description
+      description: Please describe you feature request, idea or question.
+      placeholder:
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if they can help us understand your request/idea/question.
+      placeholder:
+    validations:
+      required: false


### PR DESCRIPTION
This should help new users find the right place to go with their issue, while also letting people continue to use the blank template if they prefer.

The templates are heavily inspired by similar templates in the iD repo.

Fixes #3358

As an aside, I did think about adding more links (e.g. other map layers, each of the routing engines etc) or more templates (e.g. installation support) but I want to strike a balance between having too few links and on the other hand having an overwhelming page full of too many choices. In the original issue there was a suggestion to add a link to operations, but I found it really hard to write useful guidance for a regular mapper to be able to figure out whether it's a code or operations problem, so I've left that out for now.