### PR TITLE
Re-arrange login and signup screens as discussed in #4128

### DIFF
--- a/app/assets/javascripts/auth_providers.js
+++ b/app/assets/javascripts/auth_providers.js
@@ -1,0 +1,23 @@
+//= require qs/dist/qs
+
+$(document).ready(function () {
+  // Attach referer to authentication buttons
+  $(".auth_button").each(function () {
+    var params = Qs.parse(this.search.substring(1));
+    params.referer = $("#referer").val();
+    this.search = Qs.stringify(params);
+  });
+
+  // Add click handler to show OpenID field
+  $("#openid_open_url").click(function (e) {
+    e.preventDefault();
+    $("#openid_url").val("http://");
+    $("#login_auth_buttons").hide();
+    $("#login_openid_url").show();
+    $("#openid_login_button").show();
+  });
+
+  // Hide OpenID field for now
+  $("#login_openid_url").hide();
+  $("#openid_login_button").hide();
+});

--- a/app/assets/javascripts/auth_providers.js
+++ b/app/assets/javascripts/auth_providers.js
@@ -12,7 +12,7 @@ $(document).ready(function () {
   $("#openid_open_url").click(function (e) {
     e.preventDefault();
     $("#openid_url").val("http://");
-    $("#login_auth_buttons").hide();
+    $("#login_auth_buttons").hide().removeClass("d-flex");
     $("#login_openid_url").show();
     $("#openid_login_button").show();
   });

--- a/app/assets/javascripts/login.js
+++ b/app/assets/javascripts/login.js
@@ -1,28 +1,6 @@
-//= qs/dist/qs
-
 $(document).ready(function () {
   // Preserve location hash in referer
   if (window.location.hash) {
     $("#referer").val($("#referer").val() + window.location.hash);
   }
-
-  // Attach referer to authentication buttons
-  $(".auth_button").each(function () {
-    var params = Qs.parse(this.search.substring(1));
-    params.referer = $("#referer").val();
-    this.search = Qs.stringify(params);
-  });
-
-  // Add click handler to show OpenID field
-  $("#openid_open_url").click(function (e) {
-    e.preventDefault();
-    $("#openid_url").val("http://");
-    $("#login_auth_buttons").hide();
-    $("#login_openid_url").show();
-    $("#login_openid_submit").show();
-  });
-
-  // Hide OpenID field for now
-  $("#login_openid_url").hide();
-  $("#login_openid_submit").hide();
 });

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -726,6 +726,7 @@ tr.turn {
 
   &.new-user-main {
     background-image: image-url("sign-up-illustration.png");
+    background-position-x: 50px;
   }
 
   &.confirm-main {
@@ -734,17 +735,6 @@ tr.turn {
 
   &.new-user-terms {
     background-image: image-url("terms-illustration.png");
-  }
-
-  &.new-user-arm {
-    height: 110px;
-    width: 130px;
-    left: 280px;
-    top: 180px;
-    background-image: image-url("sign-up-illustration-arm.png");
-    position: absolute;
-    z-index: 100;
-    pointer-events: none;
   }
 }
 
@@ -1016,6 +1006,10 @@ div.secondary-actions {
       background-position: -45px -160px;
     }
   }
+}
+
+.auth-container {
+  max-width: 600px;
 }
 
 /* Rules for tabs inside secondary background sections */

--- a/app/controllers/concerns/session_methods.rb
+++ b/app/controllers/concerns/session_methods.rb
@@ -4,6 +4,18 @@ module SessionMethods
   private
 
   ##
+  # Read @preferred_auth_provider and @client_app_name from oauth2 authorization request's referer
+  def parse_oauth_referer(referer)
+    referer_query = URI(referer).query if referer
+    return unless referer_query
+
+    ref_params = CGI.parse referer_query
+    preferred = ref_params["preferred_auth_provider"].first
+    @preferred_auth_provider = preferred if preferred && Settings.key?(:"#{preferred}_auth_id")
+    @client_app_name = Oauth2Application.where(:uid => ref_params["client_id"].first).pick(:name)
+  end
+
+  ##
   # return the URL to use for authentication
   def auth_url(provider, uid, referer = nil)
     params = { :provider => provider }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,6 +15,8 @@ class SessionsController < ApplicationController
     override_content_security_policy_directives(:form_action => []) if Settings.csp_enforce || Settings.key?(:csp_report_url)
 
     session[:referer] = safe_referer(params[:referer]) if params[:referer]
+
+    parse_oauth_referer session[:referer]
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -78,10 +78,11 @@ class UsersController < ApplicationController
                                    :auth_provider => params[:auth_provider],
                                    :auth_uid => params[:auth_uid])
 
-      flash.now[:notice] = render_to_string :partial => "auth_association"
-
-      # validate before displaying to show email field if it conflicts
-      flash.now[:notice] = t ".duplicate_social_email" unless current_user.valid? && current_user.errors[:email].empty?
+      if current_user.valid? || current_user.errors[:email].empty?
+        flash.now[:notice] = render_to_string :partial => "auth_association"
+      else
+        flash.now[:warning] = t ".duplicate_social_email"
+      end
     else
       check_signup_allowed
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,6 +60,8 @@ class UsersController < ApplicationController
                  session[:referer]
                end
 
+    parse_oauth_referer @referer
+
     append_content_security_policy_directives(
       :form_action => %w[accounts.google.com *.facebook.com login.live.com github.com meta.wikimedia.org]
     )

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,7 +70,6 @@ class UsersController < ApplicationController
       redirect_to @referer || { :controller => "site", :action => "index" }
     elsif params.key?(:auth_provider) && params.key?(:auth_uid)
       self.current_user = User.new(:email => params[:email],
-                                   :email_confirmation => params[:email],
                                    :display_name => params[:nickname],
                                    :auth_provider => params[:auth_provider],
                                    :auth_uid => params[:auth_uid])
@@ -336,7 +335,7 @@ class UsersController < ApplicationController
   ##
   # return permitted user parameters
   def user_params
-    params.require(:user).permit(:email, :email_confirmation, :display_name,
+    params.require(:user).permit(:email, :display_name,
                                  :auth_provider, :auth_uid,
                                  :pass_crypt, :pass_crypt_confirmation,
                                  :consider_pd)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,7 +71,7 @@ class UsersController < ApplicationController
       # page, instead send them to the home page
       redirect_to @referer || { :controller => "site", :action => "index" }
     elsif params.key?(:auth_provider) && params.key?(:auth_uid)
-      @verified_email = params[:verified_email]
+      @email_hmac = params[:email_hmac]
 
       self.current_user = User.new(:email => params[:email],
                                    :display_name => params[:nickname],
@@ -109,7 +109,7 @@ class UsersController < ApplicationController
         render :action => "new"
       else
         # Save the user record
-        save_new_user params[:verified_email]
+        save_new_user params[:email_hmac]
       end
     end
   end
@@ -243,8 +243,8 @@ class UsersController < ApplicationController
           failed_login t("sessions.new.auth failure")
         end
       else
-        verified_email = UsersController.message_hmac(email) if email_verified && email
-        redirect_to :action => "new", :nickname => name, :email => email, :verified_email => verified_email,
+        email_hmac = UsersController.message_hmac(email) if email_verified && email
+        redirect_to :action => "new", :nickname => name, :email => email, :email_hmac => email_hmac,
                     :auth_provider => provider, :auth_uid => uid
       end
     end
@@ -262,7 +262,7 @@ class UsersController < ApplicationController
 
   def self.message_hmac(text)
     sha256 = Digest::SHA256.new
-    sha256 << Rails.application.key_generator.generate_key("openstreetmap/verified_email")
+    sha256 << Rails.application.key_generator.generate_key("openstreetmap/email_address")
     sha256 << text
     Base64.urlsafe_encode64(sha256.digest)
   end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -60,11 +60,25 @@ module UserHelper
     link_to(
       image_tag("#{name}.svg",
                 :alt => t("application.auth_providers.#{name}.alt"),
-                :class => "rounded-3",
-                :size => "36"),
+                :class => "rounded-1",
+                :size => "24"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
-      :class => "auth_button",
+      :class => "auth_button p-2 d-block",
+      :title => t("application.auth_providers.#{name}.title")
+    )
+  end
+
+  def auth_button_preferred(name, provider, options = {})
+    link_to(
+      image_tag("#{name}.svg",
+                :alt => t("application.auth_providers.#{name}.alt"),
+                :class => "rounded-1 me-3",
+                :width => "24px",
+                :height => "24px") + t("application.auth_providers.#{name}.title"),
+      auth_path(options.merge(:provider => provider)),
+      :method => :post,
+      :class => "auth_button fs-6 border rounded text-muted text-decoration-none py-2 px-4 d-flex justify-content-center align-items-center",
       :title => t("application.auth_providers.#{name}.title")
     )
   end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -53,19 +53,19 @@ module UserHelper
   # External authentication support
 
   def openid_logo
-    image_tag "openid_small.png", :alt => t("sessions.new.openid_logo_alt"), :class => "align-text-bottom"
+    image_tag "openid_small.png", :alt => t("application.auth_providers.openid_logo_alt"), :class => "align-text-bottom"
   end
 
   def auth_button(name, provider, options = {})
     link_to(
       image_tag("#{name}.svg",
-                :alt => t("sessions.new.auth_providers.#{name}.alt"),
+                :alt => t("application.auth_providers.#{name}.alt"),
                 :class => "rounded-3",
                 :size => "36"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
       :class => "auth_button",
-      :title => t("sessions.new.auth_providers.#{name}.title")
+      :title => t("application.auth_providers.#{name}.title")
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,7 +100,7 @@ class User < ApplicationRecord
                            :whitespace => { :leading => false, :trailing => false },
                            :width => { :minimum => 3 }
   validate :display_name_cannot_be_user_id_with_other_id, :if => proc { |u| u.display_name_changed? }
-  validates :email, :presence => true, :confirmation => true, :characters => true
+  validates :email, :presence => true, :characters => true
   validates :email, :if => proc { |u| u.email_changed? },
                     :uniqueness => { :case_sensitive => false }
   validates :email, :if => proc { |u| u.email_changed? },

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -1,0 +1,33 @@
+<div>
+  <div class="mb-3">
+    <label class="form-label"><%= t ".with external" %></label>
+
+    <ul class='list-inline' id="login_auth_buttons">
+      <li class="list-inline-item me-3">
+        <%= link_to image_tag("openid.png",
+                              :alt => t("application.auth_providers.openid.title"),
+                              :size => "36"),
+                    "#",
+                    :id => "openid_open_url",
+                    :title => t("application.auth_providers.openid.title") %>
+      </li>
+
+      <% %w[google facebook microsoft github wikipedia].each do |provider| %>
+        <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
+          <li class="list-inline-item me-3"><%= auth_button provider, provider %></li>
+        <% end -%>
+      <% end -%>
+    </ul>
+
+    <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
+      <div id='login_openid_url' class="mb-3">
+        <label for='openid_url' class="form-label"><%= t ".openid_html", :logo => openid_logo %></label>
+        <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>
+        <%= text_field_tag("openid_url", "", :tabindex => 5, :autocomplete => "on", :class => "openid_url form-control") %>
+        <span class="form-text text-muted">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
+      </div>
+
+      <%= submit_tag t(".openid_login_button"), :tabindex => 6, :id => "openid_login_button", :class => "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -1,33 +1,44 @@
 <div>
-  <div class="mb-3">
-    <label class="form-label"><%= t ".with external" %></label>
+  <div class="list-inline justify-content-center d-flex align-items-center flex-wrap mb-3 gap-3" id="login_auth_buttons">
 
-    <ul class='list-inline' id="login_auth_buttons">
-      <li class="list-inline-item me-3">
+    <% %w[google facebook microsoft github wikipedia].each do |provider| %>
+      <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
+        <% if @preferred_auth_provider == provider %>
+          <div class="mx-2"><%= auth_button_preferred provider, provider %></div>
+        <% end %>
+      <% end -%>
+    <% end -%>
+
+    <div class="justify-content-center d-flex gap-1">
+      <div>
         <%= link_to image_tag("openid.png",
                               :alt => t("application.auth_providers.openid.title"),
-                              :size => "36"),
+                              :size => "24"),
                     "#",
                     :id => "openid_open_url",
-                    :title => t("application.auth_providers.openid.title") %>
-      </li>
-
-      <% %w[google facebook microsoft github wikipedia].each do |provider| %>
-        <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
-          <li class="list-inline-item me-3"><%= auth_button provider, provider %></li>
-        <% end -%>
-      <% end -%>
-    </ul>
-
-    <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
-      <div id='login_openid_url' class="mb-3">
-        <label for='openid_url' class="form-label"><%= t ".openid_html", :logo => openid_logo %></label>
-        <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>
-        <%= text_field_tag("openid_url", "", :tabindex => 5, :autocomplete => "on", :class => "openid_url form-control") %>
-        <span class="form-text text-muted">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
+                    :title => t("application.auth_providers.openid.title"),
+                    :class => "p-2 d-block" %>
       </div>
 
-      <%= submit_tag t(".openid_login_button"), :tabindex => 6, :id => "openid_login_button", :class => "btn btn-primary" %>
-    <% end %>
+      <% %w[google facebook microsoft github wikipedia].each do |provider| %>
+        <% unless @preferred_auth_provider == provider %>
+          <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
+            <div><%= auth_button provider, provider %></div>
+          <% end -%>
+        <% end %>
+      <% end -%>
+    </div>
   </div>
+
+  <%# :tabindex starts high to allow rendering at the bottom of the template %>
+  <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
+    <div id="login_openid_url" class="mb-3">
+      <label for="openid_url" class="form-label"><%= t ".openid_html", :logo => openid_logo %></label>
+      <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>
+      <%= text_field_tag("openid_url", "", :tabindex => 20, :autocomplete => "on", :class => "openid_url form-control") %>
+      <span class="form-text text-muted">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
+    </div>
+
+    <%= submit_tag t(".openid_login_button"), :tabindex => 21, :id => "openid_login_button", :class => "btn btn-primary" %>
+  <% end %>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -104,7 +104,7 @@
           <%= link_to t("layouts.logout"), logout_path(:referer => request.fullpath), :method => "post", :class => "geolink dropdown-item" %>
         </div>
       </div>
-    <% else %>
+    <% elsif (controller_name != "users" and controller_name != "sessions") || action_name != "new" %>
       <div class="d-inline-flex btn-group login-menu" role="">
         <%= link_to t("layouts.log_in"), login_path(:referer => request.fullpath), :class => "geolink btn btn-outline-secondary" %>
         <%= link_to t("layouts.sign_up"), user_new_path, :class => "btn btn-outline-secondary" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -6,6 +6,10 @@
 <% content_for :heading_class, "p-0 mw-100" %>
 
 <% content_for :heading do %>
+  <% if @client_app_name %>
+    <p class="text-center text-muted fs-6 py-2 mb-0 bg-white"><%= t(".login_to_authorize_html", :client_app_name => @client_app_name) %></p>
+  <% end %>
+
   <div class="header-illustration new-user-main auth-container mx-auto">
     <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
       <li class="nav-item">
@@ -19,7 +23,14 @@
 <% end %>
 
 <div id="login_login" class="auth-container mx-auto my-0">
-  <p class='text-muted'><%= t ".no account" %> <%= link_to t(".register now"), user_new_path(:referer => params[:referer]) %></p>
+  <% if @preferred_auth_provider %>
+    <%= render :partial => "auth_providers" %>
+    <div class="d-flex justify-content-center align-items-center">
+      <div class="border-bottom border-1 flex-grow-1"></div>
+      <div class="text-secondary mx-3"><%= t ".or" %></div>
+      <div class="border-bottom border-1 flex-grow-1"></div>
+    </div>
+  <% end %>
 
   <%= bootstrap_form_tag(:action => "login", :html => { :id => "login_form" }) do |f| %>
     <%= hidden_field_tag("referer", h(params[:referer]), :autocomplete => "off") %>
@@ -40,10 +51,17 @@
       <%= f.check_box :remember_me, { :label => t(".remember"), :tabindex => 3, :checked => (params[:remember_me] == "yes") }, "yes" %>
     <% end %>
 
-    <%= f.primary t(".login_button"), :tabindex => 4 %>
+    <div class="mb-3">
+      <%= f.primary t(".login_button"), :tabindex => 4 %>
+    </div>
   <% end %>
 
-  <hr>
-
-  <%= render :partial => "auth_providers" %>
+  <% unless @preferred_auth_provider %>
+    <div class="d-flex justify-content-center align-items-center">
+      <div class="border-bottom border-1 flex-grow-1"></div>
+      <div class="text-secondary mx-3"><%= t ".with external" %></div>
+      <div class="border-bottom border-1 flex-grow-1"></div>
+    </div>
+    <%= render :partial => "auth_providers" %>
+  <% end %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -7,8 +7,15 @@
 
 <% content_for :heading do %>
   <div class="header-illustration new-user-main auth-container mx-auto">
-    <h1 class="pt-3"><%= t ".heading" %></h1>
-  <div>
+    <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
+      <li class="nav-item">
+        <%= link_to t("sessions.new.tab_title"), "#", :class => "nav-link active" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to t("users.new.tab_title"), url_for(:action => :new, :controller => :users), :class => "nav-link" %>
+      </li>
+    </ul>
+  </div>
 <% end %>
 
 <div id="login_login" class="auth-container mx-auto my-0">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for :head do %>
   <%= javascript_include_tag "login" %>
+  <%= javascript_include_tag "auth_providers" %>
 <% end %>
 
 <% content_for :heading_class, "p-0 mw-100" %>
@@ -37,37 +38,5 @@
 
   <hr>
 
-  <div id="loginForm">
-    <div class="mb-3">
-      <label class="form-label"><%= t ".with external" %></label>
-
-      <ul class='list-inline' id="login_auth_buttons">
-        <li class="list-inline-item me-3">
-          <%= link_to image_tag("openid.png",
-                                :alt => t(".auth_providers.openid.title"),
-                                :size => "36"),
-                      "#",
-                      :id => "openid_open_url",
-                      :title => t(".auth_providers.openid.title") %>
-        </li>
-
-        <% %w[google facebook microsoft github wikipedia].each do |provider| %>
-          <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
-            <li class="list-inline-item me-3"><%= auth_button provider, provider %></li>
-          <% end -%>
-        <% end -%>
-      </ul>
-
-      <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
-        <div id='login_openid_url' class="mb-3">
-          <label for='openid_url' class="form-label"><%= t ".openid_html", :logo => openid_logo %></label>
-          <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>
-          <%= text_field_tag("openid_url", "", :tabindex => 5, :autocomplete => "on", :class => "openid_url form-control") %>
-          <span class="form-text text-muted">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
-        </div>
-
-        <%= submit_tag t(".login_button"), :tabindex => 6, :id => "login_openid_submit", :class => "btn btn-primary" %>
-      <% end %>
-    </div>
-  </div>
+  <%= render :partial => "auth_providers" %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -17,7 +17,17 @@
     <%= hidden_field_tag("referer", h(params[:referer]), :autocomplete => "off") %>
 
     <%= f.text_field :username, :label => t(".email or username"), :tabindex => 1, :value => params[:username] %>
-    <%= f.password_field :password, :label => t(".password"), :tabindex => 2, :value => "", :help => link_to(t(".lost password link"), user_forgot_password_path) %>
+
+    <div class="row">
+      <div class="col">
+        <%= f.label :password, :class => "form-label" %>
+      </div>
+      <div class="col text-end">
+        <small><%= link_to(t(".lost password link"), user_forgot_password_path) %></small>
+      </div>
+    </div>
+    <input class="form-control mb-3" type="password" name="password" id="password" tabindex="2" value="" autocomplete="off" />
+
     <%= f.form_group do %>
       <%= f.check_box :remember_me, { :label => t(".remember"), :tabindex => 3, :checked => (params[:remember_me] == "yes") }, "yes" %>
     <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,11 +2,15 @@
   <%= javascript_include_tag "login" %>
 <% end %>
 
+<% content_for :heading_class, "p-0 mw-100" %>
+
 <% content_for :heading do %>
-  <h1><%= t ".heading" %></h1>
+  <div class="header-illustration new-user-main auth-container mx-auto">
+    <h1 class="pt-3"><%= t ".heading" %></h1>
+  <div>
 <% end %>
 
-<div id="login_login">
+<div id="login_login" class="auth-container mx-auto my-0">
   <p class='text-muted'><%= t ".no account" %> <%= link_to t(".register now"), user_new_path(:referer => params[:referer]) %></p>
 
   <%= bootstrap_form_tag(:action => "login", :html => { :id => "login_form" }) do |f| %>

--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -1,7 +1,14 @@
 <% content_for :heading_class, "p-0 mw-100" %>
 <% content_for :heading do %>
   <div class="header-illustration new-user-main auth-container mx-auto">
-    <h1><%= t "users.new.title" %></h1>
+    <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
+      <li class="nav-item">
+        <%= link_to t("sessions.new.tab_title"), url_for(:action => :new, :controller => :sessions), :class => "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to t("users.new.tab_title"), "#", :class => "nav-link active" %>
+      </li>
+    </ul>
   </div>
 <% end %>
 

--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -1,11 +1,11 @@
-<% content_for :heading_class, "pb-0" %>
+<% content_for :heading_class, "p-0 mw-100" %>
 <% content_for :heading do %>
-  <div class='header-illustration new-user-main'>
+  <div class="header-illustration new-user-main auth-container mx-auto">
     <h1><%= t "users.new.title" %></h1>
   </div>
 <% end %>
 
-<div class="mx-auto my-0">
+<div class="auth-container mx-auto my-0">
   <p><strong><%= t "users.new.no_auto_account_create" %></strong></p>
   <p><%= t "users.new.please_contact_support_html", :support_link => mail_to(Settings.support_email, t("users.new.support")) %></p>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,51 +2,48 @@
   <%= javascript_include_tag "user" %>
 <% end %>
 
-<% content_for :heading_class, "pb-0" %>
+<% content_for :heading_class, "p-0 mw-100" %>
+
 <% content_for :heading do %>
-  <div class='header-illustration new-user-main'>
-    <h1><%= t ".title" %></h1>
+  <div class="header-illustration new-user-main auth-container mx-auto">
+    <h1 class="pt-3"><%= t ".title" %></h1>
   </div>
-  <div class='header-illustration new-user-arm d-none d-md-block'></div>
 <% end %>
 
-<div class="row">
-  <div class='text-muted col-sm order-sm-2'>
-    <h4><%= t ".about.header" %></h4>
-    <p><%= t ".about.paragraph_1" %></p>
+<div class="auth-container mx-auto my-0">
+  <div class="text-muted fs-6">
+    <p><strong><%= t ".about.header" %></strong> <%= t ".about.paragraph_1" %></p>
     <p><%= t ".about.paragraph_2" %></p>
   </div>
 
-  <div class="col-sm">
-    <%= bootstrap_form_for current_user, :url => { :action => "create" } do |f| %>
-      <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
+  <%= bootstrap_form_for current_user, :url => { :action => "create" } do |f| %>
+    <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
 
-      <%= f.email_field :email, :tabindex => 1 %>
-      <%= f.email_field :email_confirmation, :help => t(".email_confirmation_help_html",
-                                                        :privacy_policy_link => link_to(t(".privacy_policy"),
-                                                                                        t(".privacy_policy_url"),
-                                                                                        :title => t(".privacy_policy_title"))),
-                                             :tabindex => 2 %>
+    <%= f.email_field :email, :tabindex => 1 %>
+    <%= f.email_field :email_confirmation, :help => t(".email_confirmation_help_html",
+                                                      :privacy_policy_link => link_to(t(".privacy_policy"),
+                                                                                      t(".privacy_policy_url"),
+                                                                                      :title => t(".privacy_policy_title"))),
+                                           :tabindex => 2 %>
 
-      <%= f.text_field :display_name, :help => t(".display name description"), :tabindex => 3 %>
+    <%= f.text_field :display_name, :help => t(".display name description"), :tabindex => 3 %>
 
-      <fieldset class="mb-3" id="auth_field">
-        <label for="user_auth_provider" class="form-label"><%= t(".external auth") %></label>
-        <div class="row">
-          <%= f.select(:auth_provider, Auth.providers, :default => "", :hide_label => true, :wrapper => { :class => "col-auto mb-0" }, :tabindex => 4) %>
-          <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }, :tabindex => 5) %>
-        </div>
-        <small class="form-text text-muted"><%= t ".auth no password" %></small>
-      </fieldset>
-
-      <%= f.password_field :pass_crypt, :tabindex => 6 %>
-      <%= f.password_field :pass_crypt_confirmation, :tabindex => 7 %>
-
-      <div id="auth_prompt">
-        <p><%= link_to t(".use external auth"), "#", :id => "auth_enable" %></p>
+    <fieldset class="mb-3" id="auth_field">
+      <label for="user_auth_provider" class="form-label"><%= t(".external auth") %></label>
+      <div class="row">
+        <%= f.select(:auth_provider, Auth.providers, :default => "", :hide_label => true, :wrapper => { :class => "col-auto mb-0" }, :tabindex => 4) %>
+        <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }, :tabindex => 5) %>
       </div>
