### PR TITLE
Add minitest-focus gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,7 @@ group :test do
   gem "factory_bot_rails"
   gem "jwt"
   gem "minitest", "~> 5.1"
+  gem "minitest-focus", :require => false
   gem "puma", "~> 5.6"
   gem "rails-controller-testing"
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,8 @@ GEM
     mini_racer (0.8.0)
       libv8-node (~> 18.16.0.0)
     minitest (5.22.0)
+    minitest-focus (1.4.0)
+      minitest (>= 4, < 6)
     msgpack (1.7.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -642,6 +644,7 @@ DEPENDENCIES
   marcel
   maxminddb
   minitest (~> 5.1)
+  minitest-focus
   oauth-plugin (>= 0.5.1)
   omniauth (~> 2.0.2)
   omniauth-facebook

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,7 @@ ENV["RAILS_ENV"] = "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "webmock/minitest"
+require "minitest/focus" unless ENV["CI"]
 
 WebMock.disable_net_connect!(:allow_localhost => true)
 


### PR DESCRIPTION
This PR adds the [minitest-focus](https://github.com/minitest/minitest-focus) gem, which I've been using a lot recently. It's particularly helpful if you are examining the test logs, or doing some other work which means the other tests in the file are just a distraction.

There's a small risk with focussing a test, that it might be committed as focussed. If nobody notices during review, that can cause the rest of the test suite to be skipped. To mitigate this (admittedly remote) risk, I've set it up to not be enabled on CI, so any use of the 'focus' keyword there will cause the entire suite to fail.

(My preferred mitigation would be a rubocop rule like https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecfocus which would have a similar effect, but that doesn't yet exist for rubocop-minitest).