### PR TITLE
Show unredacted element history to moderators

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -6,6 +6,7 @@ class BrowseController < ApplicationController
   before_action -> { check_database_readable(:need_api => true) }
   before_action :require_oauth
   before_action :update_totp, :only => [:query]
+  before_action :require_moderator_for_unredacted_history, :only => [:relation_history, :way_history, :node_history]
   around_action :web_timeout
   authorize_resource :class => false
 
@@ -77,4 +78,10 @@ class BrowseController < ApplicationController
   end
 
   def query; end
+
+  private
+
+  def require_moderator_for_unredacted_history
+    deny_access(nil) if params[:show_redactions] && !current_user&.moderator?
+  end
 end

--- a/app/controllers/old_nodes_controller.rb
+++ b/app/controllers/old_nodes_controller.rb
@@ -8,6 +8,7 @@ class OldNodesController < ApplicationController
 
   authorize_resource
 
+  before_action :require_moderator_for_unredacted_history
   around_action :web_timeout
 
   def show
@@ -15,5 +16,11 @@ class OldNodesController < ApplicationController
     @feature = OldNode.preload(:old_tags, :changeset => [:changeset_tags, :user]).find([params[:id], params[:version]])
   rescue ActiveRecord::RecordNotFound
     render :action => "not_found", :status => :not_found
+  end
+
+  private
+
+  def require_moderator_for_unredacted_history
+    deny_access(nil) if params[:show_redactions] && !current_user&.moderator?
   end
 end

--- a/app/controllers/old_relations_controller.rb
+++ b/app/controllers/old_relations_controller.rb
@@ -8,6 +8,7 @@ class OldRelationsController < ApplicationController
 
   authorize_resource
 
+  before_action :require_moderator_for_unredacted_history
   around_action :web_timeout
 
   def show
@@ -15,5 +16,11 @@ class OldRelationsController < ApplicationController
     @feature = OldRelation.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_members => :member).find([params[:id], params[:version]])
   rescue ActiveRecord::RecordNotFound
     render :action => "not_found", :status => :not_found
+  end
+
+  private
+
+  def require_moderator_for_unredacted_history
+    deny_access(nil) if params[:show_redactions] && !current_user&.moderator?
   end
 end

--- a/app/controllers/old_ways_controller.rb
+++ b/app/controllers/old_ways_controller.rb
@@ -8,6 +8,7 @@ class OldWaysController < ApplicationController
 
   authorize_resource
 
+  before_action :require_moderator_for_unredacted_history
   around_action :web_timeout
 
   def show
@@ -15,5 +16,11 @@ class OldWaysController < ApplicationController
     @feature = OldWay.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:node_tags, :ways] }).find([params[:id], params[:version]])
   rescue ActiveRecord::RecordNotFound
     render :action => "not_found", :status => :not_found
+  end
+
+  private
+
+  def require_moderator_for_unredacted_history
+    deny_access(nil) if params[:show_redactions] && !current_user&.moderator?
   end
 end

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,5 +1,9 @@
 <h4>
-  <%= t "browse.version" %>
+  <%= if common_details.redacted?
+        t "browse.redacted_version"
+      else
+        t "browse.version"
+      end %>
   #<%= link_to_unless_current common_details.version, :controller => "old_#{@type.pluralize}", :action => :show, :version => common_details.version %>
 </h4>
 

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -1,4 +1,4 @@
-<% if node.redacted? %>
+<% if node.redacted? && !params[:show_redactions] %>
   <div class="browse-section browse-redacted">
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.node"),
@@ -7,7 +7,7 @@
                                        :id => node.redaction.id), node.redaction) %>
   </div>
 <% else %>
