### PR TITLE
Restore original users index method; add search method for multi fetch

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -14,7 +14,7 @@ class ApiAbility
       can [:show, :download, :query], Changeset
       can [:index, :create, :comment, :feed, :show, :search], Note
       can :index, Tracepoint
-      can [:index, :show], User
+      can [:index, :search, :show], User
       can [:index, :show], Node
       can [:index, :show, :full, :ways_for_node], Way
       can [:index, :show, :full, :relations_for_node, :relations_for_way, :relations_for_relation], Relation

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -19,12 +19,28 @@ module Api
 
       raise OSM::APIBadUserInput, "No users were given to search for" if ids.empty?
 
-      @users = User.visible.where(:id => ids).in_order_of(:id, ids)
+      @users = User.visible.find(ids)
 
       # Render the result
       respond_to do |format|
         format.xml
         format.json
+      end
+    end
+
+    def search
+      raise OSM::APIBadUserInput, "The parameter users is required, and must be of the form users=id[,id[,id...]]" unless params["users"]
+
+      ids = params["users"].split(",").collect(&:to_i)
+
+      raise OSM::APIBadUserInput, "No users were given to search for" if ids.empty?
+
+      @users = User.visible.where(:id => ids)
+
+      # Render the result
+      respond_to do |format|
+        format.xml { render :action => :index }
+        format.json { render :action => :index }
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ OpenStreetMap::Application.routes.draw do
     get "user/details" => "api/users#details"
     get "user/gpx_files" => "api/users#gpx_files"
     get "users" => "api/users#index", :as => :api_users
+    get "users/search" => "api/users#search", :as => :api_users_search
 
     resources :user_preferences, :except => [:new, :create, :edit], :param => :preference_key, :path => "user/preferences", :controller => "api/user_preferences" do
       collection do


### PR DESCRIPTION
Do this https://github.com/openstreetmap/openstreetmap-website/commit/b9c85c269726faad3c2613b37f01683c8b59f5c6#commitcomment-125595007 to avoid changing the existing api behavior.

Add a users search endpoint '/api/0.6/users/search.json?users=1,2,3' that doesn't responds with an error if some users don't exist.

Currently the `users` parameter is required, this is to be relaxed later.
Currently the results order is unspecified, this is to be specified later, probably by date.