### PR TITLE
Add corporate members to the list of supporters

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -48,6 +48,7 @@
                                        :ucl => link_to(t("layouts.partners_ucl"), "https://www.ucl.ac.uk"),
                                        :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
                                        :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
+                                       :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
                                        :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
         </p>
         <div class="d-flex mx-n1">

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -69,6 +69,7 @@
         <p><%= t "layouts.hosting_partners_html", :ucl => link_to(t("layouts.partners_ucl"), "https://www.ucl.ac.uk"),
                                                   :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
                                                   :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
+                                                  :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
                                                   :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
         </p>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1526,10 +1526,11 @@ en:
     intro_header: Welcome to OpenStreetMap!
     intro_text: OpenStreetMap is a map of the world, created by people like you and free to use under an open license.
     intro_2_create_account: "Create a user account"
-    hosting_partners_html: "Hosting is supported by %{ucl}, %{fastly}, %{bytemark}, and other %{partners}."
+    hosting_partners_html: "Hosting is supported by %{ucl}, %{fastly}, %{bytemark}, our %{corpmembers}, and other %{partners}."
     partners_ucl: "UCL"
     partners_fastly: "Fastly"
     partners_bytemark: "Bytemark Hosting"
+    partners_corpmembers: "OSMF corporate members"
     partners_partners: "partners"
     tou: "Terms of Use"
     osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."


### PR DESCRIPTION
Ever since moving to commercial data centers, the membership fees of the OSMF corporate members have become substantial to ensuring funding for hosting. So lets give them a mention in the list of hosting partners.