### PR TITLE
Use with_locale instead of individual locale overrides

### DIFF
--- a/app/views/site/_about_section.html.erb
+++ b/app/views/site/_about_section.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div :class => "section", :id => local_assigns[:id] do %>
   <div class='d-flex align-items-center gap-2 mb-2'>
     <div class='flex-shrink-0 icon <%= icon %>'></div>
-    <h2 class='flex-grow-1 mb-0'><%= t "site.about.#{title}_title", :locale => @locale %></h2>
+    <h2 class='flex-grow-1 mb-0'><%= t "site.about.#{title}_title" %></h2>
   </div>
   <%= yield %>
 <% end %>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -1,45 +1,46 @@
-<%= tag.div :lang => @locale, :dir => t("html.dir", :locale => @locale) do %>
-  <div class="container-lg attr">
-    <div class='row'>
-      <div class='col-sm-7 user-image'></div>
-      <div class='col-sm-5 px-5 py-3 byosm'>
-        <p class='h5 text-white text-nowrap'><%= t ".copyright_html", :locale => @locale %></p>
+<% I18n.with_locale @locale do %>
+  <%= tag.div :lang => @locale, :dir => t("html.dir") do %>
+    <div class="container-lg attr">
+      <div class='row'>
+        <div class='col-sm-7 user-image'></div>
+        <div class='col-sm-5 px-5 py-3 byosm'>
+          <p class='h5 text-white text-nowrap'><%= t ".copyright_html" %></p>
+        </div>
+      </div>
+      <div class='row'>
+        <div class="w-100 px-5 py-4 bg-dark">
+          <h1 class="text-white fw-light"><%= t ".used_by_html", :name => tag.span("OpenStreetMap", :class => "user-name") %></h1>
+        </div>
       </div>
     </div>
-    <div class='row'>
-      <div class="w-100 px-5 py-4 bg-dark">
-        <h1 class="text-white fw-light"><%= t ".used_by_html", :name => tag.span("OpenStreetMap", :class => "user-name"), :locale => @locale %></h1>
-      </div>
+
+    <div class='bg-white px-5 py-4'>
+      <p class="lead"><%= t ".lede_text" %></p>
+
+      <%= render :layout => "about_section", :locals => { :icon => "local", :title => "local_knowledge" } do %>
+        <p><%= t "site.about.local_knowledge_html" %></p>
+      <% end %>
+
+      <%= render :layout => "about_section", :locals => { :icon => "community", :title => "community_driven" } do %>
+        <p><%= t "site.about.community_driven_html", :diary_path => diary_entries_path %></p>
+      <% end %>
+
+      <%= render :layout => "about_section", :locals => { :id => "open-data", :icon => "open", :title => "open_data" } do %>
+        <p><%= t "site.about.open_data_html", :copyright_path => copyright_path %></p>
+      <% end %>
+
+      <%= render :layout => "about_section", :locals => { :id => "legal", :icon => "legal", :title => "legal" } do %>
+        <p><%= t "site.about.legal_1_html" %></p>
+        <p><%= t "site.about.legal_2_html" %></p>
+      <% end %>
+
+      <%= render :layout => "about_section", :locals => { :id => "partners", :icon => "partners", :title => "partners" } do %>
+        <p><%= t "layouts.hosting_partners_html", :ucl => link_to(t("layouts.partners_ucl"), "https://www.ucl.ac.uk"),
+                                                  :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
+                                                  :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
+                                                  :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
+        </p>
+      <% end %>
     </div>
