### PR TITLE
Link to current and old element versions from changeset pages

### DIFF
--- a/app/assets/stylesheets/browse.scss
+++ b/app/assets/stylesheets/browse.scss
@@ -14,10 +14,6 @@
     margin-left: 25px;
   }
 
-  /* Deleted objects */
-
-  .deleted { text-decoration: line-through; }
-
   /* Nodes (and ways as areas) */
 
   .aeroway.aerodrome::before { content: image-url('browse/aerodrome.p.16.png'); }

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -7,6 +7,12 @@ module BrowseHelper
     end
   end
 
+  def element_list_item(type, object, &block)
+    tag.li :class => element_class(type, object) do
+      element_strikethrough object, &block
+    end
+  end
+
   def printable_name(object, version: false)
     id = if object.id.is_a?(Array)
            object.id[0]

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -27,7 +27,7 @@ module BrowseHelper
     name
   end
 
-  def link_class(type, object)
+  def element_class(type, object)
     classes = [type]
 
     if object.redacted?

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -2,7 +2,7 @@ module BrowseHelper
   def element_single_current_link(type, object, url)
     link_to url, { :class => element_class(type, object), :title => element_title(object), :rel => (link_follow(object) if type == "node") } do
       element_strikethrough object do
-        printable_name object
+        printable_element_name object
       end
     end
   end
@@ -13,14 +13,13 @@ module BrowseHelper
     end
   end
 
-  def printable_name(object, version: false)
+  def printable_element_name(object)
     id = if object.id.is_a?(Array)
            object.id[0]
          else
            object.id
          end
-    name = t "printable_name.with_id", :id => id.to_s
-    name = t "printable_name.with_version", :id => name, :version => object.version.to_s if version
+    name = id.to_s
 
     # don't look at object tags if redacted, so as to avoid giving
     # away redacted version tag information.
@@ -39,6 +38,10 @@ module BrowseHelper
     end
 
     name
+  end
+
+  def printable_element_version(object)
+    t "printable_name.version", :version => object.version
   end
 
   def element_strikethrough(object, &block)

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -1,4 +1,12 @@
 module BrowseHelper
+  def element_single_current_link(type, object, url)
+    link_to url, { :class => element_class(type, object), :title => link_title(object), :rel => (link_follow(object) if type == "node") } do
+      element_strikethrough object do
+        printable_name object
+      end
+    end
+  end
+
   def printable_name(object, version: false)
     id = if object.id.is_a?(Array)
            object.id[0]
@@ -27,16 +35,17 @@ module BrowseHelper
     name
   end
 
+  def element_strikethrough(object, &block)
+    if object.redacted? || !object.visible?
+      tag.s(&block)
+    else
+      yield
+    end
+  end
+
   def element_class(type, object)
     classes = [type]
-
-    if object.redacted?
-      classes << "deleted"
-    else
-      classes += icon_tags(object).flatten.map { |t| h(t) }
-      classes << "deleted" unless object.visible?
-    end
-
+    classes += icon_tags(object).flatten.map { |t| h(t) } unless object.redacted?
     classes.join(" ")
   end
 

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -1,6 +1,6 @@
 module BrowseHelper
   def element_single_current_link(type, object, url)
-    link_to url, { :class => element_class(type, object), :title => link_title(object), :rel => (link_follow(object) if type == "node") } do
+    link_to url, { :class => element_class(type, object), :title => element_title(object), :rel => (link_follow(object) if type == "node") } do
       element_strikethrough object do
         printable_name object
       end
@@ -8,7 +8,7 @@ module BrowseHelper
   end
 
   def element_list_item(type, object, &block)
-    tag.li :class => element_class(type, object) do
+    tag.li :class => element_class(type, object), :title => element_title(object) do
       element_strikethrough object, &block
     end
   end
@@ -55,7 +55,7 @@ module BrowseHelper
     classes.join(" ")
   end
 
-  def link_title(object)
+  def element_title(object)
     if object.redacted?
       ""
     else

