### PR TITLE
Show notes with no visible comments; show only first comment as note description

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -43,6 +43,7 @@ class NotesController < ApplicationController
       @note = Note.visible.find(params[:id])
       @note_comments = @note.comments
     end
+    @note_description_comments_count = !@note_comments.empty? && @note_comments[0] == @note.all_comments[0] ? 1 : 0
   rescue ActiveRecord::RecordNotFound
     render :template => "browse/not_found", :status => :not_found
   end

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -12,7 +12,7 @@
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">
     <ul class="list-unstyled">
-      <li><%= note_event("opened", @note.created_at, @note.author) %></li>
+      <li><%= note_event("opened", @note.created_at, @note.all_comments.first.author) %></li>
       <% if @note.status == "closed" %>
         <li><%= note_event(@note.status, @note.closed_at, @note.all_comments.last.author) %></li>
       <% end %>
@@ -80,7 +80,7 @@
     </form>
   <% end %>
 
-  <% if current_user && current_user != @note.author %>
+  <% if current_user && current_user != @note.all_comments.first.author %>
     <p>
       <small class="text-muted">
         <%= t ".report_link_html", :link => report_link(t(".report"), @note) %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -3,10 +3,12 @@
 <%= render "sidebar_header", :title => t(".#{@note.status}_title", :note_name => @note.id) %>
 
 <div>
-  <h4><%= t(".description") %></h4>
-  <div class="note-description">
-    <%= h(@note_comments.first.body.to_html) %>
-  </div>
+  <% if @note_comments.length > 1 %>
+    <h4><%= t(".description") %></h4>
+    <div class="note-description">
+      <%= h(@note_comments.first.body.to_html) %>
+    </div>
+  <% end %>
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">
     <ul class="list-unstyled">

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -3,7 +3,7 @@
 <%= render "sidebar_header", :title => t(".#{@note.status}_title", :note_name => @note.id) %>
 
 <div>
-  <% if @note_comments.length > 1 %>
+  <% if @note_description_comments_count > 0 %>
     <h4><%= t(".description") %></h4>
     <div class="note-description">
       <%= h(@note_comments.first.body.to_html) %>
@@ -30,10 +30,10 @@
     <p class='alert alert-warning'><%= t ".anonymous_warning" %></p>
   <% end -%>
 
-  <% if @note_comments.length > 1 %>
+  <% if @note_comments.length > @note_description_comments_count %>
     <div class='note-comments'>
       <ul class="list-unstyled">
-        <% @note_comments.drop(1).each do |comment| %>
+        <% @note_comments.drop(@note_description_comments_count).each do |comment| %>
           <li id="c<%= comment.id %>">
             <small class='text-muted'><%= note_event(comment.event, comment.created_at, comment.author) %></small>
             <%= comment.body.to_html %>

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -142,6 +142,23 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_select "div.note-comments ul li", :count => 1
   end
 
+  def test_read_note_hidden_first_comment
+    note_with_hidden_comment = create(:note_with_comments, :comments_count => 0) do |note|
+      create(:note_comment, :note => note, :body => "first", :visible => false)
+      create(:note_comment, :note => note, :body => "second")
+    end
+
+    browse_check :note_path, note_with_hidden_comment.id, "notes/show"
+    assert_select "div.note-description", :count => 0
+    assert_select "div.note-comments ul li", /second/, :count => 1
+
+    session_for(create(:moderator_user))
+
+    browse_check :note_path, note_with_hidden_comment.id, "notes/show"
+    assert_select "div.note-description", /first/
+    assert_select "div.note-comments ul li", /second/, :count => 1
+  end
+
   def test_read_note_hidden_user_comment
     hidden_user = create(:user, :deleted)
     note_with_hidden_user_comment = create(:note_with_comments, :comments_count => 2) do |note|

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -127,6 +127,21 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_select "div.note-comments ul li", :count => 2
   end
 
+  def test_read_note_hidden_all_comments
+    note_with_hidden_comment = create(:note_with_comments, :comments_count => 0) do |note|
+      create(:note_comment, :note => note, :visible => false)
+      create(:note_comment, :note => note, :visible => false)
+    end
+
+    browse_check :note_path, note_with_hidden_comment.id, "notes/show"
+    assert_select "div.note-comments", :count => 0
+
+    session_for(create(:moderator_user))
+
+    browse_check :note_path, note_with_hidden_comment.id, "notes/show"
+    assert_select "div.note-comments ul li", :count => 1
+  end
+
   def test_read_note_hidden_user_comment
     hidden_user = create(:user, :deleted)
     note_with_hidden_user_comment = create(:note_with_comments, :comments_count => 2) do |note|


### PR DESCRIPTION
* Note description is not shown if there are no visible comments or if the first visible comment is not the first actual comment. In the latter case the first visible comment is shown below "Created by", "Location" etc along with regular comments.
* Since reading `note.author` may cause a crash, don't read it, use `note.all_comments.first.author` instead. `note.all_comments.last.author` was already in use. If this user is deleted, the comment will be shown as "by deleted".

This should allow not to crash on notes without comments, fixing #2146 (and #2176 should not be required).

That's not a complete fix for notes without comments because some client-side js expects comments to be present.