### PR TITLE
Fix some German translations

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -774,7 +774,7 @@ de:
           charging_station: Ladestation
           childcare: Kinderbetreuung
           cinema: Kino
-          clinic: Krankenhaus
+          clinic: Ärztehaus
           clock: Uhr
           college: Hochschule
           community_centre: Gemeinschaftszentrum
@@ -827,7 +827,7 @@ de:
           public_bath: Öffentliches Bad
           public_bookcase: Öffentlicher Bücherschrank
           public_building: Öffentliches Gebäude
-          ranger_station: Rangerstation
+          ranger_station: Besucherstation
           recycling: Recycling-Center
           restaurant: Restaurant
           sanitary_dump_station: Sanitäre Entsorgungsstation


### PR DESCRIPTION
There are 2 German translations that stand out at being wrong:
1. Clinic is translated to the same meaning as Hospital. This is definitely wrong, because the correct translation is either "Tagesklinik", "Poliklinik" or "Ärztehaus"
2. The `amenity=ranger_station` is translated to (literally) Rangerstation, when in fact, the Wiki already suggests calling it "visitor facility building", or "Besucherzentrum"/"Besucherstation".

I fixed both and here's my PR for it