### PR TITLE
Set block ends_at to exactly created_at + duration

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -39,11 +39,13 @@ class UserBlocksController < ApplicationController
 
   def create
     if @valid_params
+      now = Time.now.utc
       @user_block = UserBlock.new(
         :user => @user,
         :creator => current_user,
         :reason => params[:user_block][:reason],
-        :ends_at => Time.now.utc + @block_period.hours,
+        :created_at => now,
+        :ends_at => now + @block_period.hours,
         :needs_view => params[:user_block][:needs_view]
       )
 

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -262,6 +262,21 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   end
 
   ##
+  # test the duration of a created block
+  def test_create_duration
+    target_user = create(:user)
+    moderator_user = create(:moderator_user)
+
+    session_for(moderator_user)
+    post user_blocks_path(:display_name => target_user.display_name,
+                          :user_block_period => "336",
+                          :user_block => { :needs_view => false, :reason => "Vandalism" })
+
+    block = UserBlock.order(:id).last
+    assert_equal 1209600, block.ends_at - block.created_at
+  end
+
+  ##
   # test the update action
   def test_update
     moderator_user = create(:moderator_user)


### PR DESCRIPTION
If you block a user for two weeks, you'll see this:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3a756071-782c-44f3-8060-875b7ce56574)

> Duration: 1 week

The block end date is computed before `created_at` and its duration ends up being slightly shorter. Everything is rounded down and you get an incorrect value.