### PR TITLE
Control menu visibility with javascript instead of css class

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -115,8 +115,8 @@ $(document).ready(function () {
     $("header").toggleClass("closed");
   });
 
-  $("nav.primary li a").on("click", function () {
-    $("header").toggleClass("closed");
+  $("nav.primary a").on("click", function () {
+    $("header").addClass("closed");
   });
 
   var application_data = $("head").data();

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -75,12 +75,22 @@ $(document).ready(function () {
   function updateHeader() {
     var windowWidth = $(window).width();
 
-    if (windowWidth < compactWidth) {
-      $("body").removeClass("compact-nav").addClass("small-nav");
-    } else if (windowWidth < headerWidth) {
-      $("body").addClass("compact-nav").removeClass("small-nav");
-    } else {
-      $("body").removeClass("compact-nav").removeClass("small-nav");
+    if (windowWidth < compactWidth && !$("body").hasClass("small-nav")) {
+      $("body").addClass("small-nav");
+      $("header nav").hide();
+    }
+
+    if (windowWidth >= compactWidth && $("body").hasClass("small-nav")) {
+      $("body").removeClass("small-nav");
+      $("header nav").show();
+    }
+
+    $("body").toggleClass("compact-nav", windowWidth >= compactWidth && windowWidth < headerWidth);
+  }
+
+  function toggleMenu() {
+    if ($(window).width() < compactWidth) {
+      $("header nav").toggle();
     }
   }
 
@@ -112,12 +122,10 @@ $(document).ready(function () {
 
   $("#menu-icon").on("click", function (e) {
     e.preventDefault();
-    $("header").toggleClass("closed");
+    toggleMenu();
   });
 
-  $("nav.primary a").on("click", function () {
-    $("header").addClass("closed");
-  });
+  $("nav.primary a").on("click", toggleMenu);
 
   var application_data = $("head").data();
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -120,11 +120,7 @@ $(document).ready(function () {
     $(window).resize(updateHeader);
   }, 0);
 
-  $("#menu-icon").on("click", function (e) {
-    e.preventDefault();
-    toggleMenu();
-  });
-
+  $("#menu-icon").on("click", toggleMenu);
   $("nav.primary a").on("click", toggleMenu);
 
   var application_data = $("head").data();

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -206,10 +206,6 @@ body.small-nav {
     min-height: $headerHeight;
     background: #fff;
 
-    &.closed nav {
-      display: none;
-    }
-
     .search_forms {
       display: block;
     }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,7 @@
       <%= t "layouts.project_name.h1" %>
     </a>
   </h1>
-  <a href="#" id="menu-icon"></a>
+  <button id="menu-icon" class="btn btn-primary border-0"></button>
   <nav class='primary'>
     <%= content_for :header %>
     <div class="btn-group">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="d-flex text-nowrap closed">
+<header class="d-flex text-nowrap">
   <h1 class="m-0 fw-semibold">
     <a href="<%= root_path %>" class="text-black text-decoration-none geolink">
       <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :width => 30, :height => 30, :class => "logo" %>


### PR DESCRIPTION
This is temporary if [Bootstrap navbar](https://getbootstrap.com/docs/5.3/components/navbar/) is going to be used. Before that I plan to get rid of `compact-nav` mode.

Also restores menu hiding when history button is clicked on narrow screens. It existed since at least https://github.com/openstreetmap/openstreetmap-website/commit/3f26761a26f1ebd8746db166be2d30fd9b7ff7d6 when primary navigation had a [list](https://github.com/openstreetmap/openstreetmap-website/blob/3f26761a26f1ebd8746db166be2d30fd9b7ff7d6/app/views/layouts/_header.html.erb#L10). That list was later changed to a div and the selector for the click handler stopped working.

And menu button is now a `<button>` instead of `<a href="#">`.