### PR TITLE
Move changeset feed locale strings from browse section to changesets

### DIFF
--- a/app/views/changesets/index.atom.builder
+++ b/app/views/changesets/index.atom.builder
@@ -25,9 +25,9 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
                  :type => "application/osmChange+xml"
 
       if !changeset.tags.empty? && changeset.tags.key?("comment")
-        entry.title t("browse.changeset.feed.title_comment", :id => changeset.id, :comment => changeset.tags["comment"])
+        entry.title t(".feed.title_comment", :id => changeset.id, :comment => changeset.tags["comment"])
       else
-        entry.title t("browse.changeset.feed.title", :id => changeset.id)
+        entry.title t(".feed.title", :id => changeset.id)
       end
 
       if changeset.user.data_public?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,9 +346,6 @@ en:
       comment_by_html: "Comment from %{user} %{time_ago}"
       changesetxml: "Changeset XML"
       osmchangexml: "osmChange XML"
-      feed:
-        title: "Changeset %{id}"
-        title_comment: "Changeset %{id} - %{comment}"
       join_discussion: "Log in to join the discussion"
       discussion: Discussion
       still_open: "Changeset still open - discussion will open once the changeset is closed."
@@ -464,6 +461,9 @@ en:
       no_more_area: "No more changesets in this area."
       no_more_user: "No more changesets by this user."
       load_more: "Load more"
+      feed:
+        title: "Changeset %{id}"
+        title_comment: "Changeset %{id} - %{comment}"
     timeout:
       sorry: "Sorry, the list of changesets you requested took too long to retrieve."
   changeset_comments:


### PR DESCRIPTION
Changeset feeds are not handled by browse controller, and I want to remove more stuff from browse controller later, possibly everything.