### PR TITLE
Allow models to load when the database is offline

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,18 +1,6 @@
 require_relative "boot"
 
-if ENV.fetch("OPENSTREETMAP_STATUS", nil) == "database_offline"
-  require "active_model/railtie"
-  require "active_job/railtie"
-  require "active_storage/engine"
-  require "action_controller/railtie"
-  require "action_mailer/railtie"
-  require "action_view/railtie"
-  require "action_cable/engine"
-  require "sprockets/railtie"
-  require "rails/test_unit/railtie"
-else
-  require "rails/all"
-end
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -39,9 +27,6 @@ module OpenStreetMap
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types
     config.active_record.schema_format = :sql unless Settings.status == "database_offline"
-
-    # Don't eager load models when the database is offline
-    config.paths["app/models"].skip_eager_load! if Settings.status == "database_offline"
 
     # Use memcached for caching if required
     config.cache_store = :mem_cache_store, Settings.memcache_servers, { :namespace => "rails:cache" } if Settings.key?(:memcache_servers)


### PR DESCRIPTION
This is an alternative to #3861 to fix #3858 and allow offline mode to be used with the community index.

It turns out that while it used to be necessary to stop `ActiveRecord` loading because it would immediately try and connect the database that is no longer the case as the introduction of switchable database connections means it now only connects when a model is used for the first time.

So we can in fact just get rid of a load of nasty code, part of which involves copying a list of loads from the rails code which then gets out of sync with rails over time.