### PR TITLE
Removed CSS which causes backwards rtl heading

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1089,10 +1089,6 @@ tr.turn:hover {
   }
 }
 
-[dir=rtl] .header-illustration {
-  transform: scaleX(-1);
-}
-
 #content.maximised {
   top: 0;
   left: 0;


### PR DESCRIPTION
This problem is on the register page. Compare the heading, which is shown backwards,
‮,like this
‬‎to the top left button which is shown in the right direction.

Currently:
![image](https://user-images.githubusercontent.com/100172442/195254782-0f83d422-98ae-4a20-822c-345463bf8e6c.png)

With removal of this CSS rule:
![image](https://user-images.githubusercontent.com/100172442/195255115-609fd543-6c36-4340-8282-0e6543d3d23b.png)

The only other thing this seems to change is the direction Earth guy is pointing, but this does not really matter
