### PR TITLE
Add color keys to note tables

### DIFF
--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,6 +1,9 @@
 <% content_for :heading do %>
   <h1><%= t ".heading", :user => @user.display_name %></h1>
-  <p><%= t ".subheading_html", :user => link_to(@user.display_name, user_path(@user)) %></p>
+  <p><%= t ".subheading_html",
+           :user => link_to(@user.display_name, user_path(@user)),
+           :submitted => tag.span(t(".subheading_submitted"), :class => "px-2 py-1 bg-primary bg-opacity-25"),
+           :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-white") %></p>
 <% end %>
 
 <% if @notes.empty? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2878,7 +2878,9 @@ en:
     index:
       title: "Notes submitted or commented on by %{user}"
       heading: "%{user}'s Notes"
-      subheading_html: "Notes submitted or commented on by %{user}"
+      subheading_html: "Notes %{submitted} or %{commented} by %{user}"
+      subheading_submitted: "submitted"
+      subheading_commented: "commented on"
       no_notes: No notes
       id: "Id"
       creator: "Creator"


### PR DESCRIPTION
Some of the rows in a note table are highlighted, but it's not clear why.

A hint to this color coding is added here.

![notes-key](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9ec72821-d774-4724-9c63-bb73cc9f4a25)

Requires some modification of i18 strings. Before it's done everything looks like it did before.