### PR TITLE
Link to user profile from user dropdown

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -80,7 +80,7 @@
     </ul>
     <% if current_user && current_user.id %>
       <div class='d-inline-flex dropdown user-menu logged-in clearfix'>
-        <a class='dropdown-toggle btn btn-outline-secondary px-2 py-1 flex-grow-1' data-bs-toggle='dropdown' href="#">
+        <a class='dropdown-toggle btn btn-outline-secondary px-2 py-1 flex-grow-1' data-bs-toggle='dropdown' href="<%= user_path(current_user) %>">
           <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1") %>
           <%= render :partial => "layouts/inbox" %>
           <span class="user-button">


### PR DESCRIPTION
When logged in, there's a dropdown menu in the upper left corner with avatar/username. When clicked, the dropdown menu with *My Dashboard*, *My Messages* etc opens. It's also a link, so it can be middle-clicked and opened in a new tab. But the link is dummy, with href="#". Since it has a username maybe it should link to the user's profile?