### PR TITLE
Fix tooltip left/right placement and arrows in rtl

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -175,8 +175,7 @@ $(document).ready(function () {
     }
   }
 
-  var placement = $("html").attr("dir") === "rtl" ? "right" : "left";
-  $(".leaflet-control .control-button").tooltip({ placement: placement, container: "body" });
+  $(".leaflet-control .control-button").tooltip({ placement: "left", container: "body" });
 
   var expiry = new Date();
   expiry.setYear(expiry.getFullYear() + 10);

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -2,6 +2,34 @@
 @import "bootstrap";
 @import "rails_bootstrap_forms";
 
+/* Bootstrap + r2 fixes */
+
+:root[dir=rtl] {
+  .bs-tooltip-auto[data-popper-placement^="right"] .tooltip-arrow {
+    /* no-r2 */
+    right: unset !important;
+    left: calc(-1 * var(--bs-tooltip-arrow-height)) !important;
+
+    &::before {
+      /* no-r2 */
+      left: unset !important;
+      right: -1px !important;
+    }
+  }
+
+  .bs-tooltip-auto[data-popper-placement^="left"] .tooltip-arrow {
+    /* no-r2 */
+    left: unset !important;
+    right: calc(-1 * var(--bs-tooltip-arrow-height)) !important;
+
+    &::before {
+      /* no-r2 */
+      right: unset !important;
+      left: -1px !important;
+    }
+  }
+}
+
 /* Styles common to large and small screens */
 
 /* Default rules for the body of every page */


### PR DESCRIPTION
As mentioned in https://github.com/openstreetmap/openstreetmap-website/issues/2527#issuecomment-582127582 (but borders are still broken, however dropdown widths seem ok without changing anything).

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9d18be24-4cbe-4a49-b984-6f3fc9ef85a8)
