### PR TITLE
Use `where()` instead of `find()` to prevent RecordNotFound

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       raise OSM::APIBadUserInput, "No users were given to search for" if ids.empty?
 
-      @users = User.visible.find(ids)
+      @users = User.visible.where(:id => ids)
 
       # Render the result
       respond_to do |format|

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       raise OSM::APIBadUserInput, "No users were given to search for" if ids.empty?
 
-      @users = User.visible.where(:id => ids)
+      @users = User.visible.where(:id => ids).order(:id)
 
       # Render the result
       respond_to do |format|

--- a/app/views/api/users/index.xml.builder
+++ b/app/views/api/users/index.xml.builder
@@ -1,4 +1,4 @@
 xml.instruct! :xml, :version => "1.0"
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << render(@users)
+  osm << (render(@users) || "")
 end

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -419,13 +419,15 @@ module Api
       check_json_details(js["users"][1], user3, false, false)
 
       get api_users_path, :params => { :users => create(:user, :suspended).id }
-      assert_response :not_found
+      assert_response :success
 
       get api_users_path, :params => { :users => create(:user, :deleted).id }
-      assert_response :not_found
+      assert_response :success
 
       get api_users_path, :params => { :users => 0 }
-      assert_response :not_found
+      assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
     end
 
     def test_index_oauth1
@@ -506,13 +508,15 @@ module Api
       check_json_details(js["users"][1], user3, false, false)
 
       signed_get api_users_path, :params => { :users => create(:user, :suspended).id }, :oauth => { :token => good_token }
-      assert_response :not_found
+      assert_response :success
 
       signed_get api_users_path, :params => { :users => create(:user, :deleted).id }, :oauth => { :token => good_token }
-      assert_response :not_found
+      assert_response :success
 
       signed_get api_users_path, :params => { :users => 0 }, :oauth => { :token => good_token }
-      assert_response :not_found
+      assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
     end
 
     def test_index_oauth2
@@ -593,13 +597,15 @@ module Api
       check_json_details(js["users"][1], user3, false, false)
 
       get api_users_path, :params => { :users => create(:user, :suspended).id }, :headers => bearer_authorization_header(good_token.token)
-      assert_response :not_found
+      assert_response :success
 
       get api_users_path, :params => { :users => create(:user, :deleted).id }, :headers => bearer_authorization_header(good_token.token)
-      assert_response :not_found
+      assert_response :success
 
       get api_users_path, :params => { :users => 0 }, :headers => bearer_authorization_header(good_token.token)
-      assert_response :not_found
+      assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
     end
 
     def test_gpx_files

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -420,9 +420,13 @@ module Api
 
       get api_users_path, :params => { :users => create(:user, :suspended).id }
       assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
 
       get api_users_path, :params => { :users => create(:user, :deleted).id }
       assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
 
       get api_users_path, :params => { :users => 0 }
       assert_response :success
@@ -509,9 +513,13 @@ module Api
 
       signed_get api_users_path, :params => { :users => create(:user, :suspended).id }, :oauth => { :token => good_token }
       assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
 
       signed_get api_users_path, :params => { :users => create(:user, :deleted).id }, :oauth => { :token => good_token }
       assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
 
       signed_get api_users_path, :params => { :users => 0 }, :oauth => { :token => good_token }
       assert_response :success
@@ -598,9 +606,13 @@ module Api
 
       get api_users_path, :params => { :users => create(:user, :suspended).id }, :headers => bearer_authorization_header(good_token.token)
       assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
 
       get api_users_path, :params => { :users => create(:user, :deleted).id }, :headers => bearer_authorization_header(good_token.token)
       assert_response :success
+      assert_equal "application/xml", response.media_type
+      assert_select "user", :count => 0
 
       get api_users_path, :params => { :users => 0 }, :headers => bearer_authorization_header(good_token.token)
       assert_response :success


### PR DESCRIPTION
When using the Users API to find a set of specific users by their ids and including an id of a user that deleted their account in this set, the request will currently fail with a 404
For example requesting the details of the users with the ids `18597840` **and** `185978900` [fails with a 404](https://www.openstreetmap.org/api/0.6/users?users=18597840,185978900) whereas limiting the query to user `18597840` returns the [correct result](https://www.openstreetmap.org/api/0.6/users?users=18597840)
This happens because user `185978900` deleted their account and `find()` raises an `ActiveRecord::RecordNotFound` "If one or more records cannot be found for the requested ids". <sup><a href="https://api.rubyonrails.org/v7.0.7.2/classes/ActiveRecord/FinderMethods.html#method-i-find">1</a></sup>

Using `where()` to find the users by their ids does not result in an error being raised if (at least) one of the records could not be found.
I also added a fallback for rendering the XML in case no user was found at all (because `@users` is nil in that case which can not be converted to a String)