### PR TITLE
Fix display of suspension message when a user is suspended mid-session 

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -23,7 +23,7 @@ class Ability
       can [:index, :show], Redaction
       can [:new, :create, :destroy], :session
       can [:index, :show, :data, :georss, :picture, :icon], Trace
-      can [:terms, :new, :create, :save,  :show, :auth_success, :auth_failure], User
+      can [:terms, :new, :create, :save, :suspended, :show, :auth_success, :auth_failure], User
       can [:index, :show, :blocks_on, :blocks_by], UserBlock
       can [:index, :show], Node
       can [:index, :show, :full, :ways_for_node], Way

--- a/test/system/user_suspension_test.rb
+++ b/test/system/user_suspension_test.rb
@@ -1,0 +1,15 @@
+require "application_system_test_case"
+
+class UserSuspensionTest < ApplicationSystemTestCase
+  test "User shown a message when suspended mid-session" do
+    user = create(:user)
+    sign_in_as(user)
+    visit edit_account_path
+    assert_content "My Settings"
+
+    user.update(:status => "suspended")
+
+    visit edit_account_path
+    assert_content "This decision will be reviewed by an administrator shortly"
+  end
+end


### PR DESCRIPTION
Without the ability defined, the user is still logged out, but then the `deny_access` check redirects to the login page. The re-login attempt would then fail anyway, with an error message, but let's fix the abilities and use the intended page.

I think this has been broken since the abilities were introduced, since there's no `suspended` action defined in the controller. I was a bit surprised that actions without definitions worked, but it seems that's a legitimate way to do things in Rails!