### PR TITLE
Rewrite bbox only in place history atom links

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -48,6 +48,9 @@ OSM.History = function (map) {
 
     if (window.location.pathname === "/history") {
       data.bbox = map.getBounds().wrap().toBBoxString();
+      var feedLink = $("link[type=\"application/atom+xml\"]"),
+          feedHref = feedLink.attr("href").split("?")[0];
+      feedLink.attr("href", feedHref + "?bbox=" + data.bbox);
     }
 
     $.ajax({
@@ -59,11 +62,6 @@ OSM.History = function (map) {
         updateMap();
       }
     });
-
-    var feedLink = $("link[type=\"application/atom+xml\"]"),
-        feedHref = feedLink.attr("href").split("?")[0];
-
-    feedLink.attr("href", feedHref + "?bbox=" + data.bbox);
   }
 
   function loadMore(e) {

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -1,0 +1,16 @@
+require "application_system_test_case"
+
+class HistoryTest < ApplicationSystemTestCase
+  test "atom link on user's history is not modified" do
+    user = create(:user)
+    create(:changeset, :user => user, :num_changes => 1) do |changeset|
+      create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "first-changeset-in-history")
+    end
+
+    visit "#{user_path(user)}/history"
+    changesets = find "div.changesets"
+    changesets.assert_text "first-changeset-in-history"
+
+    assert_css "link[type='application/atom+xml'][href$='#{user_path(user)}/history/feed']", :visible => false
+  end
+end


### PR DESCRIPTION
There are different kinds of history (changeset list) pages:

- [*friends*](https://www.openstreetmap.org/history/friends) and [*nearby*](https://www.openstreetmap.org/history/nearby) history don't have feeds and don't have links to feeds; trying to modify the link results in javascript error
- *user* history has the feed link but it doesn't use the bbox parameter
- only [*place* history](https://www.openstreetmap.org/history) feed link needs bbox updates