+      <small class="form-text text-muted"><%= t ".auth no password" %></small>
+    </fieldset>
 
-      <%= f.primary t(".continue"), :tabindex => 8 %>
-    <% end %>
-  </div>
+    <%= f.password_field :pass_crypt, :tabindex => 6 %>
+    <%= f.password_field :pass_crypt_confirmation, :tabindex => 7 %>
+
+    <div id="auth_prompt">
+      <p><%= link_to t(".use external auth"), "#", :id => "auth_enable" %></p>
+    </div>
+
+    <%= f.primary t(".continue"), :tabindex => 8 %>
+  <% end %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -43,11 +43,11 @@
 
   <%= bootstrap_form_for current_user, :url => { :action => "create" } do |f| %>
     <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
-    <%= hidden_field_tag("verified_email", h(@verified_email)) unless @verified_email.nil? %>
+    <%= hidden_field_tag("email_hmac", h(@email_hmac)) unless @email_hmac.nil? %>
     <%= f.hidden_field :auth_provider unless current_user.auth_provider.nil? %>
     <%= f.hidden_field :auth_uid unless current_user.auth_uid.nil? %>
 
-    <% if current_user.auth_uid.nil? or @verified_email.nil? or not current_user.errors[:email].empty? %>
+    <% if current_user.auth_uid.nil? or @email_hmac.nil? or not current_user.errors[:email].empty? %>
       <%= f.email_field :email, :help => t(".email_help_html",
                                            :privacy_policy_link => link_to(t(".privacy_policy"),
                                                                            t(".privacy_policy_url"),

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -6,6 +6,10 @@
 <% content_for :heading_class, "p-0 mw-100" %>
 
 <% content_for :heading do %>
+  <% if @client_app_name %>
+    <p class="text-center text-muted fs-6 py-2 mb-0 bg-white"><%= t(".signup_to_authorize_html", :client_app_name => @client_app_name) %></p>
+  <% end %>
+
   <div class="header-illustration new-user-main auth-container mx-auto">
     <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
       <li class="nav-item">
@@ -24,6 +28,15 @@
       <p><strong><%= t ".about.header" %></strong> <%= t ".about.paragraph_1" %></p>
       <p><%= t ".about.paragraph_2" %></p>
     </div>
+
+    <% unless @preferred_auth_provider.nil? %>
+      <%= render :partial => "auth_providers" %>
+      <div class="d-flex justify-content-center align-items-center">
+        <div class="border-bottom border-1 flex-grow-1"></div>
+        <div class="text-secondary mx-3"><%= t ".or" %></div>
+        <div class="border-bottom border-1 flex-grow-1"></div>
+      </div>
+    <% end %>
   <% else %>
     <h4><%= t ".about.welcome" %></h4>
   <% end %>
@@ -34,7 +47,7 @@
     <%= f.hidden_field :auth_provider unless current_user.auth_provider.nil? %>
     <%= f.hidden_field :auth_uid unless current_user.auth_uid.nil? %>
 
-    <% if current_user.auth_uid.nil? or not current_user.errors[:email].empty? %>
+    <% if current_user.auth_uid.nil? or @verified_email.nil? or not current_user.errors[:email].empty? %>
       <%= f.email_field :email, :help => t(".email_help_html",
                                            :privacy_policy_link => link_to(t(".privacy_policy"),
                                                                            t(".privacy_policy_url"),
@@ -58,18 +71,17 @@
       </div>
     <% end %>
 
-    <p class="mb-3 text-muted"><%= t(".by_signing_up_html",
-                                     :tou_link => link_to(t("layouts.tou"),
-                                                          "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
-                                                          :target => :new),
-                                     :privacy_policy_link => link_to(t(".privacy_policy"),
-                                                                     t(".privacy_policy_url"),
-                                                                     :title => t(".privacy_policy_title"),
-                                                                     :target => :new),
-                                     :contributor_terms_link => link_to(t(".contributor_terms"),
-                                                                        t(".contributor_terms_url"),
-                                                                        :target => :new)) %></p>
-
+    <p class="mb-3 text-muted fs-6"><%= t(".by_signing_up_html",
+                                          :tou_link => link_to(t("layouts.tou"),
+                                                               "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
+                                                               :target => :new),
+                                          :privacy_policy_link => link_to(t(".privacy_policy"),
+                                                                          t(".privacy_policy_url"),
+                                                                          :title => t(".privacy_policy_title"),
+                                                                          :target => :new),
+                                          :contributor_terms_link => link_to(t(".contributor_terms"),
+                                                                             t(".contributor_terms_url"),
+                                                                             :target => :new)) %></p>
     <%= f.form_group do %>
       <%= f.check_box :consider_pd,
                       :tabindex => 5,
@@ -84,8 +96,12 @@
     </div>
   <% end %>
 
-  <% if current_user.auth_uid.nil? %>
-    <hr>
+  <% if current_user.auth_uid.nil? and @preferred_auth_provider.nil? %>
+    <div class="d-flex justify-content-center align-items-center">
+      <div class="border-bottom border-1 flex-grow-1"></div>
+      <div class="text-secondary mx-3"><%= t ".use external auth" %></div>
+      <div class="border-bottom border-1 flex-grow-1"></div>
+    </div>
     <%= render :partial => "auth_providers" %>
   <% end %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,7 +7,14 @@
 
 <% content_for :heading do %>
   <div class="header-illustration new-user-main auth-container mx-auto">
-    <h1 class="pt-3"><%= t ".title" %></h1>
+    <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
+      <li class="nav-item">
+        <%= link_to t("sessions.new.tab_title"), url_for(:action => :new, :controller => :sessions), :class => "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to t("users.new.tab_title"), "#", :class => "nav-link active" %>
+      </li>
+    </ul>
   </div>
 <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,26 +19,25 @@
   <%= bootstrap_form_for current_user, :url => { :action => "create" } do |f| %>
     <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
 
-    <%= f.email_field :email, :tabindex => 1 %>
-    <%= f.email_field :email_confirmation, :help => t(".email_confirmation_help_html",
-                                                      :privacy_policy_link => link_to(t(".privacy_policy"),
-                                                                                      t(".privacy_policy_url"),
-                                                                                      :title => t(".privacy_policy_title"))),
-                                           :tabindex => 2 %>
+    <%= f.email_field :email, :help => t(".email_help_html",
+                                         :privacy_policy_link => link_to(t(".privacy_policy"),
+                                                                         t(".privacy_policy_url"),
+                                                                         :title => t(".privacy_policy_title"))),
+                              :tabindex => 1 %>
 
-    <%= f.text_field :display_name, :help => t(".display name description"), :tabindex => 3 %>
+    <%= f.text_field :display_name, :help => t(".display name description"), :tabindex => 2 %>
 
     <fieldset class="mb-3" id="auth_field">
       <label for="user_auth_provider" class="form-label"><%= t(".external auth") %></label>
       <div class="row">
-        <%= f.select(:auth_provider, Auth.providers, :default => "", :hide_label => true, :wrapper => { :class => "col-auto mb-0" }, :tabindex => 4) %>
-        <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }, :tabindex => 5) %>
+        <%= f.select(:auth_provider, Auth.providers, :default => "", :hide_label => true, :wrapper => { :class => "col-auto mb-0" }, :tabindex => 3) %>
+        <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }, :tabindex => 4) %>
       </div>
       <small class="form-text text-muted"><%= t ".auth no password" %></small>
     </fieldset>
 
