### PR TITLE
Remove duplicate keys from en locale data

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,13 +109,12 @@ en:
       trace:
         user: "User"
         visible: "Visible"
-        name: "Name"
+        name: Filename
         size: "Size"
         latitude: "Latitude"
         longitude: "Longitude"
         public: "Public"
         description: "Description"
-        name: Filename
         gpx_file: Upload GPX File
         visibility: Visibility
         tagstring: Tags
@@ -1389,7 +1388,6 @@ en:
       last_updated_time_html: "<abbr title='%{title}'>%{time}</abbr>"
       last_updated_time_user_html: "<abbr title='%{title}'>%{time}</abbr> by %{user}"
       link_to_reports: View Reports
-      reported_user: Reported User
       reports_count:
         one: "1 Report"
         other: "%{count} Reports"
@@ -2356,7 +2354,6 @@ en:
       in: "in"
     index:
       public_traces: "Public GPS Traces"
-      my_traces: "My GPS Traces"
       public_traces_from: "Public GPS Traces from %{user}"
       description: "Browse recent GPS trace uploads"
       tagged_with: " tagged with %{tags}"


### PR DESCRIPTION
It's invalid YAML to have duplicate keys. Some parsers may refuse to read the file.

(I had to scan block page heading locale strings once to find out whether they are "User A blocked by User B" or "User B blocked User A" in all possible languages. The parser threw an exception on en.yml.)