### PR TITLE
Swap older/newer diary entries buttons

### DIFF
--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -38,16 +38,6 @@
 
   <nav>
     <ul class="pagination">
-      <% if @older_entries -%>
-        <li class="page-item">
-          <%= link_to t(".older_entries"), @params.merge(:before => @entries.last.id), :class => "page-link" %>
-        </li>
-      <% else -%>
-        <li class="page-item disabled">
-          <span class="page-link"><%= t(".older_entries") %></span>
-        </li>
-      <% end -%>
-
       <% if @newer_entries -%>
         <li class="page-item">
           <%= link_to t(".newer_entries"), @params.merge(:after => @entries.first.id), :class => "page-link" %>
@@ -55,6 +45,16 @@
       <% else -%>
         <li class="page-item disabled">
           <span class="page-link"><%= t(".newer_entries") %></span>
+        </li>
+      <% end -%>
+
+      <% if @older_entries -%>
+        <li class="page-item">
+          <%= link_to t(".older_entries"), @params.merge(:before => @entries.last.id), :class => "page-link" %>
+        </li>
+      <% else -%>
+        <li class="page-item disabled">
+          <span class="page-link"><%= t(".older_entries") %></span>
         </li>
       <% end -%>
     </ul>

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -568,28 +568,28 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_select "li.page-item.disabled span.page-link", :text => "Newer Entries", :count => 1
 
     # Try and get the second page
-    get css_select("li.page-item a.page-link").first["href"]
+    get css_select("li.page-item .page-link").last["href"]
     assert_response :success
     assert_select "article.diary_post", :count => 20
     assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
     assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
 
     # Try and get the third page
-    get css_select("li.page-item a.page-link").first["href"]
+    get css_select("li.page-item .page-link").last["href"]
     assert_response :success
     assert_select "article.diary_post", :count => 10
     assert_select "li.page-item.disabled span.page-link", :text => "Older Entries", :count => 1
     assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
 
     # Go back to the second page
-    get css_select("li.page-item a.page-link").last["href"]
+    get css_select("li.page-item .page-link").first["href"]
     assert_response :success
     assert_select "article.diary_post", :count => 20
     assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
     assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
 
     # Go back to the first page
-    get css_select("li.page-item a.page-link").last["href"]
+    get css_select("li.page-item .page-link").first["href"]
     assert_response :success
     assert_select "article.diary_post", :count => 20
     assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1


### PR DESCRIPTION
https://www.openstreetmap.org/traces has "Newer Traces" button before "Older Traces"
https://www.openstreetmap.org/diary has "Older Entries" before "Newer Entries" - which is backwards because newer entries come first