### PR TITLE
Add contributor info for Czechia for copyright web page

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -125,6 +125,12 @@
               :canada => tag.strong(t(".legal_babble.contributors_ca_canada")) %>
       </li>
       <li>
+        <%= t ".legal_babble.contributors_cz_credit_html",
+              :czechia => tag.strong(t(".legal_babble.contributors_cz_czechia")),
+              :cc_licence_link => link_to(t(".legal_babble.contributors_cz_cc_licence"),
+                                          t(".legal_babble.contributors_cz_cc_licence_url")) %>
+      </li>
+      <li>
         <%= t ".legal_babble.contributors_fi_credit_html",
               :finland => tag.strong(t(".legal_babble.contributors_fi_finland")),
               :nlsfi_license_link => link_to(t(".legal_babble.contributors_fi_nlsfi_license"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1995,6 +1995,12 @@ en:
           Resources Canada), and StatCan (Geography Division,
           Statistics Canada).
         contributors_ca_canada: Canada
+        contributors_cz_credit_html: |
+          %{czechia}: Contains data from the State Administration of Land Surveying
+          and Cadastre licensed under %{cc_licence_link}
+        contributors_cz_czechia: Czechia
+        contributors_cz_cc_licence: Creative Commons Attribution 4.0 International licence (CC BY 4.0)
+        contributors_cz_cc_licence_url: https://creativecommons.org/licenses/by/4.0/
         contributors_fi_credit_html: |
           %{finland}: Contains data from the
           National Land Survey of Finland's Topographic Database


### PR DESCRIPTION
The Czech Local Chapter is in negotiation with State Administration of
Land Surveying and Cadastre about possibility to use their newly
opened data in OSM. We have the agreement with request to put them as
a source of data on the copyright web page:

https://www.openstreetmap.org/copyright/en

Czechia: Contains data from the State Administration of Land Surveying
and Cadastre licensed under Creative Commons Attribution 4.0
International license (CC BY 4.0).

and mainly czech version of this page:

Česko: Obsahuje data z produkce Zeměměřického úřadu licencovaná pro
opětovné použití pod licencí Creative Commons Attribution 4.0 (CC BY 4.0).

I expect this pull request to handle the EN main page and the CZ language version will be later prepared via https://translatewiki.net/.