### PR TITLE
Remove background image-related css from about page

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1646,10 +1646,6 @@ dl.dl-inline {
 
 .site-about #content {
   background-color: $lightgrey;
-  background-position: 50% 50%;
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-attachment: fixed;
 
   .content-inner {
     max-width: 760px;


### PR DESCRIPTION
Background images are no longer used on the about page so these properties are not required.