### PR TITLE
Enable the Action Order cop for remaining controllers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -112,27 +112,6 @@ Rails/ActionControllerFlashBeforeRender:
     - 'app/controllers/user_blocks_controller.rb'
     - 'app/controllers/users_controller.rb'
 
-# Offense count: 18
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: ExpectedOrder, Include.
-# ExpectedOrder: index, show, new, edit, create, update, destroy
-# Include: app/controllers/**/*.rb
-Rails/ActionOrder:
-  Exclude:
-    - 'app/controllers/api/changesets_controller.rb'
-    - 'app/controllers/api/nodes_controller.rb'
-    - 'app/controllers/api/notes_controller.rb'
-    - 'app/controllers/api/relations_controller.rb'
-    - 'app/controllers/api/traces_controller.rb'
-    - 'app/controllers/api/users_controller.rb'
-    - 'app/controllers/api/ways_controller.rb'
-    - 'app/controllers/diary_entries_controller.rb'
-    - 'app/controllers/messages_controller.rb'
-    - 'app/controllers/oauth_clients_controller.rb'
-    - 'app/controllers/redactions_controller.rb'
-    - 'app/controllers/traces_controller.rb'
-    - 'app/controllers/users_controller.rb'
-
 # Offense count: 5
 # Configuration parameters: Database, Include.
 # SupportedDatabases: mysql, postgresql

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -19,6 +19,20 @@ module Api
     # Helper methods for checking consistency
     include ConsistencyValidations
 
+    ##
+    # Return XML giving the basic info about the changeset. Does not
+    # return anything about the nodes, ways and relations in the changeset.
+    def show
+      @changeset = Changeset.find(params[:id])
+      @include_discussion = params[:include_discussion].presence
+      render "changeset"
+
+      respond_to do |format|
+        format.xml
+        format.json
+      end
+    end
+
     # Create a changeset from XML.
     def create
       assert_method :put
@@ -33,20 +47,6 @@ module Api
       cs.subscribers << current_user
 
       render :plain => cs.id.to_s
-    end
-
-    ##
-    # Return XML giving the basic info about the changeset. Does not
-    # return anything about the nodes, ways and relations in the changeset.
-    def show
-      @changeset = Changeset.find(params[:id])
-      @include_discussion = params[:include_discussion].presence
-      render "changeset"
-
-      respond_to do |format|
-        format.xml
-        format.json
-      end
     end
 
     ##

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -15,15 +15,21 @@ module Api
 
     before_action :set_request_formats, :except => [:create, :update, :delete]
 
-    # Create a node from XML.
-    def create
-      assert_method :put
+    # Dump the details on many nodes whose ids are given in the "nodes" parameter.
+    def index
+      raise OSM::APIBadUserInput, "The parameter nodes is required, and must be of the form nodes=id[,id[,id...]]" unless params["nodes"]
 
-      node = Node.from_xml(request.raw_post, :create => true)
+      ids = params["nodes"].split(",").collect(&:to_i)
 
-      # Assume that Node.from_xml has thrown an exception if there is an error parsing the xml
-      node.create_with_history current_user
-      render :plain => node.id.to_s
+      raise OSM::APIBadUserInput, "No nodes were given to search for" if ids.empty?
+
+      @nodes = Node.find(ids)
+
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
+      end
     end
 
     # Dump the details on a node given in params[:id]
@@ -41,6 +47,17 @@ module Api
       else
         head :gone
       end
+    end
+
+    # Create a node from XML.
+    def create
+      assert_method :put
+
+      node = Node.from_xml(request.raw_post, :create => true)
+
+      # Assume that Node.from_xml has thrown an exception if there is an error parsing the xml
+      node.create_with_history current_user
+      render :plain => node.id.to_s
     end
 
     # Update a node from given XML
@@ -65,23 +82,6 @@ module Api
 
       node.delete_with_history!(new_node, current_user)
       render :plain => node.version.to_s
-    end
-
-    # Dump the details on many nodes whose ids are given in the "nodes" parameter.
-    def index
-      raise OSM::APIBadUserInput, "The parameter nodes is required, and must be of the form nodes=id[,id[,id...]]" unless params["nodes"]
-
-      ids = params["nodes"].split(",").collect(&:to_i)
-
-      raise OSM::APIBadUserInput, "No nodes were given to search for" if ids.empty?
-
-      @nodes = Node.find(ids)
-
-      # Render the result
-      respond_to do |format|
-        format.xml
-        format.json
-      end
     end
   end
 end

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -13,14 +13,20 @@ module Api
 
     before_action :set_request_formats, :except => [:create, :update, :delete]
 
-    def create
-      assert_method :put
+    def index
+      raise OSM::APIBadUserInput, "The parameter relations is required, and must be of the form relations=id[,id[,id...]]" unless params["relations"]
 
