### PR TITLE
[iD] hide live/dev server switcher on integrated iD editor 

### DIFF
--- a/app/assets/javascripts/id.js
+++ b/app/assets/javascripts/id.js
@@ -11,15 +11,18 @@ document.addEventListener("DOMContentLoaded", function () {
       "Please upgrade your browser or use JOSM to edit the map.";
     container.className = "unsupported";
   } else {
-    var id = iD.coreContext()
+    var idContext = iD.coreContext();
+    idContext.connection().apiConnections([]);
+    idContext.preauth({
+      url: location.protocol + "//" + location.host,
+      access_token: container.dataset.token
+    });
+
+    var id = idContext
       .embed(true)
       .assetPath("iD/")
       .assetMap(JSON.parse(container.dataset.assetMap))
       .locale(container.dataset.locale)
-      .preauth({
-        url: location.protocol + "//" + location.host,
-        access_token: container.dataset.token
-      })
       .containerNode(container)
       .init();
 


### PR DESCRIPTION
This is a small additional integration adjustment needed for iD v2.23: After https://github.com/openstreetmap/iD/commit/c8a3cf154b43469d643b034f47d4e48d449582a1 the configuration of API connections is not done in the "boot-up" routine anymore. But as the integrated iD uses the pre-authentication, it is now necessary to clear the default api (_live_ / _dev_) connections such that the "api" switcher (<img src="https://user-images.githubusercontent.com/1927298/201652584-c2a4b729-6235-4bb1-a0c1-1d96df04497d.png" height=24>) on the bottom right doesn't shown up (it is only supposed to show up on the stand-alone instances of iD such as the one on https://ideditor-release.netlify.app/).

PS: this should have been part of #3789 already.