### PR TITLE
Fix ERB Lint for copyright page

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -152,9 +152,9 @@
         <%= t ".legal_babble.contributors_rs_credit_html",
               :serbia => tag.strong(t(".legal_babble.contributors_rs_serbia")),
               :rgz_link => link_to(t(".legal_babble.contributors_rs_rgz"),
-                                                 t(".legal_babble.contributors_rs_rgz_url")),
+                                   t(".legal_babble.contributors_rs_rgz_url")),
               :open_data_portal => link_to(t(".legal_babble.contributors_rs_open_data_portal"),
-                                     t(".legal_babble.contributors_rs_open_data_portal_url")) %>
+                                           t(".legal_babble.contributors_rs_open_data_portal_url")) %>
       </li>
       <li>
         <%= t ".legal_babble.contributors_si_credit_html",


### PR DESCRIPTION
When doing commit https://github.com/openstreetmap/openstreetmap-website/commit/d1fe40ac69719f4f835fbcd44a06368f9136d343, there were regression in ERB Lint which is failing now (aligning arguments). This PR tries to fix that