### PR TITLE
Element version pages

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -8,6 +8,7 @@ class Ability
          :changeset, :query], :browse
     can [:show], OldNode
     can [:show], OldWay
+    can [:show], OldRelation
     can [:show, :new], Note
     can :search, :direction
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :communities, :preview, :copyright, :key, :id], :site

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -7,6 +7,7 @@ class Ability
     can [:relation, :relation_history, :way, :way_history, :node, :node_history,
          :changeset, :query], :browse
     can [:show], OldNode
+    can [:show], OldWay
     can [:show, :new], Note
     can :search, :direction
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :communities, :preview, :copyright, :key, :id], :site

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -6,6 +6,7 @@ class Ability
   def initialize(user)
     can [:relation, :relation_history, :way, :way_history, :node, :node_history,
          :changeset, :query], :browse
+    can [:show], OldNode
     can [:show, :new], Note
     can :search, :direction
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :communities, :preview, :copyright, :key, :id], :site

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -381,6 +381,7 @@ $(document).ready(function () {
     "/node/:id(/history)": OSM.Browse(map, "node"),
     "/node/:id/history/:version": OSM.OldBrowse(),
     "/way/:id(/history)": OSM.Browse(map, "way"),
+    "/way/:id/history/:version": OSM.OldBrowse(),
     "/relation/:id(/history)": OSM.Browse(map, "relation"),
     "/changeset/:id": OSM.Changeset(map),
     "/query": OSM.Query(map)

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -383,6 +383,7 @@ $(document).ready(function () {
     "/way/:id(/history)": OSM.Browse(map, "way"),
     "/way/:id/history/:version": OSM.OldBrowse(),
     "/relation/:id(/history)": OSM.Browse(map, "relation"),
+    "/relation/:id/history/:version": OSM.OldBrowse(),
     "/changeset/:id": OSM.Changeset(map),
     "/query": OSM.Query(map)
   });

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -355,6 +355,16 @@ $(document).ready(function () {
     return page;
   };
 
+  OSM.OldBrowse = function () {
+    var page = {};
+
+    page.pushstate = page.popstate = function (path) {
+      OSM.loadSidebarContent(path);
+    };
+
+    return page;
+  };
+
   var history = OSM.History(map);
 
   OSM.router = OSM.Router(map, {
@@ -369,6 +379,7 @@ $(document).ready(function () {
     "/user/:display_name/history": history,
     "/note/:id": OSM.Note(map),
     "/node/:id(/history)": OSM.Browse(map, "node"),
+    "/node/:id/history/:version": OSM.OldBrowse(),
     "/way/:id(/history)": OSM.Browse(map, "way"),
     "/relation/:id(/history)": OSM.Browse(map, "relation"),
     "/changeset/:id": OSM.Changeset(map),

--- a/app/controllers/old_nodes_controller.rb
+++ b/app/controllers/old_nodes_controller.rb
@@ -1,0 +1,19 @@
+class OldNodesController < ApplicationController
+  layout :map_layout
+
+  before_action :authorize_web
+  before_action :set_locale
+  before_action -> { check_database_readable(:need_api => true) }
+  before_action :require_oauth
+
+  authorize_resource
+
+  around_action :web_timeout
+
+  def show
+    @type = "node"
+    @feature = OldNode.preload(:old_tags, :changeset => [:changeset_tags, :user]).find([params[:id], params[:version]])
+  rescue ActiveRecord::RecordNotFound
+    render :action => "not_found", :status => :not_found
+  end
+end

--- a/app/controllers/old_relations_controller.rb
+++ b/app/controllers/old_relations_controller.rb
@@ -1,0 +1,19 @@
+class OldRelationsController < ApplicationController
+  layout :map_layout
+
+  before_action :authorize_web
+  before_action :set_locale
+  before_action -> { check_database_readable(:need_api => true) }
+  before_action :require_oauth
+
+  authorize_resource
+
+  around_action :web_timeout
+
+  def show
+    @type = "relation"
+    @feature = OldRelation.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_members => :member).find([params[:id], params[:version]])
+  rescue ActiveRecord::RecordNotFound
+    render :action => "not_found", :status => :not_found
+  end
+end

--- a/app/controllers/old_ways_controller.rb
+++ b/app/controllers/old_ways_controller.rb
@@ -1,0 +1,19 @@
+class OldWaysController < ApplicationController
+  layout :map_layout
+
+  before_action :authorize_web
+  before_action :set_locale
+  before_action -> { check_database_readable(:need_api => true) }
+  before_action :require_oauth
+
+  authorize_resource
+
+  around_action :web_timeout
+
+  def show
+    @type = "way"
+    @feature = OldWay.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:node_tags, :ways] }).find([params[:id], params[:version]])
+  rescue ActiveRecord::RecordNotFound
+    render :action => "not_found", :status => :not_found
+  end
+end

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,6 +1,6 @@
 <h4>
   <%= t "browse.version" %>
-  #<%= link_to common_details.version, :controller => "old_#{@type.pluralize}", :action => :show, :version => common_details.version %>
+  #<%= link_to_unless_current common_details.version, :controller => "old_#{@type.pluralize}", :action => :show, :version => common_details.version %>
 </h4>
 
 <p class="fst-italic">

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -19,7 +19,7 @@
   </li>
   <li>
     <%= t "browse.in_changeset" %>
-    #<%= link_to common_details.changeset_id, :action => :changeset, :id => common_details.changeset_id %>
+    #<%= link_to common_details.changeset_id, changeset_path(common_details.changeset) %>
   </li>
 
   <% if @type == "node" and common_details.visible? %>
@@ -33,4 +33,4 @@
   <% end %>
 </ul>
 
-<%= render :partial => "tag_details", :object => common_details.tags %>
+<%= render :partial => "browse/tag_details", :object => common_details.tags %>

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,6 +1,6 @@
 <h4>
   <%= t "browse.version" %>
-  #<%= common_details.version %>
+  #<%= link_to common_details.version, :controller => "old_#{@type.pluralize}", :action => :show, :version => common_details.version %>
 </h4>
 
 <p class="fst-italic">

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -8,7 +8,7 @@
   </div>
 <% else %>
   <div class="browse-section browse-node">
-    <%= render :partial => "common_details", :object => node %>
+    <%= render :partial => "browse/common_details", :object => node %>
 
     <% unless node.ways.empty? and node.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
@@ -17,7 +17,7 @@
           <summary><%= t "browse.part_of_ways", :count => node.ways.uniq.count %></summary>
           <ul class="list-unstyled">
             <% node.ways.uniq.each do |way| %>
-              <li><%= link_to printable_name(way), { :action => "way", :id => way.id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
+              <li><%= link_to printable_name(way), way_path(way), { :class => link_class("way", way), :title => link_title(way) } %></li>
             <% end %>
           </ul>
         </details>
@@ -26,7 +26,7 @@
         <details <%= "open" if node.containing_relation_members.count < 10 %>>
           <summary><%= t "browse.part_of_relations", :count => node.containing_relation_members.uniq.count %></summary>
           <ul class="list-unstyled">
-            <%= render :partial => "containing_relation", :collection => node.containing_relation_members.uniq %>
+            <%= render :partial => "browse/containing_relation", :collection => node.containing_relation_members.uniq %>
           </ul>
         </details>
       <% end %>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -8,7 +8,7 @@
   </div>
 <% else %>
   <div class="browse-section browse-relation">
-    <%= render :partial => "common_details", :object => relation %>
+    <%= render :partial => "browse/common_details", :object => relation %>
 
     <% unless relation.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
@@ -25,7 +25,7 @@
       <details <%= "open" if relation.relation_members.count < 10 %>>
         <summary><%= t ".members_count", :count => relation.relation_members.count %></summary>
         <ul class="list-unstyled">
-          <%= render :partial => "relation_member", :collection => relation.relation_members %>
+          <%= render :partial => "browse/relation_member", :collection => relation.relation_members %>
         </ul>
       </details>
     <% end %>

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -1,5 +1,5 @@
 <% member_class = link_class(relation_member.member_type.downcase, relation_member.member)
-   linked_name = link_to printable_name(relation_member.member), { :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :title => link_title(relation_member.member), :rel => link_follow(relation_member.member) }
+   linked_name = link_to printable_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :title => link_title(relation_member.member), :rel => link_follow(relation_member.member) }
    type_str = t ".type.#{relation_member.member_type.downcase}" %>
 <li class="<%= member_class %>">
   <%= if relation_member.member_role.blank?

--- a/app/views/browse/_tag_details.html.erb
+++ b/app/views/browse/_tag_details.html.erb
@@ -2,7 +2,7 @@
   <h4><%= t ".tags" %></h4>
   <div class='mb-3 border border-grey rounded overflow-hidden'>
     <table class='mb-0 browse-tag-list table align-middle text-break'>
-      <%= render :partial => "tag", :collection => tag_details.sort %>
+      <%= render :partial => "browse/tag", :collection => tag_details.sort %>
     </table>
   </div>
 <% end %>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -8,7 +8,7 @@
   </div>
 <% else %>
   <div class="browse-section browse-way">
-    <%= render :partial => "common_details", :object => way %>
+    <%= render :partial => "browse/common_details", :object => way %>
 
     <% unless way.containing_relation_members.empty? %>
       <h4><%= t "browse.part_of" %></h4>
@@ -27,10 +27,10 @@
         <ul class="list-unstyled">
           <% way.way_nodes.each do |wn| %>
             <li>
-              <%= link_to printable_name(wn.node), { :action => "node", :id => wn.node_id.to_s }, { :class => link_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>
+              <%= link_to printable_name(wn.node), node_path(wn.node), { :class => link_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>
               <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
               <% if related_ways.size > 0 then %>
-                (<%= t ".also_part_of_html", :count => related_ways.size, :related_ways => to_sentence(related_ways.map { |w| link_to(printable_name(w), { :action => "way", :id => w.id.to_s }, { :class => link_class("way", w), :title => link_title(w) }) }) %>)
+                (<%= t ".also_part_of_html", :count => related_ways.size, :related_ways => to_sentence(related_ways.map { |w| link_to(printable_name(w), way_path(w), { :class => link_class("way", w), :title => link_title(w) }) }) %>)
               <% end %>
             </li>
           <% end %>

--- a/app/views/browse/feature.html.erb
+++ b/app/views/browse/feature.html.erb
@@ -4,10 +4,19 @@
 
 <%= render :partial => @type, :object => @feature %>
 
-<div class='secondary-actions'>
-  <% if @feature.visible? %>
+<% if @feature.visible? %>
+  <div class='secondary-actions'>
     <%= link_to(t("browse.download_xml"), :controller => "api/#{@type.pluralize}", :action => :show) %>
+  </div>
+<% end %>
+<div class='secondary-actions'>
+  <% if @feature.version > 1 %>
+    <%= link_to "<< #{t('browse.version')} #1", :controller => "old_#{@type.pluralize}", :action => :show, :version => 1 %>
     &middot;
   <% end %>
-  <%= link_to(t("browse.view_history"), :action => "#{@type}_history") %>
+    <%= link_to t("browse.view_history"), :action => "#{@type}_history" %>
+  <% if @feature.version > 1 %>
+    &middot;
+    <%= link_to "#{t('browse.version')} ##{@feature.version} >>", :controller => "old_#{@type.pluralize}", :action => :show, :version => @feature.version %>
+  <% end %>
 </div>

--- a/app/views/old_nodes/not_found.html.erb
+++ b/app/views/old_nodes/not_found.html.erb
@@ -1,0 +1,7 @@
+<% set_title(t("browse.not_found.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.not_found.title") %>
+
+<div>
+  <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
+</div>

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -4,6 +4,8 @@
 
 <%= render :partial => "browse/node", :object => @feature %>
 
-<div class='secondary-actions'>
-  <%= link_to t("browse.download_xml"), node_version_path(*@feature.id) %>
-</div>
+<% unless @feature.redacted? %>
+  <div class='secondary-actions'>
+    <%= link_to t("browse.download_xml"), node_version_path(*@feature.id) %>
+  </div>
+<% end %>

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -1,0 +1,5 @@
+<% set_title t("browse.node.title_html", :name => printable_name(@feature)) %>
+
+<%= render "sidebar_header", :title => t("browse.node.title_html", :name => printable_name(@feature)) %>
+
+<%= render :partial => "browse/node", :object => @feature %>

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -4,11 +4,13 @@
 
 <%= render :partial => "browse/node", :object => @feature %>
 
-<% unless @feature.redacted? %>
-  <div class='secondary-actions'>
+<div class='secondary-actions'>
+  <% unless @feature.redacted? %>
     <%= link_to t("browse.download_xml"), node_version_path(*@feature.id) %>
-  </div>
-<% end %>
+    &middot;
+  <% end %>
+  <%= link_to t("browse.view_details"), node_path(@feature.node_id) %>
+</div>
 
 <div class='secondary-actions'>
   <% if @feature.version > 1 %>

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -3,3 +3,7 @@
 <%= render "sidebar_header", :title => t("browse.node.title_html", :name => printable_name(@feature)) %>
 
 <%= render :partial => "browse/node", :object => @feature %>
+
+<div class='secondary-actions'>
+  <%= link_to t("browse.download_xml"), node_version_path(*@feature.id) %>
+</div>

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -9,3 +9,15 @@
     <%= link_to t("browse.download_xml"), node_version_path(*@feature.id) %>
   </div>
 <% end %>
+
+<div class='secondary-actions'>
+  <% if @feature.version > 1 %>
+    <%= link_to "<< #{t('browse.version')} ##{@feature.version - 1}", old_node_path(@feature.node_id, @feature.version - 1) %>
+    &middot;
+  <% end %>
+  <%= link_to t("browse.view_history"), node_history_path(@feature.node_id) %>
+  <% if @feature.version < @feature.current_node.version %>
+    &middot;
+    <%= link_to "#{t('browse.version')} ##{@feature.version + 1} >>", old_node_path(@feature.node_id, @feature.version + 1) %>
+  <% end %>
+</div>

--- a/app/views/old_relations/not_found.html.erb
+++ b/app/views/old_relations/not_found.html.erb
@@ -1,0 +1,7 @@
+<% set_title(t("browse.not_found.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.not_found.title") %>
+
+<div>
+  <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
+</div>

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -4,6 +4,8 @@
 
 <%= render :partial => "browse/relation", :object => @feature %>
 
-<div class='secondary-actions'>
-  <%= link_to t("browse.download_xml"), relation_version_path(*@feature.id) %>
-</div>
+<% unless @feature.redacted? %>
+  <div class='secondary-actions'>
+    <%= link_to t("browse.download_xml"), relation_version_path(*@feature.id) %>
+  </div>
+<% end %>

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -3,3 +3,7 @@
 <%= render "sidebar_header", :title => t("browse.relation.title_html", :name => printable_name(@feature)) %>
 
 <%= render :partial => "browse/relation", :object => @feature %>
+
+<div class='secondary-actions'>
+  <%= link_to t("browse.download_xml"), relation_version_path(*@feature.id) %>
+</div>

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -9,3 +9,15 @@
     <%= link_to t("browse.download_xml"), relation_version_path(*@feature.id) %>
   </div>
 <% end %>
+
+<div class='secondary-actions'>
+  <% if @feature.version > 1 %>
+    <%= link_to "<< #{t('browse.version')} ##{@feature.version - 1}", old_relation_path(@feature.relation_id, @feature.version - 1) %>
+    &middot;
+  <% end %>
+  <%= link_to t("browse.view_history"), relation_history_path(@feature.relation_id) %>
+  <% if @feature.version < @feature.current_relation.version %>
+    &middot;
+    <%= link_to "#{t('browse.version')} ##{@feature.version + 1} >>", old_relation_path(@feature.relation_id, @feature.version + 1) %>
+  <% end %>
+</div>

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -1,0 +1,5 @@
+<% set_title t("browse.relation.title_html", :name => printable_name(@feature)) %>
+
+<%= render "sidebar_header", :title => t("browse.relation.title_html", :name => printable_name(@feature)) %>
+
+<%= render :partial => "browse/relation", :object => @feature %>

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -4,11 +4,13 @@
 
 <%= render :partial => "browse/relation", :object => @feature %>
 
-<% unless @feature.redacted? %>
-  <div class='secondary-actions'>
+<div class='secondary-actions'>
+  <% unless @feature.redacted? %>
     <%= link_to t("browse.download_xml"), relation_version_path(*@feature.id) %>
-  </div>
-<% end %>
+    &middot;
+  <% end %>
+  <%= link_to t("browse.view_details"), relation_path(@feature.relation_id) %>
+</div>
 
 <div class='secondary-actions'>
   <% if @feature.version > 1 %>

--- a/app/views/old_ways/not_found.html.erb
+++ b/app/views/old_ways/not_found.html.erb
@@ -1,0 +1,7 @@
+<% set_title(t("browse.not_found.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.not_found.title") %>
+
+<div>
+  <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
+</div>

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -3,3 +3,7 @@
 <%= render "sidebar_header", :title => t("browse.way.title_html", :name => printable_name(@feature)) %>
 
 <%= render :partial => "browse/way", :object => @feature %>
+
+<div class='secondary-actions'>
+  <%= link_to t("browse.download_xml"), way_version_path(*@feature.id) %>
+</div>

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -4,11 +4,13 @@
 
 <%= render :partial => "browse/way", :object => @feature %>
 
-<% unless @feature.redacted? %>
-  <div class='secondary-actions'>
+<div class='secondary-actions'>
+  <% unless @feature.redacted? %>
     <%= link_to t("browse.download_xml"), way_version_path(*@feature.id) %>
-  </div>
-<% end %>
+    &middot;
+  <% end %>
+  <%= link_to t("browse.view_details"), way_path(@feature.way_id) %>
+</div>
 
 <div class='secondary-actions'>
   <% if @feature.version > 1 %>

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -4,6 +4,8 @@
 
 <%= render :partial => "browse/way", :object => @feature %>
 
-<div class='secondary-actions'>
-  <%= link_to t("browse.download_xml"), way_version_path(*@feature.id) %>
-</div>
+<% unless @feature.redacted? %>
+  <div class='secondary-actions'>
+    <%= link_to t("browse.download_xml"), way_version_path(*@feature.id) %>
+  </div>
+<% end %>

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -1,0 +1,5 @@
+<% set_title t("browse.way.title_html", :name => printable_name(@feature)) %>
+
+<%= render "sidebar_header", :title => t("browse.way.title_html", :name => printable_name(@feature)) %>
+
+<%= render :partial => "browse/way", :object => @feature %>

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -9,3 +9,15 @@
     <%= link_to t("browse.download_xml"), way_version_path(*@feature.id) %>
   </div>
 <% end %>
+
+<div class='secondary-actions'>
+  <% if @feature.version > 1 %>
+    <%= link_to "<< #{t('browse.version')} ##{@feature.version - 1}", old_way_path(@feature.way_id, @feature.version - 1) %>
+    &middot;
+  <% end %>
+  <%= link_to t("browse.view_history"), way_history_path(@feature.way_id) %>
+  <% if @feature.version < @feature.current_way.version %>
+    &middot;
+    <%= link_to "#{t('browse.version')} ##{@feature.version + 1} >>", old_way_path(@feature.way_id, @feature.version + 1) %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,6 +431,9 @@ en:
   old_nodes:
     not_found:
       sorry: "Sorry, node #%{id} version %{version} could not be found."
+  old_ways:
+    not_found:
+      sorry: "Sorry, way #%{id} version %{version} could not be found."
   changesets:
     changeset_paging_nav:
       showing_page: "Page %{page}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,6 +434,9 @@ en:
   old_ways:
     not_found:
       sorry: "Sorry, way #%{id} version %{version} could not be found."
+  old_relations:
+    not_found:
+      sorry: "Sorry, relation #%{id} version %{version} could not be found."
   changesets:
     changeset_paging_nav:
       showing_page: "Page %{page}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,6 +428,9 @@ en:
       introduction: "Click on the map to find nearby features."
       nearby: "Nearby features"
       enclosing: "Enclosing features"
+  old_nodes:
+    not_found:
+      sorry: "Sorry, node #%{id} version %{version} could not be found."
   changesets:
     changeset_paging_nav:
       showing_page: "Page %{page}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ OpenStreetMap::Application.routes.draw do
   get "/way/:id/history" => "browse#way_history", :id => /\d+/, :as => :way_history
   get "/node/:id" => "browse#node", :id => /\d+/, :as => :node
   get "/node/:id/history" => "browse#node_history", :id => /\d+/, :as => :node_history
+  resources :old_nodes, :path => "/node/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show
   get "/relation/:id" => "browse#relation", :id => /\d+/, :as => :relation
   get "/relation/:id/history" => "browse#relation_history", :id => /\d+/, :as => :relation_history
   get "/changeset/:id" => "browse#changeset", :as => :changeset, :id => /\d+/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,7 @@ OpenStreetMap::Application.routes.draw do
   resources :old_nodes, :path => "/node/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show
   get "/relation/:id" => "browse#relation", :id => /\d+/, :as => :relation
   get "/relation/:id/history" => "browse#relation_history", :id => /\d+/, :as => :relation_history
+  resources :old_relations, :path => "/relation/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show
   get "/changeset/:id" => "browse#changeset", :as => :changeset, :id => /\d+/
   get "/changeset/:id/comments/feed" => "changeset_comments#index", :as => :changeset_comments_feed, :id => /\d*/, :defaults => { :format => "rss" }
   resources :notes, :path => "note", :only => [:show, :new]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ OpenStreetMap::Application.routes.draw do
   # Data browsing
   get "/way/:id" => "browse#way", :id => /\d+/, :as => :way
   get "/way/:id/history" => "browse#way_history", :id => /\d+/, :as => :way_history
+  resources :old_ways, :path => "/way/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show
   get "/node/:id" => "browse#node", :id => /\d+/, :as => :node
   get "/node/:id/history" => "browse#node_history", :id => /\d+/, :as => :node_history
   resources :old_nodes, :path => "/node/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -39,35 +39,63 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_read_relation
-    browse_check :relation_path, create(:relation).id, "browse/feature"
+    relation = create(:relation)
+    browse_check :relation_path, relation.id, "browse/feature"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_relation_path relation, 1}']", :text => "1", :count => 1
+    end
+    assert_select "a[href='#{api_relation_path relation}']", :count => 1
   end
 
   def test_read_relation_history
-    browse_check :relation_history_path, create(:relation, :with_history).id, "browse/history"
+    relation = create(:relation, :with_history)
+    browse_check :relation_history_path, relation.id, "browse/history"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_relation_path relation, 1}']", :text => "1", :count => 1
+    end
   end
 
   def test_read_way
-    browse_check :way_path, create(:way).id, "browse/feature"
+    way = create(:way)
+    browse_check :way_path, way.id, "browse/feature"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_way_path way, 1}']", :text => "1", :count => 1
+    end
+    assert_select "a[href='#{api_way_path way}']", :count => 1
   end
 
   def test_read_way_history
-    browse_check :way_history_path, create(:way, :with_history).id, "browse/history"
+    way = create(:way, :with_history)
+    browse_check :way_history_path, way.id, "browse/history"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_way_path way, 1}']", :text => "1", :count => 1
+    end
   end
 
   def test_read_node
     node = create(:node)
     browse_check :node_path, node.id, "browse/feature"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_node_path node, 1}']", :text => "1", :count => 1
+    end
     assert_select "a[href='#{api_node_path node}']", :count => 1
   end
 
   def test_read_deleted_node
     node = create(:node, :visible => false)
     browse_check :node_path, node.id, "browse/feature"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_node_path node, 1}']", :text => "1", :count => 1
+    end
     assert_select "a[href='#{api_node_path node}']", :count => 0
   end
 
   def test_read_node_history
-    browse_check :node_history_path, create(:node, :with_history).id, "browse/history"
+    node = create(:node, :with_history)
+    browse_check :node_history_path, node.id, "browse/history"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_node_path node, 1}']", :text => "1", :count => 1
+    end
   end
 
   def test_read_changeset

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -44,7 +44,17 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_relation_path relation, 1}']", :text => "1", :count => 1
     end
