### PR TITLE
Added (un)hide note comments UI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,8 +32,16 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
 
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'app/abilities/api_capability.rb'
+
 Metrics/ModuleLength:
   Max: 150
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/abilities/api_capability.rb'
 
 Naming/FileName:
   Exclude:

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -46,6 +46,7 @@ class ApiAbility
 
         if user.moderator?
           can [:destroy, :restore], ChangesetComment
+          can [:destroy, :restore], NoteComment
           can :destroy, Note
 
           if user.terms_agreed?

--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -29,6 +29,7 @@ class ApiCapability
 
       if user&.moderator?
         can [:destroy, :restore], ChangesetComment if scope?(token, :write_api)
+        can [:destroy, :restore], NoteComment if scope?(token, :write_api)
         can :destroy, Note if scope?(token, :write_notes)
         if user&.terms_agreed?
           can :redact, OldNode if scope?(token, :write_api)

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -21,14 +21,22 @@ OSM.Note = function (map) {
     })
   };
 
-  function updateNote(form, method, url) {
+  function updateNote(form, method, url, include_data) {
+    var data;
+
     $(form).find("input[type=submit]").prop("disabled", true);
+
+    if (include_data) {
+      data = { text: $(form.text).val() };
+    } else {
+      data = {};
+    }
 
     $.ajax({
       url: url,
       type: method,
       oauth: true,
-      data: { text: $(form.text).val() },
+      data: data,
       success: function () {
         OSM.loadSidebarContent(window.location.pathname, page.load);
       }
@@ -51,6 +59,12 @@ OSM.Note = function (map) {
 
   function initialize(callback) {
     content.find("input[type=submit]").on("click", function (e) {
+      e.preventDefault();
+      var data = $(e.target).data();
+      updateNote(e.target.form, data.method, data.url, true);
+    });
+
+    content.find(".action-button").on("click", function (e) {
       e.preventDefault();
       var data = $(e.target).data();
       updateNote(e.target.form, data.method, data.url);

--- a/app/controllers/api/note_comments_controller.rb
+++ b/app/controllers/api/note_comments_controller.rb
@@ -1,0 +1,52 @@
+module Api
+  class NoteCommentsController < ApiController
+    before_action :authorize
+
+    authorize_resource
+
+    before_action :check_api_writable
+    before_action :check_api_readable
+    around_action :api_call_handle_error
+    around_action :api_call_timeout
+
+    ##
+    # Sets visible flag on note comment to false
+    def destroy
+      # Check the arguments are sane
+      raise OSM::APIBadUserInput, "No id was given" unless params[:id]
+
+      # Extract the arguments
+      id = params[:id].to_i
+
+      # Find the note comment
+      comment = NoteComment.find(id)
+
+      # Hide the comment
+      comment.update(:visible => false)
+
+      # Return a copy of the updated note
+      @note = comment.note
+      render(@note)
+    end
+
+    ##
+    # Sets visible flag on note comment to true
+    def restore
+      # Check the arguments are sane
+      raise OSM::APIBadUserInput, "No id was given" unless params[:id]
+
+      # Extract the arguments
+      id = params[:id].to_i
+
+      # Find the note comment
+      comment = NoteComment.find(id)
+
+      # Unhide the comment
+      comment.update(:visible => true)
+
+      # Return a copy of the updated note
+      @note = comment.note
+      render(@note)
+    end
+  end
+end

--- a/app/controllers/api/note_comments_controller.rb
+++ b/app/controllers/api/note_comments_controller.rb
@@ -21,6 +21,9 @@ module Api
       # Find the note comment
       comment = NoteComment.find(id)
 
+      # Opening comment cannot be hidden
+      raise OSM::APIBadUserInput, "Cannot hide id" if comment.event == "opened"
+
       # Hide the comment
       comment.update(:visible => false)
 
@@ -40,6 +43,9 @@ module Api
 
       # Find the note comment
       comment = NoteComment.find(id)
+
+      # Opening comment cannot be unhidden
+      raise OSM::APIBadUserInput, "Cannot unhide id" if comment.event == "opened"
 
       # Unhide the comment
       comment.update(:visible => true)

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -34,14 +34,31 @@
 
   <% if @note_comments.length > 1 %>
     <div class='note-comments'>
-      <ul class="list-unstyled">
-        <% @note_comments.drop(1).each do |comment| %>
-          <li id="c<%= comment.id %>">
-            <small class='text-muted'><%= note_event(comment.event, comment.created_at, comment.author) %></small>
-            <%= comment.body.to_html %>
-          </li>
-        <% end %>
-      </ul>
+      <form action="#">
+        <ul class="list-unstyled">
+          <% @note_comments.drop(1).each do |comment| %>
+            <% if comment.visible %>
+              <li id="c<%= comment.id %>">
+                <small class='text-muted'><%= note_event(comment.event, comment.created_at, comment.author) %>
+                  <% if current_user and current_user.moderator? %>
+                  — <span class="action-button" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= note_comment_hide_url(comment.id) %>"><%= t("javascripts.notes.show.hide_comment") %></span>
+                  <% end %>
+                </small>
+                <%= comment.body.to_html %>
+              </li>
+            <% elsif current_user and current_user.moderator? %>
+              <li id="c<%= comment.id %>">
+                <small class='text-muted'><%= note_event(comment.event, comment.created_at, comment.author) %>
+                   <% if current_user and current_user.moderator? %>
+                   — <span class="action-button text-muted" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= note_comment_unhide_url(comment.id) %>"><%= t("javascripts.notes.show.unhide_comment") %></span>
+                   <% end %>
+                </small>
+                <%= comment.body.to_html %>
+              </li>
+            <% end %>
+          <% end %>
+        </ul>
+      </form>
     </div>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2880,6 +2880,8 @@ en:
         reactivate: Reactivate
         comment_and_resolve: Comment & Resolve
         comment: Comment
+        hide_comment: "hide"
+        unhide_comment: "unhide"
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
       ascend: "Ascend"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,9 @@ OpenStreetMap::Application.routes.draw do
     post "notes/editPOIexec" => "api/notes#comment"
     get "notes/getGPX" => "api/notes#index", :format => "gpx"
     get "notes/getRSSfeed" => "api/notes#feed", :format => "rss"
+
+    post "note/comment/:id/hide" => "api/note_comments#destroy", :as => :note_comment_hide, :id => /\d+/
+    post "note/comment/:id/unhide" => "api/note_comments#restore", :as => :note_comment_unhide, :id => /\d+/
   end
 
   # Data browsing

--- a/test/controllers/api/note_comments_controller_test.rb
+++ b/test/controllers/api/note_comments_controller_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+module Api
+  class NoteCommentsControllerTest < ActionDispatch::IntegrationTest
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/api/0.6/note/comment/1/hide", :method => :post },
+        { :controller => "api/note_comments", :action => "destroy", :id => "1" }
+      )
+      assert_routing(
+        { :path => "/api/0.6/note/comment/1/unhide", :method => :post },
+        { :controller => "api/note_comments", :action => "restore", :id => "1" }
+      )
+    end
+
+    ##
+    # test hide comment fail
+    def test_destroy_comment_fail
+      # unauthorized
+      note = create(:note)
+      comment = create(:note_comment, :note => note, :body => "Note comment")
+      assert comment.visible
+
+      post note_comment_hide_path(:id => comment)
+      assert_response :unauthorized
+      assert comment.reload.visible
+
+      auth_header = basic_authorization_header create(:user).email, "test"
+
+      # not a moderator
+      post note_comment_hide_path(:id => comment), :headers => auth_header
+      assert_response :forbidden
+      assert comment.reload.visible
+
+      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+
+      # bad comment id
+      post note_comment_hide_path(:id => 9191), :headers => auth_header
+      assert_response :not_found
+      assert comment.reload.visible
+    end
+
+    ##
+    # test hide comment succes
+    def test_hide_comment_success
+      note = create(:note)
+      comment = create(:note_comment, :note => note, :body => "Note comment")
+      assert comment.visible
+
+      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+
+      post note_comment_hide_path(:id => comment, :format => "xml"), :headers => auth_header
+      assert_response :success
+      assert_not comment.reload.visible
+    end
+
+    ##
+    # test unhide comment fail
+    def test_restore_comment_fail
+      # unauthorized
+      note = create(:note)
+      comment = create(:note_comment, :note => note, :visible => false, :body => "Note comment")
+      assert_not comment.visible
+
+      post note_comment_unhide_path(:id => comment)
+      assert_response :unauthorized
+      assert_not comment.reload.visible
+
+      auth_header = basic_authorization_header create(:user).email, "test"
+
+      # not a moderator
+      post note_comment_unhide_path(:id => comment), :headers => auth_header
+      assert_response :forbidden
+      assert_not comment.reload.visible
+
+      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+
+      # bad comment id
+      post note_comment_unhide_path(:id => 999111), :headers => auth_header
+      assert_response :not_found
+      assert_not comment.reload.visible
+    end
+
+    ##
+    # test unhide comment succes
+    def test_unhide_comment_success
+      note = create(:note)
+      comment = create(:note_comment, :note => note, :visible => false, :body => "Note comment")
+      assert_not comment.visible
+
+      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+
+      post note_comment_unhide_path(:id => comment, :format => "xml"), :headers => auth_header
+      assert_response :success
+      assert comment.reload.visible
+    end
+  end
+end


### PR DESCRIPTION
UI part for #1934 , depends on API backend in #3438

This pull request provides the same "hide" / "unhide" feature  already known from changeset comments:

![modnotecomment](https://user-images.githubusercontent.com/5842757/151708551-a2c4cb3f-3475-4ef8-9d32-fbeb9a4782d0.png)

Code is very similar to https://github.com/openstreetmap/openstreetmap-website/blob/master/app/views/browse/changeset.html.erb#L33-L67

Closes https://github.com/openstreetmap/openstreetmap-website/issues/1934
Closes #975