### PR TITLE
Send welcome email instead of redirecting to welcome page when creating user from authorization

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -40,6 +40,8 @@ class ConfirmationsController < ApplicationController
           token = nil
         end
 
+        UserMailer.welcome_email(user).deliver_later
+
         if token.nil? || token.user != user
           flash[:notice] = t(".success")
           redirect_to login_path(:referer => referer)

--- a/app/helpers/user_mailer_helper.rb
+++ b/app/helpers/user_mailer_helper.rb
@@ -3,6 +3,14 @@ module UserMailerHelper
     format_paragraph(text, 72, 0)
   end
 
+  def em(text)
+    "_#{text}_"
+  end
+
+  def strong(text)
+    "*#{text}*"
+  end
+
   def link_to_user(display_name)
     link_to(
       tag.strong(

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -32,6 +32,17 @@ class UserMailer < ApplicationMailer
     end
   end
 
+  def welcome_email(user)
+    with_recipient_locale user do
+      @help_path = url_for(:controller => "site", :action => "help")
+      @root_path = url_for(:controller => "site", :action => "index")
+      @edit_path = url_for(:controller => "site", :action => "edit")
+
+      mail :to => user.email,
+           :subject => t(".subject")
+    end
+  end
+
   def lost_password(user, token)
     with_recipient_locale user do
       @url = url_for(:controller => "passwords", :action => "reset_password",

--- a/app/views/user_mailer/welcome_email.html.erb
+++ b/app/views/user_mailer/welcome_email.html.erb
@@ -1,0 +1,33 @@
+<p class="lead"><%= t ".introduction" %></p>
+<h2><%= t ".whats_on_the_map.title" %></h2>
+
+<p><%= t ".whats_on_the_map.on_the_map_html", :real_and_current => tag.em(t(".whats_on_the_map.real_and_current")) %></p>
+<p><%= t ".whats_on_the_map.off_the_map_html", :doesnt => tag.em(t(".whats_on_the_map.doesnt")) %></p>
+
+<h2><%= t ".basic_terms.title" %></h2>
+
+<p><%= t ".basic_terms.paragraph_1" %></p>
+
+<ul>
+  <li><%= t ".basic_terms.an_editor_html", :editor => tag.strong(t(".basic_terms.editor")) %></li>
+  <li><%= t ".basic_terms.a_node_html", :node => tag.strong(t(".basic_terms.node")) %></li>
+  <li><%= t ".basic_terms.a_way_html", :way => tag.strong(t(".basic_terms.way")) %></li>
+  <li><%= t ".basic_terms.a_tag_html", :tag => tag.strong(t(".basic_terms.tag")) %></li>
+</ul>
+
+<h2><%= t ".rules.title" %></h2>
+
+<p><%= t ".rules.para_1_html",
+         :imports_link => link_to(t(".rules.imports"), t(".rules.imports_url")),
+         :automated_edits_link => link_to(t(".rules.automated_edits"), t(".rules.automated_edits_url")) %></p>
+
+<h2><%= t ".any_questions.title" %></h2>
+
+<p><%= t ".any_questions.paragraph_1_html",
+         :help_link => link_to(t(".any_questions.get_help_here"), @help_path),
+         :welcome_mat_link => link_to(t(".any_questions.welcome_mat"), t(".any_questions.welcome_mat_url")) %></p>
+
+<p><a href="<%= @edit_path %>" class="button start-mapping"><%= t ".start_mapping" %></a></p>
+
+<h2><%= t ".add_a_note.title" %></h2>
+<p><%= t ".add_a_note.para_1" %></p>

--- a/app/views/user_mailer/welcome_email.text.erb
+++ b/app/views/user_mailer/welcome_email.text.erb
@@ -1,0 +1,33 @@
+<%= t ".whats_on_the_map.title" %>
+
+<%= fp (t ".whats_on_the_map.on_the_map_html", :real_and_current => em(t(".whats_on_the_map.real_and_current"))) %>
+
+<%= fp (t ".whats_on_the_map.off_the_map_html", :doesnt => em(t(".whats_on_the_map.doesnt"))) %>
+
+<%= t ".basic_terms.title" %>
+
+<%= t ".basic_terms.paragraph_1" %>
+
+  - <%= fp(t ".basic_terms.an_editor_html", :editor => strong(t(".basic_terms.editor"))) %>
+  - <%= fp(t ".basic_terms.a_node_html", :node => strong(t(".basic_terms.node"))) %>
+  - <%= fp(t ".basic_terms.a_way_html", :way => strong(t(".basic_terms.way"))) %>
+  - <%= fp(t ".basic_terms.a_tag_html", :tag => strong(t(".basic_terms.tag"))) %>
+
+<%= t ".rules.title" %>
+
+<%= fp(t ".rules.para_1_html",
+         :imports_link => t(".rules.imports_url"),
+         :automated_edits_link => t(".rules.automated_edits_url")) %>
+
+<%= t ".any_questions.title" %>
+
+<%= fp(t ".any_questions.paragraph_1_text",
+         :help_link => @help_path,
+         :welcome_mat => t(".any_questions.welcome_mat"),
+         :welcome_mat_url => t(".any_questions.welcome_mat_url")) %>
+
+<%= t ".start_mapping" %>: <%= @edit_path %>
+
+<%= t ".add_a_note.title" %>
+
+<%= fp(t ".add_a_note.para_1") %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -20,6 +20,7 @@
   <div class="col-sm">
     <%= bootstrap_form_for current_user, :url => { :action => "create" } do |f| %>
       <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
+      <%= hidden_field_tag("provider_email", h(@provider_email)) unless @provider_email.nil? %>
 
       <%= f.email_field :email, :tabindex => 1 %>
       <%= f.email_field :email_confirmation, :help => t(".email_confirmation_help_html",

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -20,7 +20,6 @@
   <div class="col-sm">
     <%= bootstrap_form_for current_user, :url => { :action => "create" } do |f| %>
       <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
-      <%= hidden_field_tag("provider_email", h(@provider_email)) unless @provider_email.nil? %>
 
       <%= f.email_field :email, :tabindex => 1 %>
       <%= f.email_field :email_confirmation, :help => t(".email_confirmation_help_html",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1594,6 +1594,90 @@ en:
       greeting: "Hi,"
       hopefully_you: "Someone (hopefully you) would like to change their email address over at %{server_url} to %{new_address}."
       click_the_link: "If this is you, please click the link below to confirm the change."
+    welcome_email:
+      subject: "[OpenStreetMap] Welcome!"
+      introduction: |
+        Welcome to OpenStreetMap, the free and editable map of the world. Now that you're signed up,
+        you're all set to get started mapping. Here's a quick guide with the most important
+        things you need to know.
+      whats_on_the_map:
+        title: What's on the Map
+        on_the_map_html: |
+          OpenStreetMap is a place for mapping things that are both %{real_and_current} -
+          it includes millions of buildings, roads, and other details about places. You can map
+          whatever real-world features are interesting to you.
+        real_and_current: real and current
+        off_the_map_html: |
+          What it %{doesnt} include is opinionated data like ratings, historical or
+          hypothetical features, and data from copyrighted sources. Unless you have special
+          permission, don't copy from online or paper maps.
+        doesnt: doesn't
+      basic_terms:
+        title: Basic Terms For Mapping
+        paragraph_1: |
+          OpenStreetMap has some of its own lingo. Here are a few key words that'll come in handy.
+        an_editor_html: An %{editor} is a program or website you can use to edit the map.
+        a_node_html: A %{node} is a point on the map, like a single restaurant or a tree.
+        a_way_html: A %{way} is a line or area, like a road, stream, lake or building.
+        a_tag_html: A %{tag} is a bit of data about a node or way, like a restaurant's name or a road's speed limit.
+        editor: editor
+        node: node
+        way: way
+        tag: tag
+      rules:
+        title: Rules!
+        para_1_html: |
+          OpenStreetMap has few formal rules but we expect all participants to collaborate
+          with, and communicate with, the community. If you are considering
+          any activities other than editing by hand, please read and follow the guidelines on
+          %{imports_link} and %{automated_edits_link}.
+        imports: Imports
+        imports_url: https://wiki.openstreetmap.org/wiki/Import/Guidelines
+        automated_edits: Automated Edits
+        automated_edits_url: https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct
+      any_questions:
+        title: Any questions?
+        paragraph_1_text: |
+          OpenStreetMap has several resources for learning about the project, asking and answering
+          questions, and collaboratively discussing and documenting mapping topics.
+          %{help_link}. With an organization making plans for OpenStreetMap? %{welcome_mat}: %{welcome_mat_url}.
+        paragraph_1_html: |
+          OpenStreetMap has several resources for learning about the project, asking and answering
+          questions, and collaboratively discussing and documenting mapping topics.
+          %{help_link}. With an organization making plans for OpenStreetMap? %{welcome_mat_link}.
+        welcome_mat: Check out the Welcome Mat
+        welcome_mat_url: https://welcome.openstreetmap.org/
+      start_mapping: Start Mapping
+      add_a_note:
+        title: No Time To Edit? Add a Note!
+        para_1: |
+          If you just want something small fixed and don't have the time to sign up and learn how to edit, it's
+          easy to add a note.
+    communities:
+      title: Communities
+      lede_text: |
+        People from all over the world contribute to or use OpenStreetMap.
+        While many participate as individuals, others have formed communities.
+        These groups come in a range of sizes and represent geographies from small towns to large multi-country regions.
+        They can also be formal or informal.
+      local_chapters:
+        title: Local Chapters
+        about_text: |
+          Local Chapters are country-level or region-level groups that have taken the formal step of
+          establishing not-for-profit legal entities. They represent the area's map and mappers when
+          dealing with local government, business, and media. They have also formed an affiliation
+          with the OpenStreetMap Foundation (OSMF), giving them a link to the legal and copyright
+          governing body.
+        list_text: |
+          The following communities are formally established as Local Chapters:
+      other_groups:
+        title: Other Groups
+        other_groups_html: |
+          There is no need to formally establish a group to the same extent as the Local Chapters.
+          Indeed many groups exist very sucessfully as an informal gathering of people or as a
+          community group. Anyone can set up or join these. Read more on the %{communities_wiki_link}.
+        communities_wiki: Communities wiki page
+        communities_wiki_url: https://wiki.openstreetmap.org/wiki/User_group
     lost_password:
       subject: "[OpenStreetMap] Password reset request"
       greeting: "Hi,"


### PR DESCRIPTION
When user creates OSM account during Oauth2 authorization initiated from a third-party app, send "Welcome" email instead of redirecting user to "Welcome" page.

- When creating OSM account from OSM website, behaviour is unchanged.
- When creating OSM account during OAuth2 authorization, send a welcome email
   and redirect user to authorization screen after completing the sign-up process.
   
  Related to #4246