### PR TITLE
Use `assert_content` instead of `assert page.has_content?`

### DIFF
--- a/test/system/confirmation_resend_test.rb
+++ b/test/system/confirmation_resend_test.rb
@@ -20,7 +20,7 @@ class ConfirmationResendSystemTest < ApplicationSystemTestCase
   test "flash message should not contain raw html" do
     visit user_confirm_resend_path(@user)
 
-    assert page.has_content?("sent a new confirmation")
-    assert_not page.has_content?("<p>")
+    assert_content "sent a new confirmation"
+    assert_no_content "<p>"
   end
 end

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -12,7 +12,7 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
 
     click_on "Send a message to the author"
 
-    assert page.has_content? "Send a new message"
+    assert_content "Send a new message"
     assert_equal "Re: #{@diary_entry.title}", page.find_field("Subject").value
   end
 
@@ -22,7 +22,7 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     sign_in_as(create(:user))
     visit diary_entries_path
 
-    assert_not page.has_content? @deleted_entry.title
+    assert_no_content @deleted_entry.title
   end
 
   test "deleted diary entries should be shown to administrators for review" do
@@ -31,7 +31,7 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     sign_in_as(create(:administrator_user))
     visit diary_entries_path
 
-    assert page.has_content? @deleted_entry.title
+    assert_content @deleted_entry.title
   end
 
   test "deleted diary entries should not be shown to admins when the user is also deleted" do
@@ -41,7 +41,7 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     sign_in_as(create(:administrator_user))
     visit diary_entries_path
 
-    assert_not page.has_content? @deleted_entry.title
+    assert_no_content @deleted_entry.title
   end
 
   test "deleted diary comments should be hidden for regular users" do
@@ -50,7 +50,7 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     sign_in_as(create(:user))
     visit diary_entry_path(@diary_entry.user, @diary_entry)
 
-    assert_not page.has_content? @deleted_comment.body
+    assert_no_content @deleted_comment.body
   end
 
   test "deleted diary comments should be shown to administrators" do
@@ -59,6 +59,6 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     sign_in_as(create(:administrator_user))
     visit diary_entry_path(@diary_entry.user, @diary_entry)
 
-    assert page.has_content? @deleted_comment.body
+    assert_content @deleted_comment.body
   end
 end

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -5,21 +5,21 @@ class IssuesTest < ApplicationSystemTestCase
 
   def test_view_issues_not_logged_in
     visit issues_path
-    assert page.has_content?(I18n.t("sessions.new.title"))
+    assert_content I18n.t("sessions.new.title")
   end
 
   def test_view_issues_normal_user
     sign_in_as(create(:user))
 
     visit issues_path
-    assert page.has_content?("Forbidden")
+    assert_content "Forbidden"
   end
 
   def test_view_no_issues
     sign_in_as(create(:moderator_user))
 
     visit issues_path
-    assert page.has_content?(I18n.t("issues.index.issues_not_found"))
+    assert_content I18n.t("issues.index.issues_not_found")
   end
 
   def test_view_issues
@@ -27,7 +27,7 @@ class IssuesTest < ApplicationSystemTestCase
     issues = create_list(:issue, 3, :assigned_role => "moderator")
 
     visit issues_path
-    assert page.has_content?(issues.first.reported_user.display_name)
+    assert_content issues.first.reported_user.display_name
   end
 
   def test_view_issues_with_no_reported_user
@@ -36,10 +36,10 @@ class IssuesTest < ApplicationSystemTestCase
     issue = create(:issue, :reportable => anonymous_note, :assigned_role => "moderator")
 
     visit issues_path
-    assert page.has_content?(reportable_title(anonymous_note))
+    assert_content reportable_title(anonymous_note)
 
     visit issue_path(issue)
-    assert page.has_content?(reportable_title(anonymous_note))
+    assert_content reportable_title(anonymous_note)
   end
 
   def test_search_issues_by_user
@@ -53,22 +53,22 @@ class IssuesTest < ApplicationSystemTestCase
     visit issues_path
     fill_in "search_by_user", :with => good_user.display_name
     click_on "Search"
-    assert_not page.has_content?(I18n.t("issues.index.user_not_found"))
-    assert page.has_content?(I18n.t("issues.index.issues_not_found"))
+    assert_no_content I18n.t("issues.index.user_not_found")
+    assert_content I18n.t("issues.index.issues_not_found")
 
     # User doesn't exist
     visit issues_path
     fill_in "search_by_user", :with => "Nonexistent User"
     click_on "Search"
-    assert page.has_content?(I18n.t("issues.index.user_not_found"))
-    assert page.has_content?(I18n.t("issues.index.issues_not_found"))
+    assert_content I18n.t("issues.index.user_not_found")
+    assert_content I18n.t("issues.index.issues_not_found")
 
     # Find Issue against bad_user
     visit issues_path
     fill_in "search_by_user", :with => bad_user.display_name
     click_on "Search"
