### PR TITLE
Add order parameter to changeset query API call

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -170,8 +170,15 @@ module Api
       changesets = conditions_closed(changesets, params["closed"])
       changesets = conditions_ids(changesets, params["changesets"])
 
-      # sort and limit the changesets
-      changesets = changesets.order("created_at DESC").limit(result_limit)
+      # sort the changesets
+      changesets = if params[:order] == "oldest"
+                     changesets.order("created_at ASC")
+                   else
+                     changesets.order("created_at DESC")
+                   end
+
+      # limit the result
+      changesets = changesets.limit(result_limit)
 
       # preload users, tags and comments, and render result
       @changesets = changesets.preload(:user, :changeset_tags, :comments)

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -1968,6 +1968,41 @@ module Api
     end
 
     ##
+    # test the query functionality of changesets with the order parameter
+    def test_query_order
+      user = create(:user)
+      changeset1 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 1, 1, 0, 0, 0), :closed_at => Time.utc(2008, 1, 2, 0, 0, 0))
+      changeset2 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 2, 1, 0, 0, 0), :closed_at => Time.utc(2008, 2, 2, 0, 0, 0))
+      changeset3 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 3, 1, 0, 0, 0), :closed_at => Time.utc(2008, 3, 2, 0, 0, 0))
+      changeset4 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 4, 1, 0, 0, 0), :closed_at => Time.utc(2008, 4, 2, 0, 0, 0))
+      changeset5 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 5, 1, 0, 0, 0), :closed_at => Time.utc(2008, 5, 2, 0, 0, 0))
+
+      get changesets_path(:order => "oldest")
+      assert_response :success
+      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4, changeset5]
+
+      get changesets_path(:order => "oldest", :time => "2008-01-01T00:00Z,2018-01-01T00:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4, changeset5]
+
+      get changesets_path(:order => "oldest", :time => "2008-01-02T00:00Z,2018-01-01T00:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4, changeset5]
+
+      get changesets_path(:order => "oldest", :time => "2008-01-02T00:01Z,2018-01-01T00:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset2, changeset3, changeset4, changeset5]
+
+      get changesets_path(:order => "oldest", :time => "2008-04-01T00:00Z,2018-01-01T00:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset4, changeset5]
+
+      get changesets_path(:order => "oldest", :time => "2008-06-01T00:00Z,2018-01-01T00:00Z")
+      assert_response :success
+      assert_changesets_in_order []
+    end
+
+    ##
     # check that errors are returned if garbage is inserted
     # into query strings
     def test_query_invalid

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -1950,18 +1950,18 @@ module Api
 
       get changesets_path
       assert_response :success
-      assert_changesets [changeset5, changeset4, changeset3, changeset2, changeset1]
+      assert_changesets_in_order [changeset5, changeset4, changeset3, changeset2, changeset1]
 
       get changesets_path(:limit => "3")
       assert_response :success
-      assert_changesets [changeset5, changeset4, changeset3]
+      assert_changesets_in_order [changeset5, changeset4, changeset3]
 
       get changesets_path(:limit => "0")
       assert_response :bad_request
 
       get changesets_path(:limit => Settings.max_changeset_query_limit)
       assert_response :success
-      assert_changesets [changeset5, changeset4, changeset3, changeset2, changeset1]
+      assert_changesets_in_order [changeset5, changeset4, changeset3, changeset2, changeset1]
 
       get changesets_path(:limit => Settings.max_changeset_query_limit + 1)
       assert_response :bad_request
@@ -2247,12 +2247,20 @@ module Api
     private
 
     ##
-    # boilerplate for checking that certain changesets exist in the
-    # output.
+    # check that certain changesets exist in the output
     def assert_changesets(changesets)
       assert_select "osm>changeset", changesets.size
       changesets.each do |changeset|
         assert_select "osm>changeset[id='#{changeset.id}']", 1
+      end
+    end
+
+    ##
+    # check that certain changesets exist in the output in the specified order
+    def assert_changesets_in_order(changesets)
+      assert_select "osm>changeset", changesets.size
+      changesets.each_with_index do |changeset, index|
+        assert_select "osm>changeset:nth-child(#{index + 1})[id='#{changeset.id}']", 1
       end
     end
 


### PR DESCRIPTION
When you want to get an unknown number of changesets matching some criteria, you use `/api/0.6/changesets` with the corresponding parameters. If you receive a number of changesets that is equal to the limit, you know there might be more matching changesets. To get the next page of changesets you set the upper limit of the `time` parameter to the last received changeset.* The lower limit is usually set to some date before osm existed. Then you run the query again and receive the next page of results. That next page should consist of changesets created earlier than the ones received previously.

But what if you want a previous page? You can't set the upper time limit to the first received changeset because you'll get the same result again.* You can set the lower limit, but then you'll still need to decide on the upper limit. If you don't set the upper limit, you'll receive the first page with the latest changesets, not the previous one. You'll have to guess the upper time limit of the previous page, and guessing it correctly may take several requests.

If you could get changesets in ascending order, specifying lower limit would be enough to get the previous page.*

This pull request adds the `order` parameter to `/api/0.6/changesets`, similar to `/api/0.6/notes/search`. `order=oldest` returns changesets in ascending order.

\* some details about same-second and overlapping changesets omitted