### PR TITLE
Fix/remove some bits of contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ bundle exec rails test:all
 
 You can view test coverage statistics by browsing the `coverage` directory.
 
-The tests are automatically run on Pull Requests and other commits with the
-results shown on [Travis CI](https://travis-ci.org/openstreetmap/openstreetmap-website).
+The tests are automatically run on Pull Requests and other commits via github
+actions. The results shown are within the PR display on github.
 
 ## Static Analysis
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,14 +79,6 @@ database, and update the list of available keys manually.
 Adding or removing keys to this list is therefore discouraged, but contributions
 to the descriptive texts are welcome.
 
-## Code Documentation
-
-To generate the HTML documentation of the API/rails code, run the command
-
-```
-rake doc:app
-```
-
 ## Committing
 
 When you submit patches, the project maintainer has to read them and


### PR DESCRIPTION
Fix/remove some bits of CONTRIBUTING.md docs
* Remove the reference to Travis CI and re-describe it
* Remove the section about `rake doc:app` which no longer works