### PR TITLE
[iD] only parse hashParams if there actually is a hash

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -4,7 +4,8 @@ $(document).ready(function () {
   var id = $("#id-embed");
 
   if (id.data("configured") === true) {
-    var hashParams = OSM.params(location.hash.substring(1));
+    var hash = location.hash.substring(1);
+    var hashParams = hash ? OSM.params(hash) : {};
     var mapParams = OSM.mapParams();
     var params = {};
 


### PR DESCRIPTION
Presumably this was an oversight in the original implementation: `OSM.params` falls back to the page's `query` string if the function's parameter (here: the page's `hash`) is an empty string.

This fixes the following inconsistent behaviour of the website: In the example below, the first URL sets the `background` to `none` while in the second example it doesn't.

* https://www.openstreetmap.org/edit.html?background=none
* https://www.openstreetmap.org/edit.html?background=none#map=…

With this PR, the `background` query parameter is ignored in both examples. Btw, the correct way to supply the `background` (and [related parameters](https://github.com/openstreetmap/openstreetmap-website/blob/c55d346/app/assets/javascripts/edit/id.js.erb#L23-L39)) is via a hash parameter:

* https://www.openstreetmap.org/edit.html#background=none
* https://www.openstreetmap.org/edit.html#background=none&map=…