-    assert_select "a[href='#{api_relation_path relation}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_relation_path relation}']", :count => 1
+    assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 0
+  end
+
+  def test_multiple_version_relation_links
+    relation = create(:relation, :with_history, :version => 2)
+    browse_check :relation_path, relation.id, "browse/feature"
+    assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_relation_path relation, 2}']", :count => 1
   end
 
   def test_read_relation_history
@@ -61,7 +71,17 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_way_path way, 1}']", :text => "1", :count => 1
     end
-    assert_select "a[href='#{api_way_path way}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_way_path way}']", :count => 1
+    assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 0
+  end
+
+  def test_multiple_version_way_links
+    way = create(:way, :with_history, :version => 2)
+    browse_check :way_path, way.id, "browse/feature"
+    assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_way_path way, 2}']", :count => 1
   end
 
   def test_read_way_history
@@ -78,7 +98,17 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_node_path node, 1}']", :text => "1", :count => 1
     end
-    assert_select "a[href='#{api_node_path node}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_node_path node}']", :count => 1
+    assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 0
+  end
+
+  def test_multiple_version_node_links
+    node = create(:node, :with_history, :version => 2)
+    browse_check :node_path, node.id, "browse/feature"
+    assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_node_path node, 2}']", :count => 1
   end
 
   def test_read_deleted_node

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -18,6 +18,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_node_path node, 1}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{node_version_path node, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
   end
 
@@ -31,6 +32,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_node_path node, 1}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{node_version_path node, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 2}']", :count => 1
 