-      relation = Relation.from_xml(request.raw_post, :create => true)
+      ids = params["relations"].split(",").collect(&:to_i)
 
-      # Assume that Relation.from_xml has thrown an exception if there is an error parsing the xml
-      relation.create_with_history current_user
-      render :plain => relation.id.to_s
+      raise OSM::APIBadUserInput, "No relations were given to search for" if ids.empty?
+
+      @relations = Relation.find(ids)
+
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
+      end
     end
 
     def show
@@ -35,6 +41,16 @@ module Api
       else
         head :gone
       end
+    end
+
+    def create
+      assert_method :put
+
+      relation = Relation.from_xml(request.raw_post, :create => true)
+
+      # Assume that Relation.from_xml has thrown an exception if there is an error parsing the xml
+      relation.create_with_history current_user
+      render :plain => relation.id.to_s
     end
 
     def update
@@ -128,22 +144,6 @@ module Api
         end
       else
         head :gone
-      end
-    end
-
-    def index
-      raise OSM::APIBadUserInput, "The parameter relations is required, and must be of the form relations=id[,id[,id...]]" unless params["relations"]
-
-      ids = params["relations"].split(",").collect(&:to_i)
-
-      raise OSM::APIBadUserInput, "No relations were given to search for" if ids.empty?
-
-      @relations = Relation.find(ids)
-
-      # Render the result
-      respond_to do |format|
-        format.xml
-        format.json
       end
     end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -12,6 +12,22 @@ module Api
 
     before_action :set_request_formats, :except => [:gpx_files]
 
+    def index
+      raise OSM::APIBadUserInput, "The parameter users is required, and must be of the form users=id[,id[,id...]]" unless params["users"]
+
+      ids = params["users"].split(",").collect(&:to_i)
+
+      raise OSM::APIBadUserInput, "No users were given to search for" if ids.empty?
+
+      @users = User.visible.find(ids)
+
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
+      end
+    end
+
     def show
       if @user.visible?
         # Render the result
@@ -30,22 +46,6 @@ module Api
       respond_to do |format|
         format.xml { render :show }
         format.json { render :show }
-      end
-    end
-
-    def index
-      raise OSM::APIBadUserInput, "The parameter users is required, and must be of the form users=id[,id[,id...]]" unless params["users"]
-
-      ids = params["users"].split(",").collect(&:to_i)
-
-      raise OSM::APIBadUserInput, "No users were given to search for" if ids.empty?
-
-      @users = User.visible.find(ids)
-
-      # Render the result
-      respond_to do |format|
-        format.xml
-        format.json
       end
     end
 

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -13,14 +13,20 @@ module Api
 
     before_action :set_request_formats, :except => [:create, :update, :delete]
 
-    def create
-      assert_method :put
+    def index
+      raise OSM::APIBadUserInput, "The parameter ways is required, and must be of the form ways=id[,id[,id...]]" unless params["ways"]
 
-      way = Way.from_xml(request.raw_post, :create => true)
+      ids = params["ways"].split(",").collect(&:to_i)
 
-      # Assume that Way.from_xml has thrown an exception if there is an error parsing the xml
-      way.create_with_history current_user
-      render :plain => way.id.to_s
+      raise OSM::APIBadUserInput, "No ways were given to search for" if ids.empty?
+
+      @ways = Way.find(ids)
+
+      # Render the result
+      respond_to do |format|
+        format.xml
+        format.json
+      end
     end
 
     def show
@@ -37,6 +43,16 @@ module Api
       else
         head :gone
       end
+    end
+
+    def create
+      assert_method :put
+
+      way = Way.from_xml(request.raw_post, :create => true)
+
+      # Assume that Way.from_xml has thrown an exception if there is an error parsing the xml
+      way.create_with_history current_user
+      render :plain => way.id.to_s
     end
 
     def update
@@ -84,22 +100,6 @@ module Api
         end
       else
         head :gone
-      end
-    end
-
-    def index
-      raise OSM::APIBadUserInput, "The parameter ways is required, and must be of the form ways=id[,id[,id...]]" unless params["ways"]
-
-      ids = params["ways"].split(",").collect(&:to_i)
-
-      raise OSM::APIBadUserInput, "No ways were given to search for" if ids.empty?
-
-      @ways = Way.find(ids)
-
-      # Render the result
-      respond_to do |format|
-        format.xml
-        format.json
       end
     end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,6 +11,23 @@ class MessagesController < ApplicationController
   before_action :check_database_writable, :only => [:new, :create, :reply, :mark, :destroy]
   before_action :allow_thirdparty_images, :only => [:new, :create, :show]
 
