### PR TITLE
Add bbox parameter to notes search api

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -235,20 +235,7 @@ module Api
     def feed
       # Get any conditions that need to be applied
       notes = closed_condition(Note.all)
-
-      # Process any bbox
-      if params[:bbox]
-        bbox = BoundingBox.from_bbox_params(params)
-
-        bbox.check_boundaries
-        bbox.check_size(Settings.max_note_request_area)
-
-        notes = notes.bbox(bbox)
-        @min_lon = bbox.min_lon
-        @min_lat = bbox.min_lat
-        @max_lon = bbox.max_lon
-        @max_lat = bbox.max_lat
-      end
+      notes = bbox_condition(notes)
 
       # Find the comments we want to return
       @comments = NoteComment.where(:note => notes)
@@ -266,6 +253,7 @@ module Api
     def search
       # Get the initial set of notes
       @notes = closed_condition(Note.all)
+      @notes = bbox_condition(@notes)
 
       # Add any user filter
       if params[:display_name] || params[:user]
@@ -375,6 +363,27 @@ module Api
                       .where(notes.arel_table[:closed_at].gt(Time.now.utc - closed_since)))
       else
         notes.where(:status => "open")
+      end
+    end
+
+    ##
+    # Generate a condition to choose which notes we want based
+    # on the user's bounding box request parameters
+    def bbox_condition(notes)
+      if params[:bbox]
+        bbox = BoundingBox.from_bbox_params(params)
+
+        bbox.check_boundaries
+        bbox.check_size(Settings.max_note_request_area)
+
+        @min_lon = bbox.min_lon
+        @min_lat = bbox.min_lat
+        @max_lon = bbox.max_lon
+        @max_lat = bbox.max_lat
+
+        notes.bbox(bbox)
+      else
+        notes
       end
     end
 

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -927,6 +927,28 @@ module Api
       end
     end
 
+    def test_search_by_bbox_success
+      notes = Array.new(5) do |i|
+        position = ((1.0 + (i * 0.1)) * GeoRecord::SCALE).to_i
+        create(:note_with_comments, :created_at => Time.parse("2020-01-01T00:00:00Z") + i.day, :latitude => position, :longitude => position)
+      end
+
+      get search_api_notes_path(:bbox => "1.0,1.0,1.6,1.6", :sort => "created_at", :order => "oldest", :format => "xml")
+      assert_response :success
+      assert_equal "application/xml", @response.media_type
+      assert_notes_in_order notes
+
+      get search_api_notes_path(:bbox => "1.25,1.25,1.45,1.45", :sort => "created_at", :order => "oldest", :format => "xml")
+      assert_response :success
+      assert_equal "application/xml", @response.media_type
+      assert_notes_in_order [notes[3], notes[4]]
+
+      get search_api_notes_path(:bbox => "2.0,2.0,2.5,2.5", :sort => "created_at", :order => "oldest", :format => "xml")
+      assert_response :success
+      assert_equal "application/xml", @response.media_type
+      assert_notes_in_order []
+    end
+
     def test_search_no_match
       create(:note_with_comments)
 
@@ -1060,6 +1082,15 @@ module Api
 
       get feed_api_notes_path(:bbox => "1,1,1.2,1.2", :limit => Settings.max_note_query_limit + 1, :format => "rss")
       assert_response :bad_request
+    end
+
+    private
+
+    def assert_notes_in_order(notes)
+      assert_select "osm>note", notes.size
+      notes.each_with_index do |note, index|
+        assert_select "osm>note:nth-child(#{index + 1})>id", :text => note.id.to_s, :count => 1
+      end
     end
   end
 end


### PR DESCRIPTION
This is an alternative to #3605.

#3605 adds the time `from`/`to` parameters to the index endpoint that already supports the `bbox`, this PR adds `bbox` to the search that already supports `from`/`to`.

You may want this PR if:

- The index endpoint is to be kept as simple as possible. The index endpoint is probably used more frequently because of the notes layer. Maybe you want to optimize it further, for example, by implementing it in cgimap. In this case the fewer parameters it has, the better.
- Changesets search already supports `bbox`.

For the use case described in #3605 you can switch over from the index endpoint to search if you want to download more notes.