### PR TITLE
Note update date in xml, json, gpx api output formats

### DIFF
--- a/app/views/api/notes/_note.gpx.builder
+++ b/app/views/api/notes/_note.gpx.builder
@@ -20,6 +20,7 @@ xml.wpt("lon" => note.lon, "lat" => note.lat) do
     end
 
     xml.date_created note.created_at
+    xml.date_updated note.updated_at
     xml.status note.status
 
     xml.date_closed note.closed_at if note.closed?

--- a/app/views/api/notes/_note.json.jbuilder
+++ b/app/views/api/notes/_note.json.jbuilder
@@ -17,6 +17,7 @@ json.properties do
   end
 
   json.date_created note.created_at.to_s
+  json.date_updated note.updated_at.to_s
   json.status note.status
   json.closed_at note.closed_at.to_s if note.closed?
 

--- a/app/views/api/notes/_note.xml.builder
+++ b/app/views/api/notes/_note.xml.builder
@@ -10,6 +10,7 @@ xml.note("lon" => note.lon, "lat" => note.lat) do
   end
 
   xml.date_created note.created_at
+  xml.date_updated note.updated_at
   xml.status note.status
 
   xml.date_closed note.closed_at if note.closed?

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -479,6 +479,7 @@ module Api
           assert_select "comment_url", comment_api_note_url(open_note, :format => "xml")
           assert_select "close_url", close_api_note_url(open_note, :format => "xml")
           assert_select "date_created", open_note.created_at.to_s
+          assert_select "date_updated", open_note.updated_at.to_s
           assert_select "status", open_note.status
           assert_select "comments", :count => 1 do
             assert_select "comment", :count => 1
@@ -516,6 +517,7 @@ module Api
       assert_equal comment_api_note_url(open_note, :format => "json"), js["properties"]["comment_url"]
       assert_equal close_api_note_url(open_note, :format => "json"), js["properties"]["close_url"]
       assert_equal open_note.created_at.to_s, js["properties"]["date_created"]
+      assert_equal open_note.updated_at.to_s, js["properties"]["date_updated"]
       assert_equal open_note.status, js["properties"]["status"]
 
       get api_note_path(:id => open_note, :format => "gpx")
@@ -532,6 +534,8 @@ module Api
             assert_select "url", api_note_url(open_note, :format => "gpx")
             assert_select "comment_url", comment_api_note_url(open_note, :format => "gpx")
             assert_select "close_url", close_api_note_url(open_note, :format => "gpx")
+            assert_select "date_created", open_note.created_at.to_s
+            assert_select "date_updated", open_note.updated_at.to_s
           end
         end
       end


### PR DESCRIPTION
Adds `update_date` to notes api output.

Internally, notes have updated_at, created_at and closed_at dates. Create and close dates are available through the api, update date is not. Usually you can look at the date of the last note comment to figure out update_date. Except it's not always possible. If the last comment is hidden the date is going to be incorrect.

Why do you need update date? Note search results can be sorted by update date. The number of returned notes is limited, the default limit is 100. What if you want to get the next 100 notes? You can add a `from` or `to` parameter to your search call with the date of a last note you got as a value.* That way you can skip the first 100 notes you already received.**

I named the added key/element `date_updated`, similar to existing `date_created` and `date_closed` keys/elements, if we ignore one naming inconsistency in json where `closed_at` is used instead of `date_closed`. I didn't add update date to rss, because there's no good possible element inside `<item>` for it.

\* actually date + 1 second for `to`
\** except for same-second notes