### PR TITLE
Use factories instead of new objects

### DIFF
--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -17,23 +17,23 @@ class IssueTest < ActiveSupport::TestCase
     diary_entry = create(:diary_entry)
     diary_comment = create(:diary_comment, :diary_entry => diary_entry)
 
-    issue = Issue.new(:reportable => user, :assigned_role => "administrator")
+    issue = build(:issue, :reportable => user, :assigned_role => "administrator")
     issue.save!
     assert_equal issue.reported_user, user
 
-    issue = Issue.new(:reportable => note, :assigned_role => "administrator")
+    issue = build(:issue, :reportable => note, :assigned_role => "administrator")
     issue.save!
     assert_equal issue.reported_user, note.author
 
-    issue = Issue.new(:reportable => anonymous_note, :assigned_role => "administrator")
+    issue = build(:issue, :reportable => anonymous_note, :assigned_role => "administrator")
     issue.save!
     assert_nil issue.reported_user
 
-    issue = Issue.new(:reportable => diary_entry, :assigned_role => "administrator")
+    issue = build(:issue, :reportable => diary_entry, :assigned_role => "administrator")
     issue.save!
     assert_equal issue.reported_user, diary_entry.user
 
-    issue = Issue.new(:reportable => diary_comment, :assigned_role => "administrator")
+    issue = build(:issue, :reportable => diary_comment, :assigned_role => "administrator")
     issue.save!
     assert_equal issue.reported_user, diary_comment.user
   end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -4,7 +4,7 @@ class MessageTest < ActiveSupport::TestCase
   EURO = "\xe2\x82\xac".freeze # euro symbol
 
   def test_check_empty_message_fails
-    message = Message.new
+    message = build(:message, :title => nil, :body => nil, :sent_on => nil)
     assert_not message.valid?
     assert message.errors[:title].any?
     assert message.errors[:body].any?

--- a/test/models/node_test.rb
+++ b/test/models/node_test.rb
@@ -71,13 +71,11 @@ class NodeTest < ActiveSupport::TestCase
   # Check that you can create a node and store it
   def test_create
     changeset = create(:changeset)
-    node_template = Node.new(
-      :lat => 12.3456,
-      :lon => 65.4321,
-      :changeset_id => changeset.id,
-      :visible => 1,
-      :version => 1
-    )
+    node_template = build(:node, :lat => 12.3456,
+                                 :lon => 65.4321,
+                                 :changeset_id => changeset.id,
+                                 :visible => true,
+                                 :version => 1)
     assert node_template.create_with_history(changeset.user)
 
     node = Node.find(node_template.id)

--- a/test/models/relation_test.rb
+++ b/test/models/relation_test.rb
@@ -193,10 +193,9 @@ class RelationTest < ActiveSupport::TestCase
     assert_nil changeset.max_lon
     assert_nil changeset.max_lat
     assert_nil changeset.min_lat
-    new_relation = Relation.new
-    new_relation.id = super_relation.id
-    new_relation.version = super_relation.version
-    new_relation.changeset = changeset
+    new_relation = build(:relation, :id => super_relation.id,
+                                    :version => super_relation.version,
+                                    :changeset => changeset)
     new_relation.add_member node_member.member_type, node_member.member_id, node_member.member_role
     # one member(relation type) was removed, so any_relation flag is expected to be true.
     super_relation.update_from(new_relation, user)
@@ -221,10 +220,9 @@ class RelationTest < ActiveSupport::TestCase
     assert_nil changeset.max_lat
     assert_nil changeset.min_lat
 
-    new_relation = Relation.new
-    new_relation.id = orig_relation.id
-    new_relation.version = orig_relation.version
-    new_relation.changeset_id = changeset.id
+    new_relation = build(:relation, :id => orig_relation.id,
+                                    :version => orig_relation.version,
+                                    :changeset_id => changeset.id)
     orig_relation.delete_with_history!(new_relation, user)
     changeset.reload
     assert_equal 39, changeset.min_lon

--- a/test/models/user_preference_test.rb
+++ b/test/models/user_preference_test.rb
@@ -4,7 +4,7 @@ class UserPreferenceTest < ActiveSupport::TestCase
   # Checks that you cannot add a new preference, that is a duplicate
   def test_add_duplicate_preference
     up = create(:user_preference)
-    new_up = UserPreference.new
+    new_up = build(:user_preference)
     new_up.user = up.user
     new_up.k = up.k
     new_up.v = "some other value"
@@ -16,7 +16,7 @@ class UserPreferenceTest < ActiveSupport::TestCase
     key = "k"
     val = "v"
     [1, 255].each do |i|
-      up = UserPreference.new
+      up = build(:user_preference)
       up.user = create(:user)
       up.k = key * i
       up.v = val * i
@@ -32,7 +32,7 @@ class UserPreferenceTest < ActiveSupport::TestCase
     key = "k"
     val = "v"
     [0, 256].each do |i|
-      up = UserPreference.new
+      up = build(:user_preference)
       up.user = create(:user)
       up.k = key * i
       up.v = val * i

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,12 +4,16 @@ class UserTest < ActiveSupport::TestCase
   include Rails::Dom::Testing::Assertions::SelectorAssertions
 
   def test_invalid_with_empty_attributes
-    user = User.new
+    user = build(:user, :email => nil,
+                        :pass_crypt => nil,
+                        :display_name => nil,
+                        :home_lat => nil,
+                        :home_lon => nil,
+                        :home_zoom => nil)
     assert_not user.valid?
     assert user.errors[:email].any?
     assert user.errors[:pass_crypt].any?
     assert user.errors[:display_name].any?
-    assert user.errors[:email].any?
     assert user.errors[:home_lat].none?
     assert user.errors[:home_lon].none?
     assert user.errors[:home_zoom].none?
@@ -17,28 +21,14 @@ class UserTest < ActiveSupport::TestCase
 
   def test_unique_email
     existing_user = create(:user)
-    new_user = User.new(
-      :email => existing_user.email,
-      :status => "active",
-      :pass_crypt => Digest::MD5.hexdigest("test"),
-      :display_name => "new user",
-      :data_public => 1,
-      :description => "desc"
-    )
+    new_user = build(:user, :email => existing_user.email)
     assert_not new_user.save
     assert_includes new_user.errors[:email], "has already been taken"
   end
 
   def test_unique_display_name
     existing_user = create(:user)
-    new_user = User.new(
-      :email => "tester@openstreetmap.org",
-      :status => "pending",
-      :pass_crypt => Digest::MD5.hexdigest("test"),
-      :display_name => existing_user.display_name,
-      :data_public => 1,
-      :description => "desc"
-    )
+    new_user = build(:user, :display_name => existing_user.display_name)
     assert_not new_user.save
     assert_includes new_user.errors[:display_name], "has already been taken"
   end


### PR DESCRIPTION
This PR changes various uses of `Model.new` in the tests to use FactoryBot via `build(:model)`. It's partly for consistency, but also partly because I ran into problems with those User model tests while doing some unrelated work.