### PR TITLE
Change the way notifications about messages appear

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
   $(".inbox-mark-unread").on("ajax:success", function (event, data) {
     $("#inboxanchor").remove();
-    $("#user_profile_picture").after(data.inboxanchor);
+    $(".profile_photo").append(data.inboxanchor);
 
     $("#inbox-count").replaceWith(data.inbox_count);
 
@@ -10,7 +10,7 @@ $(document).ready(function () {
 
   $(".inbox-mark-read").on("ajax:success", function (event, data) {
     $("#inboxanchor").remove();
-    $("#user_profile_picture").after(data.inboxanchor);
+    $(".profile_photo").append(data.inboxanchor);
 
     $("#inbox-count").replaceWith(data.inbox_count);
 
@@ -19,7 +19,7 @@ $(document).ready(function () {
 
   $(".inbox-destroy").on("ajax:success", function (event, data) {
     $("#inboxanchor").remove();
-    $("#user_profile_picture").after(data.inboxanchor);
+    $(".profile_photo").append(data.inboxanchor);
 
     $("#inbox-count").replaceWith(data.inbox_count);
 

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
   $(".inbox-mark-unread").on("ajax:success", function (event, data) {
     $("#inboxanchor").remove();
-    $(".user-button").before(data.inboxanchor);
+    $("#user_profile_picture").after(data.inboxanchor);
 
     $("#inbox-count").replaceWith(data.inbox_count);
 
@@ -10,7 +10,7 @@ $(document).ready(function () {
 
   $(".inbox-mark-read").on("ajax:success", function (event, data) {
     $("#inboxanchor").remove();
-    $(".user-button").before(data.inboxanchor);
+    $("#user_profile_picture").after(data.inboxanchor);
 
     $("#inbox-count").replaceWith(data.inbox_count);
 
@@ -19,7 +19,7 @@ $(document).ready(function () {
 
   $(".inbox-destroy").on("ajax:success", function (event, data) {
     $("#inboxanchor").remove();
-    $(".user-button").before(data.inboxanchor);
+    $("#user_profile_picture").after(data.inboxanchor);
 
     $("#inbox-count").replaceWith(data.inbox_count);
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -204,15 +204,6 @@ nav.secondary {
     }
   }
 
-  #inboxanchor {
-    display: inline-block;
-    height: 25px;
-    margin: 3px 0 3px 3px;
-    background-color: lighten($grey, 10%);
-    line-height: 20px;
-    border-radius: 3;
-  }
-
   .dropdown-menu {
     .count-number {
       font-size: 14px;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -85,19 +85,21 @@
     <% if current_user && current_user.id %>
       <div class='d-inline-flex dropdown user-menu logged-in clearfix'>
         <button class='dropdown-toggle btn btn-outline-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
-          <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1") %>
-          <%= render :partial => "layouts/inbox" %>
-          <span class="user-button">
-            <span class='username'>
-              <%= current_user.display_name %>
+          <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1", :id => "user_profile_picture") %>
+          <div class="d-inline position-relative">
+            <%= render :partial => "layouts/inbox" %>
+            <span class="user-button ms-1">
+              <span class='username'>
+                <%= current_user.display_name %>
+              </span>
             </span>
-          </span>
+          </div>
         </button>
         <div class='dropdown-menu dropdown-menu-end'>
           <%= link_to t("users.show.my_dashboard"), dashboard_path, :class => "dropdown-item" %>
           <%= link_to inbox_messages_path, :class => "dropdown-item" do %>
             <%= t("users.show.my messages") %>
-            <span class='count-number'><%= number_with_delimiter(current_user.new_messages.size) %></span>
+            <span class='badge bg-danger p-1'><%= number_with_delimiter(current_user.new_messages.size) %></span>
           <% end %>
           <%= link_to t("users.show.my profile"), user_path(current_user), :class => "dropdown-item" %>
           <%= link_to t("users.show.my settings"), edit_account_path, :class => "dropdown-item" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -85,15 +85,15 @@
     <% if current_user && current_user.id %>
       <div class='d-inline-flex dropdown user-menu logged-in clearfix'>
         <button class='dropdown-toggle btn btn-outline-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
-          <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1", :id => "user_profile_picture") %>
-          <div class="d-inline position-relative">
+          <div id="profile_photo" class="d-inline position-relative">
+            <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1") %>
             <%= render :partial => "layouts/inbox" %>
-            <span class="user-button ms-1">
-              <span class='username'>
-                <%= current_user.display_name %>
-              </span>
-            </span>
           </div>
+          <span class="user-button ms-1">
+            <span class='username'>
+              <%= current_user.display_name %>
+            </span>
+          </span>
         </button>
         <div class='dropdown-menu dropdown-menu-end'>
           <%= link_to t("users.show.my_dashboard"), dashboard_path, :class => "dropdown-item" %>

--- a/app/views/layouts/_inbox.html.erb
+++ b/app/views/layouts/_inbox.html.erb
@@ -1,3 +1,3 @@
 <% if current_user.new_messages.size > 0 %>
-<span id="inboxanchor" class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle" data-new-messages="<%= current_user.new_messages.size %>"></span>
+<span id="inboxanchor" class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle"></span>
 <% end %>

--- a/app/views/layouts/_inbox.html.erb
+++ b/app/views/layouts/_inbox.html.erb
@@ -1,3 +1,3 @@
 <% if current_user.new_messages.size > 0 %>
-<span id="inboxanchor" class="count-number"><%= current_user.new_messages.size %></span>
+<span id="inboxanchor" class="position-absolute top-0 start-100 translate-middle p-1 bg-danger border border-light rounded-circle" data-new-messages="<%= current_user.new_messages.size %>"></span>
 <% end %>


### PR DESCRIPTION
Ref: #3182

This PR removes the current light gray box for the message count and replaces it with a red dot. The element with messages number is also now red.

There is some jQuery code which might not work correctly, please test it (if it isn't covered by the automated test) and let me know if it works. The code is related to updating the number of unread messages on the navigation bar.

Screenshots:
Before:
![Screenshot 2023-06-19 at 16-52-09 OpenStreetMap](https://github.com/openstreetmap/openstreetmap-website/assets/19364673/c609d745-d807-432f-9a1b-bb3d5363dd85)
After:
![Screenshot 2023-06-19 at 16-52-00 OpenStreetMap](https://github.com/openstreetmap/openstreetmap-website/assets/19364673/52eab9a0-9a5f-40f3-87b3-0ab16adedeb3)
