### PR TITLE
Use friendly_date helpers throughout the site

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -47,6 +47,10 @@ small, aside {
   font-size: 12px;
 }
 
+time[title] {
+  text-decoration: underline dotted;
+}
+
 #container { position: relative; }
 
 .small_icon {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,11 +26,11 @@ module ApplicationHelper
   end
 
   def friendly_date(date)
-    tag.span(time_ago_in_words(date), :title => l(date, :format => :friendly))
+    tag.time(time_ago_in_words(date), :title => l(date, :format => :friendly), :datetime => date.xmlschema)
   end
 
   def friendly_date_ago(date)
-    tag.span(time_ago_in_words(date, :scope => :"datetime.distance_in_words_ago"), :title => l(date, :format => :friendly))
+    tag.time(time_ago_in_words(date, :scope => :"datetime.distance_in_words_ago"), :title => l(date, :format => :friendly), :datetime => date.xmlschema)
   end
 
   def body_class

--- a/app/helpers/changesets_helper.rb
+++ b/app/helpers/changesets_helper.rb
@@ -14,16 +14,18 @@ module ChangesetsHelper
       action = :created
       time = time_ago_in_words(changeset.created_at, :scope => :"datetime.distance_in_words_ago")
       title = l(changeset.created_at)
+      datetime = changeset.created_at.xmlschema
     else
       action = :closed
       time = time_ago_in_words(changeset.closed_at, :scope => :"datetime.distance_in_words_ago")
       title = safe_join([t("browse.created"), ": ", l(changeset.created_at), "&#10;".html_safe, t("browse.closed"), ": ", l(changeset.closed_at)])
+      datetime = changeset.closed_at.xmlschema
     end
 
     if params.key?(:display_name)
-      t "browse.#{action}_ago_html", :time_ago => tag.abbr(time, :title => title)
+      t "browse.#{action}_ago_html", :time_ago => tag.time(time, :title => title, :datetime => datetime)
     else
-      t "browse.#{action}_ago_by_html", :time_ago => tag.abbr(time, :title => title),
+      t "browse.#{action}_ago_by_html", :time_ago => tag.time(time, :title => title, :datetime => datetime),
                                         :user => changeset_user_link(changeset)
     end
   end

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -4,12 +4,10 @@ module NoteHelper
   def note_event(event, at, by)
     if by.nil?
       t("notes.show.event_#{event}_by_anonymous_html",
-        :time_ago => tag.abbr(friendly_date_ago(at),
-                              :title => l(at)))
+        :time_ago => friendly_date_ago(at))
     else
       t("notes.show.event_#{event}_by_html",
-        :time_ago => tag.abbr(friendly_date_ago(at),
-                              :title => l(at)),
+        :time_ago => friendly_date_ago(at),
         :user => note_author(by))
     end
   end

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -21,9 +21,4 @@ module NoteHelper
       link_to h(author.display_name), link_options.merge(:controller => "/users", :action => "show", :display_name => author.display_name)
     end
   end
-
-  def disappear_in(note)
-    date = note.freshly_closed_until
-    tag.span(distance_of_time_in_words(date, Time.now.utc), :title => l(date, :format => :friendly))
-  end
 end

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -14,8 +14,7 @@
 <ul class="list-unstyled">
   <li>
     <%= t "browse.#{common_details.visible? ? :edited : :deleted}_ago_by_html",
-          :time_ago => tag.abbr(time_ago_in_words(common_details.timestamp, :scope => :"datetime.distance_in_words_ago"),
-                                :title => l(common_details.timestamp)),
+          :time_ago => friendly_date_ago(common_details.timestamp),
           :user => changeset_user_link(common_details.changeset) %>
   </li>
   <li>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -35,8 +35,7 @@
               <li id="c<%= comment.id %>">
                 <small class='text-muted'>
                   <%= t(".comment_by_html",
-                        :time_ago => tag.abbr(friendly_date_ago(comment.created_at),
-                                              :title => l(comment.created_at)),
+                        :time_ago => friendly_date_ago(comment.created_at),
                         :user => link_to(comment.author.display_name, user_path(comment.author))) %>
                   <% if current_user and current_user.moderator? %>
                     — <span class="action-button" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_hide_url(comment.id) %>"><%= t("javascripts.changesets.show.hide_comment") %></span>
@@ -50,8 +49,7 @@
               <li id="c<%= comment.id %>">
                 <small class='text-muted'>
                   <%= t(".hidden_comment_by_html",
-                        :time_ago => tag.abbr(friendly_date_ago(comment.created_at),
-                                              :title => l(comment.created_at)),
+                        :time_ago => friendly_date_ago(comment.created_at),
                         :user => link_to(comment.author.display_name, user_path(comment.author))) %>
                   — <span class="action-button text-muted" data-comment-id="<%= comment.id %>" data-method="POST" data-url="<%= changeset_comment_unhide_url(comment.id) %>"><%= t("javascripts.changesets.show.unhide_comment") %></span>
                  </small>

