### PR TITLE
Enable cache of XML fragment for node, way and relation

### DIFF
--- a/app/views/api/nodes/_node.xml.builder
+++ b/app/views/api/nodes/_node.xml.builder
@@ -1,24 +1,26 @@
-attrs = {
-  "id" => node.id,
-  "visible" => node.visible,
-  "version" => node.version,
-  "changeset" => node.changeset_id,
-  "timestamp" => node.timestamp.xmlschema,
-  "user" => node.changeset.user.display_name,
-  "uid" => node.changeset.user_id
-}
+cache node do
+  attrs = {
+    "id" => node.id,
+    "visible" => node.visible,
+    "version" => node.version,
+    "changeset" => node.changeset_id,
+    "timestamp" => node.timestamp.xmlschema,
+    "user" => node.changeset.user.display_name,
+    "uid" => node.changeset.user_id
+  }
 
-if node.visible
-  attrs["lat"] = node.lat
-  attrs["lon"] = node.lon
-end
+  if node.visible
+    attrs["lat"] = node.lat
+    attrs["lon"] = node.lon
+  end
 
-if node.tags.empty?
-  xml.node(attrs)
-else
-  xml.node(attrs) do |nd|
-    node.tags.each do |k, v|
-      nd.tag(:k => k, :v => v)
+  if node.tags.empty?
+    xml.node(attrs)
+  else
+    xml.node(attrs) do |nd|
+      node.tags.each do |k, v|
+        nd.tag(:k => k, :v => v)
+      end
     end
   end
 end

--- a/app/views/api/relations/_relation.xml.builder
+++ b/app/views/api/relations/_relation.xml.builder
@@ -1,19 +1,21 @@
-attrs = {
-  "id" => relation.id,
-  "visible" => relation.visible,
-  "version" => relation.version,
-  "changeset" => relation.changeset_id,
-  "timestamp" => relation.timestamp.xmlschema,
-  "user" => relation.changeset.user.display_name,
-  "uid" => relation.changeset.user_id
-}
+cache relation do
+  attrs = {
+    "id" => relation.id,
+    "visible" => relation.visible,
+    "version" => relation.version,
+    "changeset" => relation.changeset_id,
+    "timestamp" => relation.timestamp.xmlschema,
+    "user" => relation.changeset.user.display_name,
+    "uid" => relation.changeset.user_id
+  }
 
-xml.relation(attrs) do |r|
-  relation.relation_members.each do |m|
-    r.member(:type => m.member_type.downcase, :ref => m.member_id, :role => m.member_role)
-  end
+  xml.relation(attrs) do |r|
+    relation.relation_members.each do |m|
+      r.member(:type => m.member_type.downcase, :ref => m.member_id, :role => m.member_role)
+    end
 
-  relation.tags.each do |k, v|
-    r.tag(:k => k, :v => v)
+    relation.tags.each do |k, v|
+      r.tag(:k => k, :v => v)
+    end
   end
 end

--- a/app/views/api/ways/_way.xml.builder
+++ b/app/views/api/ways/_way.xml.builder
@@ -1,19 +1,21 @@
-attrs = {
-  "id" => way.id,
-  "visible" => way.visible,
-  "version" => way.version,
-  "changeset" => way.changeset_id,
-  "timestamp" => way.timestamp.xmlschema,
-  "user" => way.changeset.user.display_name,
-  "uid" => way.changeset.user_id
-}
+cache way do
+  attrs = {
+    "id" => way.id,
+    "visible" => way.visible,
+    "version" => way.version,
+    "changeset" => way.changeset_id,
+    "timestamp" => way.timestamp.xmlschema,
+    "user" => way.changeset.user.display_name,
+    "uid" => way.changeset.user_id
+  }
 
-xml.way(attrs) do |w|
-  way.nodes.each do |n|
-    w.nd(:ref => n.id)
-  end
+  xml.way(attrs) do |w|
+    way.nodes.each do |n|
+      w.nd(:ref => n.id)
+    end
 
-  way.tags.each do |k, v|
-    w.tag(:k => k, :v => v)
+    way.tags.each do |k, v|
+      w.tag(:k => k, :v => v)
+    end
   end
 end


### PR DESCRIPTION
## What

This pull request changes just three files on this rails application
- `app/views/api/nodes/_node.xml.builder`
- `app/views/api/ways/_way.xml.builder`
- `app/views/api/relations/_relation.xml.builder`

## Why

- Currently, this rails app does not cache fragment of XML
- This should slow down the XML building
- Whether the caching mechanism is memory or files, it should be faster than executing SQL queries and building XML
- These files appear to have been last edited four years ago, but modern Rails' caching of XML fragments has progressed

## How

- Change the Rails Model instance handled by `*.xml.builder` to be passed to `cache` method of the Rails view
- If there are no changes to the records in the Rails Model, the SQL query execution and XML construction will be skipped and the cache will be used
- If the Rails Model record changes, the cache is destroyed and the XML is updated appropriately

## My opinion

- This change should be carefully considered as it will likely affect the behavior of the Production environment
- Still, I believe it should have a big positive impact on performance
- Please consider it and let me know what you think!


