### PR TITLE
Change Save to Comment

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
       prompt: Choose file
     submit:
       diary_comment:
-        create: Save
+        create: Comment
       diary_entry:
         create: "Publish"
         update: "Update"


### PR DESCRIPTION
This PR is to address #3650

For comment submit buttons we currently have:

"Comment" (Changeset Comments)
"Add Comment" (Issue Comments)
"Comment" (Note Comments)
"Save" (Diary Comments)

So, to make them consistent, I'd propose to change "Save" to "Comment"