-    <%= f.password_field :pass_crypt, :tabindex => 6 %>
-    <%= f.password_field :pass_crypt_confirmation, :tabindex => 7 %>
+    <%= f.password_field :pass_crypt, :tabindex => 5 %>
+    <%= f.password_field :pass_crypt_confirmation, :tabindex => 6 %>
 
     <p class="mb-3 text-muted"><%= t(".by_signing_up_html",
                                      :tou_link => link_to(t("layouts.tou"),
@@ -49,7 +48,7 @@
                                                                         :target => :new)) %></p>
 
     <div class="mb-3">
-      <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary", :tabindex => 8) %>
+      <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary", :tabindex => 7) %>
     </div>
 
     <div class="mb-3">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for :head do %>
   <%= javascript_include_tag "user" %>
+  <%= javascript_include_tag "auth_providers" %>
 <% end %>
 
 <% content_for :heading_class, "p-0 mw-100" %>
@@ -11,59 +12,73 @@
 <% end %>
 
 <div class="auth-container mx-auto my-0">
-  <div class="text-muted fs-6">
-    <p><strong><%= t ".about.header" %></strong> <%= t ".about.paragraph_1" %></p>
-    <p><%= t ".about.paragraph_2" %></p>
-  </div>
+  <% if current_user.auth_uid.nil? %>
+    <div class="text-muted fs-6">
+      <p><strong><%= t ".about.header" %></strong> <%= t ".about.paragraph_1" %></p>
+      <p><%= t ".about.paragraph_2" %></p>
+    </div>
+  <% else %>
+    <h4><%= t ".about.welcome" %></h4>
+  <% end %>
 
   <%= bootstrap_form_for current_user, :url => { :action => "create" } do |f| %>
     <%= hidden_field_tag("referer", h(@referer)) unless @referer.nil? %>
