### PR TITLE
Remove usage of Sass division operator

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -268,7 +268,8 @@ OSM.Directions = function (map) {
           I18n.t("javascripts.directions.descend") + ": " + formatHeight(route.descend) + ".");
       }
 
-      var turnByTurnTable = $("<table class='mb-3'>");
+      var turnByTurnTable = $("<table class='table table-sm mb-3'>")
+        .append($("<tbody>"));
       var directionsCloseButton = $("<button type='button' class='btn-close'>")
         .attr("aria-label", I18n.t("javascripts.close"));
 
@@ -304,8 +305,8 @@ OSM.Directions = function (map) {
         }
 
         var row = $("<tr class='turn'/>");
-        row.append("<td><div class='direction i" + direction + "'/></td> ");
-        row.append("<td class='instruction'>" + instruction);
+        row.append("<td class='border-0'><div class='direction i" + direction + "'/></td> ");
+        row.append("<td>" + instruction);
         row.append("<td class='distance'>" + dist);
 
         row.on("click", function () {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -804,15 +804,6 @@ tr.turn:hover {
     }
   }
 
-  .note-comments li, .changeset-comments li {
-    margin: $lineheight/2 0;
-
-    p {
-      margin: 10px 6px 0 6px;
-      line-height: 1.5;
-    }
-  }
-
   .subscribe-buttons input {
     font-size: 90%;
     line-height: 15px;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -698,11 +698,6 @@ div.direction {
 div.direction.i#{$i} { background-position: #{($i)*-20}px 0px; }
 }
 
-td.instruction, td.distance {
-    padding-top: $lineheight/5;
-    padding-bottom: $lineheight/5;
-    border-bottom: 1px solid $grey;
-}
 td.distance {
     color: $darkgrey;
     text-align: right;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1002,7 +1002,7 @@ tr.turn:hover {
 /* Rules for the user map */
 
 .content_map .leaflet-popup-content {
-  margin: $lineheight/2;
+  margin: $spacer;
   min-height: 50px;
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1038,9 +1038,6 @@ tr.turn:hover {
     &:first-child {
       border-top: 1px solid $grey;
     }
-    p {
-      margin-bottom: $lineheight/2;
-    }
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -886,10 +886,6 @@ tr.turn:hover {
     }
     #minlat { margin-bottom: -1px; }
   }
-
-  .export_bound {
-    margin: $lineheight/4;
-  }
 }
 
 /* Rules for edit pages */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1139,9 +1139,9 @@ nav.secondary-actions {
       flex-basis: auto;
       list-style: none;
       border-left: 1px solid $grey;
-      padding-left: $lineheight/2;
-      margin-right: $lineheight/2;
-      margin-bottom: $lineheight/8;
+      padding-left: $lineheight * 0.5;
+      margin-right: $lineheight * 0.5;
+      margin-bottom: $lineheight * 0.125;
     }
   }
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -23,7 +23,7 @@ small, aside {
 
 .small_icon {
   vertical-align: middle;
-  margin-right: $lineheight/4;
+  margin-right: $lineheight * 0.25;
 }
 
 [dir=rtl] { /* no-r2 */ text-align: right; }
@@ -102,7 +102,7 @@ header {
 
   > * {
     height: 100%;
-    padding: $lineheight/2;
+    padding: $lineheight * 0.5;
   }
 
   h1, nav.primary {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1041,17 +1041,6 @@ tr.turn:hover {
   }
 }
 
-/* Rules for the log in page */
-
-#login_auth_buttons {
-  margin-bottom: 0;
-
-  li {
-    float: left;
-    padding: $lineheight/4 $lineheight/2;
-  }
-}
-
 /* Rules for the account confirmation page */
 
 .users-terms {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -890,14 +890,6 @@ tr.turn:hover {
   .export_bound {
     margin: $lineheight/4;
   }
-
-  dl {
-    padding-left: $lineheight/2;
-    dd {
-      margin-left: 0;
-      margin-bottom: 10px;
-    }
-  }
 }
 
 /* Rules for edit pages */

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -46,7 +46,9 @@
                     — <span class="action-button" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_hide_url(comment.id) %>"><%= t("javascripts.changesets.show.hide_comment") %></span>
                   <% end %>
                 </small>
-                <%= comment.body.to_html %>
+                <div class="mx-2">
+                  <%= comment.body.to_html %>
+                </div>
               </li>
             <% elsif current_user and current_user.moderator? %>
               <li id="c<%= comment.id %>">
@@ -57,7 +59,9 @@
                         :user => link_to(comment.author.display_name, user_path(comment.author))) %>
                   — <span class="action-button text-muted" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_unhide_url(comment.id) %>"><%= t("javascripts.changesets.show.unhide_comment") %></span>
                  </small>
-                <%= comment.body.to_html %>
+                <div class="mx-2">
+                  <%= comment.body.to_html %>
+                </div>
               </li>
             <% end %>
           <% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -34,7 +34,9 @@
         <% @note_comments.drop(1).each do |comment| %>
           <li id="c<%= comment.id %>">
             <small class='text-muted'><%= note_event(comment.event, comment.created_at, comment.author) %></small>
-            <%= comment.body.to_html %>
+            <div class="mx-2">
+              <%= comment.body.to_html %>
+            </div>
           </li>
         <% end %>
       </ul>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -27,22 +27,12 @@
     <div class="mb-3">
       <label class="form-label"><%= t ".with external" %></label>
 
-      <ul class='list-unstyled' id="login_auth_buttons">
-        <li><%= link_to image_tag("openid.png", :alt => t(".auth_providers.openid.title")), "#", :id => "openid_open_url", :title => t(".auth_providers.openid.title") %></li>
-        <% if Settings.key?(:google_auth_id) -%>
-        <li><%= auth_button "google", "google" %></li>
-        <% end -%>
-        <% if Settings.key?(:facebook_auth_id) -%>
-        <li><%= auth_button "facebook", "facebook" %></li>
-        <% end -%>
-        <% if Settings.key?(:microsoft_auth_id) -%>
-        <li><%= auth_button "microsoft", "microsoft" %></li>
-        <% end -%>
-        <% if Settings.key?(:github_auth_id) -%>
-        <li><%= auth_button "github", "github" %></li>
-        <% end -%>
-        <% if Settings.key?(:wikipedia_auth_id) -%>
-        <li><%= auth_button "wikipedia", "wikipedia" %></li>
+      <ul class='list-inline' id="login_auth_buttons">
+        <li class="list-inline-item me-3"><%= link_to image_tag("openid.png", :alt => t(".auth_providers.openid.title")), "#", :id => "openid_open_url", :title => t(".auth_providers.openid.title") %></li>
+        <% %w[google facebook microsoft github wikipedia].each do |provider| %>
+          <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
+            <li class="list-inline-item me-3"><%= auth_button provider, provider %></li>
+          <% end -%>
         <% end -%>
       </ul>
 

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -9,8 +9,8 @@
     <div class='export_boxy border border-grey rounded'>
       <%= text_field_tag("maxlat", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control mx-auto") %>
       <div class="clearfix">
-        <%= text_field_tag("minlon", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control") %>
-        <%= text_field_tag("maxlon", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control") %>
+        <%= text_field_tag("minlon", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control my-2") %>
+        <%= text_field_tag("maxlon", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control my-2") %>
       </div>
       <%= text_field_tag("minlat", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control mx-auto") %>
       </div>


### PR DESCRIPTION
This PR removes the remaining usage of the Sass division operator in our stylesheets.

https://sass-lang.com/documentation/breaking-changes/slash-div/

Whereever practicable, I've done this by refactoring the way that our styles work in order to remove the need for the custom css rules. In a few situations I took the "easy option" and converted the division to a multiplication instead, for the sake of time.

This work is a pre-requisite for moving to dartsass for compiling our stylesheets (the `sassc` gem, and the libsass project it uses, are both abandoned at this point, in favour of dartsass). And moving to dartsass (using `dartsass-sprockets`) is a prerequisite for us upgrading to newer versions of Bootstrap, which are incompatible with libsass.