### PR TITLE
Add xmlns:dc namespace to note show rss actions

### DIFF
--- a/app/views/api/notes/show.rss.builder
+++ b/app/views/api/notes/show.rss.builder
@@ -1,6 +1,7 @@
 xml.instruct!
 
 xml.rss("version" => "2.0",
+        "xmlns:dc" => "http://purl.org/dc/elements/1.1/",
         "xmlns:geo" => "http://www.w3.org/2003/01/geo/wgs84_pos#",
         "xmlns:georss" => "http://www.georss.org/georss") do
   xml.channel do


### PR DESCRIPTION
Was going to write tests for rss case in #3607 and I can't use `assert_select` to get `<dc:creator>` element without this namespace declared. `<dc:creator>` is where the user's name is revealed.