### PR TITLE
Remove save user step when configuring permissions

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -47,8 +47,6 @@ $ bundle exec rails console
 => #[ ... ]
 >> user.roles.create(:role => "moderator", :granter_id => user.id)
 => #[ ... ]
->> user.save!
-=> true
 >> quit
 ```
 


### PR DESCRIPTION
`create` on a model already does the save, see https://api.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-create