### PR TITLE
Docker: Use `docker compose`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,17 +19,17 @@ jobs:
         touch config/settings.local.yml
     - name: Build Docker Image
       run: |
-        docker-compose build
-    - name: Start Docker-Compose
+        docker compose build
+    - name: Start Docker Compose
       run: |
-        docker-compose up -d
+        docker compose up -d
         sleep 15 # let the DB warm up a little
     - name: Prepare Database
       run: |
-        docker-compose run --rm web bundle exec rails db:migrate
-        docker-compose run --rm web bundle exec rails i18n:js:export
-        docker-compose run --rm web bundle exec rails assets:precompile
-        docker-compose run --rm web osmosis --rx docker/null-island.osm.xml --wd host=db database=openstreetmap user=openstreetmap password=openstreetmap validateSchemaVersion=no
+        docker compose run --rm web bundle exec rails db:migrate
+        docker compose run --rm web bundle exec rails i18n:js:export
+        docker compose run --rm web bundle exec rails assets:precompile
+        docker compose run --rm web osmosis --rx docker/null-island.osm.xml --wd host=db database=openstreetmap user=openstreetmap password=openstreetmap validateSchemaVersion=no
     - name: Test Basic Website
       run: |
         curl -siL http://127.0.0.1:3000 | egrep '^HTTP/1.1 200 OK'
@@ -37,5 +37,5 @@ jobs:
         curl -siL http://127.0.0.1:3000/api/0.6/node/1 | grep 'Null Island'
     - name: Test Complete Suite
       run: |
-        docker-compose run --rm web bundle exec rails db:test:prepare
-        docker-compose run --rm web bundle exec rails test:all
+        docker compose run --rm web bundle exec rails db:test:prepare
+        docker compose run --rm web bundle exec rails test:all

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,11 +1,26 @@
 # Using Docker and Docker Compose for Development and Testing
 
