### PR TITLE
Remove fallback code for undefined history.pushState()

### DIFF
--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -101,53 +101,43 @@ OSM.Router = function (map, rts) {
 
   var router = {};
 
-  if (window.history && window.history.pushState) {
-    $(window).on("popstate", function (e) {
-      if (!e.originalEvent.state) return; // Is it a real popstate event or just a hash change?
-      var path = window.location.pathname + window.location.search,
-          route = routes.recognize(path);
-      if (path === currentPath) return;
-      currentRoute.run("unload", null, route === currentRoute);
-      currentPath = path;
-      currentRoute = route;
-      currentRoute.run("popstate", currentPath);
-      map.setState(e.originalEvent.state, { animate: false });
-    });
+  $(window).on("popstate", function (e) {
+    if (!e.originalEvent.state) return; // Is it a real popstate event or just a hash change?
+    var path = window.location.pathname + window.location.search,
+        route = routes.recognize(path);
+    if (path === currentPath) return;
+    currentRoute.run("unload", null, route === currentRoute);
+    currentPath = path;
+    currentRoute = route;
+    currentRoute.run("popstate", currentPath);
+    map.setState(e.originalEvent.state, { animate: false });
+  });
 
-    router.route = function (url) {
-      var path = url.replace(/#.*/, ""),
-          route = routes.recognize(path);
-      if (!route) return false;
-      currentRoute.run("unload", null, route === currentRoute);
-      var state = OSM.parseHash(url);
-      map.setState(state);
-      window.history.pushState(state, document.title, url);
-      currentPath = path;
-      currentRoute = route;
-      currentRoute.run("pushstate", currentPath);
-      return true;
-    };
+  router.route = function (url) {
+    var path = url.replace(/#.*/, ""),
+        route = routes.recognize(path);
+    if (!route) return false;
+    currentRoute.run("unload", null, route === currentRoute);
+    var state = OSM.parseHash(url);
+    map.setState(state);
+    window.history.pushState(state, document.title, url);
+    currentPath = path;
+    currentRoute = route;
+    currentRoute.run("pushstate", currentPath);
+    return true;
+  };
 
-    router.replace = function (url) {
-      window.history.replaceState(OSM.parseHash(url), document.title, url);
-    };
+  router.replace = function (url) {
+    window.history.replaceState(OSM.parseHash(url), document.title, url);
+  };
 
-    router.stateChange = function (state) {
-      if (state.center) {
-        window.history.replaceState(state, document.title, OSM.formatHash(state));
-      } else {
-        window.history.replaceState(state, document.title, window.location);
-      }
-    };
-  } else {
-    router.route = router.replace = function (url) {
-      window.location.assign(url);
-    };
-
-    router.stateChange = function (state) {
-      if (state.center) window.location.replace(OSM.formatHash(state));
-    };
-  }
+  router.stateChange = function (state) {
+    if (state.center) {
+      window.history.replaceState(state, document.title, OSM.formatHash(state));
+    } else {
+      window.history.replaceState(state, document.title, window.location);
+    }
+  };
 
   router.updateHash = function () {
     var hash = OSM.formatHash(map);


### PR DESCRIPTION
There's a check if `window.history.pushState` is defined. If not, there's fallback code that uses `window.location` instead of `window.history`. Given our [current browser support](https://github.com/openstreetmap/openstreetmap-website/issues/3782) the fallback is unnecessary. `window.history.pushState` is supported by [ten years old browsers](https://caniuse.com/mdn-api_history_pushstate).