### PR TITLE
Remove 'basic attributes' comments from changeset api output builders

### DIFF
--- a/app/views/api/changesets/changeset.xml.builder
+++ b/app/views/api/changesets/changeset.xml.builder
@@ -1,7 +1,5 @@
 xml.instruct! :xml, :version => "1.0"
 
-# basic attributes
-
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
   osm << render(@changeset)
 end

--- a/app/views/api/changesets/changesets.xml.builder
+++ b/app/views/api/changesets/changesets.xml.builder
@@ -1,7 +1,5 @@
 xml.instruct! :xml, :version => "1.0"
 
-# basic attributes
-
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
   @changesets.each do |changeset|
     osm << render(changeset)


### PR DESCRIPTION
This is the place where this comment makes sense: https://github.com/openstreetmap/openstreetmap-website/blob/26f12ef11a43a83ad08a59742f15027417b2c968/app/views/api/changesets/_changeset.xml.builder#L1

But it was probably copied by accident to `changeset.xml.builder` and `changesets.xml.builder` in https://github.com/openstreetmap/openstreetmap-website/commit/538bfed8a61a576e44d8cc71d7727c0310bcf238. Json versions don't have these comments.