### PR TITLE
Add comment ids to changeset discussion api responses

### DIFF
--- a/app/views/api/changesets/_changeset.json.jbuilder
+++ b/app/views/api/changesets/_changeset.json.jbuilder
@@ -23,6 +23,7 @@ json.tags changeset.tags unless changeset.tags.empty?
 
 if @include_discussion
   json.comments(changeset.comments) do |comment|
+    json.id comment.id
     json.date comment.created_at.xmlschema
     if comment.author.data_public?
       json.uid comment.author.id

--- a/app/views/api/changesets/_changeset.xml.builder
+++ b/app/views/api/changesets/_changeset.xml.builder
@@ -28,6 +28,7 @@ xml.changeset(attrs) do |changeset_xml_node|
     changeset_xml_node.discussion do |discussion_xml_node|
       changeset.comments.includes(:author).each do |comment|
         cattrs = {
+          "id" => comment.id,
           "date" => comment.created_at.xmlschema
         }
         if comment.author.data_public?


### PR DESCRIPTION
When anything in the api returns comments, they don't have ids. This is probably because the comment ids were considered unimportant. There used to be no way to do anything with them. If you know a changeset id, you can ask the api to show this changeset, same for elements, users, notes, but not for comments.

But later changeset comment hide/unhide endpoints [were added](https://wiki.openstreetmap.org/wiki/API_v0.6#Hide_changeset_comment:_POST_/api/0.6/changeset/comment/#comment_id/hide). To use them you need to know comment ids. However there's no way to get the ids purely through the api. Currently the ids are attached to hide/unhide buttons in the web interface, with the web interface being the only way to get them.

Knowing the ids may help with scripted comment processing. For example, that name:ru vandal bombarded changeset discussions with hundreds of comments. For some users, when looking at the list of comments, you'll have to scroll through a ton of those useless comments before you find actual discussions. It would be nice to clean them up, which is easier to do when you don't have to parse comment ids out of web pages.