### PR TITLE
Remove unnecessary max_zoom from map key

### DIFF
--- a/config/key.yml
+++ b/config/key.yml
@@ -1,13 +1,13 @@
 mapnik:
   # transportation: roads.mss
-  - { min_zoom: 6, max_zoom: 19, name: motorway, image: motorway.png }
-  - { min_zoom: 6, max_zoom: 7, name: main_road, image: mainroad.png }
-  - { min_zoom: 8, max_zoom: 11, name: main_road, image: mainroad8.png }
-  - { min_zoom: 12, max_zoom: 19, name: main_road, image: mainroad12.png }
-  - { min_zoom: 13, max_zoom: 19, name: track, image: track.png }
-  - { min_zoom: 13, max_zoom: 19, name: bridleway, image: bridleway.png }
-  - { min_zoom: 13, max_zoom: 19, name: cycleway, image: cycleway.png }
-  - { min_zoom: 13, max_zoom: 19, name: footway, image: footway.png }
+  - { min_zoom:  6, name: motorway, image: motorway.png }
+  - { min_zoom:  6, name: main_road, image: mainroad.png }
+  - { min_zoom:  8, name: main_road, image: mainroad8.png }
+  - { min_zoom: 12, name: main_road, image: mainroad12.png }
+  - { min_zoom: 13, name: track, image: track.png }
+  - { min_zoom: 13, name: bridleway, image: bridleway.png }
+  - { min_zoom: 13, name: cycleway, image: cycleway.png }
+  - { min_zoom: 13, name: footway, image: footway.png }
   - { min_zoom:  8, name: rail, width: 52, height: 1, fill: "#787878" }
   - { min_zoom: 12, name: rail, image: rail12.svg }
   - { min_zoom: 18, name: rail, image: rail18.svg }
@@ -19,55 +19,55 @@ mapnik:
   - { min_zoom: 14, name: tram_only, width: 52, height: 1, fill: "#6e6e6e" }
   - { min_zoom: 15, name: tram_only, image: tram15.svg }
   - { min_zoom: 17, name: tram_only, width: 52, height: 2, fill: "#6e6e6e" }
-  - { min_zoom: 12, max_zoom: 19, name: cable, image: cable.png }
-  - { min_zoom: 11, max_zoom: 19, name: runway, image: runway.png }
+  - { min_zoom: 12, name: cable, image: cable.png }
+  - { min_zoom: 11, name: runway, image: runway.png }
   - { min_zoom: 11, name: apron_only, width: 26, height: 10, fill: "#dadae0" } # landcover.mss
   # administrative boundaries: admin.mss
   - { name: admin, width: 52, height: 2, fill: "#8d618b88" }
   # landcover z5: landcover.mss, water.mss
   - { name: lake, width: 26, height: 10, fill: "#aad3df" }
   - { name: intermittent_water, image: intermittent_water.svg }
-  - { min_zoom: 5, max_zoom: 9, name: glacier, image: glacier5.svg }
+  - { min_zoom:  5, name: glacier, image: glacier5.svg }
   - { min_zoom: 10, name: glacier, image: glacier10.svg }
   - { min_zoom: 10, name: reef, image: reef.png }
   - { min_zoom: 10, name: wetland, image: wetland.png }
-  - { min_zoom: 5, max_zoom: 11, name: forest, width: 26, height: 10, fill: "#bddab1" }
+  - { min_zoom:  5, name: forest, width: 26, height: 10, fill: "#bddab1" }
   - { min_zoom: 12, name: forest, width: 26, height: 10, fill: "#add19e" }
-  - { min_zoom: 5, max_zoom: 11, name: orchard, width: 26, height: 10, fill: "#bee5b5" }
+  - { min_zoom:  5, name: orchard, width: 26, height: 10, fill: "#bee5b5" }
   - { min_zoom: 12, name: orchard, width: 26, height: 10, fill: "#aedfa3" }
-  - { min_zoom: 5, max_zoom: 11, name: grass, width: 26, height: 10, fill: "#d7efc0" }
+  - { min_zoom:  5, name: grass, width: 26, height: 10, fill: "#d7efc0" }
   - { min_zoom: 12, name: grass, width: 26, height: 10, fill: "#cdebb0" }
-  - { min_zoom: 5, max_zoom: 11, name: farmland, width: 26, height: 10, fill: "#f1f3dd" }
+  - { min_zoom:  5, name: farmland, width: 26, height: 10, fill: "#f1f3dd" }
   - { min_zoom: 12, name: farmland, width: 26, height: 10, fill: "#eef0d5" }
-  - { min_zoom: 5, max_zoom: 11, name: heathland, width: 26, height: 10, fill: "#dee1b2" }
+  - { min_zoom:  5, name: heathland, width: 26, height: 10, fill: "#dee1b2" }
   - { min_zoom: 12, name: heathland, width: 26, height: 10, fill: "#d6d99f" }
