### PR TITLE
Add expansion of time info on touch and mouse activation

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -50,9 +50,9 @@ small, aside {
 time[title] {
   text-decoration: underline dotted;
 }
-time[title]:active::after,
-time[title]:focus::after {
-  content: " (" attr(title) ")";
+time[title][datetime]:active::after,
+time[title][datetime]:focus::after {
+  content: " (" attr(datetime) ")";
 }
 
 #container { position: relative; }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -50,6 +50,10 @@ small, aside {
 time[title] {
   text-decoration: underline dotted;
 }
+time[title]:active::after,
+time[title]:focus::after {
+  content: " (" attr(title) ")";
+}
 
 #container { position: relative; }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -53,6 +53,7 @@ time[title] {
 time[title][datetime]:active::after,
 time[title][datetime]:focus::after {
   content: " (" attr(datetime) ")";
+  display: inline-block;
 }
 
 #container { position: relative; }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,11 +26,11 @@ module ApplicationHelper
   end
 
   def friendly_date(date)
-    tag.time(time_ago_in_words(date), :title => l(date, :format => :friendly), :datetime => date.xmlschema)
+    tag.time(time_ago_in_words(date), :title => l(date, :format => :friendly), :datetime => date.xmlschema, :tabindex => 0)
   end
 
   def friendly_date_ago(date)
-    tag.time(time_ago_in_words(date, :scope => :"datetime.distance_in_words_ago"), :title => l(date, :format => :friendly), :datetime => date.xmlschema)
+    tag.time(time_ago_in_words(date, :scope => :"datetime.distance_in_words_ago"), :title => l(date, :format => :friendly), :datetime => date.xmlschema, :tabindex => 0)
   end
 
   def body_class

--- a/app/helpers/changesets_helper.rb
+++ b/app/helpers/changesets_helper.rb
@@ -23,9 +23,9 @@ module ChangesetsHelper
     end
 
     if params.key?(:display_name)
-      t "browse.#{action}_ago_html", :time_ago => tag.time(time, :title => title, :datetime => datetime)
+      t "browse.#{action}_ago_html", :time_ago => tag.time(time, :title => title, :datetime => datetime, :tabindex => 0)
     else
-      t "browse.#{action}_ago_by_html", :time_ago => tag.time(time, :title => title, :datetime => datetime),
+      t "browse.#{action}_ago_by_html", :time_ago => tag.time(time, :title => title, :datetime => datetime, :tabindex => 0),
                                         :user => changeset_user_link(changeset)
     end
   end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -57,36 +57,36 @@ class ApplicationHelperTest < ActionView::TestCase
 
   def test_friendly_date
     date = friendly_date(Time.utc(2014, 3, 5, 18, 58, 23))
-    assert_match %r{^<time title=" *5 March 2014 at 18:58" datetime="2014-03-05T18:58:23Z">.*</time>$}, date
+    assert_match %r{^<time title=" *5 March 2014 at 18:58" datetime="2014-03-05T18:58:23Z" tabindex="0">.*</time>$}, date
 
     date = friendly_date(Time.now.utc - 1.hour)
-    assert_match %r{^<time title=".*">about 1 hour</time>$}, date
+    assert_match %r{^<time title=".*" tabindex="0">about 1 hour</time>$}, date
 
     date = friendly_date(Time.now.utc - 2.days)
-    assert_match %r{^<time title=".*">2 days</time>$}, date
+    assert_match %r{^<time title=".*" tabindex="0">2 days</time>$}, date
 
     date = friendly_date(Time.now.utc - 3.weeks)
-    assert_match %r{^<time title=".*">21 days</time>$}, date
+    assert_match %r{^<time title=".*" tabindex="0">21 days</time>$}, date
 
     date = friendly_date(Time.now.utc - 4.months)
-    assert_match %r{^<time title=".*">4 months</time>$}, date
+    assert_match %r{^<time title=".*" tabindex="0">4 months</time>$}, date
   end
 
   def test_friendly_date_ago
     date = friendly_date_ago(Time.utc(2014, 3, 5, 18, 58, 23))
-    assert_match %r{^<time title=" *5 March 2014 at 18:58" datetime="2014-03-05T18:58:23Z">.*</time>$}, date
+    assert_match %r{^<time title=" *5 March 2014 at 18:58" datetime="2014-03-05T18:58:23Z" tabindex="0">.*</time>$}, date
 
     date = friendly_date_ago(Time.now.utc - 1.hour)
-    assert_match %r{^<time title=".*">about 1 hour ago</time>$}, date
+    assert_match %r{^<time title=".*" tabindex="0">about 1 hour ago</time>$}, date
 
     date = friendly_date_ago(Time.now.utc - 2.days)
-    assert_match %r{^<time title=".*">2 days ago</time>$}, date
+    assert_match %r{^<time title=".*" tabindex="0">2 days ago</time>$}, date
 
     date = friendly_date_ago(Time.now.utc - 3.weeks)
-    assert_match %r{^<time title=".*">21 days ago</time>$}, date
+    assert_match %r{^<time title=".*" tabindex="0">21 days ago</time>$}, date
 
     date = friendly_date_ago(Time.now.utc - 4.months)
-    assert_match %r{^<time title=".*">4 months ago</time>$}, date
+    assert_match %r{^<time title=".*" tabindex="0">4 months ago</time>$}, date
   end
 
   def test_body_class; end

--- a/test/helpers/changesets_helper_test.rb
+++ b/test/helpers/changesets_helper_test.rb
@@ -17,11 +17,11 @@ class ChangesetsHelperTest < ActionView::TestCase
     # We need to explicitly reset the closed_at to some point in the future, and avoid the before_save callback
     changeset.update_column(:closed_at, Time.now.utc + 1.day) # rubocop:disable Rails/SkipsModelValidations
 
-    assert_match %r{^Created <time title="Mon, 01 Jan 2007 00:00:00 \+0000" datetime="2007-01-01T00:00:00Z">.*</time> by anonymous$}, changeset_details(changeset)
+    assert_match %r{^Created <time title="Mon, 01 Jan 2007 00:00:00 \+0000" datetime="2007-01-01T00:00:00Z" tabindex="0">.*</time> by anonymous$}, changeset_details(changeset)
 
     changeset = create(:changeset, :created_at => Time.utc(2007, 1, 1, 0, 0, 0), :closed_at => Time.utc(2007, 1, 2, 0, 0, 0))
     user_link = %(<a href="/user/#{ERB::Util.u(changeset.user.display_name)}">#{changeset.user.display_name}</a>)
 
-    assert_match %r{^Closed <time title="Created: Mon, 01 Jan 2007 00:00:00 \+0000&#10;Closed: Tue, 02 Jan 2007 00:00:00 \+0000" datetime="2007-01-02T00:00:00Z">.*</time> by #{user_link}$}, changeset_details(changeset)
+    assert_match %r{^Closed <time title="Created: Mon, 01 Jan 2007 00:00:00 \+0000&#10;Closed: Tue, 02 Jan 2007 00:00:00 \+0000" datetime="2007-01-02T00:00:00Z" tabindex="0">.*</time> by #{user_link}$}, changeset_details(changeset)
   end
 end

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -8,8 +8,8 @@ class NoteHelperTest < ActionView::TestCase
     date = Time.utc(2014, 3, 5, 21, 37, 45)
     user = create(:user)
 
-    assert_match %r{^Created by anonymous <time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z">.* ago</time>$}, note_event("opened", date, nil)
-    assert_match %r{^Resolved by <a href="/user/#{ERB::Util.u(user.display_name)}">#{user.display_name}</a> <time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z">.* ago</time>$}, note_event("closed", date, user)
+    assert_match %r{^Created by anonymous <time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z" tabindex="0">.* ago</time>$}, note_event("opened", date, nil)
+    assert_match %r{^Resolved by <a href="/user/#{ERB::Util.u(user.display_name)}">#{user.display_name}</a> <time title=" 5 March 2014 at 21:37" datetime="2014-03-05T21:37:45Z" tabindex="0">.* ago</time>$}, note_event("closed", date, user)
   end
 
   def test_note_author

--- a/test/helpers/user_blocks_helper_test.rb
+++ b/test/helpers/user_blocks_helper_test.rb
@@ -8,10 +8,10 @@ class UserBlocksHelperTest < ActionView::TestCase
     assert_equal "Active until the user logs in.", block_status(block)
 
     block = create(:user_block, :needs_view, :ends_at => Time.now.utc + 1.hour)
-    assert_match %r{^Ends in <time title=".*" datetime=".*">about 1 hour</time> and after the user has logged in\.$}, block_status(block)
+    assert_match %r{^Ends in <time title=".*" datetime=".*" tabindex="0">about 1 hour</time> and after the user has logged in\.$}, block_status(block)
 
     block = create(:user_block, :ends_at => Time.now.utc + 1.hour)
-    assert_match %r{^Ends in <time title=".* datetime=".*">about 1 hour</time>\.$}, block_status(block)
+    assert_match %r{^Ends in <time title=".* datetime=".*" tabindex="0">about 1 hour</time>\.$}, block_status(block)
   end
 
   def test_block_duration_in_words


### PR DESCRIPTION
Add touch and mouse interaction of time display.

Initial no change:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/2410353/a1581884-b6bd-4a4f-94e1-c66e936ab457)

After touch or mouse focus/selection we have:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/2410353/854d6cae-6894-4429-9596-ce1108b5c039)

ref #631
Fixes the "need the exact time info on mobile" in this ticket, but not the "be able to copy the exact time into clipboard" part.
