### PR TITLE
Adjust button order on welcome banner

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -51,8 +51,8 @@
                                        :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
         </p>
         <div class="d-flex gap-2">
-          <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
           <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+          <a class="btn btn-outline-primary w-100 d-flex align-items-center justify-content-center" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Make more emphasis on edit button by changing "learn more" button style to outlined and also moving it to the right (following the reading order).

This is in line with UX best practices, hopefully could increase conversions slightly.

The proposed layout would be like this:

![obraz](https://github.com/openstreetmap/openstreetmap-website/assets/1409116/3ce70dd5-ba82-4fb1-b3fa-fd693e75f244)
