### PR TITLE
Use Bootstrap toggle buttons for layers menu

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -15,13 +15,13 @@ L.OSM.layers = function (options) {
         .prop("checked", map.hasLayer(layer))
         .appendTo(baseSection);
 
-      var mapContainer = $("<div>");
+      var mapContainer = $("<div class='position-absolute'>");
 
-      var item = $("<div class='btn btn-outline-primary border-0'>").append(
+      var item = $("<div class='btn btn-outline-primary border-0 position-relative text-start'>").append(
         mapContainer,
-        $("<label>")
+        $("<label class='position-absolute overflow-hidden'>")
           .prop("for", id)
-          .append($("<span>").append(layer.options.name)))
+          .append($("<span class='position-absolute top-0 start-0'>").append(layer.options.name)))
         .appendTo(baseSection);
 
       map.whenReady(function () {

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -21,7 +21,7 @@ L.OSM.layers = function (options) {
         mapContainer,
         $("<label class='position-absolute top-0 start-0 bottom-0 end-0 m-1 overflow-hidden'>")
           .prop("for", id)
-          .append($("<span class='position-absolute top-0 start-0'>").append(layer.options.name)))
+          .append($("<span class='position-absolute top-0 start-0 ps-2 pe-1 pt-1 m-n1 rounded-1 bg-white' style='--bs-bg-opacity:.9'>").append(layer.options.name)))
         .appendTo(baseSection);
 
       map.whenReady(function () {

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -15,11 +15,11 @@ L.OSM.layers = function (options) {
         .prop("checked", map.hasLayer(layer))
         .appendTo(baseSection);
 
-      var mapContainer = $("<div class='position-absolute'>");
+      var mapContainer = $("<div class='position-absolute top-0 start-0 bottom-0 end-0 m-1'>");
 
-      var item = $("<div class='btn btn-outline-primary border-0 position-relative text-start'>").append(
+      var item = $("<div class='btn btn-outline-primary mx-n1 border-0 position-relative text-start'>").append(
         mapContainer,
-        $("<label class='position-absolute overflow-hidden'>")
+        $("<label class='position-absolute top-0 start-0 bottom-0 end-0 m-1 overflow-hidden'>")
           .prop("for", id)
           .append($("<span class='position-absolute top-0 start-0'>").append(layer.options.name)))
         .appendTo(baseSection);

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -5,26 +5,27 @@ L.OSM.layers = function (options) {
     var layers = options.layers;
 
     var baseSection = $("<div>")
-      .attr("class", "section base-layers")
+      .attr("class", "section base-layers d-grid gap-2")
       .appendTo($ui);
 
-    var baseLayers = $("<ul class='list-unstyled mb-0'>")
-      .appendTo(baseSection);
+    layers.forEach(function (layer, i) {
+      var id = "map-ui-layer-" + i;
+      var input = $("<input type='radio' class='btn-check' name='layer'>")
+        .prop("id", id)
+        .prop("checked", map.hasLayer(layer))
+        .appendTo(baseSection);
 
-    layers.forEach(function (layer) {
-      var item = $("<li>")
-        .attr("class", "rounded-3")
-        .appendTo(baseLayers);
+      var mapContainer = $("<div>");
 
-      if (map.hasLayer(layer)) {
-        item.addClass("active");
-      }
-
-      var div = $("<div>")
-        .appendTo(item);
+      var item = $("<div class='btn btn-outline-primary border-0'>").append(
+        mapContainer,
+        $("<label>")
+          .prop("for", id)
+          .append($("<span>").append(layer.options.name)))
+        .appendTo(baseSection);
 
       map.whenReady(function () {
-        var miniMap = L.map(div[0], { attributionControl: false, zoomControl: false, keyboard: false })
+        var miniMap = L.map(mapContainer[0], { attributionControl: false, zoomControl: false, keyboard: false })
           .addLayer(new layer.constructor({ apikey: layer.options.apikey }));
 
         miniMap.dragging.disable();
@@ -55,17 +56,7 @@ L.OSM.layers = function (options) {
         }
       });
 
-      var label = $("<label>")
-        .appendTo(item);
-
-      var input = $("<input>")
-        .attr("type", "radio")
-        .prop("checked", map.hasLayer(layer))
-        .appendTo(label);
-
-      label.append(layer.options.name);
-
-      item.on("click", function () {
+      input.on("click", function () {
         layers.forEach(function (other) {
           if (other === layer) {
             map.addLayer(other);
@@ -79,7 +70,6 @@ L.OSM.layers = function (options) {
       item.on("dblclick", toggle);
 
       map.on("layeradd layerremove", function () {
-        item.toggleClass("active", map.hasLayer(layer));
         input.prop("checked", map.hasLayer(layer));
       });
     });

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -15,11 +15,11 @@ L.OSM.layers = function (options) {
         .prop("checked", map.hasLayer(layer))
         .appendTo(baseSection);
 
-      var mapContainer = $("<div class='position-absolute top-0 start-0 bottom-0 end-0 m-1'>");
+      var mapContainer = $("<div class='position-absolute top-0 start-0 bottom-0 end-0 m-1 rounded-2'>");
 
       var item = $("<div class='btn btn-outline-primary mx-n1 border-0 position-relative text-start'>").append(
         mapContainer,
-        $("<label class='position-absolute top-0 start-0 bottom-0 end-0 m-1 overflow-hidden'>")
+        $("<label class='position-absolute top-0 start-0 bottom-0 end-0 m-1 rounded-2 overflow-hidden'>")
           .prop("for", id)
           .append($("<span class='position-absolute top-0 start-0 ps-2 pe-1 pt-1 m-n1 rounded-1 bg-white' style='--bs-bg-opacity:.9'>").append(layer.options.name)))
         .appendTo(baseSection);

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -524,41 +524,33 @@ body.small-nav {
 
 .layers-ui {
   .base-layers {
-    .leaflet-container {
-      width: 100%;
-      height: 50px;
-      cursor: pointer;
-    }
-
-    li  {
-      overflow: hidden;
-      border-radius: 3px;
-      border: 2px solid #fff;
-      margin-bottom: 8px;
+    .btn {
       position: relative;
-      transition: border-color 0.08s ease-in;
+      height: 54px;
+      text-align: left;
+
+      .leaflet-container {
+        position: absolute;
+        inset: 2px;
+      }
 
       label {
         position: absolute;
-        top: 0;
-        left: 0;
-        padding: 2px 6px;
-        border-bottom-right-radius: 3px;
+        inset: 2px;
+        overflow: hidden;
         cursor: pointer;
-        font-weight: 600;
-        font-size: 16px;
-        text-stroke: 2px #fff;
-        background: rgba(255,255,255,.9);
         z-index: 1000;
-        input[type="radio"] {
-          display: none;
-        }
-      }
 
-      &.active { border-color: darken($green, 10%); }
-      &:hover {
-        border-color: $grey;
-        &.active { border-color: darken($green, 20%); }
+        span {
+          position: absolute;
+          top: 0;
+          left: 0;
+          padding: 2px 6px;
+          border-bottom-right-radius: 3px;
+          font-weight: 600;
+          font-size: 16px;
+          background: rgba(255,255,255,.9);
+        }
       }
     }
   }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -525,26 +525,18 @@ body.small-nav {
 .layers-ui {
   .base-layers {
     .btn {
-      position: relative;
       height: 54px;
-      text-align: left;
 
       .leaflet-container {
-        position: absolute;
         inset: 2px;
       }
 
       label {
-        position: absolute;
         inset: 2px;
-        overflow: hidden;
         cursor: pointer;
         z-index: 1000;
 
         span {
-          position: absolute;
-          top: 0;
-          left: 0;
           padding: 2px 6px;
           border-bottom-right-radius: 3px;
           font-weight: 600;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -525,14 +525,9 @@ body.small-nav {
 .layers-ui {
   .base-layers {
     .btn {
-      height: 54px;
-
-      .leaflet-container {
-        inset: 2px;
-      }
+      height: 58px;
 
       label {
-        inset: 2px;
         cursor: pointer;
         z-index: 1000;
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -525,19 +525,12 @@ body.small-nav {
 .layers-ui {
   .base-layers {
     .btn {
-      height: 58px;
+      height: 56px;
 
       label {
         cursor: pointer;
         z-index: 1000;
-
-        span {
-          padding: 2px 6px;
-          border-bottom-right-radius: 3px;
-          font-weight: 600;
-          font-size: 16px;
-          background: rgba(255,255,255,.9);
-        }
+        font-weight: 600;
       }
     }
   }


### PR DESCRIPTION
Enables keyboard controls for base layers section of layers sidebar.

What I didn't bother doing is making colors exactly the same as before. There was a green border on active button but every other control in the sidebar had blue active color which is also the default for bootstrap's primary buttons. So I kept the default color.

Updated version:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/ce4e95e1-5603-4599-a7ae-40283735d8ab)

The update was done to eliminate pixel values from css at the expense of having wider borders.

Version using only the first two commits:
![VirtualBox_ubuntu1_01_09_2022_18_16_56](https://user-images.githubusercontent.com/4158490/187950708-902c0238-3517-40fa-8965-775c84d19566.png)
