### PR TITLE
Welcome screen shows "Continue with authorization" when OSM account created from authorization flow

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -311,20 +311,17 @@ class UsersController < ApplicationController
 
   def welcome_options
     uri = URI(session[:referer]) if session[:referer].present?
-    welcome_options = {}
-    welcome_options["oauth_return_url"] = uri&.to_s if uri&.path == oauth_authorization_path
+
+    return { "oauth_return_url" => uri&.to_s } if uri&.path == oauth_authorization_path
 
     begin
       %r{map=(.*)/(.*)/(.*)}.match(uri.fragment) do |m|
         editor = Rack::Utils.parse_query(uri.query).slice("editor")
-        welcome_options = { "zoom" => m[1],
-                            "lat" => m[2],
-                            "lon" => m[3] }.merge(editor).merge(welcome_options)
+        return { "zoom" => m[1], "lat" => m[2], "lon" => m[3] }.merge(editor)
       end
     rescue StandardError
       # Use default
     end
-    welcome_options
   end
 
   ##

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -199,8 +199,9 @@ class UsersController < ApplicationController
 
           referer = welcome_path
 
+          uri = URI(session[:referer]) if session[:referer].present?
+
           begin
-            uri = URI(session[:referer])
             %r{map=(.*)/(.*)/(.*)}.match(uri.fragment) do |m|
               editor = Rack::Utils.parse_query(uri.query).slice("editor")
               referer = welcome_path({ "zoom" => m[1],
@@ -212,6 +213,7 @@ class UsersController < ApplicationController
           end
 
           if current_user.status == "active"
+            referer = welcome_path({"oauth_return_url" => uri.to_s}) if uri&.path == oauth_authorization_path
             session[:referer] = referer
             successful_login(current_user)
           else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -197,20 +197,6 @@ class UsersController < ApplicationController
 
           flash[:matomo_goal] = Settings.matomo["goals"]["signup"] if defined?(Settings.matomo)
 
-          uri = URI(session[:referer]) if session[:referer].present?
-          welcome_options = {}
-          welcome_options["oauth_return_url"] = uri&.to_s if uri&.path == oauth_authorization_path
-
-          begin
-            %r{map=(.*)/(.*)/(.*)}.match(uri.fragment) do |m|
-              editor = Rack::Utils.parse_query(uri.query).slice("editor")
-              welcome_options = { "zoom" => m[1],
-                                  "lat" => m[2],
-                                  "lon" => m[3] }.merge(editor).merge(welcome_options)
-            end
-          rescue StandardError
-            # Use default
-          end
           referer = welcome_path(welcome_options)
 
           if current_user.status == "active"
@@ -322,6 +308,24 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def welcome_options
+    uri = URI(session[:referer]) if session[:referer].present?
+    welcome_options = {}
+    welcome_options["oauth_return_url"] = uri&.to_s if uri&.path == oauth_authorization_path
+
+    begin
+      %r{map=(.*)/(.*)/(.*)}.match(uri.fragment) do |m|
+        editor = Rack::Utils.parse_query(uri.query).slice("editor")
+        welcome_options = { "zoom" => m[1],
+                            "lat" => m[2],
+                            "lon" => m[3] }.merge(editor).merge(welcome_options)
+      end
+    rescue StandardError
+      # Use default
+    end
+    welcome_options
+  end
 
   ##
   # ensure that there is a "user" instance variable

--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -60,7 +60,13 @@
 </div>
 
 <div class='clearfix text-center'>
-  <p class="display-5"><a href="<%= edit_path %>" class="button start-mapping"><%= t ".start_mapping" %></a></p>
+  <p class="display-5">
+<% if params[:oauth_return_url] %>
+  <a class="btn btn-primary" href="<%= params[:oauth_return_url] %>"><%= t ".continue_authorization" %></a>
+<% else %>
+  <a class="button btn btn-primary start-mapping" href="<%= edit_path %>"><%= t ".start_mapping" %></a>
+<% end %>
+  </p>
 </div>
 
 <div class='alert alert-primary'>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2382,6 +2382,7 @@ en:
         automated_edits: Automated Edits
         automated_edits_url: https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct
       start_mapping: Start Mapping
+      continue_authorization: Continue Authorization
       add_a_note:
         title: No Time To Edit? Add a Note!
         para_1: |


### PR DESCRIPTION
When user wants to authorize 3rd party app with OSM, and wants to create an OSM account during OAuth authorization, the welcome screen displays "Continue with authorization" instead of "Start mapping".

![continue-auth](https://github.com/openstreetmap/openstreetmap-website/assets/99971018/2dc03e7a-8f3d-418f-8f7f-95e708bc120b)
