### PR TITLE
Replace <h5> used to set the font size with Bootstrap class h5

### DIFF
--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -3,7 +3,7 @@
     <div class='row'>
       <div class='col-sm-7 user-image'></div>
       <div class='col-sm-5 px-5 py-3 byosm'>
-        <h5 class='text-white text-nowrap'><%= t ".copyright_html", :locale => @locale %></h5>
+        <p class='h5 text-white text-nowrap'><%= t ".copyright_html", :locale => @locale %></p>
       </div>
     </div>
     <div class='row'>


### PR DESCRIPTION
This `<h5>` creates an [incorrect document outline](https://validator.w3.org/nu/?showoutline=yes&doc=https%3A%2F%2Fwww.openstreetmap.org%2Fabout).