### PR TITLE
Kramdown formatting on reports text

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -36,4 +36,8 @@ class Report < ApplicationRecord
     else %w[other]
     end
   end
+
+  def details
+    RichText.new("markdown", self[:details])
+  end
 end

--- a/app/views/issues/_reports.html.erb
+++ b/app/views/issues/_reports.html.erb
@@ -9,7 +9,7 @@
                                    :user => link_to(report.user.display_name, user_path(report.user)),
                                    :updated_at => l(report.updated_at.to_datetime, :format => :friendly) %>
       </p>
-      <p><%= report.details %></p>
+      <p class="richtext text-break"><%= report.details.to_html %></p>
     </div>
   </div>
   <hr>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -18,6 +18,6 @@
   <% end %>
 
   <%= f.collection_radio_buttons :category, report_categories(@report.issue.reportable), :id, :label %>
-  <%= f.text_area :details, :rows => 5, :label_as_placeholder => true %>
+  <%= f.richtext_field :details, :rows => 18, :label_as_placeholder => true, :format => "markdown" %>
   <%= f.primary %>
 <% end %>

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -32,4 +32,9 @@ class ReportTest < ActiveSupport::TestCase
     report.category = ""
     assert_not report.valid?
   end
+
+  def test_details
+    report = create(:report)
+    assert_instance_of(RichText::Markdown, report.details)
+  end
 end

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -33,11 +33,12 @@ class IssuesTest < ApplicationSystemTestCase
   def test_view_issue_with_report
     sign_in_as(create(:moderator_user))
     issue = create(:issue, :assigned_role => "moderator")
-    issue.reports << create(:report, :details => "test report text")
+    issue.reports << create(:report, :details => "test report text **with kramdown**")
 
     visit issue_path(issue)
     assert_content I18n.t("issues.show.reports", :count => 1)
-    assert_content "test report text"
+    assert_content "test report text with kramdown"
+    assert_selector "strong", :text => "with kramdown"
   end
 
   def test_view_issues_with_no_reported_user

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -30,6 +30,16 @@ class IssuesTest < ApplicationSystemTestCase
     assert_content issues.first.reported_user.display_name
   end
 
+  def test_view_issue_with_report
+    sign_in_as(create(:moderator_user))
+    issue = create(:issue, :assigned_role => "moderator")
+    issue.reports << create(:report, :details => "test report text")
+
+    visit issue_path(issue)
+    assert_content I18n.t("issues.show.reports", :count => 1)
+    assert_content "test report text"
+  end
+
   def test_view_issues_with_no_reported_user
     sign_in_as(create(:moderator_user))
     anonymous_note = create(:note_with_comments)


### PR DESCRIPTION
Pass the text of reports ('details' field) through the RichText formatter to give us kramdown formatting support.

Users don't generally get to see their reports. Only a few admins ever see them displayed, but DWG folks working with reports have complained of a **"wall of text"** problem when looking at some longer reports. This solves it, particularly with basic paragraphs rendered from double-newlines. Other kramdown tricks are a bonus:

<img width="900" alt="before-after" src="https://user-images.githubusercontent.com/227525/165867251-d671ad4b-3910-4149-8c9b-8dc13970d433.png">

We don't need to do support of alternative HTML formatting as we did for legacy diary entries. I don't think we need any special treatment for old reports in the database. We can bung them all through the kramdown formatter and it will either make no difference or will improve the display. 