### PR TITLE
Alias the user creation_time column

### DIFF
--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -1,7 +1,7 @@
 json.user do
   json.id user.id
   json.display_name user.display_name
-  json.account_created user.creation_time.xmlschema
+  json.account_created user.created_at.xmlschema
   json.description user.description if user.description
 
   if current_user && current_user == user && can?(:details, User)

--- a/app/views/api/users/_user.xml.builder
+++ b/app/views/api/users/_user.xml.builder
@@ -1,6 +1,6 @@
 xml.tag! "user", :id => user.id,
                  :display_name => user.display_name,
-                 :account_created => user.creation_time.xmlschema do
+                 :account_created => user.created_at.xmlschema do
   xml.tag! "description", user.description if user.description
   if current_user && current_user == user && can?(:details, User)
     xml.tag! "contributor-terms", :agreed => user.terms_agreed.present?,

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -8,11 +8,11 @@
         <%= t "users.index.summary_html",
               :name => link_to(user.display_name, user_path(user)),
               :ip_address => link_to(user.creation_ip, :ip => user.creation_ip),
-              :date => l(user.creation_time, :format => :friendly) %>
+              :date => l(user.created_at, :format => :friendly) %>
       <% else %>
         <%= t "users.index.summary_no_ip_html",
               :name => link_to(user.display_name, user_path(user)),
-              :date => l(user.creation_time, :format => :friendly) %>
+              :date => l(user.created_at, :format => :friendly) %>
       <% end %>
     </p>
     <div class="richtext text-break"><%= user.description.to_html %></div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -120,7 +120,7 @@
         <small>
           <dl class="dl-inline">
             <dt><%= t ".mapper since" %></dt>
-            <dd><%= l @user.creation_time.to_date, :format => :long %></dd>
+            <dd><%= l @user.created_at.to_date, :format => :long %></dd>
             <% unless @user.terms_agreed %>
               <dt><%= t ".ct status" %></dt>
               <dd>


### PR DESCRIPTION
This allows rails to set the created_at automatically, and so avoids us from having to do so in a callback. It also hides the unusual db column name from the rest of the app.