### PR TITLE
Ignore .bundle/config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .DS_Store
+.bundle/config
 .idea
 .ruby-gemset
 .ruby-version


### PR DESCRIPTION
This can be created by passing flags to bundler, such as the ones used in our vagrant provisioning