### PR TITLE
Add a primary key to the changeset_tags table

### DIFF
--- a/db/migrate/20231007141103_add_primary_key_to_changeset_tags.rb
+++ b/db/migrate/20231007141103_add_primary_key_to_changeset_tags.rb
@@ -1,0 +1,13 @@
+class AddPrimaryKeyToChangesetTags < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_primary_key :changeset_tags, [:changeset_id, :k], :algorithm => :concurrently
+    remove_index :changeset_tags, [:changeset_id]
+  end
+
+  def down
+    add_index :changeset_tags, [:changeset_id], :algorithm => :concurrently
+    remove_primary_key :changeset_tags
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1839,6 +1839,14 @@ ALTER TABLE ONLY public.changeset_comments
 
 
 --
+-- Name: changeset_tags changeset_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.changeset_tags
+    ADD CONSTRAINT changeset_tags_pkey PRIMARY KEY (changeset_id, k);
+
+
+--
 -- Name: changesets changesets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2203,13 +2211,6 @@ ALTER TABLE ONLY public.ways
 --
 
 CREATE INDEX acls_k_idx ON public.acls USING btree (k);
-
-
---
--- Name: changeset_tags_id_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX changeset_tags_id_idx ON public.changeset_tags USING btree (changeset_id);
 
 
 --
@@ -3466,6 +3467,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230825162137'),
 ('20230830115219'),
 ('20230830115220'),
+('20231007141103'),
 ('21'),
 ('22'),
 ('23'),


### PR DESCRIPTION
This seems to be the only table that doesn't actually have a primary key defined in the database for some reason, instead we just lie to rails about it's existence.

It also improves our monkey patched primary key support for migrations to allow concurrent builds of primary keys and fix removal of primary keys which it seems has never worked.