### PR TITLE
Remove <picture> from logo in header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,7 @@
 <header class="closed clearfix">
   <h1>
     <a href="<%= root_path %>" class="geolink">
-      <picture>
-        <source srcset="<%= image_path "osm_logo.svg" %>" type="image/svg+xml" />
-        <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :class => "logo" %>
-      </picture>
+      <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :class => "logo" %>
       <%= t "layouts.project_name.h1" %>
     </a>
   </h1>


### PR DESCRIPTION
A `picture` element was added to show svg logo in https://github.com/openstreetmap/openstreetmap-website/commit/ecc4b64a23d0d27d5a1a2eb472082123cdf985cd. Then a `srcset` attribute was added in case `picture` is not supported in https://github.com/openstreetmap/openstreetmap-website/commit/37a4fc6dd14dfedc0c44a8d7bf6453df0db9e1b5. But why do you need both nowadays? Basic `<img src...>` is supported by anything, so if some browser doesn't understand `srcset`, there's a fallback.

(I know that picture+srcset is used similarly in several other places. I'm not removing picture everywhere in case I'm wrong.)