### PR TITLE
Check required bbox parameter presence outside of BoundingBox class

### DIFF
--- a/app/controllers/api/map_controller.rb
+++ b/app/controllers/api/map_controller.rb
@@ -22,6 +22,8 @@ module Api
       # check boundary is sane and area within defined
       # see /config/application.yml
       begin
+        raise OSM::APIBadUserInput, "The parameter bbox is required" unless params[:bbox]
+
         @bounds = BoundingBox.from_bbox_params(params)
         @bounds.check_boundaries
         @bounds.check_size

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -18,13 +18,10 @@ module Api
       # support the old, deprecated, method with four arguments
       if params[:bbox]
         bbox = BoundingBox.from_bbox_params(params)
-      else
-        raise OSM::APIBadUserInput, "No l was given" unless params[:l]
-        raise OSM::APIBadUserInput, "No r was given" unless params[:r]
-        raise OSM::APIBadUserInput, "No b was given" unless params[:b]
-        raise OSM::APIBadUserInput, "No t was given" unless params[:t]
-
+      elsif params[:l] && params[:r] && params[:b] && params[:t]
         bbox = BoundingBox.from_lrbt_params(params)
+      else
+        raise OSM::APIBadUserInput, "The parameter bbox is required"
       end
 
       # Get any conditions that need to be applied

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -23,6 +23,8 @@ module Api
       # check boundary is sane and area within defined
       # see /config/application.yml
       begin
+        raise OSM::APIBadUserInput, "The parameter bbox is required" unless params[:bbox]
+
         bbox = BoundingBox.from_bbox_params(params)
         bbox.check_boundaries
         bbox.check_size

--- a/lib/bounding_box.rb
+++ b/lib/bounding_box.rb
@@ -157,7 +157,7 @@ class BoundingBox
     private
 
     def from_bbox_array(bbox_array)
-      raise OSM::APIBadUserInput, "The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat" unless bbox_array
+      raise OSM::APIBadUserInput, "The parameter bbox must be of the form min_lon,min_lat,max_lon,max_lat" unless bbox_array
 
       # Take an array of length 4, create a bounding box with min_lon, min_lat, max_lon and
       # max_lat within their respective boundaries.

--- a/test/controllers/api/map_controller_test.rb
+++ b/test/controllers/api/map_controller_test.rb
@@ -278,7 +278,7 @@ module Api
     def test_map_without_bbox
       get map_path
       assert_response :bad_request
-      assert_equal "The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat", @response.body, "A bbox param was expected"
+      assert_equal "The parameter bbox is required", @response.body, "A bbox param was expected"
     end
 
     def test_bbox_too_big
@@ -293,7 +293,7 @@ module Api
       @badmalformedbbox.each do |bbox|
         get map_path(:bbox => bbox)
         assert_response :bad_request, "The bbox:#{bbox} was expected to be malformed"
-        assert_equal "The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat", @response.body, "bbox: #{bbox}"
+        assert_equal "The parameter bbox must be of the form min_lon,min_lat,max_lon,max_lat", @response.body, "bbox: #{bbox}"
       end
     end
 

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -786,6 +786,10 @@ module Api
     end
 
     def test_index_bad_params
+      get api_notes_path
+      assert_response :bad_request
+      assert_equal "The parameter bbox is required", @response.body
+
       get api_notes_path(:bbox => "-2.5,-2.5,2.5")
       assert_response :bad_request
 

--- a/test/controllers/api/tracepoints_controller_test.rb
+++ b/test/controllers/api/tracepoints_controller_test.rb
@@ -102,7 +102,7 @@ module Api
     def test_index_without_bbox
       get trackpoints_path
       assert_response :bad_request
-      assert_equal "The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat", @response.body, "A bbox param was expected"
+      assert_equal "The parameter bbox is required", @response.body, "A bbox param was expected"
     end
 
     def test_traces_page_less_than_zero
@@ -129,7 +129,7 @@ module Api
       @badmalformedbbox.each do |bbox|
         get trackpoints_path(:bbox => bbox)
         assert_response :bad_request, "The bbox:#{bbox} was expected to be malformed"
-        assert_equal "The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat", @response.body, "bbox: #{bbox}"
+        assert_equal "The parameter bbox must be of the form min_lon,min_lat,max_lon,max_lat", @response.body, "bbox: #{bbox}"
       end
     end
 

--- a/test/lib/bounding_box_test.rb
+++ b/test/lib/bounding_box_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class BoundingBoxTest < ActiveSupport::TestCase
   def setup
     @size_error_message = "The maximum bbox size is 0.25, and your request was too large. Either request a smaller area, or use planet.osm"
-    @malformed_error_message = "The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat"
+    @malformed_error_message = "The parameter bbox must be of the form min_lon,min_lat,max_lon,max_lat"
     @lon_order_error_message = "The minimum longitude must be less than the maximum longitude, but it wasn't"
     @lat_order_error_message = "The minimum latitude must be less than the maximum latitude, but it wasn't"
     @bbox_out_of_limits_error_message = "The latitudes must be between -90.0 and 90.0, and longitudes between -180.0 and 180.0"


### PR DESCRIPTION
The `bbox` parameter is not always required when it can be used (#4214, api changesets query). But the error message inside BoundingBox reads that it is: "The parameter bbox is required, and must be of the form min_lon,min_lat,max_lon,max_lat".

We can check if `bbox` is present before calling a bbox constructor, and write a different error message when necessary.