### PR TITLE
Get the value of the text node to unescape it

### DIFF
--- a/lib/nominatim.rb
+++ b/lib/nominatim.rb
@@ -19,7 +19,7 @@ module Nominatim
       end
 
       if response && result = response.get_text("reversegeocode/result")
-        result.to_s
+        result.value
       else
         "#{number_with_precision(lat, :precision => 3)}, #{number_with_precision(lon, :precision => 3)}"
       end


### PR DESCRIPTION
get_text("reversegeocode/result") returns an XML text node.  We want to get the value of that node.

This will un-escape &#039; into an apostrophe.

All callers of this function will later re-encode it depending out output whether it be HTML in an email, or XML in an RSS feed.

* app/mailers/user_mail.rb
* app/helpers/geocode_helper.rb
* app/views/api/notes/feed.rss.builder
* app/views/api/notes/_note.rss.builder

Fixes openstreetmap/openstreetmap-website#3761