### PR TITLE
Enable active_record.belongs_to_required_by_default

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -36,8 +36,8 @@
 #
 
 class AccessToken < OauthToken
-  belongs_to :user
-  belongs_to :client_application
+  belongs_to :user, :optional => true
+  belongs_to :client_application, :optional => true
 
   scope :valid, -> { where(:invalidated_at => nil) }
 

--- a/app/models/client_application.rb
+++ b/app/models/client_application.rb
@@ -31,7 +31,7 @@
 #
 
 class ClientApplication < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, :optional => true
   has_many :tokens, :class_name => "OauthToken", :dependent => :delete_all
   has_many :access_tokens
   has_many :oauth2_verifiers

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -32,9 +32,9 @@
 
 class Issue < ApplicationRecord
   belongs_to :reportable, :polymorphic => true
-  belongs_to :reported_user, :class_name => "User"
-  belongs_to :user_resolved, :class_name => "User", :foreign_key => :resolved_by
-  belongs_to :user_updated, :class_name => "User", :foreign_key => :updated_by
+  belongs_to :reported_user, :class_name => "User", :optional => true
+  belongs_to :user_resolved, :class_name => "User", :foreign_key => :resolved_by, :optional => true
+  belongs_to :user_updated, :class_name => "User", :foreign_key => :updated_by, :optional => true
 
   has_many :reports, :dependent => :destroy
   has_many :comments, :class_name => "IssueComment", :dependent => :destroy

--- a/app/models/note_comment.rb
+++ b/app/models/note_comment.rb
@@ -25,7 +25,7 @@
 
 class NoteComment < ApplicationRecord
   belongs_to :note, :touch => true
-  belongs_to :author, :class_name => "User"
+  belongs_to :author, :class_name => "User", :optional => true
 
   validates :id, :uniqueness => true, :presence => { :on => :update },
                  :numericality => { :on => :update, :only_integer => true }

--- a/app/models/oauth_token.rb
+++ b/app/models/oauth_token.rb
@@ -36,8 +36,8 @@
 #
 
 class OauthToken < ApplicationRecord
-  belongs_to :client_application
-  belongs_to :user
+  belongs_to :client_application, :optional => true
+  belongs_to :user, :optional => true
 
   scope :authorized, -> { where("authorized_at IS NOT NULL and invalidated_at IS NULL") }
 

--- a/app/models/old_node.rb
+++ b/app/models/old_node.rb
@@ -46,7 +46,7 @@ class OldNode < ApplicationRecord
   validate :validate_position
 
   belongs_to :changeset
-  belongs_to :redaction
+  belongs_to :redaction, :optional => true
   belongs_to :current_node, :class_name => "Node", :foreign_key => "node_id"
 
   has_many :old_tags, :class_name => "OldNodeTag", :foreign_key => [:node_id, :version]

--- a/app/models/old_relation.rb
+++ b/app/models/old_relation.rb
@@ -31,7 +31,7 @@ class OldRelation < ApplicationRecord
   include Redactable
 
   belongs_to :changeset
-  belongs_to :redaction
+  belongs_to :redaction, :optional => true
   belongs_to :current_relation, :class_name => "Relation", :foreign_key => "relation_id"
 
   has_many :old_members, -> { order(:sequence_id) }, :class_name => "OldRelationMember", :foreign_key => [:relation_id, :version]

--- a/app/models/old_way.rb
+++ b/app/models/old_way.rb
@@ -31,7 +31,7 @@ class OldWay < ApplicationRecord
   include Redactable
 
   belongs_to :changeset
-  belongs_to :redaction
+  belongs_to :redaction, :optional => true
   belongs_to :current_way, :class_name => "Way", :foreign_key => "way_id"
 
   has_many :old_nodes, :class_name => "OldWayNode", :foreign_key => [:way_id, :version]

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -31,8 +31,8 @@ class Trace < ApplicationRecord
   self.table_name = "gpx_files"
 
   belongs_to :user, :counter_cache => true
-  has_many :tags, :class_name => "Tracetag", :foreign_key => "gpx_id", :dependent => :delete_all
-  has_many :points, :class_name => "Tracepoint", :foreign_key => "gpx_id", :dependent => :delete_all
+  has_many :tags, :class_name => "Tracetag", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => "trace"
+  has_many :points, :class_name => "Tracepoint", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => "trace"
 
   scope :visible, -> { where(:visible => true) }
   scope :visible_to, ->(u) { visible.where("visibility IN ('public', 'identifiable') OR user_id = ?", u) }

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -31,8 +31,8 @@ class Trace < ApplicationRecord
   self.table_name = "gpx_files"
 
   belongs_to :user, :counter_cache => true
-  has_many :tags, :class_name => "Tracetag", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => "trace"
-  has_many :points, :class_name => "Tracepoint", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => "trace"
+  has_many :tags, :class_name => "Tracetag", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => :trace
+  has_many :points, :class_name => "Tracepoint", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => :trace
 
   scope :visible, -> { where(:visible => true) }
   scope :visible_to, ->(u) { visible.where("visibility IN ('public', 'identifiable') OR user_id = ?", u) }

--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -30,7 +30,7 @@ class UserBlock < ApplicationRecord
 
   belongs_to :user, :class_name => "User"
   belongs_to :creator, :class_name => "User"
-  belongs_to :revoker, :class_name => "User"
+  belongs_to :revoker, :class_name => "User", :optional => true
 
   PERIODS = Settings.user_block_periods
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,10 +35,6 @@ module OpenStreetMap
     # This has defaulted to false since rails 6.0
     config.action_view.default_enforce_utf8 = true
 
-    # This defaults to true from rails 5.0 but our code doesn't comply
-    # with it at all so we turn it off
-    config.active_record.belongs_to_required_by_default = false unless Settings.status == "database_offline"
-
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types


### PR DESCRIPTION
This switches the logic so that `belongs_to` parent objects must exist by default, and marks the optional ones explicitly. This is reflected in the null/not_null status on the relevant db columns.

Doing this exposed a small corner case where we were relying on the previous default (of everything being optional) in order for trace objects to pass validation. When the `belongs_to` was made required by default, rails couldn't autodetect the inverse relationship, and so thought that all tracetags for new traces were invalid. Adding inverse_of fixed this. See also https://guides.rubyonrails.org/association_basics.html#bi-directional-associations for a better explanation.