### PR TITLE
Don't display error messages when second scheduled rc command fails

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -236,20 +236,20 @@ $(document).ready(function () {
           });
 
     if (object && object.type !== "note") query.set("select", object.type + object.id); // can't select notes
-    sendRemoteEditCommand(remoteEditHost + "/load_and_zoom?" + query, function () {
-      if (object && object.type === "note") {
-        const noteQuery = new URLSearchParams({ url: osmHost + OSM.apiUrl(object) });
-        sendRemoteEditCommand(remoteEditHost + "/import?" + noteQuery);
-      }
-    }, function () {
-      // eslint-disable-next-line no-alert
-      alert(I18n.t("site.index.remote_failed"));
-    });
+    sendRemoteEditCommand(remoteEditHost + "/load_and_zoom?" + query)
+      .then(() => {
+        if (object && object.type === "note") {
+          const noteQuery = new URLSearchParams({ url: osmHost + OSM.apiUrl(object) });
+          sendRemoteEditCommand(remoteEditHost + "/import?" + noteQuery);
+        }
+      })
+      .catch(() => {
+        // eslint-disable-next-line no-alert
+        alert(I18n.t("site.index.remote_failed"));
+      });
 
-    function sendRemoteEditCommand(url, callback, errorCallback) {
-      fetch(url, { mode: "no-cors", signal: AbortSignal.timeout(5000) })
-        .then(callback)
-        .catch(errorCallback);
+    function sendRemoteEditCommand(url) {
+      return fetch(url, { mode: "no-cors", signal: AbortSignal.timeout(5000) });
     }
 
     return false;

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -241,15 +241,15 @@ $(document).ready(function () {
         const noteQuery = new URLSearchParams({ url: osmHost + OSM.apiUrl(object) });
         sendRemoteEditCommand(remoteEditHost + "/import?" + noteQuery);
       }
+    }, function () {
+      // eslint-disable-next-line no-alert
+      alert(I18n.t("site.index.remote_failed"));
     });
 
-    function sendRemoteEditCommand(url, callback) {
+    function sendRemoteEditCommand(url, callback, errorCallback) {
       fetch(url, { mode: "no-cors", signal: AbortSignal.timeout(5000) })
         .then(callback)
-        .catch(function () {
-          // eslint-disable-next-line no-alert
-          alert(I18n.t("site.index.remote_failed"));
-        });
+        .catch(errorCallback);
     }
 
     return false;


### PR DESCRIPTION
If we care about errors when using editors like Potlatch,
rc note loading gives an error in Potlatch anyway because Potlatch doesn't have the `import` command. In case of Potlatch there's no way to check what commands are supported. Potlatch won't even tell that it's Potlatch, unlike JOSM that sends this header: `Server: JOSM RemoteControl`. And we can't assume that it's Potlatch when there's no server header because we don't get to read the response as long as we make cors-avoiding requests (https://github.com/openstreetmap/openstreetmap-website/pull/3760).

The error message that is displayed when the note import fails is not helpful. It tells the user to check if the editor is launched and rc enabled. But we already know that it's the case because otherwise the first (`load_and_zoom`) command would have failed. It's better not to display any message at all in this case.

We can't know if `load_and_zoom` fully worked either. For example, on element pages `load_and_zoom` gets a parameter to select the element. This parameter is ignored by Potlatch and there's no error message about it. It makes sense then not to display the message about a failed note load.