### PR TITLE
Drop the trace_use_job_queue option

### DIFF
--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -38,7 +38,7 @@ module Api
       if trace.user == current_user
         trace.visible = false
         trace.save!
-        TraceDestroyerJob.perform_later(trace) if Settings.trace_use_job_queue
+        TraceDestroyerJob.perform_later(trace)
 
         head :ok
       else
@@ -79,7 +79,7 @@ module Api
         trace = do_create(params[:file], tags, description, visibility)
 
         if trace.id
-          TraceImporterJob.perform_later(trace) if Settings.trace_use_job_queue
+          TraceImporterJob.perform_later(trace)
           render :plain => trace.id.to_s
         elsif trace.valid?
           head :internal_server_error

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -110,7 +110,7 @@ class TracesController < ApplicationController
         flash[:notice] = t ".trace_uploaded"
         flash[:warning] = t ".traces_waiting", :count => current_user.traces.where(:inserted => false).count if current_user.traces.where(:inserted => false).count > 4
 
-        TraceImporterJob.perform_later(@trace) if Settings.trace_use_job_queue
+        TraceImporterJob.perform_later(@trace)
         redirect_to :action => :index, :display_name => current_user.display_name
       else
         flash[:error] = t("traces.create.upload_failed") if @trace.valid?
@@ -194,7 +194,7 @@ class TracesController < ApplicationController
       trace.visible = false
       trace.save
       flash[:notice] = t ".scheduled_for_deletion"
-      TraceDestroyerJob.perform_later(trace) if Settings.trace_use_job_queue
+      TraceDestroyerJob.perform_later(trace)
       redirect_to :action => :index, :display_name => trace.user.display_name
     end
   rescue ActiveRecord::RecordNotFound

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,10 +63,6 @@ spam_threshold: 50
 diary_feed_delay: 0
 # Default legale (jurisdiction location) for contributor terms
 default_legale: GB
-# Use the built-in jobs queue for importing traces
-# Set to false if you are using the external high-speed gpx importer
-# https://github.com/openstreetmap/gpx-import
-trace_use_job_queue: true
 # Location of GPX traces and images
 gpx_trace_dir: "/home/osm/traces"
 gpx_image_dir: "/home/osm/images"


### PR DESCRIPTION
This has been set as true by default, and in production, for many years. I don't think there's much use in keeping the setting around any longer.