### PR TITLE
Add diary discussion heading and move subscribe button next to it

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -827,14 +827,11 @@ tr.turn:hover {
     height: 400px;
     display: none;
   }
-  .comments {
-    max-width: 740px;
+  .diary-comment .col-auto {
+    width: 62px;
   }
-  .diary-comment {
-    border-top: 1px dashed $grey;
-    &:first-child {
-      border-top: 1px solid $grey;
-    }
+  .diary-comment .col {
+    max-width: 690px;
   }
 }
 

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -1,5 +1,5 @@
-<div class="row diary-comment py-3<%= " text-muted bg-danger bg-opacity-10" unless diary_comment.visible? %>">
-  <div class="col-auto">
+<div class="row diary-comment border-bottom py-3<%= " text-muted bg-danger bg-opacity-10" unless diary_comment.visible? %>">
+  <div class="col-auto pe-0 text-center">
     <%= user_thumbnail diary_comment.user %>
   </div>
   <div class="col">

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -12,8 +12,8 @@
 
 <%= render @entry %>
 
-<div id="comments" class="comments">
-  <div class="row">
+<div id="comments" class="comments mb-3">
+  <div class="row border-bottom border-grey">
     <h2 class="col"><%= t(".discussion") %></h2>
 
     <% if current_user %>
@@ -29,8 +29,6 @@
 
   <%= render :partial => "diary_comment", :collection => @comments %>
 </div>
-
-<hr>
 
 <div>
   <% if current_user %>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -13,7 +13,21 @@
 <%= render @entry %>
 
 <div id="comments" class="comments">
-<%= render :partial => "diary_comment", :collection => @comments %>
+  <div class="row">
+    <h2 class="col"><%= t(".discussion") %></h2>
+
+    <% if current_user %>
+      <div class="col-auto">
+        <% if @entry.subscribers.exists?(current_user.id) %>
+          <%= link_to t("javascripts.changesets.show.unsubscribe"), diary_entry_unsubscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => "btn btn-sm btn-primary" %>
+        <% else %>
+          <%= link_to t("javascripts.changesets.show.subscribe"), diary_entry_subscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => "btn btn-sm btn-primary" %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render :partial => "diary_comment", :collection => @comments %>
 </div>
 
 <hr>
@@ -25,11 +39,6 @@
     <%= bootstrap_form_for @entry.comments.new, :url => { :action => "comment" } do |f| %>
       <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
       <%= f.primary %>
-      <% if @entry.subscribers.exists?(current_user.id) %>
-        <%= link_to t("javascripts.changesets.show.unsubscribe"), diary_entry_unsubscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => "btn btn-light" %>
-      <% else %>
-        <%= link_to t("javascripts.changesets.show.subscribe"), diary_entry_subscribe_path(:display_name => @entry.user.display_name, :id => @entry.id), :method => :post, :class => "btn btn-light" %>
-      <% end %>
     <% end %>
   <% else %>
     <h3 id="newcomment"><%= t(".login_to_leave_a_comment_html", :login_link => link_to(t(".login"), login_path(:referer => request.fullpath))) %></h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,6 +524,7 @@ en:
     show:
       title: "%{user}'s Diary | %{title}"
       user_title: "%{user}'s Diary"
+      discussion: "Discussion"
       leave_a_comment: "Leave a comment"
       login_to_leave_a_comment_html: "%{login_link} to leave a comment"
       login: "Login"


### PR DESCRIPTION
Places (un)subscribe button on diary entry pages like it's on changeset pages. That requires adding a heading above the comments to make it clear to what you're subscribing.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/df945d38-f810-47b2-81f3-696f52bbfdcc)

Previously the button was right below the new comment box which is somewhat confusing, see #4491. You don't want to accidentally press it after typing in a comment.