### PR TITLE
Read layers with available map key from config/key.yml

### DIFF
--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -24,7 +24,7 @@ L.OSM.key = function (options) {
     }
 
     function updateButton() {
-      var disabled = ["mapnik", "cyclemap"].indexOf(map.getMapBaseLayerId()) === -1;
+      var disabled = OSM.LAYERS_WITH_MAP_KEY.indexOf(map.getMapBaseLayerId()) === -1;
       button
         .toggleClass("disabled", disabled)
         .attr("data-bs-original-title",

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -1,5 +1,6 @@
 //= depend_on settings.yml
 //= depend_on settings.local.yml
+//= depend_on key.yml
 //= require qs/dist/qs
 
 OSM = {
@@ -28,6 +29,8 @@ OSM = {
 <% if Settings.key?(:tracestrack_key) %>
   TRACESTRACK_KEY:         <%= Settings.tracestrack_key.to_json %>,
 <% end %>
+
+  LAYERS_WITH_MAP_KEY:     <%= YAML.load_file(Rails.root.join("config/key.yml")).keys.to_json %>,
 
   MARKER_GREEN:            <%= image_path("marker-green.png").to_json %>,
   MARKER_RED:              <%= image_path("marker-red.png").to_json %>,


### PR DESCRIPTION
There's a bunch of map layer configuration specified directly in javascript files, and I added more in https://github.com/openstreetmap/openstreetmap-website/pull/4367, the check for a layer name that can't be embedded. But it would be more convenient to have this configuration outside.

Here the map key button checks if the layer is one of `["mapnik", "cyclemap"]` to enable/disable itself, with these layer names directly in js. But we can look into `key.yml`, see which layers have keys and enable the key button based on that.