### PR TITLE
Add revoke all blocks moderator action

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -61,7 +61,7 @@ class Ability
           can [:index, :show, :resolve, :ignore, :reopen], Issue
           can :create, IssueComment
           can [:new, :create, :edit, :update, :destroy], Redaction
-          can [:new, :edit, :create, :update, :revoke], UserBlock
+          can [:new, :edit, :create, :update, :revoke, :revoke_all], UserBlock
         end
 
         if user.administrator?

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -8,7 +8,7 @@ class UserBlocksController < ApplicationController
 
   authorize_resource
 
-  before_action :lookup_user, :only => [:new, :create, :blocks_on, :blocks_by]
+  before_action :lookup_user, :only => [:new, :create, :revoke_all, :blocks_on, :blocks_by]
   before_action :lookup_user_block, :only => [:show, :edit, :update, :revoke]
   before_action :require_valid_params, :only => [:create, :update]
   before_action :check_database_readable

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -90,6 +90,12 @@ class UserBlocksController < ApplicationController
   end
 
   ##
+  # revokes all active blocks
+  def revoke_all
+    # TODO revoke
+  end
+
+  ##
   # shows a list of all the blocks on the given user
   def blocks_on
     @params = params.permit(:display_name)

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -12,7 +12,7 @@ class UserBlocksController < ApplicationController
   before_action :lookup_user_block, :only => [:show, :edit, :update, :revoke]
   before_action :require_valid_params, :only => [:create, :update]
   before_action :check_database_readable
-  before_action :check_database_writable, :only => [:create, :update, :revoke]
+  before_action :check_database_writable, :only => [:create, :update, :revoke, :revoke_all]
 
   def index
     @params = params.permit
@@ -92,7 +92,11 @@ class UserBlocksController < ApplicationController
   ##
   # revokes all active blocks
   def revoke_all
-    # TODO revoke
+    if request.post? && params[:confirm]
+      @user.blocks.active.each { |block| block.revoke!(current_user) }
+      flash[:notice] = t ".flash"
+      redirect_to user_blocks_on_path(@user)
+    end
   end
 
   ##

--- a/app/views/user_blocks/revoke_all.html.erb
+++ b/app/views/user_blocks/revoke_all.html.erb
@@ -6,3 +6,22 @@
             :block_on => link_to(@user.display_name,
                                  user_path(@user)) %></h1>
 <% end %>
+
+<% unless @user.blocks.active.empty? %>
+
+  <%= bootstrap_form_for :revoke_all, :url => { :action => "revoke_all" } do |f| %>
+    <div class="mb-3">
+      <div class="form-check">
+        <%= check_box_tag "confirm", "yes", false, { :class => "form-check-input" } %>
+        <%= label_tag "confirm", t(".confirm",
+                                   :active_blocks => t(".active_blocks",
+                                                       :count => @user.blocks.active.count)), { :class => "form-check-label" } %>
+      </div>
+    </div>
+
+    <%= f.primary t(".revoke") %>
+  <% end %>
+
+<% else %>
+<p><%= t ".empty", :name => @user.display_name %></p>
+<% end %>

--- a/app/views/user_blocks/revoke_all.html.erb
+++ b/app/views/user_blocks/revoke_all.html.erb
@@ -1,0 +1,8 @@
+<% @title = t ".title",
+              :block_on => @user.display_name %>
+
+<% content_for :heading do %>
+  <h1><%= t ".heading_html",
+            :block_on => link_to(@user.display_name,
+                                 user_path(@user)) %></h1>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -101,6 +101,12 @@
               </li>
             <% end %>
 
+            <% if can?(:revoke_all, UserBlock) and @user.blocks.active.exists? %>
+              <li>
+                <%= link_to t(".revoke_all_blocks"), revoke_all_user_blocks_path(@user) %>
+              </li>
+            <% end %>
+
             <% if can?(:create, UserBlock) %>
               <li>
                 <%= link_to t(".create_block"), new_user_block_path(@user) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2896,6 +2896,12 @@ en:
     revoke_all:
       title: "Revoking all blocks on %{block_on}"
       heading_html: "Revoking all blocks on %{block_on}"
