### PR TITLE
Drop help.openstreetmap.org from the help page

### DIFF
--- a/app/views/site/help.html.erb
+++ b/app/views/site/help.html.erb
@@ -4,7 +4,7 @@
 
 <p class='introduction'><%= t ".introduction" %></p>
 
-<% sites = %w[beginners_guide help mailing_lists community irc switch2osm welcomemat wiki] %>
+<% sites = %w[beginners_guide community mailing_lists irc switch2osm welcomemat wiki] %>
 <% sites.prepend("welcome") if current_user %>
 
 <div class="row row-cols-sm-3 g-4 mb-3">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2228,18 +2228,14 @@ en:
         url: https://wiki.openstreetmap.org/wiki/Beginners%27_guide
         title: Beginners' Guide
         description: Community maintained guide for beginners.
-      help:
-        url: https://help.openstreetmap.org/
-        title: Help Forum
-        description: Ask a question or look up answers on OpenStreetMap's question-and-answer site.
+      community:
+        url: https://community.openstreetmap.org/
+        title: Help & Community Forum
+        description: A shared place for to seek help and have conversations about OpenStreetMap.
       mailing_lists:
         url: https://lists.openstreetmap.org/
         title: Mailing Lists
         description: Ask a question or discuss interesting matters on a wide range of topical or regional mailing lists.
-      community:
-        url: https://community.openstreetmap.org/
-        title: Community forum
-        description: A shared place for conversations about OpenStreetMap.
       irc:
         url: https://irc.openstreetmap.org/
         title: IRC


### PR DESCRIPTION
Move the community.openstreetmap.org tab up to replace it and rename it to mentaion help as well as community.

Fixes #4497