### PR TITLE
Facelift `offline.html` and use Bootstrap classes for "notifications" under the search bar

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1253,22 +1253,6 @@ tr.turn:hover {
   display: none;
 }
 
-/* Rules for "flash" notice boxes shown at the top of the content area */
-
-.flash {
-  &.error {
-    background-color: #ff7070;
-  }
-
-  &.warning {
-    background-color: #ffe0cc;
-  }
-
-  &.notice {
-    background-color: #CBEEA7;
-  }
-}
-
 /* Rules for highlighting fields with rails validation errors */
 
 .formError {

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -113,7 +113,14 @@ class SiteController < ApplicationController
 
   def export; end
 
-  def offline; end
+  def offline
+    flash.now[:warning] = if Settings.status == "database_offline"
+                            t("layouts.osm_offline")
+                          else
+                            t("layouts.osm_read_only")
+                          end
+    render :html => nil, :layout => true
+  end
 
   def preview
     render :html => RichText.new(params[:type], params[:text]).to_html

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,5 @@
 <% if flash[:error] %>
-  <div class="flash error row mx-0 p-3 align-items-center">
+  <div class="alert alert-danger row mx-0 mb-0 p-3 rounded-0 align-items-center">
     <div class="col-auto">
       <picture>
         <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml" />
@@ -11,7 +11,7 @@
 <% end %>
 
 <% if flash[:warning] %>
-  <div class="flash warning row mx-0 p-3 align-items-center">
+  <div class="alert alert-warning row mx-0 mb-0 p-3 rounded-0 align-items-center">
     <div class="col-auto">
       <picture>
         <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>
@@ -23,7 +23,7 @@
 <% end %>
 
 <% if flash[:notice] %>
-  <div class="flash notice row mx-0 p-3 align-items-center">
+  <div class="alert alert-success row mx-0 mb-0 p-3 rounded-0 align-items-center">
     <div class="col-auto">
       <picture>
         <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>

--- a/app/views/site/edit.html.erb
+++ b/app/views/site/edit.html.erb
@@ -1,8 +1,12 @@
 <% content_for :content do %>
   <% if Settings.status == "database_offline" or Settings.status == "api_offline" %>
-    <p><%= t "layouts.osm_offline" %></p>
+    <div class="alert alert-warning text-center">
+        <p class="my-2"><%= t "layouts.osm_offline" %></p>
+    </div>
   <% elsif Settings.status == "database_readonly" or Settings.status == "api_readonly" %>
-    <p><%= t "layouts.osm_read_only" %></p>
+    <div class="alert alert-warning text-center">
+        <p class="my-2"><%= t "layouts.osm_read_only" %></p>
+    </div>
   <% elsif !current_user.data_public? %>
     <p><%= t ".not_public" %></p>
     <p><%= t ".not_public_description_html", :user_page => (link_to t(".user_page_link"), edit_account_path(:anchor => "public")) %></p>

--- a/app/views/site/offline.html.erb
+++ b/app/views/site/offline.html.erb
@@ -1,7 +1,0 @@
-<% if Settings.status == "database_offline" %>
-<p><%= t "layouts.osm_offline" %>
-</p>
-<% else %>
-<p><%= t "layouts.osm_read_only" %>
-</p>
-<% end %>

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -60,7 +60,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     patch account_path, :params => { :user => new_attributes }
     assert_response :success
     assert_template :edit
-    assert_select ".notice", false
+    assert_select ".alert-success", false
     assert_select "form#accountForm > div > input.is-invalid#user_display_name"
 
     # Changing name to one that exists should fail, regardless of case
@@ -68,7 +68,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     patch account_path, :params => { :user => new_attributes }
     assert_response :success
     assert_template :edit
-    assert_select ".notice", false
+    assert_select ".alert-success", false
     assert_select "form#accountForm > div > input.is-invalid#user_display_name"
 
     # Changing name to one that doesn't exist should work
@@ -79,7 +79,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     get edit_account_path
     assert_response :success
     assert_template :edit
-    assert_select ".notice", /^User information updated successfully/
+    assert_select ".alert-success", /^User information updated successfully/
     assert_select "form#accountForm > div > input#user_display_name[value=?]", "new tester"
 
     # Record the change of name
@@ -94,7 +94,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
     assert_template :edit
-    assert_select ".notice", false
+    assert_select ".alert-success", false
     assert_select "form#accountForm > div > input.is-invalid#user_new_email"
 
     # Changing email to one that exists should fail, regardless of case
@@ -106,7 +106,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
     assert_template :edit
-    assert_select ".notice", false
+    assert_select ".alert-success", false
     assert_select "form#accountForm > div > input.is-invalid#user_new_email"
 
     # Changing email to one that doesn't exist should work
@@ -121,7 +121,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     get edit_account_path
     assert_response :success
     assert_template :edit
-    assert_select ".notice", /^User information updated successfully/
+    assert_select ".alert-success", /^User information updated successfully/
     assert_select "form#accountForm > div > input#user_new_email[value=?]", user.new_email
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -220,7 +220,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
                                :message => { :title => "Test Message", :body => "Test message body" })
             assert_response :success
             assert_template "new"
