### PR TITLE
Update oauth configuration url input label

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -63,7 +63,7 @@ For iD, do the following:
 
 * Go to "[OAuth 2 applications](http://localhost:3000/oauth2/applications)" on the My settings page.
 * Click on "Register new application".
-* Unless you have set up alternatives, use Name: "Local iD" and Main Application URL: "http://localhost:3000"
+* Unless you have set up alternatives, use Name: "Local iD" and Redirect URIs: "http://localhost:3000"
 * Check boxes for the following Permissions
   * 'Read user preferences'
   * 'Modify user preferences'


### PR DESCRIPTION
I don't think it's used anywhere, especially given https://github.com/openstreetmap/openstreetmap-website/issues/3613, but it can't be left blank.