### PR TITLE
Remove unused .current from primary nav

### DIFF
--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -58,7 +58,6 @@ OSM.Export = function (map) {
   }
 
   page.pushstate = page.popstate = function (path) {
-    $("#export_tab").addClass("current");
     OSM.loadSidebarContent(path, page.load);
   };
 
@@ -79,8 +78,6 @@ OSM.Export = function (map) {
     map
       .removeLayer(locationFilter)
       .off("moveend", update);
-
-    $("#export_tab").removeClass("current");
   };
 
   return page;

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -146,7 +146,6 @@ OSM.History = function (map) {
   }
 
   page.pushstate = page.popstate = function (path) {
-    $("#history_tab").addClass("current");
     OSM.loadSidebarContent(path, page.load);
   };
 
@@ -165,8 +164,6 @@ OSM.History = function (map) {
   page.unload = function () {
     map.removeLayer(group);
     map.off("moveend", update);
-
-    $("#history_tab").removeClass("current");
   };
 
   return page;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,7 +9,7 @@
   <nav class='primary'>
     <%= content_for :header %>
     <div class="btn-group">
-      <div id="edit_tab" class="btn-group <%= current_page_class(edit_path) %>">
+      <div id="edit_tab" class="btn-group">
         <%= link_to t("layouts.edit"),
                     edit_path,
                     :class => "btn btn-outline-primary geolink editlink",
@@ -27,8 +27,8 @@
           <% end %>
         </ul>
       </div>
-      <%= link_to t("layouts.history"), history_path, :class => "btn btn-outline-primary geolink flex-grow-1 current_page_class(history_path)", :id => "history_tab" %>
-      <%= link_to t("layouts.export"), export_path, :class => "btn btn-outline-primary geolink current_page_class(export_path)", :id => "export_tab" %>
+      <%= link_to t("layouts.history"), history_path, :class => "btn btn-outline-primary geolink flex-grow-1", :id => "history_tab" %>
+      <%= link_to t("layouts.export"), export_path, :class => "btn btn-outline-primary geolink", :id => "export_tab" %>
     </div>
   </nav>
   <nav class='secondary'>


### PR DESCRIPTION
There's this `current_page_class()` function that applies `current` css class to header menu items pointing to the current page. [This commit](https://github.com/openstreetmap/openstreetmap-website/commit/e5c33c119a9ddd4de149cd8913ed970601103a2b#diff-6d2ef58207c92d1533287af551a075122ba98240a861819047a2ae77b7674f0bR33-R34) broke it for primary nav buttons, but nobody noticed because the `current` class is not used for anything. Still the javascript applied it correctly on partial page reloads.

Here I remove `current` from primary navigation.

It's still used in secondary navigation, makes current links darker.