### PR TITLE
Remove right leaflet toolbar position override

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -324,10 +324,6 @@ body.small-nav {
   .overlay-sidebar #sidebar #banner {
     display: none;
   }
-
-  .leaflet-top.leaflet-right {
-    top: 10px !important;
-  }
 }
 
 /* Utility for styling notification numbers */


### PR DESCRIPTION
Has no effect, doesn't take rtl into account.
Was added in https://github.com/openstreetmap/openstreetmap-website/commit/537d72b0f66562475808249a1a2ef3223df5dd52#diff-fe520170ce0c939dc1e59f3395a360a1866b4da19b474c9f0b35112f72e952d8R117