### PR TITLE
Fix redirection to wiki when terms are declined

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -151,7 +151,7 @@ class UsersController < ApplicationController
 
         redirect_to referer || edit_account_path
       elsif params[:decline]
-        redirect_to t("users.terms.declined")
+        redirect_to t("users.terms.declined"), :allow_other_host => true
       else
         redirect_to :action => :terms
       end

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -8,4 +8,22 @@ class UserSignupTest < ApplicationSystemTestCase
 
     assert_content "Confirm Password"
   end
+
+  test "externally redirect when contributor terms declined" do
+    user = build(:user)
+
+    visit root_path
+    click_on "Sign Up"
+    fill_in "Email", :with => user.email
+    fill_in "Email Confirmation", :with => user.email
+    fill_in "Display Name", :with => user.display_name
+    fill_in "Password", :with => "testtest"
+    fill_in "Confirm Password", :with => "testtest"
+    click_button "Sign Up"
+
+    assert_content "Contributor terms"
+    click_on "Cancel"
+
+    assert_current_path "https://wiki.openstreetmap.org/wiki/Contributor_Terms_Declined"
+  end
 end


### PR DESCRIPTION
Adds missing test to pick this up.

Fixes #3826.