### PR TITLE
Mute hidden comment text in each table cell

### DIFF
--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -16,10 +16,10 @@
       </tr>
     </thead>
     <% @comments.each do |comment| -%>
-    <tr class="<%= "text-muted" unless comment.visible? %>">
-      <td width="25%"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
-      <td width="25%"><span title="<%= l comment.created_at, :format => :friendly %>"><%= time_ago_in_words(comment.created_at, :scope => :"datetime.distance_in_words_ago") %></span></td>
-      <td width="50%" class="richtext text-break"><%= comment.body.to_html %></td>
+    <tr>
+      <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
+      <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><span title="<%= l comment.created_at, :format => :friendly %>"><%= time_ago_in_words(comment.created_at, :scope => :"datetime.distance_in_words_ago") %></span></td>
+      <td width="50%" class="richtext text-break<%= " text-muted" unless comment.visible? %>"><%= comment.body.to_html %></td>
     </tr>
     <% end -%>
   </table>


### PR DESCRIPTION
How hidden comments in `/user/<username>/diary/comments` are displayed for those with permissions to see them:

Before:
![mute-comment-before](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/47d40d9b-5e4b-4ef4-8dd2-72da446f42fc)

After:
![mute-comment-after](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9f195091-7f6d-4a1a-ad17-9124f6e9aec3)

This depends on Bootstrap's internal details of striped tables. I also wanted to change deleted comment backgrounds to a danger color like done elsewhere, but that depends on internal details even more (striped background is not really a background but a shadow and how its color is derived seems to have changed in later versions of Bootstrap).