### PR TITLE
Allow arrays of names in map key entries

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -50,6 +50,9 @@ class SiteController < ApplicationController
     expires_in 7.days, :public => true
     @key = YAML.load_file(Rails.root.join("config/key.yml"))
     @key.each_value do |layer_data|
+      layer_data.each do |entry|
+        entry["name"] = Array(entry["name"])
+      end
       layer_data.each_cons(2) do |entry, next_entry|
         entry["max_zoom"] = next_entry["min_zoom"] - 1 if entry["name"] == next_entry["name"] && !entry["max_zoom"] && next_entry["min_zoom"]
       end

--- a/app/views/site/key.html.erb
+++ b/app/views/site/key.html.erb
@@ -11,7 +11,7 @@
             <% end %>
           </td>
           <td>
-            <%= Array(t(".table.entry.#{entry['name']}")).to_sentence %>
+            <%= entry["name"].map { |feature_name| t ".table.entry.#{feature_name}" }.join(" · ") %>
           </td>
         <% end %>
       <% end %>

--- a/config/key.yml
+++ b/config/key.yml
@@ -19,27 +19,27 @@ mapnik:
   - { min_zoom: 14, name: tram_only, width: 52, height: 1, fill: "#6e6e6e" }
   - { min_zoom: 15, name: tram_only, image: tram15.svg }
   - { min_zoom: 17, name: tram_only, width: 52, height: 2, fill: "#6e6e6e" }
-  - { min_zoom: 12, name: cable, image: cable.png }
-  - { min_zoom: 11, name: runway, image: runway11.svg }
-  - { min_zoom: 12, name: runway, image: runway12.svg }
-  - { min_zoom: 13, name: runway, image: runway13.svg }
-  - { min_zoom: 14, name: runway, image: runway14.svg }
+  - { min_zoom: 12, name: [cable_car, chair_lift], image: cable.png }
+  - { min_zoom: 11, name: [runway_only, taxiway], image: runway11.svg }
+  - { min_zoom: 12, name: [runway_only, taxiway], image: runway12.svg }
+  - { min_zoom: 13, name: [runway_only, taxiway], image: runway13.svg }
+  - { min_zoom: 14, name: [runway_only, taxiway], image: runway14.svg }
   - { min_zoom: 11, name: apron_only, width: 26, height: 10, fill: "#dadae0" } # landcover.mss
   # administrative boundaries: admin.mss
   - { name: admin, width: 52, height: 2, fill: "#8d618b88" }
   # landcover z5: landcover.mss, water.mss
-  - { name: lake, width: 26, height: 10, fill: "#aad3df" }
+  - { name: [lake_only, reservoir], width: 26, height: 10, fill: "#aad3df" }
   - { name: intermittent_water, image: intermittent_water.svg }
   - { min_zoom:  5, name: glacier, image: glacier5.svg }
   - { min_zoom: 10, name: glacier, image: glacier10.svg }
   - { min_zoom: 10, name: reef, image: reef.png }
   - { min_zoom: 10, name: wetland, image: wetland.png }
-  - { min_zoom:  5, name: forest, width: 26, height: 10, fill: "#bddab1" }
-  - { min_zoom: 12, name: forest, width: 26, height: 10, fill: "#add19e" }
-  - { min_zoom:  5, name: orchard, width: 26, height: 10, fill: "#bee5b5" }
-  - { min_zoom: 12, name: orchard, width: 26, height: 10, fill: "#aedfa3" }
-  - { min_zoom:  5, name: grass, width: 26, height: 10, fill: "#d7efc0" }
-  - { min_zoom: 12, name: grass, width: 26, height: 10, fill: "#cdebb0" }
+  - { min_zoom:  5, name: [forest_only, wood], width: 26, height: 10, fill: "#bddab1" }
+  - { min_zoom: 12, name: [forest_only, wood], width: 26, height: 10, fill: "#add19e" }
+  - { min_zoom:  5, name: [orchard_only, vineyard], width: 26, height: 10, fill: "#bee5b5" }
+  - { min_zoom: 12, name: [orchard_only, vineyard], width: 26, height: 10, fill: "#aedfa3" }
+  - { min_zoom:  5, name: [grass_only, meadow], width: 26, height: 10, fill: "#d7efc0" }
+  - { min_zoom: 12, name: [grass_only, meadow], width: 26, height: 10, fill: "#cdebb0" }
   - { min_zoom:  5, name: farmland, width: 26, height: 10, fill: "#f1f3dd" }
   - { min_zoom: 12, name: farmland, width: 26, height: 10, fill: "#eef0d5" }
   - { min_zoom:  5, name: heathland, width: 26, height: 10, fill: "#dee1b2" }
