### PR TITLE
Remove more usage of html_safe

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,7 +52,7 @@ class SessionsController < ApplicationController
     elsif (user = User.authenticate(:username => username, :password => password, :pending => true))
       unconfirmed_login(user)
     elsif User.authenticate(:username => username, :password => password, :suspended => true)
-      failed_login t("sessions.new.account is suspended", :webmaster => "mailto:#{Settings.support_email}").html_safe, username
+      failed_login({ :partial => "sessions/suspended_flash" }, username)
     else
       failed_login t("sessions.new.auth failure"), username
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -290,7 +290,7 @@ class UsersController < ApplicationController
         when "active", "confirmed"
           successful_login(user, request.env["omniauth.params"]["referer"])
         when "suspended"
-          failed_login t("sessions.new.account is suspended", :webmaster => "mailto:#{Settings.support_email}").html_safe
+          failed_login({ :partial => "sessions/suspended_flash" })
         else
           failed_login t("sessions.new.auth failure")
         end

--- a/app/views/changesets/history.html.erb
+++ b/app/views/changesets/history.html.erb
@@ -6,7 +6,7 @@
 
 <% set_title(changeset_index_title(params, current_user))
    @heading = if params[:display_name]
-                t("changesets.index.title_user", :user => link_to(params[:display_name], user_path(:display_name => params[:display_name]))).html_safe
+                t("changesets.index.title_user_link_html", :user_link => link_to(params[:display_name], user_path(:display_name => params[:display_name])))
               else
                 @title
               end %>

--- a/app/views/sessions/_suspended_flash.html.erb
+++ b/app/views/sessions/_suspended_flash.html.erb
@@ -1,0 +1,2 @@
+<p><%= t ".suspended" %></p>
+<p><%= t ".contact_support_html", :support_link => mail_to(Settings.support_email, t(".support")) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1782,7 +1782,6 @@ en:
       create account minute: Create an account. It only takes a minute.
       no account: Don't have an account?
       account not active: "Sorry, your account is not active yet.<br />Please use the link in the account confirmation email to activate your account, or <a href=\"%{reconfirm}\">request a new confirmation email</a>."
-      account is suspended: Sorry, your account has been suspended due to suspicious activity.<br />Please contact <a href="%{webmaster}">support</a> if you wish to discuss this.
       auth failure: "Sorry, could not log in with those details."
       openid_logo_alt: "Log in with an OpenID"
       auth_providers:
@@ -1814,6 +1813,10 @@ en:
       title: "Logout"
       heading: "Logout from OpenStreetMap"
       logout_button: "Logout"
+    suspended_flash:
+      suspended: Sorry, your account has been suspended due to suspicious activity.
+      contact_support_html: Please contact %{support_link} if you wish to discuss this.
+      support: support
   shared:
     markdown_help:
       title_html: Parsed with <a href="https://kramdown.gettalong.org/quickref.html">kramdown</a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -446,6 +446,7 @@ en:
     index:
       title: "Changesets"
       title_user: "Changesets by %{user}"
+      title_user_link_html: "Changesets by %{user_link}"
       title_friend: "Changesets by my friends"
       title_nearby: "Changesets by nearby users"
       empty: "No changesets found."


### PR DESCRIPTION
Following on from #2898 and #2919, and using the flash technique from #3232 we can get rid of more uses of `html_safe` in our views. This takes care of the user suspended flash message, and a link in the browse sidebar.