### PR TITLE
Add markdown guidance for code blocks

### DIFF
--- a/app/views/shared/_markdown_help.html.erb
+++ b/app/views/shared/_markdown_help.html.erb
@@ -18,4 +18,7 @@
 
   <dt><%= t ".image" %></dt>
   <dd>![<%= t ".alt" %>](<%= t ".url" %>)</dd>
+
+  <dt><%= t ".codeblock%></dt>
+  <dd>~~~<br><%= t ".codeblock%><br>~~~</dd>
 </dl>

--- a/app/views/shared/_markdown_help.html.erb
+++ b/app/views/shared/_markdown_help.html.erb
@@ -19,6 +19,6 @@
   <dt><%= t ".image" %></dt>
   <dd>![<%= t ".alt" %>](<%= t ".url" %>)</dd>
 
-  <dt><%= t ".codeblock%></dt>
-  <dd>~~~<br><%= t ".codeblock%><br>~~~</dd>
+  <dt><%= t ".codeblock" %></dt>
+  <dd>~~~<br><%= t ".codeblock" %><br>~~~</dd>
 </dl>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1870,6 +1870,7 @@ en:
       image: Image
       alt: Alt text
       url: URL
+      codeblock: Code block
     richtext_field:
       edit: Edit
       preview: Preview


### PR DESCRIPTION
Kramdown's code block markdown syntax is slightly different from the popular markdown dialect used on GitHub and GitLab, causing some confusion for users. 

![image](https://github.com/openstreetmap/openstreetmap-website/assets/70379302/ed0f7889-38da-4261-a673-2fd12cca6d3e)

We can solve this problem by adding code block markdown guidance to `_markdown_help.html.erb`.