### PR TITLE
Consistent plural forms for browse.way.nodes_count

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -350,6 +350,7 @@ en:
       history_title_html: "Way History: %{name}"
       nodes: "Nodes"
       nodes_count:
+        one: "%{count} node"
         other: "%{count} nodes"
       also_part_of_html:
         one: "part of way %{related_ways}"


### PR DESCRIPTION
Without this, translatewiki's validator shows an error for English.