### PR TITLE
Add "garden" to map key

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2195,6 +2195,7 @@ en:
           common:
             - Common
             - meadow
+            - garden
           retail: "Retail area"
           industrial: "Industrial area"
           commercial: "Commercial area"


### PR DESCRIPTION
Make map key list "common, meadow, garden" instead of just "common, meadow".

This is in response to a DWG ticket ( #2022051810000111) where a resident complained that their private garden was "listed as 'common, meadow' " in OSM because they consulted the map key. Listing "garden" along these should clear up that misunderstanding.