### PR TITLE
Remove html type from changeset feed entry titles

### DIFF
--- a/app/views/changesets/index.atom.builder
+++ b/app/views/changesets/index.atom.builder
@@ -25,7 +25,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
                  :type => "application/osmChange+xml"
 
       if !changeset.tags.empty? && changeset.tags.key?("comment")
-        entry.title t("browse.changeset.feed.title_comment", :id => changeset.id, :comment => changeset.tags["comment"]), :type => "html"
+        entry.title t("browse.changeset.feed.title_comment", :id => changeset.id, :comment => changeset.tags["comment"])
       else
         entry.title t("browse.changeset.feed.title", :id => changeset.id)
       end

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -243,6 +243,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     create(:changeset_tag, :changeset => changeset)
     create(:changeset_tag, :changeset => changeset, :k => "website", :v => "http://example.com/")
     closed_changeset = create(:changeset, :closed, :num_changes => 1)
+    create(:changeset_tag, :changeset => closed_changeset, :k => "website", :v => "https://osm.org/")
     _empty_changeset = create(:changeset, :num_changes => 0)
 
     get history_feed_path(:format => :atom)
@@ -250,7 +251,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     assert_template "index"
     assert_equal "application/atom+xml", response.media_type
 
-    check_feed_result([changeset, closed_changeset])
+    check_feed_result([closed_changeset, changeset])
   end
 
   ##
@@ -268,7 +269,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     assert_template "index"
     assert_equal "application/atom+xml", response.media_type
 
-    check_feed_result([changeset, closed_changeset])
+    check_feed_result([closed_changeset, changeset])
   end
 
   ##
@@ -286,7 +287,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     assert_template "index"
     assert_equal "application/atom+xml", response.media_type
 
-    check_feed_result(changesets)
+    check_feed_result(changesets.reverse)
   end
 
   ##
@@ -325,15 +326,18 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "feed", :count => [changesets.size, 1].min do
       assert_select "> title", :count => 1, :text => /^Changesets/
-      assert_select "> entry", :count => changesets.size
-
-      changesets.each do |changeset|
-        assert_select "> entry > id", changeset_url(:id => changeset.id)
-
-        assert_select "> entry > content > xhtml|div > xhtml|table" do
-          assert_select "> xhtml|tr > xhtml|td > xhtml|table" do
-            changeset.tags.each_key do |key|
-              assert_select "> xhtml|tr > xhtml|td", :text => /^#{key} = /
+      assert_select "> entry", :count => changesets.size do |entries|
+        entries.zip(changesets) do |entry, changeset|
+          assert_select entry, "> id", :text => changeset_url(:id => changeset.id)
+          assert_select entry, "> content > xhtml|div > xhtml|table" do
+            if changeset.tags.empty?
+              assert_select "> xhtml|tr > xhtml|td > xhtml|table", :count => 0
+            else
+              assert_select "> xhtml|tr > xhtml|td > xhtml|table", :count => 1 do
+                changeset.tags.each_key do |key|
+                  assert_select "> xhtml|tr > xhtml|td", :text => /^#{key} = /
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
Look at https://github.com/openstreetmap/openstreetmap-website/commit/fc9768f34c803f9a9746d1705af097655d55f3e2. It added `type="html"` to changeset feed entries for the reasons stated in the commit message. But is it actually correct? Let's check.

I created a couple of changesets. This is how their comments are shown on the `/history` page. I expect to see the same in a feed reader.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/13398e89-74d7-441a-8583-3b0c45a3b968)

This is how their titles look in `/history/feed` output. They are always escaped once.

    <title type="html">Changeset 58 - is it going to &lt;em&gt;emphasize&lt;/em&gt;?</title>
    ...
    <title type="html">Changeset 57 - this is unescaped (&lt;); this is escaped (&amp;lt;)</title>

This is how they look in [Liferea](https://en.wikipedia.org/wiki/Liferea). Not what's expected.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/abf9d80f-1e57-4254-9d6c-bc5391f0e48a)

This is how they look after `type="html"` is removed.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/8999b9f3-7047-4e3e-b906-e1ba0aafd0af)