+      empty: "%{name} has no active blocks."
+      confirm: "Are you sure you wish to revoke %{active_blocks}?"
+      active_blocks:
+        one: "%{count} active block"
+        other: "%{count} active blocks"
+      revoke: "Revoke!"
     helper:
       time_future_html: "Ends in %{time}."
       until_login: "Active until the user logs in."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2893,6 +2893,9 @@ en:
       confirm: "Are you sure you wish to revoke this block?"
       revoke: "Revoke!"
       flash: "This block has been revoked."
+    revoke_all:
+      title: "Revoking all blocks on %{block_on}"
+      heading_html: "Revoking all blocks on %{block_on}"
     helper:
       time_future_html: "Ends in %{time}."
       until_login: "Active until the user logs in."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2790,6 +2790,7 @@ en:
           importer: "Revoke importer access"
       block_history: "Active Blocks"
       moderator_history: "Blocks Given"
+      revoke_all_blocks: "Revoke all blocks"
       comments: "Comments"
       create_block: "Block this User"
       activate_user: "Activate this User"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2902,6 +2902,7 @@ en:
         one: "%{count} active block"
         other: "%{count} active blocks"
       revoke: "Revoke!"
+      flash: "All active blocks have been revoked."
     helper:
       time_future_html: "Ends in %{time}."
       until_login: "Active until the user logs in."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -321,6 +321,7 @@ OpenStreetMap::Application.routes.draw do
   get "/blocks/new/:display_name" => "user_blocks#new", :as => "new_user_block"
   resources :user_blocks
   match "/blocks/:id/revoke" => "user_blocks#revoke", :via => [:get, :post], :as => "revoke_user_block"
+  match "/user/:display_name/blocks/revoke_all" => "user_blocks#revoke_all", :via => [:get, :post], :as => "revoke_all_user_blocks"
 
   # issues and reports
   resources :issues do

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -54,6 +54,14 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
       { :path => "/user/username/blocks_by", :method => :get },
       { :controller => "user_blocks", :action => "blocks_by", :display_name => "username" }
     )
+    assert_routing(
+      { :path => "/user/username/blocks/revoke_all", :method => :get },
+      { :controller => "user_blocks", :action => "revoke_all", :display_name => "username" }
+    )
+    assert_routing(
+      { :path => "/user/username/blocks/revoke_all", :method => :post },
+      { :controller => "user_blocks", :action => "revoke_all", :display_name => "username" }
+    )
   end
 
   ##

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -395,6 +395,36 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   end
 
   ##
+  # test the revoke all action
+  def test_revoke_all
+    blocked_user = create(:user)
+    create(:user_block, :user => blocked_user)
+
+    # Asking for the revoke all blocks page with a bogus user name should fail
+    get user_blocks_on_path(:display_name => "non_existent_user")
+    assert_response :not_found
+
+    # Check that the revoke all blocks page requires us to login
+    get revoke_all_user_blocks_path(blocked_user)
+    assert_redirected_to login_path(:referer => revoke_all_user_blocks_path(blocked_user))
+
+    # Login as a normal user
+    session_for(create(:user))
+
+    # Check that normal users can't load the revoke all blocks page
+    get revoke_all_user_blocks_path(blocked_user)
+    assert_response :redirect
+    assert_redirected_to :controller => "errors", :action => "forbidden"
+
+    # Login as a moderator
+    session_for(create(:moderator_user))
+
+    # Check that the revoke all blocks page loads for moderators
+    get revoke_all_user_blocks_path(blocked_user)
+    assert_response :success
+  end
+
+  ##
   # test the blocks_on action
   def test_blocks_on
     blocked_user = create(:user)

--- a/test/system/user_blocks_test.rb
+++ b/test/system/user_blocks_test.rb
@@ -27,12 +27,16 @@ class ReportNoteTest < ApplicationSystemTestCase
     assert_no_link "Revoke all blocks"
   end
 
-  test "revoke all link is present for moderators when viewed user has active blocks" do
+  test "revoke all link is present and working for moderators when viewed user has active blocks" do
     blocked_user = create(:user)
     create(:user_block, :user => blocked_user)
     sign_in_as(create(:moderator_user))
 
     visit user_path(blocked_user)
     assert_link "Revoke all blocks"
