### PR TITLE
Don't limit blocks table width

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -968,6 +968,14 @@ tr.turn:hover {
   padding: $lineheight;
 }
 
+/* Rules for block table pages */
+
+.user_blocks-index, .user_blocks-blocks_by, .user_blocks-blocks_on {
+  #content .content-inner {
+    max-width: unset;
+  }
+}
+
 /* Overrides for pages that use new layout conventions */
 
 .header-illustration {


### PR DESCRIPTION
https://www.openstreetmap.org/user_blocks contains a lot of information. It's more technical than a usual page here. Therefore it doesn't have to be limited to 960px like the most of non-map pages.