### PR TITLE
Remove unused 0 bottom margin from map ui css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -533,13 +533,6 @@ body.small-nav {
   }
 }
 
-.layers-ui,
-.share-ui {
-  li:last-child {
-    margin-bottom: 0;
-  }
-}
-
 .layers-ui {
   .base-layers {
     .leaflet-container {


### PR DESCRIPTION
Share panel doesn't have any lists.

Layers panel has two:
- The bottom one with checkboxes has zero margins anyway.
- The one with layer buttons overrides margins with its own values. Merging #3674 will remove this list.