### PR TITLE
Remove incorrect language blocks from copyright page

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -3,19 +3,17 @@
   <!-- Maybe ease foreigners back to their native page -->
 
     <% if t(".legal_babble", :locale => I18n.locale) != t(".legal_babble", :locale => :en) %>
-      <%= tag.div :lang => @locale, :dir => t("html.dir", :locale => @locale) do %>
-        <h1><%= t ".native.title" %></h1>
-        <p>
-          <%= t ".native.html",
-                :native_link => link_to(t(".native.native_link"),
-                                        :controller => "site",
-                                        :action => "copyright",
-                                        :copyright_locale => nil),
-                :mapping_link => link_to(t(".native.mapping_link"),
-                                         :controller => "site",
-                                         :action => "index") %>
-        </p>
-      <% end %>
+      <h1><%= t ".native.title" %></h1>
+      <p>
+        <%= t ".native.html",
+              :native_link => link_to(t(".native.native_link"),
+                                      :controller => "site",
+                                      :action => "copyright",
+                                      :copyright_locale => nil),
+              :mapping_link => link_to(t(".native.mapping_link"),
+                                       :controller => "site",
+                                       :action => "index") %>
+      </p>
       <hr />
     <% end %>
   <% else %>

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -19,16 +19,14 @@
   <% else %>
     <!-- Maybe note that this page has been translated -->
     <% if t(".legal_babble", :locale => @locale) != t(".legal_babble", :locale => :en) %>
-      <%= tag.div :lang => "en", :dir => t("html.dir", :locale => "en") do %>
-        <h1><%= t ".foreign.title" %></h1>
-        <p>
-          <%= t ".foreign.html",
-                :english_original_link => link_to(t(".foreign.english_link"),
-                                                  :controller => "site",
-                                                  :action => "copyright",
-                                                  :copyright_locale => "en") %>
-        </p>
-      <% end %>
+      <h1><%= t ".foreign.title" %></h1>
+      <p>
+        <%= t ".foreign.html",
+              :english_original_link => link_to(t(".foreign.english_link"),
+                                                :controller => "site",
+                                                :action => "copyright",
+                                                :copyright_locale => "en") %>
+      </p>
       <hr />
     <% end %>
   <% end %>


### PR DESCRIPTION
This PR removes two incorrect language blocks declarations from the copyright page. In both cases, the text is shown in the users native language that is used for the rest of the page (i.e. there are no `@locale` overrides) and so no additional language declarations are required for those parts of the page.

Although marking the language incorrectly in html doesn't have much of a user-visible impact, the dir attribute causes problems that are easier to see. If you set your language preference to `ar` and view the copyright page, then you will see Arabic written LTR due to these incorrect declarations.

![Screenshot from 2023-03-22 10-00-52](https://user-images.githubusercontent.com/360803/226868848-81de9335-7504-4cf0-ac99-3e258b263cea.png)

The solution is to remove them, while keeping the language (and direction) overrides for the parts of the page that use the `@locale` override.