### PR TITLE
Add space between form and Publish diary button

### DIFF
--- a/app/views/diary_entries/_form.html.erb
+++ b/app/views/diary_entries/_form.html.erb
@@ -7,7 +7,7 @@
 
   <%= tag.div "", :id => "map", :class => "border border-grey rounded", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
 
-  <div class="row">
+  <div class="row mb-3">
     <%= f.text_field :latitude, :wrapper_class => "col-sm-4", :id => "latitude" %>
     <%= f.text_field :longitude, :wrapper_class => "col-sm-4", :id => "longitude" %>
     <div class="col-sm-4">


### PR DESCRIPTION
It was missing some space between the form and the Publish button:
![image](https://user-images.githubusercontent.com/666291/224393038-7bd6a27c-ae3b-4bb5-852e-b8a7d2b2ad74.png)

With this change:
![image](https://user-images.githubusercontent.com/666291/224393100-61cafe1e-5a7a-44fc-aac8-7df3a5e63039.png)
