### PR TITLE
Remove unnecessary wrapper divs

### DIFF
--- a/app/assets/javascripts/index/browse.js
+++ b/app/assets/javascripts/index/browse.js
@@ -50,18 +50,16 @@ OSM.initializeBrowse = function (map) {
     $("#browse_status").html(
       $("<div>").append(
         $("<div class='d-flex'>").append(
-          $("<div class='flex-grow-1 text-break'>").append(
-            $("<h2>")
-              .text(I18n.t("browse.start_rjs.load_data"))),
+          $("<h2 class='flex-grow-1 text-break'>")
+            .text(I18n.t("browse.start_rjs.load_data")),
           $("<div>").append(
             $("<button type='button' class='btn-close'>")
               .click(cancel))),
-        $("<div>").append(
-          $("<p class='alert alert-warning'></p>")
-            .text(I18n.t("browse.start_rjs.feature_warning", { num_features: count, max_features: limit })),
-          $("<input type='submit' class='btn btn-primary'>")
-            .val(I18n.t("browse.start_rjs.load_data"))
-            .click(add))));
+        $("<p class='alert alert-warning'>")
+          .text(I18n.t("browse.start_rjs.feature_warning", { num_features: count, max_features: limit })),
+        $("<input type='submit' class='btn btn-primary'>")
+          .val(I18n.t("browse.start_rjs.load_data"))
+          .click(add)));
   }
 
   var dataLoader;

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -271,9 +271,8 @@ OSM.Directions = function (map) {
         .empty()
         .append(
           $("<div class='d-flex'>").append(
-            $("<div class='flex-grow-1 text-break'>").append(
-              $("<h2>")
-                .text(I18n.t("javascripts.directions.directions"))),
+            $("<h2 class='flex-grow-1 text-break'>")
+              .text(I18n.t("javascripts.directions.directions")),
             $("<div>").append(directionsCloseButton)),
           distanceText,
           turnByTurnTable

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -22,9 +22,8 @@ L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
 
     $("<div class='sidebar_heading d-flex'>")
       .appendTo($ui)
-      .append($("<div class='flex-grow-1 text-break'>")
-        .append($("<h4>")
-          .text(I18n.t(paneTitle))))
+      .append($("<h4 class='flex-grow-1 text-break'>")
+        .text(I18n.t(paneTitle)))
       .append($("<div>")
         .append($("<button type='button' class='btn-close'>")
           .attr("aria-label", I18n.t("javascripts.close"))

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -1,7 +1,5 @@
 <div class="d-flex w-100">
-  <div class="flex-grow-1 text-break">
-    <h2><%= title %></h2>
-  </div>
+  <h2 class="flex-grow-1 text-break"><%= title %></h2>
   <div>
     <a class="geolink d-block btn-close" href="<%= root_path %>"></a>
   </div>


### PR DESCRIPTION
Mostly it's `<h*>` elements wrapped in `<div>`, which is not necessary because `<h*>` are already block-level elements.