### PR TITLE
Wording to discourage note reporting

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -841,6 +841,10 @@ tr.turn:hover {
     }
   }
 
+  form.note-comment-resolve {
+    margin: 10px 0px 40px 0px;
+  }
+
   .subscribe-buttons input {
     font-size: 90%;
     line-height: 15px;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -841,10 +841,6 @@ tr.turn:hover {
     }
   }
 
-  form.note-comment-resolve {
-    margin: 10px 0px 40px 0px;
-  }
-
   .subscribe-buttons input {
     font-size: 90%;
     line-height: 15px;

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -29,7 +29,7 @@
   <% end -%>
 
   <% if current_user && current_user != @note.author %>
-    <p class="text-muted"><%= report_link(t(".report"), @note) %></p>
+    <p class="text-muted"><%= t "javascripts.notes.show.report_link_html", :link => report_link(t(".report"), @note) %></p>
   <% end %>
 
   <% if @note_comments.length > 1 %>

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -43,7 +43,7 @@
 
   <% if @note.status == "open" %>
     <% if current_user -%>
-      <form class="note-comment-resolve" action="#">
+      <form class="mb-3" action="#">
         <div class="mb-3">
           <textarea class="form-control" name="text" cols="40" rows="5" maxlength="2000"></textarea>
         </div>
@@ -57,7 +57,7 @@
       </form>
     <% end -%>
   <% else %>
-    <form class="note-comment-resolve" action="#">
+    <form class="mb-3" action="#">
       <input type="hidden" name="text" value="" autocomplete="off">
       <div class="btn-wrapper">
         <% if current_user and current_user.moderator? -%>
@@ -71,6 +71,6 @@
   <% end %>
 
   <% if current_user && current_user != @note.author %>
-    <p class="text-muted"><%= t "javascripts.notes.show.report_link_html", :link => report_link(t(".report"), @note) %></p>
+    <p><small class="text-muted"><%= t "javascripts.notes.show.report_link_html", :link => report_link(t(".report"), @note) %></small></p>
   <% end %>
 </div>

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -28,10 +28,6 @@
     <p class='alert alert-warning'><%= t "javascripts.notes.show.anonymous_warning" %></p>
   <% end -%>
 
-  <% if current_user && current_user != @note.author %>
-    <p class="text-muted"><%= t "javascripts.notes.show.report_link_html", :link => report_link(t(".report"), @note) %></p>
-  <% end %>
-
   <% if @note_comments.length > 1 %>
     <div class='note-comments'>
       <ul class="list-unstyled">
@@ -47,7 +43,7 @@
 
   <% if @note.status == "open" %>
     <% if current_user -%>
-      <form action="#">
+      <form class="note-comment-resolve" action="#">
         <div class="mb-3">
           <textarea class="form-control" name="text" cols="40" rows="5" maxlength="2000"></textarea>
         </div>
@@ -61,7 +57,7 @@
       </form>
     <% end -%>
   <% else %>
-    <form action="#">
+    <form class="note-comment-resolve" action="#">
       <input type="hidden" name="text" value="" autocomplete="off">
       <div class="btn-wrapper">
         <% if current_user and current_user.moderator? -%>
@@ -72,5 +68,9 @@
         <% end -%>
       </div>
     </form>
+  <% end %>
+
+  <% if current_user && current_user != @note.author %>
+    <p class="text-muted"><%= t "javascripts.notes.show.report_link_html", :link => report_link(t(".report"), @note) %></p>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -421,7 +421,7 @@ en:
       reopened_by_html: "Reactivated by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
       reopened_by_anonymous_html: "Reactivated by anonymous <abbr title='%{exact_time}'>%{when}</abbr>"
       hidden_by_html: "Hidden by %{user} <abbr title='%{exact_time}'>%{when}</abbr>"
-      report: Report this note
+      report: report this note
       coordinates_html: "%{latitude}, %{longitude}"
     query:
       title: "Query Features"
@@ -2883,6 +2883,7 @@ en:
         reactivate: Reactivate
         comment_and_resolve: Comment & Resolve
         comment: Comment
+        report_link_html: "If this note contains sensitive information that needs to be removed, you can %{link}. For all other problems with the note, please resolve it yourself with a comment."
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
       ascend: "Ascend"


### PR DESCRIPTION
Add some wording wrapped around the 'Report this note' link to explain to users to resolve the note instead.

Also re-arrange to place this down at the bottom with less prominence than the comment/resolve form.

Tackling the issue reported by DWG, that too many note reports are coming to them, where the users could deal with it themselves: https://github.com/openstreetmap/openstreetmap-website/issues/3071

<img width="191" alt="notes-reporting-text2" src="https://user-images.githubusercontent.com/227525/176447305-e2ee697b-01c5-46a1-af86-4e2a46332a40.png">


