### PR TITLE
Adding information about Serbia sources

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -149,6 +149,14 @@
                                      t(".legal_babble.contributors_nz_cc_by_url")) %>
       </li>
       <li>
+        <%= t ".legal_babble.contributors_rs_credit_html",
+              :serbia => tag.strong(t(".legal_babble.contributors_rs_serbia")),
+              :rgz_link => link_to(t(".legal_babble.contributors_rs_rgz"),
+                                                 t(".legal_babble.contributors_rs_rgz_url")),
+              :open_data_portal => link_to(t(".legal_babble.contributors_rs_open_data_portal"),
+                                     t(".legal_babble.contributors_rs_open_data_portal_url")) %>
+      </li>
+      <li>
         <%= t ".legal_babble.contributors_si_credit_html",
               :slovenia => tag.strong(t(".legal_babble.contributors_si_slovenia")),
               :gu_link => link_to(t(".legal_babble.contributors_si_gu"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2015,6 +2015,14 @@ en:
         contributors_nz_linz_data_service_url: https://data.linz.govt.nz/
         contributors_nz_cc_by: CC BY 4.0
         contributors_nz_cc_by_url: https://creativecommons.org/licenses/by/4.0/
+        contributors_rs_credit_html: |
+          %{serbia}: Contains data from the %{rgz_link} and %{open_data_portal}
+          (public information of Serbia), 2018.
+        contributors_rs_serbia: Serbia
+        contributors_rs_rgz: Serbian Geodetic Authority
+        contributors_rs_rgz_url: https://geosrbija.rs/
+        contributors_rs_open_data_portal: National Open Data Portal
+        contributors_rs_open_data_portal_url: https://data.gov.rs/sr/
         contributors_si_credit_html: |
           %{slovenia}: Contains data from the %{gu_link} and %{mkgp_link}
           (public information of Slovenia).


### PR DESCRIPTION
We are required to cite the source of open data in accordance with the Serbian Open License (Law on eGovernment, Article 26). This PR is adding proper copyright text for Serbia official sources