### PR TITLE
Fix vagrant storage.yml config

### DIFF
--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -60,6 +60,9 @@ sudo -u vagrant psql -d openstreetmap -f db/functions/functions.sql
 if [ ! -f config/database.yml ]; then
     sudo -u vagrant cp config/example.database.yml config/database.yml
 fi
+if [ ! -f config/storage.yml ]; then
+    cp config/example.storage.yml config/storage.yml
+fi
 touch config/settings.local.yml
 # migrate the database to the latest version
 sudo -u vagrant bundle exec rake db:migrate


### PR DESCRIPTION
Tell vagrant to copy the example storage.yml config file into place as per INSTALL.md instructions. Allows the migrations to run.

This was @timwaters' suggestion here: https://github.com/openstreetmap/openstreetmap-website/issues/2343#issuecomment-519995283 . I can confirm it works.