### PR TITLE
Switch reverse_directions link to use a button

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1288,10 +1288,6 @@ tr.turn:hover {
       vertical-align: middle;
     }
   }
-
-  a.reverse_directions {
-    cursor: pointer;
-  }
 }
 
 /* Rules for user images */

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -47,7 +47,7 @@
     </div>
     <div class="row gx-2 m-1">
       <div class="col offset-1">
-        <a class="reverse_directions"><%= t("site.search.reverse_directions_text") %></a>
+        <button class="btn btn-sm btn-link reverse_directions"><%= t("site.search.reverse_directions_text") %></a>
       </div>
     </div>
 


### PR DESCRIPTION
This makes it keyboard selectable, and also preserves the event handler.

I had originally looked at using `tabindex="0"` to make the link itself selectable, but then the onclick event doesn't fire, so I went with using a button instead.

Refs #3637