### PR TITLE
Use assert_not_predicate in tests that have assert_predicate

### DIFF
--- a/test/lib/bounding_box_test.rb
+++ b/test/lib/bounding_box_test.rb
@@ -222,7 +222,7 @@ class BoundingBoxTest < ActiveSupport::TestCase
   end
 
   def test_complete
-    assert_not @bbox_from_nils.complete?, "should contain a nil"
+    assert_not_predicate @bbox_from_nils, :complete?, "should contain a nil"
     assert_predicate @bbox_from_string, :complete?, "should not contain a nil"
   end
 

--- a/test/models/acl_test.rb
+++ b/test/models/acl_test.rb
@@ -5,7 +5,7 @@ class AclTest < ActiveSupport::TestCase
     acl = create(:acl)
     assert_predicate acl, :valid?
     acl.k = nil
-    assert_not acl.valid?
+    assert_not_predicate acl, :valid?
   end
 
   def test_no_account_creation_by_subnet

--- a/test/models/changeset_comment_test.rb
+++ b/test/models/changeset_comment_test.rb
@@ -6,27 +6,27 @@ class ChangesetCommentTest < ActiveSupport::TestCase
     comment = create(:changeset_comment)
 
     comment.author = nil
-    assert_not comment.valid?
+    assert_not_predicate comment, :valid?
 
     comment.author_id = 999111
-    assert_not comment.valid?
+    assert_not_predicate comment, :valid?
   end
 
   def test_does_not_accept_invalid_changeset
     comment = create(:changeset_comment)
 
     comment.changeset = nil
-    assert_not comment.valid?
+    assert_not_predicate comment, :valid?
 
     comment.changeset_id = 999111
-    assert_not comment.valid?
+    assert_not_predicate comment, :valid?
   end
 
   def test_does_not_accept_empty_visible
     comment = create(:changeset_comment)
 
     comment.visible = nil
-    assert_not comment.valid?
+    assert_not_predicate comment, :valid?
   end
 
   def test_comments_of_changeset_count
@@ -50,7 +50,7 @@ class ChangesetCommentTest < ActiveSupport::TestCase
     bad.each do |body|
       changeset_comment = create(:changeset_comment)
       changeset_comment.body = body
-      assert_not changeset_comment.valid?, "#{body} is valid when it shouldn't be"
+      assert_not_predicate changeset_comment, :valid?, "#{body} is valid when it shouldn't be"
     end
   end
 end

--- a/test/models/changeset_tag_test.rb
+++ b/test/models/changeset_tag_test.rb
@@ -20,21 +20,21 @@ class ChangesetTagTest < ActiveSupport::TestCase
   def test_length_key_invalid
     tag = create(:changeset_tag)
     tag.k = "k" * 256
-    assert_not tag.valid?, "Key should be too long"
+    assert_not_predicate tag, :valid?, "Key should be too long"
     assert_predicate tag.errors[:k], :any?
   end
 
   def test_length_value_invalid
     tag = create(:changeset_tag)
     tag.v = "v" * 256
-    assert_not tag.valid?, "Value should be too long"
+    assert_not_predicate tag, :valid?, "Value should be too long"
     assert_predicate tag.errors[:v], :any?
   end
 
   def test_orphaned_tag_invalid
     tag = create(:changeset_tag)
     tag.changeset = nil
-    assert_not tag.valid?, "Orphaned tag should be invalid"
+    assert_not_predicate tag, :valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:changeset], :any?
   end
 
@@ -42,7 +42,7 @@ class ChangesetTagTest < ActiveSupport::TestCase
     existing = create(:changeset_tag)
     tag = build(:changeset_tag, :changeset => existing.changeset, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
-    assert_not tag.valid?
+    assert_not_predicate tag, :valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }
     assert_predicate tag, :new_record?
   end

--- a/test/models/client_application_test.rb
+++ b/test/models/client_application_test.rb
@@ -14,7 +14,7 @@ class ClientApplicationTest < ActiveSupport::TestCase
     bad.each do |url|
       app = build(:client_application)
       app.url = url
-      assert_not app.valid?, "#{url} is valid when it shouldn't be"
+      assert_not_predicate app, :valid?, "#{url} is valid when it shouldn't be"
     end
   end
 
