### PR TITLE
Use implicit style for associations with factory overrides

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,11 @@ AllCops:
 Rails:
   Enabled: true
 
+# Config can be removed after https://github.com/rubocop/rubocop-factory_bot/issues/53
+FactoryBot/AssociationStyle:
+  Include:
+    - 'test/factories/**/*'
+
 Layout/ExtraSpacing:
   AllowForAlignment: true
 

--- a/test/factories/changeset_comments.rb
+++ b/test/factories/changeset_comments.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
 
     changeset
 
-    association :author, :factory => :user
+    author :factory => :user
   end
 end

--- a/test/factories/friendships.rb
+++ b/test/factories/friendships.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :friendship do
-    association :befriender, :factory => :user
-    association :befriendee, :factory => :user
+    befriender :factory => :user
+    befriendee :factory => :user
   end
 end

--- a/test/factories/issues.rb
+++ b/test/factories/issues.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :issue do
     # Default to reporting users
-    association :reportable, :factory => :user
-    association :reported_user, :factory => :user
+    reportable :factory => :user
+    reported_user :factory => :user
 
     # Default to assigning to an administrator
     assigned_role { "administrator" }

--- a/test/factories/messages.rb
+++ b/test/factories/messages.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
     sequence(:body) { |n| "Body text for message #{n}" }
     sent_on { Time.now.utc }
 
-    association :sender, :factory => :user
-    association :recipient, :factory => :user
+    sender :factory => :user
+    recipient :factory => :user
 
     trait :unread do
       message_read { false }

--- a/test/factories/oauth_access_grant.rb
+++ b/test/factories/oauth_access_grant.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :oauth_access_grant, :class => "Doorkeeper::AccessGrant" do
-    association :resource_owner_id, :factory => :user
-    association :application, :factory => :oauth_application
+    resource_owner_id :factory => :user
+    application :factory => :oauth_application
 
     expires_in { 86400 }
     redirect_uri { application.redirect_uri }

--- a/test/factories/oauth_access_token.rb
+++ b/test/factories/oauth_access_token.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :oauth_access_token, :class => "Doorkeeper::AccessToken" do
-    association :application, :factory => :oauth_application
+    application :factory => :oauth_application
   end
 end

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     sequence(:name) { |n| "OAuth application #{n}" }
     sequence(:redirect_uri) { |n| "https://example.com/app/#{n}" }
 
-    association :owner, :factory => :user
+    owner :factory => :user
   end
 end

--- a/test/factories/old_node.rb
+++ b/test/factories/old_node.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     longitude { 1 * GeoRecord::SCALE }
 
     changeset
-    association :current_node, :factory => :node
+    current_node :factory => :node
 
     visible { true }
     timestamp { Time.now.utc }

--- a/test/factories/old_relation.rb
+++ b/test/factories/old_relation.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     version { 1 }
 
     changeset
-    association :current_relation, :factory => :relation
+    current_relation :factory => :relation
   end
 end

--- a/test/factories/old_relation_member.rb
+++ b/test/factories/old_relation_member.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
 
     old_relation
     # Default to creating nodes, but could be ways or relations as members
-    association :member, :factory => :node
+    member :factory => :node
   end
 end

--- a/test/factories/old_way.rb
+++ b/test/factories/old_way.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     version { 1 }
 
     changeset
-    association :current_way, :factory => :way
+    current_way :factory => :way
   end
 end

--- a/test/factories/relation_member.rb
+++ b/test/factories/relation_member.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
 
     relation
     # Default to creating nodes, but could be ways or relations as members
-    association :member, :factory => :node
+    member :factory => :node
   end
 end

--- a/test/factories/user_blocks.rb
+++ b/test/factories/user_blocks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     ends_at { Time.now.utc + 1.day }
 
     user
-    association :creator, :factory => :moderator_user
+    creator :factory => :moderator_user
 
     trait :needs_view do
       needs_view { true }
@@ -15,7 +15,7 @@ FactoryBot.define do
     end
 
     trait :revoked do
-      association :revoker, :factory => :moderator_user
+      revoker :factory => :moderator_user
     end
   end
 end

--- a/test/factories/user_role.rb
+++ b/test/factories/user_role.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user_role do
     user
-    association :granter, :factory => :user
+    granter :factory => :user
   end
 end


### PR DESCRIPTION
This matches our usage of implicit style for associations generally, e.g. `user`.

This isn't currently picked up by rubocop-factory_bot, due to a bug with the [default include paths](https://github.com/rubocop/rubocop-factory_bot/issues/53). Until the fix is released we can use the rubocop configuration to include our factories in the cop.

While working with upstream [on a fix](https://github.com/rubocop/rubocop-factory_bot/pull/55), I realised I didn't like the output of the autocorrect. So since this change will need some manual input eventually, I thought I'd just do it sooner rather than later. 

(The autocorrect goes from `association :author, :factory => :user` to `author :factory => [:user]` but in our case there's no need for the array).