### PR TITLE
Fix predicate method names in the user model

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -93,16 +93,6 @@ Minitest/MultipleAssertions:
   Max: 54
 
 # Offense count: 1
-# Configuration parameters: NamePrefix, ForbiddenPrefixes, AllowedMethods, MethodDefinitionMacros.
-# NamePrefix: is_, has_, have_
-# ForbiddenPrefixes: is_, has_, have_
-# AllowedMethods: is_a?
-# MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicateName:
-  Exclude:
-    - 'app/models/user.rb'
-
-# Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/ActionControllerFlashBeforeRender:
   Exclude:

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -280,7 +280,7 @@ class DiaryEntriesController < ApplicationController
       @lon = @diary_entry.longitude
       @lat = @diary_entry.latitude
       @zoom = 12
-    elsif !current_user.has_home?
+    elsif !current_user.home_location?
       @lon = params[:lon] || -0.1
       @lat = params[:lat] || 51.5
       @zoom = params[:zoom] || 4

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -19,7 +19,7 @@ class IssueCommentsController < ApplicationController
       reassign_issue(@issue)
       flash[:notice] = t ".issue_reassigned"
 
-      if current_user.has_role? @issue.assigned_role
+      if current_user.role? @issue.assigned_role
         redirect_to @issue
       else
         redirect_to issues_path(:status => "open")

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -41,7 +41,7 @@ class UserRolesController < ApplicationController
   ##
   # checks that the user doesn't already have this role
   def not_in_role
-    if @user.has_role? @role
+    if @user.role? @role
       flash[:error] = t("user_role.filter.already_has_role", :role => @role)
       redirect_to user_path(@user)
     end
@@ -50,7 +50,7 @@ class UserRolesController < ApplicationController
   ##
   # checks that the user already has this role
   def in_role
-    unless @user.has_role? @role
+    unless @user.role? @role
       flash[:error] = t("user_role.filter.doesnt_have_role", :role => @role)
       redirect_to user_path(@user)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,7 @@ module ApplicationHelper
     if current_user
       data[:user] = current_user.id.to_json
 
-      data[:user_home] = { :lat => current_user.home_lat, :lon => current_user.home_lon } if current_user.has_home?
+      data[:user_home] = { :lat => current_user.home_lat, :lon => current_user.home_lon } if current_user.home_location?
     end
 
     data[:location] = session[:location] if session[:location]

--- a/app/helpers/user_roles_helper.rb
+++ b/app/helpers/user_roles_helper.rb
@@ -5,7 +5,7 @@ module UserRolesHelper
 
   def role_icon(user, role)
     if current_user&.administrator?
-      if user.has_role?(role)
+      if user.role?(role)
         image = "roles/#{role}"
         alt = t("users.show.role.revoke.#{role}")
         title = t("users.show.role.revoke.#{role}")
@@ -18,7 +18,7 @@ module UserRolesHelper
         url = grant_role_path(:display_name => user.display_name, :role => role)
         confirm = t("user_role.grant.are_you_sure", :name => user.display_name, :role => role)
       end
-    elsif user.has_role?(role)
+    elsif user.role?(role)
       image = "roles/#{role}"
       alt = t("users.show.role.#{role}")
       title = t("users.show.role.#{role}")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -238,12 +238,12 @@ class User < ApplicationRecord
     @preferred_languages ||= Locale.list(languages)
   end
 
-  def has_home?
+  def home_location?
     home_lat && home_lon
   end
 
   def nearby(radius = Settings.nearby_radius, num = Settings.nearby_users)
-    if has_home?
+    if home_location?
       gc = OSM::GreatCircle.new(home_lat, home_lon)
       sql_for_area = QuadTile.sql_for_area(gc.bounds(radius), "home_")
       sql_for_distance = gc.sql_for_distance("home_lat", "home_lon")
@@ -282,18 +282,18 @@ class User < ApplicationRecord
   ##
   # returns true if the user has the moderator role, false otherwise
   def moderator?
-    has_role? "moderator"
+    role? "moderator"
   end
 
   ##
   # returns true if the user has the administrator role, false otherwise
   def administrator?
-    has_role? "administrator"
+    role? "administrator"
   end
 
   ##
   # returns true if the user has the requested role
-  def has_role?(role)
+  def role?(role)
     roles.any? { |r| r.role == role }
   end
 
@@ -405,6 +405,6 @@ class User < ApplicationRecord
   end
 
   def update_tile
