### PR TITLE
Load the community model when the database is offline

### DIFF
--- a/lib/osm_community_index.rb
+++ b/lib/osm_community_index.rb
@@ -1,4 +1,6 @@
 module OsmCommunityIndex
+  require_relative "../app/models/community" if Settings.status == "database_offline"
+
   def self.add_to_i18n
     # Filter the communities here to avoid loading excessive numbers of translations
     communities = Community.where(:type => "osm-lc").where.not(:id => "OSMF")


### PR DESCRIPTION
Normally all the models are loaded automatically, but when the database is offline the app/models directory is ignored. The community model can still be used offline, since it doesn't depend on activerecord.

Fixes #3858

I'm not 100% happy with this, since I would prefer to keep the mechanics of the database_offline and file loading confined to one place (i.e. `config/application.rb`). But I couldn't find a way to deal with the eager_loading on a file-by-file basis, so that we could say "ignore all the files in this directory, but then for this one file..."

```ruby
# Don't eager load models when the database is offline
if Settings.status == "database_offline"
  config.paths["app/models"].skip_eager_load!
  config.paths["app/models/community.rb"].eager_load!  # <- yeah that doesn't work
  config.paths.add("app/models/community.rb", :eager_load => true)# <- yeah that doesn't work either
end
```

I'm also not 100% on the subtleties of "eager load" vs "auto load" here. I would have thought that marking the directory as not eligible for eager loading would mean that in production they aren't loaded during application boot, but were still auto loaded when required, and in any case were auto loaded during development. But the failure to auto-load from app/models when they are marked as "skip_eager_load!" suggests that I don't fully understand how auto_load and eager_load interact.

So based on that, adding the `require_relative` to the code run from the initializer a relatively nonintrusive way to fix this.