### PR TITLE
Return an error when a disabled authentication mechanism is used

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -107,7 +107,7 @@ class ApiController < ApplicationController
       self.current_user = User.find(doorkeeper_token.resource_owner_id)
     elsif Authenticator.new(self, [:token]).allow?
       # self.current_user setup by OAuth
-    elsif Settings.basic_auth_support
+    else
       username, passwd = auth_data # parse from headers
       # authenticate per-scheme
       self.current_user = if username.nil?
@@ -117,8 +117,14 @@ class ApiController < ApplicationController
                           else
                             User.authenticate(:username => username, :password => passwd) # basic auth
                           end
-      # log if we have authenticated using basic auth
-      logger.info "Authenticated as user #{current_user.id} using basic authentication" if current_user
+      if username && current_user
+        if Settings.basic_auth_support
+          # log if we have authenticated using basic auth
+          logger.info "Authenticated as user #{current_user.id} using basic authentication"
+        else
+          report_error t("application.basic_auth_disabled", :link => t("application.auth_disabled_link")), :forbidden
+        end
+      end
     end
 
     # have we identified the user?

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -106,7 +106,11 @@ class ApiController < ApplicationController
     if doorkeeper_token&.accessible?
       self.current_user = User.find(doorkeeper_token.resource_owner_id)
     elsif Authenticator.new(self, [:token]).allow?
-      # self.current_user setup by OAuth
+      if Settings.oauth_10a_support
+        # self.current_user setup by OAuth
+      else
+        report_error t("application.oauth_10a_disabled", :link => t("application.auth_disabled_link")), :forbidden
+      end
     else
       username, passwd = auth_data # parse from headers
       # authenticate per-scheme

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,6 +69,10 @@ class ApplicationController < ActionController::Base
     @oauth_token = current_user.oauth_token(Settings.oauth_application) if current_user && Settings.key?(:oauth_application)
   end
 
+  def require_oauth_10a_support
+    report_error t("application.oauth_10a_disabled", :link => t("application.auth_disabled_link")), :forbidden unless Settings.oauth_10a_support
+  end
+
   ##
   # require the user to have cookies enabled in their browser
   def require_cookies

--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -5,6 +5,8 @@ class OauthController < ApplicationController
   # a login, but we want to check authorization on every action.
   authorize_resource :class => false
 
+  before_action :require_oauth_10a_support
+
   layout "site"
 
   def revoke

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2556,6 +2556,7 @@ en:
       description_without_count: "GPX file from %{user}"
   application:
     basic_auth_disabled: "HTTP Basic Authentication is disabled: %{link}"
+    oauth_10a_disabled: "OAuth 1.0 and 1.0a are disabled: %{link}"
     auth_disabled_link: "https://wiki.openstreetmap.org/wiki/2024_authentication_update"
     permission_denied: You do not have permission to access that action
     require_cookies:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2555,6 +2555,8 @@ en:
         other: "GPX file with %{count} points from %{user}"
       description_without_count: "GPX file from %{user}"
   application:
+    basic_auth_disabled: "HTTP Basic Authentication is disabled: %{link}"
+    auth_disabled_link: "https://wiki.openstreetmap.org/wiki/2024_authentication_update"
     permission_denied: You do not have permission to access that action
     require_cookies:
       cookies_needed: "You appear to have cookies disabled - please enable cookies in your browser before continuing."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,9 +95,12 @@ attachments_dir: ":rails_root/public/attachments"
 #memcache_servers: []
 # Enable HTTP basic authentication support
 basic_auth_support: true
+# Enable OAuth 1.0/1.0a registration
+oauth_10_registration: true
 # Enable legacy OAuth 1.0 support
 oauth_10_support: true
-oauth_10_registration: true
+# Enable OAuth 1.0a support
+oauth_10a_support: true
 # URL of Nominatim instance to use for geocoding
 nominatim_url: "https://nominatim.openstreetmap.org/"
 # Default editor


### PR DESCRIPTION
This extends the previous work to allow authentication basic auth and OAuth 1 to be disabled to return an error message so that users have some chance of discovering what is going on.

I'll make this a draft for now as we may want to add more detail to the messages...