### PR TITLE
Add transportation map key for opnvkarte

### DIFF
--- a/app/assets/images/key/opnvkarte/bus_stop13.svg
+++ b/app/assets/images/key/opnvkarte/bus_stop13.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='5' height='5'>
+<circle cx='2.5' cy='2.5' r='2.15' stroke='black' fill='#ffffff' />
+</svg>

--- a/app/assets/images/key/opnvkarte/bus_stop15.svg
+++ b/app/assets/images/key/opnvkarte/bus_stop15.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='9' height='9'>
+<circle cx='4.5' cy='4.5' r='4' stroke='black' fill='#ffffff' />
+</svg>

--- a/app/assets/images/key/opnvkarte/rail11.svg
+++ b/app/assets/images/key/opnvkarte/rail11.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='52' height='3'>
+<rect width='100%' height='100%' fill='#868686' />
+<line x2='100%' y1='50%' y2='50%' stroke='#eeeeee' stroke-dasharray='10 10' stroke-dashoffset='9' />
+</svg>

--- a/app/assets/images/key/opnvkarte/rail15.svg
+++ b/app/assets/images/key/opnvkarte/rail15.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='52' height='4'>
+<rect width='100%' height='100%' fill='#868686' />
+<line x2='100%' y1='50%' y2='50%' stroke='#eeeeee' stroke-dasharray='10 10' stroke-dashoffset='9' stroke-width='2' />
+</svg>

--- a/app/assets/images/key/opnvkarte/rail17.svg
+++ b/app/assets/images/key/opnvkarte/rail17.svg
@@ -1,0 +1,9 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='52' height='12' stroke='#999999' stroke-dashoffset='-1'>
+  <g stroke-dasharray='2 4'>
+    <line x2='100%' y1='1' y2='1' stroke-width='2' />
+    <line x2='100%' y1='6' y2='6' stroke-width='4' />
+    <line x2='100%' y1='11' y2='11' stroke-width='2' />
+  </g>
+  <line x2='100%' y1='2.5' y2='2.5' stroke-width='1' />
+  <line x2='100%' y1='9.5' y2='9.5' stroke-width='1' />
+</svg>

--- a/app/assets/images/key/opnvkarte/stop13.svg
+++ b/app/assets/images/key/opnvkarte/stop13.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='5' height='5'>
+<circle cx='2.5' cy='2.5' r='2.15' stroke='black' fill='#e23148' />
+</svg>

--- a/app/assets/images/key/opnvkarte/stop15.svg
+++ b/app/assets/images/key/opnvkarte/stop15.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='9' height='9'>
+<circle cx='4.5' cy='4.5' r='4' stroke='black' fill='#e23148' />
+</svg>

--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -39,11 +39,11 @@ L.OSM.key = function (options) {
 
       $(".mapkey-table-entry").each(function () {
         var data = $(this).data();
-        if (layer === data.layer && zoom >= data.zoomMin && zoom <= data.zoomMax) {
-          $(this).show();
-        } else {
-          $(this).hide();
-        }
+        $(this).toggle(
+          layer === data.layer &&
+          (!data.zoomMin || zoom >= data.zoomMin) &&
+          (!data.zoomMax || zoom <= data.zoomMax)
+        );
       });
     }
   };

--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -2,7 +2,7 @@
   <table class="table table-sm table-borderless mapkey-table mb-0">
     <% YAML.load_file(Rails.root.join("config/key.yml")).each do |name,data| %>
       <% data.each do |entry| %>
