### PR TITLE
Change map ui sidebar height together with map height

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -522,6 +522,13 @@ body.small-nav {
       height: 50%;
     }
 
+    #map-ui {
+      z-index: 9999;
+      width: 100%;
+      height: 50%;
+      overflow-y: scroll;
+    }
+
     .overlay-sidebar {
       #sidebar {
         position: absolute;
@@ -530,15 +537,9 @@ body.small-nav {
         overflow: hidden;
       }
 
-      #map {
+      #map, #map-ui {
         height: 100%;
       }
-    }
-
-    #map-ui {
-      z-index: 9999;
-      width: 100%;
-      overflow-y: scroll;
     }
   }
 }


### PR DESCRIPTION
There was a fix #2547 for some bugs that set `height: 50%;` for the `#map` container but not for `#map-ui` sidebar. But `#map-ui` should be the same height as the map itself, right?

Fixes #3053