@@ -42,6 +44,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_node_path node, 2}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{node_version_path node, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 1
   end
@@ -54,6 +57,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_nodes/show"
     assert_template :layout => "map"
+    assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 0
     assert_select ".secondary-actions a[href='#{node_version_path node, 1}']", :count => 0
   end

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -17,6 +17,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_node_path node, 1}']", :count => 0
     end
+    assert_select "a[href='#{node_version_path node, 1}']", :count => 1
   end
 
   def test_not_found

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -14,6 +14,9 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_nodes/show"
     assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_node_path node, 1}']", :count => 0
+    end
   end
 
   def test_not_found

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class OldNodesControllerTest < ActionDispatch::IntegrationTest
+  def test_routes
+    assert_routing(
+      { :path => "/node/1/history/2", :method => :get },
+      { :controller => "old_nodes", :action => "show", :id => "1", :version => "2" }
+    )
+  end
+
+  def test_visible
+    node = create(:node, :with_history)
+    get old_node_path(node, 1)
+    assert_response :success
+    assert_template "old_nodes/show"
+    assert_template :layout => "map"
+  end
+
+  def test_not_found
+    get old_node_path(0, 0)
+    assert_response :not_found
+    assert_template "old_nodes/not_found"
+    assert_template :layout => "map"
+    assert_select "#sidebar_content", /node #0 version 0 could not be found/
+  end
+end

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -8,7 +8,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def test_visible
+  def test_visible_with_one_version
     node = create(:node, :with_history)
     get old_node_path(node, 1)
     assert_response :success
