### PR TITLE
Allow localhost for OAuth2 redirect uri

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -267,7 +267,7 @@ Doorkeeper.configure do
   # redirects to localhost for example).
 
   force_ssl_in_redirect_uri do |uri|
-    !Rails.env.development? && uri.host != "127.0.0.1"
+    !Rails.env.development? && uri.host != "127.0.0.1" && uri.host != "localhost"
   end
 
   # Specify what redirect URI's you want to block during Application creation.


### PR DESCRIPTION
I had to spend an hour debugging and digging deep into Doorkeeper to learn that the website was configured to accept only `127.0.0.1`, but not `localhost`. I guess this fixes that.