### PR TITLE
Show user id on profile pages to moderators and admins

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -131,6 +131,10 @@
                 <% end -%>
               </dd>
             <% end -%>
+            <% if current_user&.moderator? || current_user&.administrator? %>
+              <dt class="list-inline-item m-0"><%= t ".uid" %></dt>
+              <dd class="list-inline-item"><%= link_to @user.id, api_user_path(:id => @user.id) %></dd>
+            <% end -%>
           </dl>
         </small>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2697,6 +2697,7 @@ en:
       remove as friend: Unfriend
       add as friend: Add Friend
       mapper since: "Mapper since:"
+      uid: "User id:"
       ct status: "Contributor terms:"
       ct undecided: Undecided
       ct declined: Declined

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -495,6 +495,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks']", 0
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks_by']", 0
       assert_select "a[href='/blocks/new/#{ERB::Util.u(user.display_name)}']", 0
+      assert_select "a[href='/api/0.6/user/#{ERB::Util.u(user.id)}']", 0
     end
 
     # Login as a moderator
@@ -512,6 +513,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks']", 0
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks_by']", 0
       assert_select "a[href='/blocks/new/#{ERB::Util.u(user.display_name)}']", 1
+      assert_select "a[href='/api/0.6/user/#{ERB::Util.u(user.id)}']", 1
     end
   end
 


### PR DESCRIPTION
From DWG wishlist:
> It would be nice if the user ID could be made visible on the user profile page (perhaps subject to some “expert mode” as discussed initially).

"Expert mode" in this PR is being logged in as a moderator or an administrator.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/a640bc1a-837a-40e8-af54-300c0b60eb43)

Actually the id is visible to anyone if they look at the *Report this User* link, so no new information is revealed here.