### PR TITLE
Display how long until a note will disappear

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -351,9 +351,9 @@ module Api
     # on their status and the user's request parameters
     def closed_condition(notes)
       closed_since = if params[:closed]
-                       params[:closed].to_i
+                       params[:closed].to_i.days
                      else
-                       7
+                       Note::DEFAULT_FRESHLY_CLOSED_LIMIT
                      end
 
       if closed_since.negative?
@@ -361,7 +361,7 @@ module Api
       elsif closed_since.positive?
         notes.where(:status => "open")
              .or(notes.where(:status => "closed")
-                      .where(notes.arel_table[:closed_at].gt(Time.now.utc - closed_since.days)))
+                      .where(notes.arel_table[:closed_at].gt(Time.now.utc - closed_since)))
       else
         notes.where(:status => "open")
       end

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -23,4 +23,9 @@ module NoteHelper
       link_to h(author.display_name), link_options.merge(:controller => "/users", :action => "show", :display_name => author.display_name)
     end
   end
+
+  def disappear_in(note)
+    date = note.freshly_closed_until
+    tag.span(distance_of_time_in_words(date, Time.now.utc), :title => l(date, :format => :friendly))
+  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -66,6 +66,18 @@ class Note < ApplicationRecord
     !closed_at.nil?
   end
 
+  def freshly_closed?
+    return false unless closed?
+
+    Time.now.utc < freshly_closed_until
+  end
+
+  def freshly_closed_until
+    return nil unless closed?
+
+    closed_at + 7.days
+  end
+
   # Return the author object, derived from the first comment
   def author
     comments.first.author

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -37,6 +37,8 @@ class Note < ApplicationRecord
 
   after_initialize :set_defaults
 
+  DEFAULT_FRESHLY_CLOSED_LIMIT = 7.days
+
   # Sanity check the latitude and longitude and add an error if it's broken
   def validate_position
     errors.add(:base, "Note is not in the world") unless in_world?
@@ -75,7 +77,7 @@ class Note < ApplicationRecord
   def freshly_closed_until
     return nil unless closed?
 
-    closed_at + 7.days
+    closed_at + DEFAULT_FRESHLY_CLOSED_LIMIT
   end
 
   # Return the author object, derived from the first comment

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -71,6 +71,21 @@
   <% end %>
 
   <% if current_user && current_user != @note.author %>
-    <p><small class="text-muted"><%= t "javascripts.notes.show.report_link_html", :link => report_link(t(".report"), @note) %></small></p>
+    <p>
+      <small class="text-muted">
+        <%= t "javascripts.notes.show.report_link_html", :link => report_link(t(".report"), @note) %>
+        <% if @note.status == "open" %>
+          <%= t "javascripts.notes.show.other_problems_resolve", :link => report_link(t(".report"), @note) %>
+        <% elsif @note.status == "closed" %>
+          <%= t "javascripts.notes.show.other_problems_resolved" %>
+        <% end %>
+      </small>
+    </p>
+  <% end %>
+
+  <% if @note.freshly_closed? %>
+    <small class="text-muted">
+      <%= t "javascripts.notes.show.disappear_date_html", :disappear_in => disappear_in(@note) %>
+    </small>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2888,7 +2888,10 @@ en:
         reactivate: Reactivate
         comment_and_resolve: Comment & Resolve
         comment: Comment
-        report_link_html: "If this note contains sensitive information that needs to be removed, you can %{link}. For all other problems with the note, please resolve it yourself with a comment."
+        report_link_html: "If this note contains sensitive information that needs to be removed, you can %{link}."
+        other_problems_resolve: "For all other problems with the note, please resolve it yourself with a comment."
+        other_problems_resolved: "For all other problems, resolving is sufficient."
+        disappear_date_html: "This resolved note will disappear from the map in %{disappear_in}."
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
       ascend: "Ascend"

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -21,4 +21,13 @@ class NoteHelperTest < ActionView::TestCase
     assert_equal "<a href=\"/user/#{ERB::Util.u(user.display_name)}\">#{user.display_name}</a>", note_author(user)
     assert_equal "<a href=\"http://test.host/user/#{ERB::Util.u(user.display_name)}\">#{user.display_name}</a>", note_author(user, :only_path => false)
   end
+
+  def test_disappear_in
+    note_closed_date = Time.new(2022, 1, 1, 12, 0, 0, "+00:00")
+    note = create(:note, :closed_at => note_closed_date)
+
+    travel_to note_closed_date + 1.day do
+      assert_match %r{^<span title=" 8 January 2022 at 12:00">6 days</span>$}, disappear_in(note)
+    end
+  end
 end


### PR DESCRIPTION
Modify the message displayed at the bottom of the notes sidepanel. For already resolved notes we don't want to say "please resolve it". Fixes https://github.com/openstreetmap/openstreetmap-website/issues/3663  .

Instead explain that it will disappear from the map (so reporting is probably not necessary) and display how long to go until that happens. Tackling https://github.com/openstreetmap/openstreetmap-website/issues/3071

_"For all other problems, resolving is sufficient. This resolved note will disappear from the map in X days"_