@@ -17,7 +17,33 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_node_path node, 1}']", :count => 0
     end
-    assert_select "a[href='#{node_version_path node, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{node_version_path node, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
+  end
+
+  def test_visible_with_two_versions
+    node = create(:node, :with_history, :version => 2)
+    get old_node_path(node, 1)
+    assert_response :success
+    assert_template "old_nodes/show"
+    assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_node_path node, 1}']", :count => 0
+    end
+    assert_select ".secondary-actions a[href='#{node_version_path node, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_node_path node, 2}']", :count => 1
+
+    get old_node_path(node, 2)
+    assert_response :success
+    assert_template "old_nodes/show"
+    assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_node_path node, 2}']", :count => 0
+    end
+    assert_select ".secondary-actions a[href='#{node_version_path node, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 1
   end
 
   def test_redacted
@@ -28,8 +54,8 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_nodes/show"
     assert_template :layout => "map"
-    assert_select "a[href='#{old_node_path node, 1}']", :count => 0
-    assert_select "a[href='#{node_version_path node, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{node_version_path node, 1}']", :count => 0
   end
 
   def test_not_found

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -20,6 +20,18 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{node_version_path node, 1}']", :count => 1
   end
 
+  def test_redacted
+    node = create(:node, :with_history, :deleted, :version => 2)
+    node_v1 = node.old_nodes.find_by(:version => 1)
+    node_v1.redact!(create(:redaction))
+    get old_node_path(node, 1)
+    assert_response :success
+    assert_template "old_nodes/show"
+    assert_template :layout => "map"
+    assert_select "a[href='#{old_node_path node, 1}']", :count => 0
+    assert_select "a[href='#{node_version_path node, 1}']", :count => 0
+  end
+
   def test_not_found
     get old_node_path(0, 0)
     assert_response :not_found

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -17,6 +17,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
     end