@@ -71,7 +71,7 @@ mapnik:
   - { min_zoom: 11, name: centre, width: 26, height: 10, fill: "#dffce2" }
   - { min_zoom: 10, name: reserve, image: reserve.svg } # admin.mss
   - { min_zoom:  8, name: military, image: military.svg }
-  - { min_zoom: 13, name: school, image: school.svg }
+  - { min_zoom: 13, name: [school_only, university, hospital], image: school.svg }
   # buildings: buildings.mss
   - { min_zoom: 14, name: building, width: 10, height: 10, fill: "#ab9793" }
   - { min_zoom: 15, name: building, image: building15.svg }
@@ -81,7 +81,7 @@ mapnik:
   - { min_zoom: 13, name: station, width: 6, height: 6, fill: "#7981b0" }
   - { min_zoom: 15, name: station, width: 9, height: 9, fill: "#7981b0" }
   # other
-  - { min_zoom: 11, name: summit, image: summit.svg } # amenity-points.mss
+  - { min_zoom: 11, name: [summit_only, peak], image: summit.svg } # amenity-points.mss
   - { min_zoom: 13, name: tunnel, image: tunnel.svg } # roads.mss
   - { min_zoom: 13, name: bridge, image: bridge.svg } # roads.mss
   - { min_zoom: 15, name: private, image: private.png }
@@ -108,9 +108,11 @@ cyclemap:
   - { min_zoom: 13, name: footway, image: footway.svg }
   - { min_zoom:  7, name: rail, image: rail.png }
   - { min_zoom: 14, name: rail, image: rail14.png }
-  - { min_zoom:  9, name: forest, width: 26, height: 10, fill: "#b3d6a4" }
-  - { min_zoom: 10, name: common, width: 26, height: 10, fill: "#c0de9c" }
-  - { min_zoom:  1, name: lake, width: 26, height: 10, fill: "#addeff" }
+  - { min_zoom:  1, name: [lake_only, reservoir], width: 26, height: 10, fill: "#addeff" }
+  - { min_zoom:  9, name: [forest_only, wood], width: 26, height: 10, fill: "#b3d6a4" }
+  - { min_zoom: 10, name: meadow, width: 26, height: 10, fill: "#c0de9c" }
+  - { min_zoom: 10, name: park, width: 26, height: 10, fill: "#cbe4c4" }
+  - { min_zoom: 10, name: common_only, width: 26, height: 10, fill: "#d4f0d1" }
   - { min_zoom: 14, name: bicycle_shop, image: bicycle_shop.png }
   - { min_zoom: 14, name: bicycle_parking, image: bicycle_parking.png }
   - { min_zoom: 16, name: toilets, image: toilets.png }
@@ -162,9 +164,9 @@ opnvkarte:
   - { min_zoom: 15, name: main_road, image: main_road15.svg }
   - { min_zoom: 17, name: main_road, image: main_road17.svg }
   # landcover
-  - { min_zoom:  0, name: lake, width: 26, height: 10, fill: "#a1cbea" }
-  - { min_zoom:  8, name: lake, width: 26, height: 10, fill: "#bfd3ef" }
-  - { min_zoom:  4, name: forest, width: 26, height: 10, fill: "#b9c5a3" }
+  - { min_zoom:  0, name: [lake_only, reservoir], width: 26, height: 10, fill: "#a1cbea" }
+  - { min_zoom:  8, name: [lake_only, reservoir], width: 26, height: 10, fill: "#bfd3ef" }
+  - { min_zoom:  4, name: [forest_only, wood], width: 26, height: 10, fill: "#b9c5a3" }
   - { min_zoom:  4, name: built_up, width: 26, height: 10, fill: "#d8d8d8" }
   - { min_zoom:  9, name: farmland, width: 26, height: 10, fill: "#eae8d6" }
