### PR TITLE
Remove unused small.scss symlinks

### DIFF
--- a/app/assets/stylesheets/ltr/small.scss
+++ b/app/assets/stylesheets/ltr/small.scss
@@ -1,1 +1,0 @@
-../small.scss

--- a/app/assets/stylesheets/rtl/small.r2.scss
+++ b/app/assets/stylesheets/rtl/small.r2.scss
@@ -1,1 +1,0 @@
-../small.scss


### PR DESCRIPTION
These should have been removed as part of 5ab682dbbdc0bc4034d1c93aae3d082dae09fa65