+    assert_select "a[href='#{relation_version_path relation, 1}']", :count => 1
   end
 
   def test_visible_with_members

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -8,7 +8,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def test_visible
+  def test_visible_with_one_version
     relation = create(:relation, :with_history)
     get old_relation_path(relation, 1)
     assert_response :success
@@ -17,7 +17,33 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
     end
-    assert_select "a[href='#{relation_version_path relation, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{relation_version_path relation, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
+  end
+
+  def test_visible_with_two_versions
+    relation = create(:relation, :with_history, :version => 2)
+    get old_relation_path(relation, 1)
+    assert_response :success
+    assert_template "old_relations/show"
+    assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
+    end
+    assert_select ".secondary-actions a[href='#{relation_version_path relation, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_relation_path relation, 2}']", :count => 1
+
+    get old_relation_path(relation, 2)
+    assert_response :success
+    assert_template "old_relations/show"
+    assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_relation_path relation, 2}']", :count => 0
+    end
+    assert_select ".secondary-actions a[href='#{relation_version_path relation, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 1
   end
 
   def test_visible_with_members
@@ -37,8 +63,8 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_relations/show"
     assert_template :layout => "map"
-    assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
-    assert_select "a[href='#{relation_version_path relation, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{relation_version_path relation, 1}']", :count => 0
   end
 
   def test_not_found

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -29,6 +29,18 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_template :layout => "map"
   end
 
