### PR TITLE
Remove unused icon list css from welcome pages

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1514,15 +1514,6 @@ dl.dl-inline {
     display: block;
   }
 
-  .icon-list {
-    padding-bottom: 20px;
-    div {
-      margin-bottom: 10px;
-      p {
-        padding-top: 10px;
-      }
-    }
-  }
   .sprite.small {
     width: 50px;
     height: 50px;


### PR DESCRIPTION
No longer in use since https://github.com/openstreetmap/openstreetmap-website/commit/1bf671f6847c0c5c6561520ef4970689a0977e55 and https://github.com/openstreetmap/openstreetmap-website/commit/0b1aafb7015c7ab1986407870d048b3a3dcefda6.