### PR TITLE
Remove query spinner show delay because the spinner is not hidden

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -168,10 +168,6 @@ OSM.Query = function (map) {
     $ul.empty();
     $section.show();
 
-    $section.find(".loader").oneTime(1000, "loading", function () {
-      $(this).show();
-    });
-
     if ($section.data("ajax")) {
       $section.data("ajax").abort();
     }
@@ -188,7 +184,7 @@ OSM.Query = function (map) {
       success: function (results) {
         var elements;
 
-        $section.find(".loader").stopTime("loading").hide();
+        $section.find(".loader").hide();
 
         if (merge) {
           elements = results.elements.reduce(function (hash, element) {
@@ -243,7 +239,7 @@ OSM.Query = function (map) {
         }
       },
       error: function (xhr, status, error) {
-        $section.find(".loader").stopTime("loading").hide();
+        $section.find(".loader").hide();
 
         $("<li>")
           .addClass("query-result list-group-item")


### PR DESCRIPTION
This is for "Query features" map tool. What was supposed to happen [here](https://github.com/openstreetmap/openstreetmap-website/commit/078059b76b8304368fd7ddac2dd563470e83472e#diff-8275a6df0995b2af17f0b52a0dfe5a00f8b09d9d51b89516e2612a3faa9d8c0fR127) is this I guess:

- the spinner is initially hidden
- when the query runs it's still hidden
- if the query runs longer than a second, the spinner is shown

The problem is that the spinner was never hidden. Therefore there's no point in having this delay timer.