### PR TITLE
Merge changeset <ol>s on Load more

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -43,6 +43,18 @@ OSM.History = function (map) {
     $("#changeset_" + id).find("a.changeset_id").simulate("click", e);
   }
 
+  function displayFirstChangesets(html) {
+    $("#sidebar_content .changesets").html(html);
+  }
+
+  function displayMoreChangesets(html) {
+    $("#sidebar_content .changeset_more").replaceWith(html);
+    var oldList = $("#sidebar_content .changesets ol").first();
+    var newList = oldList.next("ol");
+    newList.children().appendTo(oldList);
+    newList.remove();
+  }
+
   function update() {
     var data = { list: "1" };
 
@@ -58,7 +70,7 @@ OSM.History = function (map) {
       method: "GET",
       data: data,
       success: function (html) {
-        $("#sidebar_content .changesets").html(html);
+        displayFirstChangesets(html);
         updateMap();
       }
     });
@@ -73,8 +85,8 @@ OSM.History = function (map) {
     $(this).hide();
     div.find(".loader").show();
 
-    $.get($(this).attr("href"), function (data) {
-      div.replaceWith(data);
+    $.get($(this).attr("href"), function (html) {
+      displayMoreChangesets(html);
       updateMap();
     });
   }

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -1,6 +1,8 @@
 require "application_system_test_case"
 
 class HistoryTest < ApplicationSystemTestCase
+  PAGE_SIZE = 20
+
   test "atom link on user's history is not modified" do
     user = create(:user)
     create(:changeset, :user => user, :num_changes => 1) do |changeset|
@@ -12,5 +14,46 @@ class HistoryTest < ApplicationSystemTestCase
     changesets.assert_text "first-changeset-in-history"
 
     assert_css "link[type='application/atom+xml'][href$='#{user_path(user)}/history/feed']", :visible => false
+  end
+
+  test "have only one list element on user's changesets page" do
+    user = create(:user)
+    create_visible_changeset(user, "first-changeset-in-history")
+    create_visible_changeset(user, "bottom-changeset-in-batch-2")
+    (PAGE_SIZE - 1).times do
+      create_visible_changeset(user, "next-changeset")
+    end
+    create_visible_changeset(user, "bottom-changeset-in-batch-1")
+    (PAGE_SIZE - 1).times do
+      create_visible_changeset(user, "next-changeset")
+    end
+
+    visit "#{user_path(user)}/history"
+    changesets = find "div.changesets"
+    changesets.assert_text "bottom-changeset-in-batch-1"
+    changesets.assert_no_text "bottom-changeset-in-batch-2"
+    changesets.assert_no_text "first-changeset-in-history"
+    changesets.assert_selector "ol", :count => 1
+    changesets.assert_selector "li", :count => PAGE_SIZE
+
+    changesets.find(".changeset_more a.btn").click
+    changesets.assert_text "bottom-changeset-in-batch-1"
+    changesets.assert_text "bottom-changeset-in-batch-2"
+    changesets.assert_no_text "first-changeset-in-history"
+    changesets.assert_selector "ol", :count => 1
+    changesets.assert_selector "li", :count => 2 * PAGE_SIZE
+
+    changesets.find(".changeset_more a.btn").click
+    changesets.assert_text "bottom-changeset-in-batch-1"
+    changesets.assert_text "bottom-changeset-in-batch-2"
+    changesets.assert_text "first-changeset-in-history"
+    changesets.assert_selector "ol", :count => 1
+    changesets.assert_selector "li", :count => (2 * PAGE_SIZE) + 1
+  end
+
+  def create_visible_changeset(user, comment)
+    create(:changeset, :user => user, :num_changes => 1) do |changeset|
+      create(:changeset_tag, :changeset => changeset, :k => "comment", :v => comment)
+    end
   end
 end


### PR DESCRIPTION
Since the pull request https://github.com/openstreetmap/openstreetmap-website/pull/3682 is not going anywhere I'll start taking it apart. Here are the changes in https://github.com/openstreetmap/openstreetmap-website/pull/3682/commits/10319cac0d54ddb9e8f1f467cf16928646474730.

On any history page that displays a list of changesets the "Load more" button loads more changesets. This button creates another list element for those changesets. You get as many lists as the number of times you pressed the button plus the original list. There's a line between list items but no line between lists. To the user it looks like some dividing lines are missing. Here you can see that there's no line between the second and the third changesets:
![history-ols](https://user-images.githubusercontent.com/4158490/198023636-64481df5-e98f-46f7-a166-9504782b6be1.png)

This PR makes "Load more" to merge the changesets it loads into the original html list so there's only one list.