-    assert_not page.has_content?(I18n.t("issues.index.user_not_found"))
-    assert_not page.has_content?(I18n.t("issues.index.issues_not_found"))
+    assert_no_content I18n.t("issues.index.user_not_found")
+    assert_no_content I18n.t("issues.index.issues_not_found")
   end
 
   def test_commenting
@@ -79,8 +79,8 @@ class IssuesTest < ApplicationSystemTestCase
 
     fill_in :issue_comment_body, :with => "test comment"
     click_on "Add Comment"
-    assert page.has_content?(I18n.t("issue_comments.create.comment_created"))
-    assert page.has_content?("test comment")
+    assert_content I18n.t("issue_comments.create.comment_created")
+    assert_content "test comment"
 
     issue.reload
     assert_equal("test comment", issue.comments.first.body)

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -113,7 +113,7 @@ class IssuesTest < ApplicationSystemTestCase
 
     visit issues_path
 
-    assert page.has_link?(I18n.t("issues.index.reports_count", :count => issue1.reports_count), :href => issue_path(issue1))
-    assert page.has_link?(I18n.t("issues.index.reports_count", :count => issue2.reports_count), :href => issue_path(issue2))
+    assert_link I18n.t("issues.index.reports_count", :count => issue1.reports_count), :href => issue_path(issue1)
+    assert_link I18n.t("issues.index.reports_count", :count => issue2.reports_count), :href => issue_path(issue2)
   end
 end

--- a/test/system/preferences_test.rb
+++ b/test/system/preferences_test.rb
@@ -7,7 +7,7 @@ class PreferencesTest < ApplicationSystemTestCase
     visit edit_preferences_path
     click_on "Update Preferences"
 
-    assert page.has_content?("Preferences updated")
+    assert_content "Preferences updated"
   end
 
   def test_flash_message_shows_in_new_language
@@ -17,6 +17,6 @@ class PreferencesTest < ApplicationSystemTestCase
     fill_in "Preferred Languages", :with => "fr"
     click_on "Update Preferences"
 
-    assert page.has_content?("Préférences mises à jour")
+    assert_content "Préférences mises à jour"
   end
 end

--- a/test/system/report_diary_comment_test.rb
+++ b/test/system/report_diary_comment_test.rb
@@ -9,19 +9,19 @@ class ReportDiaryCommentTest < ApplicationSystemTestCase
 
   def test_no_link_when_not_logged_in
     visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
-    assert page.has_content?(@comment.body)
+    assert_content @comment.body
 
-    assert_not page.has_content?(I18n.t("diary_entries.diary_comment.report"))
+    assert_no_content I18n.t("diary_entries.diary_comment.report")
   end
 
   def test_it_works
     sign_in_as(create(:user))
     visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
-    assert page.has_content? @diary_entry.title
+    assert_content @diary_entry.title
 
     click_on I18n.t("diary_entries.diary_comment.report")
-    assert page.has_content? "Report"
-    assert page.has_content? I18n.t("reports.new.disclaimer.intro")
+    assert_content "Report"
+    assert_content I18n.t("reports.new.disclaimer.intro")
 
     choose I18n.t("reports.new.categories.diary_comment.spam_label")
     fill_in "report_details", :with => "This comment is spam"
@@ -29,7 +29,7 @@ class ReportDiaryCommentTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered successfully"
+    assert_content "Your report has been registered successfully"
 
     assert_equal @comment, Issue.last.reportable
     assert_equal "administrator", Issue.last.assigned_role

--- a/test/system/report_diary_entry_test.rb
+++ b/test/system/report_diary_entry_test.rb
@@ -8,19 +8,19 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
 
   def test_no_link_when_not_logged_in
     visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
-    assert page.has_content?(@diary_entry.title)
+    assert_content @diary_entry.title
 
-    assert_not page.has_content?(I18n.t("diary_entries.diary_entry.report"))
+    assert_no_content I18n.t("diary_entries.diary_entry.report")
   end
 
   def test_it_works
     sign_in_as(create(:user))
     visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
-    assert page.has_content? @diary_entry.title
+    assert_content @diary_entry.title
 
     click_on I18n.t("diary_entries.diary_entry.report")
-    assert page.has_content? "Report"
-    assert page.has_content? I18n.t("reports.new.disclaimer.intro")
+    assert_content "Report"
+    assert_content I18n.t("reports.new.disclaimer.intro")
 
     choose I18n.t("reports.new.categories.diary_entry.spam_label")
     fill_in "report_details", :with => "This is advertising"
