### PR TITLE
Introduce "reload" js controller method

### DIFF
--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -18,6 +18,10 @@
        as arguments the URL path plus any matching arguments for placeholders
        in the path template.
 
+     * The `reload` method, when defined, is called by the router when a page
+       reload is requested by the user. When not defined, the `load` method is
+       called instead.
+
      * The `pushstate` method is called when a page which matches the route's path
        template is loaded via pushState. It is passed the same arguments as `load`.
 
@@ -79,6 +83,10 @@ OSM.Router = function (map, rts) {
       params = params.concat(Array.prototype.slice.call(arguments, 2));
 
       return (controller[action] || $.noop).apply(controller, params);
+    };
+
+    route.has = function (action) {
+      return action in controller;
     };
 
     return route;
@@ -179,8 +187,20 @@ OSM.Router = function (map, rts) {
   };
 
   router.load = function () {
-    var loadState = currentRoute.run("load", currentPath);
+    var loadState = loadOrReload();
     router.stateChange(loadState || {});
+
+    function loadOrReload() {
+      if (currentRoute.has("reload") && window.performance) {
+        var wasReloaded = window.performance.getEntriesByType("navigation").some(function (entry) {
+          return entry.type === "reload";
+        });
+        if (wasReloaded) {
+          return currentRoute.run("reload", currentPath);
+        }
+      }
+      return currentRoute.run("load", currentPath);
+    }
   };
 
   router.setCurrentPath = function (path) {


### PR DESCRIPTION
Part of https://github.com/openstreetmap/openstreetmap-website/pull/3682/commits/2d1862120c1b7c18ce9493139fb874a6ef08a0e1.

This is a method that gets called
- for controllers that have it defined
- when the "Reload current page" button is pressed in the browser
- if it's possible to detect that this button is pressed

Otherwise the usual "load" method is called.

If any kind of client-side caching is used, js controllers can flush the cache in this method.