### PR TITLE
Avoid using html in translations

### DIFF
--- a/app/views/accounts/_go_public.html.erb
+++ b/app/views/accounts/_go_public.html.erb
@@ -1,0 +1,14 @@
+<hr class="mb-3" />
+<a name="public"></a>
+<h2><%= t ".heading" %></h2>
+<p>
+  <%= t ".currently_not_public" %>
+  <strong><%= t ".only_public_can_edit" %></strong>
+  <%= t ".find_out_why_html", :link => link_to(t(".find_out_why"),
+                                               t(".find_out_why_url")) %>
+</p>
+<ul>
+  <li><%= t ".email_not_revealed" %></li>
+  <li><%= t ".not_reversible" %></li>
+</ul>
+<%= button_to t(".make_edits_public_button"), user_go_public_path, :class => "btn btn-primary" %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -65,18 +65,5 @@
 <% end %>
 
 <% unless current_user.data_public? %>
-  <hr class="mb-3" />
-  <a name="public"></a>
-  <h2><%= t ".public editing note.heading" %></h2>
-  <p>
-    <%= t ".public editing note.currently_not_public" %>
-    <strong><%= t ".public editing note.only_public_can_edit" %></strong>
-    <%= t ".public editing note.find_out_why_html", :link => link_to(t(".public editing note.find_out_why"),
-                                                                     t(".public editing note.find_out_why_url")) %>
-  </p>
-  <ul>
-    <li><%= t ".public editing note.email_not_revealed" %></li>
-    <li><%= t ".public editing note.not_reversible" %></li>
-  </ul>
-  <%= button_to t(".make edits public button"), user_go_public_path, :class => "btn btn-primary" %>
+  <%= render :partial => "go_public" %>
 <% end %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -65,8 +65,18 @@
 <% end %>
 
 <% unless current_user.data_public? %>
-<a name="public"></a>
-<h2><%= t ".public editing note.heading" %></h2>
-<%= t ".public editing note.html" %>
-<%= button_to t(".make edits public button"), user_go_public_path, :class => "btn btn-primary" %>
+  <hr class="mb-3" />
+  <a name="public"></a>
+  <h2><%= t ".public editing note.heading" %></h2>
+  <p>
+    <%= t ".public editing note.currently_not_public" %>
+    <strong><%= t ".public editing note.only_public_can_edit" %></strong>
+    <%= t ".public editing note.find_out_why_html", :link => link_to(t(".public editing note.find_out_why"),
+                                                                     t(".public editing note.find_out_why_url")) %>
+  </p>
+  <ul>
+    <li><%= t ".public editing note.email_not_revealed" %></li>
+    <li><%= t ".public editing note.not_reversible" %></li>
+  </ul>
+  <%= button_to t(".make edits public button"), user_go_public_path, :class => "btn btn-primary" %>
 <% end %>

--- a/app/views/site/_any_questions.html.erb
+++ b/app/views/site/_any_questions.html.erb
@@ -1,0 +1,4 @@
+  <h2><%= t ".title" %></h2>
+  <span class='sprite small term question float-start'></span>
+  <p><%= t ".paragraph_1_html", :help_link => link_to(t(".get_help_here"), help_path),
+                                :welcome_mat_link => link_to(t(".welcome_mat"), t(".welcome_mat_url")) %></p>

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <h4><%= t ".licence" %></h4>
-  <p><%= t ".export_details_html" %></p>
+  <p><%= t ".licence_details_html", :odbl_link => link_to(t(".odbl"), t(".odbl_url")) %></p>
 
   <div id="export_osm_too_large">
     <p class="alert alert-warning">

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class='col-sm'>
     <h5><%= t "site.welcome.add_a_note.title" %></h5>
-    <p><%= t "site.welcome.add_a_note.paragraph_1_html" %></p>
+    <p><%= t "site.welcome.add_a_note.para_1" %></p>
     <p><%= t ".how_to_help.add_a_note.instructions_html", :map_url => root_path %></p>
   </div>
 </div>
@@ -29,6 +29,4 @@
 <h2><%= t ".other_concerns.title" %></h2>
 <p><%= t ".other_concerns.explanation_html" %></p>
 