-    self.home_tile = QuadTile.tile_for_point(home_lat, home_lon) if has_home?
+    self.home_tile = QuadTile.tile_for_point(home_lat, home_lon) if home_location?
   end
 end

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -46,7 +46,7 @@ json.user do
   end
 
   if current_user && current_user == user && can?(:details, User)
-    if user.has_home?
+    if user.home_location?
       json.home do
         json.lat user.home_lat
         json.lon user.home_lon

--- a/app/views/api/users/_user.xml.builder
+++ b/app/views/api/users/_user.xml.builder
@@ -25,7 +25,7 @@ xml.tag! "user", :id => user.id,
     end
   end
   if current_user && current_user == user && can?(:details, User)
-    if user.has_home?
+    if user.home_location?
       xml.tag! "home", :lat => user.home_lat,
                        :lon => user.home_lon,
                        :zoom => user.home_zoom

--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -11,7 +11,7 @@
   <div class="col">
     <p class='text-muted mb-0'>
       <%= link_to contact.display_name, user_path(contact) %>
-      <% if @user.has_home? and contact.has_home? %>
+      <% if @user.home_location? and contact.home_location? %>
         <% distance = @user.distance(contact) %>
         <% if distance < 1 %>
           (<%= t ".m away", :count => (distance * 1000).round %>)

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <% if current_user and @user.id == current_user.id %>
     <div class="col-md order-md-last">
-      <% if !@user.has_home? %>
+      <% if !@user.home_location? %>
         <div id="map" class="content_map border border-grey">
           <p class="m-3"><%= t(".no_home_location_html", :edit_profile_link => link_to(t(".edit_your_profile"), edit_profile_path)) %></p>
         </div>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for(:body_class) { "map-layout" } %>
 
-<% if current_user&.has_home? %>
+<% if current_user&.home_location? %>
   <% content_for :greeting do %>
     <%= link_to t("layouts.home"),
                 "#",

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -42,18 +42,18 @@
 
   <fieldset>
     <legend><%= t ".home location" -%></legend>
-    <p id="home_message" class="text-muted m-0<% if current_user.has_home? %> invisible<% end %>"><%= t ".no home location" %></p>
+    <p id="home_message" class="text-muted m-0<% if current_user.home_location? %> invisible<% end %>"><%= t ".no home location" %></p>
     <div class="row">
       <%= f.text_field :home_lat, :wrapper_class => "col-sm-4", :id => "home_lat" %>
       <%= f.text_field :home_lon, :wrapper_class => "col-sm-4", :id => "home_lon" %>
       <div class="col-sm-4 pt-2 align-self-end">
-        <button type="button" id="home_show" class="btn btn-outline-primary"<% unless current_user.has_home? %> hidden<% end %> disabled><%= t ".show" %></button>
-        <button type="button" id="home_delete" class="btn btn-outline-primary"<% unless current_user.has_home? %> hidden<% end %>><%= t ".delete" %></button>
+        <button type="button" id="home_show" class="btn btn-outline-primary"<% unless current_user.home_location? %> hidden<% end %> disabled><%= t ".show" %></button>
+        <button type="button" id="home_delete" class="btn btn-outline-primary"<% unless current_user.home_location? %> hidden<% end %>><%= t ".delete" %></button>
         <button type="button" id="home_undelete" class="btn btn-outline-primary" hidden><%= t ".undelete" %></button>
       </div>
     </div>
     <div class="form-check">
-      <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.has_home? %> checked <% end %> id="updatehome" />
+      <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.home_location? %> checked <% end %> id="updatehome" />
       <label class="form-check-label" for="updatehome"><%= t ".update home location on click" %></label>
     </div>
     <%= tag.div "", :id => "map", :class => "content_map set_location border border-grey rounded" %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -239,11 +239,11 @@ class UserTest < ActiveSupport::TestCase
     assert_predicate create(:administrator_user), :administrator?
   end
 
-  def test_has_role?
-    assert_not create(:user).has_role?("administrator")
-    assert_not create(:user).has_role?("moderator")
-    assert create(:administrator_user).has_role?("administrator")
-    assert create(:moderator_user).has_role?("moderator")
+  def test_role?
+    assert_not create(:user).role?("administrator")
+    assert_not create(:user).role?("moderator")
+    assert create(:administrator_user).role?("administrator")
+    assert create(:moderator_user).role?("moderator")
   end
 
   def test_soft_destroy


### PR DESCRIPTION
This renames the two `has_xxx?` predicate methods in the user model and enables the rubocop warning that catches them.