### PR TITLE
Remove the user menu focus overrides

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -201,16 +201,9 @@ nav.secondary {
       &:hover {
         border-color: $grey;
       }
-      &:focus {
-        background-color: white;
-        box-shadow: none;
-      }
     }
     &.show .btn-outline-secondary {
       background-color: white;
-      &:focus {
-        box-shadow: none;
-      }
     }
   }
 


### PR DESCRIPTION
This restores the outline effect when the user menu button is focussed (e.g. using keyboard navigation).

Refs #3633

Personally I think the outline is a bit ugly when the user menu is expanded, but I can understand the concerns about accessibility - and those outweigh my aesthetic preferences.