### PR TITLE
Use dark theme to invert banner close button

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -446,11 +446,6 @@ body.small-nav {
       display: block;
       width: $sidebarWidth;
     }
-
-    button.btn-close {
-      background-color: rgba(255, 255, 255, 0.5);
-      opacity: 1.0;
-    }
   }
 
   #map {

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -2,7 +2,7 @@
   <%= tag.div :id => "banner", :data => { :bs_theme => token_list(:dark => banner[:dark]) } do %>
     <%= link_to (image_tag banner[:img], :srcset => banner[:srcset], :alt => banner[:alt], :title => banner[:alt]), banner[:link] %>
     <button type="button"
-            class="btn-close position-absolute top-0 end-0 m-4"
+            class="btn-close position-absolute top-0 end-0 m-4 opacity-100 bg-white bg-opacity-50"
             id="<%= banner_cookie(banner[:id]) %>"
             aria-label="<%= t("javascripts.close") %>"></button>
   <% end %>

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,4 +1,9 @@
 <% unless (banner = next_banner()).nil? %>
-<%= link_to (image_tag banner[:img], :srcset => banner[:srcset], :alt => banner[:alt], :title => banner[:alt]), banner[:link] %>
-<button type="button" class="btn-close <%= "btn-close-white" if banner[:dark] %> position-absolute top-0 end-0 m-4" id="<%= banner_cookie(banner[:id]) %>" aria-label="<%= t("javascripts.close") %>"></button>
+  <%= tag.div :id => "banner", :data => { :bs_theme => token_list(:dark => banner[:dark]) } do %>
+    <%= link_to (image_tag banner[:img], :srcset => banner[:srcset], :alt => banner[:alt], :title => banner[:alt]), banner[:link] %>
+    <button type="button"
+            class="btn-close position-absolute top-0 end-0 m-4"
+            id="<%= banner_cookie(banner[:id]) %>"
+            aria-label="<%= t("javascripts.close") %>"></button>
+  <% end %>
 <% end %>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -63,9 +63,7 @@
       </div>
     <% end %>
 
-    <div id="banner">
-      <%= render :partial => "layouts/banner" %>
-    </div>
+    <%= render :partial => "layouts/banner" %>
   </div>
 
   <noscript>


### PR DESCRIPTION
`.btn-close-white` added in https://github.com/openstreetmap/openstreetmap-website/commit/e6a8b400989802b0cc47ffac30103e4b10740fb4 is deprecated: https://getbootstrap.com/docs/5.3/components/close-button/#dark-variant