+    <%= hidden_field_tag("verified_email", h(@verified_email)) unless @verified_email.nil? %>
+    <%= f.hidden_field :auth_provider unless current_user.auth_provider.nil? %>
+    <%= f.hidden_field :auth_uid unless current_user.auth_uid.nil? %>
 
-    <%= f.email_field :email, :help => t(".email_help_html",
-                                         :privacy_policy_link => link_to(t(".privacy_policy"),
-                                                                         t(".privacy_policy_url"),
-                                                                         :title => t(".privacy_policy_title"))),
-                              :tabindex => 1 %>
+    <% if current_user.auth_uid.nil? or not current_user.errors[:email].empty? %>
+      <%= f.email_field :email, :help => t(".email_help_html",
+                                           :privacy_policy_link => link_to(t(".privacy_policy"),
+                                                                           t(".privacy_policy_url"),
+                                                                           :title => t(".privacy_policy_title"),
+                                                                           :target => :new)),
+                                :tabindex => 1 %>
+    <% else %>
+      <%= f.hidden_field :email %>
+    <% end %>
 
     <%= f.text_field :display_name, :help => t(".display name description"), :tabindex => 2 %>
 
-    <fieldset class="mb-3" id="auth_field">
-      <label for="user_auth_provider" class="form-label"><%= t(".external auth") %></label>
+    <% if current_user.auth_uid.nil? %>
       <div class="row">
