### PR TITLE
Change label for leisure=horse_riding in en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -970,7 +970,7 @@ en:
           fitness_station: "Fitness Station"
           garden: "Garden"
           golf_course: "Golf Course"
-          horse_riding: "Horse Riding"
+          horse_riding: "Horse Riding Centre"
           ice_rink: "Ice Rink"
           marina: "Marina"
           miniature_golf: "Miniature Golf"


### PR DESCRIPTION
This PR just changes the label for tag [leisure=horse_riding](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dhorse_riding)
**from "Horse Riding" to "Horse Riding Centre"** in en.yml and thus resolves https://github.com/openstreetmap/openstreetmap-website/issues/3189

The motivation is to make it clearer to the user what the object tagged in this way is. Simply "hoirse riding" is too generic and an activity rather than a location for that activity. Other tags with suboptimal names also have more descriptive labels, e.g.
leisure=dance : "Dance Hall"
leisure=fishing : "Fishing Area"

The presets for leisure=horse_riding in the main editors iD and JOSM are now also named "Horse Riding Centre" (or "Horseback Riding Center" in US English, see https://github.com/openstreetmap/openstreetmap-website/issues/3189#issuecomment-1144229876 f).