+  def test_redacted
+    relation = create(:relation, :with_history, :deleted, :version => 2)
+    relation_v1 = relation.old_relations.find_by(:version => 1)
+    relation_v1.redact!(create(:redaction))
+    get old_relation_path(relation, 1)
+    assert_response :success
+    assert_template "old_relations/show"
+    assert_template :layout => "map"
+    assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
+    assert_select "a[href='#{relation_version_path relation, 1}']", :count => 0
+  end
+
   def test_not_found
     get old_relation_path(0, 0)
     assert_response :not_found

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -14,6 +14,9 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_relations/show"
     assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
+    end
   end
 
   def test_visible_with_members

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class OldRelationsControllerTest < ActionDispatch::IntegrationTest
+  def test_routes
+    assert_routing(
+      { :path => "/relation/1/history/2", :method => :get },
+      { :controller => "old_relations", :action => "show", :id => "1", :version => "2" }
+    )
+  end
+
+  def test_visible
+    relation = create(:relation, :with_history)
+    get old_relation_path(relation, 1)
+    assert_response :success
+    assert_template "old_relations/show"
+    assert_template :layout => "map"
+  end
+
+  def test_visible_with_members
+    relation = create(:relation, :with_history)
+    create(:old_relation_member, :old_relation => relation.old_relations.first)
+    get old_relation_path(relation, 1)
+    assert_response :success
+    assert_template "old_relations/show"
+    assert_template :layout => "map"
+  end
+
+  def test_not_found
+    get old_relation_path(0, 0)
+    assert_response :not_found
+    assert_template "old_relations/not_found"
+    assert_template :layout => "map"
+    assert_select "#sidebar_content", /relation #0 version 0 could not be found/
+  end
+end

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -18,6 +18,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{relation_version_path relation, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
   end
 
@@ -31,6 +32,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{relation_version_path relation, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 2}']", :count => 1
 
@@ -42,6 +44,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_relation_path relation, 2}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{relation_version_path relation, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 1
   end
@@ -63,6 +66,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_relations/show"
     assert_template :layout => "map"
+    assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 0
     assert_select ".secondary-actions a[href='#{relation_version_path relation, 1}']", :count => 0
   end

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -18,6 +18,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_way_path way, 1}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{way_version_path way, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
   end
 
@@ -31,6 +32,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_way_path way, 1}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{way_version_path way, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 2}']", :count => 1
 
