### PR TITLE
Replace padding: $spacer css with class="p-3"

### DIFF
--- a/app/assets/javascripts/index/browse.js
+++ b/app/assets/javascripts/index/browse.js
@@ -48,7 +48,7 @@ OSM.initializeBrowse = function (map) {
 
   function displayFeatureWarning(count, limit, add, cancel) {
     $("#browse_status").html(
-      $("<div>").append(
+      $("<div class='p-3'>").append(
         $("<div class='d-flex'>").append(
           $("<h2 class='flex-grow-1 text-break'>")
             .text(I18n.t("browse.start_rjs.load_data")),

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -577,10 +577,6 @@ body.small-nav {
     margin-left: auto;
     margin-right: auto;
   }
-
-  > div {
-   padding: $spacer;
-  }
 }
 
 /* Temporary label size override until we remove site-wide font customisation */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -393,10 +393,6 @@ body.small-nav {
     #sidebar_loader {
       display: none;
     }
-
-    #sidebar_content {
-      padding: $spacer;
-    }
   }
 
   .overlay-sidebar #sidebar {

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -36,7 +36,7 @@
       </div>
     </div>
 
-    <div id="sidebar_content">
+    <div id="sidebar_content" class="p-3">
       <%= yield %>
     </div>
 


### PR DESCRIPTION
If you're negating it with a Bootstrap class (`mx-n3` on children, see https://github.com/openstreetmap/openstreetmap-website/commit/c8f0a81eb7043c297e050c1f3ff8a8cf7ff613bc), why not set it with a Bootstrap class?