@@ -31,7 +31,7 @@ class ClientApplicationTest < ActiveSupport::TestCase
     bad.each do |url|
       app = build(:client_application)
       app.support_url = url
-      assert_not app.valid?, "#{url} is valid when it shouldn't be"
+      assert_not_predicate app, :valid?, "#{url} is valid when it shouldn't be"
     end
   end
 
@@ -48,7 +48,7 @@ class ClientApplicationTest < ActiveSupport::TestCase
     bad.each do |url|
       app = build(:client_application)
       app.callback_url = url
-      assert_not app.valid?, "#{url} is valid when it shouldn't be"
+      assert_not_predicate app, :valid?, "#{url} is valid when it shouldn't be"
     end
   end
 end

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -6,7 +6,7 @@ class IssueTest < ActiveSupport::TestCase
 
     assert_predicate issue, :valid?
     issue.assigned_role = "bogus"
-    assert_not issue.valid?
+    assert_not_predicate issue, :valid?
   end
 
   def test_reported_user

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -5,7 +5,7 @@ class MessageTest < ActiveSupport::TestCase
 
   def test_check_empty_message_fails
     message = build(:message, :title => nil, :body => nil, :sent_on => nil)
-    assert_not message.valid?
+    assert_not_predicate message, :valid?
     assert_predicate message.errors[:title], :any?
     assert_predicate message.errors[:body], :any?
     assert_predicate message.errors[:sent_on], :any?
@@ -23,7 +23,7 @@ class MessageTest < ActiveSupport::TestCase
     message = create(:message, :unread)
     message.sender = nil
     message.recipient = nil
-    assert_not message.valid?
+    assert_not_predicate message, :valid?
 
     assert_raise(ActiveRecord::RecordNotFound) { User.find(0) }
     message.from_user_id = 0

--- a/test/models/node_tag_test.rb
+++ b/test/models/node_tag_test.rb
@@ -20,21 +20,21 @@ class NodeTagTest < ActiveSupport::TestCase
   def test_length_key_invalid
     tag = create(:node_tag)
     tag.k = "k" * 256
-    assert_not tag.valid?, "Key should be too long"
+    assert_not_predicate tag, :valid?, "Key should be too long"
     assert_predicate tag.errors[:k], :any?
   end
 
   def test_length_value_invalid
     tag = create(:node_tag)
     tag.v = "v" * 256
-    assert_not tag.valid?, "Value should be too long"
+    assert_not_predicate tag, :valid?, "Value should be too long"
     assert_predicate tag.errors[:v], :any?
   end
 
   def test_orphaned_node_tag_invalid
     tag = create(:node_tag)
     tag.node = nil
-    assert_not tag.valid?, "Orphaned tag should be invalid"
+    assert_not_predicate tag, :valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:node], :any?
   end
 
@@ -42,7 +42,7 @@ class NodeTagTest < ActiveSupport::TestCase
     existing = create(:node_tag)
     tag = build(:node_tag, :node => existing.node, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
-    assert_not tag.valid?
+    assert_not_predicate tag, :valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }
     assert_predicate tag, :new_record?
   end

--- a/test/models/note_comment_test.rb
+++ b/test/models/note_comment_test.rb
@@ -14,7 +14,7 @@ class NoteCommentTest < ActiveSupport::TestCase
     bad.each do |event|
       note_comment = create(:note_comment)
       note_comment.event = event
-      assert_not note_comment.valid?, "#{event} is valid when it shouldn't be"
+      assert_not_predicate note_comment, :valid?, "#{event} is valid when it shouldn't be"
     end
   end
 
@@ -33,7 +33,7 @@ class NoteCommentTest < ActiveSupport::TestCase
     bad.each do |body|
       note_comment = create(:note_comment)
       note_comment.body = body
-      assert_not note_comment.valid?, "#{body} is valid when it shouldn't be"
+      assert_not_predicate note_comment, :valid?, "#{body} is valid when it shouldn't be"
     end
   end
 end

--- a/test/models/oauth_token_test.rb
+++ b/test/models/oauth_token_test.rb
@@ -5,7 +5,7 @@ class OauthTokenTest < ActiveSupport::TestCase
   # check that after calling invalidate! on a token, it is invalid.
   def test_token_invalidation
     tok = OauthToken.new
