### PR TITLE
Remove old rails error css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1208,44 +1208,6 @@ tr.turn:hover {
   display: none;
 }
 
-/* Rules for highlighting fields with rails validation errors */
-
-.formError {
-  display: inline-block;
-  padding: 5px 10px;
-  margin-top: 5px;
-  border-radius: 4px;
-  font-size: 12px;
-  color: #fff;
-  background-color: #ff7070;
-}
-
-/* Rules for rails validation error boxes */
-
-#errorExplanation {
-  width: 400px;
-  border: 2px solid #ff7070;
-  padding: 0 $lineheight/2;
-  margin-bottom: $lineheight;
-  background-color: #f0f0f0;
-
-  h2 {
-    margin: 0 -10px 10px -10px;
-    padding: $lineheight/4 $lineheight/4 $lineheight/4 15px;
-    font-weight: bold;
-    font-size: 12px;
-    background-color: #c00;
-    color: #fff;
-    text-align: left;
-  }
-
-  p {
-    color: #333;
-    margin-bottom: 0px;
-    padding: $lineheight/4;
-  }
-}
-
 .search_form {
   background-color: $lightgrey;
 


### PR DESCRIPTION
`#errorExplanation` is the old rails [error message id](https://guides.rubyonrails.org/v2.3.11/activerecord_validations_callbacks.html#customizing-the-error-messages-css)

- was added in https://github.com/openstreetmap/openstreetmap-website/commit/37bd2971b49da9364fe5dd25415e97e38b34abd7
- was updated to `.formError` in https://github.com/openstreetmap/openstreetmap-website/commit/c5fc21e6a6615646b3fa443b6fd12a80b4fef331
- was updated to bootstrap in https://github.com/openstreetmap/openstreetmap-website/commit/cc8bb7c6a5730e9d7d0389e4efd4c896702f575f