### PR TITLE
Add rate limiting for changeset comments

### DIFF
--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -29,6 +29,7 @@ OSM.Changeset = function (map) {
   function updateChangeset(form, method, url, include_data) {
     var data;
 
+    $(form).find("#comment-error").prop("hidden", true);
     $(form).find("input[type=submit]").prop("disabled", true);
 
     if (include_data) {
@@ -44,6 +45,11 @@ OSM.Changeset = function (map) {
       data: data,
       success: function () {
         OSM.loadSidebarContent(window.location.pathname, page.load);
+      },
+      error: function (xhr, xhr_status, http_status) {
+        $(form).find("#comment-error").text(http_status);
+        $(form).find("#comment-error").prop("hidden", false);
+        $(form).find("input[type=submit]").prop("disabled", false);
       }
     });
   }

--- a/app/controllers/api/changeset_comments_controller.rb
+++ b/app/controllers/api/changeset_comments_controller.rb
@@ -17,6 +17,7 @@ module Api
       # Check the arguments are sane
       raise OSM::APIBadUserInput, "No id was given" unless params[:id]
       raise OSM::APIBadUserInput, "No text was given" if params[:text].blank?
+      raise OSM::APIRateLimitExceeded if current_user.changeset_comments.where("created_at >= ?", Time.now.utc - 1.hour).count >= current_user.max_changeset_comments_per_hour
 
       # Extract the arguments
       id = params[:id].to_i

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -395,6 +395,19 @@ class User < ApplicationRecord
     max_friends.clamp(0, Settings.max_friends_per_hour)
   end
 
+  def max_changeset_comments_per_hour
+    if moderator?
+      36000
+    else
+      previous_comments = changeset_comments.limit(200).count
+      active_reports = issues.with_status(:open).sum(:reports_count)
+      max_comments = previous_comments / 200.0 * Settings.max_changeset_comments_per_hour
+      max_comments = max_comments.floor.clamp(Settings.min_changeset_comments_per_hour, Settings.max_changeset_comments_per_hour)
+      max_comments /= 2**active_reports
+      max_comments.floor.clamp(1, Settings.max_changeset_comments_per_hour)
+    end
+  end
+
   private
 
   def encrypt_password

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -78,6 +78,8 @@
         <div class="mb-3">
           <textarea class="form-control" name="text" cols="40" rows="5"></textarea>
         </div>
+        <div id="comment-error" class="alert-danger p-2 mb-3" hidden>
+        </div>
         <div>
           <input type="submit" name="comment" value="<%= t("javascripts.changesets.show.comment") %>" data-changeset-id="<%= @changeset.id %>" data-method="POST" data-url="<%= changeset_comment_url(@changeset) %>" disabled="1" class="btn btn-sm btn-primary" />
         </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,6 +55,9 @@ user_block_periods: [0, 1, 3, 6, 12, 24, 48, 96, 168, 336, 731, 4383, 8766, 8766
 max_messages_per_hour: 60
 # Rate limit for friending
 max_friends_per_hour: 60
+# Rate limit for changeset comments
+min_changeset_comments_per_hour: 6
+max_changeset_comments_per_hour: 60
 # Domain for handling message replies
 #messages_domain: "messages.openstreetmap.org"
 # MaxMind GeoIPv2 database

--- a/db/migrate/20230825162137_restore_author_index_to_changeset_comments.rb
+++ b/db/migrate/20230825162137_restore_author_index_to_changeset_comments.rb
@@ -1,0 +1,7 @@
+class RestoreAuthorIndexToChangesetComments < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :changeset_comments, [:author_id, :created_at], :algorithm => :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2371,6 +2371,13 @@ CREATE UNIQUE INDEX index_active_storage_variant_records_uniqueness ON public.ac
 
 
 --
+-- Name: index_changeset_comments_on_author_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_changeset_comments_on_author_id_and_created_at ON public.changeset_comments USING btree (author_id, created_at);
+
+
+--
 -- Name: index_changeset_comments_on_changeset_id_and_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3396,6 +3403,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220201183346'),
 ('20220223140543'),
 ('20230816135800'),
+('20230825162137'),
 ('21'),
 ('22'),
 ('23'),

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -353,6 +353,13 @@ module OSM
     end
   end
 
+  # Raised when a rate limit is exceeded
+  class APIRateLimitExceeded < APIError
+    def status
+      :too_many_requests
+    end
+  end
+
   # Helper methods for going to/from mercator and lat/lng.
   class Mercator
     include Math


### PR DESCRIPTION
This inspired by but not identical to the algorithm proposed in #4196.

It ramps up to a specified maximum rate (default 60 per hour or 1 per minute) over the first two hundred changesets, subject to a configured minimum that defaults to 1 every 10 minutes with each unresolved report of the user halving the limit.

By my calculations this algorithm, with these defaults, will take just under 12 hours to reach the maximum limit if you constantly post as soon as you can - so that would be two hundred posts in 12 hours after which you can do 60 per hour and all assuming nobody has reported you.

Moderators have an arbitrary high limit of ten per second.

The down rating for reports might be a bit harsh but we can adjust it if that turns out the be the case.