### PR TITLE
Use bin/yarn consistently for installations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,7 @@ jobs:
         restore-keys: |
           yarn-${{ env.os }}-
     - name: Install node modules
-      run: bundle exec rails yarn:install
+      run: bundle exec bin/yarn install
     - name: Create dummy database configuration
       run: cp config/example.database.yml config/database.yml
     - name: Run eslint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Export javascript strings
       run: bundle exec rails i18n:js:export
     - name: Install node modules
-      run: bundle exec rails yarn:install
+      run: bundle exec bin/yarn install
     - name: Compile assets
       run: bundle exec rails assets:precompile
     - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ADD Gemfile Gemfile.lock /app/
 RUN gem install bundler \
  && bundle install
 
-# Install NodeJS packages using yarnpkg
-# `bundle exec rails yarn:install` will not work
+# Install NodeJS packages using yarn
 ADD package.json yarn.lock /app/
-RUN yarnpkg --ignore-engines install
+ADD bin/yarn /app/bin/
+RUN bundle exec bin/yarn install

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,7 +137,7 @@ bundle install
 We use [Yarn](https://yarnpkg.com/) to manage the Node.js modules required for the project.
 
 ```
-bundle exec rails yarn:install
+bundle exec bin/yarn install
 ```
 
 ## Prepare local settings file

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -29,7 +29,7 @@ pushd /srv/openstreetmap-website
 # do bundle install as a convenience
 bundle install --retry=10 --jobs=2
 # do yarn install as a convenience
-bundle exec rake yarn:install
+bundle exec bin/yarn install
 # create user and database for openstreetmap-website
 db_user_exists=`sudo -u postgres psql postgres -tAc "select 1 from pg_roles where rolname='vagrant'"`
 if [ "$db_user_exists" != "1" ]; then


### PR DESCRIPTION
Since rails 7, the `rails yarn:install` command no longer uses bin/yarn and so it
- doesn't detect yarn binaries named "yarnpkg" (e.g. Ubuntu), and
- doesn't allow us to pass any flags to yarn, (e.g. "--ignore-engines").

Since we want to avoid making the installation more difficult (by e.g. installing yarn from other sources, or requiring particular node versions) we can instead just use our existing bin/yarn script.

The reason Dockerfile did its own thing was to avoid pulling in big chunks of rails, but bin/yarn is a standalone ruby script.

Fixes #3579