-  </div>
-
-  <div class='bg-white px-5 py-4'>
-    <p class="lead"><%= t ".lede_text", :locale => @locale %></p>
-
-    <%= render :layout => "about_section", :locals => { :icon => "local", :title => "local_knowledge" } do %>
-      <p><%= t "site.about.local_knowledge_html", :locale => @locale %></p>
-    <% end %>
-
-    <%= render :layout => "about_section", :locals => { :icon => "community", :title => "community_driven" } do %>
-      <p><%= t "site.about.community_driven_html", :locale => @locale, :diary_path => diary_entries_path %></p>
-    <% end %>
-
-    <%= render :layout => "about_section", :locals => { :id => "open-data", :icon => "open", :title => "open_data" } do %>
-      <p><%= t "site.about.open_data_html", :locale => @locale, :copyright_path => copyright_path %></p>
-    <% end %>
-
-    <%= render :layout => "about_section", :locals => { :id => "legal", :icon => "legal", :title => "legal" } do %>
-      <p><%= t "site.about.legal_1_html", :locale => @locale %></p>
-      <p><%= t "site.about.legal_2_html", :locale => @locale %></p>
-    <% end %>
-
-    <%= render :layout => "about_section", :locals => { :id => "partners", :icon => "partners", :title => "partners" } do %>
-      <p><%= t "layouts.hosting_partners_html", :locale => @locale,
-                                                :ucl => link_to(t("layouts.partners_ucl", :locale => @locale), "https://www.ucl.ac.uk"),
-                                                :fastly => link_to(t("layouts.partners_fastly", :locale => @locale), "https://www.fastly.com/"),
-                                                :bytemark => link_to(t("layouts.partners_bytemark", :locale => @locale), "https://www.bytemark.co.uk"),
-                                                :partners => link_to(t("layouts.partners_partners", :locale => @locale), "https://hardware.openstreetmap.org/thanks/") %>
-      </p>
-    <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -1,7 +1,6 @@
 <% content_for :heading do %>
-<% if @locale == "en" %>
-  <!-- Maybe ease foreigners back to their native page -->
-
+  <% if @locale == "en" %>
+    <!-- Maybe ease foreigners back to their native page -->
     <% if t(".legal_babble", :locale => I18n.locale) != t(".legal_babble", :locale => :en) %>
       <%= tag.div :lang => @locale, :dir => t("html.dir", :locale => @locale) do %>
         <h1><%= t ".native.title" %></h1>
@@ -40,7 +39,6 @@
       <%= t ".legal_babble.title_html" %>
     <% end %>
   <% end %>
-
 <% end %>
 
 <% I18n.with_locale @locale do %>

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -35,53 +35,57 @@
     <% end %>
   <% end %>
 
-  <%= tag.h1 :lang => @locale, :dir => t("html.dir", :locale => @locale) do %>
-    <%= t ".legal_babble.title_html", :locale => @locale %>
+  <% I18n.with_locale @locale do %>
+    <%= tag.h1 :lang => @locale, :dir => t("html.dir") do %>
+      <%= t ".legal_babble.title_html" %>
+    <% end %>
   <% end %>
 
 <% end %>
 
-<%= tag.div :lang => @locale, :dir => t("html.dir", :locale => @locale) do %>
-  <p><%= t ".legal_babble.intro_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.intro_2_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.intro_3_1_html", :locale => @locale %></p>
+<% I18n.with_locale @locale do %>
+  <%= tag.div :lang => @locale, :dir => t("html.dir") do %>
+    <p><%= t ".legal_babble.intro_1_html" %></p>
+    <p><%= t ".legal_babble.intro_2_html" %></p>
+    <p><%= t ".legal_babble.intro_3_1_html" %></p>
 
-  <h3><%= t ".legal_babble.credit_title_html", :locale => @locale %></h3>
-  <p><%= t ".legal_babble.credit_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.credit_2_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.credit_3_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.credit_4_html", :locale => @locale %></p>
-  <p><%= image_tag("attribution_example.png",
-                   :alt => t(".legal_babble.attribution_example.alt"),
-                   :border => 0,
-                   :title => t(".legal_babble.attribution_example.title")) %></p>
+    <h3><%= t ".legal_babble.credit_title_html" %></h3>
+    <p><%= t ".legal_babble.credit_1_html" %></p>
+    <p><%= t ".legal_babble.credit_2_1_html" %></p>
+    <p><%= t ".legal_babble.credit_3_1_html" %></p>
+    <p><%= t ".legal_babble.credit_4_html" %></p>
+    <p><%= image_tag("attribution_example.png",
+                     :alt => t(".legal_babble.attribution_example.alt"),
+                     :border => 0,
+                     :title => t(".legal_babble.attribution_example.title")) %></p>
 
-  <h3><%= t ".legal_babble.more_title_html", :locale => @locale %></h3>
-  <p><%= t ".legal_babble.more_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.more_2_html", :locale => @locale %></p>
+    <h3><%= t ".legal_babble.more_title_html" %></h3>
+    <p><%= t ".legal_babble.more_1_html" %></p>
+    <p><%= t ".legal_babble.more_2_html" %></p>
 
