### PR TITLE
Simplify primary key for relation members tables

### DIFF
--- a/app/models/old_relation_member.rb
+++ b/app/models/old_relation_member.rb
@@ -20,7 +20,6 @@
 
 class OldRelationMember < ApplicationRecord
   self.table_name = "relation_members"
-  self.primary_key = %w[relation_id version sequence_id]
 
   belongs_to :old_relation, :query_constraints => [:relation_id, :version], :inverse_of => :old_members
   # A bit messy, referring to the current tables, should do for the data browser for now

--- a/app/models/relation_member.rb
+++ b/app/models/relation_member.rb
@@ -19,7 +19,6 @@
 
 class RelationMember < ApplicationRecord
   self.table_name = "current_relation_members"
-  self.primary_key = %w[relation_id sequence_id]
 
   belongs_to :relation
   belongs_to :member, :polymorphic => true

--- a/db/migrate/20231010194809_correct_relation_members_primary_key.rb
+++ b/db/migrate/20231010194809_correct_relation_members_primary_key.rb
@@ -1,0 +1,11 @@
+class CorrectRelationMembersPrimaryKey < ActiveRecord::Migration[7.0]
+  def up
+    alter_primary_key :current_relation_members, [:relation_id, :sequence_id]
+    alter_primary_key :relation_members, [:relation_id, :version, :sequence_id]
+  end
+
+  def down
+    alter_primary_key :relation_members, [:relation_id, :version, :member_type, :member_id, :member_role, :sequence_id]
+    alter_primary_key :current_relation_members, [:relation_id, :member_type, :member_id, :member_role, :sequence_id]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1883,7 +1883,7 @@ ALTER TABLE ONLY public.current_nodes
 --
 
 ALTER TABLE ONLY public.current_relation_members
-    ADD CONSTRAINT current_relation_members_pkey PRIMARY KEY (relation_id, member_type, member_id, member_role, sequence_id);
+    ADD CONSTRAINT current_relation_members_pkey PRIMARY KEY (relation_id, sequence_id);
 
 
 --
@@ -2107,7 +2107,7 @@ ALTER TABLE ONLY public.redactions
 --
 
 ALTER TABLE ONLY public.relation_members
-    ADD CONSTRAINT relation_members_pkey PRIMARY KEY (relation_id, version, member_type, member_id, member_role, sequence_id);
+    ADD CONSTRAINT relation_members_pkey PRIMARY KEY (relation_id, version, sequence_id);
 
 
 --
@@ -3437,6 +3437,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20231010194809'),
 ('20231007141103'),
 ('20230830115220'),
 ('20230830115219'),

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -102,7 +102,7 @@ module Api
       second_relation = create(:relation_member, :member => node).relation
       _super_relation = create(:relation_member, :member => second_relation).relation
       # should combine multiple relation_member references into just one relation entry
-      create(:relation_member, :member => node, :relation => relation_with_node, :sequence_id => 2)
+      create(:relation_member, :member => node, :relation => relation_with_node)
       # should not include deleted relations
       deleted_relation = create(:relation, :deleted)
       create(:relation_member, :member => node, :relation => deleted_relation)
@@ -122,7 +122,7 @@ module Api
       second_relation = create(:relation_member, :member => way).relation
       _super_relation = create(:relation_member, :member => second_relation).relation
       # should combine multiple relation_member references into just one relation entry
-      create(:relation_member, :member => way, :relation => relation_with_way, :sequence_id => 2)
+      create(:relation_member, :member => way, :relation => relation_with_way)
       # should not include deleted relations
       deleted_relation = create(:relation, :deleted)
       create(:relation_member, :member => way, :relation => deleted_relation)
@@ -142,7 +142,7 @@ module Api
       second_relation = create(:relation_member, :member => relation).relation
       _super_relation = create(:relation_member, :member => second_relation).relation
       # should combine multiple relation_member references into just one relation entry
-      create(:relation_member, :member => relation, :relation => relation_with_relation, :sequence_id => 2)
+      create(:relation_member, :member => relation, :relation => relation_with_relation)
       # should not include deleted relations
       deleted_relation = create(:relation, :deleted)
       create(:relation_member, :member => relation, :relation => deleted_relation)

--- a/test/factories/old_relation_member.rb
+++ b/test/factories/old_relation_member.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :old_relation_member do
+    sequence(:sequence_id)
     member_role { "" }
 
     old_relation

--- a/test/factories/relation_member.rb
+++ b/test/factories/relation_member.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :relation_member do
+    sequence(:sequence_id)
     member_role { "" }
 
     relation


### PR DESCRIPTION
The two relation members tables have, for some reason that I don't really understand, a primary key that includes all the fields rather than just those needed to identify the member uniquely.

We then have to lie to rails about the primary key makeup in order for things to work properly.

I can't see any purpose to this - there don't seem to be any relationships or queries that would be helped by the extra fields, and having noise between `version` and `sequence_id` means postgres won't be able to assume ordering during an index read of members for a relation and will have to do a sort.