-  <div class="browse-section browse-node">
+  <%= tag.div :class => ["browse-section", "browse-node", { "text-muted" => node.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => node %>
 
     <% unless node.ways.empty? and node.containing_relation_members.empty? %>
@@ -31,5 +31,5 @@
         </details>
       <% end %>
     <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -1,4 +1,4 @@
-<% if relation.redacted? %>
+<% if relation.redacted? && !params[:show_redactions] %>
   <div class="browse-section browse-redacted">
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.relation"),
@@ -7,7 +7,7 @@
                                        :id => relation.redaction.id), relation.redaction) %>
   </div>
 <% else %>
-  <div class="browse-section browse-relation">
+  <%= tag.div :class => ["browse-section", "browse-relation", { "text-muted" => relation.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => relation %>
 
     <% unless relation.containing_relation_members.empty? %>
@@ -29,5 +29,5 @@
         </ul>
       </details>
     <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/browse/_version_actions.erb
+++ b/app/views/browse/_version_actions.erb
@@ -1,0 +1,32 @@
+<div class='secondary-actions'>
+  <%= link_to t("browse.view_details"), :controller => :browse, :action => @type %>
+  <% if !@feature.redacted? %>
+    &middot;
+    <%= link_to t("browse.download_xml"), :controller => "api/old_#{@type.pluralize}", :action => :version %>
+  <% elsif current_user&.moderator? %>
+    &middot;
+    <% if !params[:show_redactions] %>
+      <%= link_to t("browse.view_redacted_data"), :params => { :show_redactions => true } %>
+    <% else %>
+      <%= link_to t("browse.view_redaction_message") %>
+    <% end %>
+  <% end %>
+</div>
+
+<div class='secondary-actions'>
+  <% if @feature.version > 1 %>
+    <%= link_to({ :version => @feature.version - 1 }, { :class => "icon-link" }) do %>
+      <%= previous_page_svg_tag :height => 11 %>
+      <%= "#{t('browse.version')} ##{@feature.version - 1}" %>
+    <% end %>
+    &middot;
+  <% end %>
+  <%= link_to t("browse.view_history"), :controller => :browse, :action => "#{@type}_history" %>
+  <% unless @feature.latest_version? %>
+    &middot;
+    <%= link_to({ :version => @feature.version + 1 }, { :class => "icon-link" }) do %>
+      <%= "#{t('browse.version')} ##{@feature.version + 1}" %>
+      <%= next_page_svg_tag :height => 11 %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -1,4 +1,4 @@
-<% if way.redacted? %>
+<% if way.redacted? && !params[:show_redactions] %>
   <div class="browse-section browse-redacted">
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.way"),
@@ -7,7 +7,7 @@
                                        :id => way.redaction.id), way.redaction) %>
   </div>
 <% else %>
