### PR TITLE
Remove ":" from login form input labels

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1753,7 +1753,7 @@ en:
     new:
       title: "Lost password"
       heading: "Forgotten Password?"
-      email address: "Email Address:"
+      email address: "Email Address"
       new password button: "Reset password"
       help_text: "Enter the email address you used to sign up, we will send a link to it that you can use to reset your password."
     create:
@@ -1811,8 +1811,8 @@ en:
     new:
       title: "Login"
       heading: "Login"
-      email or username: "Email Address or Username:"
-      password: "Password:"
+      email or username: "Email Address or Username"
+      password: "Password"
       openid_html: "%{logo} OpenID:"
       remember: "Remember me"
       lost password link: "Lost your password?"


### PR DESCRIPTION
On the login page redesign PR there's a discussion about colons in input labels starting at https://github.com/openstreetmap/openstreetmap-website/pull/4455#issuecomment-1899984034. The colons are in translation strings, thus they can be dealt with outside of that PR.

Those colons are not needed because they are mostly not used in other places. One place that has a colon is an input on the "forgot password" page, let's remove it from there too.

Another place is the share panel. I'm not so sure about colons there and I'm not removing them in this PR.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/456c7928-a123-45f2-8010-443b7ef5da30)
