### PR TITLE
Remove unused css for lists inside primary nav on narrow screens

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -225,26 +225,6 @@ body.small-nav {
     margin-right: 0;
     padding: 0;
 
-    ul, li {
-      border: none;
-      border-radius: 0;
-      width: 100%;
-    }
-
-    ul {
-      border-top: 1px solid #eee;
-      li {
-        border-bottom: 1px solid #eee;
-        border-right: none;
-        > a {
-          border-radius: 0;
-          width: 100%;
-          text-align: center;
-          font-size: 15px;
-        }
-      }
-    }
-
     .btn-group {
       width: 100%;
       padding: 10px;


### PR DESCRIPTION
That list inside the primary navigation doesn't exist anymore. The only list there is the edit button dropdown, but it's hidden in small-nav mode.