### PR TITLE
Remove unused browse.changeset.comment locale string

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,7 +342,6 @@ en:
       way_paginated: "Ways (%{x}-%{y} of %{count})"
       relation: "Relations (%{count})"
       relation_paginated: "Relations (%{x}-%{y} of %{count})"
-      comment: "Comments (%{count})"
       hidden_comment_by_html: "Hidden comment from %{user} %{time_ago}"
       comment_by_html: "Comment from %{user} %{time_ago}"
       changesetxml: "Changeset XML"


### PR DESCRIPTION
Added in https://github.com/openstreetmap/openstreetmap-website/commit/14ac1babc2517320a2c90fa9b4ac36a5a6e68018 but never used. Probably was intended to be a heading for changeset comments but "Discussion" was used instead.