### PR TITLE
Remove oauth list custom css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -987,12 +987,6 @@ tr.turn:hover {
   }
 }
 
-/* Rules for the oauth authorization page */
-
-.oauth-authorize ul {
-  list-style: none;
-}
-
 /* Rules for messages pages */
 
 .messages {


### PR DESCRIPTION
No longer in use. The list was removed in https://github.com/openstreetmap/openstreetmap-website/commit/9e75b8472ff066ba98d5f2af07fa12f7c11df55f.