### PR TITLE
Add user id to api trace output

### DIFF
--- a/app/views/api/traces/_trace.builder
+++ b/app/views/api/traces/_trace.builder
@@ -3,6 +3,7 @@
 attrs = {
   "id" => trace.id,
   "name" => trace.name,
+  "uid" => trace.user_id,
   "user" => trace.user.display_name,
   "visibility" => trace.visibility,
   "pending" => trace.inserted ? "false" : "true",

--- a/test/controllers/api/traces_controller_test.rb
+++ b/test/controllers/api/traces_controller_test.rb
@@ -52,6 +52,7 @@ module Api
       auth_header = basic_authorization_header public_trace_file.user.display_name, "test"
       get api_trace_path(public_trace_file), :headers => auth_header
       assert_response :success
+      assert_select "gpx_file[id='#{public_trace_file.id}'][uid='#{public_trace_file.user.id}']", 1
     end
 
     # Check an anonymous trace can't be specifically fetched by another user


### PR DESCRIPTION
If you look at https://wiki.openstreetmap.org/wiki/API_v0.6#Download_Metadata:_GET_/api/0.6/gpx/#id/details
you'll notice that `<gpx_file>` has the `user` attribute but doesn't have the `uid`. Everywhere else in the api (changesets, elements, notes) `user` comes together with `uid`. `uid` was missing here from [the very beginning](https://github.com/openstreetmap/openstreetmap-website/commit/01cfcbd845c5d8d33f83bb22a24cf35932da2e29#diff-49ff8e13eb2bff9ffd834dad7421f568b40186cb58b28e7eac6b3e9168ec8759R58), but it doesn't make sense to try to conceal it when the name is shown.

