### PR TITLE
Hide/show welcome banner with hidden attribute

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -192,11 +192,11 @@ $(document).ready(function () {
   });
 
   if (Cookies.get("_osm_welcome") !== "hide") {
-    $(".welcome").addClass("visible");
+    $(".welcome").removeAttr("hidden");
   }
 
   $(".welcome .btn-close").on("click", function () {
-    $(".welcome").removeClass("visible");
+    $(".welcome").hide();
     Cookies.set("_osm_welcome", "hide", { secure: true, expires: expiry, path: "/", samesite: "lax" });
   });
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -317,7 +317,7 @@ body.small-nav {
     display: inline-block;
   }
 
-  .overlay-sidebar #sidebar .welcome.visible {
+  .overlay-sidebar #sidebar .welcome {
     display: none;
   }
 
@@ -439,11 +439,7 @@ body.small-nav {
     }
 
     .welcome {
-      display: none;
-
-      &.visible {
-        display: block;
-      }
+      display: block;
     }
 
     #sidebar_content {

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -41,7 +41,7 @@
     </div>
 
     <% unless current_user %>
-      <div class="welcome p-3">
+      <div class="welcome p-3" hidden>
         <%= render "sidebar_header", :title => t("layouts.intro_header") %>
         <div>
           <p><%= t "layouts.intro_text" %></p>


### PR DESCRIPTION
...instead of custom css hidden/visible classes.

I wanted it to be a simple example of a `hidden` attr use but unfortunately there are two additional conditions of welcome banner visibility: not in *small-nav* mode & in *overlay-sidebar* mode. Some `display: none/block` still have to be present in css.