-  - { min_zoom: 5, max_zoom: 11, name: scrubland, width: 26, height: 10, fill: "#d3dfbc" }
+  - { min_zoom:  5, name: scrubland, width: 26, height: 10, fill: "#d3dfbc" }
   - { min_zoom: 12, name: scrubland, width: 26, height: 10, fill: "#c8d7ab" }
-  - { min_zoom: 5, max_zoom: 11, name: bare_rock, width: 26, height: 10, fill: "#f1eae3" }
+  - { min_zoom:  5, name: bare_rock, width: 26, height: 10, fill: "#f1eae3" }
   - { min_zoom: 12, name: bare_rock, width: 26, height: 10, fill: "#eee5dc" }
-  - { min_zoom: 5, max_zoom: 11, name: sand, width: 26, height: 10, fill: "#f7edd1" }
+  - { min_zoom:  5, name: sand, width: 26, height: 10, fill: "#f7edd1" }
   - { min_zoom: 12, name: sand, width: 26, height: 10, fill: "#f5e9c6" }
   # landuse z8, z10: landcover.mss
   - { min_zoom: 10, name: park, width: 26, height: 10, fill: "#c8facc" }
   - { min_zoom: 10, name: golf, width: 26, height: 10, fill: "#def6c0" }
-  - { min_zoom: 8, max_zoom: 11, name: built_up, width: 26, height: 10, fill: "#d9d9d9" }
+  - { min_zoom:  8, name: built_up, width: 26, height: 10, fill: "#d9d9d9" }
   - { min_zoom: 12, max_zoom: 12, name: built_up, width: 26, height: 10, fill: "#dddddd" }
   - { min_zoom: 13, name: resident, width: 26, height: 10, fill: "#e0dfdf" }
   - { min_zoom: 13, name: retail, width: 26, height: 10, fill: "#ffd6d1" }
   - { min_zoom: 13, name: commercial, width: 26, height: 10, fill: "#f2dad9" }
   - { min_zoom: 13, name: industrial, width: 26, height: 10, fill: "#ebdbe8" }
-  - { min_zoom: 10, max_zoom: 11, name: farm, width: 26, height: 10, fill: "#f7e3c8" }
+  - { min_zoom: 10, name: farm, width: 26, height: 10, fill: "#f7e3c8" }
   - { min_zoom: 12, name: farm, width: 26, height: 10, fill: "#f5dcba" }
-  - { min_zoom: 10, max_zoom: 11, name: brownfield, width: 26, height: 10, fill: "#d2d2c3" }
+  - { min_zoom: 10, name: brownfield, width: 26, height: 10, fill: "#d2d2c3" }
   - { min_zoom: 12, name: brownfield, width: 26, height: 10, fill: "#c7c7b4" }
-  - { min_zoom: 10, max_zoom: 11, name: cemetery, width: 26, height: 10, fill: "#bbd5be" }
+  - { min_zoom: 10, name: cemetery, width: 26, height: 10, fill: "#bbd5be" }
   - { min_zoom: 12, name: cemetery, width: 26, height: 10, fill: "#aacbaf" }
-  - { min_zoom: 10, max_zoom: 11, name: allotments, width: 26, height: 10, fill: "#d4e6cc" }
+  - { min_zoom: 10, name: allotments, width: 26, height: 10, fill: "#d4e6cc" }
   - { min_zoom: 12, name: allotments, width: 26, height: 10, fill: "#c9e1bf" }
   - { min_zoom: 11, name: pitch, width: 26, height: 10, fill: "#88e0be" }
   - { min_zoom: 11, name: centre, width: 26, height: 10, fill: "#dffce2" }
   - { min_zoom: 10, name: reserve, image: reserve.svg } # admin.mss
-  - { min_zoom: 8, name: military, image: military.svg }
+  - { min_zoom:  8, name: military, image: military.svg }
   - { min_zoom: 13, name: school, image: school.svg }
   # buildings: buildings.mss
   - { min_zoom: 14, name: building, width: 10, height: 10, fill: "#ab9793" }
@@ -81,9 +81,9 @@ mapnik:
   - { min_zoom: 11, name: summit, image: summit.svg } # amenity-points.mss
   - { min_zoom: 13, name: tunnel, image: tunnel.svg } # roads.mss
   - { min_zoom: 13, name: bridge, image: bridge.svg } # roads.mss
-  - { min_zoom: 15, max_zoom: 19, name: private, image: private.png }
-  - { min_zoom: 15, max_zoom: 19, name: destination, image: destination.png }
-  - { min_zoom: 12, max_zoom: 19, name: construction, image: construction.png }
+  - { min_zoom: 15, name: private, image: private.png }
+  - { min_zoom: 15, name: destination, image: destination.png }
+  - { min_zoom: 12, name: construction, image: construction.png }
 cyclemap:
   - { min_zoom:  0, name: motorway, image: motorway.png }
   - { min_zoom: 12, name: motorway, image: motorway12.png }


### PR DESCRIPTION
After removing `max_zoom` from cyclemap in #4411, it makes sense to remove it from everywhere else.

`max_zoom` is necessary only for "Built-up area" in mapnik, before it splits into more specific area types.