### PR TITLE
test/system/messages_test.rb: Rename NoteCommentsTest -> MessagesTest

### DIFF
--- a/test/system/messages_test.rb
+++ b/test/system/messages_test.rb
@@ -1,6 +1,6 @@
 require "application_system_test_case"
 
-class NoteCommentsTest < ApplicationSystemTestCase
+class MessagesTest < ApplicationSystemTestCase
   def test_delete_received_message
     user = create(:user)
     create(:message, :recipient => user)


### PR DESCRIPTION
## Why are the changes necessary?

The class names are expected to match the test file names.

Follow-Up for #4437

(btw. thanks @AntonKhorev for the fix!)