### PR TITLE
Show/hide query intro text depending on query mode

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -21,19 +21,19 @@ OSM.Query = function (map) {
 
     if (queryButton.hasClass("active")) {
       disableQueryMode();
+      deactivateQueryMode();
     } else if (!queryButton.hasClass("disabled")) {
+      activateQueryMode();
       enableQueryMode();
     }
   }).on("disabled", function () {
     if (queryButton.hasClass("active")) {
-      map.off("click", clickHandler);
-      $(map.getContainer()).removeClass("query-active").addClass("query-disabled");
+      disableQueryMode();
       $(this).tooltip("show");
     }
   }).on("enabled", function () {
     if (queryButton.hasClass("active")) {
-      map.on("click", clickHandler);
-      $(map.getContainer()).removeClass("query-disabled").addClass("query-active");
+      enableQueryMode();
       $(this).tooltip("hide");
     }
   });
@@ -323,19 +323,27 @@ OSM.Query = function (map) {
     OSM.router.route("/query?lat=" + lat + "&lon=" + lng);
   }
 
-  function enableQueryMode() {
+  function activateQueryMode() {
     queryButton.addClass("active");
-    map.on("click", clickHandler);
     $(map.getContainer()).addClass("query-active");
+  }
+
+  function deactivateQueryMode() {
+    $(map.getContainer()).removeClass("query-active");
+    queryButton.removeClass("active");
+    if (marker) map.removeLayer(marker);
+  }
+
+  function enableQueryMode() {
+    map.on("click", clickHandler);
+    $(map.getContainer()).removeClass("query-disabled");
     $("#sidebar_content .query-intro").show();
   }
 
   function disableQueryMode() {
     $("#sidebar_content .query-intro").hide();
-    if (marker) map.removeLayer(marker);
-    $(map.getContainer()).removeClass("query-active").removeClass("query-disabled");
+    $(map.getContainer()).addClass("query-disabled");
     map.off("click", clickHandler);
-    queryButton.removeClass("active");
   }
 
   var page = {};
@@ -356,12 +364,19 @@ OSM.Query = function (map) {
       });
     }
 
+    if (!queryButton.hasClass("active") || queryButton.hasClass("disabled")) {
+      $("#sidebar_content .query-intro").hide();
+    }
+
     queryOverpass(params.lat, params.lon);
   };
 
   page.unload = function (sameController) {
     if (!sameController) {
-      disableQueryMode();
+      if (queryButton.hasClass("active")) {
+        disableQueryMode();
+        deactivateQueryMode();
+      }
     }
   };
 

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -296,9 +296,6 @@ OSM.Query = function (map) {
         nearby = "(" + nodes + ";" + ways + ";);out tags geom(" + bbox + ");" + relations + ";out geom(" + bbox + ");",
         isin = "is_in(" + lat + "," + lng + ")->.a;way(pivot.a);out tags bb;out ids geom(" + bbox + ");relation(pivot.a);out tags bb;";
 
-    $("#sidebar_content .query-intro")
-      .hide();
-
     if (marker) map.removeLayer(marker);
     marker = L.circle(latlng, radius, featureStyle).addTo(map);
 
@@ -330,9 +327,11 @@ OSM.Query = function (map) {
     queryButton.addClass("active");
     map.on("click", clickHandler);
     $(map.getContainer()).addClass("query-active");
+    $("#sidebar_content .query-intro").show();
   }
 
   function disableQueryMode() {
+    $("#sidebar_content .query-intro").hide();
     if (marker) map.removeLayer(marker);
     $(map.getContainer()).removeClass("query-active").removeClass("query-disabled");
     map.off("click", clickHandler);

--- a/app/views/browse/query.html.erb
+++ b/app/views/browse/query.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "sidebar_header", :title => t(".title") %>
 
-<div>
+<div class="query-intro">
   <p><%= t(".introduction") %></p>
 </div>
 


### PR DESCRIPTION
When you use *Query features* map tool, a sidebar shows with this message "Click on the map to find nearby features." The message had a `query-intro` css class added in https://github.com/openstreetmap/openstreetmap-website/commit/078059b76b. Then the class was removed in https://github.com/openstreetmap/openstreetmap-website/commit/c8f0a81eb7043c297e050c1f3ff8a8cf7ff613bc. However there's still the js code that tries to hide this message based on its class. This happens as soon as the query runs.

But the query runs as soon as the sidebar is shown. If hiding is restored, the user won't have time to read the message, and then there's no point in writing it. On the other hand, if the message is not hidden, it will tell the user to click the map even when clicking will have no effect.

Here I'm showing/hiding the message depending on if it's possible to click the map and get a query to run.