### PR TITLE
Remove unused partial _user.atom.builder

### DIFF
--- a/app/views/changesets/_user.atom.builder
+++ b/app/views/changesets/_user.atom.builder
@@ -1,1 +1,0 @@
-xml.a(user.display_name, :href => url_for(:controller => "users", :action => "view", :display_name => user.display_name))


### PR DESCRIPTION
Added in https://github.com/openstreetmap/openstreetmap-website/commit/e477f68a6c1da16b2b976ff97750a65bbd0e3dd9
Some partials from the same directory removed in https://github.com/openstreetmap/openstreetmap-website/commit/43f52daeaabd5bf5f1c43e181a1f4135364fd0e1
`_user.html.erb` removed in https://github.com/openstreetmap/openstreetmap-website/commit/68a3df4d53c84508bf443058040379c3a18eb1a7 but `_user.atom.builder` was kept