### PR TITLE
Add aria-label to close buttons

### DIFF
--- a/app/assets/javascripts/index/browse.js
+++ b/app/assets/javascripts/index/browse.js
@@ -54,6 +54,7 @@ OSM.initializeBrowse = function (map) {
             .text(I18n.t("browse.start_rjs.load_data")),
           $("<div>").append(
             $("<button type='button' class='btn-close'>")
+              .attr("aria-label", I18n.t("javascripts.close"))
               .click(cancel))),
         $("<p class='alert alert-warning'>")
           .text(I18n.t("browse.start_rjs.feature_warning", { num_features: count, max_features: limit })),

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -265,7 +265,8 @@ OSM.Directions = function (map) {
       }
 
       var turnByTurnTable = $("<table class='mb-3'>");
-      var directionsCloseButton = $("<button type='button' class='btn-close'>");
+      var directionsCloseButton = $("<button type='button' class='btn-close'>")
+        .attr("aria-label", I18n.t("javascripts.close"));
 
       $("#sidebar_content")
         .empty()

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex w-100">
   <h2 class="flex-grow-1 text-break"><%= title %></h2>
   <div>
-    <button type="button" class="btn-close"></button>
+    <button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button>
   </div>
 </div>

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,4 +1,4 @@
 <% unless (banner = next_banner()).nil? %>
 <%= link_to (image_tag banner[:img], :alt => banner[:alt], :title => banner[:alt]), banner[:link] %>
-<button type="button" class="btn-close position-absolute top-0 end-0 p-4" id="<%= banner_cookie(banner[:id]) %>"></button>
+<button type="button" class="btn-close position-absolute top-0 end-0 p-4" id="<%= banner_cookie(banner[:id]) %>" aria-label="<%= t("javascripts.close") %>"></button>
 <% end %>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -19,7 +19,7 @@
   </form>
 
   <form method="GET" action="<%= directions_path %>" class="directions_form pb-3">
-    <div class="d-flex flex-row-reverse px-3 py-3"><button type="button" class="btn-close"></button></div>
+    <div class="d-flex flex-row-reverse px-3 py-3"><button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button></div>
 
     <div class="row gx-2 m-1">
       <div class="col-1">


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/pull/3631#issuecomment-1203797930. Now that all close buttons are actually button html elements, I can finish adding aria labels.