### PR TITLE
Fix Bootstrap 5 rounded authentication buttons

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -58,7 +58,7 @@ module UserHelper
 
   def auth_button(name, provider, options = {})
     link_to(
-      image_tag("#{name}.svg", :alt => t("sessions.new.auth_providers.#{name}.alt"), :class => "rounded-lg"),
+      image_tag("#{name}.svg", :alt => t("sessions.new.auth_providers.#{name}.alt"), :class => "rounded-3"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
       :class => "auth_button",


### PR DESCRIPTION
Changes unused `rounded-lg` to respective `rounded-3`.