### PR TITLE
Fix verification redirect on missing report category

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -28,7 +28,8 @@ class ReportsController < ApplicationController
 
       redirect_to helpers.reportable_url(@report.issue.reportable), :notice => t(".successful_report")
     else
-      redirect_to new_report_path(:reportable_type => @report.issue.reportable_type, :reportable_id => @report.issue.reportable_id), :notice => t(".provide_details")
+      flash[:notice] = t(".provide_details")
+      render :action => "new"
     end
   end
 

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -63,10 +63,12 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
       category = "other"
       post reports_path(:report => {
                           :category => category,
-                          :issue => { :reportable_id => 1, :reportable_type => "User" }
+                          :issue => { :reportable_id => target_user.id, :reportable_type => "User" }
                         })
     end
-    assert_response :redirect
+    assert_response :success
+    assert_template :new
+    assert_match(/Please provide the required details/, flash[:notice])
 
     assert_equal 1, issue.reports.count
   end


### PR DESCRIPTION
Fix an issue with the report verification, causing it to lose the text of a report if the user fails to fill in a category. In the absence of the required field 'category' it redirects to the new report form. This redirect should retain the value of the 'details' field.