### PR TITLE
Bootstrap pagination in changeset pages for nodes/ways/relations

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -101,10 +101,6 @@ time[title] {
   border-color: $grey !important;
 }
 
-.border-lightgrey {
-  border-color: $lightgrey !important;
-}
-
 /* Rules for the header */
 
 #menu-icon {

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -64,6 +64,29 @@ module BrowseHelper
     end
   end
 
+  def sidebar_classic_pagination(pages, page_param)
+    max_width_for_default_padding = 35
+
+    width = 0
+    pagination_items(pages, {}).each do |body|
+      width += 2 # padding width
+      width += body.length
+    end
+    link_classes = ["page-link", { "px-1" => width > max_width_for_default_padding }]
+
+    tag.ul :class => "pagination pagination-sm mb-1 ms-auto" do
+      pagination_items(pages, {}).each do |body, n|
+        linked = !(n.is_a? String)
+        link = if linked
+                 link_to body, url_for(page_param => n), :class => link_classes
+               else
+                 tag.span body, :class => link_classes
+               end
+        concat tag.li link, :class => ["page-item", { n => !linked }]
+      end
+    end
+  end
+
   private
 
   ICON_TAGS = %w[aeroway amenity barrier building highway historic landuse leisure man_made natural railway shop tourism waterway].freeze

--- a/app/views/browse/_paging_nav.html.erb
+++ b/app/views/browse/_paging_nav.html.erb
@@ -4,11 +4,7 @@
   </div>
   <% if pages.page_count > 1 %>
     <div class="col-auto">
-      <h4>
-        <span class="border border-lightgrey rounded p-1">
-          <%= raw pagination_links_each(pages, {}) { |n| link_to(n, page_param => n) } %>
-        </span>
-      </h4>
+      <%= raw pagination_links_bootstrap(pages, {}) { |n| url_for(page_param => n) } %>
     </div>
   <% end %>
 </div>

--- a/app/views/browse/_paging_nav.html.erb
+++ b/app/views/browse/_paging_nav.html.erb
@@ -1,8 +1,8 @@
 <div class="d-flex flex-wrap gap-2">
   <h4 class="fs-5 mb-0"><%= heading %></h4>
   <% if pages.page_count > 1 %>
-    <div class="ms-auto">
+    <ul class="pagination pagination-sm mb-1 ms-auto">
       <%= raw pagination_links_bootstrap(pages, {}) { |n| url_for(page_param => n) } %>
-    </div>
+    </ul>
   <% end %>
 </div>

--- a/app/views/browse/_paging_nav.html.erb
+++ b/app/views/browse/_paging_nav.html.erb
@@ -2,18 +2,32 @@
   <h4 class="fs-5 mb-0"><%= heading %></h4>
   <% if pages.page_count > 1 %>
     <ul class="pagination pagination-sm mb-1 ms-auto">
-    <% pagination_items(pages, {}).each do |body, n| %>
-      <% linked = !(n.is_a? String)
-         classes = ["page-item"]
-         classes.push(n) unless linked %>
-      <%= content_tag "li", :class => classes do
-        if linked
-          link_to(body, url_for(page_param => n), :class => "page-link")
-        else
-          content_tag("span", body, :class => "page-link")
-        end
-      end %>
-    <% end %>
+    <%
+      max_width_for_default_padding = 35
+
+      width = 0
+      pagination_items(pages, {}).each do |body, n|
+        width += 2 # padding width
+        width += body.length
+      end
+      link_classes = ["page-link"]
+      link_classes.push("px-1") if width > max_width_for_default_padding
+
+      pagination_items(pages, {}).each do |body, n|
+        linked = !(n.is_a? String)
+        item_classes = ["page-item"]
+        item_classes.push(n) unless linked
+    %>
+    <%= content_tag "li", :class => item_classes do
+          if linked
+            link_to(body, url_for(page_param => n), :class => link_classes)
+          else
+            content_tag("span", body, :class => link_classes)
+          end
+        end %>
+    <%
+      end
+    %>
     </ul>
   <% end %>
 </div>

--- a/app/views/browse/_paging_nav.html.erb
+++ b/app/views/browse/_paging_nav.html.erb
@@ -1,9 +1,7 @@
-<div class="row">
-  <div class="col">
-    <h4><%= heading %></h4>
-  </div>
+<div class="d-flex flex-wrap gap-2">
+  <h4 class="fs-5 mb-0"><%= heading %></h4>
   <% if pages.page_count > 1 %>
