### PR TITLE
Format right-to-left and bi-di text in OSM tag values

### DIFF
--- a/app/views/browse/_tag.html.erb
+++ b/app/views/browse/_tag.html.erb
@@ -1,4 +1,4 @@
 <tr>
-  <th class='py-1 border-grey table-light fw-normal'><%= format_key(tag[0]) %></th>
-  <td class='py-1 border-grey border-start'><%= format_value(tag[0], tag[1]) %></td>
+  <th class='py-1 border-grey table-light fw-normal' dir='auto'><%= format_key(tag[0]) %></th>
+  <td class='py-1 border-grey border-start' dir='auto'><%= format_value(tag[0], tag[1]) %></td>
 </tr>


### PR DESCRIPTION
The change fixes an issue where right-to-left language strings can be rendered incorrectly in the Tags table of Map Data or History views

## Sample bug in text rendering

I noticed this street label in Erbil with mismatched parentheses. This turned out to be an error in the name string:

<img width="560" alt="Screen Shot 2023-11-08 at 11 01 08 AM" src="https://github.com/openstreetmap/openstreetmap-website/assets/643918/c89e5bce-aade-45b5-be20-ff8fe08a4e9a">

When reviewing the name in the Map Data (or now, [History view](https://www.openstreetmap.org/way/195240072/history)), it looks like the name is wrapped in parentheses. With a wider box or shorter string, the parentheses appear to wrap one word (مشکۆ) . What we're really seeing is the 0th character of the name string , ( , displayed on the left end of this line. 

<img width="332" alt="Screen Shot 2023-11-08 at 11 06 06 AM" src="https://github.com/openstreetmap/openstreetmap-website/assets/643918/d1acdd04-4e99-4099-ac56-ea188523e116">
<img width="314" alt="Screen Shot 2023-11-08 at 11 21 52 AM" src="https://github.com/openstreetmap/openstreetmap-website/assets/643918/826b3441-587d-4e78-a855-9930e24dc531">

## Corrected

In an updated version with `dir="auto"`, the string renders like it did in the tiles. This makes the misplaced and unpaired parenthesis visible in the web view.

<img width="314" alt="Screen Shot 2023-11-08 at 11 22 16 AM" src="https://github.com/openstreetmap/openstreetmap-website/assets/643918/f488bc2a-5e25-461d-8b43-8e96a9ae6fe2">

CSS has a direction property, but it can only be set to `ltr` or `rtl`, not `auto`

I've edited the name of the original way, but the issue can still be seen in the History tab.