### PR TITLE
Allow setting JSON return type by HTTP ACCEPT header for notes API

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -9,6 +9,7 @@ module Api
 
     before_action :set_locale
     around_action :api_call_handle_error, :api_call_timeout
+    before_action :set_request_formats, :except => [:feed]
 
     ##
     # Return a list of notes in a given area

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ OpenStreetMap::Application.routes.draw do
     get "gpx/:id/data" => "api/traces#data", :as => :api_trace_data
 
     # Map notes API
-    resources :notes, :except => [:new, :edit, :update], :constraints => { :id => /\d+/ }, :defaults => { :format => "xml" }, :controller => "api/notes" do
+    resources :notes, :except => [:new, :edit, :update], :constraints => { :id => /\d+/ }, :controller => "api/notes" do
       collection do
         get "search"
         get "feed", :defaults => { :format => "rss" }

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -14,11 +14,11 @@ module Api
     def test_routes
       assert_routing(
         { :path => "/api/0.6/notes", :method => :post },
-        { :controller => "api/notes", :action => "create", :format => "xml" }
+        { :controller => "api/notes", :action => "create" }
       )
       assert_routing(
         { :path => "/api/0.6/notes/1", :method => :get },
-        { :controller => "api/notes", :action => "show", :id => "1", :format => "xml" }
+        { :controller => "api/notes", :action => "show", :id => "1" }
       )
       assert_recognizes(
         { :controller => "api/notes", :action => "show", :id => "1", :format => "xml" },
@@ -38,24 +38,24 @@ module Api
       )
       assert_routing(
         { :path => "/api/0.6/notes/1/comment", :method => :post },
-        { :controller => "api/notes", :action => "comment", :id => "1", :format => "xml" }
+        { :controller => "api/notes", :action => "comment", :id => "1" }
       )
       assert_routing(
         { :path => "/api/0.6/notes/1/close", :method => :post },
-        { :controller => "api/notes", :action => "close", :id => "1", :format => "xml" }
+        { :controller => "api/notes", :action => "close", :id => "1" }
       )
       assert_routing(
         { :path => "/api/0.6/notes/1/reopen", :method => :post },
-        { :controller => "api/notes", :action => "reopen", :id => "1", :format => "xml" }
+        { :controller => "api/notes", :action => "reopen", :id => "1" }
       )
       assert_routing(
         { :path => "/api/0.6/notes/1", :method => :delete },
-        { :controller => "api/notes", :action => "destroy", :id => "1", :format => "xml" }
+        { :controller => "api/notes", :action => "destroy", :id => "1" }
       )
 
       assert_routing(
         { :path => "/api/0.6/notes", :method => :get },
-        { :controller => "api/notes", :action => "index", :format => "xml" }
+        { :controller => "api/notes", :action => "index" }
       )
       assert_recognizes(
         { :controller => "api/notes", :action => "index", :format => "xml" },
@@ -76,7 +76,7 @@ module Api
 
       assert_routing(
         { :path => "/api/0.6/notes/search", :method => :get },
-        { :controller => "api/notes", :action => "search", :format => "xml" }
+        { :controller => "api/notes", :action => "search" }
       )
       assert_recognizes(
         { :controller => "api/notes", :action => "search", :format => "xml" },


### PR DESCRIPTION
Currently the notes API json return type can only be specified by appending the .json file extension at the end of the URL path. This is inconsistent to other JSON API entry points which also allow specifying the return type via the HTTP ACCEPT header.

I guess the routing tests (see example below) do not catch these cases because they do not allow to specify headers.

```
      assert_routing(
        { :path => "/api/0.6/notes/1.json", :method => :get },
        { :controller => "api/notes", :action => "show", :id => "1", :format => "json" }
      )
```