### PR TITLE
Remove apache packages from install instructions and vagrant config

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ These can be installed on Ubuntu 20.04 or later with:
 sudo apt-get update
 sudo apt-get install ruby2.7 libruby2.7 ruby2.7-dev \
                      libvips-dev libxml2-dev libxslt1-dev nodejs \
-                     apache2 apache2-dev build-essential git-core firefox-geckodriver \
+                     build-essential git-core firefox-geckodriver \
                      postgresql postgresql-contrib libpq-dev libsasl2-dev \
                      libffi-dev libgd-dev libarchive-dev libbz2-dev yarnpkg
 sudo gem2.7 install bundler

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -18,7 +18,7 @@ apt-get upgrade -y
 # install packages as explained in INSTALL.md
 apt-get install -y ruby2.7 libruby2.7 ruby2.7-dev \
                      libxml2-dev libxslt1-dev nodejs yarnpkg \
-                     apache2 apache2-dev build-essential git-core firefox-geckodriver \
+                     build-essential git-core firefox-geckodriver \
                      postgresql postgresql-contrib libpq-dev libvips-dev \
                      libsasl2-dev libffi-dev libgd-dev libarchive-dev libbz2-dev
 gem2.7 install rake


### PR DESCRIPTION
These are unnecessary for development environments, and are not used in the Fedora instructions nor in the Dockerfile.

[It looks like it was me who added them back in 2013](c3d7cfd7ff90879511ff1c8b54a5d280e2e15057), but I don't know why!