### PR TITLE
Remove custom css and large left margin for map noscript message

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -318,14 +318,6 @@ body.small-nav {
   font-weight: $font-weight-normal;
 }
 
-/* Rules for the message shown in place of the map when javascript is disabled */
-
-#noscript {
-  z-index: 20000000;
-  margin-left: 400px;
-  margin-top: 50px;
-}
-
 /* Rules for Leaflet maps */
 
 .leaflet-top.leaflet-right,

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -67,7 +67,7 @@
   </div>
 
   <noscript>
-    <div id="noscript">
+    <div class="mt-5 p-3">
       <p><%= t "site.index.js_1" %></p>
       <p><%= t "site.index.js_2" %></p>
     </div>


### PR DESCRIPTION
Currently the message for disabled javascript has a large left margin. But what if the window is small? Also `z-index` doesn't do anything because it has static positioning.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/ebd821c0-4448-427b-9518-31e74231fbd2)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6c5e6ab6-018c-4319-87ec-38c53e8bf942)