+  # Show a message
+  def show
+    @title = t ".title"
+    @message = Message.find(params[:id])
+
+    if @message.recipient == current_user || @message.sender == current_user
+      @message.message_read = true if @message.recipient == current_user
+      @message.save
+    else
+      flash[:notice] = t ".wrong_user", :user => current_user.display_name
+      redirect_to login_path(:referer => request.fullpath)
+    end
+  rescue ActiveRecord::RecordNotFound
+    @title = t "messages.no_such_message.title"
+    render :action => "no_such_message", :status => :not_found
+  end
+
   # Allow the user to write a new message to another user. This action also
   # deals with the sending of that message to the other user when the user
   # clicks send.
@@ -39,6 +56,23 @@ class MessagesController < ApplicationController
     end
   end
 
+  # Destroy the message.
+  def destroy
+    @message = Message.where("to_user_id = ? OR from_user_id = ?", current_user.id, current_user.id).find(params[:id])
+    @message.from_user_visible = false if @message.sender == current_user
+    @message.to_user_visible = false if @message.recipient == current_user
+    if @message.save && !request.xhr?
+      flash[:notice] = t ".destroyed"
+
+      referer = safe_referer(params[:referer]) if params[:referer]
+
+      redirect_to referer || { :action => :inbox }
+    end
+  rescue ActiveRecord::RecordNotFound
+    @title = t "messages.no_such_message.title"
+    render :action => "no_such_message", :status => :not_found
+  end
+
   # Allow the user to reply to another message.
   def reply
     message = Message.find(params[:message_id])
@@ -55,23 +89,6 @@ class MessagesController < ApplicationController
       @title = @message.title
 
       render :action => "new"
-    else
-      flash[:notice] = t ".wrong_user", :user => current_user.display_name
-      redirect_to login_path(:referer => request.fullpath)
-    end
-  rescue ActiveRecord::RecordNotFound
-    @title = t "messages.no_such_message.title"
-    render :action => "no_such_message", :status => :not_found
-  end
-
-  # Show a message
-  def show
-    @title = t ".title"
-    @message = Message.find(params[:id])
-
-    if @message.recipient == current_user || @message.sender == current_user
-      @message.message_read = true if @message.recipient == current_user
-      @message.save
     else
       flash[:notice] = t ".wrong_user", :user => current_user.display_name
       redirect_to login_path(:referer => request.fullpath)
@@ -105,23 +122,6 @@ class MessagesController < ApplicationController
     if @message.save && !request.xhr?
       flash[:notice] = notice
       redirect_to :action => :inbox
-    end
-  rescue ActiveRecord::RecordNotFound
-    @title = t "messages.no_such_message.title"
-    render :action => "no_such_message", :status => :not_found
-  end
-
-  # Destroy the message.
-  def destroy
-    @message = Message.where("to_user_id = ? OR from_user_id = ?", current_user.id, current_user.id).find(params[:id])
-    @message.from_user_visible = false if @message.sender == current_user
-    @message.to_user_visible = false if @message.recipient == current_user
-    if @message.save && !request.xhr?
-      flash[:notice] = t ".destroyed"
-
-      referer = safe_referer(params[:referer]) if params[:referer]
-
-      redirect_to referer || { :action => :inbox }
     end
   rescue ActiveRecord::RecordNotFound
     @title = t "messages.no_such_message.title"

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -28,10 +28,7 @@ class MessagesController < ApplicationController
     render :action => "no_such_message", :status => :not_found
   end
 
-  # Allow the user to write a new message to another user. This action also
-  # deals with the sending of that message to the other user when the user
-  # clicks send.
-  # The display_name param is the display name of the user that the message is being sent to.
+  # Allow the user to write a new message to another user.
   def new
     @message = Message.new(message_params.merge(:recipient => @user))
     @title = t ".title"

--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -11,8 +11,22 @@ class OauthClientsController < ApplicationController
     @tokens = current_user.oauth_tokens.authorized
   end
 
+  def show
+    @client_application = current_user.client_applications.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    @type = "client application"
+    render :action => "not_found", :status => :not_found
+  end
+
   def new
     @client_application = ClientApplication.new
+  end
+
+  def edit
+    @client_application = current_user.client_applications.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    @type = "client application"
+    render :action => "not_found", :status => :not_found
   end
 
   def create
@@ -23,20 +37,6 @@ class OauthClientsController < ApplicationController
     else
       render :action => "new"
     end
-  end
-
-  def show
-    @client_application = current_user.client_applications.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    @type = "client application"
-    render :action => "not_found", :status => :not_found
-  end
-
-  def edit
-    @client_application = current_user.client_applications.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    @type = "client application"
-    render :action => "not_found", :status => :not_found
   end
 
   def update

