### PR TITLE
Remove max zoom from cyclemap map key

### DIFF
--- a/config/key.yml
+++ b/config/key.yml
@@ -85,31 +85,31 @@ mapnik:
   - { min_zoom: 15, max_zoom: 19, name: destination, image: destination.png }
   - { min_zoom: 12, max_zoom: 19, name: construction, image: construction.png }
 cyclemap:
-  - { min_zoom: 0, max_zoom: 11, name: motorway, image: motorway.png }
-  - { min_zoom: 12, max_zoom: 19, name: motorway, image: motorway12.png }
-  - { min_zoom: 0, max_zoom: 11, name: trunk, image: trunk.png }
-  - { min_zoom: 12, max_zoom: 19, name: trunk, image: trunk12.png }
-  - { min_zoom: 7, max_zoom: 11, name: primary, image: primary.png }
-  - { min_zoom: 12, max_zoom: 19, name: primary, image: primary12.png }
-  - { min_zoom: 9, max_zoom: 11, name: secondary, image: secondary.png }
-  - { min_zoom: 12, max_zoom: 19, name: secondary, image: secondary12.png }
-  - { min_zoom: 13, max_zoom: 19, name: track, image: track.png }
-  - { min_zoom: 8, max_zoom: 19, name: cycleway, image: cycleway.png }
-  - { min_zoom: 5, max_zoom: 12, name: cycleway_national, image: cycleway_national.png }
-  - { min_zoom: 13, max_zoom: 19, name: cycleway_national, image: cycleway_national13.png }
-  - { min_zoom: 5, max_zoom: 12, name: cycleway_regional, image: cycleway_regional.png }
-  - { min_zoom: 13, max_zoom: 19, name: cycleway_regional, image: cycleway_regional13.png }
-  - { min_zoom: 8, max_zoom: 12, name: cycleway_local, image: cycleway_local.png }
-  - { min_zoom: 13, max_zoom: 19, name: cycleway_local, image: cycleway_local13.png }
-  - { min_zoom: 13, max_zoom: 19, name: footway, image: footway.png }
-  - { min_zoom: 7, max_zoom: 13, name: rail, image: rail.png }
-  - { min_zoom: 14, max_zoom: 19, name: rail, image: rail14.png }
-  - { min_zoom: 9, max_zoom: 19, name: forest, image: forest.png }
-  - { min_zoom: 10, max_zoom: 19, name: common, image: common.png }
-  - { min_zoom: 7, max_zoom: 19, name: lake, image: lake.png }
-  - { min_zoom: 14, max_zoom: 19, name: bicycle_shop, image: bicycle_shop.png }
-  - { min_zoom: 14, max_zoom: 19, name: bicycle_parking, image: bicycle_parking.png }
-  - { min_zoom: 16, max_zoom: 19, name: toilets, image: toilets.png }
+  - { min_zoom:  0, name: motorway, image: motorway.png }
+  - { min_zoom: 12, name: motorway, image: motorway12.png }
+  - { min_zoom:  0, name: trunk, image: trunk.png }
+  - { min_zoom: 12, name: trunk, image: trunk12.png }
+  - { min_zoom:  7, name: primary, image: primary.png }
+  - { min_zoom: 12, name: primary, image: primary12.png }
+  - { min_zoom:  9, name: secondary, image: secondary.png }
+  - { min_zoom: 12, name: secondary, image: secondary12.png }
+  - { min_zoom: 13, name: track, image: track.png }
+  - { min_zoom:  8, name: cycleway, image: cycleway.png }
+  - { min_zoom:  5, name: cycleway_national, image: cycleway_national.png }
+  - { min_zoom: 13, name: cycleway_national, image: cycleway_national13.png }
+  - { min_zoom:  5, name: cycleway_regional, image: cycleway_regional.png }
+  - { min_zoom: 13, name: cycleway_regional, image: cycleway_regional13.png }
+  - { min_zoom:  8, name: cycleway_local, image: cycleway_local.png }
+  - { min_zoom: 13, name: cycleway_local, image: cycleway_local13.png }
+  - { min_zoom: 13, name: footway, image: footway.png }
+  - { min_zoom:  7, name: rail, image: rail.png }
+  - { min_zoom: 14, name: rail, image: rail14.png }
+  - { min_zoom:  9, name: forest, image: forest.png }
+  - { min_zoom: 10, name: common, image: common.png }
+  - { min_zoom:  7, name: lake, image: lake.png }
+  - { min_zoom: 14, name: bicycle_shop, image: bicycle_shop.png }
+  - { min_zoom: 14, name: bicycle_parking, image: bicycle_parking.png }
+  - { min_zoom: 16, name: toilets, image: toilets.png }
 opnvkarte:
   - { min_zoom:  6, name: rail, width: 52, height: 1, fill: "#868686" }
   - { min_zoom:  8, name: rail, width: 52, height: 2, fill: "#868686" }


### PR DESCRIPTION
You can zoom up to 21 on cyclemap, yet the map key has `max_zoom: 19` statements and disappears on z20 and z21.