-        <tr class="mapkey-table-entry" data-layer="<%= name %>" data-zoom-min="<%= entry["min_zoom"] %>" data-zoom-max="<%= entry["max_zoom"] %>">
+        <%= tag.tr :class => "mapkey-table-entry", :data => { :layer => name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
           <td class="mapkey-table-key align-middle">
             <% if entry["width"] && entry["height"] && entry["fill"] %>
               <%= image_tag "data:image/svg+xml,#{u("<svg xmlns='http://www.w3.org/2000/svg' width='#{entry['width']}' height='#{entry['height']}'><rect width='100%' height='100%' fill='#{entry['fill']}' /></svg>")}" %>
@@ -13,7 +13,7 @@
           <td class="mapkey-table-value">
             <%= Array(t(".table.entry.#{entry['name']}")).to_sentence %>
           </td>
-        </tr>
+        <% end %>
       <% end %>
     <% end %>
   </table>

--- a/config/key.yml
+++ b/config/key.yml
@@ -70,11 +70,20 @@ cyclemap:
   - { min_zoom: 14, max_zoom: 19, name: bicycle_parking, image: bicycle_parking.png }
   - { min_zoom: 16, max_zoom: 19, name: toilets, image: toilets.png }
 opnvkarte:
-  - { min_zoom: 6, name: rail, width: 52, height: 4, fill: "#868686" }
-  - { min_zoom: 6, name: train, width: 52, height: 4, fill: "#ffc366" }
+  - { min_zoom: 6, max_zoom: 7, name: rail, width: 52, height: 1, fill: "#868686" }
+  - { min_zoom: 8, max_zoom: 10, name: rail, width: 52, height: 2, fill: "#868686" }
+  - { min_zoom: 11, max_zoom: 14, name: rail, width: 52, height: 3, fill: "#868686" }
+  - { min_zoom: 15, name: rail, width: 52, height: 4, fill: "#868686" }
+  - { min_zoom: 6, max_zoom: 9, name: train, width: 52, height: 2, fill: "#ffc366" }
+  - { min_zoom: 10, max_zoom: 11, name: train, width: 52, height: 3, fill: "#ffc366" }
+  - { min_zoom: 12, name: train, width: 52, height: 4, fill: "#ffc366" }
   - { min_zoom: 10, name: light_rail, width: 52, height: 4, fill: "#66ff66" }
   - { min_zoom: 10, name: tram_only, width: 52, height: 4, fill: "#3333fe" }
   - { min_zoom: 10, name: subway, width: 52, height: 4, fill: "#33339f" }
-  - { min_zoom: 9, name: ferry, width: 52, height: 4, fill: "#9f339f" }
+  - { min_zoom: 9, max_zoom: 13, name: ferry, width: 52, height: 2, fill: "#9f339f" }
+  - { min_zoom: 14, name: ferry, width: 52, height: 3, fill: "#9f339f" }
   - { min_zoom: 10, name: trolleybus, width: 52, height: 4, fill: "#9f3333" }
-  - { min_zoom: 11, name: bus, width: 52, height: 4, fill: "#fe3333" }
+  - { min_zoom: 11, max_zoom: 11, name: bus, width: 52, height: 1, fill: "#fe3333" }
+  - { min_zoom: 12, max_zoom: 12, name: bus, width: 52, height: 2, fill: "#fe3333" }
+  - { min_zoom: 13, max_zoom: 13, name: bus, width: 52, height: 3, fill: "#fe3333" }
+  - { min_zoom: 14, name: bus, width: 52, height: 4, fill: "#fe3333" }

--- a/config/key.yml
+++ b/config/key.yml
@@ -69,3 +69,12 @@ cyclemap:
   - { min_zoom: 14, max_zoom: 19, name: bicycle_shop, image: bicycle_shop.png }
   - { min_zoom: 14, max_zoom: 19, name: bicycle_parking, image: bicycle_parking.png }
   - { min_zoom: 16, max_zoom: 19, name: toilets, image: toilets.png }
+opnvkarte:
+  - { min_zoom: 6, name: rail, width: 52, height: 4, fill: "#868686" }
+  - { min_zoom: 6, name: train, width: 52, height: 4, fill: "#ffc366" }
+  - { min_zoom: 10, name: light_rail, width: 52, height: 4, fill: "#66ff66" }
+  - { min_zoom: 10, name: tram_only, width: 52, height: 4, fill: "#3333fe" }
+  - { min_zoom: 10, name: subway, width: 52, height: 4, fill: "#33339f" }
+  - { min_zoom: 9, name: ferry, width: 52, height: 4, fill: "#9f339f" }
+  - { min_zoom: 10, name: trolleybus, width: 52, height: 4, fill: "#9f3333" }
+  - { min_zoom: 11, name: bus, width: 52, height: 4, fill: "#fe3333" }

--- a/config/key.yml
+++ b/config/key.yml
@@ -73,7 +73,8 @@ opnvkarte:
   - { min_zoom: 6, max_zoom: 7, name: rail, width: 52, height: 1, fill: "#868686" }
   - { min_zoom: 8, max_zoom: 10, name: rail, width: 52, height: 2, fill: "#868686" }
   - { min_zoom: 11, max_zoom: 14, name: rail, image: rail11.svg }
-  - { min_zoom: 15, name: rail, image: rail15.svg }
+  - { min_zoom: 15, max_zoom: 16, name: rail, image: rail15.svg }
+  - { min_zoom: 17, name: rail, image: rail17.svg }
   - { min_zoom: 6, max_zoom: 9, name: train, width: 52, height: 2, fill: "#ffc366" }
   - { min_zoom: 10, max_zoom: 11, name: train, width: 52, height: 3, fill: "#ffc366" }
   - { min_zoom: 12, name: train, width: 52, height: 4, fill: "#ffc366" }

--- a/config/key.yml
+++ b/config/key.yml
@@ -88,3 +88,7 @@ opnvkarte:
   - { min_zoom: 12, max_zoom: 12, name: bus, width: 52, height: 2, fill: "#fe3333" }
   - { min_zoom: 13, max_zoom: 13, name: bus, width: 52, height: 3, fill: "#fe3333" }
   - { min_zoom: 14, name: bus, width: 52, height: 4, fill: "#fe3333" }
+  - { min_zoom: 13, max_zoom: 14, name: bus_stop, image: bus_stop13.svg }
+  - { min_zoom: 15, name: bus_stop, image: bus_stop15.svg }
+  - { min_zoom: 13, max_zoom: 14, name: stop, image: stop13.svg }
+  - { min_zoom: 15, name: stop, image: stop15.svg }

--- a/config/key.yml
+++ b/config/key.yml
@@ -72,8 +72,8 @@ cyclemap:
 opnvkarte:
   - { min_zoom: 6, max_zoom: 7, name: rail, width: 52, height: 1, fill: "#868686" }
   - { min_zoom: 8, max_zoom: 10, name: rail, width: 52, height: 2, fill: "#868686" }
-  - { min_zoom: 11, max_zoom: 14, name: rail, width: 52, height: 3, fill: "#868686" }
-  - { min_zoom: 15, name: rail, width: 52, height: 4, fill: "#868686" }
+  - { min_zoom: 11, max_zoom: 14, name: rail, image: rail11.svg }
+  - { min_zoom: 15, name: rail, image: rail15.svg }
   - { min_zoom: 6, max_zoom: 9, name: train, width: 52, height: 2, fill: "#ffc366" }
   - { min_zoom: 10, max_zoom: 11, name: train, width: 52, height: 3, fill: "#ffc366" }
   - { min_zoom: 12, name: train, width: 52, height: 4, fill: "#ffc366" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2344,6 +2344,8 @@ en:
           private: "Private access"
           destination: "Destination access"
           construction: "Roads under construction"
+          bus_stop: "Bus stop"
+          stop: "Stop"
           bicycle_shop: "Bicycle shop"
           bicycle_parking: "Bicycle parking"
           toilets: "Toilets"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2287,10 +2287,16 @@ en:
           cycleway_local: "Local cycleway"
           footway: "Footway"
           rail: "Railway"
+          train: "Train"
           subway: "Subway"
+          ferry: "Ferry"
           tram:
             - Light rail
             - tram
+          light_rail: "Light rail"
+          tram_only: "Tram"
+          trolleybus: "Trolleybus"
+          bus: "Bus"
           cable:
             - Cable car
             - chair lift


### PR DESCRIPTION
I decided to check how adding a map key would work by adding one for opnvkarte.

At first I wanted to copy the images from the key at https://publictransportmap.org/. They were base64 data uris, <s>so I added the ability to specify image sources directly in `key.yml`</s>, otherwise they are composed as `key/<layer name>/<image name>`. But I ended up making my own images <s>because the already existing i18n strings want to combine light rail and tram</s>.

I only did the transportation section. Now it's possible to see if a line is a bus or a tram. Other things on that map are more obvious.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/8ef0f5c6-24df-4dd3-9545-dd6ff2afa702)
