### PR TITLE
Move previous/next user's changeset links to bottom

### DIFF
--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -117,6 +117,12 @@
   <% end %>
 </div>
 
+<div class='secondary-actions'>
+  <%= link_to(t(".changesetxml"), :controller => "api/changesets", :action => "show") %>
+  &middot;
+  <%= link_to(t(".osmchangexml"), :controller => "api/changesets", :action => "download") %>
+</div>
+
 <% if @next_by_user || @prev_by_user %>
   <div class='secondary-actions'>
     <% if @prev_by_user %>
@@ -137,9 +143,3 @@
     <% end %>
   </div>
 <% end %>
-
-<div class='secondary-actions'>
-  <%= link_to(t(".changesetxml"), :controller => "api/changesets", :action => "show") %>
-  &middot;
-  <%= link_to(t(".osmchangexml"), :controller => "api/changesets", :action => "download") %>
-</div>


### PR DESCRIPTION
Links in the sidebar on /changeset/_id_ pages before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/ffe96fa8-1075-4f92-88fd-1296d429fbf3)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d7721b5d-b763-4d64-8232-0a8903a700ea)

The idea is that "Changeset XML" and "osmChange XML" are related to the current changeset and should be closer to the changeset details than links for navigation between changesets.

A similar order is already in use on element version pages:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/41117e28-c682-41cb-92ce-c95ecba1f593)