-        <%= f.select(:auth_provider, Auth.providers, :default => "", :hide_label => true, :wrapper => { :class => "col-auto mb-0" }, :tabindex => 3) %>
-        <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }, :tabindex => 4) %>
+        <div class="col-sm">
+          <%= f.password_field :pass_crypt, :tabindex => 3 %>
+        </div>
+        <div class="col-sm">
+          <%= f.password_field :pass_crypt_confirmation, :tabindex => 4 %>
+        </div>
       </div>
-      <small class="form-text text-muted"><%= t ".auth no password" %></small>
-    </fieldset>
-
-    <%= f.password_field :pass_crypt, :tabindex => 5 %>
-    <%= f.password_field :pass_crypt_confirmation, :tabindex => 6 %>
+    <% end %>
 
     <p class="mb-3 text-muted"><%= t(".by_signing_up_html",
                                      :tou_link => link_to(t("layouts.tou"),
                                                           "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
                                                           :target => :new),
+                                     :privacy_policy_link => link_to(t(".privacy_policy"),
+                                                                     t(".privacy_policy_url"),
+                                                                     :title => t(".privacy_policy_title"),
+                                                                     :target => :new),
                                      :contributor_terms_link => link_to(t(".contributor_terms"),
                                                                         t(".contributor_terms_url"),
                                                                         :target => :new)) %></p>
 
-    <div class="mb-3">
-      <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary", :tabindex => 7) %>
-    </div>
+    <%= f.form_group do %>
+      <%= f.check_box :consider_pd,
+                      :tabindex => 5,
+                      :label => t(".consider_pd_html",
+                                  :consider_pd_link => link_to(t(".consider_pd"),
+                                                               t(".consider_pd_url"),
+                                                               :target => :new)) %>
+    <% end %>
 
     <div class="mb-3">
-      <div class="form-check">
-        <%= check_box("user", "consider_pd", :class => "form-check-input") %>
-          <label for="user_consider_pd" class="form-check-label">
-            <%= t ".consider_pd" %>
-          </label>
-        <span class="minorNote">(<%= link_to(t(".consider_pd_why"), t(".consider_pd_why_url"), :target => :new) %>)</span>
-      </div>
+      <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary", :tabindex => 6) %>
     </div>
+  <% end %>
 
-    <div id="auth_prompt">
-      <p><%= link_to t(".use external auth"), "#", :id => "auth_enable" %></p>
-    </div>
-
+  <% if current_user.auth_uid.nil? %>
+    <hr>
+    <%= render :partial => "auth_providers" %>
   <% end %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -40,10 +40,31 @@
     <%= f.password_field :pass_crypt, :tabindex => 6 %>
     <%= f.password_field :pass_crypt_confirmation, :tabindex => 7 %>
 
+    <p class="mb-3 text-muted"><%= t(".by_signing_up_html",
+                                     :tou_link => link_to(t("layouts.tou"),
+                                                          "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
+                                                          :target => :new),
+                                     :contributor_terms_link => link_to(t(".contributor_terms"),
+                                                                        t(".contributor_terms_url"),
+                                                                        :target => :new)) %></p>
+
+    <div class="mb-3">
+      <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary", :tabindex => 8) %>
+    </div>
+
+    <div class="mb-3">
+      <div class="form-check">
+        <%= check_box("user", "consider_pd", :class => "form-check-input") %>
+          <label for="user_consider_pd" class="form-check-label">
+            <%= t ".consider_pd" %>
+          </label>
+        <span class="minorNote">(<%= link_to(t(".consider_pd_why"), t(".consider_pd_why_url"), :target => :new) %>)</span>
+      </div>
+    </div>
+
     <div id="auth_prompt">
       <p><%= link_to t(".use external auth"), "#", :id => "auth_enable" %></p>
     </div>
 
-    <%= f.primary t(".continue"), :tabindex => 8 %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2735,6 +2735,8 @@ en:
         header: Free and editable.
         paragraph_1: Unlike other maps, OpenStreetMap is completely created by people like you, and it's free for anyone to fix, update, download and use.
         paragraph_2: Sign up to get started contributing. We'll send an email to confirm your account.
+        welcome: "Welcome to OpenStreetMap"
+      duplicate_social_email: "If you already have an OpenStreetMap account and wish to use a 3rd party identity provider, please log in using your password and modify the settings of your account."
       display name description: "Your publicly displayed username. You can change this later in the preferences."
       by_signing_up_html: "By signing up, you agree to our %{contributor_terms_link} and %{tou_link}."
       contributor_terms_url: "https://wiki.osmfoundation.org/wiki/Licence/Contributor_Terms"
@@ -2748,9 +2750,9 @@ en:
       privacy_policy: privacy policy
       privacy_policy_url: https://wiki.osmfoundation.org/wiki/Privacy_Policy
       privacy_policy_title: OSMF privacy policy including section on email addresses
-      consider_pd: "In addition to the above, I consider my contributions to be in the Public Domain"
-      consider_pd_why: "what's this?"
-      consider_pd_why_url: https://wiki.osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
+      consider_pd_html: "I consider my contributions to be in the %{consider_pd_link}."
+      consider_pd: "public domain"
+      consider_pd_url: https://wiki.osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
     terms:
       title: "Terms"
       heading: "Terms"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1848,15 +1848,15 @@ en:
     new:
       title: "Log in"
       tab_title: "Log in"
-      heading: "Log in"
+      login_to_authorize_html: "Log in to OpenStreetMap to access %{client_app_name}."
       email or username: "Email Address or Username"
       password: "Password"
       remember: "Remember me"
       lost password link: "Lost your password?"
       login_button: "Log in"
       register now: Register now
-      with external: "Alternatively, use a third party to log in:"
-      no account: Don't have an account?
+      with external: "or log in with a third party"
+      or: "or"
       auth failure: "Sorry, could not log in with those details."
     destroy:
       title: "Logout"
@@ -2576,7 +2576,6 @@ en:
       openid_logo_alt: "Log in with an OpenID"
       openid_html: "%{logo} OpenID"
       openid_login_button: "Continue"
-      with external: "Alternatively, use a third party to login:"
       openid:
         title: Log in with OpenID
         alt: Log in with an OpenID URL
@@ -2730,22 +2729,22 @@ en:
     new:
       title: "Sign Up"
       tab_title: "Sign up"
+      signup_to_authorize_html: "Sign up with OpenStreetMap to access %{client_app_name}."
       no_auto_account_create: "Unfortunately we are not currently able to create an account for you automatically."
       please_contact_support_html: 'Please contact %{support_link} to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
       support: support
       about:
         header: Free and editable.
         paragraph_1: Unlike other maps, OpenStreetMap is completely created by people like you, and it's free for anyone to fix, update, download and use.
-        paragraph_2: Sign up to get started contributing. We'll send an email to confirm your account.
+        paragraph_2: Sign up to get started contributing.
         welcome: "Welcome to OpenStreetMap"
       duplicate_social_email: "If you already have an OpenStreetMap account and wish to use a 3rd party identity provider, please log in using your password and modify the settings of your account."
       display name description: "Your publicly displayed username. You can change this later in the preferences."
-      by_signing_up_html: "By signing up, you agree to our %{contributor_terms_link} and %{tou_link}."
+      by_signing_up_html: "By signing up, you agree to our %{tou_link}, %{privacy_policy_link} and %{contributor_terms_link}."
+      tou: "terms of use"
       contributor_terms_url: "https://wiki.osmfoundation.org/wiki/Licence/Contributor_Terms"
-      contributor_terms: "Contributor terms"
+      contributor_terms: "contributor terms"
       external auth: "Third Party Authentication:"
-      use external auth: "Alternatively, use a third party to log in"
-      auth no password: "With third party authentication a password is not required, but some extra tools or server may still need one."
       continue: Sign Up
       terms accepted: "Thanks for accepting the new contributor terms!"
       email_help_html: 'Your address is not displayed publicly, see our %{privacy_policy_link} for more information.'
@@ -2755,6 +2754,8 @@ en:
       consider_pd_html: "I consider my contributions to be in the %{consider_pd_link}."
       consider_pd: "public domain"
       consider_pd_url: https://wiki.osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
+      or: "or"
+      use external auth: "or sign up with a third party"
     terms:
       title: "Terms"
       heading: "Terms"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1850,7 +1850,6 @@ en:
       heading: "Log in"
       email or username: "Email Address or Username"
       password: "Password"
-      openid_html: "%{logo} OpenID"
       remember: "Remember me"
       lost password link: "Lost your password?"
       login_button: "Log in"
@@ -1858,32 +1857,6 @@ en:
       with external: "Alternatively, use a third party to log in:"
       no account: Don't have an account?
       auth failure: "Sorry, could not log in with those details."
