### PR TITLE
Refer to the receiver in wrong user notification

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1693,7 +1693,7 @@ en:
       no_sent_messages_html: "You have no sent messages yet. Why not get in touch with some of the %{people_mapping_nearby_link}?"
       people_mapping_nearby: "people mapping nearby"
     reply:
-      wrong_user: "You are logged in as `%{user}' but the message you have asked to reply to was not sent to that user. Please login as the correct user in order to reply."
+      wrong_user: "You are logged in as `%{user}' but the message you have been asked to reply to was not sent to that user. Please login as the correct user in order to reply."
     show:
       title: "Read message"
       from: "From"
@@ -1704,7 +1704,7 @@ en:
       destroy_button: "Delete"
       back: "Back"
       to: "To"
-      wrong_user: "You are logged in as `%{user}' but the message you have asked to read was not sent by or to that user. Please login as the correct user in order to read it."
+      wrong_user: "You are logged in as `%{user}' but the message you have been asked to read was not sent by or to that user. Please login as the correct user in order to read it."
     sent_message_summary:
       destroy_button: "Delete"
     mark:


### PR DESCRIPTION
You -the receiver- "have _been_ asked" to read something, not someone else ("have asked").
(assuming this string is still in use)