### PR TITLE
Add Link and text for the new community forum

### DIFF
--- a/app/views/site/help.html.erb
+++ b/app/views/site/help.html.erb
@@ -4,7 +4,7 @@
 
 <p class='introduction'><%= t ".introduction" %></p>
 
-<% sites = %w[beginners_guide help mailing_lists forums irc switch2osm welcomemat wiki] %>
+<% sites = %w[beginners_guide help mailing_lists forums community irc switch2osm welcomemat wiki] %>
 <% sites.prepend("welcome") if current_user %>
 
 <div class="row row-cols-sm-3 g-4 mb-3">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2125,8 +2125,12 @@ en:
         description: Ask a question or discuss interesting matters on a wide range of topical or regional mailing lists.
       forums:
         url: https://forum.openstreetmap.org/
-        title: Forums
+        title: Forums (Legacy)
         description: Questions and discussions for those that prefer a bulletin board style interface.
+      community:
+        url: https://community.openstreetmap.org/
+        title: Community forum
+        description: A shared place for conversations about OpenStreetMap.
       irc:
         url: https://irc.openstreetmap.org/
         title: IRC


### PR DESCRIPTION
Add link to the new [community forum](https://community.openstreetmap.org), replacing the link to the original "legacy" forum.

Intentionally replaced the translation keys to ensure replacement in the translated text.