### PR TITLE
Add some validations for i18n values

### DIFF
--- a/test/lib/i18n_test.rb
+++ b/test/lib/i18n_test.rb
@@ -55,6 +55,20 @@ class I18nTest < ActiveSupport::TestCase
     end
   end
 
+  def test_en_for_raw_html
+    en = YAML.load_file(Rails.root.join("config/locales/en.yml"))
+    assert_nothing_raised do
+      check_values_for_raw_html(en)
+    end
+  end
+
+  def test_en_for_nil_values
+    en = YAML.load_file(Rails.root.join("config/locales/en.yml"))
+    assert_nothing_raised do
+      check_values_for_nil(en)
+    end
+  end
+
   private
 
   def translation_keys(scope = nil)
@@ -80,5 +94,26 @@ class I18nTest < ActiveSupport::TestCase
     I18n.t("i18n.plural.keys", :locale => locale, :raise => true) + [:zero]
   rescue I18n::MissingTranslationData
     [:zero, :one, :other]
+  end
+
+  def check_values_for_raw_html(hash)
+    hash.each_pair do |k, v|
+      if v.is_a? Hash
+        check_values_for_raw_html(v)
+      else
+        next unless k.end_with?("_html")
+        raise "Avoid using raw html in '#{k}: #{v}'" if v.include? "<"
+      end
+    end
+  end
+
+  def check_values_for_nil(hash)
+    hash.each_pair do |k, v|
+      if v.is_a? Hash
+        check_values_for_nil(v)
+      else
+        raise "Avoid nil values in '#{k}: nil'" if v.nil?
+      end
+    end
   end
 end


### PR DESCRIPTION
These only apply to the en.yml file for now, but can be expanded in due course.

I had a long search for any third-party utilities that could do this for us, but I didn't find anything appropriate. None of the generic yaml validators that I found allowed custom validations of values (most were just focussed on validating the type of the value, int/string/hash etc against a fixed schema). I also checked for any i18n-specific validators, but again I didn't find any that could validate the values.

I expect to expand these checks to cover the rest of the translations, but there are currently a bunch of translations in the output that contain html elements (that aren't included in en.yml, which is interesting). I also expect to expand these check to add more validations, perhaps validating urls point to the same domain, and things like that.