### PR TITLE
Notes ordering: show unresolved notes first

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -20,7 +20,7 @@ class NotesController < ApplicationController
         @page_size = 10
         @notes = @user.notes
         @notes = @notes.visible unless current_user&.moderator?
-        @notes = @notes.order("updated_at DESC, id").distinct.offset((@page - 1) * @page_size).limit(@page_size).preload(:comments => :author)
+        @notes = @notes.order("status, updated_at DESC, id").distinct.offset((@page - 1) * @page_size).limit(@page_size).preload(:comments => :author)
       else
         @title = t "users.no_such_user.title"
         @not_found_user = params[:display_name]


### PR DESCRIPTION
This simple PR changes ordering when showing user notes on the public website (`https://www.openstreetmap.org/user/USERNAME/notes`)

Previously, notes were sorted by date of last update (newest first), regardless of their status `open`/`closed`.

With this, it displays `open` notes first (as that is most likely what the user is interested in), followed by all `closed` notes.
Apart from that, the notes remain sorted as before - by date of last update (newest first).

While not completely solving it, this should alleviate most grave problems of https://github.com/openstreetmap/openstreetmap-website/issues/832#issuecomment-829383983