### PR TITLE
Strip trailing whitespace from copyright notice

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1913,12 +1913,12 @@ en:
           </ul>
         credit_3_1_html: |
          For the copyright notice, we have different requirements on how this should be 
-         displayed, depending on how you are using our data. For example, different 
-         rules apply on how to show the copyright notice depending on whether you have 
-         created a browsable map, a printed map or a static image. Full details on the 
-         requirements can be found in the 
-         <a href="https://wiki.osmfoundation.org/wiki/Licence/Attribution_Guidelines">Attribution 
-         Guidelines</a>. 
+         displayed, depending on how you are using our data. For example, different
+         rules apply on how to show the copyright notice depending on whether you have
+         created a browsable map, a printed map or a static image. Full details on the
+         requirements can be found in the
+         <a href="https://wiki.osmfoundation.org/wiki/Licence/Attribution_Guidelines">Attribution
+         Guidelines</a>.
         credit_4_html: |
           To make clear that the data is available under the Open
           Database License, you may link to


### PR DESCRIPTION
My editor does this any time the file is saved, so let's fix this.

Was introduced recently in #3565