--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -23,7 +23,7 @@
     <p class="mb-0">
       <% changeset = contact.changesets.first %>
       <% if changeset %>
-        <%= t("users.show.latest edit", :ago => time_ago_in_words(changeset.created_at, :scope => :"datetime.distance_in_words_ago")) %>
+        <%= t(".latest_edit_html", :ago => friendly_date_ago(changeset.created_at)) %>
         <% comment = changeset.tags["comment"].to_s == "" ? t("browse.no_comment") : changeset.tags["comment"] %>
         <q><%= link_to(comment,
                        { :controller => "browse", :action => "changeset", :id => changeset.id },

--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -18,7 +18,9 @@
     <% @comments.each do |comment| -%>
     <tr>
       <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
-      <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><span title="<%= l comment.created_at, :format => :friendly %>"><%= time_ago_in_words(comment.created_at, :scope => :"datetime.distance_in_words_ago") %></span></td>
+      <td width="25%" class="<%= "text-muted" unless comment.visible? %>">
+        <%= friendly_date_ago(comment.created_at) %>
+      </td>
       <td width="50%" class="richtext text-break<%= " text-muted" unless comment.visible? %>"><%= comment.body.to_html %></td>
     </tr>
     <% end -%>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -61,13 +61,11 @@
           <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
           <td><%= link_to issue.reported_user.display_name, user_path(issue.reported_user) if issue.reported_user %></td>
           <td>
-            <% time_ago_tag = tag.abbr(time_ago_in_words(issue.updated_at, :scope => :"datetime.distance_in_words_ago"),
-                                       :title => l(issue.updated_at)) %>
             <% if issue.user_updated %>
               <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, user_path(issue.user_updated)),
-                                                        :time_ago => time_ago_tag %>
+                                                        :time_ago => friendly_date_ago(issue.updated_at) %>
             <% else %>
-              <%= time_ago_tag %>
+              <%= friendly_date_ago(issue.updated_at) %>
             <% end %>
           </td>
         </tr>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -95,7 +95,7 @@
 
   <% if @note.freshly_closed? %>
     <small class="text-muted">
-      <%= t ".disappear_date_html", :disappear_in => disappear_in(@note) %>
+      <%= t ".disappear_date_html", :disappear_in => friendly_date(@note.freshly_closed_until) %>
     </small>
   <% end %>
 </div>

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -29,9 +29,7 @@
       </li>
     </ul>
     <p class="text-muted mb-0">
-      <span title="<%= trace.timestamp %>">
-        <%= time_ago_in_words(trace.timestamp, :scope => :"datetime.distance_in_words_ago") %>
-      </span>
+      <%= friendly_date_ago(trace.timestamp) %>
       <%= t ".by" %> <%= link_to trace.user.display_name, user_path(trace.user) %>
       <% if !trace.tags.empty? %>
         <%= t ".in" %>

--- a/app/views/user_blocks/revoke.html.erb
+++ b/app/views/user_blocks/revoke.html.erb
@@ -12,7 +12,7 @@
 
 <% if @user_block.ends_at > Time.now %>
   <p>
-    <%= t(".time_future", :time => distance_of_time_in_words_to_now(@user_block.ends_at)) %>
+    <%= t(".time_future_html", :time => friendly_date(@user_block.ends_at)) %>
   </p>
 
   <%= bootstrap_form_for :revoke, :url => { :action => "revoke" } do |f| %>
@@ -28,6 +28,6 @@
 
 <% else %>
   <p>
-    <%= t(".past", :time => time_ago_in_words(@user_block.ends_at, :scope => :"datetime.distance_in_words_ago")) %>
+    <%= t(".past_html", :time => friendly_date_ago(@user_block.ends_at)) %>
   </p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2844,8 +2844,8 @@ en:
     revoke:
       title: "Revoking block on %{block_on}"
       heading_html: "Revoking block on %{block_on} by %{block_by}"
-      time_future: "This block will end in %{time}."
-      past: "This block ended %{time} and cannot be revoked now."
+      time_future_html: "This block will end in %{time}."
+      past_html: "This block ended %{time} and cannot be revoked now."
       confirm: "Are you sure you wish to revoke this block?"
       revoke: "Revoke!"
       flash: "This block has been revoked."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -465,6 +465,7 @@ en:
     contact:
       km away: "%{count}km away"
       m away: "%{count}m away"
