### PR TITLE
Add oauth scope for redactions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -66,7 +66,7 @@ Metrics/ClassLength:
 # Offense count: 59
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/CyclomaticComplexity:
-  Max: 26
+  Max: 29
 
 # Offense count: 753
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
@@ -81,7 +81,7 @@ Metrics/ParameterLists:
 # Offense count: 56
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/PerceivedComplexity:
-  Max: 29
+  Max: 30
 
 # Offense count: 2394
 # This cop supports safe autocorrection (--autocorrect).

--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -32,9 +32,9 @@ class ApiCapability
           can [:destroy, :restore], ChangesetComment if scope?(token, :write_api)
           can :destroy, Note if scope?(token, :write_notes)
           if user&.terms_agreed?
-            can :redact, OldNode if scope?(token, :write_api)
-            can :redact, OldWay if scope?(token, :write_api)
-            can :redact, OldRelation if scope?(token, :write_api)
+            can :redact, OldNode if scope?(token, :write_api) || scope?(token, :write_redactions)
+            can :redact, OldWay if scope?(token, :write_api) || scope?(token, :write_redactions)
+            can :redact, OldRelation if scope?(token, :write_api) || scope?(token, :write_redactions)
           end
         end
       end

--- a/app/helpers/authorization_helper.rb
+++ b/app/helpers/authorization_helper.rb
@@ -1,0 +1,13 @@
+module AuthorizationHelper
+  include ActionView::Helpers::TranslationHelper
+
+  def authorization_scope(scope)
+    html = []
+    html << t("oauth.scopes.#{scope}")
+    if Oauth::MODERATOR_SCOPES.include? scope
+      html << " "
+      html << image_tag("roles/moderator.png", :srcset => image_path("roles/moderator.svg", :class => "align-text-bottom"), :size => "20x20")
+    end
+    safe_join(html)
+  end
+end

--- a/app/views/oauth2_applications/_application.html.erb
+++ b/app/views/oauth2_applications/_application.html.erb
@@ -10,7 +10,7 @@
   <td class="align-middle">
     <ul class="list-unstyled mb-0">
       <% application.scopes.each do |scope| -%>
-        <li><%= t "oauth.scopes.#{scope}" %> <code class="text-muted">(<%= scope %>)</code></li>
+        <li><%= authorization_scope(scope) %> <code class="text-muted">(<%= scope %>)</code></li>
       <% end -%>
     </ul>
   </td>

--- a/app/views/oauth2_authorizations/new.html.erb
+++ b/app/views/oauth2_authorizations/new.html.erb
@@ -6,7 +6,7 @@
 
 <ul>
   <% @pre_auth.scopes.each do |scope| -%>
-    <li><%= t "oauth.scopes.#{scope}" %></li>
+    <li><%= authorization_scope(scope) %></li>
   <% end -%>
 </ul>
 

--- a/app/views/oauth2_authorized_applications/_application.html.erb
+++ b/app/views/oauth2_authorized_applications/_application.html.erb
@@ -5,7 +5,7 @@
   <td class="align-middle">
     <ul class="list-unstyled mb-0">
       <% application.authorized_scopes_for(current_user).each do |scope| -%>
-        <li><%= t "oauth.scopes.#{scope}" %></li>
+        <li><%= authorization_scope(scope) %></li>
       <% end -%>
     </ul>
   </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2609,6 +2609,7 @@ en:
       read_gpx: Read private GPS traces
       write_gpx: Upload GPS traces
       write_notes: Modify notes
+      write_redactions: Redact map data
       read_email: Read user email address
       skip_authorization: Auto approve application
   oauth_clients:

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -1,6 +1,7 @@
 module Oauth
   SCOPES = %w[read_prefs write_prefs write_diary write_api read_gpx write_gpx write_notes].freeze
   PRIVILEGED_SCOPES = %w[read_email skip_authorization].freeze
+  MODERATOR_SCOPES = %w[].freeze
   OAUTH2_SCOPES = %w[openid].freeze
 
   class Scope

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -1,8 +1,8 @@
 module Oauth
   SCOPES = %w[read_prefs write_prefs write_diary write_api read_gpx write_gpx write_notes].freeze
   PRIVILEGED_SCOPES = %w[read_email skip_authorization].freeze
-  MODERATOR_SCOPES = %w[].freeze
-  OAUTH2_SCOPES = %w[openid].freeze
+  MODERATOR_SCOPES = %w[write_redactions].freeze
+  OAUTH2_SCOPES = %w[write_redactions openid].freeze
 
   class Scope
     attr_reader :name

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -238,6 +238,43 @@ module Api
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
     end
 
