### PR TITLE
Rework some tests to use factories instead of new objects

### DIFF
--- a/test/models/changeset_tag_test.rb
+++ b/test/models/changeset_tag_test.rb
@@ -49,9 +49,10 @@ class ChangesetTagTest < ActiveSupport::TestCase
     end
   end
 
-  def test_empty_tag_invalid
-    tag = ChangesetTag.new
-    assert_not tag.valid?, "Empty tag should be invalid"
+  def test_orphaned_tag_invalid
+    tag = create(:changeset_tag)
+    tag.changeset = nil
+    assert_not tag.valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:changeset], :any?
   end
 

--- a/test/models/changeset_tag_test.rb
+++ b/test/models/changeset_tag_test.rb
@@ -40,10 +40,7 @@ class ChangesetTagTest < ActiveSupport::TestCase
 
   def test_uniqueness
     existing = create(:changeset_tag)
-    tag = ChangesetTag.new
-    tag.changeset_id = existing.changeset_id
-    tag.k = existing.k
-    tag.v = existing.v
+    tag = build(:changeset_tag, :changeset => existing.changeset, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
     assert_not tag.valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }

--- a/test/models/changeset_tag_test.rb
+++ b/test/models/changeset_tag_test.rb
@@ -2,51 +2,33 @@ require "test_helper"
 
 class ChangesetTagTest < ActiveSupport::TestCase
   def test_length_key_valid
-    changeset = create(:changeset)
-
-    key = "k"
+    tag = create(:changeset_tag)
     [0, 255].each do |i|
-      tag = ChangesetTag.new
-      tag.changeset_id = changeset.id
-      tag.k = key * i
-      tag.v = "v"
+      tag.k = "k" * i
       assert_predicate tag, :valid?
     end
   end
 
   def test_length_value_valid
-    changeset = create(:changeset)
-
-    val = "v"
+    tag = create(:changeset_tag)
     [0, 255].each do |i|
-      tag = ChangesetTag.new
-      tag.changeset_id = changeset.id
-      tag.k = "k"
-      tag.v = val * i
+      tag.v = "v" * i
       assert_predicate tag, :valid?
     end
   end
 
   def test_length_key_invalid
-    ["k" * 256].each do |k|
-      tag = ChangesetTag.new
-      tag.changeset_id = 1
-      tag.k = k
-      tag.v = "v"
-      assert_not tag.valid?, "Key #{k} should be too long"
-      assert_predicate tag.errors[:k], :any?
-    end
+    tag = create(:changeset_tag)
+    tag.k = "k" * 256
+    assert_not tag.valid?, "Key should be too long"
+    assert_predicate tag.errors[:k], :any?
   end
 
   def test_length_value_invalid
-    ["v" * 256].each do |v|
-      tag = ChangesetTag.new
-      tag.changeset_id = 1
-      tag.k = "k"
-      tag.v = v
-      assert_not tag.valid?, "Value #{v} should be too long"
-      assert_predicate tag.errors[:v], :any?
-    end
+    tag = create(:changeset_tag)
+    tag.v = "v" * 256
+    assert_not tag.valid?, "Value should be too long"
+    assert_predicate tag.errors[:v], :any?
   end
 
   def test_orphaned_tag_invalid

--- a/test/models/node_tag_test.rb
+++ b/test/models/node_tag_test.rb
@@ -31,9 +31,10 @@ class NodeTagTest < ActiveSupport::TestCase
     assert_predicate tag.errors[:v], :any?
   end
 
-  def test_empty_node_tag_invalid
-    tag = NodeTag.new
-    assert_not tag.valid?, "Empty tag should be invalid"
+  def test_orphaned_node_tag_invalid
+    tag = create(:node_tag)
+    tag.node = nil
+    assert_not tag.valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:node], :any?
   end
 

--- a/test/models/node_tag_test.rb
+++ b/test/models/node_tag_test.rb
@@ -40,10 +40,7 @@ class NodeTagTest < ActiveSupport::TestCase
 
   def test_uniqueness
     existing = create(:node_tag)
-    tag = NodeTag.new
-    tag.node_id = existing.node_id
-    tag.k = existing.k
-    tag.v = existing.v
+    tag = build(:node_tag, :node => existing.node, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
     assert_not tag.valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }

--- a/test/models/old_node_tag_test.rb
+++ b/test/models/old_node_tag_test.rb
@@ -31,9 +31,10 @@ class OldNodeTagTest < ActiveSupport::TestCase
     assert_predicate tag.errors[:v], :any?
   end
 
-  def test_empty_tag_invalid
-    tag = OldNodeTag.new
-    assert_not tag.valid?, "Empty tag should be invalid"
+  def test_orphaned_tag_invalid
+    tag = create(:old_node_tag)
+    tag.old_node = nil
+    assert_not tag.valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:old_node], :any?
   end
 

--- a/test/models/old_node_tag_test.rb
+++ b/test/models/old_node_tag_test.rb
@@ -40,11 +40,7 @@ class OldNodeTagTest < ActiveSupport::TestCase
 
   def test_uniqueness
     existing = create(:old_node_tag)