--- a/app/views/browse/_containing_relation.html.erb
+++ b/app/views/browse/_containing_relation.html.erb
@@ -1,4 +1,4 @@
-<li><%= linked_name = link_to printable_name(containing_relation.relation), :action => "relation", :id => containing_relation.relation.id.to_s
+<li><%= linked_name = link_to printable_element_name(containing_relation.relation), :action => "relation", :id => containing_relation.relation.id.to_s
         if containing_relation.member_role.blank?
           t ".entry_html", :relation_name => linked_name
         else

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -17,7 +17,7 @@
           <summary><%= t "browse.part_of_ways", :count => node.ways.uniq.count %></summary>
           <ul class="list-unstyled">
             <% node.ways.uniq.each do |way| %>
-              <li><%= link_to printable_name(way), way_path(way), { :class => element_class("way", way), :title => link_title(way) } %></li>
+              <li><%= element_single_current_link "way", way, way_path(way) %></li>
             <% end %>
           </ul>
         </details>

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -17,7 +17,7 @@
           <summary><%= t "browse.part_of_ways", :count => node.ways.uniq.count %></summary>
           <ul class="list-unstyled">
             <% node.ways.uniq.each do |way| %>
-              <li><%= link_to printable_name(way), way_path(way), { :class => link_class("way", way), :title => link_title(way) } %></li>
+              <li><%= link_to printable_name(way), way_path(way), { :class => element_class("way", way), :title => link_title(way) } %></li>
             <% end %>
           </ul>
         </details>

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -1,4 +1,4 @@
-<% linked_name = link_to printable_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :rel => link_follow(relation_member.member) }
+<% linked_name = link_to printable_element_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :rel => link_follow(relation_member.member) }
    type_str = t ".type.#{relation_member.member_type.downcase}" %>
 <%= element_list_item relation_member.member_type.downcase, relation_member.member do %>
   <%= if relation_member.member_role.blank?

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -1,12 +1,9 @@
-<% member_class = element_class(relation_member.member_type.downcase, relation_member.member)
-   linked_name = link_to printable_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :title => link_title(relation_member.member), :rel => link_follow(relation_member.member) }
+<% linked_name = link_to printable_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :title => link_title(relation_member.member), :rel => link_follow(relation_member.member) }
    type_str = t ".type.#{relation_member.member_type.downcase}" %>
-<li class="<%= member_class %>">
-  <%= element_strikethrough relation_member.member do %>
-    <%= if relation_member.member_role.blank?
-          t ".entry_html", :type => type_str, :name => linked_name
-        else
-          t ".entry_role_html", :type => type_str, :name => linked_name, :role => relation_member.member_role
-        end %>
-  <% end %>
-</li>
+<%= element_list_item relation_member.member_type.downcase, relation_member.member do %>
+  <%= if relation_member.member_role.blank?
+        t ".entry_html", :type => type_str, :name => linked_name
+      else
+        t ".entry_role_html", :type => type_str, :name => linked_name, :role => relation_member.member_role
+      end %>
+<% end %>

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -1,4 +1,4 @@
-<% member_class = link_class(relation_member.member_type.downcase, relation_member.member)
+<% member_class = element_class(relation_member.member_type.downcase, relation_member.member)
    linked_name = link_to printable_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :title => link_title(relation_member.member), :rel => link_follow(relation_member.member) }
    type_str = t ".type.#{relation_member.member_type.downcase}" %>
 <li class="<%= member_class %>">

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -2,9 +2,11 @@
    linked_name = link_to printable_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :title => link_title(relation_member.member), :rel => link_follow(relation_member.member) }
    type_str = t ".type.#{relation_member.member_type.downcase}" %>
 <li class="<%= member_class %>">
-  <%= if relation_member.member_role.blank?
-        t ".entry_html", :type => type_str, :name => linked_name
-      else
-        t ".entry_role_html", :type => type_str, :name => linked_name, :role => relation_member.member_role
-      end %>
+  <%= element_strikethrough relation_member.member do %>
+    <%= if relation_member.member_role.blank?
+          t ".entry_html", :type => type_str, :name => linked_name
+        else
+          t ".entry_role_html", :type => type_str, :name => linked_name, :role => relation_member.member_role
+        end %>
+  <% end %>
 </li>

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -1,4 +1,4 @@
-<% linked_name = link_to printable_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :title => link_title(relation_member.member), :rel => link_follow(relation_member.member) }
+<% linked_name = link_to printable_name(relation_member.member), { :controller => :browse, :action => relation_member.member_type.downcase, :id => relation_member.member_id.to_s }, { :rel => link_follow(relation_member.member) }
    type_str = t ".type.#{relation_member.member_type.downcase}" %>
 <%= element_list_item relation_member.member_type.downcase, relation_member.member do %>
   <%= if relation_member.member_role.blank?

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -27,10 +27,12 @@
         <ul class="list-unstyled">
           <% way.way_nodes.each do |wn| %>
             <li>
