### PR TITLE
Discard jobs when then encounter a deserialization error

### DIFF
--- a/app/jobs/mail_delivery_job.rb
+++ b/app/jobs/mail_delivery_job.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class ApplicationJob < ActiveJob::Base
+class MailDeliveryJob < ActionMailer::MailDeliveryJob
   discard_on ActiveJob::DeserializationError
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
+  self.delivery_job = ActionMailer::MailDeliveryJob
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  self.delivery_job = ActionMailer::MailDeliveryJob
+  self.delivery_job = MailDeliveryJob
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,8 +3,6 @@
 class UserMailer < ApplicationMailer
   include ActionView::Helpers::AssetUrlHelper
 
-  self.delivery_job = ActionMailer::MailDeliveryJob
-
   default :from => Settings.email_from,
           :return_path => Settings.email_return_path,
           :auto_submitted => "auto-generated"

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -184,7 +184,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_difference "User.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 1 do
         post users_path, :params => { :user => user.attributes, :referer => "/edit?editor=id#map=1/2/3" }
-        assert_enqueued_with :job => ActionMailer::MailDeliveryJob,
+        assert_enqueued_with :job => MailDeliveryJob,
                              :args => proc { |args| args[3][:params][:referer] == welcome_path(:editor => "id", :zoom => 1, :lat => 2, :lon => 3) }
         perform_enqueued_jobs
       end


### PR DESCRIPTION
This attempts to ensure that background jobs which fail to deserialise are discarded rather than retrying multiple times which is unlikely to achieve anything.

The main cause of such errors is database objects being deleted before the job runs - for example somebody adding a friend and then removing them again before the mail job runs causing a failure to find the friendship when the job runs.