-      openid_logo_alt: "Log in with an OpenID"
-      auth_providers:
-        openid:
-          title: Log in with OpenID
-          alt: Log in with an OpenID URL
-        google:
-          title: Log in with Google
-          alt: Log in with a Google OpenID
-        facebook:
-          title: Log in with Facebook
-          alt: Log in with a Facebook Account
-        microsoft:
-          title: Log in with Microsoft
-          alt: Log in with a Microsoft Account
-        github:
-          title: Log in with GitHub
-          alt: Log in with a GitHub Account
-        wikipedia:
-          title: Log in with Wikipedia
-          alt: Log in with a Wikipedia Account
-        wordpress:
-          title: Log in with Wordpress
-          alt: Log in with a Wordpress OpenID
-        aol:
-          title: Log in with AOL
-          alt: Log in with an AOL OpenID
     destroy:
       title: "Logout"
       heading: "Logout from OpenStreetMap"
@@ -2598,6 +2571,35 @@ en:
       oauth2_applications: OAuth 2 applications
       oauth2_authorizations: OAuth 2 authorizations
       muted_users: Muted Users
+    auth_providers:
+      openid_logo_alt: "Log in with an OpenID"
+      openid_html: "%{logo} OpenID"
+      openid_login_button: "Continue"
+      with external: "Alternatively, use a third party to login:"
+      openid:
+        title: Log in with OpenID
+        alt: Log in with an OpenID URL
+      google:
+        title: Log in with Google
+        alt: Log in with a Google OpenID
+      facebook:
+        title: Log in with Facebook
+        alt: Log in with a Facebook Account
+      microsoft:
+        title: Log in with Microsoft
+        alt: Log in with a Microsoft Account
+      github:
+        title: Log in with GitHub
+        alt: Log in with a GitHub Account
+      wikipedia:
+        title: Log in with Wikipedia
+        alt: Log in with a Wikipedia Account
+      wordpress:
+        title: Log in with Wordpress
+        alt: Log in with a Wordpress OpenID
+      aol:
+        title: Log in with AOL
+        alt: Log in with an AOL OpenID
   oauth:
     authorize:
       title: "Authorize access to your account"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2735,6 +2735,9 @@ en:
         paragraph_1: Unlike other maps, OpenStreetMap is completely created by people like you, and it's free for anyone to fix, update, download and use.
         paragraph_2: Sign up to get started contributing. We'll send an email to confirm your account.
       display name description: "Your publicly displayed username. You can change this later in the preferences."
+      by_signing_up_html: "By signing up, you agree to our %{contributor_terms_link} and %{tou_link}."
+      contributor_terms_url: "https://wiki.osmfoundation.org/wiki/Licence/Contributor_Terms"
+      contributor_terms: "Contributor terms"
       external auth: "Third Party Authentication:"
       use external auth: "Alternatively, use a third party to log in"
       auth no password: "With third party authentication a password is not required, but some extra tools or server may still need one."
@@ -2744,6 +2747,9 @@ en:
       privacy_policy: privacy policy
       privacy_policy_url: https://wiki.osmfoundation.org/wiki/Privacy_Policy
       privacy_policy_title: OSMF privacy policy including section on email addresses
+      consider_pd: "In addition to the above, I consider my contributions to be in the Public Domain"
+      consider_pd_why: "what's this?"
+      consider_pd_why_url: https://wiki.osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
     terms:
       title: "Terms"
       heading: "Terms"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1847,6 +1847,7 @@ en:
   sessions:
     new:
       title: "Log in"
+      tab_title: "Log in"
       heading: "Log in"
       email or username: "Email Address or Username"
       password: "Password"
@@ -2728,6 +2729,7 @@ en:
   users:
     new:
       title: "Sign Up"
+      tab_title: "Sign up"
       no_auto_account_create: "Unfortunately we are not currently able to create an account for you automatically."
       please_contact_support_html: 'Please contact %{support_link} to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
       support: support

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,7 +142,6 @@ en:
         auth_provider: Authentication Provider
         auth_uid: Authentication UID
         email: "Email"
-        email_confirmation: "Email Confirmation"
         new_email: "New Email Address"
         active: "Active"
         display_name: "Display Name"
@@ -2743,7 +2742,7 @@ en:
       auth no password: "With third party authentication a password is not required, but some extra tools or server may still need one."
       continue: Sign Up
       terms accepted: "Thanks for accepting the new contributor terms!"
-      email_confirmation_help_html: 'Your address is not displayed publicly, see our %{privacy_policy_link} for more information.'
+      email_help_html: 'Your address is not displayed publicly, see our %{privacy_policy_link} for more information.'
       privacy_policy: privacy policy
       privacy_policy_url: https://wiki.osmfoundation.org/wiki/Privacy_Policy
       privacy_policy_title: OSMF privacy policy including section on email addresses

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2731,7 +2731,7 @@ en:
       please_contact_support_html: 'Please contact %{support_link} to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
       support: support
       about:
-        header: Free and editable
+        header: Free and editable.
         paragraph_1: Unlike other maps, OpenStreetMap is completely created by people like you, and it's free for anyone to fix, update, download and use.
         paragraph_2: Sign up to get started contributing. We'll send an email to confirm your account.
       display name description: "Your publicly displayed username. You can change this later in the preferences."

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -38,7 +38,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_get
     user = build(:user, :pending)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     get user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
@@ -50,7 +49,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     # Get the confirmation page
@@ -71,7 +69,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post logout_path
@@ -85,7 +82,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
@@ -96,7 +92,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post logout_path
@@ -111,7 +106,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post logout_path
@@ -125,7 +119,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string, :referer => new_diary_entry_path }
@@ -136,7 +129,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post logout_path
@@ -151,7 +143,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     travel 2.weeks do
@@ -165,7 +156,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string, :referer => new_diary_entry_path }
@@ -183,7 +173,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     User.find_by(:display_name => user.display_name).hide!
@@ -201,7 +190,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_resend_success
     user = build(:user, :pending)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
 
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
       perform_enqueued_jobs do
@@ -220,25 +208,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     ActionMailer::Base.deliveries.clear
   end
 
-  def test_confirm_resend_no_token
-    user = build(:user, :pending)
-    # only complete first half of registration
-    post user_new_path, :params => { :user => user.attributes }
-
-    assert_no_difference "ActionMailer::Base.deliveries.size" do
-      perform_enqueued_jobs do
-        get user_confirm_resend_path(user)
-      end
-    end
-
-    assert_redirected_to login_path
-    assert_match "User #{user.display_name} not found.", flash[:error]
-  end
-
   def test_confirm_resend_deleted
     user = build(:user, :pending)
     post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
 
     User.find_by(:display_name => user.display_name).hide!
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -82,7 +82,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         assert_select "div#content", :count => 1 do
           assert_select "form[action='/user/new'][method='post']", :count => 1 do
             assert_select "input[id='user_email']", :count => 1
-            assert_select "input[id='user_email_confirmation']", :count => 1
             assert_select "input[id='user_display_name']", :count => 1
             assert_select "input[id='user_pass_crypt'][type='password']", :count => 1
             assert_select "input[id='user_pass_crypt_confirmation'][type='password']", :count => 1

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -106,18 +106,10 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_new_success
     user = build(:user, :pending)
 
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_new_path, :params => { :user => user.attributes }
-        end
-      end
-    end
-
     assert_difference "User.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 1 do
         perform_enqueued_jobs do
-          post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
+          post user_new_path, :params => { :user => user.attributes }
         end
       end
     end
@@ -151,55 +143,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "form > div > input.is-invalid#user_email"
   end
 
-  def test_save_duplicate_email
+  def test_new_duplicate_email_uppercase
     user = build(:user, :pending)
-
-    # Set up our user as being half-way through registration
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_new_path, :params => { :user => user.attributes }
-        end
-      end
-    end
-
-    # Now create another user with that email
-    create(:user, :email => user.email)
-
-    # Check that the second half of registration fails
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
-        end
-      end
-    end
-
-    assert_response :success
-    assert_template "new"
-    assert_select "form > div > input.is-invalid#user_email"
-  end
-
-  def test_save_duplicate_email_uppercase
-    user = build(:user, :pending)
-
-    # Set up our user as being half-way through registration
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_new_path, :params => { :user => user.attributes }
-        end
-      end
-    end
-
-    # Now create another user with that email, but uppercased
     create(:user, :email => user.email.upcase)
 
-    # Check that the second half of registration fails
     assert_no_difference "User.count" do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
         perform_enqueued_jobs do
-          post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
+          post user_new_path, :params => { :user => user.attributes }
         end
       end
     end
@@ -209,26 +160,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "form > div > input.is-invalid#user_email"
   end
 
-  def test_save_duplicate_name
+  def test_new_duplicate_name
     user = build(:user, :pending)
-
-    # Set up our user as being half-way through registration
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_new_path, :params => { :user => user.attributes }
-        end
-      end
-    end
-
-    # Now create another user with that display name
     create(:user, :display_name => user.display_name)
 
