### PR TITLE
Remove global text-align declarations

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -54,10 +54,6 @@ small, aside {
   margin-right: $lineheight * 0.25;
 }
 
-[dir=rtl] { /* no-r2 */ text-align: right; }
-
-[dir=ltr] { /* no-r2 */ text-align: left; }
-
 /* Rules for icons */
 
 .icon {


### PR DESCRIPTION
These interfere with directions set in `dir` attributes, e.g. `dir='auto'`.

The corresponding text-align was removed in Bootstrap 5.

Fixes #3432.