### PR TITLE
Use $.ajax instead of iframe to make remote control requests

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -255,20 +255,10 @@ $(document).ready(function () {
     });
 
     function sendRemoteEditCommand(url, callback) {
-      var iframe = $("<iframe>");
-      var timeoutId = setTimeout(function () {
-        alert(I18n.t("site.index.remote_failed"));
-        iframe.remove();
-      }, 5000);
-
-      iframe
-        .hide()
-        .appendTo("body")
-        .attr("src", url)
-        .on("load", function () {
-          clearTimeout(timeoutId);
-          iframe.remove();
-          if (callback) callback();
+      $.ajax(url, { timeout: 5000 })
+        .done(callback)
+        .fail(function () {
+          alert(I18n.t("site.index.remote_failed"));
         });
     }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -253,9 +253,7 @@ class ApplicationController < ActionController::Base
   def map_layout
     policy = request.content_security_policy.clone
 
-    policy.child_src(*policy.child_src, "http://127.0.0.1:8111", "https://127.0.0.1:8112")
-    policy.frame_src(*policy.frame_src, "http://127.0.0.1:8111", "https://127.0.0.1:8112")
-    policy.connect_src(*policy.connect_src, Settings.nominatim_url, Settings.overpass_url, Settings.fossgis_osrm_url, Settings.graphhopper_url, Settings.fossgis_valhalla_url)
+    policy.connect_src(*policy.connect_src, "http://127.0.0.1:8111", Settings.nominatim_url, Settings.overpass_url, Settings.fossgis_osrm_url, Settings.graphhopper_url, Settings.fossgis_valhalla_url)
     policy.form_action(*policy.form_action, "render.openstreetmap.org")
     policy.style_src(*policy.style_src, :unsafe_inline)
 


### PR DESCRIPTION
iframe with src set to remote control request urls first appeared in https://github.com/openstreetmap/openstreetmap-website/commit/c3453cf57df864b008dca6479f84504f81c0b131 and was updated with timeout alert in https://github.com/openstreetmap/openstreetmap-website/commit/d4135390acff291f2f2c15d9fb86723ebf4fe755.

jQuery's $.ajax can make the same requests and has builtin timeout support.