-    # Check that the second half of registration fails
     assert_no_difference "User.count" do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
         perform_enqueued_jobs do
-          post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
+          post user_new_path, :params => { :user => user.attributes }
         end
       end
     end
@@ -238,26 +177,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "form > div > input.is-invalid#user_display_name"
   end
 
-  def test_save_duplicate_name_uppercase
+  def test_new_duplicate_name_uppercase
     user = build(:user, :pending)
-
-    # Set up our user as being half-way through registration
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_new_path, :params => { :user => user.attributes }
-        end
-      end
-    end
-
-    # Now create another user with that display_name, but uppercased
     create(:user, :display_name => user.display_name.upcase)
 
-    # Check that the second half of registration fails
     assert_no_difference "User.count" do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
         perform_enqueued_jobs do
-          post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
+          post user_new_path, :params => { :user => user.attributes }
         end
       end
     end
@@ -267,17 +194,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "form > div > input.is-invalid#user_display_name"
   end
 
-  def test_save_blocked_domain
+  def test_new_blocked_domain
     user = build(:user, :pending, :email => "user@example.net")
-
-    # Set up our user as being half-way through registration
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_new_path, :params => { :user => user.attributes }
-        end
-      end
-    end
 
     # Now block that domain
     create(:acl, :domain => "example.net", :k => "no_account_creation")
@@ -286,7 +204,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "User.count" do
       assert_no_difference "ActionMailer::Base.deliveries.size" do
         perform_enqueued_jobs do
-          post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
+          post user_new_path, :params => { :user => user.attributes }
         end
       end
     end
@@ -298,18 +216,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_save_referer_params
     user = build(:user, :pending)
 
-    # Set up our user as being half-way through registration
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_new_path, :params => { :user => user.attributes, :referer => "/edit?editor=id#map=1/2/3" }
-        end
-      end
-    end
-
     assert_difference "User.count", 1 do
       assert_difference "ActionMailer::Base.deliveries.size", 1 do
-        post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
+        post user_new_path, :params => { :user => user.attributes, :referer => "/edit?editor=id#map=1/2/3" }
         assert_enqueued_with :job => ActionMailer::MailDeliveryJob,
                              :args => proc { |args| args[3][:args][2] == welcome_path(:editor => "id", :zoom => 1, :lat => 2, :lon => 3) }
         perform_enqueued_jobs
@@ -317,24 +226,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
 
     ActionMailer::Base.deliveries.clear
-  end
-
-  def test_terms_new_user
-    user = build(:user, :pending)
-
-    # Set up our user as being half-way through registration
-    assert_no_difference "User.count" do
-      assert_no_difference "ActionMailer::Base.deliveries.size" do
-        perform_enqueued_jobs do
-          post user_new_path, :params => { :user => user.attributes }
-        end
-      end
-    end
-
-    get user_terms_path
-
-    assert_response :success
-    assert_template :terms
   end
 
   def test_terms_agreed

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -116,8 +116,8 @@ class UserHelperTest < ActionView::TestCase
 
   def test_auth_button
     button = auth_button("google", "google")
-    img_tag = "<img alt=\"Log in with a Google OpenID\" class=\"rounded-3\" src=\"/images/google.svg\" width=\"36\" height=\"36\" />"
-    assert_equal("<a class=\"auth_button\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
+    img_tag = "<img alt=\"Log in with a Google OpenID\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"24\" height=\"24\" />"
+    assert_equal("<a class=\"auth_button p-2 d-block\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
   end
 
   private

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -32,7 +32,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => dup_email,
-                                       :email_confirmation => dup_email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
                                        :pass_crypt_confirmation => "testtest",
@@ -54,7 +53,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => email,
-                                       :email_confirmation => email,
                                        :display_name => dup_display_name,
                                        :pass_crypt => "testtest",
                                        :pass_crypt_confirmation => "testtest" } }
@@ -74,7 +72,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => email,
-                                       :email_confirmation => email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
                                        :pass_crypt_confirmation => "blahblah" } }
@@ -95,7 +92,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
                                        :pass_crypt_confirmation => "testtest",
@@ -151,7 +147,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :pass_crypt => password,
                                        :pass_crypt_confirmation => password,
@@ -204,7 +199,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "openid",
                                        :auth_uid => "http://localhost:1123/new.tester",
@@ -238,7 +232,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "openid",
                                        :auth_uid => "http://localhost:1123/new.tester",
@@ -274,7 +267,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "openid",
                                        :auth_uid => "http://localhost:1123/new.tester",
@@ -333,7 +325,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "google",
                                        :pass_crypt => password,
@@ -366,7 +357,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "google",
                                        :pass_crypt => "",
@@ -403,7 +393,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "google",
                                        :pass_crypt => "testtest",
@@ -461,7 +450,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "facebook",
                                        :pass_crypt => password,
@@ -494,7 +482,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "facebook",
                                        :pass_crypt => "",
@@ -529,7 +516,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "facebook",
                                        :pass_crypt => "testtest",
@@ -587,7 +573,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "microsoft",
                                        :pass_crypt => password,
@@ -620,7 +605,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "microsoft",
                                        :pass_crypt => "",
@@ -655,7 +639,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "microsoft",
                                        :pass_crypt => "testtest",
@@ -713,7 +696,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "github",
                                        :pass_crypt => password,
@@ -746,7 +728,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "github",
                                        :pass_crypt => "",
@@ -781,7 +762,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "github",
                                        :pass_crypt => "testtest",
@@ -839,7 +819,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "wikipedia",
                                        :pass_crypt => password,
@@ -872,7 +851,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "wikipedia",
                                        :pass_crypt => "",
@@ -907,7 +885,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs do
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :email_confirmation => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "wikipedia",
                                        :pass_crypt => "testtest",

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -366,7 +366,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_google_success
     new_email = "newtester-google@osm.org"
-    verified_email = UsersController.message_hmac(new_email)
+    email_hmac = UsersController.message_hmac(new_email)
     display_name = "new_tester-google"
     auth_uid = "123454321"
 
@@ -382,7 +382,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "google")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => new_email, :verified_email => verified_email,
+                               :email => new_email, :email_hmac => email_hmac,
                                :auth_provider => "google", :auth_uid => auth_uid
           follow_redirect!
 
@@ -392,7 +392,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "google",
                                        :auth_uid => auth_uid,
                                        :consider_pd => "1" },
-                            :verified_email => verified_email }
+                            :email_hmac => email_hmac }
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -420,7 +420,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
     assert_redirected_to :controller => :users, :action => "new", :nickname => display_name, :email => dup_user.email,
-                         :verified_email => UsersController.message_hmac(dup_user.email),
+                         :email_hmac => UsersController.message_hmac(dup_user.email),
                          :auth_provider => "google", :auth_uid => auth_uid
     follow_redirect!
 
@@ -452,7 +452,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_google_redirect
     orig_email = "redirect_tester_google_orig@google.com"
-    verified_email = UsersController.message_hmac(orig_email)
+    email_hmac = UsersController.message_hmac(orig_email)
     new_email =  "redirect_tester_google@osm.org"
     display_name = "redirect_tester_google"
     auth_uid = "123454321"
@@ -469,12 +469,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "google")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => orig_email, :verified_email => verified_email,
+                               :email => orig_email, :email_hmac => email_hmac,
                                :auth_provider => "google", :auth_uid => auth_uid
           follow_redirect!
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :verified_email => verified_email,
+                                       :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "google",
                                        :auth_uid => auth_uid,
@@ -516,7 +516,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_facebook_success
     new_email = "newtester-facebook@osm.org"
-    verified_email = UsersController.message_hmac(new_email)
+    email_hmac = UsersController.message_hmac(new_email)
     display_name = "new_tester-facebook"
     auth_uid = "123454321"
 
@@ -531,7 +531,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "facebook")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => new_email, :verified_email => verified_email,
+                               :email => new_email, :email_hmac => email_hmac,
                                :auth_provider => "facebook", :auth_uid => auth_uid
           follow_redirect!
 
@@ -541,7 +541,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "facebook",
                                        :auth_uid => auth_uid,
                                        :consider_pd => "1" },
-                            :verified_email => verified_email }
+                            :email_hmac => email_hmac }
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -568,7 +568,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
     assert_redirected_to :controller => :users, :action => "new", :nickname => display_name, :email => dup_user.email,
-                         :verified_email => UsersController.message_hmac(dup_user.email),
+                         :email_hmac => UsersController.message_hmac(dup_user.email),
                          :auth_provider => "facebook", :auth_uid => auth_uid
     follow_redirect!
 
@@ -600,7 +600,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_facebook_redirect
     orig_email = "redirect_tester_facebook_orig@osm.org"
-    verified_email = UsersController.message_hmac(orig_email)
+    email_hmac = UsersController.message_hmac(orig_email)
     new_email = "redirect_tester_facebook@osm.org"
     display_name = "redirect_tester_facebook"
     auth_uid = "123454321"
