### PR TITLE
Remove default values from id columns

### DIFF
--- a/db/migrate/20220223140543_remove_id_defaults.rb
+++ b/db/migrate/20220223140543_remove_id_defaults.rb
@@ -1,0 +1,13 @@
+class RemoveIdDefaults < ActiveRecord::Migration[7.0]
+  def change
+    # Remove defaults from foreign key references
+    change_column_default :gpx_file_tags, :gpx_id, :from => 0, :to => nil
+    change_column_default :relation_members, :relation_id, :from => 0, :to => nil
+    change_column_default :relation_tags, :relation_id, :from => 0, :to => nil
+    change_column_default :way_tags, :way_id, :from => 0, :to => nil
+
+    # Remove defaults from primary keys
+    change_column_default :relations, :relation_id, :from => 0, :to => nil
+    change_column_default :ways, :way_id, :from => 0, :to => nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -753,7 +753,7 @@ CREATE TABLE public.gps_points (
 --
 
 CREATE TABLE public.gpx_file_tags (
-    gpx_id bigint DEFAULT 0 NOT NULL,
+    gpx_id bigint NOT NULL,
     tag character varying NOT NULL,
     id bigint NOT NULL
 );
@@ -1274,7 +1274,7 @@ ALTER SEQUENCE public.redactions_id_seq OWNED BY public.redactions.id;
 --
 
 CREATE TABLE public.relation_members (
-    relation_id bigint DEFAULT 0 NOT NULL,
+    relation_id bigint NOT NULL,
     member_type public.nwr_enum NOT NULL,
     member_id bigint NOT NULL,
     member_role character varying NOT NULL,
@@ -1288,7 +1288,7 @@ CREATE TABLE public.relation_members (
 --
 
 CREATE TABLE public.relation_tags (
-    relation_id bigint DEFAULT 0 NOT NULL,
+    relation_id bigint NOT NULL,
     k character varying DEFAULT ''::character varying NOT NULL,
     v character varying DEFAULT ''::character varying NOT NULL,
     version bigint NOT NULL
@@ -1300,7 +1300,7 @@ CREATE TABLE public.relation_tags (
 --
 
 CREATE TABLE public.relations (
-    relation_id bigint DEFAULT 0 NOT NULL,
+    relation_id bigint NOT NULL,
     changeset_id bigint NOT NULL,
     "timestamp" timestamp without time zone NOT NULL,
     version bigint NOT NULL,
@@ -1541,7 +1541,7 @@ CREATE TABLE public.way_nodes (
 --
 
 CREATE TABLE public.way_tags (
-    way_id bigint DEFAULT 0 NOT NULL,
+    way_id bigint NOT NULL,
     k character varying NOT NULL,
     v character varying NOT NULL,
     version bigint NOT NULL
@@ -1553,7 +1553,7 @@ CREATE TABLE public.way_tags (
 --
 
 CREATE TABLE public.ways (
-    way_id bigint DEFAULT 0 NOT NULL,
+    way_id bigint NOT NULL,
     changeset_id bigint NOT NULL,
     "timestamp" timestamp without time zone NOT NULL,
     version bigint NOT NULL,
@@ -3427,6 +3427,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210511104518'),
 ('20211216185316'),
 ('20220201183346'),
+('20220223140543'),
 ('21'),
 ('22'),
 ('23'),


### PR DESCRIPTION
In both the case of primary keys, and also foreign key references, there's no need to set a default value.

This doesn't have a big impact in routine situations, but can be very confusing when debugging corner cases.