### PR TITLE
Fixes delimiter direction in map key

### DIFF
--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -7,7 +7,18 @@
             <%= image_tag "key/#{name}/#{entry['image']}" %>
           </td>
           <td class="mapkey-table-value">
-            <%= Array(t(".table.entry.#{entry['name']}")).to_sentence %>
+            <% if I18n.t("html.dir") = "rtl" %>
+              <%= Array(t(".table.entry.#{entry['name']}")).to_sentence(
+                words_connector: '، ',
+                two_words_connector: '، ',
+                last_word_connector: '، ') %>
+            <% end %>
+            <% if I18n.t("html.dir") = "ltr" %>
+              <%= Array(t(".table.entry.#{entry['name']}")).to_sentence(
+                words_connector: ', ',
+                two_words_connector: ', ',
+                last_word_connector: ', ') %>
+            <% end %>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
![Screenshot_20221003-182747](https://user-images.githubusercontent.com/100172442/193697167-9b2db132-71b7-4ddb-80a2-4a46d2f94e27.png)

This screenshot of the map key in Punjabi above shows the situation this PR is intebded to address, where "and" and opposite direction commas appear interspersed with the localized map key. This is because of the localized strings being joined with `to_sentence`, which is not aware of every locale and how to delimit a list for each one. Rather than asking all translators to translate "and" and provide a comma, this just uses either a left-to-right comma or a right-to-left comma depending on the known direction in order to keep things simple.