### PR TITLE
Fix feature request GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -5,7 +5,7 @@ description: You want to request a feature, share an idea or have a question.
 # assignees:
 body:
   - type: textarea
-    id: idea
+    id: problem
     attributes:
       label: Problem
       description: Please describe the problem or use case that is the cause for your feature request or idea.


### PR DESCRIPTION
The syntax for the feature request GitHub issue template yaml file was wrong because two elements had the same ids and thus the feature request issue form did not work. This changes one that was the same.