### PR TITLE
Align structure with generated output

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -17,6 +17,13 @@ CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA public;
 
 
 --
+-- Name: EXTENSION btree_gist; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION btree_gist IS 'support for indexing common datatypes in GiST';
+
+
+--
 -- Name: format_enum; Type: TYPE; Schema: public; Owner: -
 --
 

--- a/script/normalise-structure
+++ b/script/normalise-structure
@@ -8,5 +8,3 @@
 /^    AS integer$/d
 
 s/ IMMUTABLE / /
-
-s/ timestamp(6) / timestamp /

--- a/script/normalise-structure
+++ b/script/normalise-structure
@@ -5,6 +5,5 @@
 /^SET default_with_oids /d
 /^SET default_table_access_method /d
 /^SET idle_in_transaction_session_timeout /d
-/^    AS integer$/d
 
 s/ IMMUTABLE / /

--- a/script/normalise-structure
+++ b/script/normalise-structure
@@ -1,7 +1,5 @@
 /^$/d
 /^--/d
-/^CREATE EXTENSION IF NOT EXISTS plpgsql /d
-/^COMMENT ON EXTENSION plpgsql /d
 /^SET default_with_oids /d
 /^SET default_table_access_method /d
 /^SET idle_in_transaction_session_timeout /d

--- a/script/normalise-structure
+++ b/script/normalise-structure
@@ -3,5 +3,3 @@
 /^SET default_with_oids /d
 /^SET default_table_access_method /d
 /^SET idle_in_transaction_session_timeout /d
-
-s/ IMMUTABLE / /

--- a/script/normalise-structure
+++ b/script/normalise-structure
@@ -2,7 +2,6 @@
 /^--/d
 /^CREATE EXTENSION IF NOT EXISTS plpgsql /d
 /^COMMENT ON EXTENSION plpgsql /d
-/^COMMENT ON EXTENSION btree_gist /d
 /^SET default_with_oids /d
 /^SET default_table_access_method /d
 /^SET idle_in_transaction_session_timeout /d


### PR DESCRIPTION
This PR makes a minor change to the structure.sql file to align it with the output from running migrations, along with some changes to the normalisation script. These normalisations can be removed since they aren't actually doing anything in CI.

* Adds the btree_gist comment. All developers will have this in their generated output from running the migrations so we should have it here too, to avoid noise in `git diff` (and therefore to make it easier to submit PRs with migrations).
* Remove the timestamp normalisation - see https://github.com/openstreetmap/openstreetmap-website/issues/4298#issuecomment-1832194246 on how to update really old pre-rails-6 databases, if you have one.
* Remove sequence type normalisation - this is actually important, and [differences shouldn't be suppressed](https://github.com/openstreetmap/openstreetmap-website/issues/4298#issuecomment-1832615439)
* Remove references to plpgsql extension, since it's been built-in since PostgreSQL 9.0
* Remove normalisation of immutable keyword, since we no longer have any functions that use it.