### PR TITLE
Fix small error in _header.html.erb

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -107,7 +107,7 @@
       <div class="d-inline-flex btn-group login-menu" role="">
         <%= link_to t("layouts.log_in"), login_path(:referer => request.fullpath), :class => "geolink btn btn-outline-secondary" %>
         <%= link_to t("layouts.sign_up"), user_new_path, :class => "btn btn-outline-secondary" %>
-      </ul>
+      </div>
     <% end %>
   </nav>
 </header>


### PR DESCRIPTION
P.S. I've noticed that all `<li>`s from [line 47 to line 61](https://github.com/openstreetmap/openstreetmap-website/blob/master/app/views/layouts/_header.html.erb#L47-L61) have `<%= current_page_class(traces_path) %>` which seems to return nothing. It's the same on [lines 73 to 77](https://github.com/openstreetmap/openstreetmap-website/blob/master/app/views/layouts/_header.html.erb#L73-L77). It may be worth removing it all together if it's not working and if it's not needed any more.