-  <h3><%= t ".legal_babble.contributors_title_html", :locale => @locale %></h3>
-  <p><%= t ".legal_babble.contributors_intro_html", :locale => @locale %></p>
-  <ul id="contributors">
-    <li><%= t ".legal_babble.contributors_at_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_au_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_ca_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_fi_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_fr_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_nl_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_nz_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_si_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_es_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_za_html", :locale => @locale %></li>
-    <li><%= t ".legal_babble.contributors_gb_html", :locale => @locale %></li>
-  </ul>
-  <p><%= t ".legal_babble.contributors_footer_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.contributors_footer_2_html", :locale => @locale %></p>
+    <h3><%= t ".legal_babble.contributors_title_html" %></h3>
+    <p><%= t ".legal_babble.contributors_intro_html" %></p>
+    <ul id="contributors">
+      <li><%= t ".legal_babble.contributors_at_html" %></li>
+      <li><%= t ".legal_babble.contributors_au_html" %></li>
+      <li><%= t ".legal_babble.contributors_ca_html" %></li>
+      <li><%= t ".legal_babble.contributors_fi_html" %></li>
+      <li><%= t ".legal_babble.contributors_fr_html" %></li>
+      <li><%= t ".legal_babble.contributors_nl_html" %></li>
+      <li><%= t ".legal_babble.contributors_nz_html" %></li>
+      <li><%= t ".legal_babble.contributors_si_html" %></li>
+      <li><%= t ".legal_babble.contributors_es_html" %></li>
+      <li><%= t ".legal_babble.contributors_za_html" %></li>
+      <li><%= t ".legal_babble.contributors_gb_html" %></li>
+    </ul>
+    <p><%= t ".legal_babble.contributors_footer_1_html" %></p>
+    <p><%= t ".legal_babble.contributors_footer_2_html" %></p>
 
-  <h3><%= t ".legal_babble.infringement_title_html", :locale => @locale %></h3>
-  <p><%= t ".legal_babble.infringement_1_html", :locale => @locale %></p>
-  <p><%= t ".legal_babble.infringement_2_html", :locale => @locale %></p>
+    <h3><%= t ".legal_babble.infringement_title_html" %></h3>
+    <p><%= t ".legal_babble.infringement_1_html" %></p>
+    <p><%= t ".legal_babble.infringement_2_html" %></p>
 
-  <h3><%= t ".legal_babble.trademarks_title_html", :locale => @locale %></h3>
-  <p><%= t ".legal_babble.trademarks_1_html", :locale => @locale %></p>
+    <h3><%= t ".legal_babble.trademarks_title_html" %></h3>
+    <p><%= t ".legal_babble.trademarks_1_html" %></p>
+  <% end %>
 <% end %>

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -476,6 +476,11 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "about"
     assert_select "div[lang='ar'][dir='rtl']"
+
+    # Page should still render even with incorrect locale
+    get about_path(:about_locale => "zzz")
+    assert_response :success
+    assert_template "about"
   end
 
   # Test the export page


### PR DESCRIPTION
This PR changes the about and copyright pages to use `I18n.with_locale` blocks, instead of using `:locale` overrides on each translation.

This makes it slightly less verbose, and slightly easier to get right when adding additional translations to these sections. But more importantly, it makes it much less verbose when using interpolated translations, e.g. 

```erb
<%= t ".foo_html", :locale => @locale,
                   :first_link => link_to(t(".bar", :locale => @locale), t(".bar_url", :locale => @locale)),
                   :second_link => link_to(t(".baz", :locale => @locale), t(".baz_url", :locale => @locale)),
... etc ...
```

vs

```erb
<% I18n.with_locale @locale do %>
  <%= t ".foo_html", :first_link => link_to(t(".bar"), t(".bar_url")),
                     :second_link => link_to(t(".baz", t(".baz_url"))
... etc ...
```

The `with_locale` setting also applies to partials used within the block, so the override is no longer needed there. The indentation fix commit makes it a bit easier to understand the logic at the top of the copyright page, and is a historic whitespace issue.