### PR TITLE
Add missing locale string for /oauth2/authorized_applications

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2683,6 +2683,7 @@ en:
       application: "Application"
       permissions: "Permissions"
       no_applications_html: "You have not yet authorized any %{oauth2} applications."
+      oauth_2: "OAuth 2"
     application:
       revoke: "Revoke Access"
       confirm_revoke: "Revoke access for this application?"

--- a/test/system/oauth2_test.rb
+++ b/test/system/oauth2_test.rb
@@ -1,0 +1,10 @@
+require "application_system_test_case"
+
+class Oauth2Test < ApplicationSystemTestCase
+  def test_authorized_applications
+    sign_in_as(create(:user))
+    visit oauth_authorized_applications_path
+
+    assert_text "You have not yet authorized any OAuth 2 applications."
+  end
+end


### PR DESCRIPTION
for this message when no no authorized apps:

> You have not yet authorized any [OAuth 2](https://oauth.net/2/) applications.