### PR TITLE
Upgrade to bootstrap 5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "pg"
 # Use SCSS for stylesheets
 gem "dartsass-sprockets"
 # Pin the dependentent sass-embedded to avoid deprecation warnings in bootstrap
-gem "sass-embedded", "~> 1.55.0"
+gem "sass-embedded", "~> 1.64.0"
 
 # Use Terser as compressor for JavaScript assets
 gem "terser"
@@ -45,7 +45,7 @@ gem "sprockets-exporters_pack"
 gem "actionpack-page_caching", ">= 1.2.0"
 gem "activerecord-import"
 gem "active_record_union"
-gem "bootstrap", :github => "gravitystorm/bootstrap-rubygem", :branch => "dartsass_5_1_3"
+gem "bootstrap", :github => "gravitystorm/bootstrap-rubygem", :branch => "dartsass_5_2_3"
 gem "bootstrap_form", "~> 5.0"
 gem "cancancan"
 gem "composite_primary_keys", "~> 14.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/gravitystorm/bootstrap-rubygem.git
-  revision: 8c48a63412e0ef1a280b95ef5344667be92d374a
-  branch: dartsass_5_1_3
+  revision: 7bd2caa8a2897a55892915a789d4e020906adb60
+  branch: dartsass_5_2_3
   specs:
-    bootstrap (5.1.3)
+    bootstrap (5.2.3)
       autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.9.3, < 3)
+      popper_js (>= 2.11.6, < 3)
 
 GEM
   remote: https://rubygems.org/
@@ -488,9 +488,9 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sass-embedded (1.55.0)
-      google-protobuf (~> 3.19)
-      rake (>= 10.0.0)
+    sass-embedded (1.64.2)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     secure_headers (6.5.0)
     selenium-webdriver (4.13.1)
       rexml (~> 3.2, >= 3.2.5)
@@ -629,7 +629,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rake
   sanitize
-  sass-embedded (~> 1.55.0)
+  sass-embedded (~> 1.64.0)
   secure_headers
   selenium-webdriver
   simplecov

--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -24,13 +24,3 @@ $link-hover-decoration: underline;
 $table-striped-bg: $offwhite;
 
 $enable-negative-margins: true;
-
-// Workaround for a dartsass bug with bootstrap 5.1
-// This can be removed after upgrading to bootstrap 5.2
-// This copies definitions straight from bootstrap, but uses the sass-native
-// version of the subtract function.
-$border-width: 1px;
-$border-radius: .25rem;
-$card-border-radius: $border-radius;
-$card-border-width: $border-width;
-$card-inner-border-radius: subtract($card-border-radius, $card-border-width);


### PR DESCRIPTION
This PR builds on #4260 and upgrades Bootstrap to the 5.2 release. 

It again uses a backported fix to avoid the hardcoded dependency on `sassc-rails`, and removes a workaround that was necessary for 5.1. The version of sass-embedded is updated too.

The only visual changes are slightly wider border rounding on form inputs - I haven't spotted anything else during review.