### PR TITLE
Remove authorize_web call from traces api controller

### DIFF
--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -2,7 +2,6 @@ module Api
   class TracesController < ApiController
     before_action :check_database_readable, :except => [:show, :data]
     before_action :check_database_writable, :only => [:create, :update, :destroy]
-    before_action :authorize_web
     before_action :set_locale
     before_action :authorize
 


### PR DESCRIPTION
Traces api controller happens to be the only api controller that calls authorize_web.

This call was there since the traces api was added in https://github.com/openstreetmap/openstreetmap-website/commit/01cfcbd845c5d8d33f83bb22a24cf35932da2e29 and was copied over when web and api controllers were separated in https://github.com/openstreetmap/openstreetmap-website/commit/5f59845575ed313688eca669fd73f4f6a5993c23.

But it doesn't do anything. There's no session so no if branches with conditions on session are run https://github.com/openstreetmap/openstreetmap-website/blob/0e21afc56593eb9fce14d8cfe0984494e758c150/app/controllers/application_controller.rb#L24

There's no current_user at this point so the final line also doesn't do anything
https://github.com/openstreetmap/openstreetmap-website/blob/0e21afc56593eb9fce14d8cfe0984494e758c150/app/controllers/application_controller.rb#L51