### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -12,7 +12,7 @@ window.onload = function () {
     I18n.locale = navigator.language;
   }
 
-  var query = (window.location.search || '?').substr(1),
+  var query = (window.location.search || '?').slice(1),
       args  = {};
 
   var pairs = query.split('&');

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -103,8 +103,8 @@ OSM.Query = function (map) {
         value = tags[key];
 
         if (prefixes[key]) {
-          var first = value.substr(0, 1).toUpperCase(),
-              rest = value.substr(1).replace(/_/g, " ");
+          var first = value.slice(0, 1).toUpperCase(),
+              rest = value.slice(1).replace(/_/g, " ");
 
           return first + rest;
         }

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -146,7 +146,7 @@ OSM = {
       return args;
     }
 
-    hash = Qs.parse(hash.substr(i + 1));
+    hash = Qs.parse(hash.slice(i + 1));
 
     var map = (hash.map || '').split('/'),
       zoom = parseInt(map[0], 10),


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.