### PR TITLE
Remove unused pager secondary nav css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1428,7 +1428,7 @@ abbr.geo {
   border-bottom: none;
 }
 
-/* General styles for action lists / subnavs / pager navs */
+/* General styles for action lists / subnavs */
 
 
 nav.secondary-actions {
@@ -1441,10 +1441,6 @@ nav.secondary-actions {
     margin-bottom: 0;
     margin-left: -1px;
     padding: 0;
-    &.pager {
-      display: inline-block;
-      margin-right: 60px;
-    }
     > li {
       flex-basis: auto;
       list-style: none;


### PR DESCRIPTION
I don't see it being used anywhere.

`pager` class was introduced in https://github.com/openstreetmap/openstreetmap-website/commit/a36f3558dd43dd5a598e36dd21fd5f7d2b4a94f5 for views that no longer exist. Last time that part of css was updated in https://github.com/openstreetmap/openstreetmap-website/commit/29e98571454a450f0af1e2649d1688c6f2afffdb and there weren't any `pager` classes in use.