### PR TITLE
Fix redirecting links to osmfoundation.org

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,7 +282,7 @@ en:
         not yet agreed: "You have not yet agreed to the new Contributor Terms."
         review link text: "Please follow this link at your convenience to review and accept the new Contributor Terms."
         agreed_with_pd: "You have also declared that you consider your edits to be in the Public Domain."
-        link: "https://www.osmfoundation.org/wiki/License/Contributor_Terms"
+        link: "https://wiki.osmfoundation.org/wiki/Licence/Contributor_Terms"
         link text: "what is this?"
       save changes button: Save Changes
       make edits public button: Make all my edits public
@@ -2013,7 +2013,7 @@ en:
         infringement_2_html: |
           If you believe that copyrighted material has been inappropriately
           added to the OpenStreetMap database or this site, please refer
-          to our <a href="https://www.osmfoundation.org/wiki/License/Takedown_procedure">takedown
+          to our <a href="https://wiki.osmfoundation.org/wiki/Takedown_procedure">takedown
           procedure</a> or file directly at our
           <a href="https://dmca.openstreetmap.org/">on-line filing page</a>.
         trademarks_title_html: <span id="trademarks"></span>Trademarks
@@ -2543,7 +2543,7 @@ en:
       read_tou: "I have read and agree to the Terms of Use"
       consider_pd: "In addition to the above, I consider my contributions to be in the Public Domain"
       consider_pd_why: "what's this?"
-      consider_pd_why_url: https://www.osmfoundation.org/wiki/License/Why_would_I_want_my_contributions_to_be_public_domain
+      consider_pd_why_url: https://wiki.osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
       guidance_html: 'Information to help understand these terms: a <a href="%{summary}">human readable summary</a> and some <a href="%{translations}">informal translations</a>'
       continue: Continue
       declined: "https://wiki.openstreetmap.org/wiki/Contributor_Terms_Declined"


### PR DESCRIPTION
Fix some links to osmfoundation.org pages which are redirecting (not broken links but this is just avoiding a slightly messy redirection)