### PR TITLE
Include hashtags in notes

### DIFF
--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -50,7 +50,7 @@ OSM.NewNote = function (map) {
       data: {
         lat: location.lat,
         lon: location.lng,
-        text: $(form.text).val()
+        text: $(form.text).val() + "#osm.org"
       },
       success: function (feature) {
         noteCreated(feature, marker);

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -50,7 +50,7 @@ OSM.NewNote = function (map) {
       data: {
         lat: location.lat,
         lon: location.lng,
-        text: $(form.text).val() + "#osm.org"
+        text: $(form.text).val() + " #website"
       },
       success: function (feature) {
         noteCreated(feature, marker);


### PR DESCRIPTION
This allows to identify notes created from website, from other notes, which is useful when filtering and solving notes.