-  <div class="browse-section browse-way">
+  <%= tag.div :class => ["browse-section", "browse-way", { "text-muted" => way.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => way %>
 
     <% unless way.containing_relation_members.empty? %>
@@ -39,5 +39,5 @@
         </ul>
       </details>
     <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/browse/feature.html.erb
+++ b/app/views/browse/feature.html.erb
@@ -18,6 +18,10 @@
     &middot;
   <% end %>
     <%= link_to t("browse.view_history"), :action => "#{@type}_history" %>
+  <% if current_user&.moderator? %>
+    &middot;
+    <%= link_to(t("browse.view_unredacted_history"), :action => "#{@type}_history", :params => { :show_redactions => true }) %>
+  <% end %>
   <% if @feature.version > 1 %>
     &middot;
     <%= link_to({ :controller => "old_#{@type.pluralize}", :action => :show, :version => @feature.version }, :class => "icon-link") do %>

--- a/app/views/browse/history.html.erb
+++ b/app/views/browse/history.html.erb
@@ -8,4 +8,11 @@
   <%= link_to(t("browse.download_xml"), :controller => "api/old_#{@type.pluralize}", :action => "history") %>
   &middot;
   <%= link_to(t("browse.view_details"), :action => @type) %>
+  <% if params[:show_redactions] %>
+    &middot;
+    <%= link_to(t("browse.view_history"), :action => "#{@type}_history") %>
+  <% elsif current_user&.moderator? %>
+    &middot;
+    <%= link_to(t("browse.view_unredacted_history"), :action => "#{@type}_history", :params => { :show_redactions => true }) %>
+  <% end %>
 </div>

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -4,35 +4,4 @@
 
 <%= render :partial => "browse/node", :object => @feature %>
 
-<div class='secondary-actions'>
-  <%= link_to t("browse.view_details"), node_path(@feature.node_id) %>
-  <% if !@feature.redacted? %>
-    &middot;
-    <%= link_to t("browse.download_xml"), node_version_path(*@feature.id) %>
-  <% elsif current_user&.moderator? %>
-    &middot;
-    <% if !params[:show_redactions] %>
-      <%= link_to t("browse.view_redacted_data"), old_node_path(*@feature.id, :params => { :show_redactions => true }) %>
-    <% else %>
-      <%= link_to t("browse.view_redaction_message"), old_node_path(*@feature.id) %>
-    <% end %>
-  <% end %>
-</div>
-
-<div class='secondary-actions'>
-  <% if @feature.version > 1 %>
-    <%= link_to old_node_path(@feature.node_id, @feature.version - 1), :class => "icon-link" do %>
-      <%= previous_page_svg_tag :height => 11 %>
-      <%= "#{t('browse.version')} ##{@feature.version - 1}" %>
-    <% end %>
-    &middot;
-  <% end %>
-  <%= link_to t("browse.view_history"), node_history_path(@feature.node_id) %>
-  <% if @feature.version < @feature.current_node.version %>
-    &middot;
-    <%= link_to old_node_path(@feature.node_id, @feature.version + 1), :class => "icon-link" do %>
-      <%= "#{t('browse.version')} ##{@feature.version + 1}" %>
-      <%= next_page_svg_tag :height => 11 %>
-    <% end %>
-  <% end %>
-</div>
+<%= render :partial => "browse/version_actions" %>

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -5,11 +5,18 @@
 <%= render :partial => "browse/node", :object => @feature %>
 
 <div class='secondary-actions'>
-  <% unless @feature.redacted? %>
-    <%= link_to t("browse.download_xml"), node_version_path(*@feature.id) %>
-    &middot;
-  <% end %>
   <%= link_to t("browse.view_details"), node_path(@feature.node_id) %>
+  <% if !@feature.redacted? %>
+    &middot;
+    <%= link_to t("browse.download_xml"), node_version_path(*@feature.id) %>
+  <% elsif current_user&.moderator? %>
+    &middot;
+    <% if !params[:show_redactions] %>
+      <%= link_to t("browse.view_redacted_data"), old_node_path(*@feature.id, :params => { :show_redactions => true }) %>
+    <% else %>
+      <%= link_to t("browse.view_redaction_message"), old_node_path(*@feature.id) %>
+    <% end %>
+  <% end %>
 </div>
 
 <div class='secondary-actions'>

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -4,35 +4,4 @@
 
 <%= render :partial => "browse/relation", :object => @feature %>
 
-<div class='secondary-actions'>
-  <%= link_to t("browse.view_details"), relation_path(@feature.relation_id) %>
-  <% if !@feature.redacted? %>
-    &middot;
-    <%= link_to t("browse.download_xml"), relation_version_path(*@feature.id) %>
-  <% elsif current_user&.moderator? %>
-    &middot;
-    <% if !params[:show_redactions] %>
-      <%= link_to t("browse.view_redacted_data"), old_relation_path(*@feature.id, :params => { :show_redactions => true }) %>
-    <% else %>
-      <%= link_to t("browse.view_redaction_message"), old_relation_path(*@feature.id) %>
-    <% end %>
-  <% end %>
-</div>
-
-<div class='secondary-actions'>
-  <% if @feature.version > 1 %>
-    <%= link_to old_relation_path(@feature.relation_id, @feature.version - 1), :class => "icon-link" do %>
-      <%= previous_page_svg_tag :height => 11 %>
-      <%= "#{t('browse.version')} ##{@feature.version - 1}" %>
-    <% end %>
-    &middot;
-  <% end %>
-  <%= link_to t("browse.view_history"), relation_history_path(@feature.relation_id) %>
-  <% if @feature.version < @feature.current_relation.version %>
-    &middot;
-    <%= link_to old_relation_path(@feature.relation_id, @feature.version + 1), :class => "icon-link" do %>
-      <%= "#{t('browse.version')} ##{@feature.version + 1}" %>
-      <%= next_page_svg_tag :height => 11 %>
-    <% end %>
-  <% end %>
-</div>
+<%= render :partial => "browse/version_actions" %>

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -5,11 +5,18 @@
 <%= render :partial => "browse/relation", :object => @feature %>
 
 <div class='secondary-actions'>
-  <% unless @feature.redacted? %>
-    <%= link_to t("browse.download_xml"), relation_version_path(*@feature.id) %>
-    &middot;
-  <% end %>
   <%= link_to t("browse.view_details"), relation_path(@feature.relation_id) %>
+  <% if !@feature.redacted? %>
+    &middot;
+    <%= link_to t("browse.download_xml"), relation_version_path(*@feature.id) %>
+  <% elsif current_user&.moderator? %>
+    &middot;
+    <% if !params[:show_redactions] %>
+      <%= link_to t("browse.view_redacted_data"), old_relation_path(*@feature.id, :params => { :show_redactions => true }) %>
+    <% else %>
+      <%= link_to t("browse.view_redaction_message"), old_relation_path(*@feature.id) %>
+    <% end %>
+  <% end %>
 </div>
 
 <div class='secondary-actions'>

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -5,11 +5,18 @@
 <%= render :partial => "browse/way", :object => @feature %>
 
 <div class='secondary-actions'>
-  <% unless @feature.redacted? %>
-    <%= link_to t("browse.download_xml"), way_version_path(*@feature.id) %>
-    &middot;
-  <% end %>
   <%= link_to t("browse.view_details"), way_path(@feature.way_id) %>
+  <% if !@feature.redacted? %>
+    &middot;
+    <%= link_to t("browse.download_xml"), way_version_path(*@feature.id) %>
+  <% elsif current_user&.moderator? %>
+    &middot;
+    <% if !params[:show_redactions] %>
+      <%= link_to t("browse.view_redacted_data"), old_way_path(*@feature.id, :params => { :show_redactions => true }) %>
+    <% else %>
+      <%= link_to t("browse.view_redaction_message"), old_way_path(*@feature.id) %>
+    <% end %>
+  <% end %>
 </div>
 
 <div class='secondary-actions'>

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -4,35 +4,4 @@
 
 <%= render :partial => "browse/way", :object => @feature %>
 
-<div class='secondary-actions'>
-  <%= link_to t("browse.view_details"), way_path(@feature.way_id) %>
-  <% if !@feature.redacted? %>
-    &middot;
-    <%= link_to t("browse.download_xml"), way_version_path(*@feature.id) %>
-  <% elsif current_user&.moderator? %>
-    &middot;
-    <% if !params[:show_redactions] %>
-      <%= link_to t("browse.view_redacted_data"), old_way_path(*@feature.id, :params => { :show_redactions => true }) %>
-    <% else %>
-      <%= link_to t("browse.view_redaction_message"), old_way_path(*@feature.id) %>
-    <% end %>
-  <% end %>
-</div>
-
-<div class='secondary-actions'>
-  <% if @feature.version > 1 %>
-    <%= link_to old_way_path(@feature.way_id, @feature.version - 1), :class => "icon-link" do %>
-      <%= previous_page_svg_tag :height => 11 %>
-      <%= "#{t('browse.version')} ##{@feature.version - 1}" %>
-    <% end %>
-    &middot;
-  <% end %>
-  <%= link_to t("browse.view_history"), way_history_path(@feature.way_id) %>
-  <% if @feature.version < @feature.current_way.version %>
-    &middot;
-    <%= link_to old_way_path(@feature.way_id, @feature.version + 1), :class => "icon-link" do %>
-      <%= "#{t('browse.version')} ##{@feature.version + 1}" %>
-      <%= next_page_svg_tag :height => 11 %>
-    <% end %>
-  <% end %>
-</div>
+<%= render :partial => "browse/version_actions" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,6 +332,8 @@ en:
     view_history: "View History"
     view_unredacted_history: "View Unredacted History"
     view_details: "View Details"
+    view_redacted_data: "View Redacted Data"
+    view_redaction_message: "View Redaction Message"
     location: "Location:"
     common_details:
       coordinates_html: "%{latitude}, %{longitude}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,6 +317,7 @@ en:
     deleted_ago_by_html: "Deleted %{time_ago} by %{user}"
     edited_ago_by_html: "Edited %{time_ago} by %{user}"
     version: "Version"
+    redacted_version: "Redacted Version"
     in_changeset: "Changeset"
     anonymous: "anonymous"
     no_comment: "(no comment)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,7 @@ en:
       other: "%{count} ways"
     download_xml: "Download XML"
     view_history: "View History"
+    view_unredacted_history: "View Unredacted History"
     view_details: "View Details"
     location: "Location:"
     common_details:

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -235,6 +235,87 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_template "browse/query"
   end
 
+  def test_anonymous_user_feature_page_secondary_actions
+    node = create(:node, :with_history)
+    get node_path(:id => node)
+    assert_response :success
+    assert_select ".secondary-actions a", :text => "View Details", :count => 0
+    assert_select ".secondary-actions a", :text => "View History", :count => 1
+    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 0
+  end
+
+  def test_regular_user_feature_page_secondary_actions
+    session_for(create(:user))
+    node = create(:node, :with_history)
+    get node_path(:id => node)
+    assert_response :success
+    assert_select ".secondary-actions a", :text => "View Details", :count => 0
+    assert_select ".secondary-actions a", :text => "View History", :count => 1
+    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 0
+  end
+
+  def test_moderator_user_feature_page_secondary_actions
+    session_for(create(:moderator_user))
+    node = create(:node, :with_history)
+    get node_path(:id => node)
+    assert_response :success
+    assert_select ".secondary-actions a", :text => "View Details", :count => 0
+    assert_select ".secondary-actions a", :text => "View History", :count => 1
+    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 1
+  end
+
+  def test_anonymous_user_history_page_secondary_actions
+    node = create(:node, :with_history)
+    get node_history_path(:id => node)
+    assert_response :success
+    assert_select ".secondary-actions a", :text => "View Details", :count => 1
+    assert_select ".secondary-actions a", :text => "View History", :count => 0
+    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 0
+  end
+
+  def test_regular_user_history_page_secondary_actions
+    session_for(create(:user))
+    node = create(:node, :with_history)
+    get node_history_path(:id => node)
+    assert_response :success
+    assert_select ".secondary-actions a", :text => "View Details", :count => 1
+    assert_select ".secondary-actions a", :text => "View History", :count => 0
+    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 0
+  end
+
+  def test_moderator_user_history_page_secondary_actions
+    session_for(create(:moderator_user))
+    node = create(:node, :with_history)
+    get node_history_path(:id => node)
+    assert_response :success
+    assert_select ".secondary-actions a", :text => "View Details", :count => 1
+    assert_select ".secondary-actions a", :text => "View History", :count => 0
+    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 1
+  end
+
+  def test_anonymous_user_unredacted_history_page_secondary_actions
+    node = create(:node, :with_history)
+    get node_history_path(:id => node, :params => { :show_redactions => true })
+    assert_response :redirect
+  end
+
+  def test_regular_user_unredacted_history_page_secondary_actions
+    session_for(create(:user))
+    node = create(:node, :with_history)
+    get node_history_path(:id => node, :params => { :show_redactions => true })
+    assert_response :redirect
+  end
+
+  def test_moderator_user_unredacted_history_page_secondary_actions
+    session_for(create(:moderator_user))
+    node = create(:node, :with_history)
+    get node_history_path(:id => node, :params => { :show_redactions => true })
+    assert_response :success
+    assert_select ".secondary-actions a", :text => "View Details", :count => 1
+    assert_select ".secondary-actions a", :text => "View History", :count => 1
+    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 0
+  end
+
   private
 
   # This is a convenience method for most of the above checks

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -193,6 +193,21 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".browse-section.browse-node .longitude", 0
   end
 
+  def test_redacted_node_unredacted_history
+    session_for(create(:moderator_user))
+    node = create(:node, :with_history, :deleted, :version => 2)
+    node_v1 = node.old_nodes.find_by(:version => 1)
+    node_v1.redact!(create(:redaction))
+
+    get node_history_path(:id => node, :params => { :show_redactions => true })
+    assert_response :success
+    assert_template "browse/history"
+
+    assert_select ".browse-section", 2
+    assert_select ".browse-section.browse-redacted", 0
+    assert_select ".browse-section.browse-node", 2
+  end
+
   def test_redacted_way_history
     way = create(:way, :with_history, :version => 4)
     way_v1 = way.old_ways.find_by(:version => 1)
@@ -211,6 +226,23 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".browse-section.browse-way", 2
   end
 
+  def test_redacted_way_unredacted_history
+    session_for(create(:moderator_user))
+    way = create(:way, :with_history, :version => 4)
+    way_v1 = way.old_ways.find_by(:version => 1)
+    way_v1.redact!(create(:redaction))
+    way_v3 = way.old_ways.find_by(:version => 3)
+    way_v3.redact!(create(:redaction))
+
+    get way_history_path(:id => way, :params => { :show_redactions => true })
+    assert_response :success
+    assert_template "browse/history"
+
+    assert_select ".browse-section", 4
+    assert_select ".browse-section.browse-redacted", 0
+    assert_select ".browse-section.browse-way", 4
+  end
+
   def test_redacted_relation_history
     relation = create(:relation, :with_history, :version => 4)
     relation_v1 = relation.old_relations.find_by(:version => 1)
@@ -227,6 +259,23 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".browse-section", 4
     assert_select ".browse-section.browse-redacted", 2
     assert_select ".browse-section.browse-relation", 2
+  end
+
+  def test_redacted_relation_unredacted_history
+    session_for(create(:moderator_user))
+    relation = create(:relation, :with_history, :version => 4)
+    relation_v1 = relation.old_relations.find_by(:version => 1)
+    relation_v1.redact!(create(:redaction))
+    relation_v3 = relation.old_relations.find_by(:version => 3)
+    relation_v3.redact!(create(:redaction))
+
+    get relation_history_path(:id => relation, :params => { :show_redactions => true })
+    assert_response :success
+    assert_template "browse/history"
+
+    assert_select ".browse-section", 4
+    assert_select ".browse-section.browse-redacted", 0
+    assert_select ".browse-section.browse-relation", 4
   end
 
   def test_query


### PR DESCRIPTION
Currently there's no obvious way to view redacted versions. The website won't show them. API-using apps will skip them because redacted versions are missing from element history request results unless a parameter that few people know about is added.

---

History page if logged in as a moderator:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b7ad0f3b-40b2-4e74-994c-3b8299db8916)

After clicking the "View Unredacted History":
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/17e323a0-be03-4b96-8960-7e1548cd3b11)
