### PR TITLE
Migrate some sequences to use bigints

### DIFF
--- a/db/migrate/20231206141457_alter_sequences_bigint.rb
+++ b/db/migrate/20231206141457_alter_sequences_bigint.rb
@@ -1,0 +1,17 @@
+class AlterSequencesBigint < ActiveRecord::Migration[7.1]
+  def up
+    safety_assured do
+      execute "ALTER SEQUENCE oauth_nonces_id_seq AS bigint"
+      execute "ALTER SEQUENCE notes_id_seq AS bigint"
+      execute "ALTER SEQUENCE note_comments_id_seq AS bigint"
+    end
+  end
+
+  def down
+    safety_assured do
+      execute "ALTER SEQUENCE oauth_nonces_id_seq AS integer"
+      execute "ALTER SEQUENCE notes_id_seq AS integer"
+      execute "ALTER SEQUENCE note_comments_id_seq AS integer"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1017,7 +1017,6 @@ CREATE TABLE public.note_comments (
 --
 
 CREATE SEQUENCE public.note_comments_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1053,7 +1052,6 @@ CREATE TABLE public.notes (
 --
 
 CREATE SEQUENCE public.notes_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1199,7 +1197,6 @@ CREATE TABLE public.oauth_nonces (
 --
 
 CREATE SEQUENCE public.oauth_nonces_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3506,6 +3503,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20231206141457'),
 ('20231117170422'),
 ('20231101222146'),
 ('20231029151516'),


### PR DESCRIPTION
These primary keys were converted to bigints in migrations, but the sequences were left unmentioned. If the original migrations are run on postgresql 10.0+, then this leads to a mismatch in column types vs sequence types. This migration fixes these mismatches.

If the original migrations were run on postgresql < 10, all sequences were bigints anyway, and this migration is a no-op.

If the sequence is a bigint, then postgresql doesn't output that fact in the statement dump.

Refs #4298