### PR TITLE
Add :closed trait to note factory

### DIFF
--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -345,7 +345,7 @@ module Api
       end
       assert_response :gone
 
-      closed_note_with_comment = create(:note_with_comments, :status => "closed", :closed_at => Time.now.utc)
+      closed_note_with_comment = create(:note_with_comments, :closed)
 
       assert_no_difference "NoteComment.count" do
         post comment_api_note_path(:id => closed_note_with_comment, :text => "This is an additional comment"), :headers => auth_header
@@ -406,14 +406,14 @@ module Api
       post close_api_note_path(:id => hidden_note_with_comment), :headers => auth_header
       assert_response :gone
 
-      closed_note_with_comment = create(:note_with_comments, :status => "closed", :closed_at => Time.now.utc)
+      closed_note_with_comment = create(:note_with_comments, :closed)
 
       post close_api_note_path(:id => closed_note_with_comment), :headers => auth_header
       assert_response :conflict
     end
 
     def test_reopen_success
-      closed_note_with_comment = create(:note_with_comments, :status => "closed", :closed_at => Time.now.utc)
+      closed_note_with_comment = create(:note_with_comments, :closed)
       user = create(:user)
 
       post reopen_api_note_path(:id => closed_note_with_comment, :text => "This is a reopen comment", :format => "json")
@@ -428,7 +428,7 @@ module Api
       assert_equal "Feature", js["type"]
       assert_equal closed_note_with_comment.id, js["properties"]["id"]
       assert_equal "open", js["properties"]["status"]
-      assert_equal 2, js["properties"]["comments"].count
+      assert_equal 3, js["properties"]["comments"].count
       assert_equal "reopened", js["properties"]["comments"].last["action"]
       assert_equal "This is a reopen comment", js["properties"]["comments"].last["text"]
       assert_equal user.display_name, js["properties"]["comments"].last["user"]
@@ -440,7 +440,7 @@ module Api
       assert_equal "Feature", js["type"]
       assert_equal closed_note_with_comment.id, js["properties"]["id"]
       assert_equal "open", js["properties"]["status"]
-      assert_equal 2, js["properties"]["comments"].count
+      assert_equal 3, js["properties"]["comments"].count
       assert_equal "reopened", js["properties"]["comments"].last["action"]
       assert_equal "This is a reopen comment", js["properties"]["comments"].last["text"]
       assert_equal user.display_name, js["properties"]["comments"].last["user"]
@@ -752,8 +752,8 @@ module Api
     end
 
     def test_index_closed
-      create(:note_with_comments, :status => "closed", :closed_at => Time.now.utc - 5.days)
-      create(:note_with_comments, :status => "closed", :closed_at => Time.now.utc - 100.days)
+      create(:note_with_comments, :closed, :closed_at => Time.now.utc - 5.days)
+      create(:note_with_comments, :closed, :closed_at => Time.now.utc - 100.days)
       create(:note_with_comments, :status => "hidden")
       create(:note_with_comments)
 

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -144,9 +144,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
 
   def test_read_closed_note
     user = create(:user)
-    closed_note = create(:note_with_comments, :status => "closed", :closed_at => Time.now.utc, :comments_count => 2) do |note|
-      create(:note_comment, :event => "closed", :note => note, :author => user)
-    end
+    closed_note = create(:note_with_comments, :closed, :closed_by => user, :comments_count => 2)
 
     browse_check :note_path, closed_note.id, "notes/show"
     assert_select "div.note-comments ul li", :count => 2

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -5,11 +5,15 @@ FactoryBot.define do
     # tile { QuadTile.tile_for_point(1,1) }
 
     trait :closed do
+      transient do
+        closed_by { nil }
+      end
+
       status { "closed" }
       closed_at { Time.now.utc }
 
-      after(:create) do |note|
-        create(:note_comment, :body => "Closing comment", :event => "closed", :note => note)
+      after(:create) do |note, context|
+        create(:note_comment, :author => context.closed_by, :body => "Closing comment", :event => "closed", :note => note)
       end
     end
 

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -4,6 +4,15 @@ FactoryBot.define do
     longitude { 1 * GeoRecord::SCALE }
     # tile { QuadTile.tile_for_point(1,1) }
 
+    trait :closed do
+      status { "closed" }
+      closed_at { Time.now.utc }
+
+      after(:create) do |note|
+        create(:note_comment, :body => "Closing comment", :event => "closed", :note => note)
+      end
+    end
+
     factory :note_with_comments do
       transient do
         comments_count { 1 }

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -14,7 +14,7 @@ class NoteTest < ActiveSupport::TestCase
     bad.each do |status|
       note = create(:note)
       note.status = status
-      assert_not note.valid?, "#{status} is valid when it shouldn't be"
+      assert_not_predicate note, :valid?, "#{status} is valid when it shouldn't be"
     end
   end
 
@@ -28,7 +28,7 @@ class NoteTest < ActiveSupport::TestCase
   end
 
   def test_reopen
-    note = create(:note, :status => "closed", :closed_at => Time.now.utc)
+    note = create(:note, :closed)
     assert_equal "closed", note.status
     assert_not_nil note.closed_at
     note.reopen
@@ -38,13 +38,13 @@ class NoteTest < ActiveSupport::TestCase
 
   def test_visible?
     assert_predicate create(:note, :status => "open"), :visible?
-    assert_predicate create(:note, :status => "closed"), :visible?
-    assert_not create(:note, :status => "hidden").visible?
+    assert_predicate create(:note, :closed), :visible?
+    assert_not_predicate create(:note, :status => "hidden"), :visible?
   end
 
   def test_closed?
-    assert_predicate create(:note, :status => "closed", :closed_at => Time.now.utc), :closed?
-    assert_not create(:note, :status => "open", :closed_at => nil).closed?
+    assert_predicate create(:note, :closed), :closed?
+    assert_not_predicate create(:note, :status => "open", :closed_at => nil), :closed?
   end
 
   def test_author

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -11,7 +11,7 @@ class NoteCommentsTest < ApplicationSystemTestCase
   end
 
   test "closed note has no login notice" do
-    note = create(:note_with_comments, :status => "closed", :closed_at => Time.now.utc)
+    note = create(:note_with_comments, :closed)
     visit note_path(note)
 
     assert_no_button "Reactivate"


### PR DESCRIPTION
Currently you create a closed note in tests like this:

```ruby
create(:note, :status => "closed", :closed_at => Time.now.utc)
```

You have to remember to set `:closed_at`. There's code that assumes that closed notes have this time set. If omitted, it's going to be unset.

Here I add the `:closed` trait to the note factory that will set `:closed_at` and also add a closing comment.