### PR TITLE
Fix malformed tags table in changeset atom feed

### DIFF
--- a/app/views/changesets/index.atom.builder
+++ b/app/views/changesets/index.atom.builder
@@ -62,7 +62,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
                 td.table :cellpadding => "0" do |tag_table|
                   changeset.tags.sort.each do |tag|
                     tag_table.tr do |tag_tr|
-                      tag_tr.td << "#{tag[0]} = #{linkify(tag[1])}"
+                      tag_tr.td "#{tag[0]} = #{linkify(tag[1])}"
                     end
                   end
                 end


### PR DESCRIPTION
Prior to this change, the feed contained XHTML like
```xhtml
              <table cellpadding="0">
                <tr>
                  <td/>
changesets_count = 1                </tr>
                <tr>
                  <td/>
comment = Test                </tr>
                <tr>
                  <td/>
created_by = iD 2.22.0                </tr>
                <tr>
                  <td/>
host = http://localhost:3000/edit                </tr>
                <tr>
                  <td/>
imagery_used = Bing Maps Aerial                </tr>
                <tr>
                  <td/>
locale = en-US                </tr>
              </table>
```

after this change this is correctly rendered as
```xhtml
<table cellpadding="0">
  <tr>
    <td>changesets_count = 1</td>
  </tr>
  <tr>
    <td>comment = Test</td>
  </tr>
  <tr>
    <td>created_by = iD 2.22.0</td>
  </tr>
  <tr>
    <td>host = http://localhost:3000/edit</td>
  </tr>
  <tr>
    <td>imagery_used = Bing Maps Aerial</td>
  </tr>
  <tr>
    <td>locale = en-US</td>
  </tr>
</table>
```