-    <div class="col-auto">
+    <div class="ms-auto">
       <%= raw pagination_links_bootstrap(pages, {}) { |n| url_for(page_param => n) } %>
     </div>
   <% end %>

--- a/app/views/browse/_paging_nav.html.erb
+++ b/app/views/browse/_paging_nav.html.erb
@@ -1,30 +1,6 @@
 <div class="d-flex flex-wrap gap-2">
   <h4 class="fs-5 mb-0"><%= heading %></h4>
   <% if pages.page_count > 1 %>
-    <ul class="pagination pagination-sm mb-1 ms-auto">
-    <%
-      max_width_for_default_padding = 35
-
-      width = 0
-      pagination_items(pages, {}).each do |body, n|
-        width += 2 # padding width
-        width += body.length
-      end
-      link_classes = ["page-link", {"px-1" => width > max_width_for_default_padding}]
-
-      pagination_items(pages, {}).each do |body, n|
-        linked = !(n.is_a? String)
-    %>
-    <%= content_tag "li", :class => ["page-item", {n => !linked}] do
-          if linked
-            link_to(body, url_for(page_param => n), :class => link_classes)
-          else
-            content_tag("span", body, :class => link_classes)
-          end
-        end %>
-    <%
-      end
-    %>
-    </ul>
+    <%= sidebar_classic_pagination(pages, page_param) %>
   <% end %>
 </div>

--- a/app/views/browse/_paging_nav.html.erb
+++ b/app/views/browse/_paging_nav.html.erb
@@ -2,7 +2,18 @@
   <h4 class="fs-5 mb-0"><%= heading %></h4>
   <% if pages.page_count > 1 %>
     <ul class="pagination pagination-sm mb-1 ms-auto">
-      <%= raw pagination_links_bootstrap(pages, {}) { |n| url_for(page_param => n) } %>
+    <% pagination_items(pages, {}).each do |body, n| %>
+      <% linked = !(n.is_a? String)
+         classes = ["page-item"]
+         classes.push(n) unless linked %>
+      <%= content_tag "li", :class => classes do
+        if linked
+          link_to(body, url_for(page_param => n), :class => "page-link")
+        else
+          content_tag("span", body, :class => "page-link")
+        end
+      end %>
+    <% end %>
     </ul>
   <% end %>
 </div>

--- a/app/views/browse/_paging_nav.html.erb
+++ b/app/views/browse/_paging_nav.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex flex-wrap gap-2">
-  <h4 class="fs-5 mb-0"><%= heading %></h4>
+  <h4 class="fs-5 mb-0"><%= type_and_paginated_count(type, pages) %></h4>
   <% if pages.page_count > 1 %>
-    <%= sidebar_classic_pagination(pages, page_param) %>
+    <%= sidebar_classic_pagination(pages, "#{type}_page") %>
   <% end %>
 </div>

--- a/app/views/browse/_paging_nav.html.erb
+++ b/app/views/browse/_paging_nav.html.erb
@@ -10,15 +10,12 @@
         width += 2 # padding width
         width += body.length
       end
-      link_classes = ["page-link"]
-      link_classes.push("px-1") if width > max_width_for_default_padding
+      link_classes = ["page-link", {"px-1" => width > max_width_for_default_padding}]
 
       pagination_items(pages, {}).each do |body, n|
         linked = !(n.is_a? String)
-        item_classes = ["page-item"]
-        item_classes.push(n) unless linked
     %>
-    <%= content_tag "li", :class => item_classes do
+    <%= content_tag "li", :class => ["page-item", {n => !linked}] do
           if linked
             link_to(body, url_for(page_param => n), :class => link_classes)
           else

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -90,7 +90,7 @@
   <% end %>
 
   <% unless @ways.empty? %>
-    <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("way", @way_pages), :pages => @way_pages, :page_param => "way_page" } %>
+    <%= render :partial => "paging_nav", :locals => { :type => "way", :pages => @way_pages } %>
     <ul class="list-unstyled">
       <% @ways.each do |way| %>
         <li><%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
@@ -99,7 +99,7 @@
   <% end %>
 
   <% unless @relations.empty? %>
-    <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("relation", @relation_pages), :pages => @relation_pages, :page_param => "relation_page" } %>
+    <%= render :partial => "paging_nav", :locals => { :type => "relation", :pages => @relation_pages } %>
     <ul class="list-unstyled">
       <% @relations.each do |relation| %>
         <li><%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :class => link_class("relation", relation), :title => link_title(relation) } %></li>
@@ -108,7 +108,7 @@
   <% end %>
 
   <% unless @nodes.empty? %>
