### PR TITLE
Update minimum PostgreSQL version to 13 in documentatation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ of packages required before you can get the various gems installed.
 ## Minimum requirements
 
 * Ruby 3.0+
-* PostgreSQL 12+
+* PostgreSQL 13+
 * Bundler (see note below about [developer Ruby setup](#rbenv))
 * Javascript Runtime
 


### PR DESCRIPTION
Refs #4405

* instructions are already written for 22.04 so otherwise don't need updating
* vagrant is 22.04
* [docker uses postgres 14 image already](https://github.com/openstreetmap/openstreetmap-website/blob/master/docker/postgres/Dockerfile)
* [github actions 20.04 image uses postgres 14](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md#postgresql)

... so I think that this is the only thing that needs changing.