### PR TITLE
Update vagrant provisioning for 22.04

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,10 +33,11 @@ These can be installed on Ubuntu 22.04 or later with:
 sudo apt-get update
 sudo apt-get install ruby3.0 libruby3.0 ruby3.0-dev \
                      libvips-dev libxml2-dev libxslt1-dev nodejs \
-                     build-essential git-core firefox-geckodriver \
+                     build-essential git-core \
                      postgresql postgresql-contrib libpq-dev libsasl2-dev \
-                     libffi-dev libgd-dev libarchive-dev libbz2-dev yarnpkg
+                     libffi-dev libgd-dev libarchive-dev libbz2-dev npm
 sudo gem3.0 install bundler
+sudo npm install --global yarn
 ```
 
 ### Alternative platforms

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
   # use official ubuntu image for virtualbox
   config.vm.provider "virtualbox" do |vb, override|
-    override.vm.box = "ubuntu/focal64"
+    override.vm.box = "ubuntu/jammy64"
     override.vm.synced_folder ".", "/srv/openstreetmap-website"
     vb.customize ["modifyvm", :id, "--memory", "4096"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]
@@ -16,13 +16,13 @@ Vagrant.configure("2") do |config|
 
   # use third party image and sshfs or NFS sharing for lxc
   config.vm.provider "lxc" do |_, override|
-    override.vm.box = "generic/ubuntu2004"
+    override.vm.box = "generic/ubuntu2204"
     override.vm.synced_folder ".", "/srv/openstreetmap-website", :type => sharing_type
   end
 
   # use third party image and sshfs or NFS sharing for libvirt
   config.vm.provider "libvirt" do |_, override|
-    override.vm.box = "generic/ubuntu2004"
+    override.vm.box = "generic/ubuntu2204"
     override.vm.synced_folder ".", "/srv/openstreetmap-website", :type => sharing_type
   end
 

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -16,12 +16,13 @@ apt-get update
 apt-get upgrade -y
 
 # install packages as explained in INSTALL.md
-apt-get install -y ruby2.7 libruby2.7 ruby2.7-dev \
-                     libxml2-dev libxslt1-dev nodejs yarnpkg \
-                     build-essential git-core firefox-geckodriver \
+apt-get install -y ruby3.0 libruby3.0 ruby3.0-dev \
+                     libxml2-dev libxslt1-dev nodejs npm \
+                     build-essential git-core \
                      postgresql postgresql-contrib libpq-dev libvips-dev \
                      libsasl2-dev libffi-dev libgd-dev libarchive-dev libbz2-dev
-gem2.7 install --version "~> 2.1.4" bundler
+gem3.0 install --version "~> 2.1.4" bundler
+npm install --global yarn
 
 ## install the bundle necessary for openstreetmap-website
 pushd /srv/openstreetmap-website


### PR DESCRIPTION
Refs #4048

* geckodriver is now inside the firefox snap package
* the yarnpkg package is completely broken, see https://bugs.launchpad.net/ubuntu/+source/node-yarnpkg/+bug/2003697