### PR TITLE
Fix SVG query icon font

### DIFF
--- a/app/assets/images/sprite.svg
+++ b/app/assets/images/sprite.svg
@@ -7,7 +7,7 @@
   <g id="Layer_1">
     <g id="query">
       <text transform="matrix(1, 0, 0, 1, 276.165, 12.5)" id="tspan3023">
-        <tspan x="-3.665" y="6.012" font-family="Helvetica-Bold" font-size="12" fill="#FFFFFF">?</tspan>
+        <tspan x="-3.665" y="6.012" font-family="Helvetica, sans-serif" font-weight="Bold" font-size="12" fill="#FFFFFF">?</tspan>
       </text>
       <path d="M263,1 C263,1 272,8 272,8 C270.944,8.587 269.888,9.173 268.832,9.76 L271.863,16.375 C272.209,17.128 271.878,18.018 271.125,18.364 C270.372,18.709 269.482,18.378 269.136,17.625 L266.201,11.221 C265.134,11.814 264.067,12.407 263,13 L263,1 z" fill="#FFFFFF"/>
     </g>


### PR DESCRIPTION
The question mark on the query icon is using a font that does not exist and is defaulting to serif. This fix uses the built-in web safe Helvetica with sans-serif fallback. This should match the PNG version of the icon.

Issue:
![image](https://user-images.githubusercontent.com/32040254/158910378-c9cb9aab-b0aa-4912-b882-03ae35cf8770.png)
