### PR TITLE
Update OSGB date range for copyright

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2004,7 +2004,7 @@ en:
         contributors_gb_html: |
           <strong>United Kingdom</strong>: Contains Ordnance
           Survey data &copy; Crown copyright and database right
-          2010-19.
+          2010-22.
         contributors_footer_1_html: |
           For further details of these, and other sources that have been used
           to help improve OpenStreetMap, please see the <a

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2004,7 +2004,7 @@ en:
         contributors_gb_html: |
           <strong>United Kingdom</strong>: Contains Ordnance
           Survey data &copy; Crown copyright and database right
-          2010-22.
+          2010-2023.
         contributors_footer_1_html: |
           For further details of these, and other sources that have been used
           to help improve OpenStreetMap, please see the <a


### PR DESCRIPTION
Change the date range for Ordnance Survey Open Data licensed under the Open Government Licence (OGL) from "2010-19" to "2010-22" to comply with OGL terms.

Fixes #3845

