### PR TITLE
fix formatting of tag values with semicolon-separated URLs

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -32,7 +32,7 @@ module BrowseTagsHelper
     elsif colour_value = colour_preview(key, value)
       tag.span("", :class => "colour-preview-box", :"data-colour" => colour_value, :title => t("browse.tag_details.colour_preview", :colour_value => colour_value)) + colour_value
     else
-      linkify h(value)
+      safe_join(h(value).split(";").map{|x| linkify(x) }, ";")
     end
   end
 

--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -32,7 +32,7 @@ module BrowseTagsHelper
     elsif colour_value = colour_preview(key, value)
       tag.span("", :class => "colour-preview-box", :"data-colour" => colour_value, :title => t("browse.tag_details.colour_preview", :colour_value => colour_value)) + colour_value
     else
-      safe_join(h(value).split(";").map{|x| linkify(x) }, ";")
+      safe_join(h(value).split(";").map { |x| linkify(x) }, ";")
     end
   end
 

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -49,6 +49,12 @@ class BrowseTagsHelperTest < ActionView::TestCase
 
     html = format_value("contact", "foo@example.com")
     assert_dom_equal "<a title=\"Email foo@example.com\" href=\"mailto:foo@example.com\">foo@example.com</a>", html
+
+    html = format_value("source", "https://example.com")
+    assert_dom_equal "<a href=\"https://example.com\" rel=\"nofollow\">https://example.com</a>", html
+
+    html = format_value("source", "https://example.com;hello;https://example.net")
+    assert_dom_equal "<a href=\"https://example.com\" rel=\"nofollow\">https://example.com</a>;hello;<a href=\"https://example.net\" rel=\"nofollow\">https://example.net</a>", html
   end
 
   def test_wiki_link


### PR DESCRIPTION
If a tag value currently contains two URLs separated by a semicolon, the website creates a broken clickable link. 

[This example node](https://osm.org/node/9335292678) can be viewed on osm.org and in the Washington, D.C. example from [the installation guide](https://github.com/openstreetmap/openstreetmap-website/blob/master/DOCKER.md#loading-an-osm-extract).

<table>
<tr>
<td><strong>Before
<td><strong>After
<tr>
<td><img src="https://user-images.githubusercontent.com/16009897/210159559-222dab8d-6562-4e5b-9471-1ed0123ced86.jpg" />
<td><img src="https://user-images.githubusercontent.com/16009897/210159568-b5d9a27c-e801-4c46-afa5-f6afe3acd213.jpg" />
</table>

Closes openstreetmap/iD#9444 which was opened in the wrong issue tracker.


p.s. Please reconsider merging #3575, it's impossible for first time contributors to run the tests without digging through the issue tracker to find that rejected PR. 