### PR TITLE
Add buried to list of secondary Wiki prefixes

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -1,7 +1,7 @@
 module BrowseTagsHelper
   # https://wiki.openstreetmap.org/wiki/Key:wikipedia#Secondary_Wikipedia_links
   # https://wiki.openstreetmap.org/wiki/Key:wikidata#Secondary_Wikidata_links
-  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|flag|genus|name:etymology|network|operator|species|subject".freeze
+  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|name:etymology|network|operator|species|subject".freeze
 
   def format_key(key)
     if url = wiki_link("key", key)

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -132,6 +132,11 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_equal "//www.wikidata.org/entity/Q24?uselang=en", links[0][:url]
     assert_equal "Q24", links[0][:title]
 
+    # This verified buried is working
+    links = wikidata_links("buried:wikidata", "Q24")
+    assert_equal "//www.wikidata.org/entity/Q24?uselang=en", links[0][:url]
+    assert_equal "Q24", links[0][:title]
+
     links = wikidata_links("species:wikidata", "Q26899")
     assert_equal "//www.wikidata.org/entity/Q26899?uselang=en", links[0][:url]
     assert_equal "Q26899", links[0][:title]


### PR DESCRIPTION
This pull request adds the buried wikipedia/wikidata/wikicommon tag to the allowed secondary wiki prefixes