### PR TITLE
Add notes feed description for unspecified area

### DIFF
--- a/app/views/api/notes/feed.rss.builder
+++ b/app/views/api/notes/feed.rss.builder
@@ -6,7 +6,11 @@ xml.rss("version" => "2.0",
         "xmlns:georss" => "http://www.georss.org/georss") do
   xml.channel do
     xml.title t("api.notes.rss.title")
-    xml.description t("api.notes.rss.description_area", :min_lat => @min_lat, :min_lon => @min_lon, :max_lat => @max_lat, :max_lon => @max_lon)
+    if @min_lat.nil? && @min_lon.nil? && @max_lat.nil? && @max_lon.nil?
+      xml.description t("api.notes.rss.description_all")
+    else
+      xml.description t("api.notes.rss.description_area", :min_lat => @min_lat, :min_lon => @min_lon, :max_lat => @max_lat, :max_lon => @max_lon)
+    end
     xml.link url_for(:controller => "/site", :action => "index", :only_path => false)
 
     @comments.each do |comment|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,6 +228,7 @@ en:
         reopened_at_by_html: "Reactivated %{when} by %{user}"
       rss:
         title: "OpenStreetMap Notes"
+        description_all: "A list of reported, commented on or closed notes"
         description_area: "A list of notes, reported, commented on or closed in your area [(%{min_lat}|%{min_lon}) -- (%{max_lat}|%{max_lon})]"
         description_item: "An rss feed for note %{id}"
         opened: "new note (near %{place})"


### PR DESCRIPTION
You can get a feed of notes unrestricted by any bounding box: https://api.openstreetmap.org/api/0.6/notes/feed

It's not entirely clear if this is planned. The query runs rather slow, the [wiki](https://wiki.openstreetmap.org/wiki/API_v0.6#RSS_Feed:_GET_/api/0.6/notes/feed) shows `bbox` as required, but the requirement was dropped more than ten years ago.

If it is supposed to work, the description element in the feed is going to look strange. It refers to an area and has slots for bounding box lat/lon, but since the area is undefined, the slots are empty:

    <description>A list of notes, reported, commented on or closed in your area [(|) -- (|)]</description>

This PR adds another description string for feeds of all notes without area restrictions.