### PR TITLE
Fix test suite to work in non-UK timezones

### DIFF
--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -56,7 +56,7 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   def test_friendly_date
-    date = friendly_date(Time.new(2014, 3, 5, 18, 58, 23).utc)
+    date = friendly_date(Time.utc(2014, 3, 5, 18, 58, 23))
     assert_match %r{^<span title=" *5 March 2014 at 18:58">.*</span>$}, date
 
     date = friendly_date(Time.now.utc - 1.hour)

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -5,7 +5,7 @@ class NoteHelperTest < ActionView::TestCase
   include ApplicationHelper
 
   def test_note_event
-    date = Time.new(2014, 3, 5, 21, 37, 45, "+00:00")
+    date = Time.utc(2014, 3, 5, 21, 37, 45)
     user = create(:user)
 
     assert_match %r{^Created by anonymous <abbr title="Wed, 05 Mar 2014 21:37:45 \+0000"><span title=" 5 March 2014 at 21:37">.* ago</span></abbr>$}, note_event("opened", date, nil)
@@ -23,7 +23,7 @@ class NoteHelperTest < ActionView::TestCase
   end
 
   def test_disappear_in
-    note_closed_date = Time.new(2022, 1, 1, 12, 0, 0, "+00:00")
+    note_closed_date = Time.utc(2022, 1, 1, 12, 0, 0)
     note = create(:note, :closed_at => note_closed_date)
 
     travel_to note_closed_date + 1.day do


### PR DESCRIPTION
The test suit currently fails if your development environment (e.g. your own laptop) is set to a timezone outside of the UK. I encountered this earlier this year, at the Karlsruhe Hack Weekend, but I'm surprised more people haven't complained about it! The failing test is:

```
Failure:
ApplicationHelperTest#test_friendly_date [/home/andy/src/openstreetmap-website/test/helpers/application_helper_test.rb:62]:
Expected /^<span title=" *5 March 2014 at 18:58">.*<\/span>$/ to match "<span title=\" 5 March 2014 at 17:58\">over 9 years</span>".
```

This is because that test uses `Time.new(...).utc`, which is not the same thing as `Time.utc(...)`.

But why does it work - all year round - in the UK? 

`Time.new` takes an optional list of year, month, day etc (defaults to midnight first of January) and an implicit "in the current system timezone". If you ask for a date in the winter, it will use the winter equivalent of your current timezone. For example:

```ruby
>> Time.now.zone
=> "BST"
>> Time.new(2020).zone
=> "GMT"
```

Therefore, there is no problem in either summer or winter for the UK, both approaches give the same time. For example:

```ruby
>> Time.new(2020).utc
=> 2020-01-01 00:00:00 UTC
>> Time.utc(2020)
=> 2020-01-01 00:00:00 UTC
```

Imagine the first line above says `Time.new(2020, 'GMT').utc` i.e. midnight GMT. Then convert that to UTC, which is the same time, also midnight.

However, if you switch your laptop to a different timezone:

```ruby
>> Time.now.zone
=> "CEST"
>> Time.new(2020).zone
=> "CET"
>> Time.new(2020).utc
=> 2019-12-31 23:00:00 UTC
>> Time.utc(2020)
=> 2020-01-01 00:00:00 UTC
```

The third line can now be considered as `Time.new(2020, CET).utc` i.e. midnight 1st January in CET, which is then converted to 23:00 the previous day in UTC.

This test previously used `Time.new(2014, 3, 5, 18, 58, 23).utc` which we can see will be created in the local timezone at 18:58 and then converted to some other time in UTC, depending on your timezone offset from UTC e.g. it might be 17:58 UTC if you are in CE(S)T.

We already used two other forms of date expression in the tests, both `Time.new(..., "+00:00")` and also `Time.utc(...)`, neither of which have this problem. I've standardized on `Time.utc(...)` in this PR because it allows the minutes, seconds etc to be omitted when they are unimportant, for better readability.
