### PR TITLE
Use mail_to help to avoid handcrafting mailto links

### DIFF
--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -8,5 +8,5 @@
 
 <div class="message">
   <h1><%= t "users.new.no_auto_account_create" %></h1>
-  <h2><%= t "users.new.contact_support_html", :support => "mailto:#{Settings.support_email}" %></h2>
+  <h2><%= t "users.new.please_contact_support_html", :support_link => mail_to(Settings.support_email, t("users.new.support")) %></h2>
 </div>

--- a/app/views/users/suspended.html.erb
+++ b/app/views/users/suspended.html.erb
@@ -4,4 +4,5 @@
   <h1><%= t ".heading" %></h1>
 <% end %>
 
-<%= t ".body_html", :webmaster => link_to(t(".support"), "mailto:#{Settings.support_email}") %>
+<p><%= t ".automatically_suspended" %></p>
+<p><%= t ".contact_support_html", :support_link => mail_to(Settings.support_email, t(".support")) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2554,7 +2554,8 @@ en:
     new:
       title: "Sign Up"
       no_auto_account_create: "Unfortunately we are not currently able to create an account for you automatically."
-      contact_support_html: 'Please contact <a href="%{support}">support</a> to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
+      please_contact_support_html: 'Please contact %{support_link} to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
+      support: support
       about:
         header: Free and editable
         html: |
@@ -2676,15 +2677,9 @@ en:
       title: Account Suspended
       heading: Account Suspended
       support: support
-      body_html: |
-        <p>
-          Sorry, your account has been automatically suspended due to
-          suspicious activity.
-        </p>
-        <p>
-          This decision will be reviewed by an administrator shortly, or
-          you may contact %{webmaster} if you wish to discuss this.
-        </p>
+      automatically_suspended: Sorry, your account has been automatically suspended due to suspicious activity.
+      contact_support_html: This decision will be reviewed by an administrator shortly, or you may contact %{support_link} if you wish to discuss this.
+      support: support
     auth_failure:
       connection_failed: Connection to authentication provider failed
       invalid_credentials: Invalid authentication credentials


### PR DESCRIPTION
This also reworks the user suspended page to avoid having html in the translation strings.