### PR TITLE
Avoid using partial rendering in /map.json

### DIFF
--- a/app/views/api/map/index.json.jbuilder
+++ b/app/views/api/map/index.json.jbuilder
@@ -4,6 +4,42 @@ json.partial! "bounds"
 
 all = @nodes + @ways + @relations
 
-json.elements(all) do |obj|
-  json.partial! obj
+json.elements(all) do |object|
+  case object
+  when Relation, Node, Way
+    json.id object.id
+    json.timestamp object.timestamp.xmlschema
+    json.version object.version
+    json.changeset object.changeset_id
+    json.user object.changeset.user.display_name
+    json.uid object.changeset.user_id
+    json.tags object.tags unless object.tags.empty?
+    json.visible object.visible unless object.visible
+
+    case object
+    when Relation
+      relation = object
+      json.type "relation"
+      unless relation.relation_members.empty?
+        json.members(relation.relation_members) do |m|
+          json.type m.member_type.downcase
+          json.ref m.member_id
+          json.role m.member_role
+        end
+      end
+    when Node
+      node = object
+      json.type "node"
+      if node.visible
+        json.lat GeoRecord::Coord.new(node.lat)
+        json.lon GeoRecord::Coord.new(node.lon)
+      end
+    when Way
+      way = object
+      json.type "way"
+      json.nodes way.nodes.ids unless way.nodes.ids.empty?
+    end
+  else
+    json.partial! object
+  end
 end


### PR DESCRIPTION
Using partial rendering too many times is slow in rails and a known issue. This is because the whole render context is given to the partial. This view is using this extensively and thousands of times. Just inlining the "osm object" should improve the performance. At the same time a lot of code can be de-duplicated. I kept a fallback in case of new objects. 

Related rails issue: https://github.com/rails/rails/issues/41452

That halfed rendering times in my case, and reduced allocations by 20%. 
```log
# With my patch:
web_1  | Completed 200 OK in 232ms (Views: 108.1ms | ActiveRecord: 31.3ms | Allocations: 221573)
web_1  | Completed 200 OK in 219ms (Views: 115.8ms | ActiveRecord: 21.0ms | Allocations: 218252)
web_1  | Completed 200 OK in 254ms (Views: 143.9ms | ActiveRecord: 22.9ms | Allocations: 218254)
web_1  | Completed 200 OK in 222ms (Views: 115.7ms | ActiveRecord: 21.9ms | Allocations: 218313)

# Without my patch:
web_1  | Completed 200 OK in 438ms (Views: 332.1ms | ActiveRecord: 22.8ms | Allocations: 253255)
web_1  | Completed 200 OK in 398ms (Views: 295.7ms | ActiveRecord: 21.8ms | Allocations: 250814)
web_1  | Completed 200 OK in 447ms (Views: 343.2ms | ActiveRecord: 22.5ms | Allocations: 250473)
web_1  | Completed 200 OK in 448ms (Views: 338.7ms | ActiveRecord: 25.2ms | Allocations: 250530)
```