### PR TITLE
Move some api call handlers to ApiController

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -143,4 +143,43 @@ class ApiController < ApplicationController
       end
     end
   end
+
+  def api_call_handle_error
+    yield
+  rescue ActionController::UnknownFormat
+    head :not_acceptable
+  rescue ActiveRecord::RecordNotFound => e
+    head :not_found
+  rescue LibXML::XML::Error, ArgumentError => e
+    report_error e.message, :bad_request
+  rescue ActiveRecord::RecordInvalid => e
+    message = "#{e.record.class} #{e.record.id}: "
+    e.record.errors.each { |error| message << "#{error.attribute}: #{error.message} (#{e.record[error.attribute].inspect})" }
+    report_error message, :bad_request
+  rescue OSM::APIError => e
+    report_error e.message, e.status
+  rescue AbstractController::ActionNotFound => e
+    raise
+  rescue StandardError => e
+    logger.info("API threw unexpected #{e.class} exception: #{e.message}")
+    e.backtrace.each { |l| logger.info(l) }
+    report_error "#{e.class}: #{e.message}", :internal_server_error
+  end
+
+  ##
+  # asserts that the request method is the +method+ given as a parameter
+  # or raises a suitable error. +method+ should be a symbol, e.g: :put or :get.
+  def assert_method(method)
+    ok = request.send(:"#{method.to_s.downcase}?")
+    raise OSM::APIBadMethodError, method unless ok
+  end
+
+  ##
+  # wrap an api call in a timeout
+  def api_call_timeout(&block)
+    Timeout.timeout(Settings.api_timeout, Timeout::Error, &block)
+  rescue Timeout::Error
+    ActiveRecord::Base.connection.raw_connection.cancel
+    raise OSM::APITimeoutError
+  end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -7,7 +7,7 @@ class NotesController < ApplicationController
   authorize_resource
 
   before_action :set_locale
-  around_action :api_call_handle_error, :api_call_timeout
+  around_action :web_timeout
 
   ##
   # Display a list of notes by a specified user


### PR DESCRIPTION
I noticed this while I was looking at the (non-API) NotesController, which doesn't need to have any api-related error handling.