### PR TITLE
Punjabi + Luba-Katanga updates to languages.yml

### DIFF
--- a/config/languages.yml
+++ b/config/languages.yml
@@ -312,7 +312,7 @@ lt:
   native: Lietuvių
 lu: 
   english: Luba-Katanga
-  native: ~
+  native: Kiluba
 lv: 
   english: Latvian
   native: Latviešu
@@ -401,14 +401,17 @@ os:
   english: Ossetic
   native: Иронау
 pa: 
-  english: Punjabi
-  native: ਪੰਜਾਬੀ
+  english: Punjabi (Gurmukhi)
+  native: ਪੰਜਾਬੀ (ਗੁਰਮੁਖੀ)
 pi: 
   english: Pali
   native: पािऴ
 pl: 
   english: Polish
   native: Polski
+pnb:
+  english: Punjabi (Shahmukhi)
+  native: پنجابی (شاہمکھی)
 ps: 
   english: Pashto
   native: پښتو


### PR DESCRIPTION
This PR adds `pnb` name and native label and updates `pa` name and native label, as these locale codes are for the same language in different scripts; `pa` being Gurmukhi used in India, `pnb` being Shahmukhi used in Pakistan.

I also noticed that Luba-Katanga was missing a native label and just had `~`, so I looked this up and added the native name Kiluba.