### PR TITLE
Use hashes to define where..in sql queries

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
 
   def authorize_web
     if session[:user]
-      self.current_user = User.where(:id => session[:user]).where("status IN ('active', 'confirmed', 'suspended')").first
+      self.current_user = User.where(:id => session[:user], :status => %w[active confirmed suspended]).first
 
       if session[:fingerprint] &&
          session[:fingerprint] != current_user.fingerprint

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -35,7 +35,7 @@ class Trace < ApplicationRecord
   has_many :points, :class_name => "Tracepoint", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => :trace
 
   scope :visible, -> { where(:visible => true) }
-  scope :visible_to, ->(u) { visible.where("visibility IN ('public', 'identifiable') OR user_id = ?", u) }
+  scope :visible_to, ->(u) { visible.where(:visibility => %w[public identifiable]).or(visible.where(:user => u)) }
   scope :visible_to_all, -> { where(:visibility => %w[public identifiable]) }
   scope :tagged, ->(t) { joins(:tags).where(:gpx_file_tags => { :tag => t }) }
 


### PR DESCRIPTION
This is preferable to using SQL statements.

I double checked the output of the `.or()` formulation, and apart from extra table names and quoting, it's the same query.

```
> print Trace.visible.where("visibility IN ('public', 'identifiable') OR user_id = ?", u).to_sql
SELECT "gpx_files".* FROM "gpx_files" WHERE "gpx_files"."visible" = TRUE
 AND (visibility IN ('public', 'identifiable') OR user_id = 1)=> nil

> print Trace.visible.where(:visibility => %w[public identifiable]).or(Trace.visible.where(:user => u)).to_sql
SELECT "gpx_files".* FROM "gpx_files" WHERE "gpx_files"."visible" = TRUE
 AND ("gpx_files"."visibility" IN ('public', 'identifiable') OR "gpx_files"."user_id" = 1)=> nil
```