### PR TITLE
Don't use monospace font in single-line share inputs

### DIFF
--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -68,7 +68,7 @@ L.OSM.share = function (options) {
       .append($("<input>")
         .attr("id", "long_input")
         .attr("type", "text")
-        .attr("class", "form-control form-control-sm font-monospace")
+        .attr("class", "form-control form-control-sm")
         .attr("readonly", true)
         .on("click", select));
 
@@ -79,7 +79,7 @@ L.OSM.share = function (options) {
       .append($("<input>")
         .attr("id", "short_input")
         .attr("type", "text")
-        .attr("class", "form-control form-control-sm font-monospace")
+        .attr("class", "form-control form-control-sm")
         .attr("readonly", true)
         .on("click", select));
 


### PR DESCRIPTION
https://github.com/openstreetmap/openstreetmap-website/commit/dc24f6c2195c6053efd43778d53ae68984e54107#commitcomment-126688182

If you don't want custom font sizes even for things that are guaranteed not to fit on screen, maybe you don't want custom fonts as well? The buttons are not in a monospace font, why the inputs are, if they are supposed to be consistent with the buttons? You can argue that if an input has just a single-line url, monospace font is not required. Look at your browser's location bar. Does it have a monospace font? Probably no.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/cc1c67f9-2038-4415-9a11-95e0dfbc26b4)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/01bee0ac-37be-4de6-a341-5c1617dc29cd)

The characters are not as wide, mote text fits on screen.