### PR TITLE
Add 'User' to selectable types in issues search for moderators

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -14,7 +14,7 @@ class IssuesController < ApplicationController
     @title = t ".title"
 
     @issue_types = []
-    @issue_types.push("Note") if current_user.moderator?
+    @issue_types.push("Note", "User") if current_user.moderator?
     @issue_types.push("DiaryEntry", "DiaryComment", "User") if current_user.administrator?
 
     @users = User.joins(:roles).where(:user_roles => { :role => current_user.roles.map(&:role) }).distinct


### PR DESCRIPTION
Reported users are either directly assigned to moderators or ofter reassigned to them.