### PR TITLE
Remove <picture>s around <img srcset=...>

### DIFF
--- a/app/helpers/user_roles_helper.rb
+++ b/app/helpers/user_roles_helper.rb
@@ -25,9 +25,7 @@ module UserRolesHelper
     end
 
     if image
-      svg_icon = tag.source(:srcset => image_path("#{image}.svg"), :type => "image/svg+xml")
-      png_icon = image_tag("#{image}.png", :srcset => image_path("#{image}.svg"), :size => "20x20", :border => 0, :alt => alt, :title => title)
-      icon = tag.picture(svg_icon + png_icon)
+      icon = image_tag("#{image}.png", :srcset => image_path("#{image}.svg"), :size => "20x20", :border => 0, :alt => alt, :title => title)
       icon = link_to(icon, url, :method => :post, :data => { :confirm => confirm }) if url
     end
 

--- a/app/views/account/deletions/show.html.erb
+++ b/app/views/account/deletions/show.html.erb
@@ -6,10 +6,7 @@
 
 <div class="alert alert-danger row mx-0 p-3 align-items-center">
   <div class="col-auto">
-    <picture>
-      <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>
-      <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
-    </picture>
+    <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
   </div>
   <div class="col">
     <p class="mb-0"><%= t ".warning" %></p>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,10 +1,7 @@
 <% if flash[:error] %>
   <div class="alert alert-danger row mx-0 mb-0 p-3 rounded-0 align-items-center">
     <div class="col-auto">
-      <picture>
-        <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml" />
-        <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
-      </picture>
+      <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
     </div>
     <div class="col"><%= render_flash(flash[:error]) %></div>
   </div>
@@ -13,10 +10,7 @@
 <% if flash[:warning] %>
   <div class="alert alert-warning row mx-0 mb-0 p-3 rounded-0 align-items-center">
     <div class="col-auto">
-      <picture>
-        <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>
-        <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
-      </picture>
+      <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
     </div>
     <div class="col"><%= render_flash(flash[:warning]) %></div>
   </div>
@@ -25,10 +19,7 @@
 <% if flash[:notice] %>
   <div class="alert alert-success row mx-0 mb-0 p-3 rounded-0 align-items-center">
     <div class="col-auto">
-      <picture>
-        <source srcset="<%= image_path "notice.svg" %>" type="image/svg+xml"></source>
-        <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
-      </picture>
+      <%= image_tag("notice.png", :srcset => image_path("notice.svg")) %>
     </div>
     <div class="col"><%= render_flash(flash[:notice]) %></div>
   </div>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -8,10 +8,7 @@
   </head>
   <body>
     <a href="<%= root_path %>">
-      <picture>
-        <source srcset="<%= image_path "osm_logo.svg" %>" type="image/svg+xml" />
-        <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :class => "logo" %>
-      </picture>
+      <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :class => "logo" %>
     </a>
     <div class="details">
       <%= yield %>

--- a/test/helpers/user_roles_helper_test.rb
+++ b/test/helpers/user_roles_helper_test.rb
@@ -11,10 +11,7 @@ class UserRolesHelperTest < ActionView::TestCase
 
     icon = role_icon(create(:moderator_user), "moderator")
     expected = <<~HTML.delete("\n")
-      <picture>
-      <source srcset="/images/roles/moderator.svg" type="image/svg+xml">
       <img srcset="/images/roles/moderator.svg" border="0" alt="This user is a moderator" title="This user is a moderator" src="/images/roles/moderator.png" width="20" height="20" />
-      </picture>
     HTML
     assert_dom_equal expected, icon
   end
@@ -26,10 +23,7 @@ class UserRolesHelperTest < ActionView::TestCase
     icon = role_icon(user, "moderator")
     expected = <<~HTML.delete("\n")
       <a data-confirm="Are you sure you want to grant the role `moderator&#39; to the user `#{user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(user.display_name)}/role/moderator/grant">
-      <picture>
-      <source srcset="/images/roles/blank_moderator.svg" type="image/svg+xml">
       <img srcset="/images/roles/blank_moderator.svg" border="0" alt="Grant moderator access" title="Grant moderator access" src="/images/roles/blank_moderator.png" width="20" height="20" />
-      </picture>
       </a>
     HTML
     assert_dom_equal expected, icon
@@ -38,10 +32,7 @@ class UserRolesHelperTest < ActionView::TestCase
     icon = role_icon(moderator_user, "moderator")
     expected = <<~HTML.delete("\n")
       <a data-confirm="Are you sure you want to revoke the role `moderator&#39; from the user `#{moderator_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(moderator_user.display_name)}/role/moderator/revoke">
-      <picture>
-      <source srcset="/images/roles/moderator.svg" type="image/svg+xml">
       <img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" />
-      </picture>
       </a>
     HTML
     assert_dom_equal expected, icon
@@ -55,23 +46,14 @@ class UserRolesHelperTest < ActionView::TestCase
 
     icons = role_icons(create(:moderator_user))
     expected = <<~HTML.delete("\n")
