### PR TITLE
Allow blank issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: There is an issue with the default map layer shown on the front page
     url: https://github.com/gravitystorm/openstreetmap-carto


### PR DESCRIPTION
This was originally intended in #3397 and I'm not sure why I set this to false.