### PR TITLE
Truncate usernames in profile links

### DIFF
--- a/app/helpers/changesets_helper.rb
+++ b/app/helpers/changesets_helper.rb
@@ -3,7 +3,7 @@ module ChangesetsHelper
     if changeset.user.status == "deleted"
       t("users.no_such_user.deleted")
     elsif changeset.user.data_public?
-      link_to changeset.user.display_name, changeset.user
+      truncated_user_link changeset.user
     else
       t("browse.anonymous")
     end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -50,6 +50,16 @@ module UserHelper
     end
   end
 
+  def truncated_user_link(user, **options)
+    classes = %w[d-inline-block align-bottom text-truncate]
+    if options[:width]
+      style = "max-width: #{options[:width]}"
+    else
+      classes <<= "mw-100"
+    end
+    link_to user.display_name, user, :class => classes, :style => style
+  end
+
   # External authentication support
 
   def openid_logo

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -1,5 +1,5 @@
 <tr id="inbox-<%= message_summary.id %>" class="inbox-row<%= "-unread" unless message_summary.message_read? %>">
-  <td><%= link_to message_summary.sender.display_name, user_path(message_summary.sender) %></td>
+  <td><%= truncated_user_link message_summary.sender, :width => "30em" %></td>
   <td><%= link_to message_summary.title, message_path(message_summary) %></td>
   <td class="text-nowrap"><%= l message_summary.sent_on, :format => :friendly %></td>
   <td class="text-nowrap d-flex justify-content-end gap-1">

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -1,5 +1,5 @@
 <tr class="inbox-row">
-  <td><%= link_to sent_message_summary.recipient.display_name, user_path(sent_message_summary.recipient) %></td>
+  <td><%= truncated_user_link sent_message_summary.recipient, :width => "30em" %></td>
   <td><%= link_to sent_message_summary.title, message_path(sent_message_summary) %></td>
   <td class="text-nowrap"><%= l sent_message_summary.sent_on, :format => :friendly %></td>
   <td class="text-nowrap d-flex justify-content-end gap-1">

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -1,9 +1,9 @@
 <tr>
   <% if show_user_name %>
-  <td><%= link_to block.user.display_name, user_path(block.user) %></td>
+  <td><%= truncated_user_link block.user, :width => "30em" %></td>
   <% end %>
   <% if show_creator_name %>
-  <td><%= link_to block.creator.display_name, user_path(block.creator) %></td>
+  <td><%= truncated_user_link block.creator, :width => "20em" %></td>
   <% end %>
   <td><%= h truncate(block.reason) %></td>
   <td><%= h block_status(block) %></td>


### PR DESCRIPTION
Experimenting with truncation of very long usernames. In general you can't line-wrap them, see the note at https://getbootstrap.com/docs/5.3/utilities/text/#word-break

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/a5b5a17c-1ff6-4f91-864f-ece3f71de93e)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/eec097c2-bfcc-4868-be5a-0613e5aeef6a)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/87091681-c471-4886-b992-1043affa4a2a)
