### PR TITLE
Address review comments for changeset comment limiting

### DIFF
--- a/app/controllers/api/changeset_comments_controller.rb
+++ b/app/controllers/api/changeset_comments_controller.rb
@@ -17,7 +17,7 @@ module Api
       # Check the arguments are sane
       raise OSM::APIBadUserInput, "No id was given" unless params[:id]
       raise OSM::APIBadUserInput, "No text was given" if params[:text].blank?
-      raise OSM::APIRateLimitExceeded if current_user.changeset_comments.where("created_at >= ?", Time.now.utc - 1.hour).count >= current_user.max_changeset_comments_per_hour
+      raise OSM::APIRateLimitExceeded if rate_limit_exceeded?
 
       # Extract the arguments
       id = params[:id].to_i
@@ -98,6 +98,16 @@ module Api
         format.xml
         format.json
       end
+    end
+
+    private
+
+    ##
+    # Check if the current user has exceed the rate limit for comments
+    def rate_limit_exceeded?
+      recent_comments = current_user.changeset_comments.where("created_at >= ?", Time.now.utc - 1.hour).count
+
+      recent_comments >= current_user.max_changeset_comments_per_hour
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -397,14 +397,14 @@ class User < ApplicationRecord
 
   def max_changeset_comments_per_hour
     if moderator?
-      36000
+      Settings.moderator_changeset_comments_per_hour
     else
       previous_comments = changeset_comments.limit(200).count
       active_reports = issues.with_status(:open).sum(:reports_count)
       max_comments = previous_comments / 200.0 * Settings.max_changeset_comments_per_hour
-      max_comments = max_comments.floor.clamp(Settings.min_changeset_comments_per_hour, Settings.max_changeset_comments_per_hour)
+      max_comments = max_comments.floor.clamp(Settings.initial_changeset_comments_per_hour, Settings.max_changeset_comments_per_hour)
       max_comments /= 2**active_reports
-      max_comments.floor.clamp(1, Settings.max_changeset_comments_per_hour)
+      max_comments.floor.clamp(Settings.min_changeset_comments_per_hour, Settings.max_changeset_comments_per_hour)
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,8 +56,10 @@ max_messages_per_hour: 60
 # Rate limit for friending
 max_friends_per_hour: 60
 # Rate limit for changeset comments
-min_changeset_comments_per_hour: 6
+min_changeset_comments_per_hour: 1
+initial_changeset_comments_per_hour: 6
 max_changeset_comments_per_hour: 60
+moderator_changeset_comments_per_hour: 36000
 # Domain for handling message replies
 #messages_domain: "messages.openstreetmap.org"
 # MaxMind GeoIPv2 database

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -19,3 +19,6 @@ avatar_storage: "test"
 trace_file_storage: "test"
 trace_image_storage: "test"
 trace_icon_storage: "test"
+# Lower some rate limits for testing
+max_changeset_comments_per_hour: 30
+moderator_changeset_comments_per_hour: 60

--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -140,8 +140,8 @@ module Api
 
       auth_header = basic_authorization_header user.email, "test"
 
-      assert_difference "ChangesetComment.count", Settings.min_changeset_comments_per_hour do
-        1.upto(Settings.min_changeset_comments_per_hour) do |count|
+      assert_difference "ChangesetComment.count", Settings.initial_changeset_comments_per_hour do
+        1.upto(Settings.initial_changeset_comments_per_hour) do |count|
           post changeset_comment_path(:id => changeset, :text => "Comment #{count}"), :headers => auth_header
           assert_response :success
         end

--- a/test/factories/issues.rb
+++ b/test/factories/issues.rb
@@ -6,5 +6,16 @@ FactoryBot.define do
 
     # Default to assigning to an administrator
     assigned_role { "administrator" }
+
+    # Optionally create some reports for this issue
+    factory :issue_with_reports do
+      transient do
+        reports_count { 1 }
+      end
+
+      after(:create) do |issue, evaluator|
+        create_list(:report, evaluator.reports_count, :issue => issue)
+      end
+    end
   end
 end


### PR DESCRIPTION
This aims to address the review comments from #4202 which was already merged.

It mostly makes the request changes - one different is that I went with `initial` rather than `default` as the new name for the starting limit as default seemed confusing when it's only the default for a new user.