### PR TITLE
Add 'from' and 'to' changeset query parameters

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -157,6 +157,8 @@ module Api
     ##
     # query changesets by bounding box, time, user or open/closed status.
     def query
+      raise OSM::APIBadUserInput, "cannot use order=oldest with time" if params[:time] && params[:order] == "oldest"
+
       # find any bounding box
       bbox = BoundingBox.from_bbox_params(params) if params["bbox"]
 

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -172,9 +172,9 @@ module Api
 
       # sort the changesets
       changesets = if params[:order] == "oldest"
-                     changesets.order(:closed_at => :asc)
+                     changesets.order(:created_at => :asc)
                    else
-                     changesets.order(:closed_at => :desc)
+                     changesets.order(:created_at => :desc)
                    end
 
       # limit the result

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -329,7 +329,7 @@ module Api
     end
 
     ##
-    # restrict changes to those closed during a particular time period
+    # restrict changesets to those during a particular time period
     def conditions_time(changesets, time)
       if time.nil?
         changesets


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/pull/4164#issuecomment-1677667971

These parameters work exactly like they do with note searches when notes are sorted by `created_at`.
`time` parameter is left unchanged, but its use together with `order=oldest` is disallowed.
Sorting is restored to `created_at`.

Supersedes #4168