-            assert_select ".error", /wait a while/
+            assert_select ".alert.alert-danger", /wait a while/
           end
         end
       end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -81,7 +81,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
     assert_template :lost_password
-    assert_select ".error", /^Could not find that email address/
+    assert_select ".alert.alert-danger", /^Could not find that email address/
 
     # Test resetting using the address as recorded for a user that has an
     # address which is case insensitively unique

--- a/test/controllers/preferences_controller_test.rb
+++ b/test/controllers/preferences_controller_test.rb
@@ -29,8 +29,8 @@ class PreferencesControllerTest < ActionDispatch::IntegrationTest
     put preferences_path, :params => { :user => user.attributes }
     assert_response :success
     assert_template :edit
-    assert_select ".notice", false
-    assert_select ".error", true
+    assert_select ".alert-success", false
+    assert_select ".alert-danger", true
     assert_select "form > div > select#user_preferred_editor > option[selected]", false
 
     # Changing to a valid editor should work
@@ -40,7 +40,7 @@ class PreferencesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to preferences_path
     follow_redirect!
     assert_template :show
-    assert_select ".notice", /^Preferences updated/
+    assert_select ".alert-success", /^Preferences updated/
     assert_select "dd", "iD (in-browser editor)"
 
     # Changing to the default editor should work
@@ -50,7 +50,7 @@ class PreferencesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to preferences_path
     follow_redirect!
     assert_template :show
-    assert_select ".notice", /^Preferences updated/
+    assert_select ".alert-success", /^Preferences updated/
     assert_select "dd", "Default (currently iD)"
   end
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -26,7 +26,7 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template :show
-    assert_select ".notice", /^Profile updated./
+    assert_select ".alert-success", /^Profile updated./
     assert_select "div", "new description"
 
     # Changing to an uploaded image should work
@@ -37,7 +37,7 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template :show
-    assert_select ".notice", /^Profile updated./
+    assert_select ".alert-success", /^Profile updated./
     get edit_profile_path
     assert_select "form > fieldset > div > div.col-sm-10 > div.form-check > input[name=avatar_action][checked][value=?]", "keep"
 
@@ -48,7 +48,7 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template :show
-    assert_select ".notice", /^Profile updated./
+    assert_select ".alert-success", /^Profile updated./
     get edit_profile_path
     assert_select "form > fieldset > div > div.col-sm-10 > div > div.form-check > input[name=avatar_action][checked][value=?]", "gravatar"
 
