### PR TITLE
Remove most of custom css in message inbox/outbox tables

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -28,7 +28,7 @@ $(document).ready(function () {
     $(target).closest("tr")
       .toggleClass("inbox-row", isRead)
       .toggleClass("inbox-row-unread", !isRead)
-      .find(".inbox-mark-unread button").prop("hidden", !isRead).end()
-      .find(".inbox-mark-read button").prop("hidden", isRead);
+      .find(".inbox-mark-unread").prop("hidden", !isRead).end()
+      .find(".inbox-mark-read").prop("hidden", isRead);
   }
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -27,6 +27,8 @@ $(document).ready(function () {
   function updateReadState(target, isRead) {
     $(target).closest("tr")
       .toggleClass("inbox-row", isRead)
-      .toggleClass("inbox-row-unread", !isRead);
+      .toggleClass("inbox-row-unread", !isRead)
+      .find(".inbox-mark-unread button").prop("hidden", !isRead).end()
+      .find(".inbox-mark-read button").prop("hidden", isRead);
   }
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,30 +1,32 @@
 $(document).ready(function () {
   $(".inbox-mark-unread").on("ajax:success", function (event, data) {
-    $("#inboxanchor").remove();
-    $(".user-button").before(data.inboxanchor);
-
-    $("#inbox-count").replaceWith(data.inbox_count);
-
-    $(this).parents(".inbox-row").removeClass("inbox-row").addClass("inbox-row-unread");
+    updateHtml(data);
+    updateReadState(this, false);
   });
 
   $(".inbox-mark-read").on("ajax:success", function (event, data) {
-    $("#inboxanchor").remove();
-    $(".user-button").before(data.inboxanchor);
-
-    $("#inbox-count").replaceWith(data.inbox_count);
-
-    $(this).parents(".inbox-row-unread").removeClass("inbox-row-unread").addClass("inbox-row");
+    updateHtml(data);
+    updateReadState(this, true);
   });
 
   $(".inbox-destroy").on("ajax:success", function (event, data) {
+    updateHtml(data);
+
+    $(this).closest("tr").fadeOut(800, "linear", function () {
+      $(this).remove();
+    });
+  });
+
+  function updateHtml(data) {
     $("#inboxanchor").remove();
     $(".user-button").before(data.inboxanchor);
 
     $("#inbox-count").replaceWith(data.inbox_count);
+  }
 
-    $(this).parents(".inbox-row, .inbox-row-unread").fadeOut(800, "linear", function () {
-      $(this).remove();
-    });
-  });
+  function updateReadState(target, isRead) {
+    $(target).closest("tr")
+      .toggleClass("inbox-row", isRead)
+      .toggleClass("inbox-row-unread", !isRead);
+  }
 });

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1147,21 +1147,15 @@ tr.turn:hover {
 }
 
 .inbox-row .inbox-mark-read {
-  display: none;
+  display: none !important;
 }
 
 .inbox-sent {
   white-space: nowrap;
 }
 
-.inbox-mark-unread,
-.inbox-mark-read,
-.inbox-delete {
-  width: 1%;
-}
-
 .inbox-row-unread .inbox-mark-unread {
-  display: none;
+  display: none !important;
 }
 
 .search_form {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1141,14 +1141,6 @@ tr.turn:hover {
   }
 }
 
-.inbox-row .inbox-mark-read {
-  display: none !important;
-}
-
-.inbox-row-unread .inbox-mark-unread {
-  display: none !important;
-}
-
 .search_form {
   background-color: $lightgrey;
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1132,11 +1132,6 @@ tr.turn:hover {
 /* Rules for messages pages */
 
 .messages {
-  button[type="submit"] {
-    margin: auto;
-    white-space: nowrap;
-  }
-
   .inbox-row {
     background: $offwhite;
   }
@@ -1148,10 +1143,6 @@ tr.turn:hover {
 
 .inbox-row .inbox-mark-read {
   display: none !important;
-}
-
-.inbox-sent {
-  white-space: nowrap;
 }
 
 .inbox-row-unread .inbox-mark-unread {

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -2,7 +2,9 @@
   <td class="inbox-sender"><%= link_to message_summary.sender.display_name, user_path(message_summary.sender) %></td>
   <td class="inbox-subject"><%= link_to message_summary.title, message_path(message_summary) %></td>
   <td class="inbox-sent"><%= l message_summary.sent_on, :format => :friendly %></td>
-  <td class="inbox-mark-unread"><%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary" %></td>
-  <td class="inbox-mark-read"><%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true, :class => "btn btn-sm btn-primary" %></td>
-  <td class="inbox-destroy"><%= button_to t(".destroy_button"), message_path(message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger" %></td>
+  <td class="text-end">
+    <%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-unread" %>
+    <%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-read" %>
+    <%= button_to t(".destroy_button"), message_path(message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "d-inline-block inbox-destroy" %>
+  </td>
 </tr>

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -1,6 +1,6 @@
 <tr id="inbox-<%= message_summary.id %>" class="inbox-row<%= "-unread" unless message_summary.message_read? %>">
-  <td class="inbox-sender"><%= link_to message_summary.sender.display_name, user_path(message_summary.sender) %></td>
-  <td class="inbox-subject"><%= link_to message_summary.title, message_path(message_summary) %></td>
+  <td><%= link_to message_summary.sender.display_name, user_path(message_summary.sender) %></td>
+  <td><%= link_to message_summary.title, message_path(message_summary) %></td>
   <td class="text-nowrap"><%= l message_summary.sent_on, :format => :friendly %></td>
   <td class="text-nowrap text-end">
     <%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-unread", :hidden => !message_summary.message_read? %>

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -2,9 +2,9 @@
   <td><%= link_to message_summary.sender.display_name, user_path(message_summary.sender) %></td>
   <td><%= link_to message_summary.title, message_path(message_summary) %></td>
   <td class="text-nowrap"><%= l message_summary.sent_on, :format => :friendly %></td>
-  <td class="text-nowrap text-end">
-    <%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-unread", :hidden => !message_summary.message_read? %>
-    <%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-read", :hidden => message_summary.message_read? %>
-    <%= button_to t(".destroy_button"), message_path(message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "d-inline-block inbox-destroy" %>
+  <td class="text-nowrap d-flex justify-content-end gap-1">
+    <%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary", :form => { :class => "inbox-mark-unread", :hidden => !message_summary.message_read? } %>
+    <%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true, :class => "btn btn-sm btn-primary", :form => { :class => "inbox-mark-read", :hidden => message_summary.message_read? } %>
+    <%= button_to t(".destroy_button"), message_path(message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "inbox-destroy" %>
   </td>
 </tr>

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -1,8 +1,8 @@
 <tr id="inbox-<%= message_summary.id %>" class="inbox-row<%= "-unread" unless message_summary.message_read? %>">
   <td class="inbox-sender"><%= link_to message_summary.sender.display_name, user_path(message_summary.sender) %></td>
   <td class="inbox-subject"><%= link_to message_summary.title, message_path(message_summary) %></td>
-  <td class="inbox-sent"><%= l message_summary.sent_on, :format => :friendly %></td>
-  <td class="text-end">
+  <td class="text-nowrap"><%= l message_summary.sent_on, :format => :friendly %></td>
+  <td class="text-nowrap text-end">
     <%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-unread" %>
     <%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-read" %>
     <%= button_to t(".destroy_button"), message_path(message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "d-inline-block inbox-destroy" %>

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -3,8 +3,8 @@
   <td class="inbox-subject"><%= link_to message_summary.title, message_path(message_summary) %></td>
   <td class="text-nowrap"><%= l message_summary.sent_on, :format => :friendly %></td>
   <td class="text-nowrap text-end">
-    <%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-unread" %>
-    <%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-read" %>
+    <%= button_to t(".unread_button"), message_mark_path(message_summary, :mark => "unread"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-unread", :hidden => !message_summary.message_read? %>
+    <%= button_to t(".read_button"), message_mark_path(message_summary, :mark => "read"), :remote => true, :class => "btn btn-sm btn-primary", :form_class => "d-inline-block inbox-mark-read", :hidden => message_summary.message_read? %>
     <%= button_to t(".destroy_button"), message_path(message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "d-inline-block inbox-destroy" %>
   </td>
 </tr>

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -2,7 +2,7 @@
   <td><%= link_to sent_message_summary.recipient.display_name, user_path(sent_message_summary.recipient) %></td>
   <td><%= link_to sent_message_summary.title, message_path(sent_message_summary) %></td>
   <td class="text-nowrap"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
-  <td class="text-nowrap text-end">
-    <%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "d-inline-block inbox-destroy" %>
+  <td class="text-nowrap d-flex justify-content-end gap-1">
+    <%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "inbox-destroy" %>
   </td>
 </tr>

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -1,8 +1,8 @@
 <tr class="inbox-row">
   <td class="inbox-sender"><%= link_to sent_message_summary.recipient.display_name, user_path(sent_message_summary.recipient) %></td>
   <td class="inbox-subject"><%= link_to sent_message_summary.title, message_path(sent_message_summary) %></td>
-  <td class="inbox-sent"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
-  <td class="text-end">
+  <td class="text-nowrap"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
+  <td class="text-nowrap text-end">
     <%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "d-inline-block inbox-destroy" %>
   </td>
 </tr>

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -2,5 +2,7 @@
   <td class="inbox-sender"><%= link_to sent_message_summary.recipient.display_name, user_path(sent_message_summary.recipient) %></td>
   <td class="inbox-subject"><%= link_to sent_message_summary.title, message_path(sent_message_summary) %></td>
   <td class="inbox-sent"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
-  <td class="inbox-destroy"><%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger" %></td>
+  <td class="text-end">
+    <%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "d-inline-block inbox-destroy" %>
+  </td>
 </tr>

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -1,6 +1,6 @@
 <tr class="inbox-row">
-  <td class="inbox-sender"><%= link_to sent_message_summary.recipient.display_name, user_path(sent_message_summary.recipient) %></td>
-  <td class="inbox-subject"><%= link_to sent_message_summary.title, message_path(sent_message_summary) %></td>
+  <td><%= link_to sent_message_summary.recipient.display_name, user_path(sent_message_summary.recipient) %></td>
+  <td><%= link_to sent_message_summary.title, message_path(sent_message_summary) %></td>
   <td class="text-nowrap"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
   <td class="text-nowrap text-end">
     <%= button_to t(".destroy_button"), message_path(sent_message_summary, :referer => request.fullpath), :method => :delete, :remote => true, :class => "btn btn-sm btn-danger", :form_class => "d-inline-block inbox-destroy" %>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -25,8 +25,6 @@
         <th><%= t ".from" %></th>
         <th><%= t ".subject" %></th>
         <th><%= t ".date" %></th>
-        <th></th>
-        <th></th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -19,7 +19,7 @@
   <h4><%= render :partial => "message_count" %></h4>
 
 <% if current_user.messages.size > 0 %>
-  <table class="table table-sm">
+  <table class="table table-sm align-middle">
     <thead>
       <tr>
         <th><%= t ".from" %></th>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -26,7 +26,6 @@
         <th><%= t ".to" %></th>
         <th><%= t ".subject" %></th>
         <th><%= t ".date" %></th>
-        <th></th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -20,7 +20,7 @@
 <h4><%= t ".messages", :count => current_user.sent_messages.size %></h4>
 
 <% if current_user.sent_messages.size > 0 %>
-  <table class="table table-sm">
+  <table class="table table-sm align-middle">
     <thead>
       <tr>
         <th><%= t ".to" %></th>


### PR DESCRIPTION
- `width: 1%;` wasn't working correctly because `.inbox-delete` no longer existsted after rename in https://github.com/openstreetmap/openstreetmap-website/commit/73df8447e3918f08156dd69ddf631652d048f191
- Instead of showing/hiding cells with buttons I show/hide their wrapping forms.
- Many class names had `inbox` in them even if they were used in outbox. `.inbox-row-*` is still kept because it is used in tests and sets row colors which I don't want to change yet.