-              <%= link_to printable_name(wn.node), node_path(wn.node), { :class => element_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>
+              <%= element_single_current_link "node", wn.node, node_path(wn.node) %>
               <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
               <% if related_ways.size > 0 then %>
-                (<%= t ".also_part_of_html", :count => related_ways.size, :related_ways => to_sentence(related_ways.map { |w| link_to(printable_name(w), way_path(w), { :class => element_class("way", w), :title => link_title(w) }) }) %>)
+                (<%= t ".also_part_of_html",
+                       :count => related_ways.size,
+                       :related_ways => to_sentence(related_ways.map { |w| element_single_current_link "way", w, way_path(w) }) %>)
               <% end %>
             </li>
           <% end %>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -27,10 +27,10 @@
         <ul class="list-unstyled">
           <% way.way_nodes.each do |wn| %>
             <li>
-              <%= link_to printable_name(wn.node), node_path(wn.node), { :class => link_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>
+              <%= link_to printable_name(wn.node), node_path(wn.node), { :class => element_class("node", wn.node), :title => link_title(wn.node), :rel => link_follow(wn.node) } %>
               <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
               <% if related_ways.size > 0 then %>
-                (<%= t ".also_part_of_html", :count => related_ways.size, :related_ways => to_sentence(related_ways.map { |w| link_to(printable_name(w), way_path(w), { :class => link_class("way", w), :title => link_title(w) }) }) %>)
+                (<%= t ".also_part_of_html", :count => related_ways.size, :related_ways => to_sentence(related_ways.map { |w| link_to(printable_name(w), way_path(w), { :class => element_class("way", w), :title => link_title(w) }) }) %>)
               <% end %>
             </li>
           <% end %>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -94,7 +94,7 @@
     <ul class="list-unstyled">
       <% @ways.each do |way| %>
         <%= element_list_item "way", way do %>
-          <%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :title => link_title(way) } %>
+          <%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s } %>
         <% end %>
       <% end %>
     </ul>
@@ -105,7 +105,7 @@
     <ul class="list-unstyled">
       <% @relations.each do |relation| %>
         <%= element_list_item "relation", relation do %>
-          <%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :title => link_title(relation) } %>
+          <%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s } %>
         <% end %>
       <% end %>
     </ul>
@@ -116,7 +116,7 @@
     <ul class="list-unstyled">
       <% @nodes.each do |node| %>
         <%= element_list_item "node", node do %>
-          <%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :title => link_title(node), :rel => link_follow(node) } %>
+          <%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :rel => link_follow(node) } %>
         <% end %>
       <% end %>
     </ul>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -94,7 +94,9 @@
     <ul class="list-unstyled">
       <% @ways.each do |way| %>
         <%= element_list_item "way", way do %>
-          <%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s } %>
+          <%= t "printable_name.current_and_old_links_html",
+                :current_link => link_to(printable_element_name(way), way_path(way.way_id)),
+                :old_link => link_to(printable_element_version(way), old_way_path(way.way_id, way.version)) %>
         <% end %>
       <% end %>
     </ul>
@@ -105,7 +107,9 @@
     <ul class="list-unstyled">
       <% @relations.each do |relation| %>
         <%= element_list_item "relation", relation do %>
-          <%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s } %>
+          <%= t "printable_name.current_and_old_links_html",
+                :current_link => link_to(printable_element_name(relation), relation_path(relation.relation_id)),
+                :old_link => link_to(printable_element_version(relation), old_relation_path(relation.relation_id, relation.version)) %>
         <% end %>
       <% end %>
     </ul>
@@ -116,7 +120,9 @@
     <ul class="list-unstyled">
       <% @nodes.each do |node| %>
         <%= element_list_item "node", node do %>
