### PR TITLE
Use a secondary-actions nav for issue actions

### DIFF
--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -10,13 +10,19 @@
     <%= " | #{t('.last_updated_at', :datetime => l(@issue.updated_at.to_datetime, :format => :friendly), :displayname => @issue.user_updated.display_name)}" if @issue.user_updated %>
   </small>
 </p>
-<p>
-  <%= link_to t(".resolve"), resolve_issue_url(@issue), :method => :post if @issue.may_resolve? %>
-  <% if @issue.may_ignore? %>
-  | <%= link_to t(".ignore"), ignore_issue_url(@issue), :method => :post %>
-  <% end %>
-</p>
-<p><%= link_to t(".reopen"), reopen_issue_url(@issue), :method => :post if @issue.may_reopen? %></p>
+<nav class="secondary-actions">
+  <ul class="clearfix">
+    <% if @issue.may_resolve? %>
+      <li><%= link_to t(".resolve"), resolve_issue_url(@issue), :method => :post %></li>
+    <% end %>
+    <% if @issue.may_ignore? %>
+      <li><%= link_to t(".ignore"), ignore_issue_url(@issue), :method => :post %></li>
+    <% end %>
+    <% if @issue.may_reopen? %>
+      <li><%= link_to t(".reopen"), reopen_issue_url(@issue), :method => :post %></li>
+    <% end %>
+  </ul>
+</nav>
 <% end %>
 
 <div class="row">


### PR DESCRIPTION
This fits with actions on other pages, avoids using pipe characters, and resolves an issue with empty paragraphs.