### PR TITLE
Display icon for current note only if this icon is defined

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -261,11 +261,13 @@ L.OSM.Map = L.Map.extend({
 
       L.circleMarker(object.latLng, haloStyle).addTo(this._objectLayer);
 
-      L.marker(object.latLng, {
-        icon: object.icon,
-        opacity: 1,
-        interactive: true
-      }).addTo(this._objectLayer);
+      if (object.icon) {
+        L.marker(object.latLng, {
+          icon: object.icon,
+          opacity: 1,
+          interactive: true
+        }).addTo(this._objectLayer);
+      }
 
       if (callback) callback(this._objectLayer.getBounds());
     } else { // element or changeset handled by L.OSM.DataLayer

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -18,4 +18,23 @@ class IndexTest < ApplicationSystemTestCase
     find("#sidebar .btn-close").click
     assert_no_selector "#editanchor[href*='?note=#{note.id}#']"
   end
+
+  test "can navigate from hidden note to visible note" do
+    sign_in_as(create(:moderator_user))
+    hidden_note = create(:note, :status => "hidden")
+    create(:note_comment, :note => hidden_note, :body => "this-is-a-hidden-note")
+    position = (1.003 * GeoRecord::SCALE).to_i
+    visible_note = create(:note, :latitude => position, :longitude => position)
+    create(:note_comment, :note => visible_note, :body => "this-is-a-visible-note")
+
+    visit root_path(:anchor => "map=15/1/1") # view place of hidden note in case it is not rendered during browse_note_path(hidden_note)
+    visit browse_note_path(hidden_note)
+    find(".leaflet-control.control-layers .control-button").click
+    find("#map-ui .overlay-layers .form-check-label", :text => "Map Notes").click
+    visible_note_marker = find(".leaflet-marker-icon[title=this-is-a-visible-note]")
+    assert_selector "#sidebar", :text => "this-is-a-hidden-note"
+
+    visible_note_marker.click
+    assert_selector "#sidebar", :text => "this-is-a-visible-note"
+  end
 end


### PR DESCRIPTION
An alternative to displaying some other icon instead of the missing "hidden" icon. Don't display any icon for hidden and other unknown note states, only show a "halo" circle marker.

Previous version with "closed" icon: https://github.com/openstreetmap/openstreetmap-website/pull/3718#discussion_r981484149

Fixes https://github.com/openstreetmap/openstreetmap-website/issues/1215 - when you have note layer enabled you can click on other notes after hiding a note.

Fixes https://github.com/openstreetmap/openstreetmap-website/issues/546 - although this bug doesn't fully manifests itself in current website versions. Before the fix clicking "history" works, but it's a full page reload. What is supposed to happen is a partial reload of the sidebar.