-          <%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :rel => link_follow(node) } %>
+          <%= t "printable_name.current_and_old_links_html",
+                :current_link => link_to(printable_element_name(node), node_path(node.node_id), { :rel => link_follow(node) }),
+                :old_link => link_to(printable_element_version(node), old_node_path(node.node_id, node.version), { :rel => link_follow(node) }) %>
         <% end %>
       <% end %>
     </ul>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -93,7 +93,9 @@
     <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("way", @way_pages), :pages => @way_pages, :page_param => "way_page" } %>
     <ul class="list-unstyled">
       <% @ways.each do |way| %>
-        <li><%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :class => link_class("way", way), :title => link_title(way) } %></li>
+        <li class="<%= element_class("way", way) %>">
+          <%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :title => link_title(way) } %>
+        </li>
       <% end %>
     </ul>
   <% end %>
@@ -102,7 +104,9 @@
     <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("relation", @relation_pages), :pages => @relation_pages, :page_param => "relation_page" } %>
     <ul class="list-unstyled">
       <% @relations.each do |relation| %>
-        <li><%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :class => link_class("relation", relation), :title => link_title(relation) } %></li>
+        <li class="<%= element_class("relation", relation) %>">
+          <%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :title => link_title(relation) } %>
+        </li>
       <% end %>
     </ul>
   <% end %>
@@ -111,7 +115,9 @@
     <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("node", @node_pages), :pages => @node_pages, :page_param => "node_page" } %>
     <ul class="list-unstyled">
       <% @nodes.each do |node| %>
-        <li><%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :class => link_class("node", node), :title => link_title(node), :rel => link_follow(node) } %></li>
+        <li class="<%= element_class("node", node) %>">
+          <%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :title => link_title(node), :rel => link_follow(node) } %>
+        </li>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -94,7 +94,9 @@
     <ul class="list-unstyled">
       <% @ways.each do |way| %>
         <li class="<%= element_class("way", way) %>">
-          <%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :title => link_title(way) } %>
+          <%= element_strikethrough way do %>
+            <%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :title => link_title(way) } %>
+          <% end %>
         </li>
       <% end %>
     </ul>
@@ -105,7 +107,9 @@
     <ul class="list-unstyled">
       <% @relations.each do |relation| %>
         <li class="<%= element_class("relation", relation) %>">
-          <%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :title => link_title(relation) } %>
+          <%= element_strikethrough relation do %>
+            <%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :title => link_title(relation) } %>
+          <% end %>
         </li>
       <% end %>
     </ul>
@@ -116,7 +120,9 @@
     <ul class="list-unstyled">
       <% @nodes.each do |node| %>
         <li class="<%= element_class("node", node) %>">
-          <%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :title => link_title(node), :rel => link_follow(node) } %>
+          <%= element_strikethrough node do %>
+            <%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :title => link_title(node), :rel => link_follow(node) } %>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/app/views/browse/changeset.html.erb
+++ b/app/views/browse/changeset.html.erb
@@ -93,11 +93,9 @@
     <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("way", @way_pages), :pages => @way_pages, :page_param => "way_page" } %>
     <ul class="list-unstyled">
       <% @ways.each do |way| %>
-        <li class="<%= element_class("way", way) %>">
-          <%= element_strikethrough way do %>
-            <%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :title => link_title(way) } %>
-          <% end %>
-        </li>
+        <%= element_list_item "way", way do %>
+          <%= link_to printable_name(way, :version => true), { :action => "way", :id => way.way_id.to_s }, { :title => link_title(way) } %>
+        <% end %>
       <% end %>
     </ul>
   <% end %>
@@ -106,11 +104,9 @@
     <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("relation", @relation_pages), :pages => @relation_pages, :page_param => "relation_page" } %>
     <ul class="list-unstyled">
       <% @relations.each do |relation| %>
-        <li class="<%= element_class("relation", relation) %>">
-          <%= element_strikethrough relation do %>
-            <%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :title => link_title(relation) } %>
-          <% end %>
-        </li>
+        <%= element_list_item "relation", relation do %>
+          <%= link_to printable_name(relation, :version => true), { :action => "relation", :id => relation.relation_id.to_s }, { :title => link_title(relation) } %>
+        <% end %>
       <% end %>
     </ul>
   <% end %>
@@ -119,11 +115,9 @@
     <%= render :partial => "paging_nav", :locals => { :heading => type_and_paginated_count("node", @node_pages), :pages => @node_pages, :page_param => "node_page" } %>
     <ul class="list-unstyled">
       <% @nodes.each do |node| %>
