### PR TITLE
Use input group in search bar, but avoid positioning "where is this" in pixels

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1055,11 +1055,12 @@ tr.turn:hover {
 .search_form {
   background-color: $lightgrey;
 
+  #query {
+    z-index: 0;
+  }
+
   .describe_location {
-    top: 6px;
-    right: 6px;
     font-size: 10px;
-    color: $blue;
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -143,7 +143,7 @@ header {
 
 
 nav.primary {
-  .btn-outline-primary {
+  & > .btn-group .btn-outline-primary {
     @include button-outline-variant($green, $color-hover: $white, $active-color: $white);
   }
 

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -5,7 +5,7 @@
         <div class="input-group flex-nowrap">
           <%= text_field_tag "query", params[:query], :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control form-control-sm", :dir => "auto" %>
           <div class="input-group-text border-start-0 p-0 position-relative">
-            <%= link_to t("site.search.where_am_i"), "#", :class => "describe_location position-absolute end-0 me-1 btn btn-sm btn-outline-primary border-0 bg-transparent", :title => t("site.search.where_am_i_title") %>
+            <%= button_tag t("site.search.where_am_i"), :type => "button", :class => "describe_location position-absolute end-0 me-1 btn btn-sm btn-outline-primary border-0 bg-transparent", :title => t("site.search.where_am_i_title") %>
           </div>
           <%= submit_tag t("site.search.submit_text"), :class => "btn btn-sm btn-primary", :data => { :disable_with => false } %>
         </div>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -2,12 +2,12 @@
   <form method="GET" action="<%= search_path %>" class="search_form px-1 py-2">
     <div class="row gx-2 mx-0">
       <div class="col">
-        <div class="d-flex">
-          <span class='position-relative flex-grow-1'>
-            <%= link_to t("site.search.where_am_i"), "#", :class => "describe_location position-absolute", :title => t("site.search.where_am_i_title") %>
-            <%= text_field_tag "query", params[:query], :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control form-control-sm rounded-0 rounded-start border-end-0", :dir => "auto" %>
-          </span>
-          <%= submit_tag t("site.search.submit_text"), :class => "btn btn-sm btn-primary rounded-0 rounded-end", :data => { :disable_with => false } %>
+        <div class="input-group flex-nowrap">
+          <%= text_field_tag "query", params[:query], :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control form-control-sm", :dir => "auto" %>
+          <div class="input-group-text border-start-0 p-0 position-relative">
+            <%= link_to t("site.search.where_am_i"), "#", :class => "describe_location position-absolute end-0 me-1 btn btn-sm btn-outline-primary border-0 bg-transparent", :title => t("site.search.where_am_i_title") %>
+          </div>
+          <%= submit_tag t("site.search.submit_text"), :class => "btn btn-sm btn-primary", :data => { :disable_with => false } %>
         </div>
       </div>
       <div class="col-auto">


### PR DESCRIPTION
https://github.com/openstreetmap/openstreetmap-website/pull/3690#issuecomment-1737780556

- color override problems are avoided by limiting the override to the direct button group child of the primary navigation ("edit", "history", "export" buttons)

- "where is this?" is turned into a button which makes is as tall as everything else in the search input group and "top: 6px;" is no longer required

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/55d75493-823f-4a1b-863e-abdfeec3c4b8)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/f7edc9cf-58cc-43a9-871e-1c51a3f475c7)
