### PR TITLE
Move map attribution print styles to print.scss

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -642,19 +642,6 @@ body.small-nav {
 
 #attribution {
   display: none;
-
-  table {
-    width: 100%
-  }
-}
-
-.attribution_license,
-.attribution_project {
-  text-align: left;
-}
-
-.attribution_notice {
-  text-align: center;
 }
 
 .donate-attr { color: darken($green, 10%) !important; }

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -18,6 +18,8 @@ html {
   border: 1px solid black;
 }
 
+/* Rules for attribution text under the main map shown on printouts */
+
 #attribution {
   position: absolute !important;
   bottom: 0;
@@ -25,5 +27,18 @@ html {
   right: 0;
   height: 40px;
   font-size: 12px;
+  text-align: center;
+
+  table {
+    width: 100%
+  }
+}
+
+.attribution_license,
+.attribution_project {
+  text-align: left;
+}
+
+.attribution_notice {
   text-align: center;
 }


### PR DESCRIPTION
They weren't applied to print media (according to print media simulation in Firefox).