-    assert_not tok.invalidated?, "Token should be created valid."
+    assert_not_predicate tok, :invalidated?, "Token should be created valid."
     tok.invalidate!
     assert_predicate tok, :invalidated?, "Token should now be invalid."
   end
@@ -14,10 +14,10 @@ class OauthTokenTest < ActiveSupport::TestCase
   # check that an authorized token is authorised and can be invalidated
   def test_token_authorisation
     tok = RequestToken.create(:client_application => create(:client_application))
-    assert_not tok.authorized?, "Token should be created unauthorised."
+    assert_not_predicate tok, :authorized?, "Token should be created unauthorised."
     tok.authorize!(create(:user))
     assert_predicate tok, :authorized?, "Token should now be authorised."
     tok.invalidate!
-    assert_not tok.authorized?, "Token should now be invalid."
+    assert_not_predicate tok, :authorized?, "Token should now be invalid."
   end
 end

--- a/test/models/old_node_tag_test.rb
+++ b/test/models/old_node_tag_test.rb
@@ -20,21 +20,21 @@ class OldNodeTagTest < ActiveSupport::TestCase
   def test_length_key_invalid
     tag = create(:old_node_tag)
     tag.k = "k" * 256
-    assert_not tag.valid?
+    assert_not_predicate tag, :valid?
     assert_predicate tag.errors[:k], :any?
   end
 
   def test_length_value_invalid
     tag = create(:old_node_tag)
     tag.v = "v" * 256
-    assert_not tag.valid?, "Value should be too long"
+    assert_not_predicate tag, :valid?, "Value should be too long"
     assert_predicate tag.errors[:v], :any?
   end
 
   def test_orphaned_tag_invalid
     tag = create(:old_node_tag)
     tag.old_node = nil
-    assert_not tag.valid?, "Orphaned tag should be invalid"
+    assert_not_predicate tag, :valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:old_node], :any?
   end
 
@@ -42,7 +42,7 @@ class OldNodeTagTest < ActiveSupport::TestCase
     existing = create(:old_node_tag)
     tag = build(:old_node_tag, :old_node => existing.old_node, :version => existing.version, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
-    assert_not tag.valid?
+    assert_not_predicate tag, :valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }
     assert_predicate tag, :new_record?
   end

--- a/test/models/old_relation_tag_test.rb
+++ b/test/models/old_relation_tag_test.rb
@@ -20,21 +20,21 @@ class OldRelationTagTest < ActiveSupport::TestCase
   def test_length_key_invalid
     tag = create(:old_relation_tag)
     tag.k = "k" * 256
-    assert_not tag.valid?, "Key should be too long"
+    assert_not_predicate tag, :valid?, "Key should be too long"
     assert_predicate tag.errors[:k], :any?
   end
 
   def test_length_value_invalid
     tag = create(:old_relation_tag)
     tag.v = "v" * 256
-    assert_not tag.valid?, "Value should be too long"
+    assert_not_predicate tag, :valid?, "Value should be too long"
     assert_predicate tag.errors[:v], :any?
   end
 
   def test_orphaned_tag_invalid
     tag = create(:old_relation_tag)
     tag.old_relation = nil
-    assert_not tag.valid?, "Orphaned tag should be invalid"
+    assert_not_predicate tag, :valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:old_relation], :any?
   end
 
@@ -42,7 +42,7 @@ class OldRelationTagTest < ActiveSupport::TestCase
     existing = create(:old_relation_tag)
     tag = build(:old_relation_tag, :old_relation => existing.old_relation, :version => existing.version, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
-    assert_not tag.valid?
+    assert_not_predicate tag, :valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }
     assert_predicate tag, :new_record?
   end

--- a/test/models/old_way_tag_test.rb
+++ b/test/models/old_way_tag_test.rb
@@ -20,21 +20,21 @@ class OldWayTagTest < ActiveSupport::TestCase
   def test_length_key_invalid
     tag = create(:old_way_tag)
     tag.k = "k" * 256
-    assert_not tag.valid?, "Key should be too long"
+    assert_not_predicate tag, :valid?, "Key should be too long"
     assert_predicate tag.errors[:k], :any?
   end
 
   def test_length_value_invalid
     tag = create(:old_way_tag)
     tag.v = "v" * 256
-    assert_not tag.valid?, "Value should be too long"
+    assert_not_predicate tag, :valid?, "Value should be too long"
     assert_predicate tag.errors[:v], :any?
   end
 
   def test_orphaned_tag_invalid
     tag = create(:old_way_tag)
     tag.old_way = nil
