### PR TITLE
Added (un)hide note comments API endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,8 +32,16 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
 
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'app/abilities/api_capability.rb'
+
 Metrics/ModuleLength:
   Max: 150
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/abilities/api_capability.rb'
 
 Naming/FileName:
   Exclude:

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -46,6 +46,7 @@ class ApiAbility
 
         if user.moderator?
           can [:destroy, :restore], ChangesetComment
+          can [:destroy, :restore], NoteComment
           can :destroy, Note
 
           if user.terms_agreed?

--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -29,6 +29,7 @@ class ApiCapability
 
       if user&.moderator?
         can [:destroy, :restore], ChangesetComment if scope?(token, :write_api)
+        can [:destroy, :restore], NoteComment if scope?(token, :write_api)
         can :destroy, Note if scope?(token, :write_notes)
         if user&.terms_agreed?
           can :redact, OldNode if scope?(token, :write_api)

--- a/app/controllers/api/note_comments_controller.rb
+++ b/app/controllers/api/note_comments_controller.rb
@@ -1,0 +1,52 @@
+module Api
+  class NoteCommentsController < ApiController
+    before_action :authorize
+
+    authorize_resource
+
+    before_action :check_api_writable
+    before_action :check_api_readable
+    around_action :api_call_handle_error
+    around_action :api_call_timeout
+
+    ##
+    # Sets visible flag on note comment to false
+    def destroy
+      # Check the arguments are sane
+      raise OSM::APIBadUserInput, "No id was given" unless params[:id]
+
+      # Extract the arguments
+      id = params[:id].to_i
+
+      # Find the note comment
+      comment = NoteComment.find(id)
+
+      # Hide the comment
+      comment.update(:visible => false)
+
+      # Return a copy of the updated note
+      @note = comment.note
+      render(@note)
+    end
+
+    ##
+    # Sets visible flag on note comment to true
+    def restore
+      # Check the arguments are sane
+      raise OSM::APIBadUserInput, "No id was given" unless params[:id]
+
+      # Extract the arguments
+      id = params[:id].to_i
+
+      # Find the note comment
+      comment = NoteComment.find(id)
+
+      # Unhide the comment
+      comment.update(:visible => true)
+
+      # Return a copy of the updated note
+      @note = comment.note
+      render(@note)
+    end
+  end
+end

--- a/app/controllers/api/note_comments_controller.rb
+++ b/app/controllers/api/note_comments_controller.rb
@@ -21,6 +21,9 @@ module Api
       # Find the note comment
       comment = NoteComment.find(id)
 
+      # Opening comment cannot be hidden
+      raise OSM::APIBadUserInput, "Cannot hide id" if comment.event == "opened"
+
       # Hide the comment
       comment.update(:visible => false)
 
@@ -40,6 +43,9 @@ module Api
 
       # Find the note comment
       comment = NoteComment.find(id)
+
+      # Opening comment cannot be unhidden
+      raise OSM::APIBadUserInput, "Cannot unhide id" if comment.event == "opened"
 
       # Unhide the comment
       comment.update(:visible => true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,9 @@ OpenStreetMap::Application.routes.draw do
     post "notes/editPOIexec" => "api/notes#comment"
     get "notes/getGPX" => "api/notes#index", :format => "gpx"
     get "notes/getRSSfeed" => "api/notes#feed", :format => "rss"
+
+    post "note/comment/:id/hide" => "api/note_comments#destroy", :as => :note_comment_hide, :id => /\d+/
+    post "note/comment/:id/unhide" => "api/note_comments#restore", :as => :note_comment_unhide, :id => /\d+/
   end
 
   # Data browsing

--- a/test/controllers/api/note_comments_controller_test.rb
+++ b/test/controllers/api/note_comments_controller_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+module Api
+  class NoteCommentsControllerTest < ActionDispatch::IntegrationTest
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/api/0.6/note/comment/1/hide", :method => :post },
+        { :controller => "api/note_comments", :action => "destroy", :id => "1" }
+      )
+      assert_routing(
+        { :path => "/api/0.6/note/comment/1/unhide", :method => :post },
+        { :controller => "api/note_comments", :action => "restore", :id => "1" }
+      )
+    end
+
+    ##
+    # test hide comment fail
+    def test_destroy_comment_fail
+      # unauthorized
+      note = create(:note)
+      comment = create(:note_comment, :note => note, :body => "Note comment")
+      assert comment.visible
+
+      post note_comment_hide_path(:id => comment)
+      assert_response :unauthorized
+      assert comment.reload.visible
+
+      auth_header = basic_authorization_header create(:user).email, "test"
+
+      # not a moderator
+      post note_comment_hide_path(:id => comment), :headers => auth_header
+      assert_response :forbidden
+      assert comment.reload.visible
+
+      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+
+      # bad comment id
+      post note_comment_hide_path(:id => 9191), :headers => auth_header
+      assert_response :not_found
+      assert comment.reload.visible
+    end
+
+    ##
+    # test hide comment succes
+    def test_hide_comment_success
+      note = create(:note)
+      comment = create(:note_comment, :note => note, :body => "Note comment")
+      assert comment.visible
+
+      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+
+      post note_comment_hide_path(:id => comment, :format => "xml"), :headers => auth_header
+      assert_response :success
+      assert_not comment.reload.visible
+    end
+
+    ##
+    # test unhide comment fail
+    def test_restore_comment_fail
+      # unauthorized
+      note = create(:note)
+      comment = create(:note_comment, :note => note, :visible => false, :body => "Note comment")
+      assert_not comment.visible
+
+      post note_comment_unhide_path(:id => comment)
+      assert_response :unauthorized
+      assert_not comment.reload.visible
+
+      auth_header = basic_authorization_header create(:user).email, "test"
+
+      # not a moderator
+      post note_comment_unhide_path(:id => comment), :headers => auth_header
+      assert_response :forbidden
+      assert_not comment.reload.visible
+
+      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+
+      # bad comment id
+      post note_comment_unhide_path(:id => 999111), :headers => auth_header
+      assert_response :not_found
+      assert_not comment.reload.visible
+    end
+
+    ##
+    # test unhide comment succes
+    def test_unhide_comment_success
+      note = create(:note)
+      comment = create(:note_comment, :note => note, :visible => false, :body => "Note comment")
+      assert_not comment.visible
+
+      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+
+      post note_comment_unhide_path(:id => comment, :format => "xml"), :headers => auth_header
+      assert_response :success
+      assert comment.reload.visible
+    end
+  end
+end


### PR DESCRIPTION
Adding the API part to address #1934 to hide/unhide single note comments for moderators. The code is very closely following the existing changeset comment hide / destroy implementation.

NotesController `comment` method could be moved to the new NoteCommentsController, to more closely follow the overall design in ChangesetCommentsController. I left that for another request to keep this one as small as possible.

UI part is covered in #3441, providing  the familiar "hide" / "unhide" feature:

![modnotecomment](https://user-images.githubusercontent.com/5842757/151633008-51fecb72-9b04-4243-aecf-8ffe37a232db.png)

- [ ] Resolve discussion in https://github.com/openstreetmap/openstreetmap-website/issues/3450#issuecomment-1034913872 on how to handle "opening" events

Previous discussion:

> An "opened" event is used exclusively when creating a new note. https://github.com/openstreetmap/openstreetmap-website/blob/master/app/controllers/api/notes_controller.rb#L76
> 
> I think what needs to be clarified first is whether we want the opening event to be hidden at all. Depending on this decision other parts of the code need to be adjusted to handle this case properly.

