### PR TITLE
Add note limit settings, use them in capabilities and tests

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -345,13 +345,13 @@ module Api
     # Get the maximum number of results to return
     def result_limit
       if params[:limit]
-        if params[:limit].to_i.positive? && params[:limit].to_i <= 10000
+        if params[:limit].to_i.positive? && params[:limit].to_i <= Settings.max_note_query_limit
           params[:limit].to_i
         else
-          raise OSM::APIBadUserInput, "Note limit must be between 1 and 10000"
+          raise OSM::APIBadUserInput, "Note limit must be between 1 and #{Settings.max_note_query_limit}"
         end
       else
-        100
+        Settings.default_note_query_limit
       end
     end
 

--- a/app/views/api/capabilities/show.builder
+++ b/app/views/api/capabilities/show.builder
@@ -10,6 +10,8 @@ xml.osm(OSM::API.new.xml_root_attributes) do |osm|
     api.changesets(:maximum_elements => Changeset::MAX_ELEMENTS,
                    :default_query_limit => Settings.default_changeset_query_limit,
                    :maximum_query_limit => Settings.max_changeset_query_limit)
+    api.notes(:default_query_limit => Settings.default_note_query_limit,
+              :maximum_query_limit => Settings.max_note_query_limit)
     api.timeout(:seconds => Settings.api_timeout)
     api.status(:database => @database_status,
                :api => @api_status,

--- a/app/views/api/capabilities/show.json.jbuilder
+++ b/app/views/api/capabilities/show.json.jbuilder
@@ -25,6 +25,10 @@ json.api do
     json.default_query_limit Settings.default_changeset_query_limit
     json.maximum_query_limit Settings.max_changeset_query_limit
   end
+  json.notes do
+    json.default_query_limit Settings.default_note_query_limit
+    json.maximum_query_limit Settings.max_note_query_limit
+  end
   json.timeout do
     json.seconds Settings.api_timeout
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,6 +39,10 @@ max_number_of_way_nodes: 2000
 max_number_of_relation_members: 32000
 # The maximum area you're allowed to request notes from, in square degrees
 max_note_request_area: 25
+# Default limit on the number of notes returned by the note search api method
+default_note_query_limit: 100
+# Maximum limit on the number of notes returned by the note search api method
+max_note_query_limit: 10000
 # Zoom level to use for postcode results from the geocoder
 postcode_zoom: 15
 # Timeout for API calls in seconds

--- a/test/controllers/api/capabilities_controller_test.rb
+++ b/test/controllers/api/capabilities_controller_test.rb
@@ -32,7 +32,10 @@ module Api
           assert_select "area[maximum='#{Settings.max_request_area}']", :count => 1
           assert_select "note_area[maximum='#{Settings.max_note_request_area}']", :count => 1
           assert_select "tracepoints[per_page='#{Settings.tracepoints_per_page}']", :count => 1
-          assert_select "changesets[maximum_elements='#{Changeset::MAX_ELEMENTS}']", :count => 1
+          assert_select "changesets" \
+                        "[maximum_elements='#{Changeset::MAX_ELEMENTS}']" \
+                        "[default_query_limit='#{Settings.default_changeset_query_limit}']" \
+                        "[maximum_query_limit='#{Settings.max_changeset_query_limit}']", :count => 1
           assert_select "relationmembers[maximum='#{Settings.max_number_of_relation_members}']", :count => 1
           assert_select "status[database='online']", :count => 1
           assert_select "status[api='online']", :count => 1

--- a/test/controllers/api/capabilities_controller_test.rb
+++ b/test/controllers/api/capabilities_controller_test.rb
@@ -37,6 +37,9 @@ module Api
                         "[default_query_limit='#{Settings.default_changeset_query_limit}']" \
                         "[maximum_query_limit='#{Settings.max_changeset_query_limit}']", :count => 1
           assert_select "relationmembers[maximum='#{Settings.max_number_of_relation_members}']", :count => 1
+          assert_select "notes" \
+                        "[default_query_limit='#{Settings.default_note_query_limit}']" \
+                        "[maximum_query_limit='#{Settings.max_note_query_limit}']", :count => 1
           assert_select "status[database='online']", :count => 1
           assert_select "status[api='online']", :count => 1
           assert_select "status[gpx='online']", :count => 1
@@ -61,6 +64,8 @@ module Api
       assert_equal Settings.default_changeset_query_limit, js["api"]["changesets"]["default_query_limit"]
       assert_equal Settings.max_changeset_query_limit, js["api"]["changesets"]["maximum_query_limit"]
       assert_equal Settings.max_number_of_relation_members, js["api"]["relationmembers"]["maximum"]
+      assert_equal Settings.default_note_query_limit, js["api"]["notes"]["default_query_limit"]
+      assert_equal Settings.max_note_query_limit, js["api"]["notes"]["maximum_query_limit"]
       assert_equal "online", js["api"]["status"]["database"]
       assert_equal "online", js["api"]["status"]["api"]
       assert_equal "online", js["api"]["status"]["gpx"]

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -695,6 +695,9 @@ module Api
       assert_select "gpx", :count => 1 do
         assert_select "wpt", :count => 1
       end
+
+      get api_notes_path(:bbox => "1,1,1.2,1.2", :limit => Settings.max_note_query_limit, :format => "rss")
+      assert_response :success
     end
 
     def test_index_empty_area
@@ -804,7 +807,7 @@ module Api
       get api_notes_path(:bbox => "1,1,1.7,1.7", :limit => "0", :format => "json")
       assert_response :bad_request
 
-      get api_notes_path(:bbox => "1,1,1.7,1.7", :limit => "10001", :format => "json")
+      get api_notes_path(:bbox => "1,1,1.7,1.7", :limit => Settings.max_note_query_limit + 1, :format => "json")
       assert_response :bad_request
     end
 
@@ -841,6 +844,9 @@ module Api
       assert_select "gpx", :count => 1 do
         assert_select "wpt", :count => 1
       end
+
+      get search_api_notes_path(:q => "note comment", :limit => Settings.max_note_query_limit, :format => "xml")
+      assert_response :success
     end
 
     def test_search_by_display_name_success
@@ -995,7 +1001,7 @@ module Api
       get search_api_notes_path(:q => "no match", :limit => "0", :format => "json")
       assert_response :bad_request
 
-      get search_api_notes_path(:q => "no match", :limit => "10001", :format => "json")
+      get search_api_notes_path(:q => "no match", :limit => Settings.max_note_query_limit + 1, :format => "json")
       assert_response :bad_request
 
       get search_api_notes_path(:display_name => "non-existent")
@@ -1037,6 +1043,9 @@ module Api
           assert_select "item", :count => 2
         end
       end
+
+      get feed_api_notes_path(:bbox => "1,1,1.2,1.2", :limit => Settings.max_note_query_limit, :format => "rss")
+      assert_response :success
     end
 
     def test_feed_fail
@@ -1049,7 +1058,7 @@ module Api
       get feed_api_notes_path(:bbox => "1,1,1.2,1.2", :limit => "0", :format => "rss")
       assert_response :bad_request
 
-      get feed_api_notes_path(:bbox => "1,1,1.2,1.2", :limit => "10001", :format => "rss")
+      get feed_api_notes_path(:bbox => "1,1,1.2,1.2", :limit => Settings.max_note_query_limit + 1, :format => "rss")
       assert_response :bad_request
     end
   end


### PR DESCRIPTION
Same as #4142 but for notes.

Makes note and changeset query limit code the same.