-<h2><%= t "site.welcome.questions.title" %></h2>
-<span class='sprite small term question float-start'></span>
-<p><%= t "site.welcome.questions.paragraph_1_html", :help_url => help_path %></p>
+<%= render "any_questions" %>

--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -6,7 +6,7 @@
   <h1><%= t ".title" %></h1>
 <% end %>
 
-<p class="lead"><%= t ".introduction_html" %></p>
+<p class="lead"><%= t ".introduction" %></p>
 
 <h2><%= t ".whats_on_the_map.title" %></h2>
 
@@ -15,49 +15,48 @@
     <div>
       <span class='sprite small check mx-auto'></span>
     </div>
-    <p><%= t ".whats_on_the_map.on_html" %></p>
+    <p><%= t ".whats_on_the_map.on_the_map_html", :real_and_current => tag.em(t(".whats_on_the_map.real_and_current")) %></p>
   </div>
   <div class='col'>
     <div class='center'>
       <span class='sprite small x mx-auto'></span>
     </div>
-    <p><%= t ".whats_on_the_map.off_html" %></p>
+    <p><%= t ".whats_on_the_map.off_the_map_html", :doesnt => tag.em(t(".whats_on_the_map.doesnt")) %></p>
   </div>
 </div>
 
 <h2><%= t ".basic_terms.title" %></h2>
 
-<p><%= t ".basic_terms.paragraph_1_html" %></p>
+<p><%= t ".basic_terms.paragraph_1" %></p>
 
 <div class='clearfix'>
   <div class='clearfix'>
     <span class='sprite small term editor float-start'></span>
-    <p><%= t ".basic_terms.editor_html" %></p>
+    <p><%= t ".basic_terms.an_editor_html", :editor => tag.strong(t(".basic_terms.editor")) %></p>
   </div>
   <div class='clearfix'>
     <span class='sprite small term node float-start'></span>
-    <p><%= t ".basic_terms.node_html" %></p>
+    <p><%= t ".basic_terms.a_node_html", :node => tag.strong(t(".basic_terms.node")) %></p>
   </div>
   <div class='clearfix'>
     <span class='sprite small term way float-start'></span>
-    <p><%= t ".basic_terms.way_html" %></p>
+    <p><%= t ".basic_terms.a_way_html", :way => tag.strong(t(".basic_terms.way")) %></p>
   </div>
   <div class='clearfix'>
     <span class='sprite small term tag float-start'></span>
-    <p><%= t ".basic_terms.tag_html" %></p>
+    <p><%= t ".basic_terms.a_tag_html", :tag => tag.strong(t(".basic_terms.tag")) %></p>
   </div>
 </div>
 
 <div class='clearfix'>
   <h2><%= t ".rules.title" %></h2>
   <span class='sprite small term rules float-start'></span>
-  <p><%= t ".rules.paragraph_1_html" %></p>
+  <p><%= t ".rules.para_1_html", :imports_link => link_to(t(".rules.imports"), t(".rules.imports_url")),
+                                 :automated_edits_link => link_to(t(".rules.automated_edits"), t(".rules.automated_edits_url")) %></p>
 </div>
 
 <div class='clearfix'>
-  <h2><%= t ".questions.title" %></h2>
-  <span class='sprite small term question float-start'></span>
-  <p><%= t ".questions.paragraph_1_html", :help_url => help_path %></p>
+  <%= render "any_questions" %>
 </div>
 
 <div class='clearfix text-center'>
@@ -66,6 +65,7 @@
 
 <div class='alert alert-primary'>
   <h2><%= t ".add_a_note.title" %></h2>
-  <p><%= t ".add_a_note.paragraph_1_html" %></p>
-  <p><%= t ".add_a_note.paragraph_2_html", :map_url => root_path %></p>
+  <p><%= t ".add_a_note.para_1" %></p>
+  <p><%= t ".add_a_note.para_2_html", :map_link => link_to(t(".add_a_note.the_map"), root_path),
+                                      :note_icon => tag.span(:class => "icon note") %></p>
 </div>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -76,5 +76,7 @@
 
   <%= render "trace_paging_nav", :page => @page, :page_size => @page_size, :traces => @traces, :params => @params %>
 <% else %>
