### PR TITLE
Delete button in Home location section of user profiles

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -51,25 +51,41 @@ $(document).ready(function () {
       }
 
       map.on("click", function (e) {
-        if ($("#updatehome").is(":checked")) {
-          var zoom = map.getZoom(),
-              precision = OSM.zoomPrecision(zoom),
-              location = e.latlng.wrap();
+        if (!$("#updatehome").is(":checked")) return;
 
-          $("#home_lat").val(location.lat.toFixed(precision));
-          $("#home_lon").val(location.lng.toFixed(precision));
+        var zoom = map.getZoom(),
+            precision = OSM.zoomPrecision(zoom),
+            location = e.latlng.wrap();
 
-          respondToHomeUpdate();
-        }
+        $("#home_lat").val(location.lat.toFixed(precision));
+        $("#home_lon").val(location.lng.toFixed(precision));
+
+        deleted_lat = null;
+        deleted_lon = null;
+        respondToHomeUpdate();
       });
 
-      $("#home_lat, #home_lon").on("input", respondToHomeUpdate);
+      $("#home_lat, #home_lon").on("input", function () {
+        deleted_lat = null;
+        deleted_lon = null;
+        respondToHomeUpdate();
+      });
 
       $("#home_show").click(function () {
         var lat = $("#home_lat").val(),
             lon = $("#home_lon").val();
 
         map.panTo([lat, lon]);
+      });
+
+      $("#home_delete").click(function () {
+        var lat = $("#home_lat").val(),
+            lon = $("#home_lon").val();
+
+        $("#home_lat, #home_lon").val("");
+        deleted_lat = lat;
+        deleted_lon = lon;
+        respondToHomeUpdate();
       });
     } else {
       $("[data-user]").each(function () {

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -64,6 +64,11 @@ $(document).ready(function () {
         deleted_lat = null;
         deleted_lon = null;
         respondToHomeUpdate();
+      }).on("moveend", function () {
+        var lat = $("#home_lat").val(),
+            lon = $("#home_lon").val();
+
+        $("#home_show").prop("disabled", isCloseEnoughToMapCenter(lat, lon));
       });
 
       $("#home_lat, #home_lon").on("input", function () {
@@ -123,6 +128,13 @@ $(document).ready(function () {
     } else {
       marker.removeFrom(map);
     }
+  }
+
+  function isCloseEnoughToMapCenter(lat, lon) {
+    var inputPt = map.latLngToContainerPoint([lat, lon]),
+        centerPt = map.latLngToContainerPoint(map.getCenter());
+
+    return centerPt.distanceTo(inputPt) < 10;
   }
 
   function updateAuthUID() {

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -70,9 +70,18 @@ $(document).ready(function () {
         respondToHomeUpdate();
       }).on("moveend", function () {
         var lat = $("#home_lat").val(),
-            lon = $("#home_lon").val();
+            lon = $("#home_lon").val(),
+            location;
 
-        $("#home_show").prop("disabled", isCloseEnoughToMapCenter(lat, lon));
+        try {
+          if (lat && lon) {
+            location = L.latLng(lat, lon);
+          }
+        } catch (error) {
+          // keep location undefined
+        }
+
+        $("#home_show").prop("disabled", !location || isCloseEnoughToMapCenter(location));
       });
 
       $("#home_lat, #home_lon").on("input", function () {
@@ -121,13 +130,19 @@ $(document).ready(function () {
   function respondToHomeUpdate() {
     var lat = $("#home_lat").val(),
         lon = $("#home_lon").val(),
-        has_home = !!(lat && lon);
+        location;
 
-    $("#home_message").toggleClass("invisible", has_home);
-    $("#home_show").prop("hidden", !has_home);
-    $("#home_delete").prop("hidden", !has_home);
-    $("#home_undelete").prop("hidden", !(!has_home && deleted_lat && deleted_lon));
-    if (has_home) {
+    try {
+      if (lat && lon) {
+        location = L.latLng(lat, lon);
+      }
+    } catch (error) {}
+
+    $("#home_message").toggleClass("invisible", Boolean(location));
+    $("#home_show").prop("hidden", !location);
+    $("#home_delete").prop("hidden", !location);
+    $("#home_undelete").prop("hidden", !(!location && deleted_lat && deleted_lon));
+    if (location) {
       marker.setLatLng([lat, lon]);
       marker.addTo(map);
       map.panTo([lat, lon]);
@@ -136,8 +151,8 @@ $(document).ready(function () {
     }
   }
 
-  function isCloseEnoughToMapCenter(lat, lon) {
-    var inputPt = map.latLngToContainerPoint([lat, lon]),
+  function isCloseEnoughToMapCenter(location) {
+    var inputPt = map.latLngToContainerPoint(location),
         centerPt = map.latLngToContainerPoint(map.getCenter());
 
     return centerPt.distanceTo(inputPt) < 10;

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -69,8 +69,8 @@ $(document).ready(function () {
         deleted_lon = null;
         respondToHomeUpdate();
       }).on("moveend", function () {
-        var lat = $("#home_lat").val(),
-            lon = $("#home_lon").val(),
+        var lat = $("#home_lat").val().trim(),
+            lon = $("#home_lon").val().trim(),
             location;
 
         try {
@@ -128,15 +128,19 @@ $(document).ready(function () {
   }
 
   function respondToHomeUpdate() {
-    var lat = $("#home_lat").val(),
-        lon = $("#home_lon").val(),
+    var lat = $("#home_lat").val().trim(),
+        lon = $("#home_lon").val().trim(),
         location;
 
     try {
       if (lat && lon) {
         location = L.latLng(lat, lon);
       }
-    } catch (error) {}
+      $("#home_lat, #home_lon").removeClass("is-invalid");
+    } catch (error) {
+      if (lat && isNaN(lat)) $("#home_lat").addClass("is-invalid");
+      if (lon && isNaN(lon)) $("#home_lon").addClass("is-invalid");
+    }
 
     $("#home_message").toggleClass("invisible", Boolean(location));
     $("#home_show").prop("hidden", !location);

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -87,6 +87,14 @@ $(document).ready(function () {
         deleted_lon = lon;
         respondToHomeUpdate();
       });
+
+      $("#home_undelete").click(function () {
+        $("#home_lat").val(deleted_lat);
+        $("#home_lon").val(deleted_lon);
+        deleted_lat = null;
+        deleted_lon = null;
+        respondToHomeUpdate();
+      });
     } else {
       $("[data-user]").each(function () {
         var user = $(this).data("user");

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,8 +1,10 @@
 //= require leaflet.locatecontrol/src/L.Control.Locate
 
 $(document).ready(function () {
+  var map, marker, deleted_lat, deleted_lon;
+
   if ($("#map").length) {
-    var map = L.map("map", {
+    map = L.map("map", {
       attributionControl: false,
       zoomControl: false
     }).addLayer(new L.OSM.Mapnik());
@@ -41,7 +43,7 @@ $(document).ready(function () {
     }
 
     if ($("#map").hasClass("set_location")) {
-      var marker = L.marker([0, 0], { icon: OSM.getUserIcon() });
+      marker = L.marker([0, 0], { icon: OSM.getUserIcon() });
 
       if (OSM.home) {
         marker.setLatLng([OSM.home.lat, OSM.home.lon]);
@@ -54,14 +56,14 @@ $(document).ready(function () {
               precision = OSM.zoomPrecision(zoom),
               location = e.latlng.wrap();
 
-          $("#home_message").hide();
           $("#home_lat").val(location.lat.toFixed(precision));
           $("#home_lon").val(location.lng.toFixed(precision));
 
-          marker.setLatLng(e.latlng);
-          marker.addTo(map);
+          respondToHomeUpdate();
         }
       });
+
+      $("#home_lat, #home_lon").on("input", respondToHomeUpdate);
     } else {
       $("[data-user]").each(function () {
         var user = $(this).data("user");
@@ -70,6 +72,24 @@ $(document).ready(function () {
             .bindPopup(user.description);
         }
       });
+    }
+  }
+
+  function respondToHomeUpdate() {
+    var lat = $("#home_lat").val(),
+        lon = $("#home_lon").val(),
+        has_home = !!(lat && lon);
+
+    $("#home_message").toggleClass("invisible", has_home);
+    $("#home_show").prop("hidden", !has_home);
+    $("#home_delete").prop("hidden", !has_home);
+    $("#home_undelete").prop("hidden", !(!has_home && deleted_lat && deleted_lon));
+    if (has_home) {
+      marker.setLatLng([lat, lon]);
+      marker.addTo(map);
+      map.panTo([lat, lon]);
+    } else {
+      marker.removeFrom(map);
     }
   }
 

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -96,6 +96,7 @@ $(document).ready(function () {
         deleted_lat = lat;
         deleted_lon = lon;
         respondToHomeUpdate();
+        $("#home_undelete").trigger("focus");
       });
 
       $("#home_undelete").click(function () {
@@ -104,6 +105,7 @@ $(document).ready(function () {
         deleted_lat = null;
         deleted_lon = null;
         respondToHomeUpdate();
+        $("#home_delete").trigger("focus");
       });
     } else {
       $("[data-user]").each(function () {

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -44,7 +44,11 @@ $(document).ready(function () {
     }
 
     if ($("#map").hasClass("set_location")) {
-      marker = L.marker([0, 0], { icon: OSM.getUserIcon() });
+      marker = L.marker([0, 0], {
+        icon: OSM.getUserIcon(),
+        keyboard: false,
+        interactive: false
+      });
 
       if (OSM.home) {
         marker.setLatLng([OSM.home.lat, OSM.home.lon]);

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -64,6 +64,13 @@ $(document).ready(function () {
       });
 
       $("#home_lat, #home_lon").on("input", respondToHomeUpdate);
+
+      $("#home_show").click(function () {
+        var lat = $("#home_lat").val(),
+            lon = $("#home_lon").val();
+
+        map.panTo([lat, lon]);
+      });
     } else {
       $("[data-user]").each(function () {
         var user = $(this).data("user");

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,6 +1,7 @@
 //= require leaflet.locatecontrol/src/L.Control.Locate
 
 $(document).ready(function () {
+  var defaultHomeZoom = 12;
   var map, marker, deleted_lat, deleted_lon;
 
   if ($("#map").length) {
@@ -37,7 +38,7 @@ $(document).ready(function () {
       .addClass("control-button");
 
     if (OSM.home) {
-      map.setView([OSM.home.lat, OSM.home.lon], 12);
+      map.setView([OSM.home.lat, OSM.home.lon], defaultHomeZoom);
     } else {
       map.setView([0, 0], 0);
     }
@@ -75,7 +76,7 @@ $(document).ready(function () {
         var lat = $("#home_lat").val(),
             lon = $("#home_lon").val();
 
-        map.panTo([lat, lon]);
+        map.setView([lat, lon], defaultHomeZoom);
       });
 
       $("#home_delete").click(function () {

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -280,7 +280,7 @@ class DiaryEntriesController < ApplicationController
       @lon = @diary_entry.longitude
       @lat = @diary_entry.latitude
       @zoom = 12
-    elsif current_user.home_lat.nil? || current_user.home_lon.nil?
+    elsif !current_user.has_home?
       @lon = params[:lon] || -0.1
       @lat = params[:lat] || 51.5
       @zoom = params[:zoom] || 4

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,7 @@ module ApplicationHelper
     if current_user
       data[:user] = current_user.id.to_json
 
-      data[:user_home] = { :lat => current_user.home_lat, :lon => current_user.home_lon } unless current_user.home_lon.nil? || current_user.home_lat.nil?
+      data[:user_home] = { :lat => current_user.home_lat, :lon => current_user.home_lon } if current_user.has_home?
     end
 
     data[:location] = session[:location] if session[:location]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -238,8 +238,12 @@ class User < ApplicationRecord
     @preferred_languages ||= Locale.list(languages)
   end
 
+  def has_home?
+    home_lat && home_lon
+  end
+
   def nearby(radius = Settings.nearby_radius, num = Settings.nearby_users)
-    if home_lon && home_lat
+    if has_home?
       gc = OSM::GreatCircle.new(home_lat, home_lon)
       sql_for_area = QuadTile.sql_for_area(gc.bounds(radius), "home_")
       sql_for_distance = gc.sql_for_distance("home_lat", "home_lon")
@@ -401,6 +405,6 @@ class User < ApplicationRecord
   end
 
   def update_tile
-    self.home_tile = QuadTile.tile_for_point(home_lat, home_lon) if home_lat && home_lon
+    self.home_tile = QuadTile.tile_for_point(home_lat, home_lon) if has_home?
   end
 end

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -46,7 +46,7 @@ json.user do
   end
 
   if current_user && current_user == user && can?(:details, User)
-    if user.home_lat && user.home_lon
+    if user.has_home?
       json.home do
         json.lat user.home_lat
         json.lon user.home_lon

--- a/app/views/api/users/_user.xml.builder
+++ b/app/views/api/users/_user.xml.builder
@@ -25,7 +25,7 @@ xml.tag! "user", :id => user.id,
     end
   end
   if current_user && current_user == user && can?(:details, User)
-    if user.home_lat && user.home_lon
+    if user.has_home?
       xml.tag! "home", :lat => user.home_lat,
                        :lon => user.home_lon,
                        :zoom => user.home_zoom

--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -11,7 +11,7 @@
   <div class="col">
     <p class='text-muted mb-0'>
       <%= link_to contact.display_name, user_path(contact) %>
-      <% if @user.home_lon and @user.home_lat and contact.home_lon and contact.home_lat %>
+      <% if @user.has_home? and contact.has_home? %>
         <% distance = @user.distance(contact) %>
         <% if distance < 1 %>
           (<%= t ".m away", :count => (distance * 1000).round %>)

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <% if current_user and @user.id == current_user.id %>
     <div class="col-md order-md-last">
-      <% if @user.home_lat.nil? or @user.home_lon.nil? %>
+      <% if !@user.has_home? %>
         <div id="map" class="content_map border border-grey">
           <p class="m-3"><%= t(".no_home_location_html", :edit_profile_link => link_to(t(".edit_your_profile"), edit_profile_path)) %></p>
         </div>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for(:body_class) { "map-layout" } %>
 
-<% if current_user and !current_user.home_lon.nil? and !current_user.home_lat.nil? %>
+<% if current_user&.has_home? %>
   <% content_for :greeting do %>
     <%= link_to t("layouts.home"),
                 "#",

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -42,13 +42,13 @@
 
   <fieldset>
     <legend><%= t ".home location" -%></legend>
-    <p id="home_message" class="text-muted"<% if current_user.home_lat and current_user.home_lon %> hidden<% end %>><%= t ".no home location" %></p>
+    <p id="home_message" class="text-muted"<% if current_user.has_home? %> hidden<% end %>><%= t ".no home location" %></p>
     <div class="row">
       <%= f.text_field :home_lat, :wrapper_class => "col-sm-4", :id => "home_lat" %>
       <%= f.text_field :home_lon, :wrapper_class => "col-sm-4", :id => "home_lon" %>
     </div>
     <div class="form-check">
-      <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.home_lat and current_user.home_lon %> checked="checked" <% end %> id="updatehome" />
+      <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.has_home? %> checked="checked" <% end %> id="updatehome" />
       <label class="form-check-label" for="updatehome"><%= t ".update home location on click" %></label>
     </div>
     <%= tag.div "", :id => "map", :class => "content_map set_location border border-grey rounded" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -47,7 +47,7 @@
       <%= f.text_field :home_lat, :wrapper_class => "col-sm-4", :id => "home_lat" %>
       <%= f.text_field :home_lon, :wrapper_class => "col-sm-4", :id => "home_lon" %>
       <div class="col-sm-4 pt-2 align-self-end">
-        <button type="button" id="home_show" class="btn btn-outline-primary"<% unless current_user.has_home? %> hidden<% end %>><%= t ".show" %></button>
+        <button type="button" id="home_show" class="btn btn-outline-primary"<% unless current_user.has_home? %> hidden<% end %> disabled><%= t ".show" %></button>
         <button type="button" id="home_delete" class="btn btn-outline-primary"<% unless current_user.has_home? %> hidden<% end %>><%= t ".delete" %></button>
         <button type="button" id="home_undelete" class="btn btn-outline-primary" hidden><%= t ".undelete" %></button>
       </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -42,13 +42,18 @@
 
   <fieldset>
     <legend><%= t ".home location" -%></legend>
-    <p id="home_message" class="text-muted"<% if current_user.has_home? %> hidden<% end %>><%= t ".no home location" %></p>
+    <p id="home_message" class="text-muted m-0<% if current_user.has_home? %> invisible<% end %>"><%= t ".no home location" %></p>
     <div class="row">
       <%= f.text_field :home_lat, :wrapper_class => "col-sm-4", :id => "home_lat" %>
       <%= f.text_field :home_lon, :wrapper_class => "col-sm-4", :id => "home_lon" %>
+      <div class="col-sm-4 pt-2 align-self-end">
+        <button type="button" id="home_show" class="btn btn-outline-primary"<% unless current_user.has_home? %> hidden<% end %>><%= t ".show" %></button>
+        <button type="button" id="home_delete" class="btn btn-outline-primary"<% unless current_user.has_home? %> hidden<% end %>><%= t ".delete" %></button>
+        <button type="button" id="home_undelete" class="btn btn-outline-primary" hidden><%= t ".undelete" %></button>
+      </div>
     </div>
     <div class="form-check">
-      <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.has_home? %> checked="checked" <% end %> id="updatehome" />
+      <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.has_home? %> checked <% end %> id="updatehome" />
       <label class="form-check-label" for="updatehome"><%= t ".update home location on click" %></label>
     </div>
     <%= tag.div "", :id => "map", :class => "content_map set_location border border-grey rounded" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1754,6 +1754,9 @@ en:
       home location: "Home Location"
       no home location: "You have not entered your home location."
       update home location on click: "Update home location when I click on the map?"
+      show: "Show"
+      delete: "Delete"
+      undelete: "Undo delete"
     update:
       success: Profile updated.
       failure: Couldn't update profile.


### PR DESCRIPTION
![home](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/89bb7604-cb3b-4510-bc41-9dd7b93906c7)

- also undo delete button
- also show button to center map on currently entered coordinates
- also `has_home?` method in user models instead of doing home_lat && home_lon

Fixes #3725