### PR TITLE
Include count in messages for the "one" plural category

### DIFF
--- a/app/views/user_mailer/gpx_success.html.erb
+++ b/app/views/user_mailer/gpx_success.html.erb
@@ -2,6 +2,5 @@
 
 <p>
   <%= render :partial => "gpx_description" %>
-  <%= t(".loaded_successfully",
-        :trace_points => @trace_points, :possible_points => @possible_points, :count => @possible_points) %>
+  <%= t(".loaded", :trace_points => @trace_points, :count => @possible_points) %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,41 +159,41 @@ en:
   datetime:
     distance_in_words_ago:
       about_x_hours:
-        one: about 1 hour ago
+        one: about %{count} hour ago
         other: about %{count} hours ago
       about_x_months:
-        one: about 1 month ago
+        one: about %{count} month ago
         other: about %{count} months ago
       about_x_years:
-        one: about 1 year ago
+        one: about %{count} year ago
         other: about %{count} years ago
       almost_x_years:
-        one: almost 1 year ago
+        one: almost %{count} year ago
         other: almost %{count} years ago
       half_a_minute: half a minute ago
       less_than_x_seconds:
-        one: less than 1 second ago
+        one: less than %{count} second ago
         other: less than %{count} seconds ago
       less_than_x_minutes:
-        one: less than a minute ago
+        one: less than %{count} minute ago
         other: less than %{count} minutes ago
       over_x_years:
-        one: over 1 year ago
+        one: over %{count} year ago
         other: over %{count} years ago
       x_seconds:
-        one: 1 second ago
+        one: "%{count} second ago"
         other: "%{count} seconds ago"
       x_minutes:
-        one: 1 minute ago
+        one: "%{count} minute ago"
         other: "%{count} minutes ago"
       x_days:
-        one: 1 day ago
+        one: "%{count} day ago"
         other: "%{count} days ago"
       x_months:
-        one: 1 month ago
+        one: "%{count} month ago"
         other: "%{count} months ago"
       x_years:
-        one: 1 year ago
+        one: "%{count} year ago"
         other: "%{count} years ago"
   printable_name:
     with_id: "%{id}"
@@ -312,10 +312,10 @@ en:
     no_comment: "(no comment)"
     part_of: "Part of"
     part_of_relations:
-      one: 1 relation
+      one: "%{count} relation"
       other: "%{count} relations"
     part_of_ways:
-      one: 1 way
+      one: "%{count} way"
       other: "%{count} ways"
     download_xml: "Download XML"
     view_history: "View History"
@@ -360,7 +360,7 @@ en:
       history_title_html: "Relation History: %{name}"
       members: "Members"
       members_count:
-        one: 1 member
+        one: "%{count} member"
         other: "%{count} members"
     relation_member:
       entry_html: "%{type} %{name}"
@@ -1391,7 +1391,7 @@ en:
       last_updated_time_user_html: "<abbr title='%{title}'>%{time}</abbr> by %{user}"
       link_to_reports: View Reports
       reports_count:
-        one: "1 Report"
+        one: "%{count} Report"
         other: "%{count} Reports"
       reported_item: Reported Item
       states:
@@ -1402,7 +1402,7 @@ en:
       title: "%{status} Issue #%{issue_id}"
       reports:
         zero: No reports
-        one: 1 report
+        one: "%{count} report"
         other: "%{count} reports"
       report_created_at: "First reported at %{datetime}"
       last_resolved_at: "Last resolved at %{datetime}"
@@ -1552,9 +1552,9 @@ en:
       subject: "[OpenStreetMap] GPX Import failure"
     gpx_success:
       hi: "Hi %{to_user},"
-      loaded_successfully:
-        one: loaded successfully with %{trace_points} out of a possible 1 point.
-        other: loaded successfully with %{trace_points} out of a possible %{possible_points} points.
+      loaded:
+        one: "loaded successfully with %{trace_points} out of a possible %{count} point."
+        other: "loaded successfully with %{trace_points} out of a possible %{count} points."
       subject: "[OpenStreetMap] GPX Import success"
     signup_confirm:
       subject: "[OpenStreetMap] Welcome to OpenStreetMap"
@@ -2368,7 +2368,7 @@ en:
     trace:
       pending: "PENDING"
       count_points:
-        one: "1 point"
+        one: "%{count} point"
         other: "%{count} points"
       more: "more"
       trace_details: "View Trace Details"
@@ -2746,19 +2746,19 @@ en:
       time_past_html: "Ended %{time}."
       block_duration:
         hours:
-          one: "1 hour"
+          one: "%{count} hour"
           other: "%{count} hours"
         days:
-          one: "1 day"
+          one: "%{count} day"
           other: "%{count} days"
         weeks:
-          one: "1 week"
+          one: "%{count} week"
           other: "%{count} weeks"
         months:
-          one: "1 month"
+          one: "%{count} month"
           other: "%{count} months"
         years:
-          one: "1 year"
+          one: "%{count} year"
           other: "%{count} years"
     blocks_on:
       title: "Blocks on %{name}"
@@ -2874,10 +2874,10 @@ en:
       locate:
         title: Show My Location
         metersPopup:
-          one: You are within one meter of this point
+          one: You are within %{count} meter of this point
           other: You are within %{count} meters of this point
         feetPopup:
-          one: You are within one foot of this point
+          one: You are within %{count} foot of this point
           other: You are within %{count} feet of this point
       base:
         standard: Standard


### PR DESCRIPTION
This fixes almost all the cases referred to in #3972.

I think the only remaining case is `users.index.showing` which is kind of weird and is only ever seen by administrators.