### PR TITLE
Fix alignment in profile and diary location forms

### DIFF
--- a/app/views/diary_entries/_form.html.erb
+++ b/app/views/diary_entries/_form.html.erb
@@ -8,8 +8,8 @@
   <%= tag.div "", :id => "map", :class => "border border-grey rounded mb-3", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
 
   <div class="row mb-3">
-    <%= f.text_field :latitude, :wrapper_class => "col-sm-4", :id => "latitude" %>
-    <%= f.text_field :longitude, :wrapper_class => "col-sm-4", :id => "longitude" %>
+    <%= f.text_field :latitude, :wrapper_class => "col-sm-4 d-flex flex-column", :class => "mt-auto", :id => "latitude" %>
+    <%= f.text_field :longitude, :wrapper_class => "col-sm-4 d-flex flex-column", :class => "mt-auto", :id => "longitude" %>
     <div class="col-sm-4 align-self-end pt-2">
       <button type="button" id="usemap" class="btn btn-outline-primary"><%= t ".use_map_link" -%></button>
     </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -44,8 +44,8 @@
     <legend><%= t ".home location" -%></legend>
     <p id="home_message" class="text-muted m-0<% if current_user.home_location? %> invisible<% end %>"><%= t ".no home location" %></p>
     <div class="row">
-      <%= f.text_field :home_lat, :wrapper_class => "col-sm-4", :id => "home_lat" %>
-      <%= f.text_field :home_lon, :wrapper_class => "col-sm-4", :id => "home_lon" %>
+      <%= f.text_field :home_lat, :wrapper_class => "col-sm-4 d-flex flex-column", :class => "mt-auto", :id => "home_lat" %>
+      <%= f.text_field :home_lon, :wrapper_class => "col-sm-4 d-flex flex-column", :class => "mt-auto", :id => "home_lon" %>
       <div class="col-sm-4 pt-2 align-self-end">
         <button type="button" id="home_show" class="btn btn-outline-primary"<% unless current_user.home_location? %> hidden<% end %> disabled><%= t ".show" %></button>
         <button type="button" id="home_delete" class="btn btn-outline-primary"<% unless current_user.home_location? %> hidden<% end %>><%= t ".delete" %></button>


### PR DESCRIPTION
Some languages have labels that wrap on certain screen widths, breaking input alignment.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c56905f0-670d-4080-a85f-68a8db257975)


After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/49e75e27-6361-4945-be02-9f22442c4f3f)