@@ -617,13 +617,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "facebook")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => orig_email, :verified_email => verified_email,
+                               :email => orig_email, :email_hmac => email_hmac,
                                :auth_provider => "facebook", :auth_uid => auth_uid
           follow_redirect!
 
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :verified_email => verified_email,
+                                       :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "facebook",
                                        :auth_uid => auth_uid,
@@ -665,7 +665,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_microsoft_success
     new_email = "newtester-microsoft@osm.org"
-    verified_email = UsersController.message_hmac(new_email)
+    email_hmac = UsersController.message_hmac(new_email)
     display_name = "new_tester-microsoft"
     auth_uid = "123454321"
 
@@ -680,7 +680,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "microsoft")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => new_email, :verified_email => verified_email,
+                               :email => new_email, :email_hmac => email_hmac,
                                :auth_provider => "microsoft", :auth_uid => auth_uid
           follow_redirect!
           post "/user/new",
@@ -689,7 +689,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "microsoft",
                                        :auth_uid => auth_uid,
                                        :consider_pd => "1" },
-                            :verified_email => verified_email }
+                            :email_hmac => email_hmac }
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -716,7 +716,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_redirected_to auth_success_path(:provider => "microsoft")
     follow_redirect!
     assert_redirected_to :controller => :users, :action => "new", :nickname => display_name, :email => dup_user.email,
-                         :verified_email => UsersController.message_hmac(dup_user.email),
+                         :email_hmac => UsersController.message_hmac(dup_user.email),
                          :auth_provider => "microsoft", :auth_uid => auth_uid
     follow_redirect!
 
@@ -748,7 +748,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_microsoft_redirect
     orig_email = "redirect_tester_microsoft_orig@osm.org"
-    verified_email = UsersController.message_hmac(orig_email)
+    email_hmac = UsersController.message_hmac(orig_email)
     new_email = "redirect_tester_microsoft@osm.org"
     display_name = "redirect_tester_microsoft"
     auth_uid = "123454321"
@@ -764,13 +764,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "microsoft")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => orig_email, :verified_email => verified_email,
+                               :email => orig_email, :email_hmac => email_hmac,
                                :auth_provider => "microsoft", :auth_uid => auth_uid
           follow_redirect!
 
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :verified_email => verified_email,
+                                       :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "microsoft",
                                        :auth_uid => auth_uid,
@@ -812,7 +812,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_github_success
     new_email = "newtester-github@osm.org"
-    verified_email = UsersController.message_hmac(new_email)
+    email_hmac = UsersController.message_hmac(new_email)
     display_name = "new_tester-github"
     password = "testtest"
     auth_uid = "123454321"
@@ -828,7 +828,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "github")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => new_email, :verified_email => verified_email,
+                               :email => new_email, :email_hmac => email_hmac,
                                :auth_provider => "github", :auth_uid => auth_uid
           follow_redirect!
 
@@ -841,7 +841,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => password },
                             :read_ct => 1,
                             :read_tou => 1,
-                            :verified_email => verified_email }
+                            :email_hmac => email_hmac }
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -869,7 +869,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
     assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                         :email => dup_user.email, :verified_email => UsersController.message_hmac(dup_user.email),
+                         :email => dup_user.email, :email_hmac => UsersController.message_hmac(dup_user.email),
                          :auth_provider => "github", :auth_uid => auth_uid
     follow_redirect!
 
@@ -900,7 +900,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_github_redirect
     orig_email = "redirect_tester_github_orig@osm.org"
-    verified_email = UsersController.message_hmac(orig_email)
+    email_hmac = UsersController.message_hmac(orig_email)
     new_email = "redirect_tester_github@osm.org"
     display_name = "redirect_tester_github"
     auth_uid = "123454321"
@@ -916,12 +916,12 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "github")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => orig_email, :verified_email => verified_email,
+                               :email => orig_email, :email_hmac => email_hmac,
                                :auth_provider => "github", :auth_uid => auth_uid
           follow_redirect!
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :verified_email => verified_email,
+                                       :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "github",
                                        :auth_uid => auth_uid,
@@ -963,7 +963,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_wikipedia_success
     new_email = "newtester-wikipedia@osm.org"
-    verified_email = UsersController.message_hmac(new_email)
+    email_hmac = UsersController.message_hmac(new_email)
     display_name = "new_tester-wikipedia"
     password = "testtest"
     auth_uid = "123454321"
@@ -979,7 +979,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => new_email, :verified_email => verified_email,
+                               :email => new_email, :email_hmac => email_hmac,
                                :auth_provider => "wikipedia", :auth_uid => auth_uid
           follow_redirect!
           post "/user/new",
@@ -991,7 +991,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => password },
                             :read_ct => 1,
                             :read_tou => 1,
-                            :verified_email => verified_email }
+                            :email_hmac => email_hmac }
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -1016,7 +1016,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
     follow_redirect!
     assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                         :email => dup_user.email, :verified_email => UsersController.message_hmac(dup_user.email),
+                         :email => dup_user.email, :email_hmac => UsersController.message_hmac(dup_user.email),
                          :auth_provider => "wikipedia", :auth_uid => auth_uid
     follow_redirect!
 
@@ -1048,7 +1048,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
   def test_user_create_wikipedia_redirect
     orig_email = "redirect_tester_wikipedia_orig@osm.org"
-    verified_email = UsersController.message_hmac(orig_email)
+    email_hmac = UsersController.message_hmac(orig_email)
     new_email = "redirect_tester_wikipedia@osm.org"
     display_name = "redirect_tester_wikipedia"
     auth_uid = "123454321"
@@ -1065,13 +1065,13 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name,
-                               :email => orig_email, :verified_email => verified_email,
+                               :email => orig_email, :email_hmac => email_hmac,
                                :auth_provider => "wikipedia", :auth_uid => auth_uid
           follow_redirect!
 
           post "/user/new",
                :params => { :user => { :email => new_email,
-                                       :verified_email => verified_email,
+                                       :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "wikipedia",
                                        :auth_uid => auth_uid,

--- a/test/system/confirmation_resend_test.rb
+++ b/test/system/confirmation_resend_test.rb
@@ -13,10 +13,6 @@ class ConfirmationResendSystemTest < ApplicationSystemTestCase
       fill_in "Confirm Password", :with => "testtest"
       click_on "Sign Up"
     end
-
-    check "I have read and agree to the above contributor terms"
-    check "I have read and agree to the Terms of Use"
-    click_on "Continue"
   end
 
   test "flash message should not contain raw html" do

--- a/test/system/confirmation_resend_test.rb
+++ b/test/system/confirmation_resend_test.rb
@@ -7,7 +7,6 @@ class ConfirmationResendSystemTest < ApplicationSystemTestCase
 
     within ".new_user" do
       fill_in "Email", :with => @user.email
-      fill_in "Email Confirmation", :with => @user.email
       fill_in "Display Name", :with => @user.display_name
       fill_in "Password", :with => "testtest"
       fill_in "Confirm Password", :with => "testtest"

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -4,7 +4,7 @@ class UserSignupTest < ApplicationSystemTestCase
   test "Sign up from login page" do
     visit login_path
 
-    click_on "Register now"
+    click_on "Sign up"
 
     assert_content "Confirm Password"
   end

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -8,25 +8,4 @@ class UserSignupTest < ApplicationSystemTestCase
 
     assert_content "Confirm Password"
   end
-
-  test "externally redirect when contributor terms declined" do
-    user = build(:user)
-
-    visit root_path
-    click_on "Sign Up"
-
-    within ".new_user" do
-      fill_in "Email", :with => user.email
-      fill_in "Email Confirmation", :with => user.email
-      fill_in "Display Name", :with => user.display_name
-      fill_in "Password", :with => "testtest"
-      fill_in "Confirm Password", :with => "testtest"
-      click_on "Sign Up"
-    end
-
-    assert_content "Contributor terms"
-    click_on "Cancel"
-
-    assert_current_path "https://wiki.openstreetmap.org/wiki/Contributor_Terms_Declined"
-  end
 end


### PR DESCRIPTION
Implements proposal discussed in [Issue 4128](https://github.com/openstreetmap/openstreetmap-website/issues/4128).

- Merge Signup screen and Terms screen during signup process.
- Use links to Contributor terms and Terms of use instead of in-place edit box.
- Terms screen used for accepting the new terms left unchanged.
- Re-arranged signup and login screens to feel like two tabs as in #4128.
- Add `preferred_auth_provider` parameter to signup and login screens, as well as the authorization request.
  This allows 3rd party apps to initiate authorization by adding `preferred_auth_provider`
  
  Screenshots in dev environment:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/99971018/0743bde6-90e6-4bd8-aacc-f9516499024c)
  
![image](https://github.com/openstreetmap/openstreetmap-website/assets/99971018/6547e215-8e15-4e72-bd80-8157b503efa6)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/99971018/82c2263e-f5ef-46c3-ab70-bcf3fdb7cc59)