-  <h4><%= t ".empty_html", :upload_link => new_trace_path %></h4>
+  <h2><%= t ".empty_title" %></h2>
+  <p><%= t ".empty_upload_html", :upload_link => link_to(t(".upload_new"), new_trace_path),
+                                 :wiki_link => link_to(t(".wiki_page"), t(".wiki_page_url")) %></p>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -13,7 +13,8 @@
 <div class="row">
   <div class='text-muted col-sm order-sm-2'>
     <h4><%= t ".about.header" %></h4>
-    <%= t ".about.html" %>
+    <p><%= t ".about.paragraph_1" %></p>
+    <p><%= t ".about.paragraph_2" %></p>
   </div>
 
   <div class="col-sm">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2396,7 +2396,11 @@ en:
       public_traces_from: "Public GPS Traces from %{user}"
       description: "Browse recent GPS trace uploads"
       tagged_with: " tagged with %{tags}"
-      empty_html: "Nothing here yet. <a href='%{upload_link}'>Upload a new trace</a> or learn more about GPS tracing on the <a href='https://wiki.openstreetmap.org/wiki/Beginners_Guide_1.2'>wiki page</a>."
+      empty_title: Nothing here yet
+      empty_upload_html: "%{upload_link} or learn more about GPS tracing on the %{wiki_link}."
+      upload_new: Upload a new trace
+      wiki_page: wiki page
+      wiki_page_url: https://wiki.openstreetmap.org/wiki/Beginners_Guide_1.2
       upload_trace: "Upload a trace"
       all_traces: "All Traces"
       my_traces: "My Traces"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,7 +275,13 @@ en:
         disabled link text: "why can't I edit?"
       public editing note:
         heading: "Public editing"
-        html: "Currently your edits are anonymous and people cannot send you messages or see your location. To show what you edited and allow people to contact you through the website, click the button below. <b>Since the 0.6 API changeover, only public users can edit map data</b>. (<a href=\"https://wiki.openstreetmap.org/wiki/Anonymous_edits\">find out why</a>).<ul><li>Your email address will not be revealed by becoming public.</li><li>This action cannot be reversed and all new users are now public by default.</li></ul>"
+        currently_not_public: "Currently your edits are anonymous and people cannot send you messages or see your location. To show what you edited and allow people to contact you through the website, click the button below."
+        only_public_can_edit: Since the 0.6 API changeover, only public users can edit map data.
+        find_out_why_html: (%{link}).
+        find_out_why: "find out why"
+        find_out_why_url: https://wiki.openstreetmap.org/wiki/Anonymous_edits
+        email_not_revealed: Your email address will not be revealed by becoming public.
+        not_reversible: This action cannot be reversed and all new users are now public by default.
       contributor terms:
         heading: "Contributor Terms"
         agreed: "You have agreed to the new Contributor Terms."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,15 +273,6 @@ en:
         enabled link text: "what is this?"
         disabled: "Disabled and cannot edit data, all previous edits are anonymous."
         disabled link text: "why can't I edit?"
-      public editing note:
-        heading: "Public editing"
-        currently_not_public: "Currently your edits are anonymous and people cannot send you messages or see your location. To show what you edited and allow people to contact you through the website, click the button below."
-        only_public_can_edit: Since the 0.6 API changeover, only public users can edit map data.
-        find_out_why_html: (%{link}).
-        find_out_why: "find out why"
-        find_out_why_url: https://wiki.openstreetmap.org/wiki/Anonymous_edits
-        email_not_revealed: Your email address will not be revealed by becoming public.
-        not_reversible: This action cannot be reversed and all new users are now public by default.
       contributor terms:
         heading: "Contributor Terms"
         agreed: "You have agreed to the new Contributor Terms."
@@ -291,8 +282,17 @@ en:
         link: "https://wiki.osmfoundation.org/wiki/Licence/Contributor_Terms"
         link text: "what is this?"
       save changes button: Save Changes
