### PR TITLE
Use a reduced priority for batch trace uploads

### DIFF
--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -35,7 +35,7 @@ module Api
         trace = do_create(params[:file], tags, description, visibility)
 
         if trace.id
-          TraceImporterJob.perform_later(trace)
+          trace.schedule_import
           render :plain => trace.id.to_s
         elsif trace.valid?
           head :internal_server_error
@@ -66,7 +66,7 @@ module Api
       if trace.user == current_user
         trace.visible = false
         trace.save!
-        TraceDestroyerJob.perform_later(trace)
+        trace.schedule_destruction
 
         head :ok
       else

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -126,7 +126,7 @@ class TracesController < ApplicationController
         flash[:notice] = t ".trace_uploaded"
         flash[:warning] = t ".traces_waiting", :count => current_user.traces.where(:inserted => false).count if current_user.traces.where(:inserted => false).count > 4
 
-        TraceImporterJob.perform_later(@trace)
+        @trace.schedule_import
         redirect_to :action => :index, :display_name => current_user.display_name
       else
         flash[:error] = t(".upload_failed") if @trace.valid?
@@ -176,7 +176,7 @@ class TracesController < ApplicationController
       trace.visible = false
       trace.save
       flash[:notice] = t ".scheduled_for_deletion"
-      TraceDestroyerJob.perform_later(trace)
+      trace.schedule_destruction
       redirect_to :action => :index, :display_name => trace.user.display_name
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -267,6 +267,14 @@ class Trace < ApplicationRecord
     end
   end
 
+  def schedule_import
+    TraceImporterJob.perform_later(self)
+  end
+
+  def schedule_destruction
+    TraceDestroyerJob.perform_later(self)
+  end
+
   private
 
   def content_type(file)

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -268,7 +268,7 @@ class Trace < ApplicationRecord
   end
 
   def schedule_import
-    TraceImporterJob.perform_later(self)
+    TraceImporterJob.new(self).enqueue(:priority => user.traces.where(:inserted => false).count)
   end
 
   def schedule_destruction


### PR DESCRIPTION
This sets the priority of the trace import job based on the number of pending traces the user has so the more they up load at once the lower the priority, thus allowing other users who only upload a few to jump in front of them.