### PR TITLE
Silence image_optim warnings in development

### DIFF
--- a/config/image_optim/development.yml
+++ b/config/image_optim/development.yml
@@ -1,0 +1,12 @@
+skip_missing_workers: true
+advpng: false
+gifsicle: false
+jhead: false
+jpegoptim: false
+jpegtran: false
+optipng: false
+oxipng: false
+pngquant: false
+pngout: false
+pngcrush: false
+svgo: false


### PR DESCRIPTION
Lots of new developers see this during configuration (e.g. rails db:migrate) and then spend time trying to fix them, by figuring out what packages are missing (or just worrying that something is wrong). So let's silence the warnings entirely in the development environment.

An alterative would be to expand the installation instructions to add all the additional packages, but this just makes the (already lengthy) installation process take more time, for little gain.

I was surprised to find this topic mentioned in #4038 since it's been so long since I've seen the warnings. But then I found that I've created this file (and locally ignored it using .git/info/excludes) many years ago. So I think it's reasonable to have the same approach happen out-of-the-box for new developers.

The main argument against doing this is that it's less noticeable the the packages are missing if you want to set up a fully-optimised production environment. But in this case, I'd rather optimise for a smoother first-time-developer experience.

Refs #1795 where we disabled the warnings in the test environment.