### PR TITLE
Restore sorting by created_at for descending order changeset queries

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -174,7 +174,7 @@ module Api
       changesets = if params[:order] == "oldest"
                      changesets.order(:closed_at => :asc)
                    else
-                     changesets.order(:closed_at => :desc)
+                     changesets.order(:created_at => :desc)
                    end
 
       # limit the result

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -2003,6 +2003,25 @@ module Api
     end
 
     ##
+    # test the query functionality of overlapping changesets
+    def test_query_order_overlapping
+      user = create(:user)
+      changeset11 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 17, 0, 0), :closed_at => Time.utc(2015, 6, 4, 17, 0, 0))
+      changeset12 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 16, 0, 0), :closed_at => Time.utc(2015, 6, 4, 18, 0, 0))
+      changeset13 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 14, 0, 0), :closed_at => Time.utc(2015, 6, 4, 20, 0, 0))
+      changeset14 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 3, 23, 0, 0), :closed_at => Time.utc(2015, 6, 4, 23, 0, 0))
+      create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 2, 23, 0, 0), :closed_at => Time.utc(2015, 6, 3, 23, 0, 0))
+
+      get changesets_path(:time => "2015-06-04T00:00:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset11, changeset12, changeset13, changeset14]
+
+      get changesets_path(:time => "2015-06-04T16:00:00Z,2015-06-04T16:30:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset12, changeset13, changeset14]
+    end
+
+    ##
     # check that errors are returned if garbage is inserted
     # into query strings
     def test_query_invalid


### PR DESCRIPTION
The fix https://github.com/openstreetmap/openstreetmap-website/commit/702c071e191e0c79537f2e68f1084aa42bcb3c7a changed all changeset sorting to closed_at. This altered the behavior existing before the `order` parameter and made descending-order queries slow.