### PR TITLE
Stretch login menu buttons in small nav mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -304,7 +304,7 @@ body.small-nav {
   }
 
   nav.secondary {
-    .user-menu {
+    .user-menu, .login-menu {
       width: 100%;
     }
   }


### PR DESCRIPTION
User menu (dropdown with username) is stretched horizontally in small navigation mode, but login menu isn't. Let's stretch it too.

Before:

![stretch-0](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/a90f6c2b-8259-4e8a-9515-b05e7cf5ed61)

After:

![stretch-1](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/06f8a28b-519c-4e91-94b9-746c43b5ede5)