### PR TITLE
Remove unnecessary css from diary entry locations

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1216,14 +1216,7 @@ img.user_thumbnail_tiny {
   max-height: 25px;
 }
 
-/* Rules for geo microformats */
-
-abbr.geo {
-  border-bottom: none;
-}
-
 /* General styles for action lists / subnavs */
-
 
 nav.secondary-actions {
   margin-left: -11px;


### PR DESCRIPTION
Probably was there to remove double underline, one from border, other from text decoration. Nowadays there are no borders on abbrs/links, and Bootstrap does [its reset](https://getbootstrap.com/docs/5.1/content/reboot/#inline-elements).

Was added in https://github.com/openstreetmap/openstreetmap-website/commit/0b913efd0583570c5a9cd900189fc88085218d61 .