### PR TITLE
Allow users to delete their own accounts

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -36,13 +36,14 @@ class Ability
     if user
       can :welcome, :site
       can [:revoke, :authorize], :oauth
+      can [:show], :deletion
 
       if Settings.status != "database_offline"
         can [:index, :new, :create, :show, :edit, :update, :destroy], ClientApplication
         can [:index, :new, :create, :show, :edit, :update, :destroy], :oauth2_application
         can [:index, :destroy], :oauth2_authorized_application
         can [:new, :show, :create, :destroy], :oauth2_authorization
-        can [:edit, :update], :account
+        can [:edit, :update, :destroy], :account
         can [:show], :dashboard
         can [:new, :create, :edit, :update, :comment, :subscribe, :unsubscribe], DiaryEntry
         can [:make_friend, :remove_friend], Friendship

--- a/app/controllers/account/deletions_controller.rb
+++ b/app/controllers/account/deletions_controller.rb
@@ -1,0 +1,12 @@
+module Account
+  class DeletionsController < ApplicationController
+    layout "site"
+
+    before_action :authorize_web
+    before_action :set_locale
+
+    authorize_resource :class => false
+
+    def show; end
+  end
+end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -51,4 +51,14 @@ class AccountsController < ApplicationController
       redirect_to auth_url(params[:user][:auth_provider], params[:user][:auth_uid]), :status => :temporary_redirect
     end
   end
+
+  def destroy
+    current_user.soft_destroy!
+
+    session.delete(:user)
+    session_expires_automatically
+
+    flash[:notice] = t ".success"
+    redirect_to root_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -349,7 +349,7 @@ class ApplicationController < ActionController::Base
     elsif current_user
       set_locale
       respond_to do |format|
-        format.html { redirect_to :controller => "errors", :action => "forbidden" }
+        format.html { redirect_to :controller => "/errors", :action => "forbidden" }
         format.any { report_error t("application.permission_denied"), :forbidden }
       end
     elsif request.get?

--- a/app/views/account/deletions/show.html.erb
+++ b/app/views/account/deletions/show.html.erb
@@ -1,0 +1,38 @@
+<% content_for :heading do %>
+  <h1><%= t ".title" %></h1>
+<% end %>
+
+<%= render :partial => "settings_menu" %>
+
+<div class="alert alert-danger row mx-0 p-3 align-items-center">
+  <div class="col-auto">
+    <picture>
+      <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>
+      <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
+    </picture>
+  </div>
+  <div class="col">
+    <p class="mb-0"><%= t ".warning" %></p>
+  </div>
+</div>
+
+<p><%= t ".delete_introduction" %></p>
+
+<ul>
+  <li><%= t ".delete_profile" %></li>
+  <li><%= t ".delete_display_name" %></li>
+</ul>
+
+<p><%= t ".retain_caveats" %></p>
+
+<ul>
+  <li><%= t ".retain_edits" %></li>
+  <li><%= t ".retain_traces" %></li>
+  <li><%= t ".retain_diary_entries" %></li>
+  <li><%= t ".retain_notes" %></li>
+  <li><%= t ".retain_changeset_discussions" %></li>
+  <li><%= t ".retain_email" %></li>
+</ul>
+
+<%= link_to t(".delete_account"), account_path, { :method => :delete, :class => "btn btn-danger", :data => { :confirm => t(".confirm_delete") } } %>
+<%= link_to t(".cancel"), edit_account_path, :class => "btn btn-link" %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -54,7 +54,14 @@
     </span>
   </div>
 
-  <%= f.primary t(".save changes button") %>
+  <div class="row justify-content-between">
+    <div class="col-auto btn-wrapper">
+      <%= f.primary t(".save changes button") %>
+    </div>
+    <div class="col-auto btn-wrapper">
+      <%= link_to t(".delete_account"), account_deletion_path, :class => "btn btn-outline-danger" %>
+    </div>
+  </div>
 <% end %>
 
 <% unless current_user.data_public? %>

--- a/app/views/application/_settings_menu.html.erb
+++ b/app/views/application/_settings_menu.html.erb
@@ -3,7 +3,7 @@
 <% content_for :heading do %>
   <ul class="nav nav-tabs flex-column flex-sm-row">
     <li class="nav-item">
-      <%= link_to t(".account_settings"), edit_account_path, :class => "nav-link #{'active' if controller_name == 'accounts'}" %>
+      <%= link_to t(".account_settings"), edit_account_path, :class => "nav-link #{'active' if %w[accounts deletions].include?(controller_name)}" %>
     </li>
     <li class="nav-item">
       <%= link_to t(".oauth1_settings"), oauth_clients_path(current_user), :class => "nav-link #{'active' if controller_name == 'oauth_clients'}" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,6 +239,24 @@ en:
       entry:
         comment: Comment
         full: Full note