-    <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("node", @node_pages), :pages => @node_pages, :page_param => "node_page" } %>
+    <%= render :partial => "paging_nav", :locals => { :type => "node", :pages => @node_pages } %>
     <ul class="list-unstyled">
       <% @nodes.each do |node| %>
         <li><%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :class => link_class("node", node), :title => link_title(node), :rel => link_follow(node) } %></li>

--- a/lib/classic_pagination/pagination_helper.rb
+++ b/lib/classic_pagination/pagination_helper.rb
@@ -151,21 +151,21 @@ module ActionView
         html << "<ul class='pagination pagination-sm'>"
 
         if always_show_anchors && !(wp_first = window_pages[0]).first?
-          html << bootstrap_page_item(first.number.to_s, yield(first.number))
-          html << bootstrap_page_item("...") if wp_first.number - first.number > 1
+          html << bootstrap_page_item_link(first.number.to_s, yield(first.number))
+          html << bootstrap_page_item_disabled("...") if wp_first.number - first.number > 1
         end
 
         window_pages.each do |page|
           html << if current_page == page && !link_to_current_page
-                    bootstrap_page_item(page.number.to_s)
+                    bootstrap_page_item_active(page.number.to_s)
                   else
-                    bootstrap_page_item(page.number.to_s, yield(page.number))
+                    bootstrap_page_item_link(page.number.to_s, yield(page.number))
                   end
         end
 
         if always_show_anchors && !(wp_last = window_pages[-1]).last?
-          html << bootstrap_page_item("...") if last.number - wp_last.number > 1
-          html << bootstrap_page_item(last.number.to_s, yield(last.number))
+          html << bootstrap_page_item_disabled("...") if last.number - wp_last.number > 1
+          html << bootstrap_page_item_link(last.number.to_s, yield(last.number))
         end
 
         html << "</ul>"
@@ -175,15 +175,21 @@ module ActionView
       
       private
 
-      def bootstrap_page_item(body, url = nil)
-        if url
-          content_tag "li", :class => "page-item" do
-            link_to body, url, :class => "page-link"
-          end
-        else
-          content_tag "li", :class => "page-item disabled" do
-            content_tag "a", body, :class => "page-link"
-          end
+      def bootstrap_page_item_disabled(body)
+        content_tag "li", :class => "page-item disabled" do
+          content_tag "span", body, :class => "page-link"
+        end
+      end
+
+      def bootstrap_page_item_active(body)
+        content_tag "li", :class => "page-item active", :'aria-current' => "page" do
+          content_tag "span", body, :class => "page-link"
+        end
+      end
+
+      def bootstrap_page_item_link(body, url)
+        content_tag "li", :class => "page-item" do
+          link_to body, url, :class => "page-link"
         end
       end
     end

--- a/lib/classic_pagination/pagination_helper.rb
+++ b/lib/classic_pagination/pagination_helper.rb
@@ -148,7 +148,7 @@ module ActionView
 
         html = ""
 
-        html << "<ul class='pagination pagination-sm'>"
+        html << "<ul class='pagination pagination-sm mb-1'>"
 
         if always_show_anchors && !(wp_first = window_pages[0]).first?
           html << bootstrap_page_item_link(first.number.to_s, yield(first.number))

--- a/lib/classic_pagination/pagination_helper.rb
+++ b/lib/classic_pagination/pagination_helper.rb
@@ -130,6 +130,62 @@ module ActionView
 
         html
       end
+
+      # Same as above, but
+      # - with bootstrap classes
+      # - invoked block returns the page url
+      def pagination_links_bootstrap(paginator, options)
+        options = DEFAULT_OPTIONS.merge(options)
+        link_to_current_page = options[:link_to_current_page]
+        always_show_anchors = options[:always_show_anchors]
+
+        current_page = paginator.current_page
+        window_pages = current_page.window(options[:window_size]).pages
+        return unless link_to_current_page || window_pages.length > 1
+
+        first = paginator.first
+        last = paginator.last
+
+        html = ""
+
+        html << "<ul class='pagination pagination-sm'>"
+
+        if always_show_anchors && !(wp_first = window_pages[0]).first?
+          html << bootstrap_page_item(first.number.to_s, yield(first.number))
+          html << bootstrap_page_item("...") if wp_first.number - first.number > 1
+        end
+
+        window_pages.each do |page|
+          html << if current_page == page && !link_to_current_page
+                    bootstrap_page_item(page.number.to_s)
+                  else
+                    bootstrap_page_item(page.number.to_s, yield(page.number))
+                  end
+        end
+
+        if always_show_anchors && !(wp_last = window_pages[-1]).last?
+          html << bootstrap_page_item("...") if last.number - wp_last.number > 1
+          html << bootstrap_page_item(last.number.to_s, yield(last.number))
+        end
+
+        html << "</ul>"
+
+        html
+      end
+      
+      private
+
+      def bootstrap_page_item(body, url = nil)
+        if url
+          content_tag "li", :class => "page-item" do
+            link_to body, url, :class => "page-link"
+          end
+        else
+          content_tag "li", :class => "page-item disabled" do
+            content_tag "a", body, :class => "page-link"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/classic_pagination/pagination_helper.rb
+++ b/lib/classic_pagination/pagination_helper.rb
@@ -133,6 +133,7 @@ module ActionView
 
       # Same as above, but
       # - with bootstrap classes
