### PR TITLE
Make sidebar resizable

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -354,6 +354,8 @@ body.compact-nav {
     float: left;
     width: $sidebarWidth;
     background: #fff;
+    resize: horizontal;
+    overflow: auto;
 
     #sidebar_loader {
       display: none;

--- a/app/assets/stylesheets/small.scss
+++ b/app/assets/stylesheets/small.scss
@@ -35,6 +35,10 @@ body.small-nav {
     display: none;
   }
 
+  #sidebar {
+    resize: none;
+  }
+
   nav.primary {
     padding: 0;
 


### PR DESCRIPTION
This commit makes the sidebar horizontally resizable. It is not resizable on small screens.

Is my assumption right, that the `small.scss` file is the CSS for small screens? Because i want the sidebar to not be resizable on small screens, because it is above the map then. Would it make sense to make the sidebar vertically resizable on small screens?

In the `common.scss` i use `overflow: auto;`, but i saw [some lines above](https://github.com/openstreetmap/openstreetmap-website/blob/master/app/assets/stylesheets/common.scss#L349) that there are other overflow rules. Does this interfere with my lines? I do not know how to optimize this.

The result of this commit shall be the same as the result of my [Greasemonkey script](https://gitlab.com/Strubbl/userscripts/-/blob/master/osm_sidebar_resizer.user.js), which i wrote first. In the German forum i [was recommended](https://forum.openstreetmap.org/viewtopic.php?pid=856287#p856287) to propose this change to this repository.