### PR TITLE
List of user's changeset comments

### DIFF
--- a/app/controllers/changeset_comments_controller.rb
+++ b/app/controllers/changeset_comments_controller.rb
@@ -1,0 +1,19 @@
+class ChangesetCommentsController < ApplicationController
+  include UserMethods
+
+  layout "site"
+
+  before_action :authorize_web
+  before_action :set_locale
+
+  authorize_resource
+
+  before_action :lookup_user
+  before_action -> { check_database_readable(:need_api => true) }
+  around_action :web_timeout
+
+  def index
+    @title = t ".title", :user => @user.display_name
+    @comments = []
+  end
+end

--- a/app/controllers/changeset_comments_controller.rb
+++ b/app/controllers/changeset_comments_controller.rb
@@ -1,5 +1,6 @@
 class ChangesetCommentsController < ApplicationController
   include UserMethods
+  include PaginationMethods
 
   layout "site"
 
@@ -14,6 +15,12 @@ class ChangesetCommentsController < ApplicationController
 
   def index
     @title = t ".title", :user => @user.display_name
-    @comments = []
+
+    comments = ChangesetComment.where(:author => @user)
+    comments = comments.visible unless current_user&.moderator?
+
+    @params = params.permit(:display_name, :before, :after)
+
+    @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, :includes => [:author])
   end
 end

--- a/app/models/changeset_comment.rb
+++ b/app/models/changeset_comment.rb
@@ -25,6 +25,8 @@ class ChangesetComment < ApplicationRecord
   belongs_to :changeset
   belongs_to :author, :class_name => "User"
 
+  scope :visible, -> { where(:visible => true) }
+
   validates :id, :uniqueness => true, :presence => { :on => :update },
                  :numericality => { :on => :update, :only_integer => true }
   validates :changeset, :associated => true

--- a/app/views/changeset_comments/_page.html.erb
+++ b/app/views/changeset_comments/_page.html.erb
@@ -1,0 +1,23 @@
+<turbo-frame id="pagination" target="_top" data-turbo="false">
+  <table class="table table-striped" width="100%">
+    <thead>
+      <tr>
+        <th width="25%"><%= t "diary_comments.page.changeset" %></th>
+        <th width="25%"><%= t "diary_comments.page.when" %></th>
+        <th width="50%"><%= t "diary_comments.page.comment" %></th>
+      </tr>
+    </thead>
+    <% @comments.each do |comment| -%>
+    <tr>
+      <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><%= link_to comment.changeset.id, changeset_path(comment.changeset) %></td>
+      <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><span title="<%= l comment.created_at, :format => :friendly %>"><%= time_ago_in_words(comment.created_at, :scope => :"datetime.distance_in_words_ago") %></span></td>
+      <td width="50%" class="richtext text-break<%= " text-muted" unless comment.visible? %>"><%= comment.body.to_html %></td>
+    </tr>
+    <% end -%>
+  </table>
+
+  <%= render "shared/pagination",
+             :translation_scope => "shared.pagination.diary_comments",
+             :newer_id => @newer_comments_id,
+             :older_id => @older_comments_id %>
+</turbo-frame>

--- a/app/views/changeset_comments/index.html.erb
+++ b/app/views/changeset_comments/index.html.erb
@@ -11,3 +11,9 @@
     </li>
   </ul>
 <% end %>
+
+<% if @comments.empty? %>
+  <h4><%= t "diary_comments.index.no_comments" %></h4>
+<% else %>
+  <%= render :partial => "page" %>
+<% end -%>

--- a/app/views/changeset_comments/index.html.erb
+++ b/app/views/changeset_comments/index.html.erb
@@ -1,0 +1,13 @@
+<% content_for :heading_class, "pb-0" %>
+
+<% content_for :heading do %>
+  <h1><%= t "diary_comments.index.heading_html", :user => link_to(@user.display_name, user_path(@user)) %></h1>
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <%= link_to t("diary_comments.index.diary_entries"), diary_comments_path(@user), :class => "nav-link" %>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link active"><%= t "diary_comments.index.changesets" %></a>
+    </li>
+  </ul>
+<% end %>

--- a/app/views/diary_comments/index.html.erb
+++ b/app/views/diary_comments/index.html.erb
@@ -1,6 +1,15 @@
+<% content_for :heading_class, "pb-0" %>
+
 <% content_for :heading do %>