-These instructions are designed for setting up `openstreetmap-website` for development and testing using [Docker](https://www.docker.com/). This will allow you to install the OpenStreetMap application and all its dependencies in Docker images and then run them in containers, almost with a single command. You will need to install Docker and Docker Compose on your development machine:
+These instructions are designed for setting up `openstreetmap-website` for development and testing using [Docker](https://www.docker.com/). This will allow you to install the OpenStreetMap application and all its dependencies in Docker images and then run them in containers, almost with a single command.
 
-- [Install Docker](https://docs.docker.com/install/)
-- [Install Docker Compose](https://docs.docker.com/compose/install/)
+## Install Docker
 
-**Windows users: You must enable git symlinks before cloning the repository.** This repository uses symbolic links that are not enabled by default on Windows git. To enable them, [turn on Developer Mode](https://windowsreport.com/windows-11-developer-mode/) on Windows and run `git config --global core.symlinks true` to enable symlinks in Git. See [this StackOverflow question](https://stackoverflow.com/questions/5917249/git-symbolic-links-in-windows) for more information.
+### Windows
+
+1. Use Docker Desktop via [docker.com Download](https://www.docker.com/products/docker-desktop/).
+
+2. You have to enable git symlinks before cloning the repository.
+   This repository uses symbolic links that are not enabled by default on Windows git. To enable them, [turn on Developer Mode](https://windowsreport.com/windows-11-developer-mode/) on Windows and run `git config --global core.symlinks true` to enable symlinks in Git. See [this StackOverflow question](https://stackoverflow.com/questions/5917249/git-symbolic-links-in-windows) for more information.
+
+### Mac
+
+- Use Docker Desktop via [docker.com Download](https://www.docker.com/products/docker-desktop/).
+- Or [Homebrew](https://formulae.brew.sh/cask/docker).
+
+### Linux
+
+Use [Docker Engine](https://docs.docker.com/engine/install/ubuntu/) with the [docker-compose-plugin](https://docs.docker.com/compose/install/linux/)
+
+## Clone repository
 
 The first step is to fork/clone the repo to your local machine:
 
@@ -37,30 +52,34 @@ This is a workaround. [See issues/2185 for details](https://github.com/openstree
 
 To build local Docker images run from the root directory of the repository:
 
-    docker-compose build
+    docker compose build
 
 If this is your first time running or you have removed cache this will take some time to complete. Once the Docker images have finished building you can launch the images as containers.
 
 To launch the app run:
 
-    docker-compose up -d
+    docker compose up -d
 
 This will launch one Docker container for each 'service' specified in `docker-compose.yml` and run them in the background. There are two options for inspecting the logs of these running containers:
 
-- You can tail logs of a running container with a command like this: `docker-compose logs -f web` or `docker-compose logs -f db`.
-- Instead of running the containers in the background with the `-d` flag, you can launch the containers in the foreground with `docker-compose up`. The downside of this is that the logs of all the 'services' defined in `docker-compose.yml` will be intermingled. If you don't want this you can mix and match - for example, you can run the database in background with `docker-compose up -d db` and then run the Rails app in the foreground via `docker-compose up web`.
+- You can tail logs of a running container with a command like this: `docker compose logs -f web` or `docker compose logs -f db`.
+- Instead of running the containers in the background with the `-d` flag, you can launch the containers in the foreground with `docker compose up`. The downside of this is that the logs of all the 'services' defined in `docker-compose.yml` will be intermingled. If you don't want this you can mix and match - for example, you can run the database in background with `docker compose up -d db` and then run the Rails app in the foreground via `docker compose up web`.
 
 ### Migrations
 
 Run the Rails database migrations:
 
-    docker-compose run --rm web bundle exec rails db:migrate
+    docker compose run --rm web bundle exec rails db:migrate
 
 ### Tests
 
-Run the test suite by running:
+Prepare the test database:
 
-    docker-compose run --rm web bundle exec rails test:all
+     docker compose run --rm web bundle exec rails db:test:prepare
+
+Run the test suite:
+
+    docker compose run --rm web bundle exec rails test:all
 
 ### Loading an OSM extract
 
@@ -72,7 +91,7 @@ For example, let's download the District of Columbia from Geofabrik or [any othe
 
 You can now use Docker to load this extract into your local Docker-based OSM instance:
 
-    docker-compose run --rm web osmosis \
+    docker compose run --rm web osmosis \
         -verbose    \
         --read-pbf district-of-columbia-latest.osm.pbf \
         --log-progress \
@@ -84,7 +103,7 @@ You can now use Docker to load this extract into your local Docker-based OSM ins
 
 **Windows users:** Powershell uses `` ` `` and CMD uses `^` at the end of each line, e.g.:
 
-    docker-compose run --rm web osmosis `
+    docker compose run --rm web osmosis `
         -verbose    `
         --read-pbf district-of-columbia-latest.osm.pbf `
         --log-progress `
@@ -104,12 +123,12 @@ See [`CONFIGURE.md`](CONFIGURE.md) for information on how to manage users and en
 
 If you want to get into a web container and run specific commands you can fire up a throwaway container to run bash in via:
 
-    docker-compose run --rm web bash
+    docker compose run --rm web bash
 
 Alternatively, if you want to use the already-running `web` container then you can `exec` into it via:
 
-    docker-compose exec web bash
+    docker compose exec web bash
 
 Similarly, if you want to `exec` in the db container use:
 
-    docker-compose exec db bash
+    docker compose exec db bash

--- a/config/docker.database.yml
+++ b/config/docker.database.yml
@@ -1,4 +1,4 @@
-# This configuration is tailored for use with docker-compose. See DOCKER.md for more information.
+# This configuration is tailored for use with docker compose. See DOCKER.md for more information.
 
 development:
   adapter: postgresql


### PR DESCRIPTION
This PR change the `docker-compose` commands to the newer `docker compose`.

My understanding is, that `docker-compose` is deprecated and `docker compose` is more or less a drop in replacement.

https://docs.docker.com/compose/migrate/

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.

I did a fresh setup on MacOS with this updated docs and it all worked out except for some failing tests which I suspect are unrelated.

This PR also extends the "Tests" section on how to prepare the tests db to make the copy-paste steps complete.

---

Open todos

- [x] Update installation section – https://github.com/openstreetmap/openstreetmap-website/pull/4257#issuecomment-1737513727
- [x] Update github actions to use `docker compose` – https://github.com/openstreetmap/openstreetmap-website/pull/4257#issuecomment-1737549187