@@ -59,7 +59,7 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template :show
-    assert_select ".notice", /^Profile updated./
+    assert_select ".alert-success", /^Profile updated./
     get edit_profile_path
     assert_select "form > fieldset > div > div.col-sm-10 > div > input[name=avatar_action][checked]", false
     assert_select "form > fieldset > div > div.col-sm-10 > div > div.form-check > input[name=avatar_action][checked]", false

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -495,7 +495,7 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
   def test_offline
     get offline_path
     assert_response :success
-    assert_template "offline"
+    assert_select ".alert-warning"
   end
 
   # Test the rich text preview

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -113,7 +113,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -125,7 +125,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -137,7 +137,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -270,7 +270,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -282,7 +282,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -294,7 +294,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -409,7 +409,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -457,7 +457,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Connection to authentication provider failed"
+    assert_select "div.alert.alert-danger", "Connection to authentication provider failed"
     assert_select "span.username", false
   end
 
@@ -482,7 +482,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Invalid authentication credentials"
+    assert_select "div.alert.alert-danger", "Invalid authentication credentials"
     assert_select "span.username", false
   end
 
@@ -572,7 +572,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -621,7 +621,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Connection to authentication provider failed"
+    assert_select "div.alert.alert-danger", "Connection to authentication provider failed"
     assert_select "span.username", false
   end
 
@@ -645,7 +645,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Invalid authentication credentials"
+    assert_select "div.alert.alert-danger", "Invalid authentication credentials"
     assert_select "span.username", false
   end
 
@@ -758,7 +758,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -805,7 +805,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Connection to authentication provider failed"
+    assert_select "div.alert.alert-danger", "Connection to authentication provider failed"
     assert_select "span.username", false
   end
 
@@ -829,7 +829,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Invalid authentication credentials"
+    assert_select "div.alert.alert-danger", "Invalid authentication credentials"
     assert_select "span.username", false
   end
 
@@ -913,7 +913,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -960,7 +960,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Connection to authentication provider failed"
+    assert_select "div.alert.alert-danger", "Connection to authentication provider failed"
     assert_select "span.username", false
   end
 
@@ -984,7 +984,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Invalid authentication credentials"
+    assert_select "div.alert.alert-danger", "Invalid authentication credentials"
     assert_select "span.username", false
   end
 
@@ -1068,7 +1068,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -1115,7 +1115,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Connection to authentication provider failed"
+    assert_select "div.alert.alert-danger", "Connection to authentication provider failed"
     assert_select "span.username", false
   end
 
@@ -1139,7 +1139,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Invalid authentication credentials"
+    assert_select "div.alert.alert-danger", "Invalid authentication credentials"
     assert_select "span.username", false
   end
 
@@ -1223,7 +1223,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     assert_select "span.username", false
-    assert_select "div.flash.error", /your account has been suspended/ do
+    assert_select "div.alert.alert-danger", /your account has been suspended/ do
       assert_select "a[href='mailto:openstreetmap@example.com']", "support"
     end
   end
@@ -1270,7 +1270,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Connection to authentication provider failed"
+    assert_select "div.alert.alert-danger", "Connection to authentication provider failed"
     assert_select "span.username", false
   end
 
@@ -1294,7 +1294,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
-    assert_select "div.flash.error", "Invalid authentication credentials"
+    assert_select "div.alert.alert-danger", "Invalid authentication credentials"
     assert_select "span.username", false
   end
 


### PR DESCRIPTION
This PR makes the following changes:
- Notices, warnings and error messages which appear under the search bar will use Bootstrap's classes (instead of the custom `flash` classes)
- The `offline.html` page gets a facelift (red background around the message)
- The `edit.html` page also gets facelift although I wasn't able to test it since it redirects me to `/offline/`.

Note that `alert-success` uses `#D4EDDA` while `flash flash-notice` uses `#CBEEA7` for background colour. It w

![image](https://user-images.githubusercontent.com/19364673/213911897-603f6b9e-2bba-432a-8132-592c0395525a.png)
![image](https://user-images.githubusercontent.com/19364673/213911457-1b014961-d49e-4ee8-a6d3-a03f7510c65e.png)
