### PR TITLE
Click login below inputs in system test sign in

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -243,9 +243,11 @@ module ActiveSupport
 
     def sign_in_as(user)
       visit login_path
-      fill_in "username", :with => user.email
-      fill_in "password", :with => "test"
-      click_on "Login", :match => :first
+      within "form", :text => "Email Address or Username" do
+        fill_in "username", :with => user.email
+        fill_in "password", :with => "test"
+        click_on "Login"
+      end
     end
 
     def session_for(user)


### PR DESCRIPTION
Currently logins in system tests work by going to the login page, filling in the username and password and clicking the first "Login" thing. You hope that this first "Login" thing is the login button of the login form, which it currently is. But if you change the website navigation, it may no longer be. #4455 makes such change, adding a "Login" tab above the form. Then it adds workarounds [1](https://github.com/openstreetmap/openstreetmap-website/pull/4455/files#diff-29beaabe278fd17493296745cecb67919f0906b47b8246ab770f5517615d9ef7R203-R205) [2](https://github.com/openstreetmap/openstreetmap-website/pull/4455/files#diff-ba37813ca277c227a74a372479b7b05b7f3ff085d890ab708f80d62573efdb7aR248).

How about we click the button below the inputs instead?