### PR TITLE
Use multiple columns for map controls if they don't fit vertically

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -351,6 +351,15 @@ body.small-nav {
 
 /* Rules for Leaflet maps */
 
+.leaflet-top.leaflet-right,
+.leaflet-top.leaflet-left {
+  height: 100%;
+  column-gap: 10px;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap-reverse;
+}
+
 .leaflet-control .control-button {
   display: block;
   height: 40px;


### PR DESCRIPTION
![mapcontrols](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/5a144961-7e7a-4743-8797-2ee32c52e954)

fixes #4121
maybe fixes #849