### PR TITLE
Optimize escaping of data uri svgs

### DIFF
--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -1,0 +1,8 @@
+module SvgHelper
+  def solid_svg_image_tag(width, height, fill)
+    svg = "<svg xmlns='http://www.w3.org/2000/svg' width='#{width}' height='#{height}'>" \
+          "<rect width='100%' height='100%' fill='#{fill}' />" \
+          "</svg>"
+    image_tag "data:image/svg+xml,#{u(svg)}"
+  end
+end

--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -4,6 +4,6 @@ module SvgHelper
           "<rect width='100%' height='100%' fill='#{fill}' />" \
           "</svg>"
     escaped_svg = svg.gsub(/[\r\n%#()<>?\[\\\]^`{|}]/) { |c| u(c) }
-    image_tag "data:image/svg+xml,#{escaped_svg}"
+    tag.img :src => "data:image/svg+xml,#{escaped_svg}", :escape => false
   end
 end

--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -3,6 +3,7 @@ module SvgHelper
     svg = "<svg xmlns='http://www.w3.org/2000/svg' width='#{width}' height='#{height}'>" \
           "<rect width='100%' height='100%' fill='#{fill}' />" \
           "</svg>"
-    image_tag "data:image/svg+xml,#{u(svg)}"
+    escaped_svg = svg.gsub(/[\r\n%#()<>?\[\\\]^`{|}]/) { |c| u(c) }
+    image_tag "data:image/svg+xml,#{escaped_svg}"
   end
 end

--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -5,7 +5,7 @@
         <%= tag.tr :class => "mapkey-table-entry", :data => { :layer => layer_name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
           <td class="mapkey-table-key align-middle">
             <% if entry["width"] && entry["height"] && entry["fill"] %>
-              <%= image_tag "data:image/svg+xml,#{u("<svg xmlns='http://www.w3.org/2000/svg' width='#{entry['width']}' height='#{entry['height']}'><rect width='100%' height='100%' fill='#{entry['fill']}' /></svg>")}" %>
+              <%= solid_svg_image_tag entry["width"], entry["height"], entry["fill"] %>
             <% else %>
               <%= image_tag "key/#{layer_name}/#{entry['image']}" %>
             <% end %>


### PR DESCRIPTION
Now data uri svgs are used throughout the map key, and they affect the generated file size.

The default `url_encode` function %-encodes too many characters. There's a question which ones have to be encoded. `#` certainly is one of them, unencoded `#` will break the uri. If you strictly follow [the rfc from 1998](https://www.ietf.org/rfc/rfc2397.txt), spaces need to be encoded, yet nobody does that with svgs. For example [this library here](https://github.com/tigt/mini-svg-data-uri/blob/00dc78c8f77eb7b47299a9e3d564749105810c9c/index.js#L31) deliberately unencodes them. `<>` are commonly encoded by svg data uri libraries, yet the example in Wikipedia [contains them unencoded](https://en.wikipedia.org/wiki/Data_URI_scheme) and it seems to work fine.

I'm %-encoding [these chars](https://github.com/yoksel/url-encoder/blob/2c31ea619932c61f418bb8dfb945ddc95f9927fd/src/js/script.js#L15C44-L15C44) as used in [this tool](https://yoksel.github.io/url-encoder/).

Before:

    <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%2752%27%20height%3D%271%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%23787878%27%20%2F%3E%3C%2Fsvg%3E" />

After:

    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='52' height='1'%3E%3Crect width='100%25' height='100%25' fill='%23787878' /%3E%3C/svg%3E">