### PR TITLE
Add login notice for note discussions

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -65,6 +65,10 @@
                                                    :url => comment_api_note_url(@note, "json") } %>
         </div>
       </form>
+    <% else -%>
+      <p>
+        <%= link_to t(".log_in_to_comment"), login_path(:referer => request.fullpath) %>
+      </p>
     <% end -%>
   <% else %>
     <form class="mb-3" action="#">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3005,6 +3005,7 @@ en:
       reactivate: Reactivate
       comment_and_resolve: Comment & Resolve
       comment: Comment
+      log_in_to_comment: "Log in to comment on this note"
       report_link_html: "If this note contains sensitive information that needs to be removed, you can %{link}."
       other_problems_resolve: "For all other problems with the note, please resolve it yourself with a comment."
       other_problems_resolved: "For all other problems, resolving is sufficient."

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -1,6 +1,23 @@
 require "application_system_test_case"
 
 class NoteCommentsTest < ApplicationSystemTestCase
+  test "open note has login notice" do
+    note = create(:note_with_comments)
+    visit note_path(note)
+
+    assert_no_button "Resolve"
+    assert_no_button "Comment"
+    assert_link "Log in to comment on this note", :href => login_path(:referer => note_path(note))
+  end
+
+  test "closed note has no login notice" do
+    note = create(:note_with_comments, :status => "closed", :closed_at => Time.now.utc)
+    visit note_path(note)
+
+    assert_no_button "Reactivate"
+    assert_no_link "Log in to comment on this note"
+  end
+
   def test_action_text
     note = create(:note_with_comments)
     sign_in_as(create(:user))


### PR DESCRIPTION
Add "Log in to comment on this note" link as requested in the [original post](https://github.com/openstreetmap/openstreetmap-website/issues/2761#issue-675527428) in https://github.com/openstreetmap/openstreetmap-website/issues/2761.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/935d29eb-1b6b-4d9c-bd16-abd095073a8f)

There also was [another request](https://github.com/openstreetmap/openstreetmap-website/issues/2761#issuecomment-1225816994) which I **didn't do**: adding "Log in to resolve/reactivate". Some users close and reopen notes several times for no apparent reason and previously we added texts to discourage that. I don't want to write anything that will encourage these actions.