-  - { min_zoom: 12, name: park, width: 26, height: 10, fill: "#c2d89a" } # also allotments
+  - { min_zoom: 12, name: [park, allotments], width: 26, height: 10, fill: "#c2d89a" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2298,32 +2298,24 @@ en:
           tram_only: "Tram"
           trolleybus: "Trolleybus"
           bus: "Bus"
-          cable:
-            - Cable car
-            - chair lift
-          runway:
-            - Airport Runway
-            - taxiway
+          cable_car: "Cable car"
+          chair_lift: "Chair lift"
+          runway_only: "Airport Runway"
+          taxiway: "Taxiway"
           apron_only: "Airport apron"
           admin: "Administrative boundary"
-          orchard:
-            - Orchard
-            - vineyard
-          forest:
-            - Forest
-            - wood
+          orchard_only: "Orchard"
+          vineyard: "Vineyard"
+          forest_only: "Forest"
+          wood: "Wood"
           farmland: "Farmland"
-          grass:
-            - Grass
-            - meadow
+          grass_only: "Grass"
+          meadow: "Meadow"
           bare_rock: "Bare rock"
           sand: "Sand"
           golf: "Golf course"
           park: "Park"
-          common:
-            - Common
-            - meadow
-            - garden
+          common_only: "Common"
           built_up: "Built-up area"
           resident: "Residential area"
           retail: "Retail area"
@@ -2331,9 +2323,8 @@ en:
           commercial: "Commercial area"
           heathland: "Heathland"
           scrubland: "Scrubland"
-          lake:
-            - Lake
-            - reservoir
+          lake_only: "Lake"
+          reservoir: "Reservoir"
           intermittent_water: "Intermittent waterbody"
           glacier: "Glacier"
           reef: "Reef"
@@ -2346,15 +2337,13 @@ en:
           centre: "Sports centre"
           reserve: "Nature reserve"
           military: "Military area"
-          school:
-            - School
-            - university
-            - hospital
+          school_only: "School"
+          university: "University"
+          hospital: "Hospital"
           building: "Significant building"
           station: "Railway station"
-          summit:
-            - Summit
-            - peak
+          summit_only: "Summit"
+          peak: "Peak"
           tunnel: "Dashed casing = tunnel"
           bridge: "Black casing = bridge"
           private: "Private access"


### PR DESCRIPTION
Fix #3816 by not constructing sentences and not having combined i18n strings.

I don't think sentences are expected in map key, so instead of this:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/efe18e2e-e5d6-4fc1-a6b6-cb0197069ba4)
we can connect terms by dots, like we do with *secondary actions* ("Download XML ·View History" on element pages etc):
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/654078b9-7fe3-4104-8f1d-e946532db78c)

Don't group locale strings in site.key.table.entry. Instead of this:

          cable:
            - Cable car
            - chair lift

have this:

          cable_car: "Cable car"
          chair_lift: "Chair lift"

Group them in `key.yml`, depending on layer. Instead of this:

    - { min_zoom: 12, name: cable, image: cable.png }

have this:

    - { min_zoom: 12, name: [cable_car, chair_lift], image: cable.png }

---

The advantage is that if features are grouped differently on various layers, their names can be translated independently. For example, mapnik has different colors for parks and allotments with two different entries in `key.yml`:

    - { min_zoom: 10, name: park, width: 26, height: 10, fill: "#c8facc" }
    - { min_zoom: 10, name: allotments, width: 26, height: 10, fill: "#d4e6cc" }

Opnvkarte renders parks and allotments the same, they can have one entry:

    - { min_zoom: 12, name: [park, allotments], width: 26, height: 10, fill: "#c2d89a" }

And there can be two independent locale strings:

    park: "Park"
    allotments: "Allotments"
