### PR TITLE
Remove unused maximiseMap/minimiseMap functions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -68,14 +68,6 @@ window.updateLinks = function (loc, zoom, layers, object) {
     .toggleClass("disabled", editDisabled);
 };
 
-window.maximiseMap = function () {
-  $("#content").addClass("maximised");
-};
-
-window.minimiseMap = function () {
-  $("#content").removeClass("maximised");
-};
-
 $(document).ready(function () {
   var headerWidth = 0,
       compactWidth = 0;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -915,15 +915,6 @@ tr.turn:hover {
   }
 }
 
-#content.maximised {
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  border: 0;
-  z-index: 2000;
-}
-
 /* Rules for small maps in content areas */
 
 .content_map {


### PR DESCRIPTION
Supposedly they were used in Potlatch:

https://github.com/openstreetmap/openstreetmap-website/blame/d62e8c43f3f404542dbdc310e31e4ed38cc2428b/app/views/site/edit.html.erb#L19