+      latest_edit_html: "Latest edit (%{ago}):"
     popup:
       your location: "Your location"
       nearby mapper: "Nearby mapper"
@@ -2731,7 +2732,6 @@ en:
       ct status: "Contributor terms:"
       ct undecided: Undecided
       ct declined: Declined
-      latest edit: "Latest edit (%{ago}):"
       email address: "Email address:"
       created from: "Created from:"
       status: "Status:"

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -57,19 +57,19 @@ class ApplicationHelperTest < ActionView::TestCase
 
   def test_friendly_date
     date = friendly_date(Time.utc(2014, 3, 5, 18, 58, 23))
-    assert_match %r{^<span title=" *5 March 2014 at 18:58">.*</span>$}, date
+    assert_match %r{^<time title=" *5 March 2014 at 18:58" datetime="2014-03-05T18:58:23Z">.*</time>$}, date
 
     date = friendly_date(Time.now.utc - 1.hour)
-    assert_match %r{^<span title=".*">about 1 hour</span>$}, date
+    assert_match %r{^<time title=".*">about 1 hour</time>$}, date
 
     date = friendly_date(Time.now.utc - 2.days)
-    assert_match %r{^<span title=".*">2 days</span>$}, date
+    assert_match %r{^<time title=".*">2 days</time>$}, date
 
     date = friendly_date(Time.now.utc - 3.weeks)
-    assert_match %r{^<span title=".*">21 days</span>$}, date
+    assert_match %r{^<time title=".*">21 days</time>$}, date
 
     date = friendly_date(Time.now.utc - 4.months)
-    assert_match %r{^<span title=".*">4 months</span>$}, date
+    assert_match %r{^<time title=".*">4 months</time>$}, date
   end
 
   def test_body_class; end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -72,6 +72,23 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match %r{^<time title=".*">4 months</time>$}, date
   end
 
+  def test_friendly_date_ago
+    date = friendly_date_ago(Time.utc(2014, 3, 5, 18, 58, 23))
+    assert_match %r{^<time title=" *5 March 2014 at 18:58" datetime="2014-03-05T18:58:23Z">.*</time>$}, date
+
+    date = friendly_date_ago(Time.now.utc - 1.hour)
+    assert_match %r{^<time title=".*">about 1 hour ago</time>$}, date
+
+    date = friendly_date_ago(Time.now.utc - 2.days)
+    assert_match %r{^<time title=".*">2 days ago</time>$}, date
+
+    date = friendly_date_ago(Time.now.utc - 3.weeks)
+    assert_match %r{^<time title=".*">21 days ago</time>$}, date
+
+    date = friendly_date_ago(Time.now.utc - 4.months)
+    assert_match %r{^<time title=".*">4 months ago</time>$}, date
+  end
+
   def test_body_class; end
 
   def test_current_page_class; end

--- a/test/helpers/changesets_helper_test.rb
+++ b/test/helpers/changesets_helper_test.rb
@@ -17,11 +17,11 @@ class ChangesetsHelperTest < ActionView::TestCase
     # We need to explicitly reset the closed_at to some point in the future, and avoid the before_save callback
     changeset.update_column(:closed_at, Time.now.utc + 1.day) # rubocop:disable Rails/SkipsModelValidations
 