@@ -42,6 +44,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='#{old_way_path way, 2}']", :count => 0
     end
     assert_select ".secondary-actions a[href='#{way_version_path way, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 1
   end
@@ -68,6 +71,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_ways/show"
     assert_template :layout => "map"
+    assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 0
     assert_select ".secondary-actions a[href='#{way_version_path way, 1}']", :count => 0
   end

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -14,6 +14,9 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_ways/show"
     assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_way_path way, 1}']", :count => 0
+    end
   end
 
   def test_visible_with_shared_nodes

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -34,6 +34,18 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_template :layout => "map"
   end
 
+  def test_redacted
+    way = create(:way, :with_history, :deleted, :version => 2)
+    way_v1 = way.old_ways.find_by(:version => 1)
+    way_v1.redact!(create(:redaction))
+    get old_way_path(way, 1)
+    assert_response :success
+    assert_template "old_ways/show"
+    assert_template :layout => "map"
+    assert_select "a[href='#{old_way_path way, 1}']", :count => 0
+    assert_select "a[href='#{way_version_path way, 1}']", :count => 0
+  end
+
   def test_not_found
     get old_way_path(0, 0)
     assert_response :not_found

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -17,6 +17,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_way_path way, 1}']", :count => 0
     end
+    assert_select "a[href='#{way_version_path way, 1}']", :count => 1
   end
 
   def test_visible_with_shared_nodes

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class OldWaysControllerTest < ActionDispatch::IntegrationTest
+  def test_routes
+    assert_routing(
+      { :path => "/way/1/history/2", :method => :get },
+      { :controller => "old_ways", :action => "show", :id => "1", :version => "2" }
+    )
+  end
+
+  def test_visible
+    way = create(:way, :with_history)
+    get old_way_path(way, 1)
+    assert_response :success
+    assert_template "old_ways/show"
+    assert_template :layout => "map"
+  end
+
+  def test_visible_with_shared_nodes
+    node = create(:node, :with_history)
+    way = create(:way, :with_history)
+    create(:way_node, :way => way, :node => node)
+    create(:old_way_node, :old_way => way.old_ways.first, :node => node)
+    sharing_way = create(:way, :with_history)
+    create(:way_node, :way => sharing_way, :node => node)
+    create(:old_way_node, :old_way => sharing_way.old_ways.first, :node => node)
+    get old_way_path(way, 1)
+    assert_response :success
+    assert_template "old_ways/show"
+    assert_template :layout => "map"
+  end
+
+  def test_not_found
+    get old_way_path(0, 0)
+    assert_response :not_found
+    assert_template "old_ways/not_found"
+    assert_template :layout => "map"
+    assert_select "#sidebar_content", /way #0 version 0 could not be found/
+  end
+end

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -8,7 +8,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  def test_visible
+  def test_visible_with_one_version
     way = create(:way, :with_history)
     get old_way_path(way, 1)
     assert_response :success
