### PR TITLE
Move user lookup/error methods from app controller to concerns

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -216,24 +216,6 @@ class ApplicationController < ActionController::Base
   end
 
   ##
-  # ensure that there is a "user" instance variable
-  def lookup_user
-    render_unknown_user params[:display_name] unless @user = User.active.find_by(:display_name => params[:display_name])
-  end
-
-  ##
-  # render a "no such user" page
-  def render_unknown_user(name)
-    @title = t "users.no_such_user.title"
-    @not_found_user = name
-
-    respond_to do |format|
-      format.html { render :template => "users/no_such_user", :status => :not_found }
-      format.all { head :not_found }
-    end
-  end
-
-  ##
   # Unfortunately if a PUT or POST request that has a body fails to
   # read it then Apache will sometimes fail to return the response it
   # is given to the client properly, instead erroring:

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -1,6 +1,8 @@
 # The ChangesetController is the RESTful interface to Changeset objects
 
 class ChangesetsController < ApplicationController
+  include UserMethods
+
   layout "site"
   require "xml/libxml"
 

--- a/app/controllers/concerns/user_methods.rb
+++ b/app/controllers/concerns/user_methods.rb
@@ -18,7 +18,7 @@ module UserMethods
     @not_found_user = name
 
     respond_to do |format|
-      format.html { render :template => "users/no_such_user", :status => :not_found }
+      format.html { render :template => "users/no_such_user", :status => :not_found, :layout => "site" }
       format.all { head :not_found }
     end
   end

--- a/app/controllers/concerns/user_methods.rb
+++ b/app/controllers/concerns/user_methods.rb
@@ -4,6 +4,26 @@ module UserMethods
   private
 
   ##
+  # ensure that there is a "user" instance variable
+  def lookup_user
+    @user = User.active.find_by!(:display_name => params[:display_name])
+  rescue ActiveRecord::RecordNotFound
+    render_unknown_user params[:display_name]
+  end
+
+  ##
+  # render a "no such user" page
+  def render_unknown_user(name)
+    @title = t "users.no_such_user.title"
+    @not_found_user = name
+
+    respond_to do |format|
+      format.html { render :template => "users/no_such_user", :status => :not_found }
+      format.all { head :not_found }
+    end
+  end
+
+  ##
   # update a user's details
   def update_user(user, params)
     user.display_name = params[:display_name]

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,5 +1,6 @@
 class ConfirmationsController < ApplicationController
   include SessionMethods
+  include UserMethods
 
   layout "site"
 

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -1,4 +1,6 @@
 class DiaryEntriesController < ApplicationController
+  include UserMethods
+
   layout "site", :except => :rss
 
   before_action :authorize_web

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,4 +1,6 @@
 class FriendshipsController < ApplicationController
+  include UserMethods
+
   layout "site"
 
   before_action :authorize_web

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,6 @@
 class MessagesController < ApplicationController
+  include UserMethods
+
   layout "site"
 
   before_action :authorize_web

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -9,27 +9,22 @@ class NotesController < ApplicationController
 
   authorize_resource
 
+  before_action :lookup_user, :only => [:index]
   before_action :set_locale
   around_action :web_timeout
 
   ##
   # Display a list of notes by a specified user
   def index
-    if params[:display_name]
-      if @user = User.active.find_by(:display_name => params[:display_name])
-        @params = params.permit(:display_name)
-        @title = t ".title", :user => @user.display_name
-        @page = (params[:page] || 1).to_i
-        @page_size = 10
-        @notes = @user.notes
-        @notes = @notes.visible unless current_user&.moderator?
-        @notes = @notes.order("updated_at DESC, id").distinct.offset((@page - 1) * @page_size).limit(@page_size).preload(:comments => :author)
+    @params = params.permit(:display_name)
+    @title = t ".title", :user => @user.display_name
+    @page = (params[:page] || 1).to_i
+    @page_size = 10
+    @notes = @user.notes
+    @notes = @notes.visible unless current_user&.moderator?
+    @notes = @notes.order("updated_at DESC, id").distinct.offset((@page - 1) * @page_size).limit(@page_size).preload(:comments => :author)
 
-        render :layout => "site"
-      else
-        render_unknown_user params[:display_name]
-      end
-    end
+    render :layout => "site"
   end
 
   def show

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -27,10 +27,7 @@ class NotesController < ApplicationController
 
         render :layout => "site"
       else
-        @title = t "users.no_such_user.title"
-        @not_found_user = params[:display_name]
-
-        render :template => "users/no_such_user", :status => :not_found, :layout => "site"
+        render_unknown_user params[:display_name]
       end
     end
   end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,4 +1,6 @@
 class NotesController < ApplicationController
+  include UserMethods
+
   layout :map_layout
 
   before_action :check_api_readable

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -1,4 +1,6 @@
 class TracesController < ApplicationController
+  include UserMethods
+
   layout "site", :except => :georss
 
   before_action :authorize_web

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -1,4 +1,6 @@
 class UserBlocksController < ApplicationController
+  include UserMethods
+
   layout "site"
 
   before_action :authorize_web

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,4 +1,6 @@
 class UserRolesController < ApplicationController
+  include UserMethods
+
   layout "site"
 
   before_action :authorize_web


### PR DESCRIPTION
For things that have username in their path like `https://www.openstreetmap.org/user/<username>/diary`. Later also for things with user id in their path.

The goal is to make `ApplicationController` smaller. <s>Code dealing with resolving user names/ids will go into the base class.</s> Adding anything to `ApplicationController` will cause Rubocop to complain.