### PR TITLE
Remove 'need to return bbox' comment on conditions_bbox

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -283,7 +283,6 @@ module Api
     ##
     # if a bounding box was specified do some sanity checks.
     # restrict changesets to those enclosed by a bounding box
-    # we need to return both the changesets and the bounding box
     def conditions_bbox(changesets, bbox)
       if bbox
         bbox.check_boundaries

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -83,7 +83,6 @@ class ChangesetsController < ApplicationController
   ##
   # if a bounding box was specified do some sanity checks.
   # restrict changesets to those enclosed by a bounding box
-  # we need to return both the changesets and the bounding box
   def conditions_bbox(changesets, bbox)
     if bbox
       bbox.check_boundaries


### PR DESCRIPTION
This comment was added in https://github.com/openstreetmap/openstreetmap-website/commit/95d899786a1bbabacc0cd12ef1c4814118d9d0de when the `conditions_bbox` method actually returned bbox. Bbox returning was removed in https://github.com/openstreetmap/openstreetmap-website/commit/9c28a626cbefd289d17556747979bd73ee3a77cd yet the comment stayed and got copypasted later to the api controller.