### PR TITLE
Fix highway crossing in nominatim description terms

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -822,7 +822,6 @@ en:
           window_construction: "Window Construction"
           winery: "Winery"
           "yes": "Craft Shop"
-        crossing: "Crossing"
         emergency:
           access_point: "Access Point"
           ambulance_station: "Ambulance Station"
@@ -843,6 +842,7 @@ en:
           bus_stop: "Bus Stop"
           construction: "Highway under Construction"
           corridor: "Corridor"
+          crossing: "Crossing"
           cycleway: "Cycle Path"
           elevator: "Elevator"
           emergency_access_point: "Emergency Access Point"


### PR DESCRIPTION
The entry is syntactically wrong. The description terms expect a list of values for each key.

Given that 'crossing' is not a main tag, the key shouldn't be featured in the list at all. I've added highway=crossing instead.