### PR TITLE
Move email-related methods to mixin

### DIFF
--- a/app/controllers/concerns/email_methods.rb
+++ b/app/controllers/concerns/email_methods.rb
@@ -1,0 +1,27 @@
+module EmailMethods
+  extend ActiveSupport::Concern
+
+  private
+
+  def canonical_email(email)
+    local_part, domain = if email.nil?
+                           nil
+                         else
+                           email.split("@")
+                         end
+
+    local_part.sub!(/\+.*$/, "")
+
+    local_part.delete!(".") if %w[gmail.com googlemail.com].include?(domain)
+
+    "#{local_part}@#{domain}"
+  end
+
+  ##
+  # get list of MX servers for a domains
+  def domain_mx_servers(domain)
+    Resolv::DNS.open do |dns|
+      dns.getresources(domain, Resolv::DNS::Resource::IN::MX).collect { |mx| mx.exchange.to_s }
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  include EmailMethods
   include SessionMethods
   include UserMethods
 
@@ -360,27 +361,5 @@ class UsersController < ApplicationController
     end
 
     !blocked
-  end
-
-  def canonical_email(email)
-    local_part, domain = if email.nil?
-                           nil
-                         else
-                           email.split("@")
-                         end
-
-    local_part.sub!(/\+.*$/, "")
-
-    local_part.delete!(".") if %w[gmail.com googlemail.com].include?(domain)
-
-    "#{local_part}@#{domain}"
-  end
-
-  ##
-  # get list of MX servers for a domains
-  def domain_mx_servers(domain)
-    Resolv::DNS.open do |dns|
-      dns.getresources(domain, Resolv::DNS::Resource::IN::MX).collect { |mx| mx.exchange.to_s }
-    end
   end
 end


### PR DESCRIPTION
The methods are not directly related to users.

Rubocop complains about users controller being too large.