### PR TITLE
Switch to bootstrap recommended viewport definition

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,6 +1,6 @@
 <%= tag.head :data => application_data do %>
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= javascript_include_tag "es6" unless browser.es6? %>
   <%= javascript_include_tag "application" %>
   <%= javascript_include_tag "i18n/#{I18n.locale}" %>


### PR DESCRIPTION
Original version was introduced in 6674873478c9fe221d2fd78f76cabc6d4b03c0aa and has not been changed since.

Google's PageSpeed Insights tool also flagged this up as an accessibility issue, since it previously prohibited users zooming into the site.