### PR TITLE
Rework common details to avoid awkward line breaks

### DIFF
--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,4 +1,4 @@
-<h4 class="details">
+<h4>
   <%= t "browse.version" %>
   #<%= common_details.version %>
 </h4>
@@ -11,24 +11,27 @@
   <% end %>
 </p>
 
-<p class="details">
-  <%= t "browse.#{common_details.visible? ? :edited : :deleted}_by_html",
-        :time => time_ago_in_words(common_details.timestamp, :scope => :"datetime.distance_in_words_ago"),
-        :user => changeset_user_link(common_details.changeset),
-        :title => l(common_details.timestamp) %>
-  &middot;
-  <%= t "browse.in_changeset" %>
-  #<%= link_to common_details.changeset_id, :action => :changeset, :id => common_details.changeset_id %>
-</p>
+<ul class="list-unstyled">
+  <li>
+    <%= t "browse.#{common_details.visible? ? :edited : :deleted}_by_html",
+          :time => time_ago_in_words(common_details.timestamp, :scope => :"datetime.distance_in_words_ago"),
+          :user => changeset_user_link(common_details.changeset),
+          :title => l(common_details.timestamp) %>
+  </li>
+  <li>
+    <%= t "browse.in_changeset" %>
+    #<%= link_to common_details.changeset_id, :action => :changeset, :id => common_details.changeset_id %>
+  </li>
 
-<% if @type == "node" and common_details.visible? %>
-<div class="details geo">
-  <%= t "browse.location" %>
-  <%= link_to(t(".coordinates_html",
-                :latitude => tag.span(number_with_delimiter(common_details.lat), :class => "latitude"),
-                :longitude => tag.span(number_with_delimiter(common_details.lon), :class => "longitude")),
-              root_path(:anchor => "map=18/#{common_details.lat}/#{common_details.lon}")) %>
-</div>
-<% end %>
+  <% if @type == "node" and common_details.visible? %>
+    <li>
+      <%= t "browse.location" %>
+      <%= link_to(t(".coordinates_html",
+                    :latitude => tag.span(number_with_delimiter(common_details.lat), :class => "latitude"),
+                    :longitude => tag.span(number_with_delimiter(common_details.lon), :class => "longitude")),
+                  root_path(:anchor => "map=18/#{common_details.lat}/#{common_details.lon}")) %>
+    </li>
+  <% end %>
+</ul>
 
 <%= render :partial => "tag_details", :object => common_details.tags %>


### PR DESCRIPTION
Fixes #3435

Also brings the location information into the list, which avoids a
lack of padding before the next header.

Before:
![Screenshot from 2022-04-27 11-33-33](https://user-images.githubusercontent.com/360803/165502153-f6af930c-ce1a-4cb1-b0e7-51246c08ddac.png)

After:
![Screenshot from 2022-04-27 11-33-21](https://user-images.githubusercontent.com/360803/165502188-0fdffe20-9ca2-4fee-8a94-6f1dc60ec7dd.png)
