### PR TITLE
Remove top margins from close buttons

### DIFF
--- a/app/assets/javascripts/index/browse.js
+++ b/app/assets/javascripts/index/browse.js
@@ -54,7 +54,7 @@ OSM.initializeBrowse = function (map) {
             $("<h2>")
               .text(I18n.t("browse.start_rjs.load_data"))),
           $("<div>").append(
-            $("<button type='button' class='btn-close mt-1'>")
+            $("<button type='button' class='btn-close'>")
               .click(cancel))),
         $("<div>").append(
           $("<p class='alert alert-warning'></p>")

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -265,7 +265,7 @@ OSM.Directions = function (map) {
       }
 
       var turnByTurnTable = $("<table class='mb-3'>");
-      var directionsCloseButton = $("<button type='button' class='btn-close mt-1'>");
+      var directionsCloseButton = $("<button type='button' class='btn-close'>");
 
       $("#sidebar_content")
         .empty()

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -26,7 +26,7 @@ L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
         .append($("<h4>")
           .text(I18n.t(paneTitle))))
       .append($("<div>")
-        .append($("<button type='button' class='btn-close mt-1'>")
+        .append($("<button type='button' class='btn-close'>")
           .attr("aria-label", I18n.t("javascripts.close"))
           .bind("click", toggle)));
 

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -3,6 +3,6 @@
     <h2><%= title %></h2>
   </div>
   <div>
-    <a class="geolink d-block btn-close mt-1" href="<%= root_path %>"></a>
+    <a class="geolink d-block btn-close" href="<%= root_path %>"></a>
   </div>
 </div>


### PR DESCRIPTION
The margins mentioned in https://github.com/openstreetmap/openstreetmap-website/pull/3631#issuecomment-1203797930 are likely no longer necessary. They were leftovers from floated buttons put inside headers, probably to align the buttons with the text baseline. And they only affect the button position in the left sidebar.

| With margin-top | Without margin-top |
| --- | --- |
| ![b0](https://user-images.githubusercontent.com/4158490/188168631-ba9a6ff0-e236-4395-b1cf-961cd6c1cc11.png) | ![b1](https://user-images.githubusercontent.com/4158490/188168690-983a3aaa-c64b-44cc-ae6f-2a86f4e816c9.png)
