### PR TITLE
Position close buttons with flexbox

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,5 +1,6 @@
 //= require_self
 //= require leaflet.sidebar
+//= require leaflet.sidebar-pane
 //= require leaflet.locatecontrol/src/L.Control.Locate
 //= require leaflet.layers
 //= require leaflet.key

--- a/app/assets/javascripts/index/browse.js
+++ b/app/assets/javascripts/index/browse.js
@@ -48,21 +48,20 @@ OSM.initializeBrowse = function (map) {
 
   function displayFeatureWarning(count, limit, add, cancel) {
     $("#browse_status").html(
-      $("<div>")
-        .append(
-          $("<button type='button' class='btn-close float-end mt-1'>")
-            .click(cancel),
-          $("<h2>")
-            .text(I18n.t("browse.start_rjs.load_data"))
-            .prepend(),
-          $("<div>")
-            .append(
-              $("<p class='alert alert-warning clearfix'></p>")
-                .text(I18n.t("browse.start_rjs.feature_warning", { num_features: count, max_features: limit })))
-            .append(
-              $("<input type='submit' class='btn btn-primary'>")
-                .val(I18n.t("browse.start_rjs.load_data"))
-                .click(add))));
+      $("<div>").append(
+        $("<div class='d-flex'>").append(
+          $("<div class='flex-grow-1 text-break'>").append(
+            $("<h2>")
+              .text(I18n.t("browse.start_rjs.load_data"))),
+          $("<div>").append(
+            $("<button type='button' class='btn-close mt-1'>")
+              .click(cancel))),
+        $("<div>").append(
+          $("<p class='alert alert-warning'></p>")
+            .text(I18n.t("browse.start_rjs.feature_warning", { num_features: count, max_features: limit })),
+          $("<input type='submit' class='btn btn-primary'>")
+            .val(I18n.t("browse.start_rjs.load_data"))
+            .click(add))));
   }
 
   var dataLoader;

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -254,20 +254,31 @@ OSM.Directions = function (map) {
         map.fitBounds(polyline.getBounds().pad(0.05));
       }
 
-      var html = "<a class=\"geolink\" href=\"#\"><button type='button' class='btn-close float-end mt-1'></button></a>" +
-        "<h2>" + I18n.t("javascripts.directions.directions") + "</h2>" +
-        "<p>" +
+      var distanceText = $("<p>").append(
         I18n.t("javascripts.directions.distance") + ": " + formatDistance(route.distance) + ". " +
-        I18n.t("javascripts.directions.time") + ": " + formatTime(route.time) + ".";
+        I18n.t("javascripts.directions.time") + ": " + formatTime(route.time) + ".");
       if (typeof route.ascend !== "undefined" && typeof route.descend !== "undefined") {
-        html += "<br />" +
+        distanceText.append(
+          $("<br>"),
           I18n.t("javascripts.directions.ascend") + ": " + Math.round(route.ascend) + "m. " +
-          I18n.t("javascripts.directions.descend") + ": " + Math.round(route.descend) + "m.";
+          I18n.t("javascripts.directions.descend") + ": " + Math.round(route.descend) + "m.");
       }
-      html += "</p><table id=\"turnbyturn\" class=\"mb-3\"/>";
+
+      var turnByTurnTable = $("<table class='mb-3'>");
 
       $("#sidebar_content")
