### PR TITLE
Move system test specific sign in to system test superclass

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -24,6 +24,15 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   private
 
+  def sign_in_as(user)
+    visit login_path
+    within "form", :text => "Email Address or Username" do
+      fill_in "username", :with => user.email
+      fill_in "password", :with => "test"
+      click_on "Login"
+    end
+  end
+
   def within_sidebar(&block)
     within "#sidebar_content", &block
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -242,15 +242,6 @@ module ActiveSupport
       end
     end
 
-    def sign_in_as(user)
-      visit login_path
-      within "form", :text => "Email Address or Username" do
-        fill_in "username", :with => user.email
-        fill_in "password", :with => "test"
-        click_on "Login"
-      end
-    end
-
     def session_for(user)
       get login_path
       post login_path, :params => { :username => user.display_name, :password => "test" }


### PR DESCRIPTION
Test helper has two methods for login: `sign_in_as` and `session_for`. Which one do you use? The answer is `sign_in_as` in system test and `session_for` everywhere else. Why not then move `sign_in_as` to the system test base class? This class already has other methods and you won't be able to accidentally call `sign_in_as` from non-system tests.