### PR TITLE
Fix min zoom levels for some landcover mapnik map key features

### DIFF
--- a/config/key.yml
+++ b/config/key.yml
@@ -15,12 +15,12 @@ mapnik:
   - { min_zoom: 11, max_zoom: 19, name: runway, image: runway.png }
   - { min_zoom: 12, max_zoom: 19, name: apron, image: apron.png }
   - { min_zoom: 0, max_zoom: 19, name: admin, image: admin.png }
-  - { min_zoom: 9, max_zoom: 19, name: forest, image: forest.png }
-  - { min_zoom: 10, max_zoom: 19, name: wood, image: wood.png }
+  - { min_zoom: 5, max_zoom: 19, name: forest, image: forest.png }
+  - { min_zoom: 5, max_zoom: 19, name: wood, image: wood.png }
   - { min_zoom: 10, max_zoom: 19, name: golf, image: golf.png }
   - { min_zoom: 10, max_zoom: 19, name: park, image: park.png }
   - { min_zoom: 8, max_zoom: 19, name: resident, image: resident.png }
-  - { min_zoom: 10, max_zoom: 19, name: common, image: common.png }
+  - { min_zoom: 5, max_zoom: 19, name: common, image: common.png }
   - { min_zoom: 10, max_zoom: 19, name: retail, image: retail.png }
   - { min_zoom: 10, max_zoom: 19, name: industrial, image: industrial.png }
   - { min_zoom: 10, max_zoom: 19, name: commercial, image: commercial.png }


### PR DESCRIPTION
I wanted to got through everything enabled on zoom level 5 [here](https://github.com/gravitystorm/openstreetmap-carto/blob/master/style/landcover.mss) but had to stop because colors differ too much.