### PR TITLE
Rename User#delete to User#destroy

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -208,9 +208,9 @@ class UsersController < ApplicationController
   end
 
   ##
-  # delete a user, marking them as deleted and removing personal data
+  # destroy a user, marking them as deleted and removing personal data
   def destroy
-    @user.delete
+    @user.destroy
     redirect_to user_path(:display_name => params[:display_name])
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,8 +241,8 @@ class User < ApplicationRecord
   end
 
   ##
-  # delete a user - leave the account but purge most personal data
-  def delete
+  # destroy a user - leave the account but purge most personal data
+  def destroy
     avatar.purge_later
 
     self.display_name = "user_#{id}"

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -161,7 +161,7 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select "div.note-comments ul li", :count => 2
     assert_select "div.details", /Resolved by #{user.display_name}/
 
-    user.delete
+    user.destroy
 
     reset!
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -256,9 +256,9 @@ class UserTest < ActiveSupport::TestCase
     assert create(:moderator_user).has_role?("moderator")
   end
 
-  def test_delete
+  def test_destroy
     user = create(:user, :with_home_location, :description => "foo")
-    user.delete
+    user.destroy
     assert_equal "user_#{user.id}", user.display_name
     assert user.description.blank?
     assert_nil user.home_lat


### PR DESCRIPTION
"delete" is generally used for immediate SQL deletion without running any callbacks or other ruby code, whereas "destroy" will trigger callbacks.

Although we don't currently use any callbacks, let's rename this method to align better with the convention.