### PR TITLE
Remove resize css property from textarea

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -611,10 +611,6 @@ body.small-nav {
     }
   }
 
-  #embed_html {
-    resize: vertical;
-  }
-
   #mapnik_scale {
     width: 100px;
   }


### PR DESCRIPTION
This is already a bootstrap default: https://getbootstrap.com/docs/5.1/content/reboot/#forms