### PR TITLE
Title and alt text changed from Windows Live to Microsoft Account

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,7 +213,7 @@ en:
       openid: OpenID
       google: Google
       facebook: Facebook
-      windowslive: Windows Live
+      windowslive: Microsoft
       github: GitHub
       wikipedia: Wikipedia
   api:
@@ -1780,8 +1780,8 @@ en:
           title: Login with Facebook
           alt: Login with a Facebook Account
         windowslive:
-          title: Login with Windows Live
-          alt: Login with a Windows Live Account
+          title: Login with Microsoft
+          alt: Login with a Microsoft Account
         github:
           title: Login with GitHub
           alt: Login with a GitHub Account


### PR DESCRIPTION
Fixes Issue #1828 
Changed title and alt text of the button.
No variables were renamed, so functioning of auth should stay unaffected.
Internally the identifier "windowslive" is being used (as it was), just the UI shows "Log in with Microsoft" instead.