### PR TITLE
Remove subscribe/unsubscribe button custom css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -763,12 +763,6 @@ tr.turn:hover {
     }
   }
 
-  .subscribe-buttons input {
-    font-size: 90%;
-    line-height: 15px;
-    min-height: 20px;
-  }
-
   span.action-button:hover {
     cursor: pointer;
     text-decoration: underline;

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -17,15 +17,11 @@
 
     <% if current_user %>
       <div class="col-auto">
-        <div class="subscribe-buttons">
-          <form action="#">
-            <% if @changeset.subscribers.exists?(current_user.id) %>
-              <input class="action-button btn btn-sm btn-primary" type="submit" name="unsubscribe" value="<%= t("javascripts.changesets.show.unsubscribe") %>" data-method="POST" data-url="<%= changeset_unsubscribe_url(@changeset) %>" />
-            <% else %>
-              <input class="action-button btn btn-sm btn-primary" type="submit" name="subscribe" value="<%= t("javascripts.changesets.show.subscribe") %>" data-method="POST" data-url="<%= changeset_subscribe_url(@changeset) %>" />
-            <% end %>
-          </form>
-        </div>
+        <% if @changeset.subscribers.exists?(current_user.id) %>
+          <button class="action-button btn btn-sm btn-primary" name="unsubscribe" data-method="POST" data-url="<%= changeset_unsubscribe_url(@changeset) %>"><%= t("javascripts.changesets.show.unsubscribe") %></button>
+        <% else %>
+          <button class="action-button btn btn-sm btn-primary" name="subscribe" data-method="POST" data-url="<%= changeset_subscribe_url(@changeset) %>"><%= t("javascripts.changesets.show.subscribe") %></button>
+        <% end %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
The css was added before Bootstrap. Now together with Bootstrap it makes a small button slightly smaller. I don't see the point of it.

Button after this PR:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d065d02c-e610-4104-842f-25b14d73456b)
