### PR TITLE
Fix formatting for 'et cetera'

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -8,7 +8,7 @@ Many settings are available in `config/settings.yml`. You can customize your ins
 
 ## Populating the database
 
-Your installation comes with no geographic data loaded. You can either create new data using one of the editors (iD, JOSM etc) or by loading an OSM extract.
+Your installation comes with no geographic data loaded. You can either create new data using one of the editors (iD, JOSM, etc.) or by loading an OSM extract.
 
 After installing but before creating any users or data, import an extract with [Osmosis](https://wiki.openstreetmap.org/wiki/Osmosis) and the [``--write-apidb``](https://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage#--write-apidb_.28--wd.29) task.
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -60,7 +60,7 @@ Run the test suite by running:
 
 ### Loading an OSM extract
 
-This installation comes with no geographic data loaded. You can either create new data using one of the editors (Potlatch 2, iD, JOSM etc) or by loading an OSM extract. Here an example for loading an OSM extract into your Docker-based OSM instance.
+This installation comes with no geographic data loaded. You can either create new data using one of the editors (Potlatch 2, iD, JOSM, etc.) or by loading an OSM extract. Here an example for loading an OSM extract into your Docker-based OSM instance.
 
 For example, let's download the District of Columbia from Geofabrik or [any other region](https://download.geofabrik.de):
 
@@ -82,7 +82,7 @@ Once you have data loaded for Washington, DC you should be able to navigate to [
 
 ### Additional Configuration
 
-See [`CONFIGURE.md`](CONFIGURE.md) for information on how to manage users and enable OAuth for iD, JOSM etc.
+See [`CONFIGURE.md`](CONFIGURE.md) for information on how to manage users and enable OAuth for iD, JOSM, etc.
 
 ### Bash
 

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -11,7 +11,7 @@ class TracesController < ApplicationController
   before_action :offline_warning, :only => [:mine, :show]
   before_action :offline_redirect, :only => [:new, :create, :edit, :destroy, :data]
 
-  # Counts and selects pages of GPX traces for various criteria (by user, tags, public etc.).
+  # Counts and selects pages of GPX traces for various criteria (by user, tags, public, etc.).
   #  target_user - if set, specifies the user to fetch traces for.  if not set will fetch all traces
   def index
     # from display name, pick up user id if one user's traces only

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -355,7 +355,7 @@ Doorkeeper.configure do
   # be used with this application there. Then when authorization requested Doorkeeper
   # will call this block to check if specific Application (passed with client_id and/or
   # client_secret) is allowed to perform the request for the specific grant type
-  # (authorization, password, client_credentials, etc).
+  # (authorization, password, client_credentials, etc.).
   #
   # Example of the block:
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,7 +287,7 @@ OpenStreetMap::Application.routes.draw do
   get "/message/new/:display_name" => "messages#new", :as => "new_message"
   get "/message/read/:message_id", :to => redirect(:path => "/messages/%{message_id}")
 
-  # oauth admin pages (i.e: for setting up new clients, etc...)
+  # oauth admin pages (i.e. for setting up new clients)
   scope "/user/:display_name" do
     resources :oauth_clients
   end


### PR DESCRIPTION
Fix formatting for 'et cetera'. Excludes vendor/licensed files.