### PR TITLE
Fix link after AND rebranded GeoJunxion

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1974,7 +1974,7 @@ en:
           Direction Générale des Impôts.
         contributors_nl_html: |
           <strong>Netherlands</strong>: Contains &copy; AND data, 2007
-          (<a href="https://www.and.com">www.and.com</a>)
+          (now <a href="https://www.geojunxion.com/">GeoJunxion</a>)
         contributors_nz_html: |
           <strong>New Zealand</strong>: Contains data sourced from the
           <a href="https://data.linz.govt.nz/">LINZ Data Service</a> and


### PR DESCRIPTION
It looks like AND went through a rebrand a couple of years ago. Now known as GeoJunxion