### PR TITLE
Remove unused tooltips css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -510,14 +510,6 @@ body.small-nav {
       border-bottom: 1px solid $grey;
       padding: 10px 20px;
     }
-
-    .tooltip {
-      opacity: 1;
-      border: 1px solid $grey;
-      .tooltip-arrow {
-        border-top-color: $grey;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Currently tooltips are appended directly to `<body>`. Styles defined inside `#map-ui` can't affect them.

(originally added in https://github.com/openstreetmap/openstreetmap-website/commit/439ad373ec5ee364003625e56159b1dce5fb186e, https://github.com/openstreetmap/openstreetmap-website/commit/eda8b00fec)