### PR TITLE
Remove unused export tab translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2163,12 +2163,7 @@ en:
       no_iframe_support: "Your browser doesn't support HTML iframes, which are necessary for this feature."
     export:
       title: "Export"
-      area_to_export: "Area to Export"
       manually_select: "Manually select a different area"
-      format_to_export: "Format to Export"
-      osm_xml_data: "OpenStreetMap XML Data"
-      map_image: "Map Image (shows standard layer)"
-      embeddable_html: "Embeddable HTML"
       licence: "Licence"
       licence_details_html: OpenStreetMap data is licensed under the %{odbl_link} (ODbL).
       odbl: Open Data Commons Open Database License
@@ -2188,17 +2183,6 @@ en:
         other:
           title: "Other Sources"
           description: "Additional sources listed on the OpenStreetMap Wiki"
-      options: "Options"
-      format: "Format"
-      scale: "Scale"
-      max: "max"
-      image_size: "Image Size"
-      zoom: "Zoom"
-      add_marker: "Add a marker to the map"
-      latitude: "Lat:"
-      longitude: "Lon:"
-      output: "Output"
-      paste_html: "Paste HTML to embed in website"
       export_button: "Export"
     fixthemap:
       title: Report a problem / Fix the map


### PR DESCRIPTION
- (mostly) introduced in https://github.com/openstreetmap/openstreetmap-website/commit/1db6b392a6c9f255d74669d8ae6db67934a2ab54
- unused since https://github.com/openstreetmap/openstreetmap-website/commit/438e8be102a2ac4c0e92041da2866f1339715b40