### PR TITLE
Use 5 meter radius for input locations in Valhalla

### DIFF
--- a/app/assets/javascripts/index/directions/fossgis_valhalla.js
+++ b/app/assets/javascripts/index/directions/fossgis_valhalla.js
@@ -53,7 +53,7 @@ function FOSSGISValhallaEngine(id, costing) {
         data: {
           json: JSON.stringify({
             locations: points.map(function (p) {
-              return { lat: p.lat, lon: p.lng };
+              return { lat: p.lat, lon: p.lng, radius: 5 };
             }),
             costing: costing,
             directions_options: {


### PR DESCRIPTION
This will search for road segments within 5 meter radius of the input location and choose the best path from/to whichever segment gives the cheapest cost. It should be preferable in most scenarios compared to simply snapping to the closest segment.

I'll do the same PR for our web app at https://github.com/gis-ops/valhalla-app.