### PR TITLE
Add system test with osm website oauth app registration

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -10,4 +10,15 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, :using => :headless_firefox do |options|
     options.add_preference("intl.accept_languages", "en")
   end
+
+  def before_setup
+    super
+    osm_website_app = create(:oauth_application, :name => "OpenStreetMap Web Site", :scopes => "write_api write_notes")
+    Settings.oauth_application = osm_website_app.uid
+  end
+
+  def after_teardown
+    Settings.reload!
+    super
+  end
 end

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -18,17 +18,25 @@ class NoteCommentsTest < ApplicationSystemTestCase
     assert_no_link "Log in to comment on this note"
   end
 
-  def test_action_text
+  def test_add_comment
     note = create(:note_with_comments)
-    sign_in_as(create(:user))
+    user = create(:user)
+    sign_in_as(user)
     visit note_path(note)
 
+    assert_no_content "Comment from #{user.display_name}"
+    assert_no_content "Some newly added note comment"
     assert_button "Resolve"
     assert_button "Comment", :disabled => true
 
-    fill_in "text", :with => "Some text"
+    fill_in "text", :with => "Some newly added note comment"
 
     assert_button "Comment & Resolve"
-    assert_button "Comment"
+    assert_button "Comment", :disabled => false
+
+    click_button "Comment"
+
+    assert_content "Comment from #{user.display_name}"
+    assert_content "Some newly added note comment"
   end
 end

--- a/test/system/oauth2_test.rb
+++ b/test/system/oauth2_test.rb
@@ -5,6 +5,12 @@ class Oauth2Test < ApplicationSystemTestCase
     sign_in_as(create(:user))
     visit oauth_authorized_applications_path
 
+    assert_text "OpenStreetMap Web Site"
+
+    accept_alert do
+      click_link "Revoke Access"
+    end
+
     assert_text "You have not yet authorized any OAuth 2 applications."
   end
 end


### PR DESCRIPTION
Let's suppose you want to have a system test that checks if adding comments to notes work. This commenting is done via the api. For the api to work you have to [register the website oauth app](https://github.com/openstreetmap/openstreetmap-website/blob/master/CONFIGURE.md#oauth-consumer-keys). Here I'm adding a test superclass that does this registration in `before_setup`.