### PR TITLE
Remove some unused translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2648,8 +2648,6 @@ en:
       delete_user: "Delete this User"
       confirm: "Confirm"
       report: Report this User
-    set_home:
-      flash success: "Home location saved successfully"
     go_public:
       flash success: "All your edits are now public, and you are now allowed to edit."
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1779,13 +1779,8 @@ en:
       lost password link: "Lost your password?"
       login_button: "Login"
       register now: Register now
-      with username: "Already have an OpenStreetMap account? Please login with your username and password:"
       with external: "Alternatively, use a third party to login:"
-      new to osm: New to OpenStreetMap?
-      to make changes: To make changes to the OpenStreetMap data, you must have an account.
-      create account minute: Create an account. It only takes a minute.
       no account: Don't have an account?
-      account not active: "Sorry, your account is not active yet.<br />Please use the link in the account confirmation email to activate your account, or <a href=\"%{reconfirm}\">request a new confirmation email</a>."
       auth failure: "Sorry, could not log in with those details."
       openid_logo_alt: "Log in with an OpenID"
       auth_providers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1518,8 +1518,6 @@ en:
     community: Community
     community_blogs: "Community Blogs"
     community_blogs_title: "Blogs from members of the OpenStreetMap community"
-    foundation: Foundation
-    foundation_title: The OpenStreetMap Foundation
     make_a_donation:
       title: Support OpenStreetMap with a monetary donation
       text: Make a Donation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1694,14 +1694,10 @@ en:
       wrong_user: "You are logged in as `%{user}' but the message you have asked to reply to was not sent to that user. Please login as the correct user in order to reply."
     show:
       title: "Read message"
-      from: "From"
-      subject: "Subject"
-      date: "Date"
       reply_button: "Reply"
       unread_button: "Mark as unread"
       destroy_button: "Delete"
       back: "Back"
-      to: "To"
       wrong_user: "You are logged in as `%{user}' but the message you have asked to read was not sent by or to that user. Please login as the correct user in order to read it."
     sent_message_summary:
       destroy_button: "Delete"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2068,9 +2068,6 @@ en:
         geofabrik:
           title: "Geofabrik Downloads"
           description: "Regularly-updated extracts of continents, countries, and selected cities"
-        metro:
-          title: "Metro Extracts"
-          description: "Extracts for major world cities and their surrounding areas"
         other:
           title: "Other Sources"
           description: "Additional sources listed on the OpenStreetMap Wiki"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2705,8 +2705,6 @@ en:
       title: "Creating block on %{name}"
       heading_html: "Creating block on %{name}"
       period: "How long, starting now, the user will be blocked from the API for."
-      tried_contacting: "I have contacted the user and asked them to stop."
-      tried_waiting: "I have given a reasonable amount of time for the user to respond to those communications."
       back: "View all blocks"
     edit:
       title: "Editing block on %{name}"
@@ -2718,8 +2716,6 @@ en:
       block_expired: "The block has already expired and cannot be edited."
       block_period: "The blocking period must be one of the values selectable in the drop-down list."
     create:
-      try_contacting: "Please try contacting the user before blocking them and giving them a reasonable time to respond."
-      try_waiting: "Please try giving the user a reasonable time to respond before blocking them."
       flash: "Created a block on user %{name}."
     update:
       only_creator_can_edit: "Only the moderator who created this block can edit it."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2673,7 +2673,6 @@ en:
       support: support
       automatically_suspended: Sorry, your account has been automatically suspended due to suspicious activity.
       contact_support_html: This decision will be reviewed by an administrator shortly, or you may contact %{support_link} if you wish to discuss this.
-      support: support
     auth_failure:
       connection_failed: Connection to authentication provider failed
       invalid_credentials: Invalid authentication credentials

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2556,9 +2556,6 @@ en:
         header: Free and editable
         paragraph_1: Unlike other maps, OpenStreetMap is completely created by people like you, and it's free for anyone to fix, update, download and use.
         paragraph_2: Sign up to get started contributing. We'll send an email to confirm your account.
-      email address: "Email Address:"
-      confirm email address: "Confirm Email Address:"
-      display name: "Display Name:"
       display name description: "Your publicly displayed username. You can change this later in the preferences."
       external auth: "Third Party Authentication:"
       use external auth: "Alternatively, use a third party to login"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2598,7 +2598,6 @@ en:
       deleted: "deleted"
     show:
       my diary: My Diary
-      new diary entry: new diary entry
       my edits: My Edits
       my traces: My Traces
       my notes: My Notes
@@ -2627,8 +2626,6 @@ en:
       created from: "Created from:"
       status: "Status:"
       spam score: "Spam Score:"
-      description: Description
-      user location: User location
       role:
         administrator: "This user is an administrator"
         moderator: "This user is a moderator"
@@ -2643,7 +2640,6 @@ en:
       comments: "Comments"
       create_block: "Block this User"
       activate_user: "Activate this User"
-      deactivate_user: "Deactivate this User"
       confirm_user: "Confirm this User"
       unconfirm_user: "Unconfirm this User"
       unsuspend_user: "Unsuspend this User"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1398,10 +1398,6 @@ en:
         ignored: Ignored
         open: Open
         resolved: Resolved
-    update:
-      new_report: Your report has been registered successfully
-      successful_update: Your report has been updated successfully
-      provide_details: Please provide the required details
     show:
       title: "%{status} Issue #%{issue_id}"
       reports:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,6 @@ en:
       message: "Message"
       node: "Node"
       node_tag: "Node Tag"
-      notifier: "Notifier"
       old_node: "Old Node"
       old_node_tag: "Old Node Tag"
       old_relation: "Old Relation"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1485,10 +1485,8 @@ en:
     home: Go to Home Location
     logout: Log Out
     log_in: Log In
-    log_in_tooltip: Log in with an existing account
     sign_up: Sign Up
     start_mapping: Start Mapping
-    sign_up_tooltip: Create an account for editing
     edit: Edit
     history: History
     export: Export

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1670,8 +1670,6 @@ en:
     new:
       title: "Send message"
       send_message_to_html: "Send a new message to %{name}"
-      subject: "Subject"
-      body: "Body"
       back_to_inbox: "Back to inbox"
     create:
       message_sent: "Message sent"


### PR DESCRIPTION
This PR removes some translations that are no longer in use. These were identified by the [i18n-tasks gem](https://github.com/glebm/i18n-tasks), and then individually verified. In most cases I've linked to the commit that made them become unused.

I first stumbled across the problem when trying to figure out why there was raw html in a translation key that didn't end in `_html`, and figured out that key must have been unused since the rails 4.x era.

There are still further keys that I suspect are unused, but these will require further confirmation since the static analysis throws up many false-positives.