### PR TITLE
Fix lack of margin on changeset browsing messages

### DIFF
--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -13,9 +13,9 @@
   </div>
 <% end -%>
 <% elsif params[:bbox] %>
-  <p><%= t(params[:max_id] ? ".no_more_area" : ".empty_area") %></p>
+  <p class="mx-3"><%= t(params[:max_id] ? ".no_more_area" : ".empty_area") %></p>
 <% elsif params[:display_name] %>
-  <p><%= t(params[:max_id] ? ".no_more_user" : ".empty_user") %></p>
+  <p class="mx-3"><%= t(params[:max_id] ? ".no_more_user" : ".empty_user") %></p>
 <% else %>
-  <p><%= t(params[:max_id] ? ".no_more" : ".empty") %></p>
+  <p class="mx-3"><%= t(params[:max_id] ? ".no_more" : ".empty") %></p>
 <% end %>


### PR DESCRIPTION
The display area here uses negative margins to make the flush list work, so we need to add them back in for normal text.