+      # - no list wrapper
       # - invoked block returns the page url
       def pagination_links_bootstrap(paginator, options)
         options = DEFAULT_OPTIONS.merge(options)
@@ -147,8 +148,6 @@ module ActionView
         last = paginator.last
 
         html = ""
-
-        html << "<ul class='pagination pagination-sm mb-1'>"
 
         if always_show_anchors && !(wp_first = window_pages[0]).first?
           html << bootstrap_page_item_link(first.number.to_s, yield(first.number))
@@ -167,8 +166,6 @@ module ActionView
           html << bootstrap_page_item_disabled("...") if last.number - wp_last.number > 1
           html << bootstrap_page_item_link(last.number.to_s, yield(last.number))
         end
-
-        html << "</ul>"
 
         html
       end

--- a/lib/classic_pagination/pagination_helper.rb
+++ b/lib/classic_pagination/pagination_helper.rb
@@ -131,63 +131,38 @@ module ActionView
         html
       end
 
-      # Same as above, but
-      # - with bootstrap classes
-      # - no list wrapper
-      # - invoked block returns the page url
-      def pagination_links_bootstrap(paginator, options)
+      def pagination_items(paginator, options)
         options = DEFAULT_OPTIONS.merge(options)
         link_to_current_page = options[:link_to_current_page]
         always_show_anchors = options[:always_show_anchors]
 
         current_page = paginator.current_page
         window_pages = current_page.window(options[:window_size]).pages
-        return unless link_to_current_page || window_pages.length > 1
 
         first = paginator.first
         last = paginator.last
 
-        html = ""
+        items = []
 
         if always_show_anchors && !(wp_first = window_pages[0]).first?
-          html << bootstrap_page_item_link(first.number.to_s, yield(first.number))
-          html << bootstrap_page_item_disabled("...") if wp_first.number - first.number > 1
+          items.push [first.number.to_s, first.number]
+          items.push ["...", "disabled"] if wp_first.number - first.number > 1
         end
 
         window_pages.each do |page|
-          html << if current_page == page && !link_to_current_page
-                    bootstrap_page_item_active(page.number.to_s)
-                  else
-                    bootstrap_page_item_link(page.number.to_s, yield(page.number))
-                  end
+          if current_page == page && !link_to_current_page
+            items.push [page.number.to_s, "active"]
+          else
+            items.push [page.number.to_s, page.number]
+          end
         end
 
         if always_show_anchors && !(wp_last = window_pages[-1]).last?
-          html << bootstrap_page_item_disabled("...") if last.number - wp_last.number > 1
-          html << bootstrap_page_item_link(last.number.to_s, yield(last.number))
+          items.push ["...", "disabled"] if last.number - wp_last.number > 1
+          items.push [last.number.to_s, last.number]
         end
 
-        html
-      end
-      
-      private
-
-      def bootstrap_page_item_disabled(body)
-        content_tag "li", :class => "page-item disabled" do
-          content_tag "span", body, :class => "page-link"
-        end
-      end
-
-      def bootstrap_page_item_active(body)
-        content_tag "li", :class => "page-item active", :'aria-current' => "page" do
-          content_tag "span", body, :class => "page-link"
-        end
-      end
-
-      def bootstrap_page_item_link(body, url)
-        content_tag "li", :class => "page-item" do
-          link_to body, url, :class => "page-link"
-        end
+        items
       end
     end
   end


### PR DESCRIPTION
for sidebars of `/changeset/<id>` pages

when narrow enough:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/4b26bcd9-8ea5-442e-a422-3666c93c826e)

when wider:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c1b9cbd4-f29d-4b13-a767-f0bb40eb854a)

when really wide, with decreased padding:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/2c07084c-b658-4df7-bf66-4c54f0d86fa1)

