### PR TITLE
Use inline svgs in map key

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -562,16 +562,6 @@ header .search_forms,
   display: none;
 }
 
-/* Rules for the map key which appears in the popout sidebar */
-
-#mapkey {
- .mapkey-table-key img {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-  }
-}
-
 /* Rules for search sidebar */
 
 #sidebar .search_results_entry {

--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -1,8 +1,7 @@
 module SvgHelper
-  def solid_svg_image_tag(width, height, fill, **options)
-    svg = "<svg xmlns='http://www.w3.org/2000/svg' width='#{width}' height='#{height}'>" \
-          "<rect width='100%' height='100%' fill='#{fill}' />" \
-          "</svg>"
-    image_tag "data:image/svg+xml,#{u(svg)}", **options
+  def solid_svg_tag(width, height, fill, **options)
+    tag.svg :width => width, :height => height, **options do
+      tag.rect :width => "100%", :height => "100%", :fill => fill
+    end
   end
 end

--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -1,0 +1,8 @@
+module SvgHelper
+  def solid_svg_image_tag(width, height, fill, **options)
+    svg = "<svg xmlns='http://www.w3.org/2000/svg' width='#{width}' height='#{height}'>" \
+          "<rect width='100%' height='100%' fill='#{fill}' />" \
+          "</svg>"
+    image_tag "data:image/svg+xml,#{u(svg)}", **options
+  end
+end

--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -5,7 +5,7 @@
         <%= tag.tr :class => "mapkey-table-entry", :data => { :layer => layer_name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
           <td>
             <% if entry["width"] && entry["height"] && entry["fill"] %>
-              <%= image_tag "data:image/svg+xml,#{u("<svg xmlns='http://www.w3.org/2000/svg' width='#{entry['width']}' height='#{entry['height']}'><rect width='100%' height='100%' fill='#{entry['fill']}' /></svg>")}", :class => "d-block mx-auto" %>
+              <%= solid_svg_image_tag entry["width"], entry["height"], entry["fill"], :class => "d-block mx-auto" %>
             <% else %>
               <%= image_tag "key/#{layer_name}/#{entry['image']}", :class => "d-block mx-auto" %>
             <% end %>

--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -1,16 +1,16 @@
 <div id="mapkey">
-  <table class="table table-sm table-borderless mapkey-table mb-0">
+  <table class="table table-sm table-borderless mb-0 align-middle">
     <% @key.each do |layer_name, layer_data| %>
       <% layer_data.each do |entry| %>
         <%= tag.tr :class => "mapkey-table-entry", :data => { :layer => layer_name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
-          <td class="mapkey-table-key align-middle">
+          <td>
             <% if entry["width"] && entry["height"] && entry["fill"] %>
-              <%= image_tag "data:image/svg+xml,#{u("<svg xmlns='http://www.w3.org/2000/svg' width='#{entry['width']}' height='#{entry['height']}'><rect width='100%' height='100%' fill='#{entry['fill']}' /></svg>")}" %>
+              <%= image_tag "data:image/svg+xml,#{u("<svg xmlns='http://www.w3.org/2000/svg' width='#{entry['width']}' height='#{entry['height']}'><rect width='100%' height='100%' fill='#{entry['fill']}' /></svg>")}", :class => "d-block mx-auto" %>
             <% else %>
-              <%= image_tag "key/#{layer_name}/#{entry['image']}" %>
+              <%= image_tag "key/#{layer_name}/#{entry['image']}", :class => "d-block mx-auto" %>
             <% end %>
           </td>
-          <td class="mapkey-table-value">
+          <td>
             <%= Array(t(".table.entry.#{entry['name']}")).to_sentence %>
           </td>
         <% end %>

--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -5,7 +5,7 @@
         <%= tag.tr :class => "mapkey-table-entry", :data => { :layer => layer_name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
           <td>
             <% if entry["width"] && entry["height"] && entry["fill"] %>
-              <%= solid_svg_image_tag entry["width"], entry["height"], entry["fill"], :class => "d-block mx-auto" %>
+              <%= solid_svg_tag entry["width"], entry["height"], entry["fill"], :class => "d-block mx-auto" %>
             <% else %>
               <%= image_tag "key/#{layer_name}/#{entry['image']}", :class => "d-block mx-auto" %>
             <% end %>


### PR DESCRIPTION
Instead of [optimizing svg data uris](https://github.com/openstreetmap/openstreetmap-website/pull/4419) we can use inline svgs here.

Now this:

    <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%2752%27%20height%3D%271%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%23787878%27%20%2F%3E%3C%2Fsvg%3E" />

becomes this:

    <svg width="52" height="1" class="d-block mx-auto"><rect width="100%" height="100%" fill="#787878" /></svg>
