### PR TITLE
Add testing on Ubuntu 22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     name: Ubuntu ${{ matrix.ubuntu }}, Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ubuntu: [20.04]
-        ruby: [2.7, 3.0]
+        ubuntu: [20.04, 22.04]
+        ruby: [2.7, 3.0, 3.1]
     runs-on: ubuntu-${{ matrix.ubuntu }}
     env:
       RAILS_ENV: test


### PR DESCRIPTION
This is more painful that it ought to be for a number of annoying reasons...

Firstly https://github.com/ruby/setup-ruby currently only supports ruby 3.1 on 22.04 even though 22.04 actually ships with 3.0 as the system ruby - apparently 3.1 is the first version that builds with openssl 3 out of the box so I guess Ubuntu must have patched 3.0 for the system build.

Secondly the forced move to a snap for Firefox means that geckodriver has (currently at least) gone away ([discussion here](https://bugs.launchpad.net/ubuntu/+source/firefox/+bug/1968266)) so we need to switch to Chrome and hope we won't have the same problem there once they force a move to snap for that!

Finally because chrome in headless mode doesn't support browser preferences ([discussion here](https://bugs.chromium.org/p/chromedriver/issues/detail?id=1925)) we have to set the preferred language in the environment before starting it instead.