### PR TITLE
Add WKT point formatting to Geocoder

### DIFF
--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -211,6 +211,9 @@ class GeocoderController < ApplicationController
       elsif latlon = query.match(/^([+-]?\d+(\.\d*)?)(?:\s+|\s*,\s*)([+-]?\d+(\.\d*)?)$/)
         params.merge!(:lat => latlon[1].to_f, :lon => latlon[3].to_f).delete(:query)
 
+      elsif latlon = query.match(/^POINT(?:\s+|\s*,\s*)\(([+-]?\d+(\.\d*)?)(?:\s+|\s*,\s*)([+-]?\d+(\.\d*)?)\)$/)
+        params.merge!(:lat => latlon[3].to_f, :lon => latlon[1].to_f).delete(:query)
+
         params[:latlon_digits] = true unless params[:whereami]
       end
     end

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -222,6 +222,16 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
   end
 
   ##
+  # Test identification of lat/lon pairs using WKT formatting
+  def test_identify_latlon_wkt
+    [
+      "POINT (-50.06773, -14.37742)"
+    ].each do |code|
+      latlon_check code, -50.06773, -14.37742
+    end
+  end
+
+  ##
   # Test identification of US zipcodes
   def test_identify_us_postcode
     %w[


### PR DESCRIPTION
Hello,
first time contributing directly, I hope it is correct.
I was trying to search coordinates in WKT (from a DB dump) directly from the main search box and I noticed this wasn't recognised as a format.