### PR TITLE
Remove rtl direction fix for <code>

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1121,8 +1121,6 @@ div.secondary-actions {
   code {
     background: $lightgrey;
     padding: 2px 3px;
-    direction: inherit; /* fix for Bootstrap < 5.2 */
-    unicode-bidi: unset; /* fix for Bootstrap < 5.2 */
   }
 
   pre {


### PR DESCRIPTION
The fix was added in #4156.

No longer necessary after updating Bootstrap.