-    assert_not tag.valid?, "Orphaned tag should be invalid"
+    assert_not_predicate tag, :valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:old_way], :any?
   end
 
@@ -46,7 +46,7 @@ class OldWayTagTest < ActiveSupport::TestCase
     tag.k = existing.k
     tag.v = existing.v
     assert_predicate tag, :new_record?
-    assert_not tag.valid?
+    assert_not_predicate tag, :valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }
     assert_predicate tag, :new_record?
   end

--- a/test/models/redaction_test.rb
+++ b/test/models/redaction_test.rb
@@ -4,7 +4,7 @@ class RedactionTest < ActiveSupport::TestCase
   def test_cannot_redact_current
     n = create(:node)
     r = create(:redaction)
-    assert_not(n.redacted?, "Expected node to not be redacted already.")
+    assert_not_predicate(n, :redacted?, "Expected node to not be redacted already.")
     assert_raise(OSM::APICannotRedactError) do
       n.redact!(r)
     end
@@ -14,7 +14,7 @@ class RedactionTest < ActiveSupport::TestCase
     node = create(:node, :with_history)
     node_v1 = node.old_nodes.find_by(:version => 1)
     r = create(:redaction)
-    assert_not(node_v1.redacted?, "Expected node to not be redacted already.")
+    assert_not_predicate(node_v1, :redacted?, "Expected node to not be redacted already.")
     assert_raise(OSM::APICannotRedactError) do
       node_v1.redact!(r)
     end
@@ -26,11 +26,11 @@ class RedactionTest < ActiveSupport::TestCase
     node_v2 = node.old_nodes.find_by(:version => 2)
     r = create(:redaction)
 
-    assert_not(node_v1.redacted?, "Expected node to not be redacted already.")
+    assert_not_predicate(node_v1, :redacted?, "Expected node to not be redacted already.")
     assert_nothing_raised do
       node_v1.redact!(r)
     end
     assert_predicate(node_v1, :redacted?, "Expected node version 1 to be redacted after redact! call.")
-    assert_not(node_v2.redacted?, "Expected node version 2 to not be redacted after redact! call.")
+    assert_not_predicate(node_v2, :redacted?, "Expected node version 2 to not be redacted after redact! call.")
   end
 end

--- a/test/models/relation_member_test.rb
+++ b/test/models/relation_member_test.rb
@@ -9,7 +9,7 @@ class RelationMemberTest < ActiveSupport::TestCase
     node = create(:node)
     invalid.each do |r|
       member = build(:relation_member, :relation => relation, :member => node, :member_role => r)
-      assert_not member.valid?, "'#{r}' should not be valid"
+      assert_not_predicate member, :valid?, "'#{r}' should not be valid"
       assert_predicate member.errors[:member_role], :any?
     end
   end
@@ -18,7 +18,7 @@ class RelationMemberTest < ActiveSupport::TestCase
     relation = create(:relation)
     node = create(:node)
     member = build(:relation_member, :relation => relation, :member => node, :member_role => "r" * 256)
-    assert_not member.valid?, "Role should be too long"
+    assert_not_predicate member, :valid?, "Role should be too long"
     assert_predicate member.errors[:member_role], :any?
   end
 end

--- a/test/models/relation_tag_test.rb
+++ b/test/models/relation_tag_test.rb
@@ -20,21 +20,21 @@ class RelationTagTest < ActiveSupport::TestCase
   def test_length_key_invalid
     tag = create(:relation_tag)
     tag.k = "k" * 256
-    assert_not tag.valid?, "Key should be too long"
+    assert_not_predicate tag, :valid?, "Key should be too long"
     assert_predicate tag.errors[:k], :any?
   end
 
   def test_length_value_invalid
     tag = create(:relation_tag)
     tag.v = "v" * 256
-    assert_not tag.valid?, "Value should be too long"
+    assert_not_predicate tag, :valid?, "Value should be too long"
     assert_predicate tag.errors[:v], :any?
   end
 
   def test_orphaned_tag_invalid
     tag = create(:relation_tag)
     tag.relation = nil
-    assert_not tag.valid?, "Orphaned tag should be invalid"
+    assert_not_predicate tag, :valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:relation], :any?
   end
 
