### PR TITLE
Remove references to "The Rails Port"

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -4,7 +4,7 @@ After [installing](INSTALL.md) this software, you may need to carry out some of 
 
 ## Application configuration
 
-Many settings are available in `config/settings.yml`. You can customize your installation of The Rails Port by overriding these values using `config/settings.local.yml`
+Many settings are available in `config/settings.yml`. You can customize your installation of `openstreetmap-website` by overriding these values using `config/settings.local.yml`
 
 ## Populating the database
 
@@ -122,9 +122,9 @@ If you have more problems, please ask on the [rails-dev@openstreetmap.org mailin
 
 If your installation stops working for some reason:
 
-* Sometimes gem dependencies change. To update go to your rails_port directory and run ''bundle install'' as root.
+* Sometimes gem dependencies change. To update go to your `openstreetmap-website` directory and run ''bundle install'' as root.
 
-* The OSM database schema is changed periodically and you need to keep up with these improvements. Go to your rails_port directory and run:
+* The OSM database schema is changed periodically and you need to keep up with these improvements. Go to your `openstreetmap-website` directory and run:
 
 ```
 bundle exec rake db:migrate
@@ -132,7 +132,7 @@ bundle exec rake db:migrate
 
 ## Testing on the osm dev server
 
-For example, after developing a patch for the rails_port, you might want to demonstrate it to others or ask for comments and testing. To do this one can [set up an instance of the rails_port on the dev server in ones user directory](https://wiki.openstreetmap.org/wiki/Using_the_dev_server#Rails_Applications).
+For example, after developing a patch for `openstreetmap-website`, you might want to demonstrate it to others or ask for comments and testing. To do this one can [set up an instance of openstreetmap-website on the dev server in ones user directory](https://wiki.openstreetmap.org/wiki/Using_the_dev_server#Rails_Applications).
 
 # Contributing
 
@@ -140,7 +140,7 @@ For information on contributing changes to the codes, see [CONTRIBUTING.md](CONT
 
 # Production Deployment
 
-If you want to deploy The Rails Port for production use, you'll need to make a few changes.
+If you want to deploy `openstreetmap-website` for production use, you'll need to make a few changes.
 
 * It's not recommended to use `rails server` in production. Our recommended approach is to use [Phusion Passenger](https://www.phusionpassenger.com/). Instructions are available for [setting it up with most web servers](https://www.phusionpassenger.com/documentation_and_support#documentation).
 * Passenger will, by design, use the Production environment and therefore the production database - make sure it contains the appropriate data and user accounts.

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -132,7 +132,7 @@ bundle exec rake db:migrate
 
 ## Testing on the osm dev server
 
-For example, after developing a patch for `openstreetmap-website`, you might want to demonstrate it to others or ask for comments and testing. To do this one can [set up an instance of openstreetmap-website on the dev server in ones user directory](https://wiki.openstreetmap.org/wiki/Using_the_dev_server#Rails_Applications).
+For example, after developing a patch for `openstreetmap-website`, you might want to demonstrate it to others or ask for comments and testing. To do this you can [set up an instance of openstreetmap-website on the dev server in your user directory](https://wiki.openstreetmap.org/wiki/Using_the_dev_server#Rails_Applications).
 
 # Contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ bundle exec erblint .
 ## Testing
 
 Having a good suite of tests is very important to the stability and
-maintainability of any code base. The tests in the Rails port code are
+maintainability of any code base. The tests in the `openstreetmap-website` code are
 by no means complete, but they are extensive, and must continue to be
 so with any new functionality which is written. Tests are also useful
 in giving others confidence in the code you've written, and can

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,6 +1,6 @@
 # Using Docker and Docker Compose for Development and Testing
 
-These instructions are designed for setting up The Rails Port for development and testing using [Docker](https://www.docker.com/). This will allow you to install the OpenStreetMap application and all its dependencies in Docker images and then run them in containers, almost with a single command. You will need to install Docker and Docker Compose on your development machine:
+These instructions are designed for setting up `openstreetmap-website` for development and testing using [Docker](https://www.docker.com/). This will allow you to install the OpenStreetMap application and all its dependencies in Docker images and then run them in containers, almost with a single command. You will need to install Docker and Docker Compose on your development machine:
 
 - [Install Docker](https://docs.docker.com/install/)
 - [Install Docker Compose](https://docs.docker.com/compose/install/)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation
 
-These instructions are designed for setting up The Rails Port for development and testing.
+These instructions are designed for setting up `openstreetmap-website` for development and testing.
 If you want to deploy the software for your own project, then see the notes at the end.
 
 You can install the software directly on your machine, which is the traditional and probably best-supported approach. However, there
@@ -150,7 +150,7 @@ touch config/settings.local.yml
 
 ## Storage setup
 
-The Rails port needs to be configured with an object storage facility - for
+`openstreetmap-website` needs to be configured with an object storage facility - for
 development and testing purposes you can use the example configuration:
 
 ```
@@ -159,7 +159,7 @@ cp config/example.storage.yml config/storage.yml
 
 ## Database setup
 
-The Rails Port uses three databases -  one for development, one for testing, and one for production. The database-specific configuration
+`openstreetmap-website` uses three databases -  one for development, one for testing, and one for production. The database-specific configuration
 options are stored in `config/database.yml`, which we need to create from the example template.
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# "The Rails Port"
+# openstreetmap-website
 
 [![Lint](https://github.com/openstreetmap/openstreetmap-website/workflows/Lint/badge.svg?branch=master&event=push)](https://github.com/openstreetmap/openstreetmap-website/actions?query=workflow%3ALint%20branch%3Amaster%20event%3Apush)
 [![Tests](https://github.com/openstreetmap/openstreetmap-website/workflows/Tests/badge.svg?branch=master&event=push)](https://github.com/openstreetmap/openstreetmap-website/actions?query=workflow%3ATests%20branch%3Amaster%20event%3Apush)
 [![Coverage Status](https://coveralls.io/repos/openstreetmap/openstreetmap-website/badge.svg?branch=master)](https://coveralls.io/r/openstreetmap/openstreetmap-website?branch=master)
 
-This is The Rails Port, the [Ruby on Rails](http://rubyonrails.org/)
+This is `openstreetmap-website`, the [Ruby on Rails](http://rubyonrails.org/)
 application that powers the [OpenStreetMap](https://www.openstreetmap.org) website and API.
-The software is also known as "openstreetmap-website".
 
 This repository consists of:
 
@@ -16,7 +15,7 @@ This repository consists of:
 * The Browse pages - a web front-end to the OpenStreetMap data.
 * The GPX uploads, browsing and API.
 
-A fully-functional Rails Port installation depends on other services, including map tile
+A fully-functional `openstreetmap-website` installation depends on other services, including map tile
 servers and geocoding services, that are provided by other software. The default installation
 uses publicly-available services to help with development and testing.
 
@@ -27,7 +26,7 @@ a copy of which can be found in the [LICENSE](LICENSE) file.
 
 # Installation
 
-The Rails Port is a Ruby on Rails application that uses PostgreSQL as its database, and has a large
+`openstreetmap-website` is a Ruby on Rails application that uses PostgreSQL as its database, and has a large
 number of dependencies for installation. For full details please see [INSTALL.md](INSTALL.md).
 
 # Development

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ application that powers the [OpenStreetMap](https://www.openstreetmap.org) websi
 This repository consists of:
 
 * The web site, including user accounts, diary entries, user-to-user messaging.
-* The XML-based editing [API](https://wiki.openstreetmap.org/wiki/API_v0.6).
-* The integrated version of the [iD](https://wiki.openstreetmap.org/wiki/ID) editors.
+* The XML- and JSON-based editing [API](https://wiki.openstreetmap.org/wiki/API_v0.6).
+* The integrated version of the [iD](https://wiki.openstreetmap.org/wiki/ID) editor.
 * The Browse pages - a web front-end to the OpenStreetMap data.
 * The GPX uploads, browsing and API.
 

--- a/db/functions/quadtile.c
+++ b/db/functions/quadtile.c
@@ -18,7 +18,7 @@ PG_FUNCTION_INFO_V1(tile_for_point);
  * To bind this into PGSQL, try something like:
  *
  * CREATE FUNCTION tile_for_point(int4, int4) RETURNS int8
- *  AS '/path/to/rails-port/db/functions/libpgosm', 'tile_for_point'
+ *  AS '/path/to/openstreetmap-website/db/functions/libpgosm', 'tile_for_point'
  *  LANGUAGE C STRICT;
  *
  * (without all the *s)


### PR DESCRIPTION
As discussed in #3796 , the "rails port" terminology is confusing. This PR standardises on "openstreetmap-website" throughout.

This also picks up 3 minor documentation fixes that I found at the same time, which I've put in a separate commit.