### PR TITLE
Add cause to feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,6 +7,14 @@ body:
   - type: textarea
     id: idea
     attributes:
+      label: Problem
+      description: Please describe problem or use case that is the cause for your feature request or idea.
+      placeholder:
+    validations:
+      required: false
+  - type: textarea
+    id: idea
+    attributes:
       label: Description
       description: Please describe you feature request, idea or question.
       placeholder:
@@ -15,7 +23,7 @@ body:
   - type: textarea
     attributes:
       label: Screenshots
-      description: Please add screenshots if they can help us understand your request/idea/question.
+      description: Please add screenshots or mockups if they can help us understand your request/idea/question.
       placeholder:
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -8,7 +8,7 @@ body:
     id: idea
     attributes:
       label: Problem
-      description: Please describe problem or use case that is the cause for your feature request or idea.
+      description: Please describe the problem or use case that is the cause for your feature request or idea.
       placeholder:
     validations:
       required: false
@@ -16,7 +16,7 @@ body:
     id: idea
     attributes:
       label: Description
-      description: Please describe you feature request, idea or question.
+      description: Please describe your feature request, idea or question.
       placeholder:
     validations:
       required: false


### PR DESCRIPTION
When writing https://github.com/openstreetmap/openstreetmap-website/issues/3551 I noticed that your template is somewhat problematic.

What users really should write is how/why they have the feature request they want, i.e. what (problem) is “behind” a feature request. Similar to how user stories should always go like ”I as a [who] want [what], because [why]”, here the “why” aspect was missing.
The “Description” does not really tangle that, it only tangles _what_ the user wants.

Screenshots may also be better inline inside of a text description, but I see you want to nudge the user to add screenshots or mockups, so that's fine IMHO.