@@ -42,7 +42,7 @@ class RelationTagTest < ActiveSupport::TestCase
     existing = create(:relation_tag)
     tag = build(:relation_tag, :relation => existing.relation, :k => existing.k, :v => existing.v)
     assert_predicate tag, :new_record?
-    assert_not tag.valid?
+    assert_not_predicate tag, :valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }
     assert_predicate tag, :new_record?
   end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -6,7 +6,7 @@ class ReportTest < ActiveSupport::TestCase
 
     assert_predicate report, :valid?
     report.issue = nil
-    assert_not report.valid?
+    assert_not_predicate report, :valid?
   end
 
   def test_user_required
@@ -14,7 +14,7 @@ class ReportTest < ActiveSupport::TestCase
 
     assert_predicate report, :valid?
     report.user = nil
-    assert_not report.valid?
+    assert_not_predicate report, :valid?
   end
 
   def test_details_required
@@ -22,7 +22,7 @@ class ReportTest < ActiveSupport::TestCase
 
     assert_predicate report, :valid?
     report.details = ""
-    assert_not report.valid?
+    assert_not_predicate report, :valid?
   end
 
   def test_category_required
@@ -30,7 +30,7 @@ class ReportTest < ActiveSupport::TestCase
 
     assert_predicate report, :valid?
     report.category = ""
-    assert_not report.valid?
+    assert_not_predicate report, :valid?
   end
 
   def test_details

--- a/test/models/request_token_test.rb
+++ b/test/models/request_token_test.rb
@@ -5,6 +5,6 @@ class RequestTokenTest < ActiveSupport::TestCase
     assert_predicate RequestToken.new, :oob?
     assert_predicate RequestToken.new(:callback_url => "oob"), :oob?
     assert_predicate RequestToken.new(:callback_url => "OOB"), :oob?
-    assert_not RequestToken.new(:callback_url => "http://test.host/").oob?
+    assert_not_predicate RequestToken.new(:callback_url => "http://test.host/"), :oob?
   end
 end

--- a/test/models/trace_test.rb
+++ b/test/models/trace_test.rb
@@ -108,26 +108,26 @@ class TraceTest < ActiveSupport::TestCase
 
   def test_public?
     assert_predicate build(:trace, :visibility => "public"), :public?
-    assert_not build(:trace, :visibility => "private").public?
-    assert_not build(:trace, :visibility => "trackable").public?
+    assert_not_predicate build(:trace, :visibility => "private"), :public?
+    assert_not_predicate build(:trace, :visibility => "trackable"), :public?
     assert_predicate build(:trace, :visibility => "identifiable"), :public?
     assert_predicate build(:trace, :deleted, :visibility => "public"), :public?
   end
 
   def test_trackable?
-    assert_not build(:trace, :visibility => "public").trackable?
-    assert_not build(:trace, :visibility => "private").trackable?
+    assert_not_predicate build(:trace, :visibility => "public"), :trackable?
+    assert_not_predicate build(:trace, :visibility => "private"), :trackable?
     assert_predicate build(:trace, :visibility => "trackable"), :trackable?
     assert_predicate build(:trace, :visibility => "identifiable"), :trackable?
-    assert_not build(:trace, :deleted, :visibility => "public").trackable?
+    assert_not_predicate build(:trace, :deleted, :visibility => "public"), :trackable?
   end
 
   def test_identifiable?
-    assert_not build(:trace, :visibility => "public").identifiable?
-    assert_not build(:trace, :visibility => "private").identifiable?
-    assert_not build(:trace, :visibility => "trackable").identifiable?
+    assert_not_predicate build(:trace, :visibility => "public"), :identifiable?
+    assert_not_predicate build(:trace, :visibility => "private"), :identifiable?
+    assert_not_predicate build(:trace, :visibility => "trackable"), :identifiable?
     assert_predicate build(:trace, :visibility => "identifiable"), :identifiable?
-    assert_not build(:trace, :deleted, :visibility => "public").identifiable?
+    assert_not_predicate build(:trace, :deleted, :visibility => "public"), :identifiable?
   end
 
   def test_mime_type
@@ -208,7 +208,7 @@ class TraceTest < ActiveSupport::TestCase
   def test_import_creates_icon
     trace = create(:trace, :inserted => false, :fixture => "a")
 
