### PR TITLE
Remove element web abilities that were copied to api

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -25,12 +25,6 @@ class Ability
       can [:index, :show, :data, :georss, :picture, :icon], Trace
       can [:terms, :new, :create, :save, :suspended, :show, :auth_success, :auth_failure], User
       can [:index, :show, :blocks_on, :blocks_by], UserBlock
-      can [:index, :show], Node
-      can [:index, :show, :full, :ways_for_node], Way
-      can [:index, :show, :full, :relations_for_node, :relations_for_way, :relations_for_relation], Relation
-      can [:history, :version], OldNode
-      can [:history, :version], OldWay
-      can [:history, :version], OldRelation
     end
 
     if user&.active?


### PR DESCRIPTION
When this disentanglement https://github.com/openstreetmap/openstreetmap-website/commit/7b057545c0b2030aad9981bd93699f9e33ad7d5f happened, some abilities we left in `ability.rb` despite being api-related and copied to `api_ability.rb`.

Element abilities are handled by `browse_controller.rb` on the web side.