### PR TITLE
Improve the preview of diary entries on social media sites (using OpenGraph HTML tags)

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -66,6 +66,24 @@ class DiaryEntriesController < ApplicationController
     if @entry
       @title = t ".title", :user => params[:display_name], :title => @entry.title
       @comments = can?(:unhidecomment, DiaryEntry) ? @entry.comments : @entry.visible_comments
+      @og_tags = {
+        "og:type" => "article",
+        "og:locale" => @entry.language_code,
+
+        # helpers.user_image_url is a hack, and should be done Properly™
+        "og:image" => helpers.user_image_url(@user),
+        "og:image:secure_url" => helpers.user_image_url(@user),
+        # user_image_url returns a 100×100 image
+        "og:image:width" => "100",
+        "og:image:height" => "100",
+
+        # Should/Could this be translated?
+        "og:image:alt" => "Profile image of #{@user.display_name} on OpenStreetMap.org",
+
+        # Including the entire body sounds bad. Arbitrarily choose 300 chars as the limit.
+        # It would be better to strip out all HTML, or Markdown, syntax here.
+        "og:description" => @entry.body.to_text[0..300]
+      }
     else
       @title = t "diary_entries.no_such_entry.title", :id => params[:id]
       render :action => "no_such_entry", :status => :not_found

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -1,6 +1,7 @@
 module OpenGraphHelper
-  def opengraph_tags(title = nil)
-    tags = {
+  def opengraph_tags(title, og_tags)
+    og_tags = {} if og_tags.nil?
+    default_og_tags = {
       "og:site_name" => t("layouts.project_name.title"),
       "og:title" => [title, t("layouts.project_name.title")].compact.join(" | "),
       "og:type" => "website",
@@ -10,7 +11,9 @@ module OpenGraphHelper
       "og:description" => t("layouts.intro_text")
     }
 
-    safe_join(tags.map do |property, content|
+    og_tags = og_tags.reverse_merge(default_og_tags)
+
+    safe_join(og_tags.map do |property, content|
       tag.meta(:property => property, :content => content)
     end, "\n")
   end

--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -19,7 +19,7 @@
 <% end -%>
 <%= tag.link :rel => "search", :type => "application/opensearchdescription+xml", :title => "OpenStreetMap Search", :href => asset_path("osm.xml") %>
 <%= tag.meta :name => "description", :content => "OpenStreetMap is the free wiki world map." %>
-<%= opengraph_tags(@title) %>
+<%= opengraph_tags(@title, @og_tags) %>
 <% if flash[:matomo_goal] -%>
 <%= tag.meta :name => "matomo-goal", :content => flash[:matomo_goal] %>
 <% end -%>

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "user_helper"
 
 class UserHelperTest < ActionView::TestCase
   include ERB::Util


### PR DESCRIPTION
Currently the “open graph” tags for social media sites are very uniform across the website. The description is always a short blurb about OSM. This patch starts customizing them, with a diary entry page.

I am new to Ruby, and might have made mistakes. Please correct me if I've done something wrong.