### PR TITLE
Make mapnik map key for lakes visible on all zoom levels

### DIFF
--- a/config/key.yml
+++ b/config/key.yml
@@ -25,7 +25,7 @@ mapnik:
   - { min_zoom: 10, max_zoom: 19, name: industrial, image: industrial.png }
   - { min_zoom: 10, max_zoom: 19, name: commercial, image: commercial.png }
   - { min_zoom: 10, max_zoom: 19, name: heathland, image: heathland.png }
-  - { min_zoom: 7, max_zoom: 19, name: lake, image: lake.png }
+  - { min_zoom: 0, max_zoom: 19, name: lake, image: lake.png }
   - { min_zoom: 10, max_zoom: 19, name: farm, image: farm.png }
   - { min_zoom: 10, max_zoom: 19, name: brownfield, image: brownfield.png }
   - { min_zoom: 11, max_zoom: 19, name: cemetery, image: cemetery.png }


### PR DESCRIPTION
There seems to be no lower limit for water features. Lakes are visible even on zoom 0.

https://github.com/gravitystorm/openstreetmap-carto/blob/master/style/water.mss