### PR TITLE
Use close button instead of geolink in sidebar content

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -406,4 +406,8 @@ $(document).ready(function () {
       e.preventDefault();
     }
   });
+
+  $(document).on("click", "#sidebar_content .btn-close", function () {
+    OSM.router.route("/" + OSM.formatHash(map));
+  });
 });

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex w-100">
   <h2 class="flex-grow-1 text-break"><%= title %></h2>
   <div>
-    <a class="geolink d-block btn-close" href="<%= root_path %>"></a>
+    <button type="button" class="btn-close"></button>
   </div>
 </div>


### PR DESCRIPTION
This is https://github.com/openstreetmap/openstreetmap-website/pull/3682/commits/cc9bcce5f0531243c34ffab8d43bc2885ff106ef + https://github.com/openstreetmap/openstreetmap-website/pull/3682/commits/b9f05806dbda4c33fcad5c1d68cb59623c432989

When I was changing close buttons to Bootstrap's `class="btn-close"`, I kept the one in the left sidebar as a link. It was a "geolink" and I didn't want to remove it because "geolinks" are updated when map view changes and I didn't know exactly how it was happening. Later in https://github.com/openstreetmap/openstreetmap-website/pull/3682 I finally replaced it with a button. I think I did it so I could cache the entire sidebar without worrying about map view updates.