-      <picture>
-      <source srcset="/images/roles/moderator.svg" type="image/svg+xml">
       <img srcset="/images/roles/moderator.svg" border="0" alt="This user is a moderator" title="This user is a moderator" src="/images/roles/moderator.png" width="20" height="20" />
-      </picture>
     HTML
     assert_dom_equal expected, icons
 
     icons = role_icons(create(:super_user))
     expected = <<~HTML.delete("\n")
-      <picture>
-      <source srcset="/images/roles/administrator.svg" type="image/svg+xml">
       <img srcset="/images/roles/administrator.svg" border="0" alt="This user is an administrator" title="This user is an administrator" src="/images/roles/administrator.png" width="20" height="20" />
-      </picture>
-       <picture>
-      <source srcset="/images/roles/moderator.svg" type="image/svg+xml">
       <img srcset="/images/roles/moderator.svg" border="0" alt="This user is a moderator" title="This user is a moderator" src="/images/roles/moderator.png" width="20" height="20" />
-      </picture>
     HTML
     assert_dom_equal expected, icons
   end
@@ -83,16 +65,10 @@ class UserRolesHelperTest < ActionView::TestCase
     icons = role_icons(user)
     expected = <<~HTML.delete("\n")
       <a data-confirm="Are you sure you want to grant the role `administrator&#39; to the user `#{user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(user.display_name)}/role/administrator/grant">
-      <picture>
-      <source srcset="/images/roles/blank_administrator.svg" type="image/svg+xml">
       <img srcset="/images/roles/blank_administrator.svg" border="0" alt="Grant administrator access" title="Grant administrator access" src="/images/roles/blank_administrator.png" width="20" height="20" />
-      </picture>
       </a>
-       <a data-confirm="Are you sure you want to grant the role `moderator&#39; to the user `#{user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(user.display_name)}/role/moderator/grant">
-      <picture>
-      <source srcset="/images/roles/blank_moderator.svg" type="image/svg+xml">
+      <a data-confirm="Are you sure you want to grant the role `moderator&#39; to the user `#{user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(user.display_name)}/role/moderator/grant">
       <img srcset="/images/roles/blank_moderator.svg" border="0" alt="Grant moderator access" title="Grant moderator access" src="/images/roles/blank_moderator.png" width="20" height="20" />
-      </picture>
       </a>
     HTML
     assert_dom_equal expected, icons
@@ -101,16 +77,10 @@ class UserRolesHelperTest < ActionView::TestCase
     icons = role_icons(moderator_user)
     expected = <<~HTML.delete("\n")
       <a data-confirm="Are you sure you want to grant the role `administrator&#39; to the user `#{moderator_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(moderator_user.display_name)}/role/administrator/grant">
-      <picture>
-      <source srcset="/images/roles/blank_administrator.svg" type="image/svg+xml">
       <img srcset="/images/roles/blank_administrator.svg" border="0" alt="Grant administrator access" title="Grant administrator access" src="/images/roles/blank_administrator.png" width="20" height="20" />
-      </picture>
       </a>
-       <a data-confirm="Are you sure you want to revoke the role `moderator&#39; from the user `#{moderator_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(moderator_user.display_name)}/role/moderator/revoke">
-      <picture>
-      <source srcset="/images/roles/moderator.svg" type="image/svg+xml">
+      <a data-confirm="Are you sure you want to revoke the role `moderator&#39; from the user `#{moderator_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(moderator_user.display_name)}/role/moderator/revoke">
       <img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" />
-      </picture>
       </a>
     HTML
     assert_dom_equal expected, icons
@@ -119,16 +89,10 @@ class UserRolesHelperTest < ActionView::TestCase
     icons = role_icons(super_user)
     expected = <<~HTML.delete("\n")
       <a data-confirm="Are you sure you want to revoke the role `administrator&#39; from the user `#{super_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(super_user.display_name)}/role/administrator/revoke">
-      <picture>
-      <source srcset="/images/roles/administrator.svg" type="image/svg+xml">
       <img srcset="/images/roles/administrator.svg" border="0" alt="Revoke administrator access" title="Revoke administrator access" src="/images/roles/administrator.png" width="20" height="20" />
-      </picture>
       </a>
-       <a data-confirm="Are you sure you want to revoke the role `moderator&#39; from the user `#{super_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(super_user.display_name)}/role/moderator/revoke">
-      <picture>
-      <source srcset="/images/roles/moderator.svg" type="image/svg+xml">
+      <a data-confirm="Are you sure you want to revoke the role `moderator&#39; from the user `#{super_user.display_name}&#39;?" rel="nofollow" data-method="post" href="/user/#{ERB::Util.u(super_user.display_name)}/role/moderator/revoke">
       <img srcset="/images/roles/moderator.svg" border="0" alt="Revoke moderator access" title="Revoke moderator access" src="/images/roles/moderator.png" width="20" height="20" />
-      </picture>
       </a>
     HTML
     assert_dom_equal expected, icons


### PR DESCRIPTION
Continues #4269, removing `<picture>` from everything else.