### PR TITLE
Remove user list custom css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -932,12 +932,6 @@ tr.turn:hover {
   }
 }
 
-/* Rules for the user list */
-
-#user_list {
-  width: 100%;
-}
-
 /* Rules for the diary entry page */
 
 .diary_entries {


### PR DESCRIPTION
Bootstrap tables have 100% width by default.