### PR TITLE
Avoid using the zero key for pluralisation in English

### DIFF
--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -35,7 +35,13 @@
       <% if params[:action] == 'index' %>
         <li><%= link_to t(".comment_link"), diary_entry_path(diary_entry.user, diary_entry, :anchor => "newcomment") %></li>
         <li><%= link_to t(".reply_link"), new_message_path(diary_entry.user, :message => { :title => "Re: #{diary_entry.title}" }) %></li>
-        <li><%= link_to t(".comment_count", :count => diary_entry.visible_comments.count), diary_entry_path(diary_entry.user, diary_entry, :anchor => "comments") %></li>
+        <li>
+          <% if diary_entry.visible_comments.count > 0 %>
+            <%= link_to t(".comment_count", :count => diary_entry.visible_comments.count), diary_entry_path(diary_entry.user, diary_entry, :anchor => "comments") %>
+          <% else %>
+            <%= link_to t(".no_comments"), diary_entry_path(diary_entry.user, diary_entry, :anchor => "comments") %>
+          <% end %>
+        </li>
       <% end %>
 
       <% if current_user && current_user == diary_entry.user %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -4,7 +4,11 @@
 <p class="text-muted">
   <small>
     <%= @issue.assigned_role %>
-    | <%= t ".reports", :count => @issue.reports.count %>
+    <% if @issue.reports.count > 0 %>
+      | <%= t ".reports", :count => @issue.reports.count %>
+    <% else %>
+      | <%= t ".no_reports" %>
+    <% end %>
     | <%= t ".report_created_at", :datetime => l(@issue.created_at.to_datetime, :format => :friendly) %>
     <%= " | #{t('.last_resolved_at', :datetime => l(@issue.resolved_at.to_datetime, :format => :friendly))}" if @issue.resolved_at? %>
     <%= " | #{t('.last_updated_at', :datetime => l(@issue.updated_at.to_datetime, :format => :friendly), :displayname => @issue.user_updated.display_name)}" if @issue.user_updated %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -515,9 +515,9 @@ en:
       comment_link: Comment on this entry
       reply_link: Send a message to the author
       comment_count:
-        zero: No comments
         one: "%{count} comment"
         other: "%{count} comments"
+      no_comments: No comments
       edit_link: Edit this entry
       hide_link: Hide this entry
       unhide_link: Unhide this entry
@@ -1403,9 +1403,9 @@ en:
     show:
       title: "%{status} Issue #%{issue_id}"
       reports:
-        zero: No reports
         one: "%{count} report"
         other: "%{count} reports"
+      no_reports: No reports
       report_created_at: "First reported at %{datetime}"
       last_resolved_at: "Last resolved at %{datetime}"
       last_updated_at: "Last updated at %{datetime} by %{displayname}"

--- a/test/lib/i18n_test.rb
+++ b/test/lib/i18n_test.rb
@@ -69,6 +69,15 @@ class I18nTest < ActiveSupport::TestCase
     end
   end
 
+  # We should avoid using the key `zero:` in English, since that key
+  # is used for "numbers ending in zero" in other languages.
+  def test_en_for_zero_key
+    en = YAML.load_file(Rails.root.join("config/locales/en.yml"))
+    assert_nothing_raised do
+      check_keys_for_zero(en)
+    end
+  end
+
   private
 
   def translation_keys(scope = nil)
@@ -113,6 +122,16 @@ class I18nTest < ActiveSupport::TestCase
         check_values_for_nil(v)
       else
         raise "Avoid nil values in '#{k}: nil'" if v.nil?
+      end
+    end
+  end
+
+  def check_keys_for_zero(hash)
+    hash.each_pair do |k, v|
+      if v.is_a? Hash
+        check_keys_for_zero(v)
+      else
+        raise "Avoid using 'zero' key in '#{k}: #{v}'" if k.to_s == "zero"
       end
     end
   end


### PR DESCRIPTION
This makes it impossible to translate to other languages that use the `zero:` key, e.g. for other numbers that end in zero.

An alternative approach would be possible in future, when ruby-i18n and rails and translatewiki all have full support for `0:` and `1:` keys.

Fixes #3997