### PR TITLE
Use Bootstrap to format message headers

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1144,10 +1144,6 @@ tr.turn:hover {
   .inbox-row-unread {
     background: #CBEEA7;
   }
-
-  .right {
-    float: right;
-  }
 }
 
 .inbox-row .inbox-mark-read {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1150,20 +1150,6 @@ tr.turn:hover {
   display: none;
 }
 
-.info-line {
-  margin-bottom: $lineheight;
-  padding: $lineheight/4 0px 4px 0px;
-  border-bottom: 1px solid $grey;
-
-  form, form div {
-    display: inline;
-  }
-}
-
-.info-line .user_thumbnail_tiny {
-  vertical-align: middle;
-}
-
 .inbox-sent {
   white-space: nowrap;
 }

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -2,7 +2,7 @@
   <h1><%= @message.title %></h1>
 <% end %>
 
-<div class='info-line d-flex gap-1 flex-wrap'>
+<div class='mb-3 border-bottom border-grey py-1 d-flex gap-1 flex-wrap'>
   <% if current_user == @message.recipient %>
     <%= user_thumbnail_tiny @message.sender %>
     <%= link_to @message.sender.display_name, user_path(@message.sender) %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -2,36 +2,29 @@
   <h1><%= @message.title %></h1>
 <% end %>
 
-<% if current_user == @message.recipient %>
-  <div class='info-line d-flex gap-1 flex-wrap'>
+<div class='info-line d-flex gap-1 flex-wrap'>
+  <% if current_user == @message.recipient %>
     <%= user_thumbnail_tiny @message.sender %>
-    <%= link_to @message.sender.display_name, user_path(@message.sender) %></td>
-    <span class="ms-auto">
-      <%= l @message.sent_on, :format => :friendly %>
-    </span>
-  </div>
+    <%= link_to @message.sender.display_name, user_path(@message.sender) %>
+  <% else %>
+    <%= user_thumbnail_tiny @message.recipient %>
+    <%= link_to @message.recipient.display_name, user_path(@message.recipient) %>
+  <% end %>
+  <span class="ms-auto">
+    <%= l @message.sent_on, :format => :friendly %>
+  </span>
+</div>
 
-  <div class="richtext text-break"><%= @message.body.to_html %></div>
+<div class="richtext text-break"><%= @message.body.to_html %></div>
 
-  <div>
+<div>
+  <% if current_user == @message.recipient %>
     <%= link_to t(".reply_button"), message_reply_path(@message), :class => "btn btn-primary" %>
     <%= link_to t(".unread_button"), message_mark_path(@message, :mark => "unread"), :method => "post", :class => "btn btn-primary" %>
     <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>
     <%= link_to t(".back"), inbox_messages_path, :class => "btn btn-link" %>
-  </div>
-<% else %>
-  <div class='info-line d-flex gap-1 flex-wrap'>
-    <%= user_thumbnail_tiny @message.recipient %>
-    <%= link_to @message.recipient.display_name, user_path(@message.recipient) %></td>
-    <span class="ms-auto">
-      <%= l @message.sent_on, :format => :friendly %>
-    </span>
-  </div>
-
-  <div class="richtext text-break"><%= @message.body.to_html %></div>
-
-  <div>
+  <% else %>
     <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>
     <%= link_to t(".back"), outbox_messages_path, :class => "btn btn-link" %>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -3,12 +3,12 @@
 <% end %>
 
 <% if current_user == @message.recipient %>
-  <div class='info-line clearfix'>
+  <div class='info-line d-flex gap-1 flex-wrap'>
     <%= user_thumbnail_tiny @message.sender %>
     <%= link_to @message.sender.display_name, user_path(@message.sender) %></td>
-    <div class='right'>
+    <span class="ms-auto">
       <%= l @message.sent_on, :format => :friendly %>
-    </div>
+    </span>
   </div>
 
   <div class="richtext text-break"><%= @message.body.to_html %></div>
@@ -20,12 +20,12 @@
     <%= link_to t(".back"), inbox_messages_path, :class => "btn btn-link" %>
   </div>
 <% else %>
-  <div class='info-line clearfix'>
+  <div class='info-line d-flex gap-1 flex-wrap'>
     <%= user_thumbnail_tiny @message.recipient %>
     <%= link_to @message.recipient.display_name, user_path(@message.recipient) %></td>
-    <div class='right'>
+    <span class="ms-auto">
       <%= l @message.sent_on, :format => :friendly %>
-    </div>
+    </span>
   </div>
 
   <div class="richtext text-break"><%= @message.body.to_html %></div>


### PR DESCRIPTION
Also removed leftover `</td>`s from old table layout in de8a60a3e371e6289643dfb578b75458b856b07d.