-    assert_match %r{^Created <abbr title="Mon, 01 Jan 2007 00:00:00 \+0000">.*</abbr> by anonymous$}, changeset_details(changeset)
+    assert_match %r{^Created <time title="Mon, 01 Jan 2007 00:00:00 \+0000" datetime="2007-01-01T00:00:00Z">.*</time> by anonymous$}, changeset_details(changeset)
 
     changeset = create(:changeset, :created_at => Time.utc(2007, 1, 1, 0, 0, 0), :closed_at => Time.utc(2007, 1, 2, 0, 0, 0))
     user_link = %(<a href="/user/#{ERB::Util.u(changeset.user.display_name)}">#{changeset.user.display_name}</a>)
 
-    assert_match %r{^Closed <abbr title="Created: Mon, 01 Jan 2007 00:00:00 \+0000&#10;Closed: Tue, 02 Jan 2007 00:00:00 \+0000">.*</abbr> by #{user_link}$}, changeset_details(changeset)
+    assert_match %r{^Closed <time title="Created: Mon, 01 Jan 2007 00:00:00 \+0000&#10;Closed: Tue, 02 Jan 2007 00:00:00 \+0000" datetime="2007-01-02T00:00:00Z">.*</time> by #{user_link}$}, changeset_details(changeset)
   end
 end

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -21,13 +21,4 @@ class NoteHelperTest < ActionView::TestCase
     assert_equal "<a href=\"/user/#{ERB::Util.u(user.display_name)}\">#{user.display_name}</a>", note_author(user)
     assert_equal "<a href=\"http://test.host/user/#{ERB::Util.u(user.display_name)}\">#{user.display_name}</a>", note_author(user, :only_path => false)
   end
-
-  def test_disappear_in
-    note_closed_date = Time.utc(2022, 1, 1, 12, 0, 0)
-    note = create(:note, :closed_at => note_closed_date)
-
-    travel_to note_closed_date + 1.day do
-      assert_match %r{^<span title=" 8 January 2022 at 12:00">6 days</span>$}, disappear_in(note)
-    end
-  end
 end

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -8,8 +8,8 @@ class NoteHelperTest < ActionView::TestCase
     date = Time.utc(2014, 3, 5, 21, 37, 45)
     user = create(:user)
 
-    assert_match %r{^Created by anonymous <abbr title="Wed, 05 Mar 2014 21:37:45 \+0000"><span title=" 5 March 2014 at 21:37">.* ago</span></abbr>$}, note_event("opened", date, nil)
-    assert_match %r{^Resolved by <a href="/user/#{ERB::Util.u(user.display_name)}">#{user.display_name}</a> <abbr title="Wed, 05 Mar 2014 21:37:45 \+0000"><span title=" 5 March 2014 at 21:37">.* ago</span></abbr>$}, note_event("closed", date, user)
+    assert_match %r{^Created by anonymous <abbr title="Wed, 05 Mar 2014 21:37:45 \+0000"><time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z">.* ago</time></abbr>$}, note_event("opened", date, nil)
+    assert_match %r{^Resolved by <a href="/user/#{ERB::Util.u(user.display_name)}">#{user.display_name}</a> <abbr title="Wed, 05 Mar 2014 21:37:45 \+0000"><time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z">.* ago</time></abbr>$}, note_event("closed", date, user)
   end
 
   def test_note_author

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -8,8 +8,8 @@ class NoteHelperTest < ActionView::TestCase
     date = Time.utc(2014, 3, 5, 21, 37, 45)
     user = create(:user)
 
-    assert_match %r{^Created by anonymous <abbr title="Wed, 05 Mar 2014 21:37:45 \+0000"><time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z">.* ago</time></abbr>$}, note_event("opened", date, nil)
-    assert_match %r{^Resolved by <a href="/user/#{ERB::Util.u(user.display_name)}">#{user.display_name}</a> <abbr title="Wed, 05 Mar 2014 21:37:45 \+0000"><time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z">.* ago</time></abbr>$}, note_event("closed", date, user)
+    assert_match %r{^Created by anonymous <time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z">.* ago</time>$}, note_event("opened", date, nil)
+    assert_match %r{^Resolved by <a href="/user/#{ERB::Util.u(user.display_name)}">#{user.display_name}</a> <time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z">.* ago</time>$}, note_event("closed", date, user)
   end
 
   def test_note_author

--- a/test/helpers/user_blocks_helper_test.rb
+++ b/test/helpers/user_blocks_helper_test.rb
@@ -8,10 +8,10 @@ class UserBlocksHelperTest < ActionView::TestCase
     assert_equal "Active until the user logs in.", block_status(block)
 
     block = create(:user_block, :needs_view, :ends_at => Time.now.utc + 1.hour)
-    assert_match %r{^Ends in <span title=".*">about 1 hour</span> and after the user has logged in\.$}, block_status(block)
+    assert_match %r{^Ends in <time title=".*" datetime=".*">about 1 hour</time> and after the user has logged in\.$}, block_status(block)
 
     block = create(:user_block, :ends_at => Time.now.utc + 1.hour)
-    assert_match %r{^Ends in <span title=".*">about 1 hour</span>\.$}, block_status(block)
+    assert_match %r{^Ends in <time title=".* datetime=".*">about 1 hour</time>\.$}, block_status(block)
   end
 
   def test_block_duration_in_words


### PR DESCRIPTION
Refs #631 (site-wide consistency) and #4313 (use of `time` element instead of `abbr` or `span`).

This PR refactors our friendly date displays to be consistent throughout the site. I've standardised on using the `time` element (with the machine-readable datetime attribute, for anything that might need it), and removed all the (mis-)use of `abbr` elements. The highlighting of time periods which have titles (using dotted underlines), previously a side effect of `abbr`, is reimplemented in CSS.

I've kept the changesets_helper#changeset_details as the only place that doesn't use the friendly_date helpers, since it does some funky stuff with the titles. But I would consider refactoring that in future too, since I'm not convinced those titles are a good idea.