### PR TITLE
Quote ruby versions in yaml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 env:
   os: ubuntu-20.04
-  ruby: 2.7
+  ruby: '2.7'
 jobs:
   rubocop:
     name: RuboCop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         ubuntu: [20.04, 22.04]
-        ruby: [2.7, 3.0, 3.1]
+        ruby: ['2.7', '3.0', '3.1']
     runs-on: ubuntu-${{ matrix.ubuntu }}
     env:
       RAILS_ENV: test


### PR DESCRIPTION
Without quotes these are parsed as numbers, which can cause subtle problems. For example, "ruby: 3.0" is interpreted by the ruby/setup-ruby action as "ruby: 3", meaning 3.x instead of the intended 3.0.x

The test suite started failing a couple of days ago, with an error installing nokogiri - this is because nokogiri doesn't support ruby 3.2 yet, we were inadvertently installing "ruby: 3" instead of "ruby: '3.0'", and then when setup/ruby was updated a couple of days ago to support 3.2 this bug was unveiled.

It also means we haven't actually been testing on ruby 3.0.x since ruby 3.1 was released - our tests were just running twice on ruby 3.1 :smile: