### PR TITLE
Remove emergency=yes fallback description

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -781,7 +781,6 @@ en:
           siren: "Emergency Siren"
           suction_point: "Emergency Suction Point"
           water_tank: "Emergency Water Tank"
-          "yes": "Emergency"
         highway:
           abandoned: "Abandoned Highway"
           bridleway: "Bridleway"


### PR DESCRIPTION
This leads to confusion on features otherwise tagged (e.g. roads) while not being necessary for nominatim results.

Fixes #3170