### PR TITLE
Load notes with remote control

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,6 +33,7 @@ window.updateLinks = function (loc, zoom, layers, object) {
     delete args.way;
     delete args.relation;
     delete args.changeset;
+    delete args.note;
 
     if (object && editlink) {
       args[object.type] = object.id;

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -1,7 +1,6 @@
 OSM.Note = function (map) {
   var content = $("#sidebar_content"),
-      page = {},
-      halo, currentNote;
+      page = {};
 
   var noteIcons = {
     "new": L.icon({
@@ -35,9 +34,9 @@ OSM.Note = function (map) {
     });
   }
 
-  page.pushstate = page.popstate = function (path) {
+  page.pushstate = page.popstate = function (path, id) {
     OSM.loadSidebarContent(path, function () {
-      initialize(function () {
+      initialize(id, function () {
         var data = $(".details").data(),
             latLng = L.latLng(data.coordinates.split(","));
         if (!map.getBounds().contains(latLng)) moveToNote();
@@ -45,11 +44,11 @@ OSM.Note = function (map) {
     });
   };
 
-  page.load = function () {
-    initialize(moveToNote);
+  page.load = function (path, id) {
+    initialize(id, moveToNote);
   };
 
-  function initialize(callback) {
+  function initialize(id, callback) {
     content.find("input[type=submit]").on("click", function (e) {
       e.preventDefault();
       var data = $(e.target).data();
@@ -70,28 +69,14 @@ OSM.Note = function (map) {
 
     content.find("textarea").val("").trigger("input");
 
-    var data = $(".details").data(),
-        latLng = L.latLng(data.coordinates.split(","));
+    var data = $(".details").data();
 
-    if (!halo || !map.hasLayer(halo)) {
-      halo = L.circleMarker(latLng, {
-        weight: 2.5,
-        radius: 20,
-        fillOpacity: 0.5,
-        color: "#FF6200"
-      });
-      map.addLayer(halo);
-    }
-
-    if (currentNote && map.hasLayer(currentNote)) map.removeLayer(currentNote);
-
-    currentNote = L.marker(latLng, {
-      icon: noteIcons[data.status],
-      opacity: 1,
-      interactive: true
+    map.addObject({
+      type: "note",
+      id: parseInt(id, 10),
+      latLng: L.latLng(data.coordinates.split(",")),
+      icon: noteIcons[data.status]
     });
-
-    map.addLayer(currentNote);
 
     if (callback) callback();
   }
@@ -108,8 +93,7 @@ OSM.Note = function (map) {
   }
 
   page.unload = function () {
-    if (map.hasLayer(halo)) map.removeLayer(halo);
-    if (map.hasLayer(currentNote)) map.removeLayer(currentNote);
+    map.removeObject();
   };
 
   return page;

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -19,6 +19,7 @@ OSM.Note = function (map) {
       iconAnchor: [12, 40]
     })
   };
+  noteIcons.hidden = noteIcons.closed; // TODO replace with actual "hidden" icon when it's added
 
   page.pushstate = page.popstate = function (path, id) {
     OSM.loadSidebarContent(path, function () {

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -20,23 +20,9 @@ OSM.Note = function (map) {
     })
   };
 
-  function updateNote(form, method, url) {
-    $(form).find("input[type=submit]").prop("disabled", true);
-
-    $.ajax({
-      url: url,
-      type: method,
-      oauth: true,
-      data: { text: $(form.text).val() },
-      success: function () {
-        OSM.loadSidebarContent(window.location.pathname, page.load);
-      }
-    });
-  }
-
   page.pushstate = page.popstate = function (path, id) {
     OSM.loadSidebarContent(path, function () {
-      initialize(id, function () {
+      initialize(path, id, function () {
         var data = $(".details").data(),
             latLng = L.latLng(data.coordinates.split(","));
         if (!map.getBounds().contains(latLng)) moveToNote();
@@ -45,14 +31,28 @@ OSM.Note = function (map) {
   };
 
   page.load = function (path, id) {
-    initialize(id, moveToNote);
+    initialize(path, id, moveToNote);
   };
 
-  function initialize(id, callback) {
+  function initialize(path, id, callback) {
     content.find("input[type=submit]").on("click", function (e) {
       e.preventDefault();
       var data = $(e.target).data();
-      updateNote(e.target.form, data.method, data.url);
+      var form = e.target.form;
+
+      $(form).find("input[type=submit]").prop("disabled", true);
+
+      $.ajax({
+        url: data.url,
+        type: data.method,
+        oauth: true,
+        data: { text: $(form.text).val() },
+        success: function () {
+          OSM.loadSidebarContent(path, function () {
+            initialize(path, id, moveToNote);
+          });
+        }
+      });
     });
 
     content.find("textarea").on("input", function (e) {

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -255,6 +255,7 @@ L.OSM.Map = L.Map.extend({
       this._objectLoader = {
         abort: function () {}
       };
+      this._object = object;
       this._objectLayer = L.featureGroup().addTo(this);
       L.circleMarker(object.latLng, haloStyle).addTo(this._objectLayer);
       L.marker(object.latLng, {

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -242,42 +242,63 @@ L.OSM.Map = L.Map.extend({
       interactive: false
     };
 
+    var haloStyle = {
+      weight: 2.5,
+      radius: 20,
+      fillOpacity: 0.5,
+      color: "#FF6200"
+    };
+
     this.removeObject();
 
-    var map = this;
-    this._objectLoader = $.ajax({
-      url: OSM.apiUrl(object),
-      dataType: "xml",
-      success: function (xml) {
-        map._object = object;
+    if (object.type === "note") {
+      this._objectLoader = {
+        abort: function () {}
+      };
+      this._objectLayer = L.featureGroup().addTo(this);
+      L.circleMarker(object.latLng, haloStyle).addTo(this._objectLayer);
+      L.marker(object.latLng, {
+        icon: object.icon,
+        opacity: 1,
+        interactive: true
+      }).addTo(this._objectLayer);
+      if (callback) callback(this._objectLayer.getBounds());
+    } else { // element or changeset handled by L.OSM.DataLayer
+      var map = this;
+      this._objectLoader = $.ajax({
+        url: OSM.apiUrl(object),
+        dataType: "xml",
+        success: function (xml) {
+          map._object = object;
 
-        map._objectLayer = new L.OSM.DataLayer(null, {
-          styles: {
-            node: objectStyle,
-            way: objectStyle,
-            area: objectStyle,
-            changeset: changesetStyle
-          }
-        });
-
-        map._objectLayer.interestingNode = function (node, ways, relations) {
-          if (object.type === "node") {
-            return true;
-          } else if (object.type === "relation") {
-            for (var i = 0; i < relations.length; i++) {
-              if (relations[i].members.indexOf(node) !== -1) return true;
+          map._objectLayer = new L.OSM.DataLayer(null, {
+            styles: {
+              node: objectStyle,
+              way: objectStyle,
+              area: objectStyle,
+              changeset: changesetStyle
             }
-          } else {
-            return false;
-          }
-        };
+          });
 
-        map._objectLayer.addData(xml);
-        map._objectLayer.addTo(map);
+          map._objectLayer.interestingNode = function (node, ways, relations) {
+            if (object.type === "node") {
+              return true;
+            } else if (object.type === "relation") {
+              for (var i = 0; i < relations.length; i++) {
+                if (relations[i].members.indexOf(node) !== -1) return true;
+              }
+            } else {
+              return false;
+            }
+          };
 
-        if (callback) callback(map._objectLayer.getBounds());
-      }
-    });
+          map._objectLayer.addData(xml);
+          map._objectLayer.addTo(map);
+
+          if (callback) callback(map._objectLayer.getBounds());
+        }
+      });
+    }
   },
 
   removeObject: function () {

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -37,7 +37,8 @@ OSM = {
   SEARCHING:               <%= image_path("searching.gif").to_json %>,
 
   apiUrl: function (object) {
-    var url = "/api/" + OSM.API_VERSION + "/" + object.type + "/" + object.id;
+    var apiType = object.type === "note" ? "notes" : object.type;
+    var url = "/api/" + OSM.API_VERSION + "/" + apiType + "/" + object.id;
 
     if (object.type === "way" || object.type === "relation") {
       url += "/full";
@@ -85,6 +86,8 @@ OSM = {
       mapParams.object = {type: 'way', id: parseInt(params.way)};
     } else if (params.relation) {
       mapParams.object = {type: 'relation', id: parseInt(params.relation)};
+    } else if (params.note) {
+      mapParams.object = {type: 'note', id: parseInt(params.note)};
     }
 
     var hash = OSM.parseHash(location.hash);

--- a/app/views/browse/note.html.erb
+++ b/app/views/browse/note.html.erb
@@ -49,10 +49,10 @@
         </div>
         <div class="btn-wrapper">
           <% if current_user.moderator? -%>
-            <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
+            <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
           <% end -%>
-          <input type="submit" name="close" value="<%= t("javascripts.notes.show.resolve") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= close_note_url(@note, "json") %>">
-          <input type="submit" name="comment" value="<%= t("javascripts.notes.show.comment") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= comment_note_url(@note, "json") %>" disabled="1">
+          <input type="submit" name="close" value="<%= t("javascripts.notes.show.resolve") %>" class="btn btn-primary" data-method="POST" data-url="<%= close_note_url(@note, "json") %>">
+          <input type="submit" name="comment" value="<%= t("javascripts.notes.show.comment") %>" class="btn btn-primary" data-method="POST" data-url="<%= comment_note_url(@note, "json") %>" disabled="1">
         </div>
       </form>
     <% end -%>
@@ -61,10 +61,10 @@
       <input type="hidden" name="text" value="" autocomplete="off">
       <div class="btn-wrapper">
         <% if current_user and current_user.moderator? -%>
-          <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light" data-note-id="<%= @note.id %>" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
+          <input type="submit" name="hide" value="<%= t("javascripts.notes.show.hide") %>" class="btn btn-light" data-method="DELETE" data-url="<%= note_url(@note, "json") %>">
         <% end -%>
         <% if current_user -%>
-          <input type="submit" name="reopen" value="<%= t("javascripts.notes.show.reactivate") %>" class="btn btn-primary" data-note-id="<%= @note.id %>" data-method="POST" data-url="<%= reopen_note_url(@note, "json") %>">
+          <input type="submit" name="reopen" value="<%= t("javascripts.notes.show.reactivate") %>" class="btn btn-primary" data-method="POST" data-url="<%= reopen_note_url(@note, "json") %>">
         <% end -%>
       </div>
     </form>

--- a/test/system/browse_test.rb
+++ b/test/system/browse_test.rb
@@ -1,0 +1,17 @@
+require "application_system_test_case"
+
+class BrowseTest < ApplicationSystemTestCase
+  test "node included in edit link" do
+    node = create(:node)
+    visit node_path(node)
+
+    assert_selector "#editanchor[href*='?node=#{node.id}#']"
+  end
+
+  test "note included in edit link" do
+    note = create(:note_with_comments)
+    visit browse_note_path(note)
+
+    assert_selector "#editanchor[href*='?note=#{note.id}#']"
+  end
+end


### PR DESCRIPTION
Does part of #957: loads a note when running a remote control edit from `/note/*id*` page.

Normally you do remote control with `load_and_zoom` rc command, and it doesn't support notes. But it's not a problem because you can run another rc command after that. Notes can be loaded by `import` command with a url parameter pointing to note data.