### PR TITLE
Stick search input and Go button together with flex instead of input group

### DIFF
--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -2,14 +2,12 @@
   <form method="GET" action="<%= search_path %>" class="search_form px-1 py-2">
     <div class="row gx-2 mx-0">
       <div class="col">
-        <div class="input-group flex-nowrap">
-          <div class='query_wrapper position-relative flex-grow-1'>
+        <div class="d-flex">
+          <span class='position-relative flex-grow-1'>
             <%= link_to t("site.search.where_am_i"), "#", :class => "describe_location position-absolute", :title => t("site.search.where_am_i_title") %>
-            <%= text_field_tag "query", params[:query], :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control form-control-sm", :dir => "auto" %>
-          </div>
-          <div class="input-group-append">
-            <%= submit_tag t("site.search.submit_text"), :class => "btn btn-sm btn-primary", :data => { :disable_with => false } %>
-          </div>
+            <%= text_field_tag "query", params[:query], :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control form-control-sm rounded-0 rounded-start border-end-0", :dir => "auto" %>
+          </span>
+          <%= submit_tag t("site.search.submit_text"), :class => "btn btn-sm btn-primary rounded-0 rounded-end", :data => { :disable_with => false } %>
         </div>
       </div>
       <div class="col-auto">


### PR DESCRIPTION
There is an attempt to use an [input group](https://getbootstrap.com/docs/5.1/forms/input-group/) to combine the search input and the *Go* button. It doesn't work however. You can see the controls being rounded where they touch each other and this shouldn't happen:

![search-before](https://user-images.githubusercontent.com/4158490/190255032-bd74b484-780f-4d51-9b35-40c6411ad1a5.png)

The problem is trying to combine an input group with one input being put into a container that is required to position the *Where this is?* link. You have to remove the container but then positioning the link becomes more difficult. I could come up only with positioning using javascript, which is an unnecessary complication.

The simpler way is not to use an input group and specify which corners are to be rounded by hand:

![search-after](https://user-images.githubusercontent.com/4158490/190255055-3bb9559c-bbfa-433c-9fc9-6c1858bd0bf5.png)
