### PR TITLE
Revert to the last es5-compatible version of locatecontrol

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "jquery-simulate": "^1.0.2",
     "js-cookie": "^3.0.0",
     "leaflet": "^1.6.0",
-    "leaflet.locatecontrol": "^0.76.0",
+    "leaflet.locatecontrol": "^0.75.0",
     "qs": "^6.9.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,10 +459,10 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-leaflet.locatecontrol@^0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.76.0.tgz#afca63a3ccf3161bed0e8bf94a98ddba364e90e1"
-  integrity sha512-Mx8uiihBi8KrrW3LgblsNL/pS8HR0gj60m8VFDFrnhSvDuitChazc095XcMSscf/XqZW+TSqQMCTe+AUy/4/eA==
+leaflet.locatecontrol@^0.75.0:
+  version "0.75.0"
+  resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.75.0.tgz#8c7996de4425380660431fbfa548d5fe3a3595d8"
+  integrity sha512-Mz/+4dgmUoBVxy7BN+Rtf76XcIJw2qK+S41FnejS/AC88Ec5hpaFnI5gYcS+W6zcQ90sAKxqu1rXii+c01ot5g==
 
 leaflet@^1.6.0:
   version "1.7.1"


### PR DESCRIPTION
Refs #3387

This temporarily gets the site working again for IE11 while we discuss longer term options