### PR TITLE
Remove geolink and close button nesting

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -265,6 +265,7 @@ OSM.Directions = function (map) {
       }
 
       var turnByTurnTable = $("<table class='mb-3'>");
+      var directionsCloseButton = $("<button type='button' class='btn-close mt-1'>");
 
       $("#sidebar_content")
         .empty()
@@ -273,9 +274,7 @@ OSM.Directions = function (map) {
             $("<div class='flex-grow-1 text-break'>").append(
               $("<h2>")
                 .text(I18n.t("javascripts.directions.directions"))),
-            $("<div>").append(
-              $("<a class='geolink' href='#'>").append(
-                $("<button type='button' class='btn-close mt-1'>")))),
+            $("<div>").append(directionsCloseButton)),
           distanceText,
           turnByTurnTable
         );
@@ -327,8 +326,7 @@ OSM.Directions = function (map) {
         I18n.t("javascripts.directions.instructions.courtesy", { link: chosenEngine.creditline }) +
         "</p>");
 
-      $("#sidebar_content a.geolink").on("click", function (e) {
-        e.preventDefault();
+      directionsCloseButton.on("click", function () {
         map.removeLayer(polyline);
         $("#sidebar_content").html("");
         map.setSidebarOverlaid(true);

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -3,8 +3,6 @@
     <h2><%= title %></h2>
   </div>
   <div>
-    <a class="geolink" href="<%= root_path %>">
-      <button type="button" class="btn-close mt-1"></button>
-    </a>
+    <a class="geolink d-block btn-close mt-1" href="<%= root_path %>"></a>
   </div>
 </div>


### PR DESCRIPTION
Fixes buttons within geolinks issue: https://github.com/openstreetmap/openstreetmap-website/pull/3631#issuecomment-1203797930

For the directions sidebar I removed the geolink because its close button had its own click handler that prevented default actions.