### PR TITLE
Fix statistics script to use absolute links

### DIFF
--- a/script/statistics
+++ b/script/statistics
@@ -36,7 +36,7 @@ begin
 
     Trace.where(:inserted => true).group(:user_id).order("sum_size DESC").limit(50).sum(:size).each do |user, count|
       display_name = User.find(user).display_name.gsub("@", " at ").gsub(".", " dot ")
-      puts "<tr><td><a href=\"/user/#{display_name}\">#{display_name}</a></td><td>#{count}</td></tr>"
+      puts "<tr><td><a href=\"https://www.openstreetmap.org/user/#{display_name}\">#{display_name}</a></td><td>#{count}</td></tr>"
     end
 
     puts "</table>"
@@ -75,7 +75,7 @@ begin
         else
           display_name = User.find(column[0]).display_name.gsub("@", " at ").gsub(".", " dot ")
           count = column[1]
-          puts "<td>#{count} <a href=\"/user/#{display_name}\">#{display_name}</a></td>"
+          puts "<td>#{count} <a href=\"https://www.openstreetmap.org/user/#{display_name}\">#{display_name}</a></td>"
         end
       end
       puts "</tr>"


### PR DESCRIPTION
Use absolute links instead of relative links which are incorrect since: https://github.com/openstreetmap/chef/commit/0eb2a2b70464e53cd52edcee3b2fa96ac8bc416b

Fixes: https://github.com/openstreetmap/openstreetmap-website/issues/3593