### PR TITLE
Remember loaded changesets and scroll position in user edit history

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -37,6 +37,7 @@ $(document).ready(function () {
     var title = sidebarContent[0];
     var html = sidebarContent[1];
 
+    map.setSidebarOverlaid(false);
     $("#flash").empty();
 
     var content = $(html);

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -414,4 +414,8 @@ $(document).ready(function () {
       e.preventDefault();
     }
   });
+
+  $(document).on("click", "#sidebar_content .btn-close", function () {
+    OSM.router.route("/" + OSM.formatHash(map));
+  });
 });

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -41,6 +41,7 @@ $(document).ready(function () {
     $("#flash").empty();
 
     var content = $(html);
+    content.find("img.loader").attr("src", OSM.SEARCHING);
 
     if (title) {
       document.title = decodeURIComponent(title);
@@ -57,7 +58,9 @@ $(document).ready(function () {
   };
 
   OSM.getSidebarContent = function () {
-    var html = $("#sidebar_content").html();
+    var clonedContent = $("#sidebar_content").clone();
+    clonedContent.find("img.loader").removeAttr("src");
+    var html = clonedContent.html();
     var link = $("head link[type=\"application/atom+xml\"]").prop("outerHTML");
     if (link) html = link + html;
     return [document.title, html];

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -33,6 +33,35 @@ $(document).ready(function () {
     worldCopyJump: true
   });
 
+  OSM.setSidebarContent = function (sidebarContent) {
+    var title = sidebarContent[0];
+    var html = sidebarContent[1];
+
+    $("#flash").empty();
+
+    var content = $(html);
+
+    if (title) {
+      document.title = decodeURIComponent(title);
+    }
+
+    $("head")
+      .find("link[type=\"application/atom+xml\"]")
+      .remove();
+
+    $("head")
+      .append(content.filter("link[type=\"application/atom+xml\"]"));
+
+    $("#sidebar_content").html(content.not("link[type=\"application/atom+xml\"]"));
+  };
+
+  OSM.getSidebarContent = function () {
+    var html = $("#sidebar_content").html();
+    var link = $("head link[type=\"application/atom+xml\"]").prop("outerHTML");
+    if (link) html = link + html;
+    return [document.title, html];
+  };
+
   OSM.loadSidebarContent = function (path, callback) {
     var content_path = path;
 
@@ -60,25 +89,8 @@ $(document).ready(function () {
       dataType: "html",
       complete: function (xhr) {
         clearTimeout(loaderTimeout);
-        $("#flash").empty();
         $("#sidebar_loader").hide();
-
-        var content = $(xhr.responseText);
-
-        if (xhr.getResponseHeader("X-Page-Title")) {
-          var title = xhr.getResponseHeader("X-Page-Title");
-          document.title = decodeURIComponent(title);
-        }
-
-        $("head")
-          .find("link[type=\"application/atom+xml\"]")
-          .remove();
-
-        $("head")
-          .append(content.filter("link[type=\"application/atom+xml\"]"));
-
-        $("#sidebar_content").html(content.not("link[type=\"application/atom+xml\"]"));
-
+        OSM.setSidebarContent([xhr.getResponseHeader("X-Page-Title"), xhr.responseText]);
         if (callback) {
           callback();
         }

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -143,6 +143,7 @@ OSM.History = function (map) {
         displayMoreChangesets(html);
       }
     }
+    updateMap();
     return true;
   }
 

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -289,6 +289,16 @@ OSM.History = function (map) {
     finishLoad();
   };
 
+  page.reload = function () {
+    var storeItemAndSaver = getStoreItemAndSaver();
+    var storeItem = storeItemAndSaver[0];
+    var storeSaver = storeItemAndSaver[1];
+    storeItem.sidebar = OSM.getSidebarContent();
+    storeItem.lists = []; // clear cached changesets
+    storeSaver();
+    finishLoad();
+  };
+
   page.unload = function () {
     map.removeLayer(group);
     map.off("moveend", update);

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -103,6 +103,18 @@ OSM.History = function (map) {
     return storeItem;
   }
 
+  function displayFirstChangesets(html) {
+    $("#sidebar_content .changesets").html(html);
+  }
+
+  function displayMoreChangesets(html) {
+    $("#sidebar_content .changeset_more").replaceWith(html);
+    var oldList = $("#sidebar_content .changesets ol").first();
+    var newList = oldList.next("ol");
+    newList.children().appendTo(oldList);
+    newList.remove();
+  }
+
   function saveDataToStore(html, rewrite) {
     var storeNameAndKey = getStoreNameAndKey();
     if (!storeNameAndKey) return;
@@ -126,10 +138,9 @@ OSM.History = function (map) {
     for (var i = 0; i < storeItem.lists.length; i++) {
       var html = storeItem.lists[i];
       if (i === 0) {
-        $("#sidebar_content .changesets").html(html);
+        displayFirstChangesets(html);
       } else {
-        var div = $("#sidebar_content .changeset_more").first();
-        div.replaceWith(html);
+        displayMoreChangesets(html);
       }
     }
     return true;
@@ -150,7 +161,7 @@ OSM.History = function (map) {
         data: data,
         success: function (html) {
           saveDataToStore(html, true);
-          $("#sidebar_content .changesets").html(html);
+          displayFirstChangesets(html);
           updateMap();
         }
       });
@@ -173,7 +184,7 @@ OSM.History = function (map) {
 
     $.get($(this).attr("href"), function (html) {
       saveDataToStore(html, false);
-      div.replaceWith(html);
+      displayMoreChangesets(html);
       updateMap();
     });
   }

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -59,13 +59,8 @@ OSM.History = function (map) {
     }
   }
 
-  function saveDataToStore(html, rewrite) {
+  function loadStore(storeName) {
     var requiredSchema = 1;
-    var maxStoreSize = 10;
-    var storeNameAndKey = getStoreNameAndKey();
-    if (!storeNameAndKey) return;
-    var storeName = storeNameAndKey[0];
-    var storeKey = storeNameAndKey[1];
     var storeString = sessionStorage[storeName];
     var store = {
       schema: requiredSchema,
@@ -81,31 +76,63 @@ OSM.History = function (map) {
     } catch (ex) {
       // reset store if it's damaged
     }
-    var storeItem = getStoreItem();
-    if (rewrite) {
-      storeItem.lists = [];
-    }
-    storeItem.lists.push(html);
-    sessionStorage[storeName] = JSON.stringify(store);
+    return store;
+  }
 
-    function getStoreItem() {
-      var storeItem;
-      for (var i = 0; i < store.items.length; i++) {
-        if (store.items[i].key !== storeKey) continue;
-        storeItem = store.items[i];
-        store.items.splice(i, 1);
-        store.items.unshift(storeItem);
-        return storeItem;
-      }
-      storeItem = {
-        key: storeKey,
-        // TODO timestamp - need to receive it from fn doing request
-        lists: []
-      };
-      store.items.splice(maxStoreSize - 1);
+  function saveStore(storeName, store) {
+    sessionStorage[storeName] = JSON.stringify(store);
+  }
+
+  function getStoreItem(store, storeKey) {
+    var maxStoreSize = 10;
+    var storeItem;
+    for (var i = 0; i < store.items.length; i++) {
+      if (store.items[i].key !== storeKey) continue;
+      storeItem = store.items[i];
+      store.items.splice(i, 1);
       store.items.unshift(storeItem);
       return storeItem;
     }
+    storeItem = {
+      key: storeKey,
+      // TODO timestamp - need to receive it from fn doing request
+      lists: []
+    };
+    store.items.splice(maxStoreSize - 1);
+    store.items.unshift(storeItem);
+    return storeItem;
+  }
+
+  function saveDataToStore(html, rewrite) {
+    var storeNameAndKey = getStoreNameAndKey();
+    if (!storeNameAndKey) return;
+    var storeName = storeNameAndKey[0];
+    var storeKey = storeNameAndKey[1];
+    var store = loadStore(storeName);
+    var storeItem = getStoreItem(store, storeKey);
+    if (rewrite) storeItem.lists = [];
+    storeItem.lists.push(html);
+    saveStore(storeName, store);
+  }
+
+  function loadDataFromStore() {
+    var storeNameAndKey = getStoreNameAndKey();
+    if (!storeNameAndKey) return false;
+    var storeName = storeNameAndKey[0];
+    var storeKey = storeNameAndKey[1];
+    var store = loadStore(storeName);
+    var storeItem = getStoreItem(store, storeKey);
+    if (storeItem.lists.length === 0) return false;
+    for (var i = 0; i < storeItem.lists.length; i++) {
+      var html = storeItem.lists[i];
+      if (i === 0) {
+        $("#sidebar_content .changesets").html(html);
+      } else {
+        var div = $("#sidebar_content .changeset_more").first();
+        div.replaceWith(html);
+      }
+    }
+    return true;
   }
 
   function update() {
@@ -115,16 +142,19 @@ OSM.History = function (map) {
       data.bbox = getBBoxParameter();
     }
 
-    $.ajax({
-      url: window.location.pathname,
-      method: "GET",
-      data: data,
-      success: function (html) {
-        saveDataToStore(html, true);
-        $("#sidebar_content .changesets").html(html);
-        updateMap();
-      }
-    });
+    var loadedDataFromStore = loadDataFromStore();
+    if (!loadedDataFromStore) {
+      $.ajax({
+        url: window.location.pathname,
+        method: "GET",
+        data: data,
+        success: function (html) {
+          saveDataToStore(html, true);
+          $("#sidebar_content .changesets").html(html);
+          updateMap();
+        }
+      });
+    }
 
     var feedLink = $("link[type=\"application/atom+xml\"]"),
         feedHref = feedLink.attr("href").split("?")[0];

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -47,60 +47,74 @@ OSM.History = function (map) {
     return map.getBounds().wrap().toBBoxString();
   }
 
-  function getStoreNameAndKey() {
-    if (window.location.pathname === "/history/friends") {
-      return null; // depends on current login - don't store for now
-    } else if (window.location.pathname === "/history/nearby") {
-      return null; // depends on current login - don't store for now
-    } else if (window.location.pathname === "/history") {
-      return ["history-place", getBBoxParameter()]; // separate store for places because bbox is too volatile
-    } else {
-      return ["history-user", window.location.pathname]; // has display_name inside pathname
+  // returns [item, saveFunction]; item.key is undefined if no save is going to happen
+  function getStoreItemAndSaver() {
+    var storeNameAndKey = getStoreNameAndKey();
+    if (!storeNameAndKey) {
+      return [{ lists: [] }, function () {}];
     }
-  }
+    var storeName = storeNameAndKey[0];
+    var storeKey = storeNameAndKey[1];
+    var store = loadStore(storeName);
+    var storeItem = getStoreItem(store, storeKey);
+    return [storeItem, function () {
+      saveStore(storeName, store);
+    }];
 
-  function loadStore(storeName) {
-    var requiredSchema = 1;
-    var storeString = sessionStorage[storeName];
-    var store = {
-      schema: requiredSchema,
-      items: []
-    };
-    try {
-      if (storeString) {
-        var readStore = JSON.parse(storeString);
-        if (readStore.schema === requiredSchema) {
-          store = readStore;
-        }
+    function getStoreNameAndKey() {
+      if (window.location.pathname === "/history/friends") {
+        return null; // depends on current login - don't store for now
+      } else if (window.location.pathname === "/history/nearby") {
+        return null; // depends on current login - don't store for now
+      } else if (window.location.pathname === "/history") {
+        return ["history-place", getBBoxParameter()]; // separate store for places because bbox is too volatile
+      } else {
+        return ["history-user", window.location.pathname]; // has display_name inside pathname
       }
-    } catch (ex) {
-      // reset store if it's damaged
     }
-    return store;
-  }
 
-  function saveStore(storeName, store) {
-    sessionStorage[storeName] = JSON.stringify(store);
-  }
+    function loadStore(storeName) {
+      var requiredSchema = 1;
+      var storeString = sessionStorage[storeName];
+      var store = {
+        schema: requiredSchema,
+        items: []
+      };
+      try {
+        if (storeString) {
+          var readStore = JSON.parse(storeString);
+          if (readStore.schema === requiredSchema) {
+            store = readStore;
+          }
+        }
+      } catch (ex) {
+        // reset store if it's damaged
+      }
+      return store;
+    }
 
-  function getStoreItem(store, storeKey) {
-    var maxStoreSize = 10;
-    var storeItem;
-    for (var i = 0; i < store.items.length; i++) {
-      if (store.items[i].key !== storeKey) continue;
-      storeItem = store.items[i];
-      store.items.splice(i, 1);
+    function saveStore(storeName, store) {
+      sessionStorage[storeName] = JSON.stringify(store);
+    }
+
+    function getStoreItem(store, storeKey) {
+      var maxStoreSize = 10;
+      var storeItem;
+      for (var i = 0; i < store.items.length; i++) {
+        if (store.items[i].key !== storeKey) continue;
+        storeItem = store.items[i];
+        store.items.splice(i, 1);
+        store.items.unshift(storeItem);
+        return storeItem;
+      }
+      storeItem = {
+        key: storeKey,
+        lists: []
+      };
+      store.items.splice(maxStoreSize - 1);
       store.items.unshift(storeItem);
       return storeItem;
     }
-    storeItem = {
-      key: storeKey,
-      // TODO timestamp - need to receive it from fn doing request
-      lists: []
-    };
-    store.items.splice(maxStoreSize - 1);
-    store.items.unshift(storeItem);
-    return storeItem;
   }
 
   function displayFirstChangesets(html) {
@@ -116,24 +130,18 @@ OSM.History = function (map) {
   }
 
   function saveDataToStore(html, rewrite) {
-    var storeNameAndKey = getStoreNameAndKey();
-    if (!storeNameAndKey) return;
-    var storeName = storeNameAndKey[0];
-    var storeKey = storeNameAndKey[1];
-    var store = loadStore(storeName);
-    var storeItem = getStoreItem(store, storeKey);
+    var storeItemAndSaver = getStoreItemAndSaver();
+    var storeItem = storeItemAndSaver[0];
+    var storeSaver = storeItemAndSaver[1];
+    if (!storeItem.key) return;
     if (rewrite) storeItem.lists = [];
     storeItem.lists.push(html);
-    saveStore(storeName, store);
+    storeSaver();
   }
 
   function loadDataFromStore() {
-    var storeNameAndKey = getStoreNameAndKey();
-    if (!storeNameAndKey) return false;
-    var storeName = storeNameAndKey[0];
-    var storeKey = storeNameAndKey[1];
-    var store = loadStore(storeName);
-    var storeItem = getStoreItem(store, storeKey);
+    var storeItemAndSaver = getStoreItemAndSaver();
+    var storeItem = storeItemAndSaver[0];
     if (storeItem.lists.length === 0) return false;
     for (var i = 0; i < storeItem.lists.length; i++) {
       var html = storeItem.lists[i];
@@ -244,21 +252,41 @@ OSM.History = function (map) {
     }
   }
 
-  page.pushstate = page.popstate = function (path) {
-    $("#history_tab").addClass("current");
-    OSM.loadSidebarContent(path, page.load);
-  };
-
-  page.load = function () {
+  function finishLoad() {
     map.addLayer(group);
 
     if (window.location.pathname === "/history") {
       map.on("moveend", update);
     }
-
     map.on("zoomend", updateBounds);
 
     update();
+  }
+
+  page.pushstate = page.popstate = function (path) {
+    $("#history_tab").addClass("current");
+    var storeItemAndSaver = getStoreItemAndSaver();
+    var storeItem = storeItemAndSaver[0];
+    var storeSaver = storeItemAndSaver[1];
+    if (storeItem.sidebar) {
+      OSM.setSidebarContent(storeItem.sidebar);
+      finishLoad();
+    } else {
+      OSM.loadSidebarContent(path, function () {
+        storeItem.sidebar = OSM.getSidebarContent();
+        storeSaver();
+        finishLoad();
+      });
+    }
+  };
+
+  page.load = function () {
+    var storeItemAndSaver = getStoreItemAndSaver();
+    var storeItem = storeItemAndSaver[0];
+    var storeSaver = storeItemAndSaver[1];
+    storeItem.sidebar = OSM.getSidebarContent();
+    storeSaver();
+    finishLoad();
   };
 
   page.unload = function () {

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -18,6 +18,10 @@
        as arguments the URL path plus any matching arguments for placeholders
        in the path template.
 
+     * The `reload` method, when defined, is called by the router when a page
+       reload is requested by the user. When not defined, the `load` method is
+       called instead.
+
      * The `pushstate` method is called when a page which matches the route's path
        template is loaded via pushState. It is passed the same arguments as `load`.
 
@@ -79,6 +83,10 @@ OSM.Router = function (map, rts) {
       params = params.concat(Array.prototype.slice.call(arguments, 2));
 
       return (controller[action] || $.noop).apply(controller, params);
+    };
+
+    route.has = function (action) {
+      return action in controller;
     };
 
     return route;
@@ -197,8 +205,20 @@ OSM.Router = function (map, rts) {
   };
 
   router.load = function () {
-    var loadState = currentRoute.run("load", currentPath);
+    var loadState = loadOrReload();
     router.stateChange(loadState || {});
+
+    function loadOrReload() {
+      if (currentRoute.has("reload") && window.performance) {
+        var wasReloaded = window.performance.getEntriesByType("navigation").some(function (entry) {
+          return entry.type === "reload";
+        });
+        if (wasReloaded) {
+          return currentRoute.run("reload", currentPath);
+        }
+      }
+      return currentRoute.run("load", currentPath);
+    }
   };
 
   router.setCurrentPath = function (path) {

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -102,8 +102,16 @@ OSM.Router = function (map, rts) {
   var router = {};
 
   if (window.history && window.history.pushState) {
+    $("#sidebar").scroll(function () {
+      var state = window.history.state;
+      if (!state) state = {};
+      state.sidebarScroll = this.scrollTop;
+      window.history.replaceState(state, document.title, window.location); // TODO don't replace state too often, browsers complain about that
+    });
+
     $(window).on("popstate", function (e) {
-      if (!e.originalEvent.state) return; // Is it a real popstate event or just a hash change?
+      var state = e.originalEvent.state;
+      if (!state) return; // Is it a real popstate event or just a hash change?
       var path = window.location.pathname + window.location.search,
           route = routes.recognize(path);
       if (path === currentPath) return;
@@ -111,7 +119,10 @@ OSM.Router = function (map, rts) {
       currentPath = path;
       currentRoute = route;
       currentRoute.run("popstate", currentPath);
-      map.setState(e.originalEvent.state, { animate: false });
+      map.setState(state, { animate: false });
+      if ("sidebarScroll" in state) {
+        $("#sidebar").scrollTop(state.sidebarScroll);
+      }
     });
 
     router.route = function (url) {
@@ -153,7 +164,14 @@ OSM.Router = function (map, rts) {
     var hash = OSM.formatHash(map);
     if (hash === currentHash) return;
     currentHash = hash;
-    router.stateChange(OSM.parseHash(hash));
+    var state = OSM.parseHash(hash);
+    if (window.history) {
+      var oldState = window.history.state;
+      if (oldState && "sidebarScroll" in oldState) {
+        state.sidebarScroll = oldState.sidebarScroll;
+      }
+    }
+    router.stateChange(state);
   };
 
   router.hashUpdated = function () {

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -3,6 +3,6 @@
     <h2><%= title %></h2>
   </div>
   <div>
-    <a class="geolink d-block btn-close mt-1" href="<%= root_path %>"></a>
+    <button type="button" class="btn-close mt-1"></button>
   </div>
 </div>

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -77,6 +77,20 @@ class HistoryTest < ApplicationSystemTestCase
     changesets.assert_selector "li", :count => (2 * PAGE_SIZE) + 1
   end
 
+  test "changesets list sidebar reappears when going back after closing it" do
+    user = create(:user)
+    create_visible_changeset(user, "first-changeset-in-history")
+
+    visit "#{user_path(user)}/history"
+    assert_text "first-changeset-in-history"
+
+    find("#sidebar .btn-close").click
+    assert_no_text "first-changeset-in-history"
+
+    go_back
+    assert_text "first-changeset-in-history"
+  end
+
   def create_visible_changeset(user, comment)
     create(:changeset, :user => user, :num_changes => 1) do |changeset|
       create(:changeset_tag, :changeset => changeset, :k => "comment", :v => comment)

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -23,6 +23,25 @@ class HistoryTest < ApplicationSystemTestCase
     reloaded_changesets.assert_text "first-changeset-in-history"
   end
 
+  test "reloading the changesets page updates the list" do
+    user = create(:user)
+    create_visible_changeset(user, "first-changeset-in-history")
+    visit "#{user_path(user)}/history"
+    original_changesets = find "div.changesets"
+    original_changesets.assert_text "first-changeset-in-history"
+    original_changesets.assert_no_text "second-changeset-in-history"
+
+    create_visible_changeset(user, "second-changeset-in-history")
+    visit user_path(user)
+    go_back
+    original_changesets.assert_text "first-changeset-in-history"
+    original_changesets.assert_no_text "second-changeset-in-history"
+
+    refresh
+    original_changesets.assert_text "first-changeset-in-history"
+    original_changesets.assert_text "second-changeset-in-history"
+  end
+
   test "have only one list element on user's changesets page" do
     user = create(:user)
     create_visible_changeset(user, "first-changeset-in-history")

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -1,16 +1,13 @@
 require "application_system_test_case"
 
 class HistoryTest < ApplicationSystemTestCase
+  PAGE_SIZE = 20
+
   test "restore state of user's changesets list" do
-    page_size = 20
     user = create(:user)
-    create(:changeset, :user => user, :num_changes => 1) do |changeset|
-      create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "first-changeset-in-history")
-    end
-    page_size.times do
-      create(:changeset, :user => user, :num_changes => 1) do |changeset|
-        create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "next-changeset")
-      end
+    create_visible_changeset(user, "first-changeset-in-history")
+    PAGE_SIZE.times do
+      create_visible_changeset(user, "next-changeset")
     end
 
     visit "#{user_path(user)}/history"
@@ -24,5 +21,46 @@ class HistoryTest < ApplicationSystemTestCase
     go_back
     reloaded_changesets = find "div.changesets"
     reloaded_changesets.assert_text "first-changeset-in-history"
+  end
+
+  test "have only one list element on user's changesets page" do
+    user = create(:user)
+    create_visible_changeset(user, "first-changeset-in-history")
+    create_visible_changeset(user, "bottom-changeset-in-batch-2")
+    (PAGE_SIZE - 1).times do
+      create_visible_changeset(user, "next-changeset")
+    end
+    create_visible_changeset(user, "bottom-changeset-in-batch-1")
+    (PAGE_SIZE - 1).times do
+      create_visible_changeset(user, "next-changeset")
+    end
+
+    visit "#{user_path(user)}/history"
+    changesets = find "div.changesets"
+    changesets.assert_text "bottom-changeset-in-batch-1"
+    changesets.assert_no_text "bottom-changeset-in-batch-2"
+    changesets.assert_no_text "first-changeset-in-history"
+    changesets.assert_selector "ol", :count => 1
+    changesets.assert_selector "li", :count => PAGE_SIZE
+
+    changesets.find(".changeset_more a.btn").click
+    changesets.assert_text "bottom-changeset-in-batch-1"
+    changesets.assert_text "bottom-changeset-in-batch-2"
+    changesets.assert_no_text "first-changeset-in-history"
+    changesets.assert_selector "ol", :count => 1
+    changesets.assert_selector "li", :count => 2 * PAGE_SIZE
+
+    changesets.find(".changeset_more a.btn").click
+    changesets.assert_text "bottom-changeset-in-batch-1"
+    changesets.assert_text "bottom-changeset-in-batch-2"
+    changesets.assert_text "first-changeset-in-history"
+    changesets.assert_selector "ol", :count => 1
+    changesets.assert_selector "li", :count => (2 * PAGE_SIZE) + 1
+  end
+
+  def create_visible_changeset(user, comment)
+    create(:changeset, :user => user, :num_changes => 1) do |changeset|
+      create(:changeset_tag, :changeset => changeset, :k => "comment", :v => comment)
+    end
   end
 end

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -1,0 +1,28 @@
+require "application_system_test_case"
+
+class HistoryTest < ApplicationSystemTestCase
+  test "restore state of user's changesets list" do
+    page_size = 20
+    user = create(:user)
+    create(:changeset, :user => user, :num_changes => 1) do |changeset|
+      create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "first-changeset-in-history")
+    end
+    page_size.times do
+      create(:changeset, :user => user, :num_changes => 1) do |changeset|
+        create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "next-changeset")
+      end
+    end
+
+    visit "#{user_path(user)}/history"
+    original_changesets = find "div.changesets"
+    original_changesets.assert_no_text "first-changeset-in-history"
+    load_more = original_changesets.find ".changeset_more a.btn"
+    load_more.click
+    original_changesets.assert_text "first-changeset-in-history"
+
+    visit user_path(user)
+    go_back
+    reloaded_changesets = find "div.changesets"
+    reloaded_changesets.assert_text "first-changeset-in-history"
+  end
+end


### PR DESCRIPTION
This is:

- "Improve User Edit History" on DWG wishlist
- #647
- #1089

Is saves changeset list html pieces to sessionStorage and remembers scroll position. Going to a history page, clicking some link then pressing *back* (or *forward*) should bring back the viewed history state along with everything that was loaded by pressing *Load more*. Reloading the page by pressing *reload* button throws away cached data.