### PR TITLE
Prevent the legacy oauth gem from crashing on Ruby >=3.2

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative "boot"
 
 require "rails/all"
+require_relative "../lib/legacy_oauth_gem_support"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/lib/legacy_oauth_gem_support.rb
+++ b/lib/legacy_oauth_gem_support.rb
@@ -1,0 +1,4 @@
+# This hack prevents the gem oauth 0.4.7 raising an exception on load
+# with Ruby >=3.2. Please remove this file once that version of the
+# oauth gem is not used anymore.
+File.singleton_class.alias_method(:exists?, :exist?) unless File.singleton_class.method_defined?(:exists?)


### PR DESCRIPTION
Hi 👋🏾 , openstreetmap newbie here, somewhat familiar with Rails. I wanted to try `openstreetmap-website`  locally and ran into the undefined method `File.exists?` error described [here](https://github.com/openstreetmap/openstreetmap-website/issues/4083) with Ruby 3.2.2.

The installation instructions do not explicitly rule out Ruby 3.2 so I found it a bit surprising. As said in #4083 the only reason this happens is the legacy oauth gem at 0.4.7, which is [going to be removed eventually](https://github.com/openstreetmap/operations/issues/867). Do you think the hack in this PR is an acceptable band-aid to ease the first-time developer experience until the oauth gem is removed? It's a bit ugly I admit, but couldn't think of a better way apart from forking the gem.
