### PR TITLE
google imagery blacklist entry update

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -86,8 +86,8 @@ default_editor: "id"
 # Imagery to return in capabilities as blacklisted
 imagery_blacklist:
   # Current Google imagery URLs have google or googleapis in the domain
-  # with a vt or kh endpoint, and x, y and z query parameters
-  - ".*\\.google(apis)?\\..*/(vt|kh)[\\?/].*([xyz]=.*){3}.*"
+  # with a vt or kh endpoint, and x, y and z or pb-based query parameters
+  - ".*\\.google(apis)?\\..*/(vt|kh)[\\?/].*([xyz]=.*|!\d[a-z]\d+){3}.*"
   # Blacklist VWorld
   - "http://xdworld\\.vworld\\.kr:8080/.*"
   # Blacklist here


### PR DESCRIPTION
Updated google imagery blacklist entry to include the pb implementation of the vt endpoint for URLs like these:
[https://www.google.at/maps/vt?pb=!1m4!1m3!1e{z}!2i{x}!3u{y}!2m2!1e1!2sm!3b0](https://www.openstreetmap.org/id#background=custom:https://www.google.at/maps/vt%3Fpb%3D!1m4!1m3!1e{z}!2i{x}!3u{y}!2m2!1e1!2sm!3b0)
The extension of the regular expression is specifically targeted to googles proprietary parameter design, as explored in [this stack overflow post](https://stackoverflow.com/questions/47017387/decoding-the-google-maps-embedded-parameters).