### PR TITLE
Correct name in graphhopper.js

### DIFF
--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -14,7 +14,7 @@ function GraphHopperEngine(id, vehicleType) {
 
   return {
     id: id,
-    creditline: "<a href=\"https://www.graphhopper.com/\" target=\"_blank\">Graphhopper</a>",
+    creditline: "<a href=\"https://www.graphhopper.com/\" target=\"_blank\">GraphHopper</a>",
     draggable: false,
 
     getRoute: function (points, callback) {


### PR DESCRIPTION
When using directions, the footer says "Directions courtesy of Graphhopper", it should instead say _GraphHopper_.