### PR TITLE
Remove some tag table custom css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -736,45 +736,16 @@ tr.turn:hover {
   }
 
   .browse-tag-list {
-    background-color: $offwhite;
     table-layout: fixed;
-    border-collapse: separate;
-    border-spacing: 0;
-    width: 100%;
-    margin-bottom: $spacer;
-
-    th, td {
-      border-bottom: 1px solid $grey;
-    }
+    white-space: pre-wrap;
 
     tr:last-child th, tr:last-child td {
       border-bottom: 0;
     }
 
-    .browse-tag-k,
-    .browse-tag-v {
-      width: 50%;
-      padding: 6px 10px;
-      word-wrap: break-word;
-      white-space: pre-wrap;
-    }
-
-    .browse-tag-k {
-      font-weight: 500;
-      background-color: $offwhite;
-    }
-
-    .browse-tag-v {
-      border-left: 1px solid $grey;
-      background-color: #fff;
-    }
-
     .colour-preview-box {
-      float: right;
       width: 14px;
       height: 14px;
-      margin: 4px 0px;
-      border: 1px solid rgba(0, 0, 0, .1);
       // add color via inline css on element: background-color: <tag value>;
     }
   }

--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -34,7 +34,7 @@ module BrowseTagsHelper
       end
       safe_join(phones, "; ")
     elsif colour_value = colour_preview(key, value)
-      tag.span("", :class => "colour-preview-box", :"data-colour" => colour_value, :title => t("browse.tag_details.colour_preview", :colour_value => colour_value)) + colour_value
+      tag.span("", :class => "colour-preview-box float-end m-1 border border-dark border-opacity-10", :"data-colour" => colour_value, :title => t("browse.tag_details.colour_preview", :colour_value => colour_value)) + colour_value
     else
       safe_join(value.split(";").map { |x| linkify(h(x)) }, ";")
     end

--- a/app/views/browse/_tag.html.erb
+++ b/app/views/browse/_tag.html.erb
@@ -1,4 +1,4 @@
 <tr>
-  <th class='browse-tag-k'><%= format_key(tag[0]) %></th>
-  <td class='browse-tag-v'><%= format_value(tag[0], tag[1]) %></td>
+  <th class='py-1 border-grey table-light fw-normal'><%= format_key(tag[0]) %></th>
+  <td class='py-1 border-grey border-start'><%= format_value(tag[0], tag[1]) %></td>
 </tr>

--- a/app/views/browse/_tag_details.html.erb
+++ b/app/views/browse/_tag_details.html.erb
@@ -1,6 +1,8 @@
 <% unless tag_details.empty? %>
   <h4><%= t ".tags" %></h4>
-  <table class='browse-tag-list border border-grey rounded'>
-    <%= render :partial => "tag", :collection => tag_details.sort %>
-  </table>
+  <div class='mb-3 border border-grey rounded overflow-hidden'>
+    <table class='mb-0 browse-tag-list table align-middle text-break'>
+      <%= render :partial => "tag", :collection => tag_details.sort %>
+    </table>
+  </div>
 <% end %>

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -48,7 +48,7 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_dom_equal "<a title=\"The File:Test.jpg item on Wikimedia Commons\" href=\"//commons.wikimedia.org/wiki/File:Test.jpg?uselang=en\">File:Test.jpg</a>", html
 
     html = format_value("colour", "#f00")
-    assert_dom_equal %(<span class="colour-preview-box" data-colour="#f00" title="Colour #f00 preview"></span>#f00), html
+    assert_dom_equal %(<span class="colour-preview-box float-end m-1 border border-dark border-opacity-10" data-colour="#f00" title="Colour #f00 preview"></span>#f00), html
 
     html = format_value("email", "foo@example.com")
     assert_dom_equal "<a title=\"Email foo@example.com\" href=\"mailto:foo@example.com\">foo@example.com</a>", html


### PR DESCRIPTION
I think @gravitystorm used tags table as an example of what's to be converted to Bootstrap, like in https://github.com/openstreetmap/openstreetmap-website/pull/3535#issuecomment-1125113979. I don't think think it's a good example because Bootstrap doesn't have:
- `table-layout: fixed`
- `white-space: pre-wrap`
- `border-collapse: separate`, which is required for rounded corners directly on the table
- without `border-collapse: separate` you need a wrapper with a border and rounded corners, then you can't use Bootstrap's bordered table class because it will have an outer border which you don't need.
- actually you could use `box-shadow` instead of a wrapper to draw a border, but Bootstrap doesn't have that too