@@ -17,7 +17,33 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_way_path way, 1}']", :count => 0
     end
-    assert_select "a[href='#{way_version_path way, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{way_version_path way, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
+  end
+
+  def test_visible_with_two_versions
+    way = create(:way, :with_history, :version => 2)
+    get old_way_path(way, 1)
+    assert_response :success
+    assert_template "old_ways/show"
+    assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_way_path way, 1}']", :count => 0
+    end
+    assert_select ".secondary-actions a[href='#{way_version_path way, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_way_path way, 2}']", :count => 1
+
+    get old_way_path(way, 2)
+    assert_response :success
+    assert_template "old_ways/show"
+    assert_template :layout => "map"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_way_path way, 2}']", :count => 0
+    end
+    assert_select ".secondary-actions a[href='#{way_version_path way, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
+    assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 1
   end
 
   def test_visible_with_shared_nodes
@@ -42,8 +68,8 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "old_ways/show"
     assert_template :layout => "map"
-    assert_select "a[href='#{old_way_path way, 1}']", :count => 0
-    assert_select "a[href='#{way_version_path way, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{way_version_path way, 1}']", :count => 0
   end
 
   def test_not_found


### PR DESCRIPTION
Basic support for https://github.com/openstreetmap/openstreetmap-website/issues/662. Doesn't try to show the old versions on the map.

The paths scheme is `/node/123/history/4` like it was in https://github.com/openstreetmap/openstreetmap-website/pull/720. This is because you'll probably want resourceful routes, with index pointed later to `/node/123/history`.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7022d8e2-3a52-4f05-ae96-4393b827e467)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b9264d0e-c1f2-47d9-9d97-604068a43811)

Not necessarily a replacement of https://github.com/openstreetmap/openstreetmap-website/pull/4468. You may still want links to specific versions within full history pages, especially if they'll get more version comparison functionality, for example like it was attempted in https://github.com/openstreetmap/openstreetmap-website/pull/3535.