### PR TITLE
Set og:image:alt OpenGraph header to “OpenStreetMap logo”

### DIFF
--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -6,6 +6,7 @@ module OpenGraphHelper
       "og:type" => "website",
       "og:image" => image_url("osm_logo_256.png", :protocol => "http"),
       "og:image:secure_url" => image_url("osm_logo_256.png", :protocol => "https"),
+      "og:image:alt" => "OpenStreetMap logo",
       "og:url" => url_for(:only_path => false),
       "og:description" => t("layouts.intro_text")
     }


### PR DESCRIPTION
This might prevent sites from interpreting, or guessing, at what an alt text for this image is.

The current [Facebook Debugger for osm.org](https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fwww.openstreetmap.org%2F) shows all the standard Open Graph tags that we use, but included is a Facebook derived value for `og:image:alt` of `Sexoffenderrecord Map Near Me Free`.

I have no idea where it's getting that. I hope by manually specifying this, we might be able to override it.