-        <li class="<%= element_class("node", node) %>">
-          <%= element_strikethrough node do %>
-            <%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :title => link_title(node), :rel => link_follow(node) } %>
-          <% end %>
-        </li>
+        <%= element_list_item "node", node do %>
+          <%= link_to printable_name(node, :version => true), { :action => "node", :id => node.node_id.to_s }, { :title => link_title(node), :rel => link_follow(node) } %>
+        <% end %>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/browse/feature.html.erb
+++ b/app/views/browse/feature.html.erb
@@ -1,6 +1,6 @@
-<% set_title(t("browse.#{@type}.title_html", :name => printable_name(@feature))) %>
+<% set_title(t("browse.#{@type}.title_html", :name => printable_element_name(@feature))) %>
 
-<%= render "sidebar_header", :title => t("browse.#{@type}.title_html", :name => printable_name(@feature)) %>
+<%= render "sidebar_header", :title => t("browse.#{@type}.title_html", :name => printable_element_name(@feature)) %>
 
 <%= render :partial => @type, :object => @feature %>
 

--- a/app/views/browse/history.html.erb
+++ b/app/views/browse/history.html.erb
@@ -1,6 +1,6 @@
-<% set_title(t("browse.#{@type}.history_title_html", :name => printable_name(@feature))) %>
+<% set_title(t("browse.#{@type}.history_title_html", :name => printable_element_name(@feature))) %>
 
-<%= render "sidebar_header", :title => t("browse.#{@type}.history_title_html", :name => printable_name(@feature)) %>
+<%= render "sidebar_header", :title => t("browse.#{@type}.history_title_html", :name => printable_element_name(@feature)) %>
 
 <%= render :partial => @type, :collection => @feature.send(:"old_#{@type}s").reverse %>
 

--- a/app/views/old_nodes/show.html.erb
+++ b/app/views/old_nodes/show.html.erb
@@ -1,6 +1,6 @@
-<% set_title t("browse.node.title_html", :name => printable_name(@feature)) %>
+<% set_title t("browse.node.title_html", :name => printable_element_name(@feature)) %>
 
-<%= render "sidebar_header", :title => t("browse.node.title_html", :name => printable_name(@feature)) %>
+<%= render "sidebar_header", :title => t("browse.node.title_html", :name => printable_element_name(@feature)) %>
 
 <%= render :partial => "browse/node", :object => @feature %>
 

--- a/app/views/old_relations/show.html.erb
+++ b/app/views/old_relations/show.html.erb
@@ -1,6 +1,6 @@
-<% set_title t("browse.relation.title_html", :name => printable_name(@feature)) %>
+<% set_title t("browse.relation.title_html", :name => printable_element_name(@feature)) %>
 
-<%= render "sidebar_header", :title => t("browse.relation.title_html", :name => printable_name(@feature)) %>
+<%= render "sidebar_header", :title => t("browse.relation.title_html", :name => printable_element_name(@feature)) %>
 
 <%= render :partial => "browse/relation", :object => @feature %>
 

--- a/app/views/old_ways/show.html.erb
+++ b/app/views/old_ways/show.html.erb
@@ -1,6 +1,6 @@
-<% set_title t("browse.way.title_html", :name => printable_name(@feature)) %>
+<% set_title t("browse.way.title_html", :name => printable_element_name(@feature)) %>
 
-<%= render "sidebar_header", :title => t("browse.way.title_html", :name => printable_name(@feature)) %>
+<%= render "sidebar_header", :title => t("browse.way.title_html", :name => printable_element_name(@feature)) %>
 
 <%= render :partial => "browse/way", :object => @feature %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,9 +204,9 @@ en:
         one: "%{count} year ago"
         other: "%{count} years ago"
   printable_name:
-    with_id: "%{id}"
-    with_version: "%{id}, v%{version}"
+    version: "v%{version}"
     with_name_html: "%{name} (%{id})"
+    current_and_old_links_html: "%{current_link}, %{old_link}"
   editor:
     default: "Default (currently %{name})"
     id:

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -156,6 +156,15 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select "div.changeset-comments ul li", :count => 4
   end
 