@@ -28,7 +28,7 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered successfully"
+    assert_content "Your report has been registered successfully"
 
     assert_equal @diary_entry, Issue.last.reportable
     assert_equal "administrator", Issue.last.assigned_role
@@ -40,11 +40,11 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
 
     sign_in_as(create(:user))
     visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
-    assert page.has_content? @diary_entry.title
+    assert_content @diary_entry.title
 
     click_on I18n.t("diary_entries.diary_entry.report")
-    assert page.has_content? "Report"
-    assert page.has_content? I18n.t("reports.new.disclaimer.intro")
+    assert_content "Report"
+    assert_content I18n.t("reports.new.disclaimer.intro")
 
     choose I18n.t("reports.new.categories.diary_entry.spam_label")
     fill_in "report_details", :with => "This is advertising"
@@ -60,6 +60,6 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
   def test_missing_report_params
     sign_in_as(create(:user))
     visit new_report_path
-    assert page.has_content? I18n.t("reports.new.missing_params")
+    assert_content I18n.t("reports.new.missing_params")
   end
 end

--- a/test/system/report_note_test.rb
+++ b/test/system/report_note_test.rb
@@ -4,9 +4,9 @@ class ReportNoteTest < ApplicationSystemTestCase
   def test_no_link_when_not_logged_in
     note = create(:note_with_comments)
     visit browse_note_path(note)
-    assert page.has_content?(note.comments.first.body)
+    assert_content note.comments.first.body
 
-    assert_not page.has_content?(I18n.t("browse.note.report"))
+    assert_no_content I18n.t("browse.note.report")
   end
 
   def test_can_report_anonymous_notes
@@ -15,8 +15,8 @@ class ReportNoteTest < ApplicationSystemTestCase
     visit browse_note_path(note)
 
     click_on I18n.t("browse.note.report")
-    assert page.has_content? "Report"
-    assert page.has_content? I18n.t("reports.new.disclaimer.intro")
+    assert_content "Report"
+    assert_content I18n.t("reports.new.disclaimer.intro")
 
     choose I18n.t("reports.new.categories.note.spam_label")
     fill_in "report_details", :with => "This is spam"
@@ -24,7 +24,7 @@ class ReportNoteTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered successfully"
+    assert_content "Your report has been registered successfully"
 
     assert_equal note, Issue.last.reportable
     assert_equal "moderator", Issue.last.assigned_role
@@ -36,8 +36,8 @@ class ReportNoteTest < ApplicationSystemTestCase
     visit browse_note_path(note)
 
     click_on I18n.t("browse.note.report")
-    assert page.has_content? "Report"
-    assert page.has_content? I18n.t("reports.new.disclaimer.intro")
+    assert_content "Report"
+    assert_content I18n.t("reports.new.disclaimer.intro")
 
     choose I18n.t("reports.new.categories.note.spam_label")
     fill_in "report_details", :with => "This is spam"
@@ -45,7 +45,7 @@ class ReportNoteTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered successfully"
+    assert_content "Your report has been registered successfully"
 
     assert_equal note, Issue.last.reportable
     assert_equal "moderator", Issue.last.assigned_role

--- a/test/system/report_user_test.rb
+++ b/test/system/report_user_test.rb
@@ -4,9 +4,9 @@ class ReportUserTest < ApplicationSystemTestCase
   def test_no_link_when_not_logged_in
     note = create(:note_with_comments)
     visit browse_note_path(note)
-    assert page.has_content?(note.comments.first.body)
+    assert_content note.comments.first.body
 
-    assert_not page.has_content?(I18n.t("users.show.report"))
+    assert_no_content I18n.t("users.show.report")
   end
 
   def test_can_report_user
@@ -15,8 +15,8 @@ class ReportUserTest < ApplicationSystemTestCase
     visit user_path(user)
 
     click_on I18n.t("users.show.report")
-    assert page.has_content? "Report"
-    assert page.has_content? I18n.t("reports.new.disclaimer.intro")
+    assert_content "Report"
+    assert_content I18n.t("reports.new.disclaimer.intro")
 
     choose I18n.t("reports.new.categories.user.vandal_label")
     fill_in "report_details", :with => "This user is a vandal"
@@ -24,7 +24,7 @@ class ReportUserTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered successfully"
+    assert_content "Your report has been registered successfully"
 
     assert_equal user, Issue.last.reportable
     assert_equal "moderator", Issue.last.assigned_role
@@ -36,8 +36,8 @@ class ReportUserTest < ApplicationSystemTestCase
     visit user_path(user)
 
     click_on I18n.t("users.show.report")
-    assert page.has_content? "Report"
-    assert page.has_content? I18n.t("reports.new.disclaimer.intro")
+    assert_content "Report"
+    assert_content I18n.t("reports.new.disclaimer.intro")
 
     choose I18n.t("reports.new.categories.user.vandal_label")
     fill_in "report_details", :with => "This user is a vandal"
