### PR TITLE
Relax strict version constraint on rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Require rails
-gem "rails", "7.0.4"
+gem "rails", "~> 7.0.0"
 
 # Require json for multi_json
 gem "json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -573,7 +573,7 @@ DEPENDENCIES
   r2 (~> 0.2.7)
   rack-cors
   rack-uri_sanitizer
-  rails (= 7.0.4)
+  rails (~> 7.0.0)
   rails-controller-testing
   rails-i18n (~> 7.0.0)
   rinku (>= 2.0.6)


### PR DESCRIPTION
This lets us receive 7.0.x patch releases without having to edit the Gemfile.

I considered making this `~> 7.0` since point releases are usually safe (in particular, if you run `bundle update` and the tests pass, then all good) but there's often a "new framework defaults" file that needs to be generated. So there's an argument that minor 7.x releases should still be treated differently.