### PR TITLE
Remove old map sidebar close button css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -511,15 +511,6 @@ body.small-nav {
       padding: 10px 20px;
     }
 
-    a.close-button {
-      float: right;
-      padding:5px;
-      font-size:20px;
-      line-height:10px;
-      color:#222;
-      border:1px solid $grey;
-    }
-
     .tooltip {
       opacity: 1;
       border: 1px solid $grey;


### PR DESCRIPTION
This is a pre-pre-bootstrap close button from 2013: https://github.com/openstreetmap/openstreetmap-website/commit/ded28617c7. It wasn't in use when I was replacing close buttons couple of months ago.