-    assert_not trace.icon.attached?
+    assert_not_predicate trace.icon, :attached?
 
     trace.import
 
@@ -218,7 +218,7 @@ class TraceTest < ActiveSupport::TestCase
   def test_import_creates_large_picture
     trace = create(:trace, :inserted => false, :fixture => "a")
 
-    assert_not trace.image.attached?
+    assert_not_predicate trace.image, :attached?
 
     trace.import
 

--- a/test/models/tracepoint_test.rb
+++ b/test/models/tracepoint_test.rb
@@ -5,6 +5,6 @@ class TracepointTest < ActiveSupport::TestCase
     tracepoint = create(:tracepoint)
     assert_predicate tracepoint, :valid?
     tracepoint.timestamp = nil
-    assert_not tracepoint.valid?
+    assert_not_predicate tracepoint, :valid?
   end
 end

--- a/test/models/user_preference_test.rb
+++ b/test/models/user_preference_test.rb
@@ -36,7 +36,7 @@ class UserPreferenceTest < ActiveSupport::TestCase
       up.user = create(:user)
       up.k = key * i
       up.v = val * i
-      assert_not up.valid?
+      assert_not_predicate up, :valid?
       assert_raise(ActiveRecord::RecordInvalid) { up.save! }
     end
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,7 +10,7 @@ class UserTest < ActiveSupport::TestCase
                         :home_lat => nil,
                         :home_lon => nil,
                         :home_zoom => nil)
-    assert_not user.valid?
+    assert_not_predicate user, :valid?
     assert_predicate user.errors[:email], :any?
     assert_predicate user.errors[:pass_crypt], :any?
     assert_predicate user.errors[:display_name], :any?
@@ -57,11 +57,11 @@ class UserTest < ActiveSupport::TestCase
     user.display_name = "123"
     assert_predicate user, :valid?, "should allow 3 char name name"
     user.display_name = "12"
-    assert_not user.valid?, "should not allow 2 char name"
+    assert_not_predicate user, :valid?, "should not allow 2 char name"
     user.display_name = ""
-    assert_not user.valid?, "should not allow blank/0 char name"
+    assert_not_predicate user, :valid?, "should not allow blank/0 char name"
     user.display_name = nil
-    assert_not user.valid?, "should not allow nil value"
+    assert_not_predicate user, :valid?, "should not allow nil value"
   end
 
   def test_display_name_valid
@@ -87,7 +87,7 @@ class UserTest < ActiveSupport::TestCase
     bad.each do |display_name|
       user = build(:user)
       user.display_name = display_name
-      assert_not user.valid?, "#{display_name} is valid when it shouldn't be"
+      assert_not_predicate user, :valid?, "#{display_name} is valid when it shouldn't be"
     end
   end
 
@@ -217,25 +217,25 @@ class UserTest < ActiveSupport::TestCase
     assert_predicate build(:user, :pending), :visible?
     assert_predicate build(:user, :active), :visible?
     assert_predicate build(:user, :confirmed), :visible?
-    assert_not build(:user, :suspended).visible?
-    assert_not build(:user, :deleted).visible?
+    assert_not_predicate build(:user, :suspended), :visible?
+    assert_not_predicate build(:user, :deleted), :visible?
   end
 
   def test_active?
-    assert_not build(:user, :pending).active?
+    assert_not_predicate build(:user, :pending), :active?
     assert_predicate build(:user, :active), :active?
     assert_predicate build(:user, :confirmed), :active?
-    assert_not build(:user, :suspended).active?
-    assert_not build(:user, :deleted).active?
+    assert_not_predicate build(:user, :suspended), :active?
+    assert_not_predicate build(:user, :deleted), :active?
   end
 
   def test_moderator?
-    assert_not create(:user).moderator?
+    assert_not_predicate create(:user), :moderator?
     assert_predicate create(:moderator_user), :moderator?
   end
 
   def test_administrator?
-    assert_not create(:user).administrator?
+    assert_not_predicate create(:user), :administrator?
     assert_predicate create(:administrator_user), :administrator?
   end
 
@@ -253,10 +253,10 @@ class UserTest < ActiveSupport::TestCase
     assert_predicate user.description, :blank?
     assert_nil user.home_lat
     assert_nil user.home_lon
