### PR TITLE
Faster tests

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -20,8 +20,8 @@ trace_file_storage: "test"
 trace_image_storage: "test"
 trace_icon_storage: "test"
 # Lower some rate limits for testing
-max_changeset_comments_per_hour: 30
-moderator_changeset_comments_per_hour: 60
+max_changeset_comments_per_hour: 10
+moderator_changeset_comments_per_hour: 15
 # Private key for signing id_tokens
 doorkeeper_signing_key: |
   -----BEGIN PRIVATE KEY-----

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -18,149 +18,121 @@ class UserCreationTest < ActionDispatch::IntegrationTest
   end
 
   def test_create_user_form
-    I18n.with_locale "en" do
-      I18n.available_locales.each do |locale|
-        reset!
-        get "/user/new", :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
-        follow_redirect!
-        assert_response :success
-        assert_template "users/new"
-      end
-    end
+    get "/user/new"
+    follow_redirect!
+    assert_response :success
+    assert_template "users/new"
   end
 
   def test_user_create_submit_duplicate_email
-    I18n.with_locale "en" do
-      Locale.available.each do |locale|
-        dup_email = create(:user).email
-        display_name = "#{locale}_new_tester"
-        assert_difference("User.count", 0) do
-          assert_difference("ActionMailer::Base.deliveries.size", 0) do
-            perform_enqueued_jobs do
-              post "/user/new",
-                   :params => { :user => { :email => dup_email,
-                                           :email_confirmation => dup_email,
-                                           :display_name => display_name,
-                                           :pass_crypt => "testtest",
-                                           :pass_crypt_confirmation => "testtest" } },
-                   :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
-            end
-          end
+    dup_email = create(:user).email
+    display_name = "new_tester"
+    assert_difference("User.count", 0) do
+      assert_difference("ActionMailer::Base.deliveries.size", 0) do
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => dup_email,
+                                       :email_confirmation => dup_email,
+                                       :display_name => display_name,
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" } }
         end
-        assert_response :success
-        assert_template "users/new"
-        assert_equal locale.to_s, response.headers["Content-Language"]
-        assert_select "form"
-        assert_select "form > div > input.is-invalid#user_email"
-        assert_no_missing_translations
       end
     end
+    assert_response :success
+    assert_template "users/new"
+    assert_select "form"
+    assert_select "form > div > input.is-invalid#user_email"
   end
 
   def test_user_create_submit_duplicate_username
-    I18n.with_locale "en" do
-      I18n.available_locales.each do |locale|
-        dup_display_name = create(:user).display_name
-        email = "#{locale}_new_tester"
-        assert_difference("User.count", 0) do
-          assert_difference("ActionMailer::Base.deliveries.size", 0) do
-            perform_enqueued_jobs do
-              post "/user/new",
-                   :params => { :user => { :email => email,
-                                           :email_confirmation => email,
-                                           :display_name => dup_display_name,
-                                           :pass_crypt => "testtest",
-                                           :pass_crypt_confirmation => "testtest" } },
-                   :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
-            end
-          end
+    dup_display_name = create(:user).display_name
+    email = "new_tester"
+    assert_difference("User.count", 0) do
+      assert_difference("ActionMailer::Base.deliveries.size", 0) do
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => email,
+                                       :email_confirmation => email,
+                                       :display_name => dup_display_name,
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" } }
         end
-        assert_response :success
-        assert_template "users/new"
-        assert_select "form > div > input.is-invalid#user_display_name"
-        assert_no_missing_translations
       end
     end
+    assert_response :success
+    assert_template "users/new"
+    assert_select "form > div > input.is-invalid#user_display_name"
   end
 
   def test_user_create_success
-    I18n.with_locale "en" do
-      I18n.available_locales.each do |locale|
-        new_email = "#{locale}newtester@osm.org"
-        display_name = "#{locale}_new_tester"
+    new_email = "newtester@osm.org"
+    display_name = "new_tester"
 
