### PR TITLE
OAuth updates to CONFIGURE doc + cosmetic tweak

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -54,21 +54,25 @@ $ bundle exec rails console
 
 ## OAuth Consumer Keys
 
-Three of the built-in applications communicate via the API, and therefore need OAuth consumer keys configured. These are:
+There are two built-in applications which communicate via the API, and therefore need OAuth consumer keys configured. These are:
 
 * iD
 * The website itself (for the Notes functionality)
 
-For example, to use the iD editor you need to register it as an OAuth application.
+To use the iD editor you need to register it as an OAuth 1 application.
 
 Do the following:
 * Log into your Rails Port instance - e.g. http://localhost:3000
 * Click on your user name to go to your user page
 * Click on "my settings" on the user page
-* Click on "oauth settings" on the My settings page
+* Click on "OAuth 1 settings" on the My settings page
 * Click on 'Register your application'.
-* Unless you have set up alternatives, use Name: "Local iD" and URL: "http://localhost:3000"
-* Check the 'modify the map' box.
+* Unless you have set up alternatives, use Name: "Local iD" and Main Application URL: "http://localhost:3000"
+* Check boxes for the following Permissions
+  * 'read their user preferences'
+  * 'modify the map'
+  * 'read their private GPS traces'
+  * 'modify notes'
 * Everything else can be left with the default blank values.
 * Click the "Register" button
 * On the next page, copy the "consumer key"
@@ -81,11 +85,32 @@ An example excerpt from settings.local.yml:
 ```
 # Default editor
 default_editor: "id"
-# OAuth consumer key for iD
+# OAuth 1 consumer key for iD
 id_key: "8lFmZPsagHV4l3rkAHq0hWY5vV3Ctl3oEFY1aXth"
 ```
 
-Follow the same process for registering and configuring the website/Notes (`oauth_key`), or to save time, simply reuse the same consumer key for each.
+To allow [Notes](https://wiki.openstreetmap.org/wiki/Notes) and changeset discussions to work, follow a similar process, this time registering an OAuth 2 application for the web site:
+
+* Go to "[OAuth 2 applications](http://localhost:3000/oauth2/applications)" on the My settings page.
+* Click on "Register new application".
+* Use Name: "OpenStreetMap Web Site" and Redirect URIs: "http://localhost:3000"
+* Check boxes for the following Permissions
+  * 'Modify the map'
+  * 'Modify notes'
+* On the next page, copy the "Client Secret" and "Client ID"
+* Edit config/settings.local.yml in your rails tree
+* Add the "oauth_application" configuration with the "Client ID" as the value
+* Add the "oauth_key" configuration with the "Client Secret" as the value
+* Restart your rails server
+
+An example excerpt from settings.local.yml:
+
+```
+# OAuth 2 Client ID for the web site
+oauth_application: "SGm8QJ6tmoPXEaUPIZzLUmm1iujltYZVWCp9hvGsqXg"
+# OAuth 2 Client Secret for the web site
+oauth_key: "eRHPm4GtEnw9ovB1Iw7EcCLGtUb66bXbAAspv3aJxlI"
+```
 
 ## Troubleshooting
 

--- a/app/views/oauth_clients/index.html.erb
+++ b/app/views/oauth_clients/index.html.erb
@@ -34,10 +34,12 @@
 <p><%= t(".no_apps_html", :oauth => link_to(t(".oauth"), "https://oauth.net")) %></p>
 <% else %>
 <p><%= t ".registered_apps" %></p>
-<% @client_applications.each do |client| %>
-  <div class="client_application">
-    <%= link_to client.name, :action => :show, :id => client.id %>
-  </div>
+<ul>
+  <% @client_applications.each do |client| %>
+    <li class="client_application">
+      <%= link_to client.name, :action => :show, :id => client.id %>
+    </li>
+  <% end %>
+</ul>
 <% end %>
-<% end %>
-<h3><%= link_to t(".register_new"), :action => :new %></h3>
+<%= link_to t(".register_new"), { :action => :new }, :class => "btn btn-outline-primary" %>

--- a/test/controllers/oauth_clients_controller_test.rb
+++ b/test/controllers/oauth_clients_controller_test.rb
@@ -48,7 +48,7 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     get oauth_clients_path(:display_name => user.display_name)
     assert_response :success
     assert_template "index"
-    assert_select "div.client_application", 2
+    assert_select "li.client_application", 2
   end
 
   def test_new

--- a/test/integration/client_applications_test.rb
+++ b/test/integration/client_applications_test.rb
@@ -65,7 +65,7 @@ class ClientApplicationsTest < ActionDispatch::IntegrationTest
     get "/user/#{ERB::Util.u(user.display_name)}/oauth_clients"
     assert_response :success
     assert_template "oauth_clients/index"
-    assert_in_body { assert_select "div>a", "My New App" }
+    assert_in_body { assert_select "li>a", "My New App" }
   end
 
   ##


### PR DESCRIPTION
Update the instructions in CONFIGURE.md on how to set-up the built-in apps OAuth settings.

Also a small cosmetic tweak in OAuth 1 settings button:

before & after:

![oauth-before-and-after](https://user-images.githubusercontent.com/227525/157263137-dd2b5820-4228-437d-8d98-b3310d08bb2b.png)


