### PR TITLE
Pass original event instad of leaflet event to changeset bbox click simulation

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -20,7 +20,7 @@ OSM.History = function (map) {
       unHighlightChangeset(e.layer.id);
     })
     .on("click", function (e) {
-      clickChangeset(e.layer.id, e);
+      clickChangeset(e.layer.id, e.originalEvent);
     });
 
   group.getLayerId = function (layer) {


### PR DESCRIPTION
Later there's a call to jquery.simulate to simulate a click on a changeset link inside the sidebar. The purpose of using the jquery.simulate is, I guess, to pass the modifier keys to the new event. If you do ctrl+click there should be a ctrl+click event that is later handled as *open in a new tab*. Except this doesn't work when clicking changeset bboxes because their events are neither dom nor jquery ones. We need to get the original event to simulate it correctly.

After applying this fix, ctrl+clicks on bboxes should open changeset pages in new tabs.