### PR TITLE
Put issue comments through kramdown formatter 

### DIFF
--- a/app/models/issue_comment.rb
+++ b/app/models/issue_comment.rb
@@ -25,4 +25,8 @@ class IssueComment < ApplicationRecord
   belongs_to :user
 
   validates :body, :presence => true, :characters => true
+
+  def body
+    RichText.new("markdown", self[:body])
+  end
 end

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -9,7 +9,7 @@
           <%= t ".comment_from_html", :user_link => link_to(comment.user.display_name, user_path(comment.user)),
                                       :comment_created_at => l(comment.created_at.to_datetime, :format => :friendly) %>
         </p>
-        <p><%= comment.body %></p>
+        <p><%= comment.body.to_html %></p>
       </div>
     </div>
     <hr>

--- a/test/factories/issue_comment.rb
+++ b/test/factories/issue_comment.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :issue_comment do
+    sequence(:body) { |n| "This is issue comment #{n}" }
+
+    issue
+    user
+  end
+end

--- a/test/models/issue_comment_test.rb
+++ b/test/models/issue_comment_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
 
 class IssueCommentTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "body must be present" do
+    comment = build(:issue_comment, :body => "")
+    assert_not comment.valid?
+    assert_not_nil comment.errors[:body]
+  end
 end

--- a/test/models/issue_comment_test.rb
+++ b/test/models/issue_comment_test.rb
@@ -6,4 +6,9 @@ class IssueCommentTest < ActiveSupport::TestCase
     assert_not comment.valid?
     assert_not_nil comment.errors[:body]
   end
+
+  test "body" do
+    comment = create(:issue_comment)
+    assert_instance_of(RichText::Markdown, comment.body)
+  end
 end


### PR DESCRIPTION
On issue comments (which only admins can create or see), put the body text through kramdown formatting.

We actually show the info box with kramdown syntax and preview button, but it looks like we forgot to render the formatting!

This wasn't on DWG's list of requested fixes. Nobody noticed or complained about it, but I thought I'd fix it while I'm looking at these things.

