### PR TITLE
Added `highway=turning_circle` to en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -829,6 +829,7 @@ en:
           trailhead: "Trailhead"
           trunk: "Trunk Road"
           trunk_link: "Trunk Road"
+          turning_circle: "Turning Circle"
           turning_loop: "Turning Loop"
           unclassified: "Unclassified Road"
           "yes" : "Road"


### PR DESCRIPTION
Added `highway=turning_circle` to en.yml - value was not available in TranslateWiki for translation.

A precedent has already been set that labels found through the "Find objects" tool should be made available for translation too (see discussion on topic in #3124)