-    assert_not user.avatar.attached?
+    assert_not_predicate user.avatar, :attached?
     assert_equal "deleted", user.status
-    assert_not user.visible?
-    assert_not user.active?
+    assert_not_predicate user, :visible?
+    assert_not_predicate user, :active?
   end
 
   def test_soft_destroy_revokes_oauth1_tokens

--- a/test/models/way_tag_test.rb
+++ b/test/models/way_tag_test.rb
@@ -20,21 +20,21 @@ class WayTagTest < ActiveSupport::TestCase
   def test_length_key_invalid
     tag = create(:way_tag)
     tag.k = "k" * 256
-    assert_not tag.valid?, "Key should be too long"
+    assert_not_predicate tag, :valid?, "Key should be too long"
     assert_predicate tag.errors[:k], :any?
   end
 
   def test_length_value_invalid
     tag = create(:way_tag)
     tag.v = "v" * 256
-    assert_not tag.valid?, "Value should be too long"
+    assert_not_predicate tag, :valid?, "Value should be too long"
     assert_predicate tag.errors[:v], :any?
   end
 
   def test_orphaned_tag_invalid
     tag = create(:way_tag)
     tag.way = nil
-    assert_not tag.valid?, "Orphaned tag should be invalid"
+    assert_not_predicate tag, :valid?, "Orphaned tag should be invalid"
     assert_predicate tag.errors[:way], :any?
   end
 
@@ -45,7 +45,7 @@ class WayTagTest < ActiveSupport::TestCase
     tag.k = existing.k
     tag.v = existing.v
     assert_predicate tag, :new_record?
-    assert_not tag.valid?
+    assert_not_predicate tag, :valid?
     assert_raise(ActiveRecord::RecordInvalid) { tag.save! }
     assert_predicate tag, :new_record?
   end

--- a/test/system/report_diary_entry_test.rb
+++ b/test/system/report_diary_entry_test.rb
@@ -53,7 +53,7 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
     end
 
     issue.reload
-    assert_not issue.resolved?
+    assert_not_predicate issue, :resolved?
     assert_predicate issue, :open?
   end
 

--- a/test/validators/characters_validator_test.rb
+++ b/test/validators/characters_validator_test.rb
@@ -36,7 +36,7 @@ class CharactersValidatorTest < ActiveSupport::TestCase
 
     invalid.each do |v|
       c.chars = v
-      assert_not c.valid?, "'#{v}' should not be valid"
+      assert_not_predicate c, :valid?, "'#{v}' should not be valid"
     end
   end
 
@@ -60,7 +60,7 @@ class CharactersValidatorTest < ActiveSupport::TestCase
 
     invalid.each do |v|
       c.chars = v
-      assert_not c.valid?, "'#{v}' should not be valid"
+      assert_not_predicate c, :valid?, "'#{v}' should not be valid"
     end
   end
 end

--- a/test/validators/whitespace_validator_test.rb
+++ b/test/validators/whitespace_validator_test.rb
@@ -22,7 +22,7 @@ class WhitespaceValidatorTest < ActiveSupport::TestCase
 
     strings.each do |v|
       validator.string = v
-      assert_not validator.valid?, "'#{v}' should not be valid"
+      assert_not_predicate validator, :valid?, "'#{v}' should not be valid"
     end
   end
 
@@ -44,7 +44,7 @@ class WhitespaceValidatorTest < ActiveSupport::TestCase
 
     strings.each do |v|
       validator.string = v
-      assert_not validator.valid?, "'#{v}' should not be valid"
+      assert_not_predicate validator, :valid?, "'#{v}' should not be valid"
     end
   end
 


### PR DESCRIPTION
You have a test that looks like this:

https://github.com/openstreetmap/openstreetmap-website/blob/04c697b468057d1a3604694e7ead9d2c6efd1dfa/test/models/note_test.rb#L40-L42

Then Rubocop starts complaining that you don't use `assert_predicate` and you change the test:

https://github.com/openstreetmap/openstreetmap-website/blob/6892ccd0155b431cc567b4744b1e2759df3e8c68/test/models/note_test.rb#L40-L42

Yet you keep negative assertions as `assert_not` and don't change then to `assert_not_predicate`. Are there any good reasons for that other than Rubocop no complaining?

```ruby
assert_not_predicate create(:note, :status => "hidden"), :visible?
```