-        assert_difference("User.count", 0) do
-          assert_difference("ActionMailer::Base.deliveries.size", 0) do
-            perform_enqueued_jobs do
-              post "/user/new",
-                   :params => { :user => { :email => new_email,
-                                           :email_confirmation => new_email,
-                                           :display_name => display_name,
-                                           :pass_crypt => "testtest",
-                                           :pass_crypt_confirmation => "testtest" } }
-            end
-          end
+    assert_difference("User.count", 0) do
+      assert_difference("ActionMailer::Base.deliveries.size", 0) do
+        perform_enqueued_jobs do
+          post "/user/new",
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" } }
         end
-
-        assert_redirected_to "/user/terms"
-
-        assert_difference("User.count") do
-          assert_difference("ActionMailer::Base.deliveries.size", 1) do
-            perform_enqueued_jobs do
-              post "/user/save",
-                   :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s },
-                   :params => { :read_ct => 1, :read_tou => 1 }
-              follow_redirect!
-            end
-          end
-        end
-
-        # Check the e-mail
-        register_email = ActionMailer::Base.deliveries.first
-
-        assert_equal register_email.to.first, new_email
-        # Check that the confirm account url is correct
-        assert_match(/#{@url}/, register_email.body.to_s)
-
-        # Check the page
-        assert_response :success
-        assert_template "confirmations/confirm"
-
-        ActionMailer::Base.deliveries.clear
       end
     end
+
+    assert_redirected_to "/user/terms"
+
+    assert_difference("User.count") do
+      assert_difference("ActionMailer::Base.deliveries.size", 1) do
+        perform_enqueued_jobs do
+          post "/user/save",
+               :params => { :read_ct => 1, :read_tou => 1 }
+          follow_redirect!
+        end
+      end
+    end
+
+    # Check the e-mail
+    register_email = ActionMailer::Base.deliveries.first
+
+    assert_equal register_email.to.first, new_email
+    # Check that the confirm account url is correct
+    assert_match(/#{@url}/, register_email.body.to_s)
+
+    # Check the page
+    assert_response :success
+    assert_template "confirmations/confirm"
+
+    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_no_tou_failure
-    I18n.with_locale "en" do
-      I18n.available_locales.each do |locale|
-        new_email = "#{locale}newtester@osm.org"
-        display_name = "#{locale}_new_tester"
+    new_email = "#newtester@osm.org"
+    display_name = "new_tester"
 
-        assert_difference("User.count", 0) do
-          assert_difference("ActionMailer::Base.deliveries.size", 0) do
-            perform_enqueued_jobs do
-              post "/user/new",
-                   :params => { :user => { :email => new_email,
-                                           :email_confirmation => new_email,
-                                           :display_name => display_name,
-                                           :pass_crypt => "testtest",
-                                           :pass_crypt_confirmation => "testtest" } }
-            end
-          end
-        end
-
-        assert_redirected_to "/user/terms"
-
+    assert_difference("User.count", 0) do
+      assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
-          post "/user/save",
-               :headers => { "HTTP_ACCEPT_LANGUAGE" => locale.to_s }
-          assert_redirected_to "/user/terms"
+          post "/user/new",
+               :params => { :user => { :email => new_email,
+                                       :email_confirmation => new_email,
+                                       :display_name => display_name,
+                                       :pass_crypt => "testtest",
+                                       :pass_crypt_confirmation => "testtest" } }
         end
-
-        ActionMailer::Base.deliveries.clear
       end
     end
+
+    assert_redirected_to "/user/terms"
+
+    perform_enqueued_jobs do
+      post "/user/save"
+      assert_redirected_to "/user/terms"
+    end
+
+    ActionMailer::Base.deliveries.clear
   end
 
   # Check that the user can successfully recover their password


### PR DESCRIPTION
This PR makes our test suite run several minutes quicker (single-thread timings). User creation tests drop on my machine from 200 seconds to 6 seconds.

Previously, several of the user creation tests were repeated 228 times, once in each available locale. This takes a lot of time and provides very little value.

After those were refactored, the next slowest tests were the changeset comment rate limit tests. A simple way to make them run 3-4 times faster is just to reduce the rate limits in the test settings, since this reduces the number of (uninteresting) post requests made.

Rails 7.1 ships with the `--profile` flag, which makes it easy to find the slowest tests, and these stood out when doing so.