### PR TITLE
SVG icons in element version and changeset links

### DIFF
--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -44,7 +44,7 @@ module SvgHelper
     height = 15
     pad = 2
     segment = (0.5 * height) - pad
-    width = segment + (2 * pad)
+    width = (segment + (2 * pad)).ceil
     path_data = "M#{side * (pad - (0.5 * width))},#{pad} l#{side * segment},#{segment} l#{-side * segment},#{segment}"
     path_tag = tag.path :d => path_data, :fill => "none", :stroke => "currentColor", :"stroke-width" => 1.5
     tag.svg path_tag, :width => width, :height => height, :viewBox => "-#{0.5 * width} 0 #{width} #{height}", :class => options[:class]

--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -41,7 +41,7 @@ module SvgHelper
 
   # returns "<" shape if side == -1; ">" if side == 1
   def adjacent_page_svg_tag(side, **options)
-    height = 15
+    height = options[:height] || 15
     pad = 2
     segment = (0.5 * height) - pad
     width = (segment + (2 * pad)).ceil

--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -41,13 +41,16 @@ module SvgHelper
 
   # returns "<" shape if side == -1; ">" if side == 1
   def adjacent_page_svg_tag(side, **options)
+    count = options[:count] || 1
     height = options[:height] || 15
     pad = 2
     segment = (0.5 * height) - pad
-    width = (segment + (2 * pad)).ceil
-    path_data = "M#{side * (pad - (0.5 * width))},#{pad} l#{side * segment},#{segment} l#{-side * segment},#{segment}"
+    width = (segment + (2 * count * pad)).ceil
+    angled_line_data = "l#{side * segment},#{segment} l#{-side * segment},#{segment}"
+    path_data = Array.new(count) { |i| "M#{side * ((2 * i) + 1) * pad},#{pad} #{angled_line_data}" }.join(" ")
     path_tag = tag.path :d => path_data, :fill => "none", :stroke => "currentColor", :"stroke-width" => 1.5
-    tag.svg path_tag, :width => width, :height => height, :viewBox => "-#{0.5 * width} 0 #{width} #{height}", :class => options[:class]
+    view_box = "#{-width} 0 #{width} #{height}" if side.negative?
+    tag.svg path_tag, :width => width, :height => height, :viewBox => view_box, :class => options[:class]
   end
 
   def stroke_attrs(attrs, prefix)

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -120,14 +120,20 @@
 <% if @next_by_user || @prev_by_user %>
   <div class='secondary-actions'>
     <% if @prev_by_user %>
-      <%= link_to "<< #{@prev_by_user.id}", :id => @prev_by_user.id %>
+      <%= link_to({ :id => @prev_by_user.id }, :class => "icon-link") do %>
+        <%= previous_page_svg_tag :height => 11 %>
+        <%= @prev_by_user.id %>
+      <% end %>
       &middot;
     <% end %>
     <%= user = (@prev_by_user || @next_by_user).user.display_name
         link_to tag.bdi(user), :controller => "changesets", :action => "index", :display_name => user %>
     <% if @next_by_user %>
       &middot;
-      <%= link_to "#{@next_by_user.id} >>", :id => @next_by_user.id %>
+      <%= link_to({ :id => @next_by_user.id }, :class => "icon-link") do %>
+        <%= @next_by_user.id %>
+        <%= next_page_svg_tag :height => 11 %>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/browse/feature.html.erb
+++ b/app/views/browse/feature.html.erb
@@ -11,12 +11,18 @@
 <% end %>
 <div class='secondary-actions'>
   <% if @feature.version > 1 %>
-    <%= link_to "<< #{t('browse.version')} #1", :controller => "old_#{@type.pluralize}", :action => :show, :version => 1 %>
+    <%= link_to({ :controller => "old_#{@type.pluralize}", :action => :show, :version => 1 }, :class => "icon-link") do %>
+      <%= previous_page_svg_tag :height => 11, :count => 2 %>
+      <%= "#{t('browse.version')} #1" %>
+    <% end %>
     &middot;
   <% end %>
     <%= link_to t("browse.view_history"), :action => "#{@type}_history" %>
   <% if @feature.version > 1 %>
     &middot;
