### PR TITLE
Don't show 'Download XML' link for deleted elements

### DIFF
--- a/app/views/browse/feature.html.erb
+++ b/app/views/browse/feature.html.erb
@@ -5,7 +5,9 @@
 <%= render :partial => @type, :object => @feature %>
 
 <div class='secondary-actions'>
-  <%= link_to(t("browse.download_xml"), :controller => "api/#{@type.pluralize}", :action => :show) %>
-  &middot;
+  <% if @feature.visible? %>
+    <%= link_to(t("browse.download_xml"), :controller => "api/#{@type.pluralize}", :action => :show) %>
+    &middot;
+  <% end %>
   <%= link_to(t("browse.view_history"), :action => "#{@type}_history") %>
 </div>

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -63,7 +63,15 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_read_node
-    browse_check :node_path, create(:node).id, "browse/feature"
+    node = create :node
+    browse_check :node_path, node.id, "browse/feature"
+    assert_select "a[href='#{api_node_path node}']", :count => 1
+  end
+
+  def test_read_deleted_node
+    node = create :node, :visible => false
+    browse_check :node_path, node.id, "browse/feature"
+    assert_select "a[href='#{api_node_path node}']", :count => 0
   end
 
   def test_read_node_history


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/3325. I'm not displaying the link instead of greying it out because pages of elements that never existed don't have download links.