### PR TITLE
Link prefixed wikipedia tags

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -1,4 +1,8 @@
 module BrowseTagsHelper
+  # https://wiki.openstreetmap.org/wiki/Key:wikipedia#Secondary_Wikipedia_links
+  # https://wiki.openstreetmap.org/wiki/Key:wikidata#Secondary_Wikidata_links
+  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|flag|genus|name:etymology|network|operator|species|subject".freeze
+
   def format_key(key)
     if url = wiki_link("key", key)
       link_to h(key), url, :title => t("browse.tag_details.wiki_link.key", :key => key)
@@ -60,7 +64,7 @@ module BrowseTagsHelper
     return nil if %r{^https?://}.match?(value)
 
     case key
-    when "wikipedia"
+    when "wikipedia", /^(#{SECONDARY_WIKI_PREFIXES}):wikipedia/o
       # This regex should match Wikipedia language codes, everything
       # from de to zh-classical
       lang = if value =~ /^([a-z-]{2,12}):(.+)$/i
@@ -104,7 +108,7 @@ module BrowseTagsHelper
         :title => value
       }]
     # Key has to be one of the accepted wikidata-tags
-    elsif key =~ /(architect|artist|brand|name:etymology|network|operator|subject):wikidata/ &&
+    elsif key =~ /(#{SECONDARY_WIKI_PREFIXES}):wikidata/o &&
           # Value has to be a semicolon-separated list of wikidata-IDs (whitespaces allowed before and after semicolons)
           value =~ /^[Qq][1-9][0-9]*(\s*;\s*[Qq][1-9][0-9]*)*$/
       # Splitting at every semicolon to get a separate hash for each wikidata-ID

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -120,6 +120,10 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_equal "//www.wikidata.org/entity/Q24?uselang=en", links[0][:url]
     assert_equal "Q24", links[0][:title]
 
+    links = wikidata_links("species:wikidata", "Q26899")
+    assert_equal "//www.wikidata.org/entity/Q26899?uselang=en", links[0][:url]
+    assert_equal "Q26899", links[0][:title]
+
     # Another allowed key, this time with multiple values and I18n
     I18n.with_locale "dsb" do
       links = wikidata_links("brand:wikidata", "Q936;Q2013;Q1568346")
@@ -181,6 +185,10 @@ class BrowseTagsHelperTest < ActionView::TestCase
       assert_equal "https://zh-classical.wikipedia.org/wiki/zh-classical:Test?uselang=pt-BR#Section", link[:url]
       assert_equal "zh-classical:Test#Section", link[:title]
     end
+
+    link = wikipedia_link("subject:wikipedia", "en:Catherine McAuley")
+    assert_equal "https://en.wikipedia.org/wiki/en:Catherine McAuley?uselang=en", link[:url]
+    assert_equal "en:Catherine McAuley", link[:title]
 
     link = wikipedia_link("foo", "Test")
     assert_nil link


### PR DESCRIPTION
Fixes #2184

Since I also updated the prefix list which is used for both `wikipedia` and `wikidata`, that reimplemented:

- #2812