-  <h1><%= t ".heading", :user => @user.display_name %></h1>
-  <p><%= t ".subheading_html", :user => link_to(@user.display_name, @user) %></p>
+  <h1><%= t ".heading_html", :user => link_to(@user.display_name, @user) %></h1>
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link active"><%= t ".diary_entries" %></a>
+    </li>
+    <li class="nav-item">
+      <%= link_to t(".changesets"), changeset_comments_path(@user), :class => "nav-link" %>
+    </li>
+  </ul>
 <% end %>
 
 <% if @comments.empty? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,6 +437,8 @@ en:
         title_particular: "OpenStreetMap changeset #%{changeset_id} discussion"
       timeout:
         sorry: "Sorry, the list of changeset comments you requested took too long to retrieve."
+    index:
+      title: "Changeset Comments added by %{user}"
   changesets:
     changeset:
       no_edits: "(no edits)"
@@ -598,8 +600,9 @@ en:
   diary_comments:
     index:
       title: "Diary Comments added by %{user}"
-      heading: "%{user}'s Diary Comments"
-      subheading_html: "Diary Comments added by %{user}"
+      heading_html: "%{user}'s Comments"
+      diary_entries: "Diary entries"
+      changesets: "Changesets"
       no_comments: "No diary comments"
     page:
       post: Post

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -603,9 +603,10 @@ en:
       heading_html: "%{user}'s Comments"
       diary_entries: "Diary entries"
       changesets: "Changesets"
-      no_comments: "No diary comments"
+      no_comments: "No comments"
     page:
       post: Post
+      changeset: Changeset
       when: When
       comment: Comment
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,6 +136,7 @@ OpenStreetMap::Application.routes.draw do
 
   get "/user/:display_name/history" => "changesets#index"
   get "/user/:display_name/history/feed" => "changesets#feed", :defaults => { :format => :atom }
+  resources :changeset_comments, :path => "/user/:display_name/history/comments", :only => :index
   get "/user/:display_name/notes" => "notes#index", :as => :user_notes
   get "/history/friends" => "changesets#index", :friends => true, :as => "friend_changesets", :defaults => { :format => :html }
   get "/history/nearby" => "changesets#index", :nearby => true, :as => "nearby_changesets", :defaults => { :format => :html }

--- a/test/controllers/changeset_comments_controller_test.rb
+++ b/test/controllers/changeset_comments_controller_test.rb
@@ -9,4 +9,29 @@ class ChangesetCommentsControllerTest < ActionDispatch::IntegrationTest
       { :controller => "changeset_comments", :action => "index", :display_name => "name" }
     )
   end
+
+  ##
+  # test comments webpage
+  def test_index
+    user = create(:user)
+    other_user = create(:user)
+    changeset = create(:changeset, :closed)
+    create_list(:changeset_comment, 3, :changeset => changeset, :author => user)
+    create_list(:changeset_comment, 2, :changeset => changeset, :author => other_user)
+
+    get changeset_comments_path(user)
+    assert_response :success
+    assert_select "table.table-striped tbody" do
+      assert_select "tr", :count => 3
+    end
+
+    create(:changeset_comment, :changeset => changeset, :author => user)
+    create(:changeset_comment, :changeset => changeset, :author => user, :visible => false)
+
+    get changeset_comments_path(user)
+    assert_response :success
+    assert_select "table.table-striped tbody" do
+      assert_select "tr", :count => 4
+    end
+  end
 end

--- a/test/controllers/changeset_comments_controller_test.rb
+++ b/test/controllers/changeset_comments_controller_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class ChangesetCommentsControllerTest < ActionDispatch::IntegrationTest
+  ##
+  # test all routes which lead to this controller
+  def test_routes
+    assert_routing(
+      { :path => "/user/name/history/comments", :method => :get },
+      { :controller => "changeset_comments", :action => "index", :display_name => "name" }
+    )
+  end
+end

--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -39,7 +39,7 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
     get diary_comments_path(:display_name => user.display_name)
     assert_response :success
     assert_template :index
-    assert_select "h4", :html => "No diary comments"
+    assert_select "h4", :html => "No comments"
 
     # Test a user with a comment
     create(:diary_comment, :user => other_user)


### PR DESCRIPTION
Add user's changeset comments next to user's diary comments.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/903ad0a2-4af7-41b9-9cc4-88571fe8107e)

Pagination is reused along with traces list.
Localization strings are mostly kept in diary comments section for now.
