### PR TITLE
Remove "buttons" css class used only on new note page

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1257,16 +1257,6 @@ tr.turn:hover {
   display: inline !important;
 }
 
-/* Rules for the oauth settings page */
-
-.oauth_clients .buttons .oauth-edit {
-  border-radius: 2px 0 0 2px;
-}
-
-.oauth_clients .buttons .oauth-delete {
-  border-radius: 0 2px 2px 0;
-}
-
 /* Rules for the oauth authorization page */
 
 .oauth-authorize ul {
@@ -1459,60 +1449,6 @@ nav.secondary-actions {
 div.secondary-actions {
   padding: 10px;
   text-align: center;
-}
-
-.buttons {
-  min-width: 200px;
-  input[type="submit"],
-  input[type="button"],
-  input[type="reset"],
-  .button,
-  .button_to {
-    box-sizing: border-box;
-    float: left;
-    border-radius: 0;
-    margin:0;
-    min-width: 75px;
-    max-width: 180px;
-    border-right:1px solid white;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-  input:first-child,
-  .button:first-child,
-  .button_to:first-child {
-    border-radius:2px 0 0 2px;
-  }
-  input:last-child,
-  .button:last-child,
-  .button_to:last-child {
-    border-radius:0 2px 2px 0;
-    border-right-width: 0;
-  }
-  input:only-child,
-  .button:only-child,
-  .button_to:only-child,
-  *[value="Hide"] + input:last-child,
-  *[value="Hide"] + .button:last-child,
-  *[value="Hide"] + .button_to:last-child {
-    border-radius:2px;
-    border-right-width: 0;
-  }
-    /* if a 3-button set has a hidden middle button */
-  *[value="Hide"] + input:nth-child(3),
-  *[value="Hide"] + .button:nth-child(3),
-  *[value="Hide"] + .button_to:nth-child(3) {
-    border-radius:0 2px 2px 0;
-    border-right-width: 0;
-  }
-  /* if a 3-button set starts with a hidden button */
-  *[value="Hide"] + input:nth-child(2):not(:last-child),
-  *[value="Hide"] + .button:nth-child(2):not(:last-child),
-  *[value="Hide"] + .button_to:nth-child(2):not(:last-child) {
-    border-radius:2px 0 0 2px;
-    border-right-width: 1px;
-  }
 }
 
 /* Create a single-line dl */

--- a/app/views/browse/new_note.html.erb
+++ b/app/views/browse/new_note.html.erb
@@ -10,7 +10,7 @@
     <div class="mb-3">
       <textarea class="form-control" name="text" cols="40" rows="10" maxlength="2000" placeholder="<%= t("javascripts.notes.new.advice") %>"></textarea>
     </div>
-    <div class="buttons clearfix">
+    <div class="btn-wrapper">
       <input type="submit" name="add" value="<%= t("javascripts.notes.new.add") %>" disabled="1" class="btn btn-primary">
     </div>
   </form>


### PR DESCRIPTION
[New note page](https://www.openstreetmap.org/note/new) is the only place where was still in use. Replaced by `btn-wrapper` like it was done on /note/:id pages before.

`buttons` class was originally introduced in https://github.com/openstreetmap/openstreetmap-website/commit/597fb5d27f092f956235c04d77cf74cab2012b1a for rich text edit/preview buttons and was mostly removed during Bootstrap conversions like https://github.com/openstreetmap/openstreetmap-website/commit/c0adab7abaae779d2600aeb098f4d4fce07caba4 .