-      make edits public button: Make all my edits public
       delete_account: Delete Account...
+    go_public:
+      heading: "Public editing"
+      currently_not_public: "Currently your edits are anonymous and people cannot send you messages or see your location. To show what you edited and allow people to contact you through the website, click the button below."
+      only_public_can_edit: Since the 0.6 API changeover, only public users can edit map data.
+      find_out_why_html: (%{link}).
+      find_out_why: "find out why"
+      find_out_why_url: https://wiki.openstreetmap.org/wiki/Anonymous_edits
+      email_not_revealed: Your email address will not be revealed by becoming public.
+      not_reversible: This action cannot be reversed and all new users are now public by default.
+      make_edits_public_button: Make all my edits public
     update:
       success_confirm_needed: "User information updated successfully. Check your email for a note to confirm your new email address."
       success: "User information updated successfully."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2160,6 +2160,15 @@ en:
       removed: Your default OpenStreetMap editor is set as Potlatch. Because Adobe Flash Player has been withdrawn, Potlatch is no longer available to use in a web browser.
       desktop_html: You can still use Potlatch by <a href="https://www.systemed.net/potlatch/">downloading the desktop application for Mac and Windows</a>.
       id_html: Alternatively, you can set your default editor to iD, which runs in your web browser as Potlatch formerly did. <a href="%{settings_url}">Change your preferences here</a>.
+    any_questions:
+      title: Any questions?
+      paragraph_1_html: |
+        OpenStreetMap has several resources for learning about the project, asking and answering
+        questions, and collaboratively discussing and documenting mapping topics.
+        %{help_link}. With an organization making plans for OpenStreetMap? %{welcome_mat_link}.
+      get_help_here: Get help here
+      welcome_mat: Check out the Welcome Mat
+      welcome_mat_url: https://welcome.openstreetmap.org/
     sidebar:
       search_results: Search Results
       close: Close
@@ -2246,57 +2255,56 @@ en:
           toilets: "Toilets"
     welcome:
       title: Welcome!
-      introduction_html: |
+      introduction: |
         Welcome to OpenStreetMap, the free and editable map of the world. Now that you're signed
         up, you're all set to get started mapping. Here's a quick guide with the most important
         things you need to know.
       whats_on_the_map:
         title: What's on the Map
-        on_html: |
-          OpenStreetMap is a place for mapping things that are both <em>real and current</em> -
+        on_the_map_html: |
+          OpenStreetMap is a place for mapping things that are both %{real_and_current} -
           it includes millions of buildings, roads, and other details about places. You can map
           whatever real-world features are interesting to you.
-        off_html: |
-          What it <em>doesn't</em> include is opinionated data like ratings, historical or
+        real_and_current: real and current
+        off_the_map_html: |
+          What it %{doesnt} include is opinionated data like ratings, historical or
           hypothetical features, and data from copyrighted sources. Unless you have special
           permission, don't copy from online or paper maps.
+        doesnt: doesn't
       basic_terms:
         title: Basic Terms For Mapping
-        paragraph_1_html: |
+        paragraph_1: |
           OpenStreetMap has some of its own lingo. Here are a few key words that'll come in handy.
-        editor_html: |
-          An <strong>editor</strong> is a program or website you can use to edit the map.
-        node_html: |
-          A <strong>node</strong> is a point on the map, like a single restaurant or a tree.
-        way_html: |
-          A <strong>way</strong> is a line or area, like a road, stream, lake or building.
-        tag_html: |
-          A <strong>tag</strong> is a bit of data about a node or way, like a
-          restaurant's name or a road's speed limit.
+        an_editor_html: An %{editor} is a program or website you can use to edit the map.
+        a_node_html: A %{node} is a point on the map, like a single restaurant or a tree.
+        a_way_html: A %{way} is a line or area, like a road, stream, lake or building.
+        a_tag_html: A %{tag} is a bit of data about a node or way, like a restaurant's name or a road's speed limit.
+        editor: editor
+        node: node
+        way: way
+        tag: tag
       rules:
         title: Rules!
