### PR TITLE
Use bootstrap badges to implement count-number badges

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -204,18 +204,7 @@ nav.secondary {
   }
 
   #inboxanchor {
-    display: inline-block;
-    height: 25px;
-    margin: 3px 0 3px 3px;
     background-color: lighten($grey, 10%);
-    line-height: 20px;
-    border-radius: 3;
-  }
-
-  .dropdown-menu {
-    .count-number {
-      font-size: 14px;
-    }
   }
 }
 
@@ -329,12 +318,9 @@ body.small-nav {
 /* Utility for styling notification numbers */
 
 .count-number {
-  padding: 2px $lineheight/4;
-  border-radius: 2px;
   background: lighten($green, 30%);
-  margin: 0 2px;
-  font-size: 11px;
-  color: #333;
+  color: $gray-800;
+  font-weight: $font-weight-normal;
 }
 
 /* Rules for the message shown in place of the map when javascript is disabled */

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -28,9 +28,9 @@ module IssuesHelper
   def open_issues_count
     count = Issue.visible_to(current_user).open.limit(100).size
     if count > 99
-      tag.span("99+", :class => "count-number")
+      tag.span("99+", :class => "badge count-number")
     elsif count.positive?
-      tag.span(count, :class => "count-number")
+      tag.span(count, :class => "badge count-number")
     end
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -97,7 +97,7 @@
           <%= link_to t("users.show.my_dashboard"), dashboard_path, :class => "dropdown-item" %>
           <%= link_to inbox_messages_path, :class => "dropdown-item" do %>
             <%= t("users.show.my messages") %>
-            <span class='count-number'><%= number_with_delimiter(current_user.new_messages.size) %></span>
+            <span class='badge count-number'><%= number_with_delimiter(current_user.new_messages.size) %></span>
           <% end %>
           <%= link_to t("users.show.my profile"), user_path(current_user), :class => "dropdown-item" %>
           <%= link_to t("users.show.my settings"), edit_account_path, :class => "dropdown-item" %>

--- a/app/views/layouts/_inbox.html.erb
+++ b/app/views/layouts/_inbox.html.erb
@@ -1,3 +1,3 @@
 <% if current_user.new_messages.size > 0 %>
-<span id="inboxanchor" class="count-number"><%= current_user.new_messages.size %></span>
+<span id="inboxanchor" class="badge count-number m-1"><%= current_user.new_messages.size %></span>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,18 +11,18 @@
           <ul class='clearfix'>
             <li>
               <%= link_to t(".my edits"), :controller => "changesets", :action => "index", :display_name => current_user.display_name %>
-              <span class='count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
+              <span class='badge count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
             </li>
             <li>
               <%= link_to t(".my notes"), user_notes_path(@user) %>
             </li>
             <li>
               <%= link_to t(".my traces"), :controller => "traces", :action => "mine" %>
-              <span class='count-number'><%= number_with_delimiter(current_user.traces.size) %></span>
+              <span class='badge count-number'><%= number_with_delimiter(current_user.traces.size) %></span>
             </li>
             <li>
               <%= link_to t(".my diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %>
-              <span class='count-number'><%= number_with_delimiter(current_user.diary_entries.size) %></span>
+              <span class='badge count-number'><%= number_with_delimiter(current_user.diary_entries.size) %></span>
             </li>
             <li>
               <%= link_to t(".my comments"), diary_comments_path(current_user) %>
@@ -34,14 +34,14 @@
             <% if current_user.blocks.exists? %>
               <li>
                 <%= link_to t(".blocks on me"), user_blocks_on_path(current_user) %>
-                <span class='count-number'><%= number_with_delimiter(current_user.blocks.active.size) %></span>
+                <span class='badge count-number'><%= number_with_delimiter(current_user.blocks.active.size) %></span>
               </li>
             <% end %>
 
             <% if can?(:create, UserBlock) and current_user.blocks_created.exists? %>
               <li>
                 <%= link_to t(".blocks by me"), user_blocks_by_path(current_user) %>
-                <span class='count-number'><%= number_with_delimiter(current_user.blocks_created.active.size) %></span>
+                <span class='badge count-number'><%= number_with_delimiter(current_user.blocks_created.active.size) %></span>
               </li>
             <% end %>
 
@@ -55,14 +55,14 @@
 
             <li>
               <%= link_to t(".edits"), :controller => "changesets", :action => "index", :display_name => @user.display_name %>
-              <span class='count-number'><%= number_with_delimiter(@user.changesets.size) %></span>
+              <span class='badge count-number'><%= number_with_delimiter(@user.changesets.size) %></span>
             </li>
             <li>
               <%= link_to t(".notes"), user_notes_path(@user) %>
             </li>
             <li>
               <%= link_to t(".traces"), :controller => "traces", :action => "index", :display_name => @user.display_name %>
-              <span class='count-number'><%= number_with_delimiter(@user.traces.size) %></span>
+              <span class='badge count-number'><%= number_with_delimiter(@user.traces.size) %></span>
             </li>
 
             <!-- Displaying another user's profile page -->
@@ -72,7 +72,7 @@
             </li>
             <li>
               <%= link_to t(".diary"), :controller => "diary_entries", :action => "index", :display_name => @user.display_name %>
-              <span class='count-number'><%= number_with_delimiter(@user.diary_entries.size) %></span>
+              <span class='badge count-number'><%= number_with_delimiter(@user.diary_entries.size) %></span>
             </li>
             <li>
               <%= link_to t(".comments"), diary_comments_path(@user) %>
@@ -90,14 +90,14 @@
             <% if @user.blocks.exists? %>
               <li>
                 <%= link_to t(".block_history"), user_blocks_on_path(@user) %>
-                <span class='count-number'><%= number_with_delimiter(@user.blocks.active.size) %></span>
+                <span class='badge count-number'><%= number_with_delimiter(@user.blocks.active.size) %></span>
               </li>
             <% end %>
 
             <% if @user.moderator? and @user.blocks_created.exists? %>
               <li>
                 <%= link_to t(".moderator_history"), user_blocks_by_path(@user) %>
-                <span class='count-number'><%= number_with_delimiter(@user.blocks_created.active.size) %></span>
+                <span class='badge count-number'><%= number_with_delimiter(@user.blocks_created.active.size) %></span>
               </li>
             <% end %>
 


### PR DESCRIPTION
This leaves bootstrap to take care of most aspects of the badge, while retaining the current colours and font weights.

This is the first PR in a wider project to remove our use of the Sass '/' division operator, which is deprecated and will be removed in future: https://sass-lang.com/documentation/breaking-changes/slash-div/ . All of our use of '/' division is in old custom CSS code, so my aim is to replace the code with bootstrap alternatives when possible.