+
+    click_link "Revoke all blocks"
+    assert_title "Revoking all blocks on #{blocked_user.display_name}"
+    assert_text "Revoking all blocks on #{blocked_user.display_name}"
   end
 end

--- a/test/system/user_blocks_test.rb
+++ b/test/system/user_blocks_test.rb
@@ -27,7 +27,17 @@ class ReportNoteTest < ApplicationSystemTestCase
     assert_no_link "Revoke all blocks"
   end
 
-  test "revoke all link is present and working for moderators when viewed user has active blocks" do
+  test "revoke all page has no controls when viewed user has no active blocks" do
+    blocked_user = create(:user)
+    sign_in_as(create(:moderator_user))
+
+    visit revoke_all_user_blocks_path(blocked_user)
+    assert_title "Revoking all blocks on #{blocked_user.display_name}"
+    assert_text "Revoking all blocks on #{blocked_user.display_name}"
+    assert_no_button "Revoke!"
+  end
+
+  test "revoke all link is present and working for moderators when viewed user has one active block" do
     blocked_user = create(:user)
     create(:user_block, :user => blocked_user)
     sign_in_as(create(:moderator_user))
@@ -38,5 +48,24 @@ class ReportNoteTest < ApplicationSystemTestCase
     click_link "Revoke all blocks"
     assert_title "Revoking all blocks on #{blocked_user.display_name}"
     assert_text "Revoking all blocks on #{blocked_user.display_name}"
+    assert_unchecked_field "Are you sure you wish to revoke 1 active block?"
+    assert_button "Revoke!"
+  end
+
+  test "revoke all link is present and working for moderators when viewed user has multiple active blocks" do
+    blocked_user = create(:user)
+    create(:user_block, :user => blocked_user)
+    create(:user_block, :user => blocked_user)
+    create(:user_block, :expired, :user => blocked_user)
+    sign_in_as(create(:moderator_user))
+
+    visit user_path(blocked_user)
+    assert_link "Revoke all blocks"
+
+    click_link "Revoke all blocks"
+    assert_title "Revoking all blocks on #{blocked_user.display_name}"
+    assert_text "Revoking all blocks on #{blocked_user.display_name}"
+    assert_unchecked_field "Are you sure you wish to revoke 2 active blocks?"
+    assert_button "Revoke!"
   end
 end

--- a/test/system/user_blocks_test.rb
+++ b/test/system/user_blocks_test.rb
@@ -1,0 +1,38 @@
+require "application_system_test_case"
+
+class ReportNoteTest < ApplicationSystemTestCase
+  test "revoke all link is absent for anonymous users when viewed user has active blocks" do
+    blocked_user = create(:user)
+    create(:user_block, :user => blocked_user)
+
+    visit user_path(blocked_user)
+    assert_no_link "Revoke all blocks"
+  end
+
+  test "revoke all link is absent for regular users when viewed user has active blocks" do
+    blocked_user = create(:user)
+    create(:user_block, :user => blocked_user)
+    sign_in_as(create(:user))
+
+    visit user_path(blocked_user)
+    assert_no_link "Revoke all blocks"
+  end
+
+  test "revoke all link is absent for moderators when viewed user has no active blocks" do
+    blocked_user = create(:user)
+    create(:user_block, :expired, :user => blocked_user)
+    sign_in_as(create(:moderator_user))
+
+    visit user_path(blocked_user)
+    assert_no_link "Revoke all blocks"
+  end
+
+  test "revoke all link is present for moderators when viewed user has active blocks" do
+    blocked_user = create(:user)
+    create(:user_block, :user => blocked_user)
+    sign_in_as(create(:moderator_user))
+
+    visit user_path(blocked_user)
+    assert_link "Revoke all blocks"
+  end
+end


### PR DESCRIPTION
User pages have "Revoke all blocks" link when users have active blocks. These links are only visible to moderators.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/2b9a3254-3329-4395-8feb-8b4807343365)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/e29972bc-0571-4be8-9c3c-dfb545b03f9f)

See here for reasons: https://github.com/openstreetmap/openstreetmap-website/pull/4301#discussion_r1367510802
