### PR TITLE
Override bootstrap's box-shadow effect on search field & sidebar buttons

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -265,6 +265,11 @@ body.small-nav {
 
     .search_forms {
       display: block;
+      
+      /*override bootstrap's box-shadow */
+      .form-control:focus {
+        box-shadow: none!important;
+      }
     }
   }
 


### PR DESCRIPTION

In an effort to address the issue regarding a search bar redesign opened a couple of years ago here:
https://github.com/openstreetmap/openstreetmap-website/issues/3123
and associated pull request here:
https://github.com/openstreetmap/openstreetmap-website/pull/3400

I have written a tiny bit of code to subdue the bootstrap CSS that adds a distracting blue box-shadow to the Search field and Go/Direction buttons. It is by no means a redesign, but by getting rid of the drop shadow, the Go Button no longer looks so misplaced while the user is typing. 