### PR TITLE
typo in code and app but not in translatewiki.net

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2773,7 +2773,7 @@ de:
         klicke dann auf den "Weiter"-Knopf.
       contributor_terms_explain: Diese Vereinbarung definiert die Bedingungen für
         deine bestehenden und zukünftigen Beiträge.
-      read_ct: Ich habe obige Bedingungen für Mitwirkende gelesene und stimme ihnen
+      read_ct: Ich habe obige Bedingungen für Mitwirkende gelesen und stimme ihnen
         zu
       tou_explain_html: Die %{tou_link} regeln die Benutzung der Webseite und anderer
         Infrastruktur, die von der OSMF zur Verfügung gestellt wird. Klicke bitte


### PR DESCRIPTION
### Typo _"gelesen~e~"_ on osm.org (see commit) somehow seems non existing in [translatewiki.net](https://translatewiki.net/w/i.php?title=Special:Translate&showMessage=users.terms.read_tou&group=out-osm-site&language=de&filter=&optional=1&action=translate)
![Screenshot_20221111-041342~2](https://user-images.githubusercontent.com/11715448/201255809-2750b493-68b5-4338-82fc-050ef6c24b35.png)
![Screenshot_20221111-040539~2](https://user-images.githubusercontent.com/11715448/201255347-fb4234f2-35cf-417c-8b3c-d64b594f18f5.png)
