### PR TITLE
Don't add title to note marker if note has no visible comments

### DIFF
--- a/app/assets/javascripts/index/layers/notes.js
+++ b/app/assets/javascripts/index/layers/notes.js
@@ -44,12 +44,15 @@ OSM.initializeNotesLayer = function (map) {
     if (marker) {
       marker.setIcon(noteIcons[feature.properties.status]);
     } else {
-      marker = L.marker(feature.geometry.coordinates.reverse(), {
+      var markerOptions = {
         icon: noteIcons[feature.properties.status],
-        title: feature.properties.comments[0].text,
         opacity: 0.8,
         interactive: true
-      });
+      };
+      if (feature.properties.comments.length > 0) {
+        markerOptions.title = feature.properties.comments[0].text;
+      }
+      marker = L.marker(feature.geometry.coordinates.reverse(), markerOptions);
       marker.id = feature.properties.id;
       marker.addTo(noteLayer);
     }

--- a/test/system/site_test.rb
+++ b/test/system/site_test.rb
@@ -93,4 +93,28 @@ class SiteTest < ApplicationSystemTestCase
     li.hover
     assert_selector ".tooltip", :text => "Zoom in"
   end
+
+  test "note marker should have first comment as a title" do
+    position = (1.1 * GeoRecord::SCALE).to_i
+    create(:note, :latitude => position, :longitude => position) do |note|
+      create(:note_comment, :note => note, :body => "Note description")
+    end
+
+    visit root_path(:anchor => "map=18/1.1/1.1&layers=N")
+    all "img.leaflet-marker-icon", :count => 1 do |marker|
+      assert_equal "Note description", marker["title"]
+    end
+  end
+
+  test "note marker should not have a title if the note has no visible comments" do
+    position = (1.1 * GeoRecord::SCALE).to_i
+    create(:note, :latitude => position, :longitude => position) do |note|
+      create(:note_comment, :note => note, :body => "Note description is hidden", :visible => false)
+    end
+
+    visit root_path(:anchor => "map=18/1.1/1.1&layers=N")
+    all "img.leaflet-marker-icon", :count => 1 do |marker|
+      assert_equal "", marker["title"]
+    end
+  end
 end


### PR DESCRIPTION
Fixes javascript errors when the note layer is enabled and there's a note without comments.