### PR TITLE
Switch to dartsass-sprockets for stylesheets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
       curl \
       default-jre-headless \
       file \
+      git-core \
       gpg-agent \
       libarchive-dev \
       libffi-dev \

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,9 @@ gem "json"
 gem "pg"
 
 # Use SCSS for stylesheets
-gem "sassc-rails"
+gem "dartsass-sprockets"
+# Pin the dependentent sass-embedded to avoid deprecation warnings in bootstrap
+gem "sass-embedded", "~> 1.55.0"
 
 # Use Terser as compressor for JavaScript assets
 gem "terser"
@@ -43,7 +45,7 @@ gem "sprockets-exporters_pack"
 gem "actionpack-page_caching", ">= 1.2.0"
 gem "activerecord-import"
 gem "active_record_union"
-gem "bootstrap", "~> 5.1.0"
+gem "bootstrap", :github => "gravitystorm/bootstrap-rubygem", :branch => "dartsass_5_1_3"
 gem "bootstrap_form", "~> 5.0"
 gem "cancancan"
 gem "composite_primary_keys", "~> 14.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/gravitystorm/bootstrap-rubygem.git
+  revision: 8c48a63412e0ef1a280b95ef5344667be92d374a
+  branch: dartsass_5_1_3
+  specs:
+    bootstrap (5.1.3)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.9.3, < 3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -117,10 +126,6 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    bootstrap (5.1.3)
-      autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.9.3, < 3)
-      sassc-rails (>= 2.0.0)
     bootstrap_form (5.3.2)
       actionpack (>= 6.1)
       activemodel (>= 6.1)
@@ -153,6 +158,14 @@ GEM
       rexml
     crass (1.0.6)
     dalli (3.2.6)
+    dartsass-ruby (3.0.1)
+      sass-embedded (~> 1.54)
+    dartsass-sprockets (3.0.0)
+      dartsass-ruby (~> 3.0)
+      railties (>= 4.0.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.3.3)
     debug_inspector (1.1.0)
     deep_merge (1.2.2)
@@ -231,6 +244,7 @@ GEM
       ffi (>= 1.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (3.24.3)
     hashdiff (1.0.1)
     hashie (5.0.0)
     highline (2.1.0)
@@ -474,14 +488,9 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.55.0)
+      google-protobuf (~> 3.19)
+      rake (>= 10.0.0)
     secure_headers (6.5.0)
     selenium-webdriver (4.13.1)
       rexml (~> 3.2, >= 3.2.5)
@@ -551,7 +560,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.2)
-  bootstrap (~> 5.1.0)
+  bootstrap!
   bootstrap_form (~> 5.0)
   brakeman
   browser
@@ -563,6 +572,7 @@ DEPENDENCIES
   config
   connection_pool
   dalli
+  dartsass-sprockets
   debug_inspector
   delayed_job_active_record
   doorkeeper
@@ -619,7 +629,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rake
   sanitize
-  sassc-rails
+  sass-embedded (~> 1.55.0)
   secure_headers
   selenium-webdriver
   simplecov
@@ -632,4 +642,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.26
+   2.4.19

--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -24,3 +24,13 @@ $link-hover-decoration: underline;
 $table-striped-bg: $offwhite;
 
 $enable-negative-margins: true;
+
+// Workaround for a dartsass bug with bootstrap 5.1
+// This can be removed after upgrading to bootstrap 5.2
+// This copies definitions straight from bootstrap, but uses the sass-native
+// version of the subtract function.
+$border-width: 2px;
+$border-radius: .35rem;
+$card-border-radius: $border-radius;
+$card-border-width: $border-width;
+$card-inner-border-radius: subtract($card-border-radius, $card-border-width);


### PR DESCRIPTION
[`sassc-rails`](https://github.com/sass/sassc-rails) and the underlying C-library [libsass](https://github.com/sass/libsass), are deprecated. `libsass` has problems when compiling newer versions of Bootstrap (5.2+), where it cannot re-parse its own output, and that causes problems during our asset precompilation. After extensive investigations I cannot find a workaround to keep using sassc-rails with newer versions of Bootstrap.

This PR switches our sass stylesheet compiler to [`dartsass-sprockets`](https://github.com/tablecheck/dartsass-sprockets), which is designed to be a drop-in replacement for `sassc-rails`, and which uses the currently maintained [dart implementation of sass](https://sass-lang.com/dart-sass/). 

Unfortunately the bootstrap gem had, [until recently](https://github.com/twbs/bootstrap-rubygem/commit/fde1edff90d9219bbef48ecc6a65f13835269bcd), a hard-coded dependency on `sassc-rails`, and therefore conflicted with `dartsass-sprockets` (the two cannot be used at the same time). Although this has been resolved in bootstrap-rubygems main branch, the fix has not been backported to the 5.1 and 5.2 branches. To work around this, I have backported the fix myself, and this PR uses the bootstrap 5.1 backported version.

I have also prepared two other branches, which I will open draft PRs for, namely:

* Upgrading to bootstrap 5.2, with the appropriate backport
* Upgrading to bootstrap 5.3, using bootstrap-rubygem main branch (backport no longer required)

I'm offering these as a series of incremental upgrades, with all the associated backporting hassle, just in case there are any problems with deployment that CI hasn't picked up, as well as to make them easier to review.

A note on `sass-embedded` pinning - in recent years dartsass has added a number of deprecation warnings relating to changes in the sass language. Bootstrap quickly receives fixes to deal with them, but these fixes are generally not backported to earlier releases. To avoid copious noise from these deprecations, it's best to use a version of dartsass that is contemporary with each bootstrap release.  Each PR in this series does so. When we update to 5.3+ this will be less of an issue.