### PR TITLE
Stretch changeset links in history lists

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -10,18 +10,6 @@ OSM.History = function (map) {
     })
     .on("mouseout", "[data-changeset]", function () {
       unHighlightChangeset($(this).data("changeset").id);
-    })
-    .on("mousedown", "[data-changeset]", function () {
-      var moved = false;
-      $(this)
-        .one("click", function (e) {
-          if (!moved && !$(e.target).is("a")) {
-            clickChangeset($(this).data("changeset").id, e);
-          }
-        })
-        .one("mousemove", function () {
-          moved = true;
-        });
     });
 
   var group = L.featureGroup()

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -742,10 +742,13 @@ tr.turn:hover {
 
 #sidebar .changesets {
   li {
-    cursor: pointer;
-
     &.selected { background: $list-highlight; }
     /* color is derived from changeset bbox fillColor in history.js */
+
+    a:not(.stretched-link), [title] {
+      position: relative;
+      z-index: 1;
+    }
   }
 
   .comments {

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -12,7 +12,7 @@
 
 <%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item" do %>
   <p class="fst-italic">
-    <a class="changeset_id text-dark" href="<%= changeset_path(changeset) %>">
+    <a class="changeset_id text-dark stretched-link" href="<%= changeset_path(changeset) %>">
       <%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %>
     </a>
   </p>


### PR DESCRIPTION
Use Bootstrap's stretched link instead of simulating clicking a normal link on [history](https://www.openstreetmap.org/history) pages.

Fixes https://github.com/openstreetmap/openstreetmap-website/issues/1020