### PR TITLE
Respond with plaintext when user not found in changeset query

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -307,7 +307,7 @@ module Api
               # user input checking, we don't have any UIDs < 1
               raise OSM::APIBadUserInput, "invalid user ID" if user.to_i < 1
 
-              u = User.find(user.to_i)
+              u = User.find_by(:id => user.to_i)
             else
               u = User.find_by(:display_name => name)
             end

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -1863,8 +1863,10 @@ module Api
       # not found when looking for changesets of non-existing users
       get changesets_path(:user => User.maximum(:id) + 1)
       assert_response :not_found
+      assert_equal "text/plain", @response.media_type
       get changesets_path(:display_name => " ")
       assert_response :not_found
+      assert_equal "text/plain", @response.media_type
 
       # can't get changesets of user 1 without authenticating
       get changesets_path(:user => private_user.id)


### PR DESCRIPTION
The response used to be of type xml with empty body, which is not valid xml.