### PR TITLE
Set OpenID tabindex higher than username/password form tabindexes

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -40,7 +40,7 @@
         <div id='login_openid_url' class="mb-3">
           <label for='openid_url' class="form-label"><%= t ".openid_html", :logo => openid_logo %></label>
           <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>
-          <%= text_field_tag("openid_url", "", :tabindex => 3, :autocomplete => "on", :class => "openid_url form-control") %>
+          <%= text_field_tag("openid_url", "", :tabindex => 5, :autocomplete => "on", :class => "openid_url form-control") %>
           <span class="form-text text-muted">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
         </div>
 


### PR DESCRIPTION
If you press tab while in the OpenID input, you'll get to the login button _above it_, not below. Same thing happens in #4455. `:tabindex => 3` was there since at least 2010 while things around it changed.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/1296e7a5-96e1-4365-a5c5-aaefabd88082)