-    tag = OldNodeTag.new
-    tag.node_id = existing.node_id
-    tag.version = existing.version
-    tag.k = existing.k
-    tag.v = existing.v
+    tag = build(:old_node_tag, :old_node => existing.old_node, :version => existing.version, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
     assert_not tag.valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }

--- a/test/models/old_relation_tag_test.rb
+++ b/test/models/old_relation_tag_test.rb
@@ -40,11 +40,7 @@ class OldRelationTagTest < ActiveSupport::TestCase
 
   def test_uniqueness
     existing = create(:old_relation_tag)
-    tag = OldRelationTag.new
-    tag.relation_id = existing.relation_id
-    tag.version = existing.version
-    tag.k = existing.k
-    tag.v = existing.v
+    tag = build(:old_relation_tag, :old_relation => existing.old_relation, :version => existing.version, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
     assert_not tag.valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }

--- a/test/models/old_relation_tag_test.rb
+++ b/test/models/old_relation_tag_test.rb
@@ -31,9 +31,10 @@ class OldRelationTagTest < ActiveSupport::TestCase
     assert_predicate tag.errors[:v], :any?
   end
 
-  def test_empty_tag_invalid
-    tag = OldRelationTag.new
-    assert_not tag.valid?, "Empty tag should be invalid"
+  def test_orphaned_tag_invalid
+    tag = create(:old_relation_tag)
+    tag.old_relation = nil
+    assert_not tag.valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:old_relation], :any?
   end
 

--- a/test/models/old_way_tag_test.rb
+++ b/test/models/old_way_tag_test.rb
@@ -31,9 +31,10 @@ class OldWayTagTest < ActiveSupport::TestCase
     assert_predicate tag.errors[:v], :any?
   end
 
-  def test_empty_tag_invalid
-    tag = OldWayTag.new
-    assert_not tag.valid?, "Empty tag should be invalid"
+  def test_orphaned_tag_invalid
+    tag = create(:old_way_tag)
+    tag.old_way = nil
+    assert_not tag.valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:old_way], :any?
   end
 

--- a/test/models/old_way_tag_test.rb
+++ b/test/models/old_way_tag_test.rb
@@ -40,7 +40,7 @@ class OldWayTagTest < ActiveSupport::TestCase
 
   def test_uniqueness
     existing = create(:old_way_tag)
-    tag = OldWayTag.new
+    tag = build(:old_way_tag, :old_way => existing.old_way, :version => existing.version, :k => existing.k, :v => existing.v)
     tag.way_id = existing.way_id
     tag.version = existing.version
     tag.k = existing.k

--- a/test/models/relation_tag_test.rb
+++ b/test/models/relation_tag_test.rb
@@ -40,10 +40,7 @@ class RelationTagTest < ActiveSupport::TestCase
 
   def test_uniqueness
     existing = create(:relation_tag)
-    tag = RelationTag.new
-    tag.relation_id = existing.relation_id
-    tag.k = existing.k
-    tag.v = existing.v
+    tag = build(:relation_tag, :relation => existing.relation, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
     assert_not tag.valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }

--- a/test/models/relation_tag_test.rb
+++ b/test/models/relation_tag_test.rb
@@ -31,9 +31,10 @@ class RelationTagTest < ActiveSupport::TestCase
     assert_predicate tag.errors[:v], :any?
   end
 
-  def test_empty_tag_invalid
-    tag = RelationTag.new
-    assert_not tag.valid?, "Empty relation tag should be invalid"
+  def test_orphaned_tag_invalid
+    tag = create(:relation_tag)
+    tag.relation = nil
+    assert_not tag.valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:relation], :any?
   end
 

--- a/test/models/way_tag_test.rb
+++ b/test/models/way_tag_test.rb
@@ -31,9 +31,10 @@ class WayTagTest < ActiveSupport::TestCase
     assert_predicate tag.errors[:v], :any?
   end
 
-  def test_empty_tag_invalid
-    tag = WayTag.new
-    assert_not tag.valid?, "Empty way tag should be invalid"
+  def test_orphaned_tag_invalid
+    tag = create(:way_tag)
+    tag.way = nil
+    assert_not tag.valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:way], :any?
   end
 

--- a/test/models/way_tag_test.rb
+++ b/test/models/way_tag_test.rb
@@ -40,7 +40,7 @@ class WayTagTest < ActiveSupport::TestCase
 
   def test_uniqueness
     existing = create(:way_tag)
-    tag = WayTag.new
+    tag = build(:way_tag, :way => existing.way, :k => existing.k, :v => existing.v)
     tag.way_id = existing.way_id
     tag.k = existing.k
     tag.v = existing.v


### PR DESCRIPTION
This PR reworks some model tests to use factories, instead of creating new objects. This tends to simplify the tests, since there's often less boilerplate in setting up the new object to be valid.

It also reworks the "empty" tag tests, since it wasn't clear from the naming and code exactly what was being tested. So I've refactored these to show that they are testing that the parent object is set.