### PR TITLE
Update package.json versions from yarn.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    versioning-strategy: "increase-if-necessary"
+    versioning-strategy: "increase"
     directory: "/"
     schedule:
       interval: "daily"

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "dependencies": {
     "bs-custom-file-input": "^1.3.4",
     "jquery-simulate": "^1.0.2",
-    "js-cookie": "^3.0.0",
-    "leaflet": "^1.8.0",
+    "js-cookie": "^3.0.5",
+    "leaflet": "^1.9.4",
     "leaflet.locatecontrol": "^0.79.0",
-    "osm-community-index": "^5.2.0",
-    "qs": "^6.9.4"
+    "osm-community-index": "^5.6.1",
+    "qs": "^6.11.2"
   },
   "devDependencies": {
-    "eslint": "^8.0.0"
+    "eslint": "^8.56.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,7 +228,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.0.0:
+eslint@^8.56.0:
   version "8.56.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.56.0.tgz#4957ce8da409dc0809f99ab07a1b94832ab74b15"
   integrity sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==
@@ -480,7 +480,7 @@ jquery-simulate@^1.0.2:
   resolved "https://registry.yarnpkg.com/jquery-simulate/-/jquery-simulate-1.0.2.tgz#2174b859b75123a0ac6d8ab3a9a6fb4ad7e82898"
   integrity sha512-Bq610fSrwTwvH5d06z5oskYaX/79s0BNrKiJZjZOiXRib3iL4ZkSn/wvLwzhf3P9KeXCEpk9wlIaGui/1arOpQ==
 
-js-cookie@^3.0.0:
+js-cookie@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
   integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
@@ -507,7 +507,7 @@ leaflet.locatecontrol@^0.79.0:
   resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.79.0.tgz#0236b87c699a49f9ddb2f289941fbc0d3c3f8b62"
   integrity sha512-h64QIHFkypYdr90lkSfjKvPvvk8/b8UnP3m9WuoWdp5p2AaCWC0T1NVwyuj4rd5U4fBW3tQt4ppmZ2LceHMIDg==
 
-leaflet@^1.8.0:
+leaflet@^1.9.4:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
   integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==
@@ -573,7 +573,7 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
 
-osm-community-index@^5.2.0:
+osm-community-index@^5.6.1:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/osm-community-index/-/osm-community-index-5.6.1.tgz#5be72c700145e94c57f2006e6f767a0e49d93870"
   integrity sha512-eMi5mDwwLkt3tbZtD60+aMj4kIa3smlQanxb3OcvJa2pv6w5uVCLbyCem0j8cTqAO3A+C7HD4T7dFUyt2WCYaQ==
@@ -626,7 +626,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.9.4:
+qs@^6.11.2:
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
   integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==


### PR DESCRIPTION
As a developer, I'd like to see the versions in use from the package.json file. This matches the behaviour when running `yarn upgrade-interactive --latest` to update versions manually.

Re-configure dependabot's versioning-strategy accordingly, see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy.