### PR TITLE
Add show user block api endpoint

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -21,6 +21,7 @@ class ApiAbility
       can [:history, :version], OldNode
       can [:history, :version], OldWay
       can [:history, :version], OldRelation
+      can [:show], UserBlock
     end
 
     if user&.active?

--- a/app/controllers/api/user_blocks_controller.rb
+++ b/app/controllers/api/user_blocks_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  class UserBlocksController < ApiController
+    before_action :check_api_readable
+
+    authorize_resource
+
+    around_action :api_call_handle_error, :api_call_timeout
+    before_action :set_request_formats
+
+    def show
+      raise OSM::APIBadUserInput, "No id was given" unless params[:id]
+
+      @user_block = UserBlock.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      raise OSM::APINotFoundError
+    end
+  end
+end

--- a/app/views/api/user_blocks/_user_block.json.jbuilder
+++ b/app/views/api/user_blocks/_user_block.json.jbuilder
@@ -1,0 +1,13 @@
+json.user_block do
+  json.id user_block.id
+  json.created_at user_block.created_at.xmlschema
+  json.updated_at user_block.updated_at.xmlschema
+  json.ends_at user_block.ends_at.xmlschema
+  json.needs_view user_block.needs_view
+
+  json.user :uid => user_block.user_id, :user => user_block.user.display_name
+  json.creator :uid => user_block.creator_id, :user => user_block.creator.display_name
+  json.revoker :uid => user_block.revoker_id, :user => user_block.revoker.display_name if user_block.revoker
+
+  json.reason user_block.reason
+end

--- a/app/views/api/user_blocks/_user_block.xml.builder
+++ b/app/views/api/user_blocks/_user_block.xml.builder
@@ -1,0 +1,14 @@
+attrs = {
+  "id" => user_block.id,
+  "created_at" => user_block.created_at.xmlschema,
+  "updated_at" => user_block.updated_at.xmlschema,
+  "ends_at" => user_block.ends_at.xmlschema,
+  "needs_view" => user_block.needs_view
+}
+
+xml.user_block(attrs) do
+  xml.user :uid => user_block.user_id, :user => user_block.user.display_name
+  xml.creator :uid => user_block.creator_id, :user => user_block.creator.display_name
+  xml.revoker :uid => user_block.revoker_id, :user => user_block.revoker.display_name if user_block.revoker
+  xml.reason user_block.reason
+end

--- a/app/views/api/user_blocks/show.json.jbuilder
+++ b/app/views/api/user_blocks/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.partial! "api/root_attributes"
+
+json.partial! @user_block

--- a/app/views/api/user_blocks/show.xml.builder
+++ b/app/views/api/user_blocks/show.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(@user_block) || "")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,8 @@ OpenStreetMap::Application.routes.draw do
     post "notes/editPOIexec" => "api/notes#comment"
     get "notes/getGPX" => "api/notes#index", :format => "gpx"
     get "notes/getRSSfeed" => "api/notes#feed", :format => "rss"
+
+    resources :user_blocks, :only => [:show], :constraints => { :id => /\d+/ }, :controller => "api/user_blocks", :as => :api_user_blocks
   end
 
   # Data browsing

--- a/test/controllers/api/user_blocks_controller_test.rb
+++ b/test/controllers/api/user_blocks_controller_test.rb
@@ -7,6 +7,10 @@ module Api
         { :path => "/api/0.6/user_blocks/1", :method => :get },
         { :controller => "api/user_blocks", :action => "show", :id => "1" }
       )
+      assert_routing(
+        { :path => "/api/0.6/user_blocks/1.json", :method => :get },
+        { :controller => "api/user_blocks", :action => "show", :id => "1", :format => "json" }
+      )
     end
 
     def test_show
@@ -15,6 +19,12 @@ module Api
       get api_user_block_path(:id => block)
       assert_response :success
       assert_select "user_block[id='#{block.id}']", 1
+
+      get api_user_block_path(:id => block, :format => "json")
+      assert_response :success
+      js = ActiveSupport::JSON.decode(@response.body)
+      assert_not_nil js
+      assert_equal block.id, js["user_block"]["id"]
     end
 
     def test_show_not_found

--- a/test/controllers/api/user_blocks_controller_test.rb
+++ b/test/controllers/api/user_blocks_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+module Api
+  class UserBlocksControllerTest < ActionDispatch::IntegrationTest
+    def test_routes
+      assert_routing(
+        { :path => "/api/0.6/user_blocks/1", :method => :get },
+        { :controller => "api/user_blocks", :action => "show", :id => "1" }
+      )
+    end
+
+    def test_show
+      block = create(:user_block)
+
+      get api_user_block_path(:id => block)
+      assert_response :success
+      assert_select "user_block[id='#{block.id}']", 1
+    end
+
+    def test_show_not_found
+      get api_user_block_path(:id => 123)
+      assert_response :not_found
+      assert_equal "text/plain", @response.media_type
+    end
+  end
+end


### PR DESCRIPTION
Going through the DWG Wishlist, there was a blocks api.

Currently scripted blocks in [osmtools](https://github.com/woodpeck/osm-revert-scripts) are done by emulating the browser, loading webpages and filling out forms. That requires passing the password around. It would be better to be able to access block functionality with a proper api and an oauth token.

But before doing block creation, there need to be block read api endpoints. Here the xml block show method is added at `/api/0.6/user_blocks/:id` with an output like:

```
<osm version="0.6" ...>
<user_block id="6" created_at="2023-08-01T15:55:58Z" updated_at="2023-08-05T00:46:36Z" ends_at="2023-08-05T00:46:36Z" needs_view="false">
  <user uid="1" user="fakeuser1"/>
  <creator uid="2" user="fakemod1"/>
  <revoker uid="2" user="fakemod1"/>
  <reason>longer block test</reason>
</user_block>
</osm>
```

All of this is already accessible through the web ui at `/user_blocks/:id`.