### PR TITLE
Avoid using _id in queries

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -325,7 +325,7 @@ module Api
           raise OSM::APINotFoundError if current_user.nil? || current_user != u
         end
 
-        changesets.where(:user_id => u.id)
+        changesets.where(:user => u)
       end
     end
 

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -251,7 +251,7 @@ module Api
       end
 
       # Find the comments we want to return
-      @comments = NoteComment.where(:note_id => notes).order("created_at DESC").limit(result_limit).preload(:note)
+      @comments = NoteComment.where(:note => notes).order("created_at DESC").limit(result_limit).preload(:note)
 
       # Render the result
       respond_to do |format|

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -48,16 +48,16 @@ class ChangesetsController < ApplicationController
 
       if @params[:display_name]
         changesets = if user.data_public? || user == current_user
-                       changesets.where(:user_id => user.id)
+                       changesets.where(:user => user)
                      else
                        changesets.where("false")
                      end
       elsif @params[:bbox]
         changesets = conditions_bbox(changesets, BoundingBox.from_bbox_params(params))
       elsif @params[:friends] && current_user
-        changesets = changesets.where(:user_id => current_user.friends.identifiable)
+        changesets = changesets.where(:user => current_user.friends.identifiable)
       elsif @params[:nearby] && current_user
-        changesets = changesets.where(:user_id => current_user.nearby)
+        changesets = changesets.where(:user => current_user.nearby)
       end
 
       changesets = changesets.where("changesets.id <= ?", @params[:max_id]) if @params[:max_id]

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -27,7 +27,7 @@ class DiaryEntriesController < ApplicationController
     elsif params[:friends]
       if current_user
         @title = t ".title_friends"
-        entries = DiaryEntry.where(:user_id => current_user.friends)
+        entries = DiaryEntry.where(:user => current_user.friends)
       else
         require_user
         return
@@ -35,7 +35,7 @@ class DiaryEntriesController < ApplicationController
     elsif params[:nearby]
       if current_user
         @title = t ".title_nearby"
-        entries = DiaryEntry.where(:user_id => current_user.nearby)
+        entries = DiaryEntry.where(:user => current_user.nearby)
       else
         require_user
         return

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -24,7 +24,7 @@ class IssuesController < ApplicationController
     if params[:search_by_user].present?
       @find_user = User.find_by(:display_name => params[:search_by_user])
       if @find_user
-        @issues = @issues.where(:reported_user_id => @find_user.id)
+        @issues = @issues.where(:reported_user => @find_user)
       else
         @issues = @issues.none
         flash.now[:warning] = t(".user_not_found")

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -22,7 +22,7 @@ class UserRolesController < ApplicationController
     if current_user == @user && @role == "administrator"
       flash[:error] = t("user_role.filter.not_revoke_admin_current_user")
     else
-      UserRole.where(:user_id => @user.id, :role => @role).delete_all
+      UserRole.where(:user => @user, :role => @role).delete_all
     end
     redirect_to user_path(@user)
   end

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -170,7 +170,7 @@ class Changeset < ApplicationRecord
       save!
 
       tags = self.tags
-      ChangesetTag.where(:changeset_id => id).delete_all
+      ChangesetTag.where(:changeset => id).delete_all
 
       tags.each do |k, v|
         tag = ChangesetTag.new

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -209,7 +209,7 @@ class Trace < ApplicationRecord
       first = true
 
       # If there are any existing points for this trace then delete them
-      Tracepoint.where(:gpx_id => id).delete_all
+      Tracepoint.where(:trace => id).delete_all
 
       gpx.points.each_slice(1_000) do |points|
         # Gather the trace points together for a bulk import
@@ -242,10 +242,10 @@ class Trace < ApplicationRecord
       end
 
       if gpx.actual_points.positive?
-        max_lat = Tracepoint.where(:gpx_id => id).maximum(:latitude)
-        min_lat = Tracepoint.where(:gpx_id => id).minimum(:latitude)
-        max_lon = Tracepoint.where(:gpx_id => id).maximum(:longitude)
-        min_lon = Tracepoint.where(:gpx_id => id).minimum(:longitude)
+        max_lat = Tracepoint.where(:trace => id).maximum(:latitude)
+        min_lat = Tracepoint.where(:trace => id).minimum(:latitude)
+        max_lon = Tracepoint.where(:trace => id).maximum(:longitude)
+        min_lon = Tracepoint.where(:trace => id).minimum(:longitude)
 
         max_lat = max_lat.to_f / 10000000
         min_lat = min_lat.to_f / 10000000

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -164,7 +164,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template :new
 
-    assert_nil UserPreference.where(:user_id => user.id, :k => "diary.default_language").first
+    assert_nil UserPreference.where(:user => user, :k => "diary.default_language").first
   end
 
   def test_create
@@ -189,7 +189,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # checks if user was subscribed
     assert_equal 1, entry.subscribers.length
 
-    assert_equal "en", UserPreference.where(:user_id => user.id, :k => "diary.default_language").first.v
+    assert_equal "en", UserPreference.where(:user => user, :k => "diary.default_language").first.v
   end
 
   def test_create_german
@@ -216,7 +216,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # checks if user was subscribed
     assert_equal 1, entry.subscribers.length
 
-    assert_equal "de", UserPreference.where(:user_id => user.id, :k => "diary.default_language").first.v
+    assert_equal "de", UserPreference.where(:user => user, :k => "diary.default_language").first.v
   end
 
   def test_new_spammy

--- a/test/models/trace_test.rb
+++ b/test/models/trace_test.rb
@@ -193,16 +193,16 @@ class TraceTest < ActiveSupport::TestCase
 
   def test_import_creates_tracepoints
     trace = create(:trace, :fixture => "a")
-    assert_equal 0, Tracepoint.where(:gpx_id => trace.id).count
+    assert_equal 0, Tracepoint.where(:trace => trace).count
 
     trace.import
 
     trace.reload
-    assert_equal 1, Tracepoint.where(:gpx_id => trace.id).count
+    assert_equal 1, Tracepoint.where(:trace => trace).count
 
     # Check that the tile has been set prior to the bulk import
     # i.e. that the callbacks have been run correctly
-    assert_equal 3221331576, Tracepoint.where(:gpx_id => trace.id).first.tile
+    assert_equal 3221331576, Tracepoint.where(:trace => trace).first.tile
   end
 
   def test_import_creates_icon


### PR DESCRIPTION
This PR refactors some database queries, to avoid using `_id` and use the relation names instead. Generally this involves changing `.where(user_id => u.id)` to `.where(user => u)` or similar. Sometimes the relation name is quite different from the underlying column (e.g. `gpx_id` => `trace`).

Rails is pretty forgiving on whether you pass in an id or an object, so sometimes there's nothing to change on the right hand side.