### PR TITLE
Implement allow list for account creation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -355,6 +355,8 @@ class UsersController < ApplicationController
                    domain_mx_servers(domain)
                  end
 
+    return true if Acl.allow_account_creation(request.remote_ip, :domain => domain, :mx => mx_servers)
+
     blocked = Acl.no_account_creation(request.remote_ip, :domain => domain, :mx => mx_servers)
 
     blocked ||= SIGNUP_IP_LIMITER && !SIGNUP_IP_LIMITER.allow?(request.remote_ip)

--- a/app/models/acl.rb
+++ b/app/models/acl.rb
@@ -41,6 +41,15 @@ class Acl < ApplicationRecord
     match(address, options).exists?(:k => "no_account_creation")
   end
 
+  def self.allow_account_creation(address, options = {})
+    acls = Acl.where("address >>= ?", address)
+              .and(Acl.where(:k => "allow_account_creation"))
+    acls = acls.and(Acl.where(:domain => options[:domain])) if options[:domain]
+    acls = acls.and(Acl.where(:mx => options[:mx])) if options[:mx]
+
+    !acls.empty?
+  end
+
   def self.no_note_comment(address, domain = nil)
     match(address, :domain => domain).exists?(:k => "no_note_comment")
   end

--- a/test/models/acl_test.rb
+++ b/test/models/acl_test.rb
@@ -27,4 +27,17 @@ class AclTest < ActiveSupport::TestCase
     create(:acl, :mx => "mail.example.com", :k => "no_account_creation")
     assert Acl.no_account_creation("192.168.1.1", :mx => "mail.example.com")
   end
+
+  def test_allowed_account_creation
+    assert_not Acl.allow_account_creation("192.168.1.1", :domain => "example.com", :mx => "mail.example.com")
+    create(:acl, :address => "192.168.1.1", :domain => "example.com", :mx => "mail.example.com", :k => "allow_account_creation")
+
+    assert_not Acl.allow_account_creation("192.168.1.2")
+    assert Acl.allow_account_creation("192.168.1.1")
+
+    assert_not Acl.allow_account_creation("192.168.1.2", :domain => "example.com", :mx => "mail.example.com")
+    assert_not Acl.allow_account_creation("192.168.1.1", :domain => "example1.com", :mx => "mail.example.com")
+    assert_not Acl.allow_account_creation("192.168.1.1", :domain => "example.com", :mx => "mail1.example.com")
+    assert Acl.allow_account_creation("192.168.1.1", :domain => "example.com", :mx => "mail.example.com")
+  end
 end


### PR DESCRIPTION
Allows mechanism to configure exceptions to rate limiting for account creation.

Uses ACL table with `allow_account_creation` key to allow bypassing account creation rate limiter from specific IP address/network range for users with specified email `domain` and email `mx` address.