### PR TITLE
Improve name selection with the query tool

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -124,6 +124,7 @@ $(document).ready(function () {
   I18n.fallbacks = true;
 
   OSM.preferred_editor = application_data.preferredEditor;
+  OSM.preferred_languages = application_data.preferredLanguages;
 
   if (application_data.user) {
     OSM.user = application_data.user;

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -125,7 +125,7 @@ OSM.Query = function (map) {
 
   function featureName(feature) {
     var tags = feature.tags,
-        locales = I18n.locales.get();
+        locales = OSM.preferred_languages;
 
     for (var i = 0; i < locales.length; i++) {
       if (tags["name:" + locales[i]]) {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,8 @@ module ApplicationHelper
   def application_data
     data = {
       :locale => I18n.locale,
-      :preferred_editor => preferred_editor
+      :preferred_editor => preferred_editor,
+      :preferred_languages => preferred_languages.expand.map(&:to_s)
     }
 
     if current_user


### PR DESCRIPTION
Pass the full expanded list of preferred languages to the client and use that when looking for the best name for an object.

Fixes #4310