### PR TITLE
Change spelling for club=sport

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -794,7 +794,7 @@ en:
           "yes": "Building"
         club:
           scout: "Scout Group Base"
-          sport: "Sportsclub"
+          sport: "Sports Club"
           "yes": "Club"
         craft:
           beekeeper: "Beekeeper"


### PR DESCRIPTION
"sportsclub" is an uncommon spelling of "sports club".

**Wikidata**
https://www.wikidata.org/wiki/Q847017
(See also Wikipedia)

**Wiktionary** (missing from Wikidata)

- https://en.wiktionary.org/wiki/sports_club
- https://en.wiktionary.org/wiki/Sportclub
(See also "club" for related terms)

**Dictionaries, articles**
Found no dedicated articles / dictionary pages for this spelling, but dictionary examples (almost) always use "sports club".
(i.e. (British English dictionaries); Encyclopaedia Britannica, Cambridge (Cambridge University), Oxford Learners (Oxford University))

**Google Trends**
```
"sports club", "sportsclub"
"sport club", "sportclub"
"sporting club"
```
https://trends.google.nl/trends/explore?date=all&q=sports%20club,sportsclub,sport%20club,sportclub,sporting%20club
(left out);
```
"sportsklub", "sportingclub", "sporting klub"; <1
"sportingklub"; 0
```

**Google Ngram Viewer**
```
"sports club", "sportsclub"
"sport club", "sportclub"
"sporting club"
```
https://books.google.com/ngrams/graph?content=sports+club%2Csportsclub%2Csport+club%2Csportclub%2Csporting+club&year_start=1800&year_end=2019&corpus=26&smoothing=3&direct_url=t1%3B%2Csports%20club%3B%2Cc0%3B.t1%3B%2Csportsclub%3B%2Cc0%3B.t1%3B%2Csport%20club%3B%2Cc0%3B.t1%3B%2Csportclub%3B%2Cc0%3B.t1%3B%2Csporting%20club%3B%2Cc0

**OpenStreetMap Wiki** (links to above Wikidata)
https://wiki.openstreetmap.org/wiki/Tag:club=sport
(created 2014-12-30, no changes since);
https://wiki.openstreetmap.org/w/index.php?title=Tag%3Aclub%3Dsport&type=revision&diff=2275140&oldid=1122589

**TranslateWiki** (fresh import 2020-08-16, no changes since)
https://translatewiki.net/w/i.php?title=Osm:Geocoder.search_osm_nominatim.prefix.club.sport/en&action=history