@@ -45,7 +45,7 @@ class ReportUserTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered successfully"
+    assert_content "Your report has been registered successfully"
 
     assert_equal user, Issue.last.reportable
     assert_equal "moderator", Issue.last.assigned_role
@@ -53,8 +53,8 @@ class ReportUserTest < ApplicationSystemTestCase
     visit user_path(user)
 
     click_on I18n.t("users.show.report")
-    assert page.has_content? "Report"
-    assert page.has_content? I18n.t("reports.new.disclaimer.intro")
+    assert_content "Report"
+    assert_content I18n.t("reports.new.disclaimer.intro")
 
     choose I18n.t("reports.new.categories.user.spam_label")
     fill_in "report_details", :with => "This user is a spammer"
@@ -62,7 +62,7 @@ class ReportUserTest < ApplicationSystemTestCase
       click_on "Create Report"
     end
 
-    assert page.has_content? "Your report has been registered successfully"
+    assert_content "Your report has been registered successfully"
 
     assert_equal user, Issue.last.reportable
     assert_equal "administrator", Issue.last.assigned_role

--- a/test/system/user_logout_test.rb
+++ b/test/system/user_logout_test.rb
@@ -4,45 +4,45 @@ class UserLogoutTest < ApplicationSystemTestCase
   test "Sign out via link" do
     user = create(:user)
     sign_in_as(user)
-    assert_not page.has_content? "Log In"
+    assert_no_content "Log In"
 
     click_on user.display_name
     click_on "Log Out"
-    assert page.has_content? "Log In"
+    assert_content "Log In"
   end
 
   test "Sign out via link with referer" do
     user = create(:user)
     sign_in_as(user)
     visit traces_path
-    assert_not page.has_content? "Log In"
+    assert_no_content "Log In"
 
     click_on user.display_name
     click_on "Log Out"
-    assert page.has_content? "Log In"
-    assert page.has_content? "Public GPS Traces"
+    assert_content "Log In"
+    assert_content "Public GPS Traces"
   end
 
   test "Sign out via fallback page" do
     sign_in_as(create(:user))
-    assert_not page.has_content? "Log In"
+    assert_no_content "Log In"
 
     visit logout_path
-    assert page.has_content? "Logout from OpenStreetMap"
+    assert_content "Logout from OpenStreetMap"
 
     click_button "Logout"
-    assert page.has_content? "Log In"
+    assert_content "Log In"
   end
 
   test "Sign out via fallback page with referer" do
     sign_in_as(create(:user))
-    assert_not page.has_content? "Log In"
+    assert_no_content "Log In"
 
     visit logout_path(:referer => "/traces")
-    assert page.has_content? "Logout from OpenStreetMap"
+    assert_content "Logout from OpenStreetMap"
 
     click_button "Logout"
-    assert page.has_content? "Log In"
-    assert page.has_content? "Public GPS Traces"
+    assert_content "Log In"
+    assert_content "Public GPS Traces"
   end
 end

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -6,6 +6,6 @@ class UserSignupTest < ApplicationSystemTestCase
 
     click_on "Register now"
 
-    assert page.has_content? "Confirm Password"
+    assert_content "Confirm Password"
   end
 end


### PR DESCRIPTION
This PR switches to using `assert_content` (and `assert_link`) from Capybara's list of assertions, instead of using a plain assert on the Capybara node matchers (e.g. assert page.has_content?). 

This makes little difference when the tests are working, but the error messages are much more helpful when the tests fail (e.g. during development or refactoring). The previous approach led to "Expected false to be truthy" which is not super helpful to debug!

Example for `assert_content`:
```diff
  Failure:
  DiaryEntrySystemTest#test_reply_to_diary_entry_should_prefill_the_message_subject [/test/system/diary_entry_test.rb:15]:
- Expected false to be truthy.
+ expected to find text "Receive a new message" in "OpenStreetMap\nEdit\nHistory\nExport\nGPS Traces\nUser Diaries\nCopyright\nHelp\nAbout\nUser 5\nSend a new message to User 4\nSubject\nBody\nParsed with kramdown\nHeadings\n# Heading\n## Subheading\nUnordered list\n* First item\n* Second item\nOrdered list\n1. First item\n2. Second item\nLink\n[Text](URL)\nImage\n![Alt text](URL)\nBack to inbox"
```

Example for `assert_link`:
```diff
  IssuesTest#test_issue_index_with_multiple_roles [/test/system/issues_test.rb:116]:
- Expected false to be truthy.
+ expected to find link "5 Reports" with href "/issues/446" but there were no matches
```

https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions