### PR TITLE
Vel-12/issue#3910

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -26,7 +26,7 @@ small, aside {
   margin-right: $lineheight/4;
 }
 
-[dir=rtl] { /* no-r2 */ text-align: right; }
+[dir=rtl] { /* no-r2 */ text-align: right; .form-control{ text-align: right;} }
 
 [dir=ltr] { /* no-r2 */ text-align: left; }
 


### PR DESCRIPTION
#3910
@gravitystorm

1) if u apply text-align:right in form-control. it only apply in the input tag of the website.
2) when we change the language from right to left or from left to right, text overlapping occurs only in the search input tag and 
    not anywhere else in the wesbsite.
3) From prevsious solutions, the disadvantage of using ::placeholder is that it also affects the cursor.
    Overall no problems.