-    <%= link_to "#{t('browse.version')} ##{@feature.version} >>", :controller => "old_#{@type.pluralize}", :action => :show, :version => @feature.version %>
+    <%= link_to({ :controller => "old_#{@type.pluralize}", :action => :show, :version => @feature.version }, :class => "icon-link") do %>
+      <%= "#{t('browse.version')} ##{@feature.version}" %>
+      <%= next_page_svg_tag :height => 11, :count => 2 %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -14,12 +14,18 @@
 
 <div class='secondary-actions'>
   <% if @feature.version > 1 %>
-    <%= link_to "<< #{t('browse.version')} ##{@feature.version - 1}", old_node_path(@feature.node_id, @feature.version - 1) %>
+    <%= link_to old_node_path(@feature.node_id, @feature.version - 1), :class => "icon-link" do %>
+      <%= previous_page_svg_tag :height => 11 %>
+      <%= "#{t('browse.version')} ##{@feature.version - 1}" %>
+    <% end %>
     &middot;
   <% end %>
   <%= link_to t("browse.view_history"), node_history_path(@feature.node_id) %>
   <% if @feature.version < @feature.current_node.version %>
     &middot;
-    <%= link_to "#{t('browse.version')} ##{@feature.version + 1} >>", old_node_path(@feature.node_id, @feature.version + 1) %>
+    <%= link_to old_node_path(@feature.node_id, @feature.version + 1), :class => "icon-link" do %>
+      <%= "#{t('browse.version')} ##{@feature.version + 1}" %>
+      <%= next_page_svg_tag :height => 11 %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -14,12 +14,18 @@
 
 <div class='secondary-actions'>
   <% if @feature.version > 1 %>
-    <%= link_to "<< #{t('browse.version')} ##{@feature.version - 1}", old_relation_path(@feature.relation_id, @feature.version - 1) %>
+    <%= link_to old_relation_path(@feature.relation_id, @feature.version - 1), :class => "icon-link" do %>
+      <%= previous_page_svg_tag :height => 11 %>
+      <%= "#{t('browse.version')} ##{@feature.version - 1}" %>
+    <% end %>
     &middot;
   <% end %>
   <%= link_to t("browse.view_history"), relation_history_path(@feature.relation_id) %>
   <% if @feature.version < @feature.current_relation.version %>
     &middot;
-    <%= link_to "#{t('browse.version')} ##{@feature.version + 1} >>", old_relation_path(@feature.relation_id, @feature.version + 1) %>
+    <%= link_to old_relation_path(@feature.relation_id, @feature.version + 1), :class => "icon-link" do %>
+      <%= "#{t('browse.version')} ##{@feature.version + 1}" %>
+      <%= next_page_svg_tag :height => 11 %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -14,12 +14,18 @@
 
 <div class='secondary-actions'>
   <% if @feature.version > 1 %>
-    <%= link_to "<< #{t('browse.version')} ##{@feature.version - 1}", old_way_path(@feature.way_id, @feature.version - 1) %>
+    <%= link_to old_way_path(@feature.way_id, @feature.version - 1), :class => "icon-link" do %>
+      <%= previous_page_svg_tag :height => 11 %>
+      <%= "#{t('browse.version')} ##{@feature.version - 1}" %>
+    <% end %>
     &middot;
   <% end %>
   <%= link_to t("browse.view_history"), way_history_path(@feature.way_id) %>
   <% if @feature.version < @feature.current_way.version %>
     &middot;
-    <%= link_to "#{t('browse.version')} ##{@feature.version + 1} >>", old_way_path(@feature.way_id, @feature.version + 1) %>
+    <%= link_to old_way_path(@feature.way_id, @feature.version + 1), :class => "icon-link" do %>
+      <%= "#{t('browse.version')} ##{@feature.version + 1}" %>
+      <%= next_page_svg_tag :height => 11 %>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
Links to first/last versions on the current version page:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/214fcafc-3990-4e66-a088-1f751ba1202d)

Now they look differently to previous/next version links, to avoid confusion #4506.

Links to previous/next versions on the old version page:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9e020ee8-0256-48e0-b69c-bfed7c55d532)

And also on user's changeset pages, that's where the initial "<<" / ">>" link style came from:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3c6037a5-b0fb-44d8-959f-87cda7f03333)
