### PR TITLE
Have only one changeset link in chageset list, give it a Bootstrap button outline

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -817,6 +817,14 @@ tr.turn:hover {
       position: relative;
       z-index: 2; /* needs to be higher than Bootstrap's stretched link ::after z-index */
     }
+
+    a.stretched-link:focus-visible {
+      outline: none;
+    }
+
+    a.stretched-link:focus-visible::after {
+      box-shadow: inset $input-btn-focus-box-shadow;
+    }
   }
 
   .comments {

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -20,9 +20,7 @@
     <div class="col">
       <%= changeset_details(changeset) %>
       &middot;
-      <a class="changeset_id text-dark" href="<%= changeset_path(changeset) %>">
-        #<%= changeset.id %>
-      </a>
+      #<%= changeset.id %>
     </div>
     <div class="col-auto comments comments-<%= changeset.comments.length %>">
       <%= changeset.comments.length %>


### PR DESCRIPTION
History pages have two links to every changeset: one from a comment and one form an id. Why? Maybe because there's a chance that user wrote a comment that is difficult to click, but there's no way to make an unclickable chageset id. However that's no longer relevant because the link is stretched to the entire box with the changeset info.

Second link is in the way of keyboard navigation. When tabbing through the changesets you get from the first link to the second one leading to the same place. On user's changesets page you have to press tab twice to get to the next changeset.

Here I removed the second link. Also I replaced the standard link outline that the comment has when it's keyboard-focused with a Bootstrap outline* for inputs covering the entire stretched link.

\* actually it's a box-shadow and I made it inset to keep it inside the comment box

![changeset-outline](https://user-images.githubusercontent.com/4158490/198832769-0d25c46b-091d-462e-bdba-5f2b64696595.png)
