### PR TITLE
Update macOS geckodriver installation command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -102,8 +102,7 @@ bundle config build.libxml-ruby --with-xml2-config=/usr/local/opt/libxml2/bin/xm
 If you want to run the tests, you need `geckodriver` as well:
 
 ```
-brew tap homebrew/cask
-brew cask install geckodriver
+brew install geckodriver
 ```
 
 Note that OS X does not have a /home directory by default, so if you are using the GPX functions, you will need to change the directories specified in config/application.yml.


### PR DESCRIPTION
This PR updates the command needed to install `geckodriver` via Homebrew.

I would also be a fan of adding it to the main list of dependencies instead of in a separate section so that folks are encouraged to write tests and run the test suite. I'd be happy to alter the PR if you agree.

## Background

The `geckodriver` recipe for Homebrew is no longer provided in a cask and is a core formula:

```bash
$ brew install --cask geckodriver
Error: Cask 'geckodriver' is unavailable: No Cask with this name exists.
$ brew search geckodriver
==> Formulae
geckodriver ✔                                                           exodriver
```