### PR TITLE
Remove note from edit link when it's not a current object

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,6 +33,7 @@ window.updateLinks = function (loc, zoom, layers, object) {
     delete args.way;
     delete args.relation;
     delete args.changeset;
+    delete args.note;
 
     if (object && editlink) {
       args[object.type] = object.id;

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -1,0 +1,21 @@
+require "application_system_test_case"
+
+class IndexTest < ApplicationSystemTestCase
+  test "node included in edit link" do
+    node = create(:node)
+    visit node_path(node)
+    assert_selector "#editanchor[href*='?node=#{node.id}#']"
+
+    find("#sidebar .btn-close").click
+    assert_no_selector "#editanchor[href*='?node=#{node.id}#']"
+  end
+
+  test "note included in edit link" do
+    note = create(:note_with_comments)
+    visit browse_note_path(note)
+    assert_selector "#editanchor[href*='?note=#{note.id}#']"
+
+    find("#sidebar .btn-close").click
+    assert_no_selector "#editanchor[href*='?note=#{note.id}#']"
+  end
+end


### PR DESCRIPTION
Making a note to be a current object is almost enough to generate its edit link. Actually it is enough, what's missing is deleting it from the link when sidebar is closed or another object is made current without reloading the entire page.