### PR TITLE
Margins for 'comment from' / 'reported by' lines on issues page

### DIFF
--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -5,7 +5,7 @@
         <%= link_to user_thumbnail(comment.user), user_path(comment.user) %>
       </div>
       <div class="col">
-        <p class="text-muted mb-0">
+        <p class="text-muted">
           <%= t ".comment_from_html", :user_link => link_to(comment.user.display_name, user_path(comment.user)),
                                       :comment_created_at => l(comment.created_at.to_datetime, :format => :friendly) %>
         </p>

--- a/app/views/issues/_reports.html.erb
+++ b/app/views/issues/_reports.html.erb
@@ -4,7 +4,7 @@
       <%= link_to user_thumbnail(report.user), user_path(report.user) %>
     </div>
     <div class="col">
-      <p class="text-muted mb-0">
+      <p class="text-muted">
         <%= t ".reported_by_html", :category => report.category,
                                    :user => link_to(report.user.display_name, user_path(report.user)),
                                    :updated_at => l(report.updated_at.to_datetime, :format => :friendly) %>


### PR DESCRIPTION
Don't remove margins with `mb-0` class on reported-by lines.

After enabling markdown in issue reports/comments, they can consist of several paragraphs. There's spacing between paragraphs provided by their bottom margins. But then there's a reported-by line above and it doesn't have margins. This line is displayed next to the report text without any spacing which looks strange for multi-paragraph reports.

Before merging #3566 there was a kind-of margin provided by an empty paragraph resulting from invalid html. Now that paragraph is gone.