### PR TITLE
Remove links to apps from OAuth2 authorizations page

### DIFF
--- a/app/views/oauth2_authorized_applications/_application.html.erb
+++ b/app/views/oauth2_authorized_applications/_application.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="align-middle">
-    <%= link_to application.name, oauth_application_path(application) %>
+    <%= application.name %>
   </td>
   <td class="align-middle">
     <ul class="list-unstyled mb-0">


### PR DESCRIPTION
Addresses #4103 by removing the links, which is the simplest and safest thing to do.