### PR TITLE
Simplify ruby installations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ RUN apt-get update \
       libxslt1-dev \
       locales \
       postgresql-client \
-      ruby3.0 \
-      ruby3.0-dev \
+      ruby \
+      ruby-dev \
+      ruby-bundler \
       software-properties-common \
       tzdata \
       unzip \
@@ -49,8 +50,7 @@ WORKDIR /app
 
 # Install Ruby packages
 ADD Gemfile Gemfile.lock /app/
-RUN gem install bundler \
- && bundle install
+RUN bundle install
 
 # Install NodeJS packages using yarn
 ADD package.json yarn.lock /app/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,10 +33,11 @@ These can be installed on Ubuntu 22.04 or later with:
 sudo apt-get update
 sudo apt-get install ruby3.0 libruby3.0 ruby3.0-dev \
                      libvips-dev libxml2-dev libxslt1-dev nodejs \
-                     build-essential git-core firefox-geckodriver \
+                     build-essential git-core \
                      postgresql postgresql-contrib libpq-dev libsasl2-dev \
-                     libffi-dev libgd-dev libarchive-dev libbz2-dev yarnpkg
+                     libffi-dev libgd-dev libarchive-dev libbz2-dev npm
 sudo gem3.0 install bundler
+sudo npm install --global yarn
 ```
 
 ### Alternative platforms

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,12 +31,11 @@ These can be installed on Ubuntu 22.04 or later with:
 
 ```
 sudo apt-get update
-sudo apt-get install ruby3.0 libruby3.0 ruby3.0-dev \
+sudo apt-get install ruby ruby-dev ruby-bundler \
                      libvips-dev libxml2-dev libxslt1-dev nodejs \
                      build-essential git-core \
                      postgresql postgresql-contrib libpq-dev libsasl2-dev \
                      libffi-dev libgd-dev libarchive-dev libbz2-dev npm
-sudo gem3.0 install bundler
 sudo npm install --global yarn
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
   # use official ubuntu image for virtualbox
   config.vm.provider "virtualbox" do |vb, override|
-    override.vm.box = "ubuntu/focal64"
+    override.vm.box = "ubuntu/jammy64"
     override.vm.synced_folder ".", "/srv/openstreetmap-website"
     vb.customize ["modifyvm", :id, "--memory", "4096"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]
@@ -16,13 +16,13 @@ Vagrant.configure("2") do |config|
 
   # use third party image and sshfs or NFS sharing for lxc
   config.vm.provider "lxc" do |_, override|
-    override.vm.box = "generic/ubuntu2004"
+    override.vm.box = "generic/ubuntu2204"
     override.vm.synced_folder ".", "/srv/openstreetmap-website", :type => sharing_type
   end
 
   # use third party image and sshfs or NFS sharing for libvirt
   config.vm.provider "libvirt" do |_, override|
-    override.vm.box = "generic/ubuntu2004"
+    override.vm.box = "generic/ubuntu2204"
     override.vm.synced_folder ".", "/srv/openstreetmap-website", :type => sharing_type
   end
 

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -16,12 +16,11 @@ apt-get update
 apt-get upgrade -y
 
 # install packages as explained in INSTALL.md
-apt-get install -y ruby3.0 libruby3.0 ruby3.0-dev \
+apt-get install -y ruby ruby-dev ruby-bundler \
                      libxml2-dev libxslt1-dev nodejs npm \
                      build-essential git-core \
                      postgresql postgresql-contrib libpq-dev libvips-dev \
                      libsasl2-dev libffi-dev libgd-dev libarchive-dev libbz2-dev
-gem3.0 install --version "~> 2.1.4" bundler
 npm install --global yarn
 
 ## install the bundle necessary for openstreetmap-website

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -16,12 +16,13 @@ apt-get update
 apt-get upgrade -y
 
 # install packages as explained in INSTALL.md
-apt-get install -y ruby2.7 libruby2.7 ruby2.7-dev \
-                     libxml2-dev libxslt1-dev nodejs yarnpkg \
-                     build-essential git-core firefox-geckodriver \
+apt-get install -y ruby3.0 libruby3.0 ruby3.0-dev \
+                     libxml2-dev libxslt1-dev nodejs npm \
+                     build-essential git-core \
                      postgresql postgresql-contrib libpq-dev libvips-dev \
                      libsasl2-dev libffi-dev libgd-dev libarchive-dev libbz2-dev
-gem2.7 install --version "~> 2.1.4" bundler
+gem3.0 install --version "~> 2.1.4" bundler
+npm install --global yarn
 
 ## install the bundle necessary for openstreetmap-website
 pushd /srv/openstreetmap-website


### PR DESCRIPTION
Refs https://github.com/openstreetmap/openstreetmap-website/issues/4048

* We don't currently need a specific version suffix on the package names,
  since ubuntu only ships with one ruby version (and newer versions on
  e.g. 23.04 are fine).
* We don't need to explicitly install libruby, since it's pulled in by
  other packages as required.
* Ubuntu again ships a decent enough version of bundler for our needs,
  so we don't need to install it via rubygems.

Please note: This PR builds on top of #4050 , I thought it would be useful to put this up for review even though that PR isn't yet merged.