### PR TITLE
Switch to using vips for image processing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get -yqq update
-        sudo apt-get -yqq install memcached
+        sudo apt-get -yqq install memcached libvips-dev
     - name: Install gems
       run: |
         gem install bundler

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: Ubuntu ${{ matrix.ubuntu }}, Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ubuntu: [18.04, 20.04]
+        ubuntu: [20.04]
         ruby: [2.7, 3.0]
     runs-on: ubuntu-${{ matrix.ubuntu }}
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
       libmagickwand-dev \
       libpq-dev \
       libsasl2-dev \
+      libvips-dev \
       libxml2-dev \
       libxslt1-dev \
       locales \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ RUN apt-get update \
       default-jre-headless \
       file \
       firefox-geckodriver \
-      imagemagick \
       libarchive-dev \
       libffi-dev \
       libgd-dev \
-      libmagickwand-dev \
       libpq-dev \
       libsasl2-dev \
       libvips-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,7 +89,7 @@ Installing other dependencies:
 
 * Install Homebrew from https://brew.sh/
 * Install the latest version of Ruby: `brew install ruby`
-* Install other dependencies: `brew install libxml2 gd yarn pngcrush optipng pngquant jhead jpegoptim gifsicle svgo advancecomp`
+* Install other dependencies: `brew install libxml2 gd yarn pngcrush optipng pngquant jhead jpegoptim gifsicle svgo advancecomp vips`
 * Install Bundler: `gem install bundler` (you might need to `sudo gem install bundler` if you get an error about permissions - or see note below about [developer Ruby setup](#rbenv))
 
 You will need to tell `bundler` that `libxml2` is installed in a Homebrew location. If it uses the system-installed one then you will get errors installing the `libxml-ruby` gem later on<a name="macosx-bundle-config"></a>.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,6 @@ of packages required before you can get the various gems installed.
 
 * Ruby 2.7+
 * PostgreSQL 9.1+
-* ImageMagick
 * Bundler (see note below about [developer Ruby setup](#rbenv))
 * Javascript Runtime
 
@@ -33,10 +32,10 @@ These can be installed on Ubuntu 20.04 or later with:
 ```
 sudo apt-get update
 sudo apt-get install ruby2.7 libruby2.7 ruby2.7-dev \
-                     libvips-dev libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
+                     libvips-dev libxml2-dev libxslt1-dev nodejs \
                      apache2 apache2-dev build-essential git-core firefox-geckodriver \
                      postgresql postgresql-contrib libpq-dev libsasl2-dev \
-                     imagemagick libffi-dev libgd-dev libarchive-dev libbz2-dev yarnpkg
+                     libffi-dev libgd-dev libarchive-dev libbz2-dev yarnpkg
 sudo gem2.7 install bundler
 ```
 
@@ -51,7 +50,7 @@ sudo dnf install ruby ruby-devel rubygem-rdoc rubygem-bundler rubygems \
                  libxml2-devel nodejs \
                  gcc gcc-c++ git \
                  postgresql postgresql-server postgresql-contrib libpq-devel \
-                 perl-podlators ImageMagick libffi-devel gd-devel libarchive-devel \
+                 perl-podlators libffi-devel gd-devel libarchive-devel \
                  bzip2-devel nodejs-yarn vips-devel
 ```
 
@@ -90,7 +89,7 @@ Installing other dependencies:
 
 * Install Homebrew from https://brew.sh/
 * Install the latest version of Ruby: `brew install ruby`
-* Install other dependencies: `brew install imagemagick libxml2 gd yarn pngcrush optipng pngquant jhead jpegoptim gifsicle svgo advancecomp`
+* Install other dependencies: `brew install libxml2 gd yarn pngcrush optipng pngquant jhead jpegoptim gifsicle svgo advancecomp`
 * Install Bundler: `gem install bundler` (you might need to `sudo gem install bundler` if you get an error about permissions - or see note below about [developer Ruby setup](#rbenv))
 
 You will need to tell `bundler` that `libxml2` is installed in a Homebrew location. If it uses the system-installed one then you will get errors installing the `libxml-ruby` gem later on<a name="macosx-bundle-config"></a>.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ These can be installed on Ubuntu 20.04 or later with:
 ```
 sudo apt-get update
 sudo apt-get install ruby2.7 libruby2.7 ruby2.7-dev \
-                     libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
+                     libvips-dev libmagickwand-dev libxml2-dev libxslt1-dev nodejs \
                      apache2 apache2-dev build-essential git-core firefox-geckodriver \
                      postgresql postgresql-contrib libpq-dev libsasl2-dev \
                      imagemagick libffi-dev libgd-dev libarchive-dev libbz2-dev yarnpkg
@@ -52,7 +52,7 @@ sudo dnf install ruby ruby-devel rubygem-rdoc rubygem-bundler rubygems \
                  gcc gcc-c++ git \
                  postgresql postgresql-server postgresql-contrib libpq-devel \
                  perl-podlators ImageMagick libffi-devel gd-devel libarchive-devel \
-                 bzip2-devel nodejs-yarn
+                 bzip2-devel nodejs-yarn vips-devel
 ```
 
 If you didn't already have PostgreSQL installed then create a PostgreSQL instance and start the server:

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -80,7 +80,7 @@ Rails.application.config.action_controller.raise_on_open_redirects = true
 # generate variants to use image processing macros and ruby-vips
 # operations. See the upgrading guide for detail on the changes required.
 # The `:mini_magick` option is not deprecated; it's fine to keep using it.
-# Rails.application.config.active_storage.variant_processor = :vips
+Rails.application.config.active_storage.variant_processor = :vips
 
 # If you're upgrading and haven't set `cookies_serializer` previously, your cookie serializer
 # was `:marshal`. Convert all cookies to JSON, using the `:hybrid` formatter.

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -19,7 +19,7 @@ apt-get upgrade -y
 apt-get install -y ruby2.7 libruby2.7 ruby2.7-dev \
                      libmagickwand-dev libxml2-dev libxslt1-dev nodejs yarnpkg \
                      apache2 apache2-dev build-essential git-core firefox-geckodriver \
-                     postgresql postgresql-contrib libpq-dev \
+                     postgresql postgresql-contrib libpq-dev libvips-dev \
                      libsasl2-dev imagemagick libffi-dev libgd-dev libarchive-dev libbz2-dev
 gem2.7 install rake
 gem2.7 install --version "~> 2.1.4" bundler

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -17,10 +17,10 @@ apt-get upgrade -y
 
 # install packages as explained in INSTALL.md
 apt-get install -y ruby2.7 libruby2.7 ruby2.7-dev \
-                     libmagickwand-dev libxml2-dev libxslt1-dev nodejs yarnpkg \
+                     libxml2-dev libxslt1-dev nodejs yarnpkg \
                      apache2 apache2-dev build-essential git-core firefox-geckodriver \
                      postgresql postgresql-contrib libpq-dev libvips-dev \
-                     libsasl2-dev imagemagick libffi-dev libgd-dev libarchive-dev libbz2-dev
+                     libsasl2-dev libffi-dev libgd-dev libarchive-dev libbz2-dev
 gem2.7 install rake
 gem2.7 install --version "~> 2.1.4" bundler
 


### PR DESCRIPTION
This switches to using vips (the rails 7 default) for image processing.

It also drops Ubuntu 18.04 support as the libvips it has is too old - we're coming up on the next LTS release anyway so it's probably time to let one go.