### PR TITLE
Use rails to migrate database for vagrant

### DIFF
--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -21,7 +21,6 @@ apt-get install -y ruby2.7 libruby2.7 ruby2.7-dev \
                      apache2 apache2-dev build-essential git-core firefox-geckodriver \
                      postgresql postgresql-contrib libpq-dev libvips-dev \
                      libsasl2-dev libffi-dev libgd-dev libarchive-dev libbz2-dev
-gem2.7 install rake
 gem2.7 install --version "~> 2.1.4" bundler
 
 ## install the bundle necessary for openstreetmap-website
@@ -47,5 +46,5 @@ if [ ! -f config/storage.yml ]; then
 fi
 touch config/settings.local.yml
 # migrate the database to the latest version
-sudo -u vagrant bundle exec rake db:migrate
+sudo -u vagrant bundle exec rails db:migrate
 popd


### PR DESCRIPTION
This brings the vagrant provisioning script into line with the installation notes, docker and CI.