--- a/app/controllers/redactions_controller.rb
+++ b/app/controllers/redactions_controller.rb
@@ -14,9 +14,13 @@ class RedactionsController < ApplicationController
     @redactions = Redaction.order(:id)
   end
 
+  def show; end
+
   def new
     @redaction = Redaction.new
   end
+
+  def edit; end
 
   def create
     @redaction = Redaction.new
@@ -32,10 +36,6 @@ class RedactionsController < ApplicationController
       render :action => "new"
     end
   end
-
-  def show; end
-
-  def edit; end
 
   def update
     # NOTE: don't update the user ID

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -69,10 +69,6 @@ class TracesController < ApplicationController
     @target_user = target_user
   end
 
-  def mine
-    redirect_to :action => :index, :display_name => current_user.display_name
-  end
-
   def show
     @trace = Trace.find(params[:id])
 
@@ -91,6 +87,20 @@ class TracesController < ApplicationController
   def new
     @title = t ".upload_trace"
     @trace = Trace.new(:visibility => default_visibility)
+  end
+
+  def edit
+    @trace = Trace.find(params[:id])
+
+    if !@trace.visible?
+      head :not_found
+    elsif current_user.nil? || @trace.user != current_user
+      head :forbidden
+    else
+      @title = t ".title", :name => @trace.name
+    end
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
   end
 
   def create
@@ -127,42 +137,6 @@ class TracesController < ApplicationController
     end
   end
 
-  def data
-    trace = Trace.find(params[:id])
-
-    if trace.visible? && (trace.public? || (current_user && current_user == trace.user))
-      if Acl.no_trace_download(request.remote_ip)
-        head :forbidden
-      elsif request.format == Mime[:xml]
-        send_data(trace.xml_file.read, :filename => "#{trace.id}.xml", :type => request.format.to_s, :disposition => "attachment")
-      elsif request.format == Mime[:gpx]
-        send_data(trace.xml_file.read, :filename => "#{trace.id}.gpx", :type => request.format.to_s, :disposition => "attachment")
-      elsif trace.file.attached?
-        redirect_to rails_blob_path(trace.file, :disposition => "attachment")
-      else
-        send_file(trace.trace_name, :filename => "#{trace.id}#{trace.extension_name}", :type => trace.mime_type, :disposition => "attachment")
-      end
-    else
-      head :not_found
-    end
-  rescue ActiveRecord::RecordNotFound
-    head :not_found
-  end
-
-  def edit
-    @trace = Trace.find(params[:id])
-
-    if !@trace.visible?
-      head :not_found
-    elsif current_user.nil? || @trace.user != current_user
-      head :forbidden
-    else
-      @title = t ".title", :name => @trace.name
-    end
-  rescue ActiveRecord::RecordNotFound
-    head :not_found
-  end
-
   def update
     @trace = Trace.find(params[:id])
 
@@ -194,6 +168,32 @@ class TracesController < ApplicationController
       flash[:notice] = t ".scheduled_for_deletion"
       TraceDestroyerJob.perform_later(trace)
       redirect_to :action => :index, :display_name => trace.user.display_name
+    end
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
+  def mine
+    redirect_to :action => :index, :display_name => current_user.display_name
+  end
+
+  def data
+    trace = Trace.find(params[:id])
+
+    if trace.visible? && (trace.public? || (current_user && current_user == trace.user))
+      if Acl.no_trace_download(request.remote_ip)
+        head :forbidden
+      elsif request.format == Mime[:xml]
+        send_data(trace.xml_file.read, :filename => "#{trace.id}.xml", :type => request.format.to_s, :disposition => "attachment")
+      elsif request.format == Mime[:gpx]
+        send_data(trace.xml_file.read, :filename => "#{trace.id}.gpx", :type => request.format.to_s, :disposition => "attachment")
+      elsif trace.file.attached?
+        redirect_to rails_blob_path(trace.file, :disposition => "attachment")
+      else
+        send_file(trace.trace_name, :filename => "#{trace.id}#{trace.extension_name}", :type => trace.mime_type, :disposition => "attachment")
+      end
+    else
+      head :not_found
     end
   rescue ActiveRecord::RecordNotFound
     head :not_found


### PR DESCRIPTION
Where actions were reordered, the rails standard actions were also moved to the top of each controller.

My personal preference is for index/new/create/edit/update/destroy (i.e. pair off new/create and edit/update) but I guess it's better to follow the default order, which is based on the rails scaffolding order too.

I would be delighted at some point if we get to the point of having *only* these actions, but that's work for another day. :smiley: 

I've also fixed a comment (by deleting most of it) that I noticed while reordering actions - it referred to the old approach of having multi-purpose actions which was refactored a while ago.