### PR TITLE
Remove unnecessary full-width float css from sidebar

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -422,9 +422,6 @@ body.small-nav {
 
     > div {
       position: relative;
-      float: left;
-      clear: both;
-      width: 100%;
     }
   }
 


### PR DESCRIPTION
100% width + float is like stacking vertically. But this is the default behavior for block elements. And those divs are inside another floated element.