### PR TITLE
Add pedestrian way to cyclemap map key

### DIFF
--- a/app/assets/images/key/cyclemap/pedestrian.svg
+++ b/app/assets/images/key/cyclemap/pedestrian.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='50' height='4'>
+<rect x='-.5' y='.5' width='51' height='3' fill='#e2e3e2' stroke='#9a9a9a' />
+</svg>

--- a/config/key.yml
+++ b/config/key.yml
@@ -93,6 +93,7 @@ cyclemap:
   - { min_zoom: 12, max_zoom: 19, name: primary, image: primary12.png }
   - { min_zoom: 9, max_zoom: 11, name: secondary, image: secondary.png }
   - { min_zoom: 12, max_zoom: 19, name: secondary, image: secondary12.png }
+  - { min_zoom: 15, name: pedestrian, image: pedestrian.svg }
   - { min_zoom: 13, max_zoom: 19, name: track, image: track.png }
   - { min_zoom: 8, max_zoom: 19, name: cycleway, image: cycleway.png }
   - { min_zoom: 5, max_zoom: 12, name: cycleway_national, image: cycleway_national.png }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2282,6 +2282,7 @@ en:
           primary: "Primary road"
           secondary: "Secondary road"
           unclassified: "Unclassified road"
+          pedestrian: "Pedestrian way"
           track: "Track"
           bridleway: "Bridleway"
           cycleway: "Cycleway"


### PR DESCRIPTION
As requested [here](https://github.com/openstreetmap/openstreetmap-website/issues/982#issuecomment-1822663434). Map key is actually available but the "grey street" was missing. 

It makes sense to close #982.

- there are more layers in the map key now
- there are at least some area colors in the cyclemap key
- there are “the blue lines alone the road”
- requests for individual features exist: #2956