+  def test_read_changeset_element_links
+    changeset = create(:changeset)
+    node = create(:node, :with_history, :changeset => changeset)
+
+    browse_check :changeset_path, changeset.id, "browse/changeset"
+    assert_dom "a[href='#{node_path node}']", :count => 1
+    assert_dom "a[href='#{old_node_path node, 1}']", :count => 1
+  end
+
   ##
   #  Methods to check redaction.
   #

--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -58,7 +58,7 @@ class BrowseHelperTest < ActionView::TestCase
     end
   end
 
-  def test_link_class
+  def test_element_class
     node = create(:node, :with_history, :version => 2)
     node_v1 = node.old_nodes.find_by(:version => 1)
     node_v2 = node.old_nodes.find_by(:version => 2)
@@ -68,12 +68,12 @@ class BrowseHelperTest < ActionView::TestCase
     add_old_tags_selection(node_v2)
     add_old_tags_selection(node_v1)
 
-    assert_equal "node", link_class("node", create(:node))
-    assert_equal "node deleted", link_class("node", create(:node, :deleted))
+    assert_equal "node", element_class("node", create(:node))
+    assert_equal "node deleted", element_class("node", create(:node, :deleted))
 
-    assert_equal "node building yes shop gift tourism museum", link_class("node", node)
-    assert_equal "node building yes shop gift tourism museum", link_class("node", node_v2)
-    assert_equal "node deleted", link_class("node", node_v1)
+    assert_equal "node building yes shop gift tourism museum", element_class("node", node)
+    assert_equal "node building yes shop gift tourism museum", element_class("node", node_v2)
+    assert_equal "node deleted", element_class("node", node_v1)
   end
 
   def test_link_title

--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -92,7 +92,7 @@ class BrowseHelperTest < ActionView::TestCase
     assert_equal "node", element_class("node", node_v1)
   end
 
-  def test_link_title
+  def test_element_title
     node = create(:node, :with_history, :version => 2)
     node_v1 = node.old_nodes.find_by(:version => 1)
     node_v2 = node.old_nodes.find_by(:version => 2)
@@ -102,12 +102,12 @@ class BrowseHelperTest < ActionView::TestCase
     add_old_tags_selection(node_v2)
     add_old_tags_selection(node_v1)
 
-    assert_equal "", link_title(create(:node))
-    assert_equal "", link_title(create(:node, :deleted))
+    assert_equal "", element_title(create(:node))
+    assert_equal "", element_title(create(:node, :deleted))
 
-    assert_equal "building=yes, shop=gift, and tourism=museum", link_title(node)
-    assert_equal "building=yes, shop=gift, and tourism=museum", link_title(node_v2)
-    assert_equal "", link_title(node_v1)
+    assert_equal "building=yes, shop=gift, and tourism=museum", element_title(node)
+    assert_equal "building=yes, shop=gift, and tourism=museum", element_title(node_v2)
+    assert_equal "", element_title(node_v1)
   end
 
   def test_icon_tags

--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -58,6 +58,22 @@ class BrowseHelperTest < ActionView::TestCase
     end
   end
 
+  def test_element_strikethrough
+    node = create(:node, :with_history, :version => 2)
+    node_v1 = node.old_nodes.find_by(:version => 1)
+    node_v2 = node.old_nodes.find_by(:version => 2)
+    node_v1.redact!(create(:redaction))
+
+    normal_output = element_strikethrough(node_v2) { "test" }
+    assert_equal "test", normal_output
+
+    redacted_output = element_strikethrough(node_v1) { "test" }
+    assert_equal "<s>test</s>", redacted_output
+
+    deleted_output = element_strikethrough(create(:node, :deleted)) { "test" }
+    assert_equal "<s>test</s>", deleted_output
+  end
+
   def test_element_class
     node = create(:node, :with_history, :version => 2)
     node_v1 = node.old_nodes.find_by(:version => 1)
@@ -69,11 +85,11 @@ class BrowseHelperTest < ActionView::TestCase
     add_old_tags_selection(node_v1)
 
     assert_equal "node", element_class("node", create(:node))
-    assert_equal "node deleted", element_class("node", create(:node, :deleted))
+    assert_equal "node", element_class("node", create(:node, :deleted))
 
     assert_equal "node building yes shop gift tourism museum", element_class("node", node)
     assert_equal "node building yes shop gift tourism museum", element_class("node", node_v2)