-        .html(html);
+        .empty()
+        .append(
+          $("<div class='d-flex'>").append(
+            $("<div class='flex-grow-1 text-break'>").append(
+              $("<h2>")
+                .text(I18n.t("javascripts.directions.directions"))),
+            $("<div>").append(
+              $("<a class='geolink' href='#'>").append(
+                $("<button type='button' class='btn-close mt-1'>")))),
+          distanceText,
+          turnByTurnTable
+        );
 
       // Add each row
       route.steps.forEach(function (step) {
@@ -309,7 +320,7 @@ OSM.Directions = function (map) {
           map.removeLayer(highlight);
         });
 
-        $("#turnbyturn").append(row);
+        turnByTurnTable.append(row);
       });
 
       $("#sidebar_content").append("<p class=\"text-center\">" +

--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -5,11 +5,7 @@ L.OSM.key = function (options) {
     var $container = $("<div>")
       .attr("class", "control-key");
 
-    var button = $("<a>")
-      .attr("class", "control-button")
-      .attr("href", "#")
-      .html("<span class=\"icon key\"></span>")
-      .on("click", toggle)
+    var button = this.makeButton("key", null, toggle)
       .appendTo($container);
 
     var $ui = this.makeUI("key-ui", "javascripts.key.title", toggle);

--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -1,5 +1,5 @@
 L.OSM.key = function (options) {
-  var control = L.control(options);
+  var control = L.OSM.sidebarPane(options);
 
   control.onAdd = function (map) {
     var $container = $("<div>")
@@ -12,19 +12,7 @@ L.OSM.key = function (options) {
       .on("click", toggle)
       .appendTo($container);
 
-    var $ui = $("<div>")
-      .attr("class", "key-ui");
-
-    $("<div>")
-      .attr("class", "sidebar_heading")
-      .appendTo($ui)
-      .append(
-        $("<button type='button' class='btn-close float-end mt-1'>")
-          .attr("aria-label", I18n.t("javascripts.close"))
-          .bind("click", toggle))
-      .append(
-        $("<h4>")
-          .text(I18n.t("javascripts.key.title")));
+    var $ui = this.makeUI("key-ui", "javascripts.key.title", toggle);
 
     var $section = $("<div>")
       .attr("class", "section")

--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -1,20 +1,10 @@
 L.OSM.key = function (options) {
-  var control = L.OSM.sidebarPane(options);
+  var control = L.OSM.sidebarPane(options, "key", null, "javascripts.key.title");
 
-  control.onAdd = function (map) {
-    var $container = $("<div>")
-      .attr("class", "control-key");
-
-    var button = this.makeButton("key", null, toggle)
-      .appendTo($container);
-
-    var $ui = this.makeUI("key-ui", "javascripts.key.title", toggle);
-
+  control.onAddPane = function (map, button, $ui) {
     var $section = $("<div>")
       .attr("class", "section")
       .appendTo($ui);
-
-    options.sidebar.addPane($ui);
 
     $ui
       .on("show", shown)
@@ -31,15 +21,6 @@ L.OSM.key = function (options) {
 
     function hidden() {
       map.off("zoomend baselayerchange", update);
-    }
-
-    function toggle(e) {
-      e.stopPropagation();
-      e.preventDefault();
-      if (!button.hasClass("disabled")) {
-        options.sidebar.togglePane($ui, button);
-      }
-      $(".leaflet-control .control-button").tooltip("hide");
     }
 
     function updateButton() {
@@ -65,8 +46,6 @@ L.OSM.key = function (options) {
         }
       });
     }
-
-    return $container[0];
   };
 
   return control;

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -1,16 +1,8 @@
 L.OSM.layers = function (options) {
-  var control = L.OSM.sidebarPane(options);
+  var control = L.OSM.sidebarPane(options, "layers", "javascripts.map.layers.title", "javascripts.map.layers.header");
 
-  control.onAdd = function (map) {
+  control.onAddPane = function (map, button, $ui, toggle) {
     var layers = options.layers;
-
-    var $container = $("<div>")
-      .attr("class", "control-layers");
-
-    var button = this.makeButton("layers", "javascripts.map.layers.title", toggle)
-      .appendTo($container);
-
-    var $ui = this.makeUI("layers-ui", "javascripts.map.layers.header", toggle);
 
     var baseSection = $("<div>")
       .attr("class", "section base-layers")
@@ -162,17 +154,6 @@ L.OSM.layers = function (options) {
       addOverlay(map.dataLayer, "data", OSM.MAX_REQUEST_AREA);
       addOverlay(map.gpsLayer, "gps", Number.POSITIVE_INFINITY);
     }
-
-    options.sidebar.addPane($ui);
-
-    function toggle(e) {
-      e.stopPropagation();
-      e.preventDefault();
-      options.sidebar.togglePane($ui, button);
-      $(".leaflet-control .control-button").tooltip("hide");
-    }
-
-    return $container[0];
   };
 
   return control;

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -7,12 +7,7 @@ L.OSM.layers = function (options) {
     var $container = $("<div>")
       .attr("class", "control-layers");
 
-    var button = $("<a>")
-      .attr("class", "control-button")
-      .attr("href", "#")
-      .attr("title", I18n.t("javascripts.map.layers.title"))
-      .html("<span class=\"icon layers\"></span>")
-      .on("click", toggle)
+    var button = this.makeButton("layers", "javascripts.map.layers.title", toggle)
       .appendTo($container);
 
     var $ui = this.makeUI("layers-ui", "javascripts.map.layers.header", toggle);

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -1,5 +1,5 @@
 L.OSM.layers = function (options) {
-  var control = L.control(options);
+  var control = L.OSM.sidebarPane(options);
 
   control.onAdd = function (map) {
     var layers = options.layers;
@@ -15,19 +15,7 @@ L.OSM.layers = function (options) {
       .on("click", toggle)
       .appendTo($container);
 
-    var $ui = $("<div>")
-      .attr("class", "layers-ui");
-
-    $("<div>")
-      .attr("class", "sidebar_heading")
-      .appendTo($ui)
-      .append(
-        $("<button type='button' class='btn-close float-end mt-1'>")
-          .attr("aria-label", I18n.t("javascripts.close"))
-          .bind("click", toggle))
-      .append(
-        $("<h4>")
-          .text(I18n.t("javascripts.map.layers.header")));
+    var $ui = this.makeUI("layers-ui", "javascripts.map.layers.header", toggle);
 
     var baseSection = $("<div>")
       .attr("class", "section base-layers")

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -10,12 +10,7 @@ L.OSM.share = function (options) {
     var $container = $("<div>")
       .attr("class", "control-share");
 
-    var button = $("<a>")
-      .attr("class", "control-button")
-      .attr("href", "#")
-      .attr("title", I18n.t("javascripts.share.title"))
-      .html("<span class=\"icon share\"></span>")
-      .on("click", toggle)
+    var button = this.makeButton("share", "javascripts.share.title", toggle)
       .appendTo($container);
 
     var $ui = this.makeUI("share-ui", "javascripts.share.title", toggle);

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -1,5 +1,5 @@
 L.OSM.share = function (options) {
-  var control = L.control(options),
+  var control = L.OSM.sidebarPane(options),
       marker = L.marker([0, 0], { draggable: true }),
       locationFilter = new L.LocationFilter({
         enableButton: false,
@@ -18,19 +18,7 @@ L.OSM.share = function (options) {
       .on("click", toggle)
       .appendTo($container);
 
-    var $ui = $("<div>")
-      .attr("class", "share-ui");
-
-    $("<div>")
-      .attr("class", "sidebar_heading")
-      .appendTo($ui)
-      .append(
-        $("<button type='button' class='btn-close float-end mt-1'>")
-          .attr("aria-label", I18n.t("javascripts.close"))
-          .bind("click", toggle))
-      .append(
-        $("<h4>")
-          .text(I18n.t("javascripts.share.title")));
+    var $ui = this.makeUI("share-ui", "javascripts.share.title", toggle);
 
     // Link / Embed
 

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -1,20 +1,12 @@
 L.OSM.share = function (options) {
-  var control = L.OSM.sidebarPane(options),
+  var control = L.OSM.sidebarPane(options, "share", "javascripts.share.title", "javascripts.share.title"),
       marker = L.marker([0, 0], { draggable: true }),
       locationFilter = new L.LocationFilter({
         enableButton: false,
         adjustButton: false
       });
 
-  control.onAdd = function (map) {
-    var $container = $("<div>")
-      .attr("class", "control-share");
-
-    var button = this.makeButton("share", "javascripts.share.title", toggle)
-      .appendTo($container);
-
-    var $ui = this.makeUI("share-ui", "javascripts.share.title", toggle);
-
+  control.onAddPane = function (map, button, $ui) {
     // Link / Embed
 
     var $linkSection = $("<div>")
@@ -228,28 +220,20 @@ L.OSM.share = function (options) {
     map.on("move", movedMap);
     map.on("moveend layeradd layerremove", update);
 
-    options.sidebar.addPane($ui);
-
     $ui
+      .on("show", shown)
       .on("hide", hidden);
+
+    function shown() {
+      $("#mapnik_scale").val(getScale());
+      update();
+    }
 
     function hidden() {
       map.removeLayer(marker);
       map.options.scrollWheelZoom = map.options.doubleClickZoom = true;
       locationFilter.disable();
       update();
-    }
-
-    function toggle(e) {
-      e.stopPropagation();
-      e.preventDefault();
-
-      $("#mapnik_scale").val(getScale());
-      marker.setLatLng(map.getCenter());
-
-      update();
-      options.sidebar.togglePane($ui, button);
-      $(".leaflet-control .control-button").tooltip("hide");
     }
 
     function toggleMarker() {
@@ -396,8 +380,6 @@ L.OSM.share = function (options) {
       var precision = 5 * Math.pow(10, Math.floor(Math.LOG10E * Math.log(scale)) - 2);
       return precision * Math.ceil(scale / precision);
     }
-
-    return $container[0];
   };
 
   return control;

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -20,16 +20,15 @@ L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
     var $ui = $("<div>")
       .attr("class", uiClass + "-ui");
 
-    $("<div>")
-      .attr("class", "sidebar_heading")
+    $("<div class='sidebar_heading d-flex'>")
       .appendTo($ui)
-      .append(
-        $("<button type='button' class='btn-close float-end mt-1'>")
+      .append($("<div class='flex-grow-1 text-break'>")
+        .append($("<h4>")
+          .text(I18n.t(paneTitle))))
+      .append($("<div>")
+        .append($("<button type='button' class='btn-close mt-1'>")
           .attr("aria-label", I18n.t("javascripts.close"))
-          .bind("click", toggle))
-      .append(
-        $("<h4>")
-          .text(I18n.t(paneTitle)));
+          .bind("click", toggle)));
 
     options.sidebar.addPane($ui);
 

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -1,6 +1,20 @@
 L.OSM.sidebarPane = function (options) {
   var control = L.control(options);
 
+  control.makeButton = function (buttonClass, buttonTitle, toggle) {
+    var button =  $("<a>")
+      .attr("class", "control-button")
+      .attr("href", "#")
+      .html("<span class=\"icon " + buttonClass + "\"></span>")
+      .on("click", toggle);
+    
+    if (buttonTitle) {
+      button.attr("title", I18n.t(buttonTitle))
+    }
+
+    return button;
+  };
+
   control.makeUI = function (uiClass, paneTitle, toggle) {
     var $ui = $("<div>")
       .attr("class", uiClass);

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -1,16 +1,16 @@
 L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
   var control = L.control(options);
-  
+
   control.onAdd = function (map) {
     var $container = $("<div>")
       .attr("class", "control-" + uiClass);
 
-    var button =  $("<a>")
+    var button = $("<a>")
       .attr("class", "control-button")
       .attr("href", "#")
       .html("<span class=\"icon " + uiClass + "\"></span>")
       .on("click", toggle);
-    
+
     if (buttonTitle) {
       button.attr("title", I18n.t(buttonTitle));
     }
@@ -44,7 +44,7 @@ L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
     }
 
     return $container[0];
-  }
+  };
 
   // control.onAddPane = function (map, button, $ui, toggle) {
   // }

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -1,0 +1,23 @@
+L.OSM.sidebarPane = function (options) {
+  var control = L.control(options);
+
+  control.makeUI = function (uiClass, paneTitle, toggle) {
+    var $ui = $("<div>")
+      .attr("class", uiClass);
+
+    $("<div>")
+      .attr("class", "sidebar_heading")
+      .appendTo($ui)
+      .append(
+        $("<button type='button' class='btn-close float-end mt-1'>")
+          .attr("aria-label", I18n.t("javascripts.close"))
+          .bind("click", toggle))
+      .append(
+        $("<h4>")
+          .text(I18n.t(paneTitle)));
+
+    return $ui;
+  };
+
+  return control;
+};

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -1,23 +1,24 @@
-L.OSM.sidebarPane = function (options) {
+L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
   var control = L.control(options);
+  
+  control.onAdd = function (map) {
+    var $container = $("<div>")
+      .attr("class", "control-" + uiClass);
 
-  control.makeButton = function (buttonClass, buttonTitle, toggle) {
     var button =  $("<a>")
       .attr("class", "control-button")
       .attr("href", "#")
-      .html("<span class=\"icon " + buttonClass + "\"></span>")
+      .html("<span class=\"icon " + uiClass + "\"></span>")
       .on("click", toggle);
     
     if (buttonTitle) {
-      button.attr("title", I18n.t(buttonTitle))
+      button.attr("title", I18n.t(buttonTitle));
     }
 
-    return button;
-  };
+    button.appendTo($container);
 
-  control.makeUI = function (uiClass, paneTitle, toggle) {
     var $ui = $("<div>")
-      .attr("class", uiClass);
+      .attr("class", uiClass + "-ui");
 
     $("<div>")
       .attr("class", "sidebar_heading")
@@ -30,8 +31,24 @@ L.OSM.sidebarPane = function (options) {
         $("<h4>")
           .text(I18n.t(paneTitle)));
 
-    return $ui;
-  };
+    options.sidebar.addPane($ui);
+
+    this.onAddPane(map, button, $ui, toggle);
+
+    function toggle(e) {
+      e.stopPropagation();
+      e.preventDefault();
+      if (!button.hasClass("disabled")) {
+        options.sidebar.togglePane($ui, button);
+      }
+      $(".leaflet-control .control-button").tooltip("hide");
+    }
+
+    return $container[0];
+  }
+
+  // control.onAddPane = function (map, button, $ui, toggle) {
+  // }
 
   return control;
 };

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div>
     <a class="geolink" href="<%= root_path %>">
-      <button type="button" class="btn-close float-end mt-1"></button>
+      <button type="button" class="btn-close mt-1"></button>
     </a>
   </div>
 </div>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -19,7 +19,7 @@
   </form>
 
   <form method="GET" action="<%= directions_path %>" class="directions_form pb-3">
-    <div class="clearfix px-3 py-3"><button type="button" class="btn-close float-end"></button></div>
+    <div class="d-flex flex-row-reverse px-3 py-3"><button type="button" class="btn-close"></button></div>
 
     <div class="row gx-2 m-1">
       <div class="col-1">


### PR DESCRIPTION
Implemented this:

> https://github.com/openstreetmap/openstreetmap-website/pull/3631#issuecomment-1203797930
> Many of the close buttons https://github.com/openstreetmap/openstreetmap-website/pull/2901 recently to use flexbox for layout, rather than floating, but there's still some (as found in this PR) where the icons are floating around. These could be refactored to follow the convention used in the sidebar.

Also refactored common code in Leaflet sidebars that wrote close buttons among other things.