### PR TITLE
Wait for the button to be disabled, before checking the tooltip

### DIFF
--- a/test/system/site_test.rb
+++ b/test/system/site_test.rb
@@ -71,9 +71,10 @@ class SiteTest < ApplicationSystemTestCase
       find("h1").hover # un-hover original element
 
       visit "#map=10/0/0"
+      find("#{selector}.disabled") # Ensure that capybara has waited for JS to finish processing
+
       assert_no_selector ".tooltip"
       find(selector).hover
-      sleep(0.5)
       assert_selector ".tooltip", :text => "Zoom in"
     end
   end


### PR DESCRIPTION
Rather than sleeping for a fixed period, we can use Capybara's built-in ability to wait for elements to be present. Since we're only changing the state of existing elements though, we need to wait for their "disabled" property to be set.

Fixes some timing-related problems with the test suite.