### PR TITLE
Update workflows to run on Ubuntu 22.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   test:
     name: Docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout source
       uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   ruby: '3.0'
 jobs:
   rubocop:
     name: RuboCop
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
       run: bundle exec rubocop --format fuubar
   erblint:
     name: ERB Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
       run: bundle exec erblint .
   eslint:
     name: ESLint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
       run: bundle exec rails eslint
   brakeman:
     name: Brakeman
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3


### PR DESCRIPTION
This PR changes the single-platform workflows to run on 22.04. Given that this is github-flavoured-ubuntu, it's not super important which version they run on since they all contain the same packages (node, geckodriver, etc are not from upstream Ubuntu).

Refs #4048 