### PR TITLE
add IDs to note and changeset mail subjects

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1585,8 +1585,8 @@ en:
       anonymous: An anonymous user
       greeting: "Hi,"
       commented:
-        subject_own: "[OpenStreetMap] %{commenter} has commented on one of your notes"
-        subject_other: "[OpenStreetMap] %{commenter} has commented on a note you are interested in"
+        subject_own: "[OpenStreetMap] %{commenter} has commented on your note %{note_id}"
+        subject_other: "[OpenStreetMap] %{commenter} has commented on note %{note_id} you are interested in"
         your_note: "%{commenter} has left a comment on one of your map notes near %{place}."
         your_note_html: "%{commenter} has left a comment on one of your map notes near %{place}."
         commented_note: "%{commenter} has left a comment on a map note you have commented on. The note is near %{place}."
@@ -1611,8 +1611,8 @@ en:
       hi: "Hi %{to_user},"
       greeting: "Hi,"
       commented:
-        subject_own: "[OpenStreetMap] %{commenter} has commented on one of your changesets"
-        subject_other: "[OpenStreetMap] %{commenter} has commented on a changeset you are interested in"
+        subject_own: "[OpenStreetMap] %{commenter} has commented on your changeset %{changeset_id}"
+        subject_other: "[OpenStreetMap] %{commenter} has commented on changeset %{changeset_id} you are interested in"
         your_changeset: "%{commenter} left a comment at %{time} on one of your changesets"
         your_changeset_html: "%{commenter} left a comment at %{time} on one of your changesets"
         commented_changeset: "%{commenter} left a comment at %{time} on a changeset you are watching created by %{changeset_author}"


### PR DESCRIPTION
It would be very cool to have the note ID in the subject of emails, when a note was updated. This would also be helpful for changeset mails. I only did update the locale file for en, because i do not know where and how this needs also adjustments in the code to fill the ID place holders with the actual ID. This shall at least give an idea of i want to achieve.

At the moment the ID is only given indirectly via the `noteurl` or `changeset_url` in the `user_mailer.rb`. Is it anyhow easily possible to access the ID directly in the corresponding notification functions? Would it be ok for you to improve the mail subject to contain the ID?