### PR TITLE
Enable focus outline on More button

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -187,20 +187,6 @@ nav.secondary {
     color: darken($darkgrey, 25%);
   }
 
-  .btn-outline-secondary {
-    @include button-outline-variant($darkgrey, $color-hover: $darkgrey, $active-background: white, $active-border: $darkgrey);
-    border-color: $grey;
-    &:hover {
-      border-color: $grey;
-    }
-  }
-
-  .login-menu {
-    .btn-outline-secondary {
-      @include button-outline-variant($darkgrey, $color-hover: $white, $active-color: $white);
-    }
-  }
-
   #inboxanchor {
     background-color: lighten($grey, 10%);
   }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -187,19 +187,17 @@ nav.secondary {
     color: darken($darkgrey, 25%);
   }
 
-  .login-menu {
-    .btn-outline-secondary {
-      @include button-outline-variant($darkgrey, $color-hover: $white, $active-color: $white);
+  .btn-outline-secondary {
+    @include button-outline-variant($darkgrey, $color-hover: $darkgrey, $active-background: white, $active-border: $darkgrey);
+    border-color: $grey;
+    &:hover {
+      border-color: $grey;
     }
   }
 
-  .user-menu {
+  .login-menu {
     .btn-outline-secondary {
-      @include button-outline-variant($darkgrey, $color-hover: $darkgrey, $active-background: white, $active-border: $darkgrey);
-      border-color: $grey;
-      &:hover {
-        border-color: $grey;
-      }
+      @include button-outline-variant($darkgrey, $color-hover: $white, $active-color: $white);
     }
   }
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -60,7 +60,7 @@
         <%= link_to t("layouts.about"), about_path, :class => "nav-link" %>
       </li>
       <li id="compact-secondary-nav" class="dropdown nav-item">
-        <button class="dropdown-toggle nav-link btn btn-outline-secondary border-0" type="button" data-bs-toggle="dropdown"><%= t "layouts.more" %></button>
+        <button class="dropdown-toggle nav-link btn btn-outline-secondary border-0 bg-white text-secondary" type="button" data-bs-toggle="dropdown"><%= t "layouts.more" %></button>
         <ul class="dropdown-menu">
           <% if Settings.status != "database_offline" && can?(:index, Issue) %>
             <li class="<%= current_page_class(issues_path) %>">
@@ -81,7 +81,7 @@
     </ul>
     <% if current_user && current_user.id %>
       <div class='d-inline-flex dropdown user-menu logged-in clearfix'>
-        <button class='dropdown-toggle btn btn-outline-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
+        <button class='dropdown-toggle btn btn-outline-secondary border-grey bg-white text-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
           <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1") %>
           <%= render :partial => "layouts/inbox" %>
           <span class="user-button">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -60,7 +60,7 @@
         <%= link_to t("layouts.about"), about_path, :class => "nav-link" %>
       </li>
       <li id="compact-secondary-nav" class="dropdown nav-item">
-        <button class="dropdown-toggle nav-link btn" type="button" data-bs-toggle="dropdown"><%= t "layouts.more" %></button>
+        <button class="dropdown-toggle nav-link btn btn-outline-secondary border-0" type="button" data-bs-toggle="dropdown"><%= t "layouts.more" %></button>
         <ul class="dropdown-menu">
           <% if Settings.status != "database_offline" && can?(:index, Issue) %>
             <li class="<%= current_page_class(issues_path) %>">


### PR DESCRIPTION
Currently there's no indication of keyboard focus on *More* button in compact-nav mode.

This adds a secondary button focus outline:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/062197b9-c47f-4caa-8a92-4b713f68d0a3)
