### PR TITLE
Don't include unused bootstrap css

### DIFF
--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -1,0 +1,53 @@
+/*!
+ * Bootstrap v5.1.3 (https://getbootstrap.com/)
+ * Copyright 2011-2021 The Bootstrap Authors
+ * Copyright 2011-2021 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+// scss-docs-start import-stack
+// Configuration
+@import "bootstrap/functions";
+@import "bootstrap/variables";
+@import "bootstrap/mixins";
+@import "bootstrap/utilities";
+
+// Layout & components
+@import "bootstrap/root";
+@import "bootstrap/reboot";
+@import "bootstrap/type";
+@import "bootstrap/images";
+@import "bootstrap/containers";
+@import "bootstrap/grid";
+@import "bootstrap/tables";
+@import "bootstrap/forms";
+@import "bootstrap/buttons";
+@import "bootstrap/transitions";
+@import "bootstrap/dropdown";
+@import "bootstrap/button-group";
+@import "bootstrap/nav";
+// @import "bootstrap/navbar";
+@import "bootstrap/card";
+// @import "bootstrap/accordion";
+// @import "bootstrap/breadcrumb";
+@import "bootstrap/pagination";
+@import "bootstrap/badge";
+@import "bootstrap/alert";
+// @import "bootstrap/progress";
+@import "bootstrap/list-group";
+@import "bootstrap/close";
+// @import "bootstrap/toasts";
+// @import "bootstrap/modal";
+@import "bootstrap/tooltip";
+// @import "bootstrap/popover";
+// @import "bootstrap/carousel";
+@import "bootstrap/spinners";
+// @import "bootstrap/offcanvas";
+// @import "bootstrap/placeholders";
+
+// Helpers
+@import "bootstrap/helpers";
+
+// Utilities
+@import "bootstrap/utilities/api";
+// scss-docs-end import-stack

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,5 +1,5 @@
 @import "parameters";
-@import "bootstrap";
+@import "bootstrap-custom";
 @import "rails_bootstrap_forms";
 
 /* Styles common to large and small screens */


### PR DESCRIPTION
Include only Bootstrap components that are in use as recommended [here](https://getbootstrap.com/docs/5.1/customize/sass/#importing)
by creating `_bootstrap-custom.scss` as described [here](https://github.com/twbs/bootstrap-rubygem#sass-individual-components).
Results in ~10% smaller css.

Actually I do this to modify Bootstrap's theme colors. It has to be done after importing variables but before importing components, and I can't do that if everything is imported in one `@import`.