### PR TITLE
Show dates as <time> elements on issues pages

### DIFF
--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -7,7 +7,8 @@
       <div class="col">
         <p class="text-muted">
           <%= t ".comment_from_html", :user_link => link_to(comment.user.display_name, user_path(comment.user)),
-                                      :comment_created_at => l(comment.created_at.to_datetime, :format => :friendly) %>
+                                      :comment_created_at => tag.time(l(comment.created_at.to_datetime, :format => :friendly),
+                                                                      :datetime => comment.created_at.xmlschema) %>
         </p>
         <div class="richtext text-break"><%= comment.body.to_html %></div>
       </div>

--- a/app/views/issues/_reports.html.erb
+++ b/app/views/issues/_reports.html.erb
@@ -7,7 +7,8 @@
       <p class="text-muted">
         <%= t ".reported_by_html", :category => report.category,
                                    :user => link_to(report.user.display_name, user_path(report.user)),
-                                   :updated_at => l(report.updated_at.to_datetime, :format => :friendly) %>
+                                   :updated_at => tag.time(l(report.updated_at.to_datetime, :format => :friendly),
+                                                           :datetime => report.updated_at.xmlschema) %>
       </p>
       <div class="richtext text-break"><%= report.details.to_html %></div>
     </div>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -9,15 +9,18 @@
     <% else %>
       | <%= t ".no_reports" %>
     <% end %>
-      | <%= t ".report_created_at",
-              :datetime => l(@issue.created_at.to_datetime, :format => :friendly) %>
+      | <%= t ".report_created_at_html",
+              :datetime => tag.time(l(@issue.created_at.to_datetime, :format => :friendly),
+                                    :datetime => @issue.created_at.xmlschema) %>
     <% if @issue.resolved_at? %>
-      | <%= t ".last_resolved_at",
-              :datetime => l(@issue.resolved_at.to_datetime, :format => :friendly) %>
+      | <%= t ".last_resolved_at_html",
+              :datetime => tag.time(l(@issue.resolved_at.to_datetime, :format => :friendly),
+                                    :datetime => @issue.resolved_at.xmlschema) %>
     <% end %>
     <% if @issue.user_updated %>
-      | <%= t ".last_updated_at",
-              :datetime => l(@issue.updated_at.to_datetime, :format => :friendly),
+      | <%= t ".last_updated_at_html",
+              :datetime => tag.time(l(@issue.updated_at.to_datetime, :format => :friendly),
+                                    :datetime => @issue.updated_at.xmlschema),
               :displayname => @issue.user_updated.display_name %>
     <% end %>
   </small>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -9,9 +9,17 @@
     <% else %>
       | <%= t ".no_reports" %>
     <% end %>
-    | <%= t ".report_created_at", :datetime => l(@issue.created_at.to_datetime, :format => :friendly) %>
-    <%= " | #{t('.last_resolved_at', :datetime => l(@issue.resolved_at.to_datetime, :format => :friendly))}" if @issue.resolved_at? %>
-    <%= " | #{t('.last_updated_at', :datetime => l(@issue.updated_at.to_datetime, :format => :friendly), :displayname => @issue.user_updated.display_name)}" if @issue.user_updated %>
+      | <%= t ".report_created_at",
+              :datetime => l(@issue.created_at.to_datetime, :format => :friendly) %>
+    <% if @issue.resolved_at? %>
+      | <%= t ".last_resolved_at",
+              :datetime => l(@issue.resolved_at.to_datetime, :format => :friendly) %>
+    <% end %>
+    <% if @issue.user_updated %>
+      | <%= t ".last_updated_at",
+              :datetime => l(@issue.updated_at.to_datetime, :format => :friendly),
+              :displayname => @issue.user_updated.display_name %>
+    <% end %>
   </small>
 </p>
 <nav class="secondary-actions">

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -21,7 +21,7 @@
       | <%= t ".last_updated_at_html",
               :datetime => tag.time(l(@issue.updated_at.to_datetime, :format => :friendly),
                                     :datetime => @issue.updated_at.xmlschema),
-              :displayname => @issue.user_updated.display_name %>
+              :displayname => link_to(@issue.user_updated.display_name, user_path(@issue.user_updated)) %>
     <% end %>
   </small>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1439,9 +1439,9 @@ en:
         one: "%{count} report"
         other: "%{count} reports"
       no_reports: No reports
-      report_created_at: "First reported at %{datetime}"
-      last_resolved_at: "Last resolved at %{datetime}"
-      last_updated_at: "Last updated at %{datetime} by %{displayname}"
+      report_created_at_html: "First reported at %{datetime}"
+      last_resolved_at_html: "Last resolved at %{datetime}"
+      last_updated_at_html: "Last updated at %{datetime} by %{displayname}"
       resolve: Resolve
       ignore: Ignore
       reopen: Reopen


### PR DESCRIPTION
It was done with dates everywhere else.

Also link to a profile page of the user who updated the issue. Previously it was just a display name without a link.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/4d61b20a-6d71-474a-8ad2-f730c351edd3)