+    def test_redact_node_by_regular_with_read_prefs_scope
+      auth_header = create_bearer_auth_header(create(:user), %w[read_prefs])
+      do_redact_redactable_node(auth_header)
+      assert_response :forbidden, "should need to be moderator to redact."
+    end
+
+    def test_redact_node_by_regular_with_write_api_scope
+      auth_header = create_bearer_auth_header(create(:user), %w[write_api])
+      do_redact_redactable_node(auth_header)
+      assert_response :forbidden, "should need to be moderator to redact."
+    end
+
+    def test_redact_node_by_regular_with_write_redactions_scope
+      auth_header = create_bearer_auth_header(create(:user), %w[write_redactions])
+      do_redact_redactable_node(auth_header)
+      assert_response :forbidden, "should need to be moderator to redact."
+    end
+
+    def test_redact_node_by_moderator_with_read_prefs_scope
+      auth_header = create_bearer_auth_header(create(:moderator_user), %w[read_prefs])
+      do_redact_redactable_node(auth_header)
+      assert_response :forbidden, "should need to have write_redactions scope to redact."
+    end
+
+    def test_redact_node_by_moderator_with_write_api_scope
+      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_api])
+      do_redact_redactable_node(auth_header)
+      assert_response :success, "should be OK to redact old version as moderator with write_api scope."
+      # assert_response :forbidden, "should need to have write_redactions scope to redact."
+    end
+
+    def test_redact_node_by_moderator_with_write_redactions_scope
+      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_redactions])
+      do_redact_redactable_node(auth_header)
+      assert_response :success, "should be OK to redact old version as moderator with write_redactions scope."
+    end
+
     ##
     # test that redacted nodes aren't visible, regardless of
     # authorisation except as moderator...
@@ -394,6 +431,19 @@ module Api
     end
 
     private
+
+    def create_bearer_auth_header(user, scopes)
+      token = create(:oauth_access_token,
+                     :resource_owner_id => user.id,
+                     :scopes => scopes)
+      bearer_authorization_header(token.token)
+    end
+
+    def do_redact_redactable_node(headers = {})
+      node = create(:node, :with_history, :version => 4)
+      node_v3 = node.old_nodes.find_by(:version => 3)
+      do_redact_node(node_v3, create(:redaction), headers)
+    end
 
     def do_redact_node(node, redaction, headers = {})
       get node_version_path(:id => node.node_id, :version => node.version), :headers => headers

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -118,6 +118,43 @@ module Api
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
     end
 
+    def test_redact_way_by_regular_with_read_prefs_scope
+      auth_header = create_bearer_auth_header(create(:user), %w[read_prefs])
+      do_redact_redactable_way(auth_header)
+      assert_response :forbidden, "should need to be moderator to redact."
+    end
+
+    def test_redact_way_by_regular_with_write_api_scope
+      auth_header = create_bearer_auth_header(create(:user), %w[write_api])
+      do_redact_redactable_way(auth_header)
+      assert_response :forbidden, "should need to be moderator to redact."
+    end
+
+    def test_redact_way_by_regular_with_write_redactions_scope
+      auth_header = create_bearer_auth_header(create(:user), %w[write_redactions])
+      do_redact_redactable_way(auth_header)
+      assert_response :forbidden, "should need to be moderator to redact."
+    end
+
+    def test_redact_way_by_moderator_with_read_prefs_scope
+      auth_header = create_bearer_auth_header(create(:moderator_user), %w[read_prefs])
+      do_redact_redactable_way(auth_header)
+      assert_response :forbidden, "should need to have write_redactions scope to redact."
+    end
+
+    def test_redact_way_by_moderator_with_write_api_scope
+      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_api])
+      do_redact_redactable_way(auth_header)
+      assert_response :success, "should be OK to redact old version as moderator with write_api scope."
+      # assert_response :forbidden, "should need to have write_redactions scope to redact."
+    end
+
+    def test_redact_way_by_moderator_with_write_redactions_scope
+      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_redactions])
+      do_redact_redactable_way(auth_header)
+      assert_response :success, "should be OK to redact old version as moderator with write_redactions scope."
+    end
+
     ##
     # test that redacted ways aren't visible, regardless of
     # authorisation except as moderator...
@@ -316,6 +353,19 @@ module Api
 
         assert_ways_are_equal history_way, version_way
       end
+    end
+
+    def create_bearer_auth_header(user, scopes)
+      token = create(:oauth_access_token,
+                     :resource_owner_id => user.id,
+                     :scopes => scopes)
+      bearer_authorization_header(token.token)
+    end
+
+    def do_redact_redactable_way(headers = {})
+      way = create(:way, :with_history, :version => 4)
+      way_v3 = way.old_ways.find_by(:version => 3)
+      do_redact_way(way_v3, create(:redaction), headers)
     end
 
     def do_redact_way(way, redaction, headers = {})


### PR DESCRIPTION
Currently redactions are allowed if the `write_api` is granted. But `write_api` is a very common scope requested by many apps for things like adding changeset comments. Those apps have no business being able to redact anything.

Here a separate scope for redactions is introduced. `write_api` still allows redactions, this is to be disabled in a later pull request, after [osmtools](https://github.com/woodpeck/osm-revert-scripts) are updated to request the new `write_redactions` scope. There's also redaction bot written in ruby, possibly also needs to be updated.