-    assert_equal "node deleted", element_class("node", node_v1)
+    assert_equal "node", element_class("node", node_v1)
   end
 
   def test_link_title

--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -4,7 +4,7 @@ class BrowseHelperTest < ActionView::TestCase
   include ERB::Util
   include ApplicationHelper
 
-  def test_printable_name
+  def test_printable_element_name
     node = create(:node, :with_history, :version => 2)
     node_v1 = node.old_nodes.find_by(:version => 1)
     node_v2 = node.old_nodes.find_by(:version => 2)
@@ -19,42 +19,34 @@ class BrowseHelperTest < ActionView::TestCase
 
     deleted_node = create(:node, :deleted)
 
-    assert_dom_equal deleted_node.id.to_s, printable_name(deleted_node)
-    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node)
-    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node_v2)
-    assert_dom_equal node.id.to_s, printable_name(node_v1)
-    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, :version => true)
-    assert_dom_equal "#{node.id}, v1", printable_name(node_v1, :version => true)
-    assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_name(node_with_ref_without_name)
+    assert_dom_equal deleted_node.id.to_s, printable_element_name(deleted_node)
+    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_element_name(node)
+    assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_element_name(node_v2)
+    assert_dom_equal node.id.to_s, printable_element_name(node_v1)
+    assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_element_name(node_with_ref_without_name)
 
     I18n.with_locale "pt" do
-      assert_dom_equal deleted_node.id.to_s, printable_name(deleted_node)
-      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node)
-      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node_v2)
-      assert_dom_equal node.id.to_s, printable_name(node_v1)
-      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, :version => true)
-      assert_dom_equal "#{node.id}, v1", printable_name(node_v1, :version => true)
-      assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_name(node_with_ref_without_name)
+      assert_dom_equal deleted_node.id.to_s, printable_element_name(deleted_node)
+      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_element_name(node)
+      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_element_name(node_v2)
+      assert_dom_equal node.id.to_s, printable_element_name(node_v1)
+      assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_element_name(node_with_ref_without_name)
     end
 
     I18n.with_locale "pt-BR" do
-      assert_dom_equal deleted_node.id.to_s, printable_name(deleted_node)
-      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node)
-      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node_v2)
-      assert_dom_equal node.id.to_s, printable_name(node_v1)
-      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, :version => true)
-      assert_dom_equal "#{node.id}, v1", printable_name(node_v1, :version => true)
-      assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_name(node_with_ref_without_name)
+      assert_dom_equal deleted_node.id.to_s, printable_element_name(deleted_node)
+      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_element_name(node)
+      assert_dom_equal "<bdi>Nó teste</bdi> (<bdi>#{node.id}</bdi>)", printable_element_name(node_v2)
+      assert_dom_equal node.id.to_s, printable_element_name(node_v1)
+      assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_element_name(node_with_ref_without_name)
     end
 
     I18n.with_locale "de" do
-      assert_dom_equal deleted_node.id.to_s, printable_name(deleted_node)
-      assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node)
-      assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_name(node_v2)
-      assert_dom_equal node.id.to_s, printable_name(node_v1)
-      assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}, v2</bdi>)", printable_name(node_v2, :version => true)
-      assert_dom_equal "#{node.id}, v1", printable_name(node_v1, :version => true)
-      assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_name(node_with_ref_without_name)
+      assert_dom_equal deleted_node.id.to_s, printable_element_name(deleted_node)
+      assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_element_name(node)
+      assert_dom_equal "<bdi>Test Node</bdi> (<bdi>#{node.id}</bdi>)", printable_element_name(node_v2)
+      assert_dom_equal node.id.to_s, printable_element_name(node_v1)
+      assert_dom_equal "<bdi>3.1415926</bdi> (<bdi>#{node_with_ref_without_name.id}</bdi>)", printable_element_name(node_with_ref_without_name)
     end
   end
 


### PR DESCRIPTION
Changeset pages have links to changed elements. Previously elements only had current version and full history pages, so links were to current versions. Now there are pages for each element version too, and links on changeset pages have version number displayed. It makes sense to link that v-number part to that exact version.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6e15e209-ea11-49c4-9717-3cd63c4b1948)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9ed34131-9fba-4cab-aaf3-7426a6ab9084)
