### PR TITLE
Add support for rate limiting signup requests

### DIFF
--- a/config/initializers/rate_limits.rb
+++ b/config/initializers/rate_limits.rb
@@ -1,0 +1,15 @@
+require "rate_limiter"
+
+SIGNUP_IP_LIMITER = if Settings.memcache_servers && Settings.signup_ip_per_day && Settings.signup_ip_max_burst
+                      RateLimiter.new(
+                        Dalli::Client.new(Settings.memcache_servers, :namespace => "rails:signup:ip"),
+                        86400, Settings.signup_ip_per_day, Settings.signup_ip_max_burst
+                      )
+                    end
+
+SIGNUP_EMAIL_LIMITER = if Settings.memcache_servers && Settings.signup_email_per_day && Settings.signup_email_max_burst
+                         RateLimiter.new(
+                           Dalli::Client.new(Settings.memcache_servers, :namespace => "rails:signup:email"),
+                           86400, Settings.signup_email_per_day, Settings.signup_email_max_burst
+                         )
+                       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -140,3 +140,8 @@ smtp_user_name: null
 smtp_password: null
 # Matomo settings for analytics
 #matomo:
+# Signup rate limits
+#signup_ip_per_day:
+#signup_ip_max_burst:
+#signup_email_per_day:
+#signup_email_max_burst:

--- a/lib/rate_limiter.rb
+++ b/lib/rate_limiter.rb
@@ -1,0 +1,38 @@
+class RateLimiter
+  def initialize(cache, interval, limit, max_burst)
+    @cache = cache
+    @requests_per_second = limit.to_f / interval
+    @burst_limit = max_burst
+  end
+
+  def allow?(key)
+    last_update, requests = @cache.get(key)
+
+    if last_update
+      elapsed = Time.now.to_i - last_update
+
+      requests -= elapsed * @requests_per_second
+    else
+      requests = 0.0
+    end
+
+    requests < @burst_limit
+  end
+
+  def update(key)
+    now = Time.now.to_i
+
+    last_update, requests = @cache.get(key)
+
+    if last_update
+      elapsed = now - last_update
+
+      requests -= elapsed * @requests_per_second
+      requests += 1.0
+    else
+      requests = 1.0
+    end
+
+    @cache.set(key, [now, [requests, 1.0].max])
+  end
+end


### PR DESCRIPTION
This PR attempts to add support for rate limiting signups from a given IP address and/or email address.

Obviously we only allow one account per email address but this works on the basis of a canonical address where any `+` extension is removed, and dots are stripped from the local part for gmail.