-        paragraph_1_html: |
+        para_1_html: |
           OpenStreetMap has few formal rules but we expect all participants to collaborate
           with, and communicate with, the community. If you are considering
           any activities other than editing by hand, please read and follow the guidelines on
-          <a href='https://wiki.openstreetmap.org/wiki/Import/Guidelines'>Imports</a> and
-          <a href='https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct'>Automated Edits</a>.
-      questions:
-        title: Any questions?
-        paragraph_1_html: |
-          OpenStreetMap has several resources for learning about the project, asking and answering
-          questions, and collaboratively discussing and documenting mapping topics.
-          <a href='%{help_url}'>Get help here</a>. With an organization making plans for OpenStreetMap? <a href='https://welcome.openstreetmap.org/'>Check out the Welcome Mat</a>.
+          %{imports_link} and %{automated_edits_link}.
+        imports: Imports
+        imports_url: https://wiki.openstreetmap.org/wiki/Import/Guidelines
+        automated_edits: Automated Edits
+        automated_edits_url: https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct
       start_mapping: Start Mapping
       add_a_note:
         title: No Time To Edit? Add a Note!
-        paragraph_1_html: |
+        para_1: |
           If you just want something small fixed and don't have the time to sign up and learn how to edit, it's
           easy to add a note.
-        paragraph_2_html: |
-          Just go to <a href='%{map_url}'>the map</a> and click the note icon:
-          <span class='icon note'></span>. This will add a marker to the map, which you can move
-          by dragging. Add your message, then click save, and other mappers will investigate.
+        para_2_html: |
+          Just go to %{map_link} and click the note icon: %{note_icon}.
+          This will add a marker to the map, which you can move by dragging.
+          Add your message, then click save, and other mappers will investigate.
+        the_map: the map
     communities:
       title: Communities
       lede_text: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2573,10 +2573,8 @@ en:
       support: support
       about:
         header: Free and editable
-        html: |
-          <p>Unlike other maps, OpenStreetMap is completely created by people like you,
-          and it's free for anyone to fix, update, download and use.</p>
-          <p>Sign up to get started contributing. We'll send an email to confirm your account.</p>
+        paragraph_1: Unlike other maps, OpenStreetMap is completely created by people like you, and it's free for anyone to fix, update, download and use.
+        paragraph_2: Sign up to get started contributing. We'll send an email to confirm your account.
       email address: "Email Address:"
       confirm email address: "Confirm Email Address:"
       display name: "Display Name:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2058,7 +2058,9 @@ en:
       map_image: "Map Image (shows standard layer)"
       embeddable_html: "Embeddable HTML"
       licence: "Licence"
-      export_details_html: 'OpenStreetMap data is licensed under the <a href="https://opendatacommons.org/licenses/odbl/1.0/">Open Data Commons Open Database License</a> (ODbL).'
+      licence_details_html: OpenStreetMap data is licensed under the %{odbl_link} (ODbL).
+      odbl: Open Data Commons Open Database License
+      odbl_url: https://opendatacommons.org/licenses/odbl/1.0/
       too_large:
         advice: "If the above export fails, please consider using one of the sources listed below:"
         body: "This area is too large to be exported as OpenStreetMap XML Data. Please zoom in or select a smaller area, or use one of the sources listed below for bulk data downloads."

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -756,7 +756,7 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     assert_template "index"
 
     if traces.empty?
-      assert_select "h4", /Nothing here yet/
+      assert_select "h2", /Nothing here yet/
     else
       assert_select "table#trace_list tbody", :count => 1 do
         assert_select "tr", :count => traces.length do |rows|


### PR DESCRIPTION
This is the first batch of changes to avoid using html in our translation strings. It reworks various views to make sure that all html (e.g. links, paragraphs, bold tags etc) are defined in the view, and that the translations only contain the words that need to be translated. The aim is, among other reasons, to make it easier to translate since it avoids having to get the brackets, quoting etc correct to ensure valid html.

The primary challenge with this refactoring is, as usual, to make sure that the translation keys change whenever there is a difference with interpolations, which leads to a little strain around picking new translation keys.