### PR TITLE
Remove display properties from share tabs

### DIFF
--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -66,7 +66,6 @@ L.OSM.share = function (options) {
 
     $("<div>")
       .attr("class", "share-tab")
-      .css("display", "block")
       .appendTo($form)
       .append($("<input>")
         .attr("id", "long_input")
@@ -75,6 +74,7 @@ L.OSM.share = function (options) {
 
     $("<div>")
       .attr("class", "share-tab")
+      .hide()
       .appendTo($form)
       .append($("<input>")
         .attr("id", "short_input")
@@ -83,6 +83,7 @@ L.OSM.share = function (options) {
 
     $("<div>")
       .attr("class", "share-tab")
+      .hide()
       .appendTo($form)
       .append(
         $("<textarea>")

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -591,10 +591,6 @@ body.small-nav {
 }
 
 .share-ui {
-  .share-tab {
-    display: none;
-  }
-
   .share-link {
     input[type=text],
     textarea {


### PR DESCRIPTION
`display` is already manipulated by jquery `.show()` and `.hide()`, makes sense to do it everywhere