### PR TITLE
Don't do direction override from Bootstrap reboot of <code>

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1233,6 +1233,8 @@ div.secondary-actions {
   code {
     background: $lightgrey;
     padding: 2px 3px;
+    direction: inherit; /* fix for Bootstrap < 5.2 */
+    unicode-bidi: unset; /* fix for Bootstrap < 5.2 */
   }
 
   pre {


### PR DESCRIPTION
Later versions of Bootstrap don't have it.
See https://github.com/twbs/bootstrap/pull/35230

Fixes #4104