### PR TITLE
Don't rely on /query page receiving correct lat/lon parameters

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -352,8 +352,11 @@ OSM.Query = function (map) {
   };
 
   page.load = function (path, noCentre) {
-    var params = Qs.parse(path.substring(path.indexOf("?") + 1)),
-        latlng = L.latLng(params.lat, params.lon);
+    var params = Qs.parse(path.substring(path.indexOf("?") + 1));
+
+    if (!("lat" in params) || !("lon" in params)) return;
+
+    var latlng = L.latLng(params.lat, params.lon);
 
     if (!window.location.hash && !noCentre && !map.getBounds().contains(latlng)) {
       OSM.router.withoutMoveListener(function () {

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -352,11 +352,15 @@ OSM.Query = function (map) {
   };
 
   page.load = function (path, noCentre) {
-    var params = Qs.parse(path.substring(path.indexOf("?") + 1));
+    var params = Qs.parse(path.substring(path.indexOf("?") + 1)),
+        latlng;
 
-    if (!("lat" in params) || !("lon" in params)) return;
-
-    var latlng = L.latLng(params.lat, params.lon);
+    try {
+      latlng = L.latLng(params.lat, params.lon);
+      if (!latlng) return;
+    } catch (e) {
+      return;
+    }
 
     if (!window.location.hash && !noCentre && !map.getBounds().contains(latlng)) {
       OSM.router.withoutMoveListener(function () {

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -37,4 +37,10 @@ class IndexTest < ApplicationSystemTestCase
     visible_note_marker.click
     assert_selector "#sidebar", :text => "this-is-a-visible-note"
   end
+
+  test "can close sidebar with empty query" do
+    visit query_path
+    find("#sidebar .btn-close").click
+    assert_current_path "/"
+  end
 end

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -43,4 +43,10 @@ class IndexTest < ApplicationSystemTestCase
     find("#sidebar .btn-close").click
     assert_current_path "/"
   end
+
+  test "can close sidebar with invalid query" do
+    visit "#{query_path}?lat=wrong&lon=wrong"
+    find("#sidebar .btn-close").click
+    assert_current_path "/"
+  end
 end


### PR DESCRIPTION
If you open the empty query page https://www.openstreetmap.org/query , you'll get [javascript errors](https://github.com/openstreetmap/openstreetmap-website/issues/3819#issuecomment-1341369521). Maybe it's not supposed to be accessible this way, but there's no 404 for missing parameters. You can also pass invalid lat/lon parameters that Leaflet won't recognize and won't construct a valid LatLng object. Leaflet may fail by throwing an exception or by returning `undefined`.
