### PR TITLE
Text selection improvement for stretched links on history pages.

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -745,6 +745,11 @@ tr.turn:hover {
     &.selected { background: $list-highlight; }
     /* color is derived from changeset bbox fillColor in history.js */
 
+    a.stretched-link > span {
+      position: relative;
+      z-index: 2;
+    }
+
     a:not(.stretched-link), [title] {
       position: relative;
       z-index: 1;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -745,14 +745,9 @@ tr.turn:hover {
     &.selected { background: $list-highlight; }
     /* color is derived from changeset bbox fillColor in history.js */
 
-    a.stretched-link > span {
+    a.stretched-link > span, a:not(.stretched-link), [title] {
       position: relative;
-      z-index: 2;
-    }
-
-    a:not(.stretched-link), [title] {
-      position: relative;
-      z-index: 1;
+      z-index: 2; /* needs to be higher than Bootstrap's stretched link ::after z-index */
     }
   }
 

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -13,7 +13,7 @@
 <%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item" do %>
   <p class="fst-italic">
     <a class="changeset_id text-dark stretched-link" href="<%= changeset_path(changeset) %>">
-      <%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %>
+      <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>
     </a>
   </p>
   <div class="row">

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -20,7 +20,9 @@
     <div class="col">
       <%= changeset_details(changeset) %>
       &middot;
-      #<%= changeset.id %>
+      <a class="changeset_id text-dark" href="<%= changeset_path(changeset) %>">
+        #<%= changeset.id %>
+      </a>
     </div>
     <div class="col-auto comments comments-<%= changeset.comments.length %>">
       <%= changeset.comments.length %>


### PR DESCRIPTION
There's one problem after merging #3675.

Let's suppose you're on a history page and you want to select the text of a changeset comment. It's a link so normally you'll hold Alt in addition to holding a button and moving your mouse. Except with Bootstrap stretched link it won't work because they implemented it with an ::after pseudo element inside the link that covers the link itself. Now you can only reach the pseudo element and not the text content.

But that's easily fixable by wrapping the text inside the link and lifting it above ::after.

I also made links for changeset ids so they can also be lifted above the pseudo element and be selectable while working as before when clicked.