### PR TITLE
Remove custom css from user profile edit pages

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -54,7 +54,7 @@ $(document).ready(function () {
               precision = OSM.zoomPrecision(zoom),
               location = e.latlng.wrap();
 
-          $("#homerow").removeClass();
+          $("#home_message").hide();
           $("#home_lat").val(location.lat.toFixed(precision));
           $("#home_lon").val(location.lng.toFixed(precision));
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1123,20 +1123,6 @@ tr.turn:hover {
   }
 }
 
-/* Rules for the account settings page */
-
-.nohome .location {
-  display: none;
-}
-
-#homerow .message {
-  display: none;
-}
-
-.nohome .message {
-  display: inline !important;
-}
-
 /* Rules for the oauth authorization page */
 
 .oauth-authorize ul {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1125,18 +1125,6 @@ tr.turn:hover {
 
 /* Rules for the account settings page */
 
-#accountForm .user_image {
-  margin-bottom: 0;
-}
-
-#accountForm #user_image {
-  margin-left: 20px;
-}
-
-#accountForm ul.accountImage-options {
-  margin-left: 120px;
-}
-
 .nohome .location {
   display: none;
 }

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -42,12 +42,10 @@
 
   <fieldset>
     <legend><%= t ".home location" -%></legend>
-    <div id="homerow" <% unless current_user.home_lat and current_user.home_lon %> class="nohome"<% end %>>
-      <p class="message text-muted"><%= t ".no home location" %></p>
-      <div class="row">
-        <%= f.text_field :home_lat, :wrapper_class => "col-sm-4", :id => "home_lat" %>
-        <%= f.text_field :home_lon, :wrapper_class => "col-sm-4", :id => "home_lon" %>
-      </div>
+    <p id="home_message" class="text-muted"<% if current_user.home_lat and current_user.home_lon %> hidden<% end %>><%= t ".no home location" %></p>
+    <div class="row">
+      <%= f.text_field :home_lat, :wrapper_class => "col-sm-4", :id => "home_lat" %>
+      <%= f.text_field :home_lon, :wrapper_class => "col-sm-4", :id => "home_lon" %>
     </div>
     <div class="form-check">
       <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.home_lat and current_user.home_lon %> checked="checked" <% end %> id="updatehome" />


### PR DESCRIPTION
`#accountForm` selectors weren't in use because there's no such id on profile edit pages