### PR TITLE
Allows control of cache behavior in the dev env via environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .ruby-gemset
 .ruby-version
 .vagrant
+docker-compose.override.yml
 app/assets/javascripts/i18n
 config/environments/*.local.yml
 config/settings.local.yml

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,12 +18,26 @@ Rails.application.configure do
   config.server_timing = true
 
   # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
+  # Run rails dev:cache to toggle caching, or export RAILS_DEV_CACHE=true
+  if Rails.root.join("tmp/caching-dev.txt").exist? || ENV['RAILS_DEV_CACHE'].present?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    # Enable/disable Rails page cache. By default page cache is disabled.
+    # export RAILS_PAGE_CACHE=true to enable page cache
+    if ENV['RAILS_PAGE_CACHE'].present?
+      config.action_controller.page_cache_directory = Rails.public_path
+    end
+
+    # Use memory_store or file_store. Default is memory_store.
+    # export RAILS_FILE_CACHE_DIR='path/to/file/cache/dir' to use file_store
+    unless ENV['RAILS_FILE_CACHE_DIR'].present?
+      config.cache_store = :memory_store
+    else
+      FileUtils.mkdir_p(ENV['RAILS_FILE_CACHE_DIR']) unless FileTest.exist?(ENV['RAILS_FILE_CACHE_DIR'])
+      config.cache_store = :file_store, ENV['RAILS_FILE_CACHE_DIR']
+    end
+
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,8 @@
+services:
+  web:
+    volumes:
+      - ./tmp/:/app/tmp/
+    environment:
+      RAILS_DEV_CACHE: true
+      RAILS_PAGE_CACHE: true
+      RAILS_FILE_CACHE_DIR: "/app/tmp/rails"


### PR DESCRIPTION
## What

This pull request introduce three new environment variables that allows you to control the cache behavior of this Rails application
- `RAILS_DEV_CACHE`
- `RAILS_PAGE_CACHE`
- `RAILS_FILE_CACHE_DIR`


## Why

This Rails app currently have several problem about caching, especially docker compose environment
- docker compose environment does not persists `/app/tmp` directory
  - This means that the file `/app/tmp/caching-dev.txt` will be lost each time docker compose is restarted
- Even if cache is enabled in the development environment, `config.action_controller.page_cache_directory` is not enabled
- Cache mechanism can only select memory_store, so every cache is lost after restart this rails app


## How

- I've changed `config/environments/development.rb`
  - All changes refer to new environment variables
  - If they are not specified, the behavior is the same as before
- I've added file named `docker-compose.override.example.yml` and edit `.gitignore` to ignore file named `docker-compose.override.yml`
  - The file named `docker-compose.override.yml` can override behavior of the `docker-compose.yml` settings when run-time
  - This is a common way for developers to change the behavior of Docker applications
  - https://docs.docker.com/compose/extends/
  - `docker-compose.override.example.yml` shows how to override `docker-compose.yml` to persists `/app/tmp` dir and to enable environment variables I proposed on this pull request
  - You can use it by `cp docker-compose.override.example.yml docker-compose.override.yml`


## My opinion

- I don't know how the decision was made not to persist /app/tmp in Docker, but this may be a problem
- Adding `docker-compose.override.yml` to `.gitignore` so that it can be freely written is also done in various other projects
- I want to be able to make the cache persistent in my dev env
  - I believe that file_store cache is slower than memory_store cache, but it should be faster than the XML building process on every requests
- Please let me know if you have any comments on the naming of environment variables.

