### PR TITLE
Various font size changes

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1498,19 +1498,10 @@ dl.dl-inline {
 
 /* Rules for the "Welcome" page */
 .site-welcome, .site-fixthemap {
-  .center {
-    text-align: center;
-    .sprite {
-      float: none;
-      margin: auto;
-    }
-  }
-
   .sprite {
     background-image: image-url("welcome-sprite.png");
     background-size: 500px 250px;
     display: block;
-    float: left;
   }
 
   .icon-list {
@@ -1558,15 +1549,6 @@ dl.dl-inline {
 
   .sprite.rules {
     /* no-r2 */ background-position: -350px 0;
-  }
-
-  .start-mapping {
-    margin: auto;
-    cursor: pointer;
-    border: none;
-    padding: 20px 40px;
-    font-size: 30px;
-    text-decoration: none;
   }
 
   .icon.note {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -359,14 +359,6 @@ body.compact-nav {
       width: 100%;
     }
 
-    h2 {
-      font-size: 1.5rem;
-    }
-
-    h3, h4 {
-      font-size: 1.25rem;
-    }
-
     .close-wrap {
       cursor: pointer;
       position: absolute;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1451,13 +1451,11 @@ dl.dl-inline {
 .richtext,
 .prose {
   code {
-    font-size: 13px;
     background: $lightgrey;
     padding: 2px 3px;
   }
 
   pre {
-    font-size: 13px;
     background: $lightgrey;
     padding: 2px 3px;
     white-space: pre-wrap;

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -8,14 +8,14 @@
     </div>
     <div class='row'>
       <div class="w-100 px-5 py-4 bg-dark">
-        <h1 class="text-white font-weight-light"><%= t ".used_by_html", :name => tag.span("OpenStreetMap", :class => "user-name"), :locale => @locale %></h1>
+        <h1 class="text-white fw-light"><%= t ".used_by_html", :name => tag.span("OpenStreetMap", :class => "user-name"), :locale => @locale %></h1>
       </div>
     </div>
   </div>
 
   <div class='bg-white px-5 py-4'>
     <div class='section'>
-      <p><strong><%= t ".lede_text", :locale => @locale %></strong></p>
+      <p class="lead"><%= t ".lede_text", :locale => @locale %></p>
       <h2><div class='icon local'></div><%= t ".local_knowledge_title", :locale => @locale %></h2>
       <p><%= t ".local_knowledge_html", :locale => @locale %></p>
     </div>

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -6,10 +6,10 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
-<h3><%= t "layouts.intro_header" %></h3>
-<p><%= t "layouts.intro_text" %></p>
+<h2><%= t "layouts.intro_header" %></h2>
+<p class="lead"><%= t "layouts.intro_text" %></p>
 
-<h3><%= t ".how_to_help.title" %></h3>
+<h2><%= t ".how_to_help.title" %></h2>
 
 <div class='container'>
   <div class='row'>
@@ -28,9 +28,9 @@
   </div>
 </div>
 
-<h3><%= t ".other_concerns.title" %></h3>
+<h2><%= t ".other_concerns.title" %></h2>
 <p><%= t ".other_concerns.explanation_html" %></p>
 
-<h3><%= t "site.welcome.questions.title" %></h3>
-<span class='sprite small term question'></span>
+<h2><%= t "site.welcome.questions.title" %></h2>
+<span class='sprite small term question float-start'></span>
 <p><%= t "site.welcome.questions.paragraph_1_html", :help_url => help_path %></p>

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -11,20 +11,18 @@
 
 <h2><%= t ".how_to_help.title" %></h2>
 
-<div class='container'>
-  <div class='row'>
-    <div class='col-sm'>
-      <h5><%= t ".how_to_help.join_the_community.title" %></h5>
-      <p><%= t ".how_to_help.join_the_community.explanation_html" %></p>
-      <p class='text-center'>
-        <a class="btn btn-primary" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
-      </p>
-    </div>
-    <div class='col-sm'>
-      <h5><%= t "site.welcome.add_a_note.title" %></h5>
-      <p><%= t "site.welcome.add_a_note.paragraph_1_html" %></p>
-      <p><%= t ".how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
-    </div>
+<div class='row'>
+  <div class='col-sm'>
+    <h5><%= t ".how_to_help.join_the_community.title" %></h5>
+    <p><%= t ".how_to_help.join_the_community.explanation_html" %></p>
+    <p class='text-center'>
+      <a class="btn btn-primary" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+    </p>
+  </div>
+  <div class='col-sm'>
+    <h5><%= t "site.welcome.add_a_note.title" %></h5>
+    <p><%= t "site.welcome.add_a_note.paragraph_1_html" %></p>
+    <p><%= t ".how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
   </div>
 </div>
 

--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -6,66 +6,66 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
-<p><%= t ".introduction_html" %></p>
+<p class="lead"><%= t ".introduction_html" %></p>
 
-<h3><%= t ".whats_on_the_map.title" %></h3>
+<h2><%= t ".whats_on_the_map.title" %></h2>
 
 <div class='row'>
   <div class='col'>
-    <div class='center'>
-      <span class='sprite small check'></span>
+    <div>
+      <span class='sprite small check mx-auto'></span>
     </div>
     <p><%= t ".whats_on_the_map.on_html" %></p>
   </div>
   <div class='col'>
     <div class='center'>
-      <span class='sprite small x'></span>
+      <span class='sprite small x mx-auto'></span>
     </div>
     <p><%= t ".whats_on_the_map.off_html" %></p>
   </div>
 </div>
 
-<h3><%= t ".basic_terms.title" %></h3>
+<h2><%= t ".basic_terms.title" %></h2>
 
 <p><%= t ".basic_terms.paragraph_1_html" %></p>
 
-<div class='clearfix icon-list'>
+<div class='clearfix'>
   <div class='clearfix'>
-    <span class='sprite small term editor'></span>
+    <span class='sprite small term editor float-start'></span>
     <p><%= t ".basic_terms.editor_html" %></p>
   </div>
   <div class='clearfix'>
-    <span class='sprite small term node'></span>
+    <span class='sprite small term node float-start'></span>
     <p><%= t ".basic_terms.node_html" %></p>
   </div>
   <div class='clearfix'>
-    <span class='sprite small term way'></span>
+    <span class='sprite small term way float-start'></span>
     <p><%= t ".basic_terms.way_html" %></p>
   </div>
   <div class='clearfix'>
-    <span class='sprite small term tag'></span>
+    <span class='sprite small term tag float-start'></span>
     <p><%= t ".basic_terms.tag_html" %></p>
   </div>
 </div>
 
-<div class='clearfix icon-list'>
-  <h3><%= t ".rules.title" %></h3>
-  <span class='sprite small term rules'></span>
+<div class='clearfix'>
+  <h2><%= t ".rules.title" %></h2>
+  <span class='sprite small term rules float-start'></span>
   <p><%= t ".rules.paragraph_1_html" %></p>
 </div>
 
-<div class='clearfix icon-list'>
-  <h3><%= t ".questions.title" %></h3>
-  <span class='sprite small term question'></span>
+<div class='clearfix'>
+  <h2><%= t ".questions.title" %></h2>
+  <span class='sprite small term question float-start'></span>
   <p><%= t ".questions.paragraph_1_html", :help_url => help_path %></p>
 </div>
 
-<div class='clearfix center'>
-  <p><a href="<%= edit_path %>" class="button start-mapping"><%= t ".start_mapping" %></a></p>
+<div class='clearfix text-center'>
+  <p class="display-5"><a href="<%= edit_path %>" class="button start-mapping"><%= t ".start_mapping" %></a></p>
 </div>
 
 <div class='alert alert-primary'>
-  <h3><%= t ".add_a_note.title" %></h3>
+  <h2><%= t ".add_a_note.title" %></h2>
   <p><%= t ".add_a_note.paragraph_1_html" %></p>
   <p><%= t ".add_a_note.paragraph_2_html", :map_url => root_path %></p>
 </div>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -58,8 +58,6 @@
   </tr>
 </table>
 
-<br /><br />
-
 <% if current_user && (current_user==@trace.user || current_user.administrator? || current_user.moderator?) %>
   <div>
     <% if current_user == @trace.user %>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -12,19 +12,19 @@
 
 <table class="table table-borderless table-sm">
   <tr>
-    <td><%= t ".filename" %></td>
+    <th><%= t ".filename" %></th>
     <td><%= @trace.name %> (<%= link_to t(".download"), trace_data_path(@trace) %>)</td>
   </tr>
   <tr>
-    <td><%= t ".uploaded" %></td>
+    <th><%= t ".uploaded" %></th>
     <td><%= l @trace.timestamp, :format => :friendly %></td>
   </tr>
   <% if @trace.inserted? %>
   <tr>
-    <td><%= t ".points" %></td>
+    <th><%= t ".points" %></th>
     <td><%= number_with_delimiter(@trace.size) %></td></tr>
   <tr>
-    <td><%= t ".start_coordinates" %></td>
+    <th><%= t ".start_coordinates" %></th>
     <td>
       <div class="d-inline">
         <%= t ".coordinates_html",
@@ -35,15 +35,15 @@
   </tr>
   <% end %>
   <tr>
-    <td><%= t ".owner" %></td>
+    <th><%= t ".owner" %></th>
     <td><%= link_to @trace.user.display_name, user_path(@trace.user) %></td>
   </tr>
   <tr>
-    <td><%= t ".description" %></td>
+    <th><%= t ".description" %></th>
     <td><%= @trace.description %></td>
   </tr>
   <tr>
-    <td><%= t ".tags" %></td>
+    <th><%= t ".tags" %></th>
     <td>
     <% unless @trace.tags.empty? %>
       <%= safe_join(@trace.tags.collect { |tag| link_to tag.tag, :controller => "traces", :action => "index", :tag => tag.tag, :id => nil }, ", ") %>
@@ -53,7 +53,7 @@
     </td>
   </tr>
   <tr>
-    <td><%= t ".visibility" %></td>
+    <th><%= t ".visibility" %></th>
     <td><%= t "traces.visibility.#{@trace.visibility}" %></td>
   </tr>
 </table>


### PR DESCRIPTION
Now that we're on Bootstrap 5 we are using RFS, which implements responsive font sizes. Therefore it's worth refactoring places where we have font-sizes declared in our common.scss, particularly for headers, because these custom definitions are not responsive.

I've also refactored the about, welcome and fixthemap pages slightly, to change the headers used, use the bootstrap '[lead](https://getbootstrap.com/docs/5.1/content/typography/#lead)' paragraph styling, and move some more CSS into bootstrap utils.