### PR TITLE
Don't show native language name if it's the same as English name

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -26,7 +26,7 @@ class Language < ApplicationRecord
 
   def name
     name = english_name
-    name += " (#{native_name})" unless native_name.nil?
+    name += " (#{native_name})" unless native_name.nil? || native_name == english_name
     name
   end
 end

--- a/test/models/language_test.rb
+++ b/test/models/language_test.rb
@@ -6,6 +6,11 @@ class LanguageTest < ActiveSupport::TestCase
     assert_equal "Slovenian (slovenščina)", Language.find("sl").name
   end
 
+  def test_same_native_name
+    create(:language, :code => "af", :english_name => "Afrikaans", :native_name => "Afrikaans")
+    assert_equal "Afrikaans", Language.find("af").name
+  end
+
   def test_load
     assert_equal 0, Language.count
     assert_raise ActiveRecord::RecordNotFound do


### PR DESCRIPTION
Languages have names in the format of "English name (native name)". These names are used in diary entry language links and inputs.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b1290132-9d92-48b5-83c3-20f847344427)

Sometimes *native name* is exactly the same as *English name*, so the same thing is displayed twice:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/2c23bdae-692a-4e54-841a-1e08a6feeab1)

I think we don't need "(native name)" in this case:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c7b2da51-5880-436f-94ff-a094f8336a40)
