### PR TITLE
Adds advancedcomp to the list of macOS Homebrew dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,7 +90,7 @@ Installing other dependencies:
 
 * Install Homebrew from https://brew.sh/
 * Install the latest version of Ruby: `brew install ruby`
-* Install other dependencies: `brew install imagemagick libxml2 gd yarn pngcrush optipng pngquant jhead jpegoptim gifsicle svgo`
+* Install other dependencies: `brew install imagemagick libxml2 gd yarn pngcrush optipng pngquant jhead jpegoptim gifsicle svgo advancecomp`
 * Install Bundler: `gem install bundler` (you might need to `sudo gem install bundler` if you get an error about permissions - or see note below about [developer Ruby setup](#rbenv))
 
 You will need to tell `bundler` that `libxml2` is installed in a Homebrew location. If it uses the system-installed one then you will get errors installing the `libxml-ruby` gem later on<a name="macosx-bundle-config"></a>.


### PR DESCRIPTION
This PR adds `advancecomp` to the list of macOS Homebrew dependencies which provides the required `advpng`.

## Background

When running the test suite and `assets:precompile` I noticed the following warning:

```bash
$ rake assets:precompile
advpng worker: `advpng` not found; please provide proper binary or disable this worker (--no-advpng argument or `:advpng => false` through options)
```

This can be alleviated by installing `advancecomp` which provides `advpng`.