### PR TITLE
Add links to diaries in preferred languages

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -47,6 +47,8 @@ class DiaryEntriesController < ApplicationController
         @title = t ".in_language_title", :language => Language.find(params[:language]).english_name
         entries = entries.where(:language_code => params[:language])
       else
+        candidate_codes = preferred_languages.flat_map(&:candidates).uniq.map(&:to_s)
+        @languages = Language.where(:code => candidate_codes).in_order_of(:code, candidate_codes)
         @title = t ".title"
       end
     end

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -14,15 +14,15 @@
         <ul class="clearfix">
           <% unless params[:friends] or params[:nearby] -%>
             <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>
-            <% end -%>
+          <% end -%>
 
-            <% if @user && @user == current_user || !@user && current_user %>
-              <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
-            <% end %>
+          <% if @user && @user == current_user || !@user && current_user %>
+            <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
+          <% end %>
 
-            <% if !@user && current_user %>
-              <li><%= link_to t(".my_diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %></li>
-            <% end %>
+          <% if !@user && current_user %>
+            <li><%= link_to t(".my_diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %></li>
+          <% end %>
         </ul>
       </nav>
     </div>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -20,12 +20,12 @@
             <li><%= link_to t(".in_language_title", :language => language.name), :action => "index", :language => language.code %></li>
           <% end %>
 
-          <% if @user && @user == current_user || !@user && current_user %>
-            <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
-          <% end %>
-
           <% if !@user && current_user %>
             <li><%= link_to t(".my_diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %></li>
+          <% end %>
+
+          <% if @user && @user == current_user || !@user && current_user %>
+            <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
           <% end %>
         </ul>
       </nav>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -16,6 +16,10 @@
             <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>
           <% end -%>
 
+          <% @languages&.each do |language| %>
+            <li><%= link_to t(".in_language_title", :language => language.name), :action => "index", :language => language.code %></li>
+          <% end %>
+
           <% if @user && @user == current_user || !@user && current_user %>
             <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
           <% end %>

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -3,6 +3,9 @@ require "application_system_test_case"
 class DiaryEntrySystemTest < ApplicationSystemTestCase
   def setup
     create(:language, :code => "en")
+    create(:language, :code => "pt", :english_name => "Portuguese", :native_name => "Português")
+    create(:language, :code => "pt-BR", :english_name => "Brazilian Portuguese", :native_name => "Português do Brasil")
+    create(:language, :code => "ru", :english_name => "Russian", :native_name => "Русский")
     @diary_entry = create(:diary_entry)
   end
 
@@ -60,5 +63,15 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     visit diary_entry_path(@diary_entry.user, @diary_entry)
 
     assert_content @deleted_comment.body
+  end
+
+  test "should have links to preferred languages" do
+    sign_in_as(create(:user, :languages => %w[en-US pt-BR]))
+    visit diary_entries_path
+
+    assert_link "Diary Entries in English", :href => "/diary/en"
+    assert_link "Diary Entries in Brazilian Portuguese", :href => "/diary/pt-BR"
+    assert_link "Diary Entries in Portuguese", :href => "/diary/pt"
+    assert_no_link "Diary Entries in Russian"
   end
 end


### PR DESCRIPTION
Adds a link requested in #2657 to https://www.openstreetmap.org/diary
Actually adds links for all preferred languages, using candidates logic https://github.com/openstreetmap/openstreetmap-website/blob/c95e2870f3310a68f8287bddcec6d0117b5f8961/lib/locale.rb#L44-L53

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/cd763ea9-3306-4e00-877d-f09786ac06fc)

---

#2657 also requested:

> users could tick a box to in their settings, which would make the diary page default to their preferred language url

I don't think this is necessary. You can always bookmark diary pages in any specific language or subscribe to that language feed.