### PR TITLE
Added some language codes for Pakistan to countries.xml

### DIFF
--- a/config/countries.xml
+++ b/config/countries.xml
@@ -3375,7 +3375,7 @@
 <areaInSqKm>803940.0</areaInSqKm>
 <population>184404791</population>
 <currencyCode>PKR</currencyCode>
-<languages>ur-PK,en-PK,pa,sd,ps,brh</languages>
+<languages>ur-PK,en-PK,pnb,pa-PK,sd,ps,skr-Arab,skr,bal,bgn,bcc,brh,ks-Arab</languages>
 <geonameId>1168579</geonameId>
 <west>60.878613</west>
 <north>37.097</north>


### PR DESCRIPTION
More could be added, but the ones I have included are particularly likely to have translations become available via Translatewiki. This includes the addition of `pnb`, which now has `pnb.yml` in the repository as of this week.

The locale code for `pnb` in Transifex is `pa-PK`, so I have to put both in my settings in order to see iD in Punjabi Shahmukhi. I am not sure if there is a way to alias these in the locale settings