### PR TITLE
Add notes multi fetch API call

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -12,7 +12,7 @@ class ApiAbility
 
     if Settings.status != "database_offline"
       can [:show, :download, :query], Changeset
-      can [:index, :create, :comment, :feed, :show, :search], Note
+      can [:index, :create, :comment, :feed, :show, :fetch, :search], Note
       can :index, Tracepoint
       can [:index, :show], User
       can [:index, :show], Node

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -251,6 +251,26 @@ module Api
     end
 
     ##
+    # Return a list of notes with given ids
+    def fetch
+      raise OSM::APIBadUserInput, "The parameter notes is required, and must be of the form notes=id[,id[,id...]]" unless params["notes"]
+
+      ids = params["notes"].split(",").collect(&:to_i)
+
+      raise OSM::APIBadUserInput, "No notes were given to search for" if ids.empty?
+
+      @notes = Note.find(ids)
+
+      # Render the result
+      respond_to do |format|
+        format.rss { render :action => :index }
+        format.xml { render :action => :index }
+        format.json { render :action => :index }
+        format.gpx { render :action => :index }
+      end
+    end
+
+    ##
     # Return a list of notes matching a given string
     def search
       # Get the initial set of notes

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -259,7 +259,7 @@ module Api
 
       raise OSM::APIBadUserInput, "No notes were given to search for" if ids.empty?
 
-      @notes = Note.find(ids)
+      @notes = Note.visible.find(ids)
 
       # Render the result
       respond_to do |format|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ OpenStreetMap::Application.routes.draw do
     # Map notes API
     resources :notes, :except => [:new, :edit, :update], :constraints => { :id => /\d+/ }, :defaults => { :format => "xml" }, :controller => "api/notes" do
       collection do
+        get "fetch"
         get "search"
         get "feed", :defaults => { :format => "rss" }
       end

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -96,6 +96,27 @@ module Api
       )
 
       assert_routing(
+        { :path => "/api/0.6/notes/fetch", :method => :get },
+        { :controller => "api/notes", :action => "fetch", :format => "xml" }
+      )
+      assert_recognizes(
+        { :controller => "api/notes", :action => "fetch", :format => "xml" },
+        { :path => "/api/0.6/notes/fetch.xml", :method => :get }
+      )
+      assert_routing(
+        { :path => "/api/0.6/notes/fetch.rss", :method => :get },
+        { :controller => "api/notes", :action => "fetch", :format => "rss" }
+      )
+      assert_routing(
+        { :path => "/api/0.6/notes/fetch.json", :method => :get },
+        { :controller => "api/notes", :action => "fetch", :format => "json" }
+      )
+      assert_routing(
+        { :path => "/api/0.6/notes/fetch.gpx", :method => :get },
+        { :controller => "api/notes", :action => "fetch", :format => "gpx" }
+      )
+
+      assert_routing(
         { :path => "/api/0.6/notes/feed", :method => :get },
         { :controller => "api/notes", :action => "feed", :format => "rss" }
       )

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -828,6 +828,47 @@ module Api
       assert_response :bad_request
     end
 
+    def test_fetch_success
+      note1 = create(:note)
+      note2 = create(:note)
+      note4 = create(:note)
+      note5 = create(:note)
+
+      get fetch_notes_path(:notes => "#{note4.id},#{note2.id},#{note1.id},#{note5.id}", :format => "json")
+      assert_response :success
+      assert_equal "application/json", @response.media_type
+      js = ActiveSupport::JSON.decode(@response.body)
+      assert_not_nil js
+      assert_equal "FeatureCollection", js["type"]
+      assert_equal 4, js["features"].count
+      assert_equal note4.id, js["features"][0]["properties"]["id"]
+      assert_equal note2.id, js["features"][1]["properties"]["id"]
+      assert_equal note1.id, js["features"][2]["properties"]["id"]
+      assert_equal note5.id, js["features"][3]["properties"]["id"]
+    end
+
+    def test_fetch_bad_params
+      get fetch_notes_path
+      assert_response :bad_request
+
+      get fetch_notes_path, :params => { :notes => "" }
+      assert_response :bad_request
+    end
+
+    def test_fetch_not_found
+      note1 = create(:note)
+      note2 = create(:note)
+      note3 = create(:note, :status => "hidden")
+      note4 = create(:note)
+      note5 = create(:note)
+
+      get fetch_notes_path(:notes => "#{note4.id},#{note2.id},#{note1.id},0,#{note5.id}")
+      assert_response :not_found
+
+      get fetch_notes_path(:notes => "#{note4.id},#{note2.id},#{note1.id},#{note3.id},#{note5.id}")
+      assert_response :not_found
+    end
+
     def test_search_success
       create(:note_with_comments)
 


### PR DESCRIPTION
An API call to fetch several notes at once by their ids, similar to [the elements multi fetch call](https://wiki.openstreetmap.org/wiki/API_v0.6#Multi_fetch:_GET_/api/0.6/[nodes|ways|relations]?#parameters):

`/api/0.6/notes/fetch?notes=1,2,3`

I named it `fetch` here. If I was to follow a naming convention similar to the elements' call, it should have been named  `/api/0.6/notes?notes`. However `notes` path is already in use, even twice: for bbox queries with GET and for new notes with POST.

## What is it useful for?

If you receive notes from some source other than OSM API they may contain incomplete information or be out of date. That source may be some search engine or some feed for an area. For example, [resultmaps.neis-one.org/osm-notes](https://resultmaps.neis-one.org/osm-notes) has feeds for countries. Unfortunately they don't have coordinates, so if you want to see the notes on the map, you have to get them from the API. The only way to do that is download the notes one by one by their ids. That's a lot of requests because the feeds may contain hundreds of notes. But there are API calls already that can send hundreds of notes in one response: bbox and search queries. And bbox calls are routinely made when notes layer is turned on. So there's nothing in principle that prevents fetching multiple notes in one request. If you are already committed to downloading a bunch of notes by their ids, it will be faster and less taxing for the API to get all of the notes in one call. Of course there's a limit to the url length, in this case you'd have to make several calls to get really many notes, but that's still better than making really many calls.

Another possible use is if you have a set of notes selected in some app to work on. Maybe other people also work on these notes. In this case you may want to know if any of these notes was updated. Again, the only way to do this is to download them one by one.