### PR TITLE
Show hidden comments to moderators if requested

### DIFF
--- a/app/views/api/changesets/_changeset.json.jbuilder
+++ b/app/views/api/changesets/_changeset.json.jbuilder
@@ -21,9 +21,10 @@ end
 
 json.tags changeset.tags unless changeset.tags.empty?
 
-if @include_discussion
-  json.comments(changeset.comments) do |comment|
+if @comments
+  json.comments(@comments) do |comment|
     json.id comment.id
+    json.visible comment.visible
     json.date comment.created_at.xmlschema
     if comment.author.data_public?
       json.uid comment.author.id

--- a/app/views/api/changesets/_changeset.xml.builder
+++ b/app/views/api/changesets/_changeset.xml.builder
@@ -24,12 +24,13 @@ xml.changeset(attrs) do |changeset_xml_node|
 
   # include discussion if requested
 
-  if @include_discussion
+  if @comments
     changeset_xml_node.discussion do |discussion_xml_node|
-      changeset.comments.includes(:author).each do |comment|
+      @comments.each do |comment|
         cattrs = {
           "id" => comment.id,
-          "date" => comment.created_at.xmlschema
+          "date" => comment.created_at.xmlschema,
+          "visible" => comment.visible
         }
         if comment.author.data_public?
           cattrs["uid"] = comment.author.id


### PR DESCRIPTION
Continuation of https://github.com/openstreetmap/openstreetmap-website/pull/4245.

With comment ids shown it's possible to hide specific comments. But the unhiding also requires comment ids. They are not known because the comments are hidden from the api calls.

Here a parameter is added to show hidden comments. It makes hidden comments visible to users who can unhide comments. The request looks like this:

```
/api/0.6/changeset/<id>?include_discussion=true&show_hidden_comments=true
```

I chose to add a parameter instead of showing the comments to anyone with permissions in case there are too many hidden comments. Maybe later some kind of limit will be added, making changeset with discussion requests to look like search requests. In this case `show_hidden_comments` would act similar to filters like `closed` for changesets/notes.

The `visible` attribute is added to each comment to indicate if it's hidden. See also https://github.com/zerebubuth/openstreetmap-cgimap/pull/289#issuecomment-1722363471.

See #3934 for why the parameter is named `show_hidden_...` I added `_comments` at the end in case there's something else to be hidden in changeset metadata. This allows for tags or bbox hiding to be added later if necessary.