### PR TITLE
Disallow username changes to user_n if n isn't their id

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -61,7 +61,7 @@ Metrics/BlockNesting:
 # Offense count: 26
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 299
+  Max: 305
 
 # Offense count: 59
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,7 +99,7 @@ class User < ApplicationRecord
   validates :display_name, :if => proc { |u| u.display_name_changed? },
                            :characters => { :url_safe => true },
                            :whitespace => { :leading => false, :trailing => false }
-  validate :display_name_cannot_be_user_id_with_other_id
+  validate :display_name_cannot_be_user_id_with_other_id, :if => proc { |u| u.display_name_changed? }
   validates :email, :presence => true, :confirmation => true, :characters => true
   validates :email, :if => proc { |u| u.email_changed? },
                     :uniqueness => { :case_sensitive => false }
@@ -126,7 +126,7 @@ class User < ApplicationRecord
   after_save :spam_check
 
   def display_name_cannot_be_user_id_with_other_id
-    display_name_changed? && display_name&.match(/^user_(\d+)$/i) do |m|
+    display_name&.match(/^user_(\d+)$/i) do |m|
       errors.add :display_name, I18n.t("activerecord.errors.messages.display_name_is_user_n") unless m[1].to_i == id
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,6 +99,7 @@ class User < ApplicationRecord
   validates :display_name, :if => proc { |u| u.display_name_changed? },
                            :characters => { :url_safe => true },
                            :whitespace => { :leading => false, :trailing => false }
+  validate :display_name_cannot_be_user_id_with_other_id
   validates :email, :presence => true, :confirmation => true, :characters => true
   validates :email, :if => proc { |u| u.email_changed? },
                     :uniqueness => { :case_sensitive => false }
@@ -123,6 +124,12 @@ class User < ApplicationRecord
   before_save :encrypt_password
   before_save :update_tile
   after_save :spam_check
+
+  def display_name_cannot_be_user_id_with_other_id
+    display_name_changed? && display_name&.match(/^user_(\d+)$/i) do |m|
+      errors.add :display_name, I18n.t("activerecord.errors.messages.display_name_is_user_n") unless m[1].to_i == id
+    end
+  end
 
   def to_param
     display_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
       messages:
         invalid_email_address: does not appear to be a valid e-mail address
         email_address_not_routable: is not routable
+        display_name_is_user_n: can't be user_n unless n is your user id
       models:
         user_mute:
           attributes:

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -91,6 +91,28 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  def test_display_name_user_id_new
+    existing_user = create(:user)
+    user = build(:user)
+
+    user.display_name = "user_#{existing_user.id}"
+    assert_not user.valid?, "user_<id> name is valid for existing user id when it shouldn't be"
+
+    user.display_name = "user_#{existing_user.id + 1}"
+    assert_not user.valid?, "user_<id> name is valid for new user id when it shouldn't be"
+  end
+
+  def test_display_name_user_id_rename
+    existing_user = create(:user)
+    user = create(:user)
+
+    user.display_name = "user_#{existing_user.id}"
+    assert_not user.valid?, "user_<id> name is valid for existing user id when it shouldn't be"
+
+    user.display_name = "user_#{user.id}"
+    assert_predicate user, :valid?, "user_<id> name is invalid for own id, when it should be"
+  end
+
   def test_friends_with
     alice = create(:user, :active)
     bob = create(:user, :active)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -113,6 +113,14 @@ class UserTest < ActiveSupport::TestCase
     assert_predicate user, :valid?, "user_<id> name is invalid for own id, when it should be"
   end
 
+  def test_display_name_user_id_unchanged_is_valid
+    user = build(:user, :display_name => "user_0")
+    user.save(:validate => false)
+    user.reload
+
+    assert_predicate user, :valid?, "user_0 display_name is invalid but it hasn't been changed"
+  end
+
   def test_friends_with
     alice = create(:user, :active)
     bob = create(:user, :active)


### PR DESCRIPTION
In case you don't want #4215, there's already a defacto url scheme with user ids: `/user/user_id`. That's what deleted accounts get reset to. But it has a couple of problems. "user_12345" is a valid username for anyone, not just the user with id=12345. Depending on how many usernames with this pattern already exist, we may want to stop allowing new ones.

I know one active user with this kind of name, but it matches their id.