### PR TITLE
Make spelling for "website" consistent

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
       messages:
         invalid_email_address: does not appear to be a valid e-mail address
         email_address_not_routable: is not routable
-    # Translates all the model names, which is used in error handling on the web site
+    # Translates all the model names, which is used in error handling on the website
     models:
       acl: "Access Control List"
       changeset: "Changeset"
@@ -75,8 +75,8 @@ en:
       way: "Way"
       way_node: "Way Node"
       way_tag: "Way Tag"
-    # Translates all the model attributes, which is used in error handling on the web site
-    # Only the ones that are used on the web site are translated at the moment
+    # Translates all the model attributes, which is used in error handling on the website
+    # Only the ones that are used on the website are translated at the moment
     attributes:
       client_application:
         name: Name (Required)
@@ -1838,7 +1838,7 @@ en:
     about:
       next: Next
       copyright_html: <span>&copy;</span>OpenStreetMap<br>contributors
-      used_by_html: "%{name} provides map data for thousands of web sites, mobile apps, and hardware devices"
+      used_by_html: "%{name} provides map data for thousands of websites, mobile apps, and hardware devices"
       lede_text: |
         OpenStreetMap is built by a community of mappers that contribute and maintain data
         about roads, trails, cafés, railway stations, and much more, all over the world.
@@ -2384,7 +2384,7 @@ en:
     require_admin:
       not_an_admin: You need to be an admin to perform that action.
     setup_user_auth:
-      blocked_zero_hour: "You have an urgent message on the OpenStreetMap web site. You need to read the message before you will be able to save your edits."
+      blocked_zero_hour: "You have an urgent message on the OpenStreetMap website. You need to read the message before you will be able to save your edits."
       blocked: "Your access to the API has been blocked. Please log-in to the web interface to find out more."
       need_to_see_terms: "Your access to the API is temporarily suspended. Please log-in to the web interface to view the Contributor Terms. You do not need to agree, but you must view them."
     settings_menu:


### PR DESCRIPTION
Removed redundant space in "web site".