+  account:
+    deletions:
+      show:
+        title: Delete My Account
+        warning: Warning! The account deletion process is final, and cannot be reversed.
+        delete_account: Delete Account
+        delete_introduction: "You can delete your OpenStreetMap account using the button below. Please note the following details:"
+        delete_profile: Your profile information, including your avatar, description and home location will be removed.
+        delete_display_name: Your display name will be removed, and can be reused by other accounts.
+        retain_caveats: "However, some information about you will be retained on OpenStreetMap, even after your account is deleted:"
+        retain_edits: Your edits to the map database, if any, will be retained.
+        retain_traces: Your uploaded traces, if any, will be retained.
+        retain_diary_entries: Your diary entries and diary comments, if any, will be retained but hidden from view.
+        retain_notes: Your map notes and note comments, if any, will be retained but hidden from view.
+        retain_changeset_discussions: Your changeset discussions, if any, will be retained.
+        retain_email: Your email address will be retained.
+        confirm_delete: Are you sure?
+        cancel: Cancel
   accounts:
     edit:
       title: "Edit account"
@@ -268,9 +286,12 @@ en:
         link text: "what is this?"
       save changes button: Save Changes
       make edits public button: Make all my edits public
+      delete_account: Delete Account...
     update:
       success_confirm_needed: "User information updated successfully. Check your email for a note to confirm your new email address."
       success: "User information updated successfully."
+    destroy:
+      success: "Account Deleted."
   browse:
     created: "Created"
     closed: "Closed"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,7 +240,11 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/account", :to => redirect(:path => "/account/edit")
   post "/user/:display_name/set_status" => "users#set_status", :as => :set_status_user
 
-  resource :account, :only => [:edit, :update]
+  resource :account, :only => [:edit, :update, :destroy]
+
+  namespace :account do
+    resource :deletion, :only => [:show]
+  end
   resource :dashboard, :only => [:show]
   resource :preferences, :only => [:show, :edit, :update]
   resource :profile, :only => [:edit, :update]

--- a/test/system/account_deletion_test.rb
+++ b/test/system/account_deletion_test.rb
@@ -1,0 +1,44 @@
+require "application_system_test_case"
+
+class AccountDeletionTest < ApplicationSystemTestCase
+  def setup
+    @user = create(:user, :display_name => "test user")
+    sign_in_as(@user)
+  end
+
+  test "the status is deleted and the personal data removed" do
+    visit edit_account_path
+
+    click_on "Delete Account..."
+    accept_confirm do
+      click_on "Delete Account"
+    end
+
+    assert_current_path root_path
+    @user.reload
+    assert_equal "deleted", @user.status
+    assert_equal "user_#{@user.id}", @user.display_name
+  end
+
+  test "the user is signed out after deletion" do
+    visit edit_account_path
+
+    click_on "Delete Account..."
+    accept_confirm do
+      click_on "Delete Account"
+    end
+
+    assert_content "Log In"
+  end
+
+  test "the user is shown a confirmation flash message" do
+    visit edit_account_path
+
+    click_on "Delete Account..."
+    accept_confirm do
+      click_on "Delete Account"
+    end
+
+    assert_content "Account Deleted"
+  end
+end


### PR DESCRIPTION
Account deletion is something that administrators currently do manually, when emailed with a request, but there's no reason to prevent users from being able to delete their own accounts.

I'm opening this as a draft PR in order to get early feedback on the UI. Obviously tests need to be written, and to help with development, it doesn't actually delete the account yet :smile:

The idea is to have a button on the account editing page:

![Screenshot from 2021-12-15 16-59-00](https://user-images.githubusercontent.com/360803/146233151-6d921bb3-994d-4b8f-b9dd-31896d8d51ad.png)

Which then leads to a description of what exactly will happen when you delete your account:

![Screenshot from 2021-12-15 16-54-42](https://user-images.githubusercontent.com/360803/146232783-2c53d980-aefa-4ed6-b95f-5adbe36d876f.png)

Please let me know what you think. If you want to see exactly what happens when you delete an account currently, have a look at the reasonably straightforward [`User#destroy`](https://github.com/openstreetmap/openstreetmap-website/blob/8adb486130d867070504c2c2c705fdfe74e5d394/app/models/user.rb#L243-L259) method.