### PR TITLE
Remove query result geometry when unloading the page

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -39,17 +39,21 @@ OSM.Query = function (map) {
     }
   });
 
+  function showResultGeometry() {
+    var geometry = $(this).data("geometry");
+    if (geometry) map.addLayer(geometry);
+    $(this).addClass("selected");
+  }
+
+  function hideResultGeometry() {
+    var geometry = $(this).data("geometry");
+    if (geometry) map.removeLayer(geometry);
+    $(this).removeClass("selected");
+  }
+
   $("#sidebar_content")
-    .on("mouseover", ".query-results li.query-result", function () {
-      var geometry = $(this).data("geometry");
-      if (geometry) map.addLayer(geometry);
-      $(this).addClass("selected");
-    })
-    .on("mouseout", ".query-results li.query-result", function () {
-      var geometry = $(this).data("geometry");
-      if (geometry) map.removeLayer(geometry);
-      $(this).removeClass("selected");
-    })
+    .on("mouseover", ".query-results li.query-result", showResultGeometry)
+    .on("mouseout", ".query-results li.query-result", hideResultGeometry)
     .on("mousedown", ".query-results li.query-result", function () {
       var moved = false;
       $(this).one("click", function (e) {
@@ -363,6 +367,7 @@ OSM.Query = function (map) {
   page.unload = function (sameController) {
     if (!sameController) {
       disableQueryMode();
+      $("#sidebar_content .query-results li.query-result.selected").each(hideResultGeometry);
     }
   };
 


### PR DESCRIPTION
Fixes this:

1. use "query features" tool to get nearby/enclosing features lists in the sidebar
2. type some search query in search box above the sidebar but don't press enter yet
3. hover the pointer over one of nearby/enclosing features list items to see it appear on the map
4. press enter to run the search
5. notice that the hovered feature stays on the map

Possibly related to https://github.com/openstreetmap/openstreetmap-website/issues/2082.