### PR TITLE
Consider the first author of all note comments to be the note author

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -82,12 +82,12 @@ class Note < ApplicationRecord
 
   # Return the author object, derived from the first comment
   def author
-    comments.first.author
+    all_comments.first.author
   end
 
   # Return the author IP address, derived from the first comment
   def author_ip
-    comments.first.author_ip
+    all_comments.first.author_ip
   end
 
   private

--- a/app/views/api/notes/_note.rss.builder
+++ b/app/views/api/notes/_note.rss.builder
@@ -13,7 +13,7 @@ xml.item do
   xml.guid api_note_url(note)
   xml.description render(:partial => "description", :object => note, :formats => [:html])
 
-  xml.dc :creator, note.author.display_name if note.author
+  xml.dc :creator, note.author.display_name if note.author && note.author.status != "deleted"
 
   xml.pubDate note.created_at.to_fs(:rfc822)
   xml.geo :lat, note.lat

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -64,6 +64,22 @@ class NoteTest < ActiveSupport::TestCase
     assert_equal IPAddr.new("192.168.1.1"), comment.note.author_ip
   end
 
+  def test_author_with_hidden_first_comment
+    user_author = create(:user)
+    user_commenter = create(:user)
+    note = create(:note)
+    create(:note_comment, :note => note, :author => user_author, :visible => false)
+    create(:note_comment, :note => note, :author => user_commenter)
+    assert_equal user_author, note.author
+  end
+
+  def test_author_ip_with_hidden_first_comment
+    note = create(:note)
+    create(:note_comment, :note => note, :author_ip => IPAddr.new("192.168.1.11"), :visible => false)
+    create(:note_comment, :note => note, :author_ip => IPAddr.new("192.168.1.12"))
+    assert_equal IPAddr.new("192.168.1.11"), note.author_ip
+  end
+
   # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05
   def test_lat_lon_format
     note = build(:note, :latitude => 0.00004 * GeoRecord::SCALE, :longitude => 0.00008 * GeoRecord::SCALE)


### PR DESCRIPTION
<s>This is one of the prerequisites for not crashing when showing a note with all comments hidden.</s> - not anymore for #3608, I removed access to `note.author` there