### PR TITLE
Added some key-value pairs under `railway=`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1143,6 +1143,7 @@ en:
           "yes": "Place"
         railway:
           abandoned: "Abandoned Railway"
+          buffer_stop: "Buffer Stop"
           construction: "Railway under Construction"
           disused: "Disused Railway"
           funicular: "Funicular Railway"
@@ -1156,6 +1157,7 @@ en:
           platform: "Railway Platform"
           preserved: "Preserved Railway"
           proposed: "Proposed Railway"
+          rail: "Rail"
           spur: "Railway Spur"
           station: "Railway Station"
           stop: "Railway Stop"
@@ -1164,6 +1166,7 @@ en:
           switch: "Railway Points"
           tram: "Tramway"
           tram_stop: "Tram Stop"
+          turntable: "Turntable"
           yard: "Railway Yard"
         shop:
           agrarian: "Agrarian Shop"


### PR DESCRIPTION
These labels turn up in the 'Find objects' tool. 
They should be made available for translation - hence this PR.

See discussion in the following PRs:

- Original: #3124
- Supplemental: #3391
