### PR TITLE
Remove assert_response when followed by assert_redirected_to

### DIFF
--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -25,7 +25,6 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # Make sure that you are redirected to the login page when
     # you are not logged in
     get edit_account_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/account/edit")
 
     # Make sure we get the page when we are logged in as the right user
@@ -49,10 +48,8 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
 
     # Adding external authentication should redirect to the auth provider
     patch account_path, :params => { :user => user.attributes.merge(:auth_provider => "google") }
-    assert_response :redirect
     assert_redirected_to auth_path(:provider => "google", :origin => "/account")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to %r{^https://accounts.google.com/o/oauth2/auth\?.*}
 
     # Changing name to one that exists should fail
@@ -74,7 +71,6 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # Changing name to one that doesn't exist should work
     new_attributes = user.attributes.dup.merge(:display_name => "new tester")
     patch account_path, :params => { :user => new_attributes }
-    assert_response :redirect
     assert_redirected_to edit_account_url
     get edit_account_path
     assert_response :success
@@ -116,7 +112,6 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
         patch account_path, :params => { :user => user.attributes }
       end
     end
-    assert_response :redirect
     assert_redirected_to edit_account_url
     get edit_account_path
     assert_response :success
@@ -135,7 +130,6 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # Make sure that you are redirected to the login page when
     # you are not logged in
     get edit_account_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/account/edit")
 
     # Make sure we get the page when we are logged in as the right user

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -184,7 +184,6 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     _changeset2 = create(:changeset, :user => create(:user), :num_changes => 1)
 
     get friend_changesets_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => friend_changesets_path)
 
     session_for(private_user)
@@ -210,7 +209,6 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     _changeset2 = create(:changeset, :user => far_away_user, :num_changes => 1)
 
     get nearby_changesets_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => nearby_changesets_path)
 
     session_for(private_user)
@@ -397,7 +395,6 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
   # Check that we can't request later pages of the changesets feed
   def test_feed_max_id
     get history_feed_path(:format => "atom", :max_id => 100)
-    assert_response :redirect
     assert_redirected_to :action => :feed
   end
 
@@ -408,7 +405,6 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     path = changeset_subscribe_path(changeset)
 
     get path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => path)
 
     session_for(other_user)
@@ -429,7 +425,6 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     assert_difference "changeset.subscribers.count", 1 do
       post changeset_subscribe_path(changeset)
     end
-    assert_response :redirect
     assert_redirected_to changeset_path(changeset)
     assert changeset.reload.subscribed?(other_user)
   end
@@ -466,7 +461,6 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     path = changeset_unsubscribe_path(changeset)
 
     get path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => path)
 
     session_for(other_user)
@@ -489,7 +483,6 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     assert_difference "changeset.subscribers.count", -1 do
       post changeset_unsubscribe_path(changeset)
     end
-    assert_response :redirect
     assert_redirected_to changeset_path(changeset)
     assert_not changeset.reload.subscribed?(other_user)
   end

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -64,7 +64,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     # Now try to get the confirmation page again
     get user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
-    assert_response :redirect
     assert_redirected_to root_path
   end
 
@@ -191,7 +190,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     # Get the confirmation page
     get user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
-    assert_response :redirect
     assert_redirected_to root_path
 
     # Confirm the user
@@ -211,7 +209,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert_response :redirect
     assert_redirected_to login_path
     assert_equal("confirmations/resend_success_flash", flash[:notice][:partial])
     assert_equal({ :email => user.email, :sender => Settings.email_from }, flash[:notice][:locals])
@@ -234,7 +231,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match "User #{user.display_name} not found.", flash[:error]
   end
@@ -252,7 +248,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match "User #{user.display_name} not found.", flash[:error]
   end
@@ -264,7 +259,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match "User No Such User not found.", flash[:error]
   end
@@ -284,7 +278,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     confirm_string = user.generate_token_for(:new_email)
 
     post user_confirm_email_path, :params => { :confirm_string => confirm_string }
-    assert_response :redirect
     assert_redirected_to edit_account_path
     assert_match(/Confirmed your change of email address/, flash[:notice])
   end
@@ -294,14 +287,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     confirm_string = user.generate_token_for(:new_email)
 
     post user_confirm_email_path, :params => { :confirm_string => confirm_string }
-    assert_response :redirect
     assert_redirected_to edit_account_path
     assert_match(/already been confirmed/, flash[:error])
   end
 
   def test_confirm_email_bad_token
     post user_confirm_email_path, :params => { :confirm_string => "XXXXX" }
-    assert_response :redirect
     assert_redirected_to edit_account_path
     assert_match(/confirmation code has expired or does not exist/, flash[:error])
   end
@@ -318,7 +309,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     # precondition gravatar should be turned off
     assert_not user.image_use_gravatar
     post user_confirm_email_path, :params => { :confirm_string => confirm_string }
-    assert_response :redirect
     assert_redirected_to edit_account_path
     assert_match(/Confirmed your change of email address/, flash[:notice])
     # gravatar use should now be enabled
@@ -333,7 +323,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     # precondition gravatar should be turned on
     assert user.image_use_gravatar
     post user_confirm_email_path, :params => { :confirm_string => confirm_string }
-    assert_response :redirect
     assert_redirected_to edit_account_path
     assert_match(/Confirmed your change of email address/, flash[:notice])
     # gravatar use should now be disabled

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -120,7 +120,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Make sure that you are redirected to the login page when you
     # are not logged in
     get new_diary_entry_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/diary/new")
   end
 
@@ -184,7 +183,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
                               :diary_entry => { :title => "New Title", :body => "This is a new body for the diary entry", :latitude => "1.1",
                                                 :longitude => "2.2", :language_code => "en" })
     end
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
     entry = DiaryEntry.order(:id).last
     assert_equal user.id, entry.user_id
@@ -211,7 +209,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
                               :diary_entry => { :title => "New Title", :body => "This is a new body for the diary entry", :latitude => "1.1",
                                                 :longitude => "2.2", :language_code => "de" })
     end
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
     entry = DiaryEntry.order(:id).last
     assert_equal user.id, entry.user_id
@@ -240,7 +237,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
       post diary_entries_path(:commit => "save",
                               :diary_entry => { :title => spammy_title, :body => spammy_body, :language_code => "en" })
     end
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
     entry = DiaryEntry.order(:id).last
     assert_equal user.id, entry.user_id
@@ -251,7 +247,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
 
     # Follow the redirect
     get diary_entries_path(:display_name => user.display_name)
-    assert_response :redirect
     assert_redirected_to :controller => :users, :action => :suspended
   end
 
@@ -264,7 +259,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Make sure that you are redirected to the login page when you are
     # not logged in, without and with the id of the entry you want to edit
     get edit_diary_entry_path(:display_name => entry.user.display_name, :id => entry)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/user/#{ERB::Util.u(entry.user.display_name)}/diary/#{entry.id}/edit")
 
     session_for(other_user)
@@ -272,7 +266,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Verify that you get redirected to show if you are not the user
     # that created the entry
     get edit_diary_entry_path(:display_name => entry.user.display_name, :id => entry)
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => entry.user.display_name, :id => entry.id
 
     session_for(entry.user)
@@ -315,7 +308,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     put diary_entry_path(:display_name => entry.user.display_name, :id => entry, :commit => "save",
                          :diary_entry => { :title => new_title, :body => new_body, :latitude => new_latitude,
                                            :longitude => new_longitude, :language_code => new_language_code })
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => entry.user.display_name, :id => entry.id
 
     # Now check that the new data is rendered, when logged in
@@ -407,7 +399,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
         end
       end
     end
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => entry.user.display_name, :id => entry.id
     email = ActionMailer::Base.deliveries.first
     assert_equal [user.email], email.to
@@ -450,7 +441,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
         end
       end
     end
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => entry.user.display_name, :id => entry.id
     email = ActionMailer::Base.deliveries.first
     assert_equal [user.email], email.to
@@ -466,7 +456,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
 
     # Follow the redirect
     get diary_entries_path(:display_name => user.display_name)
-    assert_response :redirect
     assert_redirected_to :controller => :users, :action => :suspended
 
     # Now show the diary entry, and check the new comment is not present
@@ -512,7 +501,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
 
     # Try a list of diary entries for your friends when not logged in
     get friends_diary_entries_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/diary/friends")
 
     # Try a list of diary entries for your friends when logged in
@@ -532,7 +520,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
 
     # Try a list of diary entries for nearby users when not logged in
     get nearby_diary_entries_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/diary/nearby")
 
     # Try a list of diary entries for nearby users when logged in
@@ -767,14 +754,12 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Now try as a normal user
     session_for(user)
     post hide_diary_entry_path(:display_name => user.display_name, :id => diary_entry)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert DiaryEntry.find(diary_entry.id).visible
 
     # Now try as a moderator
     session_for(create(:moderator_user))
     post hide_diary_entry_path(:display_name => user.display_name, :id => diary_entry)
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
     assert_not DiaryEntry.find(diary_entry.id).visible
 
@@ -784,7 +769,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Finally try as an administrator
     session_for(create(:administrator_user))
     post hide_diary_entry_path(:display_name => user.display_name, :id => diary_entry)
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
     assert_not DiaryEntry.find(diary_entry.id).visible
   end
@@ -801,14 +785,12 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Now try as a normal user
     session_for(user)
     post unhide_diary_entry_path(:display_name => user.display_name, :id => diary_entry)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert_not DiaryEntry.find(diary_entry.id).visible
 
     # Now try as a moderator
     session_for(create(:moderator_user))
     post unhide_diary_entry_path(:display_name => user.display_name, :id => diary_entry)
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
     assert DiaryEntry.find(diary_entry.id).visible
 
@@ -818,7 +800,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Finally try as an administrator
     session_for(create(:administrator_user))
     post unhide_diary_entry_path(:display_name => user.display_name, :id => diary_entry)
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
     assert DiaryEntry.find(diary_entry.id).visible
   end
@@ -836,14 +817,12 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Now try as a normal user
     session_for(user)
     post hide_diary_comment_path(:display_name => user.display_name, :id => diary_entry, :comment => diary_comment)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert DiaryComment.find(diary_comment.id).visible
 
     # Try as a moderator
     session_for(create(:moderator_user))
     post hide_diary_comment_path(:display_name => user.display_name, :id => diary_entry, :comment => diary_comment)
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => user.display_name, :id => diary_entry.id
     assert_not DiaryComment.find(diary_comment.id).visible
 
@@ -853,7 +832,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Finally try as an administrator
     session_for(create(:administrator_user))
     post hide_diary_comment_path(:display_name => user.display_name, :id => diary_entry, :comment => diary_comment)
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => user.display_name, :id => diary_entry.id
     assert_not DiaryComment.find(diary_comment.id).visible
   end
@@ -871,14 +849,12 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Now try as a normal user
     session_for(user)
     post unhide_diary_comment_path(:display_name => user.display_name, :id => diary_entry, :comment => diary_comment)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert_not DiaryComment.find(diary_comment.id).visible
 
     # Now try as a moderator
     session_for(create(:moderator_user))
     post unhide_diary_comment_path(:display_name => user.display_name, :id => diary_entry, :comment => diary_comment)
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => user.display_name, :id => diary_entry.id
     assert DiaryComment.find(diary_comment.id).visible
 
@@ -888,7 +864,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     # Finally try as an administrator
     session_for(create(:administrator_user))
     post unhide_diary_comment_path(:display_name => user.display_name, :id => diary_entry, :comment => diary_comment)
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => user.display_name, :id => diary_entry.id
     assert DiaryComment.find(diary_comment.id).visible
   end
@@ -931,7 +906,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     path = diary_entry_subscribe_path(:id => diary_entry, :display_name => user.display_name)
 
     get path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => path)
 
     session_for(other_user)
@@ -987,7 +961,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     path = diary_entry_unsubscribe_path(:id => diary_entry, :display_name => user.display_name)
 
     get path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => path)
 
     session_for(other_user)

--- a/test/controllers/export_controller_test.rb
+++ b/test/controllers/export_controller_test.rb
@@ -18,7 +18,6 @@ class ExportControllerTest < ActionDispatch::IntegrationTest
   # test the finish action for raw OSM data
   def test_finish_osm
     post export_finish_path(:minlon => 0, :minlat => 50, :maxlon => 1, :maxlat => 51, :format => "osm")
-    assert_response :redirect
     assert_redirected_to "controller" => "api/map", "action" => "index", "bbox" => "0.0,50.0,1.0,51.0"
   end
 
@@ -26,7 +25,6 @@ class ExportControllerTest < ActionDispatch::IntegrationTest
   # test the finish action for mapnik images
   def test_finish_mapnik
     post export_finish_path(:minlon => 0, :minlat => 50, :maxlon => 1, :maxlat => 51, :format => "mapnik", :mapnik_format => "test", :mapnik_scale => "12")
-    assert_response :redirect
     assert_redirected_to "https://render.openstreetmap.org/cgi-bin/export?bbox=0.0,50.0,1.0,51.0&scale=12&format=test"
   end
 

--- a/test/controllers/issue_comments_controller_test.rb
+++ b/test/controllers/issue_comments_controller_test.rb
@@ -8,7 +8,6 @@ class IssueCommentsControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:user))
 
     post issue_comments_path(:issue_id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert_equal 0, issue.comments.length
   end
@@ -20,7 +19,6 @@ class IssueCommentsControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:administrator_user))
 
     post issue_comments_path(:issue_id => issue, :issue_comment => { :body => "test comment" })
-    assert_response :redirect
     assert_redirected_to issue
     assert_equal 1, issue.comments.length
   end

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -4,13 +4,11 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
   def test_index
     # Access issues list without login
     get issues_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => issues_path)
 
     # Access issues list as normal user
     session_for(create(:user))
     get issues_path
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Access issues list as administrator
@@ -30,13 +28,11 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
 
     # Access issue without login
     get issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => issue_path(issue))
 
     # Access issue as normal user
     session_for(create(:user))
     get issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Access issue as administrator
@@ -56,13 +52,11 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
 
     # Access issue without login
     get issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => issue_path(issue))
 
     # Access issue as normal user
     session_for(create(:user))
     get issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Access issue as moderator
@@ -87,7 +81,6 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     # Resolve issue as normal user
     session_for(create(:user))
     post resolve_issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Resolve issue as administrator
@@ -114,7 +107,6 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     # Resolve issue as normal user
     session_for(create(:user))
     post resolve_issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Resolve issue as moderator
@@ -141,7 +133,6 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     # Ignore issue as normal user
     session_for(create(:user))
     post ignore_issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Ignore issue as administrator
@@ -168,7 +159,6 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     # Ignore issue as normal user
     session_for(create(:user))
     post ignore_issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Ignore issue as moderator
@@ -197,7 +187,6 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     # Reopen issue as normal user
     session_for(create(:user))
     post reopen_issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Reopen issue as administrator
@@ -226,7 +215,6 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     # Reopen issue as normal user
     session_for(create(:user))
     post reopen_issue_path(:id => issue)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Reopen issue as moderator

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -413,7 +413,6 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
 
     # Asking to mark a message with no ID should fail
     post message_mark_path
-    assert_response :redirect
     assert_redirected_to inbox_messages_path
 
     # Asking to mark a message with a bogus ID should fail
@@ -464,7 +463,6 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
 
     # Asking to destroy a message with no ID should fail
     delete message_path
-    assert_response :redirect
     assert_redirected_to inbox_messages_path
 
     # Asking to destroy a message with a bogus ID should fail

--- a/test/controllers/oauth2_applications_controller_test.rb
+++ b/test/controllers/oauth2_applications_controller_test.rb
@@ -43,7 +43,6 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
     create_list(:oauth_application, 2, :owner => user)
 
     get oauth_applications_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => oauth_applications_path)
 
     session_for(user)
@@ -58,7 +57,6 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
 
     get new_oauth_application_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => new_oauth_application_path)
 
     session_for(user)
@@ -111,7 +109,6 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
                                      :scopes => ["read_prefs"]
                                    })
     end
-    assert_response :redirect
     assert_redirected_to oauth_application_path(:id => Doorkeeper::Application.find_by(:name => "Test Application").id)
   end
 
@@ -137,7 +134,6 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
                                      :scopes => ["read_email"]
                                    })
     end
-    assert_response :redirect
     assert_redirected_to oauth_application_path(:id => Doorkeeper::Application.find_by(:name => "Test Application").id)
   end
 
@@ -147,7 +143,6 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
     other_client = create(:oauth_application)
 
     get oauth_application_path(:id => client)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => oauth_application_path(:id => client.id))
 
     session_for(user)
@@ -167,7 +162,6 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
     other_client = create(:oauth_application)
 
     get edit_oauth_application_path(:id => client)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => edit_oauth_application_path(:id => client.id))
 
     session_for(user)
@@ -216,7 +210,6 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
                                  :name => "New Name",
                                  :redirect_uri => "https://new.example.com/url"
                                })
-    assert_response :redirect
     assert_redirected_to oauth_application_path(:id => client.id)
   end
 
@@ -241,7 +234,6 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_difference "Doorkeeper::Application.count", -1 do
       delete oauth_application_path(:id => client)
     end
-    assert_response :redirect
     assert_redirected_to oauth_applications_path
   end
 end

--- a/test/controllers/oauth2_authorizations_controller_test.rb
+++ b/test/controllers/oauth2_authorizations_controller_test.rb
@@ -29,7 +29,6 @@ class Oauth2AuthorizationsControllerTest < ActionDispatch::IntegrationTest
                                  :redirect_uri => application.redirect_uri,
                                  :response_type => "code",
                                  :scope => "write_api")
-    assert_response :redirect
     assert_redirected_to login_path(:referer => oauth_authorization_path(:client_id => application.uid,
                                                                          :redirect_uri => application.redirect_uri,
                                                                          :response_type => "code",
@@ -52,7 +51,6 @@ class Oauth2AuthorizationsControllerTest < ActionDispatch::IntegrationTest
                                  :redirect_uri => application.redirect_uri,
                                  :response_type => "code",
                                  :scope => "write_api")
-    assert_response :redirect
     assert_redirected_to login_path(:referer => oauth_authorization_path(:client_id => application.uid,
                                                                          :redirect_uri => application.redirect_uri,
                                                                          :response_type => "code",
@@ -119,7 +117,6 @@ class Oauth2AuthorizationsControllerTest < ActionDispatch::IntegrationTest
                                   :redirect_uri => application.redirect_uri,
                                   :response_type => "code",
                                   :scope => "write_api")
-    assert_response :redirect
     assert_redirected_to(/^#{Regexp.escape(application.redirect_uri)}\?code=/)
   end
 
@@ -160,7 +157,6 @@ class Oauth2AuthorizationsControllerTest < ActionDispatch::IntegrationTest
                                     :redirect_uri => application.redirect_uri,
                                     :response_type => "code",
                                     :scope => "write_api")
-    assert_response :redirect
     assert_redirected_to(/^#{Regexp.escape(application.redirect_uri)}\?error=access_denied/)
   end
 

--- a/test/controllers/oauth2_authorized_applications_controller_test.rb
+++ b/test/controllers/oauth2_authorized_applications_controller_test.rb
@@ -25,7 +25,6 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
     create(:oauth_application)
 
     get oauth_authorized_applications_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => oauth_authorized_applications_path)
 
     session_for(user)
@@ -45,7 +44,6 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
     create(:oauth_access_token, :resource_owner_id => user.id, :application => application1, :scopes => %w[read_prefs write_diary])
 
     get oauth_authorized_applications_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => oauth_authorized_applications_path)
 
     session_for(user)
@@ -78,7 +76,6 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
     session_for(user)
 
     delete oauth_authorized_application_path(:id => application1.id)
-    assert_response :redirect
     assert_redirected_to oauth_authorized_applications_path
 
     get oauth_authorized_applications_path

--- a/test/controllers/oauth_clients_controller_test.rb
+++ b/test/controllers/oauth_clients_controller_test.rb
@@ -40,7 +40,6 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     create_list(:access_token, 2, :user => user)
 
     get oauth_clients_path(:display_name => user.display_name)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => oauth_clients_path(:display_name => user.display_name))
 
     session_for(user)
@@ -55,7 +54,6 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
 
     get new_oauth_client_path(:display_name => user.display_name)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => new_oauth_client_path(:display_name => user.display_name))
 
     session_for(user)
@@ -79,13 +77,11 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
 
     with_settings(:oauth_10_registration => false) do
       get new_oauth_client_path(:display_name => user.display_name)
-      assert_response :redirect
       assert_redirected_to login_path(:referer => new_oauth_client_path(:display_name => user.display_name))
 
       session_for(user)
 
       get new_oauth_client_path(:display_name => user.display_name)
-      assert_response :redirect
       assert_redirected_to oauth_clients_path(:display_name => user.display_name)
     end
   end
@@ -112,7 +108,6 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
                               :client_application => { :name => "Test Application",
                                                        :url => "http://test.example.com/" })
     end
-    assert_response :redirect
     assert_redirected_to oauth_client_path(:id => ClientApplication.find_by(:name => "Test Application").id)
   end
 
@@ -122,7 +117,6 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     other_client = create(:client_application)
 
     get oauth_client_path(:display_name => user.display_name, :id => client)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => oauth_client_path(:display_name => user.display_name, :id => client.id))
 
     session_for(user)
@@ -142,7 +136,6 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     other_client = create(:client_application)
 
     get edit_oauth_client_path(:display_name => user.display_name, :id => client)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => edit_oauth_client_path(:display_name => user.display_name, :id => client.id))
 
     session_for(user)
@@ -186,7 +179,6 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
 
     put oauth_client_path(:display_name => user.display_name, :id => client,
                           :client_application => { :name => "New Name", :url => "http://new.example.com/url" })
-    assert_response :redirect
     assert_redirected_to oauth_client_path(:id => client.id)
   end
 
@@ -211,7 +203,6 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     assert_difference "ClientApplication.count", -1 do
       delete oauth_client_path(:display_name => user.display_name, :id => client)
     end
-    assert_response :redirect
     assert_redirected_to oauth_clients_path(:display_name => user.display_name)
   end
 end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -49,7 +49,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
         post user_forgot_password_path, :params => { :email => user.email }
       end
     end
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match(/^If your email address exists/, flash[:notice])
     email = ActionMailer::Base.deliveries.first
@@ -64,7 +63,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       end
     end
     # Be paranoid about revealing there was no match
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match(/^If your email address exists/, flash[:notice])
 
@@ -75,7 +73,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
         post user_forgot_password_path, :params => { :email => user.email.upcase }
       end
     end
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match(/^If your email address exists/, flash[:notice])
     email = ActionMailer::Base.deliveries.first
@@ -91,7 +88,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
       end
     end
     # Be paranoid about revealing there was no match
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match(/^If your email address exists/, flash[:notice])
 
@@ -103,7 +99,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
         post user_forgot_password_path, :params => { :email => third_user.email }
       end
     end
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match(/^If your email address exists/, flash[:notice])
     email = ActionMailer::Base.deliveries.first
@@ -118,7 +113,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
         post user_forgot_password_path, :params => { :email => third_user.email.upcase }
       end
     end
-    assert_response :redirect
     assert_redirected_to login_path
     assert_match(/^If your email address exists/, flash[:notice])
     email = ActionMailer::Base.deliveries.first
@@ -135,7 +129,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     # Test a request with a bogus token
     get user_reset_password_path, :params => { :token => "made_up_token" }
-    assert_response :redirect
     assert_redirected_to :action => :new
 
     # Create a valid token for a user
@@ -154,7 +147,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     # Test setting a new password
     post user_reset_password_path, :params => { :token => token, :user => { :pass_crypt => "new_password", :pass_crypt_confirmation => "new_password" } }
-    assert_response :redirect
     assert_redirected_to root_path
     assert_equal user.id, session[:user]
     user.reload

--- a/test/controllers/preferences_controller_test.rb
+++ b/test/controllers/preferences_controller_test.rb
@@ -36,7 +36,6 @@ class PreferencesControllerTest < ActionDispatch::IntegrationTest
     # Changing to a valid editor should work
     user.preferred_editor = "id"
     put preferences_path, :params => { :user => user.attributes }
-    assert_response :redirect
     assert_redirected_to preferences_path
     follow_redirect!
     assert_template :show
@@ -46,7 +45,6 @@ class PreferencesControllerTest < ActionDispatch::IntegrationTest
     # Changing to the default editor should work
     user.preferred_editor = "default"
     put preferences_path, :params => { :user => user.attributes }
-    assert_response :redirect
     assert_redirected_to preferences_path
     follow_redirect!
     assert_template :show

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -21,7 +21,6 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
 
     # Updating the description should work
     put profile_path, :params => { :user => { :description => "new description" } }
-    assert_response :redirect
     assert_redirected_to user_path(user)
     follow_redirect!
     assert_response :success
@@ -32,7 +31,6 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     # Changing to an uploaded image should work
     image = Rack::Test::UploadedFile.new("test/gpx/fixtures/a.gif", "image/gif")
     put profile_path, :params => { :avatar_action => "new", :user => { :avatar => image, :description => user.description } }
-    assert_response :redirect
     assert_redirected_to user_path(user)
     follow_redirect!
     assert_response :success
@@ -43,7 +41,6 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
 
     # Changing to a gravatar image should work
     put profile_path, :params => { :avatar_action => "gravatar", :user => { :description => user.description } }
-    assert_response :redirect
     assert_redirected_to user_path(user)
     follow_redirect!
     assert_response :success
@@ -54,7 +51,6 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
 
     # Removing the image should work
     put profile_path, :params => { :avatar_action => "delete", :user => { :description => user.description } }
-    assert_response :redirect
     assert_redirected_to user_path(user)
     follow_redirect!
     assert_response :success

--- a/test/controllers/redactions_controller_test.rb
+++ b/test/controllers/redactions_controller_test.rb
@@ -47,7 +47,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
 
   def test_new
     get new_redaction_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => new_redaction_path)
   end
 
@@ -63,7 +62,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:user))
 
     get new_redaction_path
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
   end
 
@@ -71,7 +69,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:moderator_user))
 
     post redactions_path(:redaction => { :title => "Foo", :description => "Description here." })
-    assert_response :redirect
     assert_redirected_to(redaction_path(Redaction.find_by(:title => "Foo")))
   end
 
@@ -87,7 +84,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:user))
 
     post redactions_path(:redaction => { :title => "Foo", :description => "Description here." })
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
   end
 
@@ -98,7 +94,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     redaction = create(:redaction)
 
     delete redaction_path(:id => redaction)
-    assert_response :redirect
     assert_redirected_to(redactions_path)
   end
 
@@ -110,7 +105,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     create(:old_node, :redaction => redaction)
 
     delete redaction_path(:id => redaction)
-    assert_response :redirect
     assert_redirected_to(redaction_path(redaction))
     assert_match(/^Redaction is not empty/, flash[:error])
   end
@@ -119,7 +113,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:user))
 
     delete redaction_path(:id => create(:redaction))
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
   end
 
@@ -127,7 +120,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     redaction = create(:redaction)
 
     get edit_redaction_path(:id => redaction)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => edit_redaction_path(redaction))
   end
 
@@ -142,7 +134,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:user))
 
     get edit_redaction_path(:id => create(:redaction))
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
   end
 
@@ -152,7 +143,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     redaction = create(:redaction)
 
     put redaction_path(:id => redaction, :redaction => { :title => "Foo", :description => "Description here." })
-    assert_response :redirect
     assert_redirected_to(redaction_path(redaction))
   end
 
@@ -172,7 +162,6 @@ class RedactionsControllerTest < ActionDispatch::IntegrationTest
     redaction = create(:redaction)
 
     put redaction_path(:id => redaction, :redaction => { :title => "Foo", :description => "Description here." })
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
   end
 end

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -4,7 +4,6 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
   def test_new_report_without_login
     target_user = create(:user)
     get new_report_path(:reportable_id => target_user.id, :reportable_type => "User")
-    assert_response :redirect
     assert_redirected_to login_path(:referer => new_report_path(:reportable_id => target_user.id, :reportable_type => "User"))
   end
 
@@ -25,7 +24,6 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
                           :issue => { :reportable_id => target_user.id, :reportable_type => "User" }
                         })
     end
-    assert_response :redirect
     assert_redirected_to user_path(target_user)
   end
 
@@ -48,7 +46,6 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
                           :issue => { :reportable_id => target_user.id, :reportable_type => "User" }
                         })
     end
-    assert_response :redirect
     assert_redirected_to user_path(target_user)
 
     issue = Issue.last
@@ -92,7 +89,6 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
                           :issue => { :reportable_id => target_user.id, :reportable_type => "User" }
                         })
     end
-    assert_response :redirect
     assert_redirected_to user_path(target_user)
 
     issue = Issue.last

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -35,7 +35,6 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
 
     get login_path
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true)
     follow_redirect!
     assert_response :success
@@ -46,27 +45,22 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_template "sessions/new"
 
     post login_path, :params => { :username => user.display_name, :password => "test" }
-    assert_response :redirect
     assert_redirected_to root_path
 
     post login_path, :params => { :username => " #{user.display_name}", :password => "test" }
-    assert_response :redirect
     assert_redirected_to root_path
 
     post login_path, :params => { :username => "#{user.display_name} ", :password => "test" }
-    assert_response :redirect
     assert_redirected_to root_path
   end
 
   def test_logout_without_referer
     post logout_path
-    assert_response :redirect
     assert_redirected_to root_path
   end
 
   def test_logout_with_referer
     post logout_path, :params => { :referer => "/test" }
-    assert_response :redirect
     assert_redirected_to "/test"
   end
 
@@ -89,7 +83,6 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     post user_new_path, :params => { :user => user.attributes }
     post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
     post logout_path
-    assert_response :redirect
     assert_redirected_to root_path
   end
 end

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -122,31 +122,24 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
   # Test the permalink redirect
   def test_permalink
     get permalink_path(:code => "wBz3--")
-    assert_response :redirect
     assert_redirected_to :controller => :site, :action => :index, :anchor => "map=3/4.8779296875/3.955078125"
 
     get permalink_path(:code => "wBz3--", :m => "")
-    assert_response :redirect
     assert_redirected_to :controller => :site, :action => :index, :mlat => "4.8779296875", :mlon => "3.955078125", :anchor => "map=3/4.8779296875/3.955078125"
 
     get permalink_path(:code => "wBz3--", :layers => "T")
-    assert_response :redirect
     assert_redirected_to :controller => :site, :action => :index, :anchor => "map=3/4.8779296875/3.955078125&layers=T"
 
     get permalink_path(:code => "wBz3--", :node => 1)
-    assert_response :redirect
     assert_redirected_to :controller => :browse, :action => :node, :id => 1, :anchor => "map=3/4.8779296875/3.955078125"
 
     get permalink_path(:code => "wBz3--", :way => 2)
-    assert_response :redirect
     assert_redirected_to :controller => :browse, :action => :way, :id => 2, :anchor => "map=3/4.8779296875/3.955078125"
 
     get permalink_path(:code => "wBz3--", :relation => 3)
-    assert_response :redirect
     assert_redirected_to :controller => :browse, :action => :relation, :id => 3, :anchor => "map=3/4.8779296875/3.955078125"
 
     get permalink_path(:code => "wBz3--", :changeset => 4)
-    assert_response :redirect
     assert_redirected_to changeset_path(:id => 4, :anchor => "map=3/4.8779296875/3.955078125")
   end
 
@@ -163,7 +156,6 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
   def test_edit
     get edit_path
 
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/edit")
   end
 
@@ -437,7 +429,6 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
   # Test the welcome page
   def test_welcome
     get welcome_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/welcome")
 
     session_for(create(:user))
@@ -530,7 +521,6 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
   def test_id_without_login
     get id_path
 
-    assert_response :redirect
     assert_redirected_to login_path(:referer => "/id")
   end
 end

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -394,13 +394,11 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
 
     # First with no auth
     get show_trace_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
-    assert_response :redirect
     assert_redirected_to :action => :index
 
     # Now with some other user, which should not work since the trace is anon
     session_for(create(:user))
     get show_trace_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
-    assert_response :redirect
     assert_redirected_to :action => :index
 
     # And finally we should be able to do it with the owner of the trace
@@ -415,13 +413,11 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
 
     # First with a trace that has never existed
     get show_trace_path(:display_name => create(:user).display_name, :id => 0)
-    assert_response :redirect
     assert_redirected_to :action => :index
 
     # Now with a trace that has been deleted
     session_for(deleted_trace_file.user)
     get show_trace_path(:display_name => deleted_trace_file.user.display_name, :id => deleted_trace_file)
-    assert_response :redirect
     assert_redirected_to :action => :index
   end
 
@@ -612,7 +608,6 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
   def test_new_get
     # First with no auth
     get new_trace_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => new_trace_path)
 
     # Now authenticated as a user with gps.trace.visibility set
@@ -661,7 +656,6 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal "trackable", user.preferences.find_by(:k => "gps.trace.visibility").v
     session_for(user)
     post traces_path, :params => { :trace => { :gpx_file => file, :description => "New Trace", :tagstring => "new,trace", :visibility => "trackable" } }
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => user.display_name
     assert_match(/file has been uploaded/, flash[:notice])
     trace = Trace.order(:id => :desc).first
@@ -698,7 +692,6 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
 
     # First with no auth
     get edit_trace_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => edit_trace_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file.id))
 
     # Now with some other user, which should fail
@@ -752,7 +745,6 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     # Finally with a trace that we are allowed to edit
     session_for(public_trace_file.user)
     put trace_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file, :trace => new_details)
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => public_trace_file.user.display_name
     trace = Trace.find(public_trace_file.id)
     assert_equal new_details[:description], trace.description
@@ -787,7 +779,6 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     # Now with a trace that we are allowed to delete
     session_for(public_trace_file.user)
     delete trace_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => public_trace_file.user.display_name
     trace = Trace.find(public_trace_file.id)
     assert_not trace.visible
@@ -797,7 +788,6 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     admin = create(:administrator_user)
     session_for(admin)
     delete trace_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
-    assert_response :redirect
     assert_redirected_to :action => :index, :display_name => public_trace_file.user.display_name
     trace = Trace.find(public_trace_file.id)
     assert_not trace.visible

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -148,7 +148,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     # Check that normal users can't load the block creation page
     get new_user_block_path(:display_name => target_user.display_name)
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as a moderator
@@ -186,7 +185,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     # Check that normal users can't load the block edit page
     get edit_user_block_path(:id => active_block)
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as a moderator
@@ -224,7 +222,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     # Check that normal users can't create blocks
     post user_blocks_path
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as a moderator
@@ -300,7 +297,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     # Check that normal users can't update blocks
     put user_block_path(:id => active_block)
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as the wrong moderator
@@ -359,7 +355,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     # Check that normal users can't load the block revoke page
     get revoke_user_block_path(:id => active_block)
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as a moderator
@@ -413,7 +408,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     # Check that normal users can't load the revoke all blocks page
     get revoke_all_user_blocks_path(blocked_user)
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as a moderator
@@ -443,7 +437,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     # Check that normal users can't load the block revoke page
     get revoke_all_user_blocks_path(:blocked_user)
-    assert_response :redirect
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as a moderator

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -69,7 +69,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   # The user creation page loads
   def test_new_view
     get user_new_path
-    assert_response :redirect
     assert_redirected_to user_new_path(:cookie_test => "true")
 
     get user_new_path, :params => { :cookie_test => "true" }
@@ -98,11 +97,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:user))
 
     get user_new_path
-    assert_response :redirect
     assert_redirected_to root_path
 
     get user_new_path, :params => { :referer => "/test" }
-    assert_response :redirect
     assert_redirected_to "/test"
   end
 
@@ -346,7 +343,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     session_for(user)
 
     get user_terms_path
-    assert_response :redirect
     assert_redirected_to edit_account_path
   end
 
@@ -360,7 +356,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_template :terms
 
     post user_save_path, :params => { :user => { :consider_pd => true }, :read_ct => 1, :read_tou => 1 }
-    assert_response :redirect
     assert_redirected_to edit_account_path
     assert_equal "Thanks for accepting the new contributor terms!", flash[:notice]
 
@@ -381,7 +376,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_template :terms
 
     post user_save_path, :params => { :user => { :consider_pd => true }, :referer => "/test", :read_ct => 1, :read_tou => 1 }
-    assert_response :redirect
     assert_redirected_to "/test"
     assert_equal "Thanks for accepting the new contributor terms!", flash[:notice]
 
@@ -399,7 +393,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     session_for(user)
 
     get edit_account_path
-    assert_response :redirect
     assert_redirected_to :controller => :users, :action => :terms, :referer => "/account/edit"
   end
 
@@ -415,7 +408,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     post user_go_public_path
 
-    assert_response :redirect
     assert_redirected_to edit_account_path
     assert User.find(user.id).data_public
   end
@@ -552,13 +544,11 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     # Now try as a normal user
     session_for(user)
     post set_status_user_path(user), :params => { :event => "confirm" }
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Finally try as an administrator
     session_for(create(:administrator_user))
     post set_status_user_path(user), :params => { :event => "confirm" }
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => user.display_name
     assert_equal "confirmed", User.find(user.id).status
   end
@@ -573,13 +563,11 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     # Now try as a normal user
     session_for(user)
     delete user_path(user)
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Finally try as an administrator
     session_for(create(:administrator_user))
     delete user_path(user)
-    assert_response :redirect
     assert_redirected_to :action => :show, :display_name => user.display_name
 
     # Check that the user was deleted properly
@@ -609,21 +597,18 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     # Shouldn't work when not logged in
     get users_path
-    assert_response :redirect
     assert_redirected_to login_path(:referer => users_path)
 
     session_for(user)
 
     # Shouldn't work when logged in as a normal user
     get users_path
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     session_for(moderator_user)
 
     # Shouldn't work when logged in as a moderator
     get users_path
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     session_for(administrator_user)
@@ -695,7 +680,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "User.active.count" do
       post users_path, :params => { :confirm => 1, :user => { inactive_user.id => 1, suspended_user.id => 1 } }
     end
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert_equal "pending", inactive_user.reload.status
     assert_equal "suspended", suspended_user.reload.status
@@ -706,7 +690,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "User.active.count" do
       post users_path, :params => { :confirm => 1, :user => { inactive_user.id => 1, suspended_user.id => 1 } }
     end
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert_equal "pending", inactive_user.reload.status
     assert_equal "suspended", suspended_user.reload.status
@@ -717,7 +700,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_difference "User.active.count", 2 do
       post users_path, :params => { :confirm => 1, :user => { inactive_user.id => 1, suspended_user.id => 1 } }
     end
-    assert_response :redirect
     assert_redirected_to :action => :index
     assert_equal "confirmed", inactive_user.reload.status
     assert_equal "confirmed", suspended_user.reload.status
@@ -742,7 +724,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "User.active.count" do
       post users_path, :params => { :hide => 1, :user => { normal_user.id => 1, confirmed_user.id => 1 } }
     end
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert_equal "active", normal_user.reload.status
     assert_equal "confirmed", confirmed_user.reload.status
@@ -753,7 +734,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "User.active.count" do
       post users_path, :params => { :hide => 1, :user => { normal_user.id => 1, confirmed_user.id => 1 } }
     end
-    assert_response :redirect
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert_equal "active", normal_user.reload.status
     assert_equal "confirmed", confirmed_user.reload.status
@@ -764,7 +744,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_difference "User.active.count", -2 do
       post users_path, :params => { :hide => 1, :user => { normal_user.id => 1, confirmed_user.id => 1 } }
     end
-    assert_response :redirect
     assert_redirected_to :action => :index
     assert_equal "deleted", normal_user.reload.status
     assert_equal "deleted", confirmed_user.reload.status
@@ -772,15 +751,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_auth_failure_callback
     get auth_failure_path
-    assert_response :redirect
     assert_redirected_to login_path
 
     get auth_failure_path, :params => { :origin => "/" }
-    assert_response :redirect
     assert_redirected_to root_path
 
     get auth_failure_path, :params => { :origin => "http://www.google.com" }
-    assert_response :redirect
     assert_redirected_to login_path
   end
 end

--- a/test/integration/client_applications_test.rb
+++ b/test/integration/client_applications_test.rb
@@ -8,7 +8,6 @@ class ClientApplicationsTest < ActionDispatch::IntegrationTest
     user = create(:user)
 
     get "/login"
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => "true")
     follow_redirect!
     assert_response :success

--- a/test/integration/oauth2_test.rb
+++ b/test/integration/oauth2_test.rb
@@ -157,7 +157,6 @@ class OAuth2Test < ActionDispatch::IntegrationTest
     }.merge(options)
 
     get oauth_authorization_path(options)
-    assert_response :redirect
     assert_redirected_to login_path(:referer => request.fullpath)
 
     post login_path(:username => user.email, :password => "test")

--- a/test/integration/oauth_test.rb
+++ b/test/integration/oauth_test.rb
@@ -58,7 +58,6 @@ class OAuthTest < ActionDispatch::IntegrationTest
          :params => { :oauth_token => token.token,
                       :allow_read_prefs => "1", :allow_write_prefs => "1" }
     if client.callback_url
-      assert_response :redirect
       assert_redirected_to "#{client.callback_url}?oauth_token=#{token.token}"
     else
       assert_response :success
@@ -156,7 +155,6 @@ class OAuthTest < ActionDispatch::IntegrationTest
     post "/oauth/authorize",
          :params => { :oauth_token => token.token, :oauth_callback => callback_url,
                       :allow_write_api => "1", :allow_read_gpx => "1" }
-    assert_response :redirect
     assert_redirected_to "#{callback_url}?oauth_token=#{token.token}"
     token.reload
     assert_not_nil token.created_at

--- a/test/integration/redirect_test.rb
+++ b/test/integration/redirect_test.rb
@@ -3,105 +3,82 @@ require "test_helper"
 class RedirectTest < ActionDispatch::IntegrationTest
   def test_legacy_redirects
     get "/index.html"
-    assert_response :redirect
     assert_redirected_to "/"
 
     get "/create-account.html"
-    assert_response :redirect
     assert_redirected_to "/user/new"
 
     get "/forgot-password.html"
-    assert_response :redirect
     assert_redirected_to "/user/forgot-password"
   end
 
   def test_search_redirects
     get "/?query=test"
-    assert_response :redirect
     assert_redirected_to "/search?query=test"
   end
 
   def test_history_redirects
     get "/browse"
-    assert_response :redirect
     assert_redirected_to "/history"
 
     get "/browse/changesets"
-    assert_response :redirect
     assert_redirected_to "/history"
 
     get "/browse/changesets?bbox=-80.54%2C40.358%2C-79.526%2C40.779"
-    assert_response :redirect
     assert_redirected_to "/history?bbox=-80.54%2C40.358%2C-79.526%2C40.779"
 
     get "/browse/friends"
-    assert_response :redirect
     assert_redirected_to "/history/friends"
 
     get "/browse/nearby"
-    assert_response :redirect
     assert_redirected_to "/history/nearby"
 
     get "/user/name/edits"
-    assert_response :redirect
     assert_redirected_to "/user/name/history"
 
     get "/user/name%20with%20spaces/edits"
-    assert_response :redirect
     assert_redirected_to "/user/name%20with%20spaces/history"
   end
 
   def test_history_feed_redirects
     get "/browse/changesets/feed"
-    assert_response :redirect
     assert_redirected_to "/history/feed"
 
     get "/browse/changesets/feed?bbox=-80.54%2C40.358%2C-79.526%2C40.779"
-    assert_response :redirect
     assert_redirected_to "/history/feed?bbox=-80.54%2C40.358%2C-79.526%2C40.779"
 
     get "/user/name/edits/feed"
-    assert_response :redirect
     assert_redirected_to "/user/name/history/feed"
 
     get "/user/name%20with%20spaces/edits/feed"
-    assert_response :redirect
     assert_redirected_to "/user/name%20with%20spaces/history/feed"
   end
 
   def test_browse_redirects
     get "/browse/node/1"
-    assert_response :redirect
     assert_redirected_to "/node/1"
 
     get "/browse/way/1"
-    assert_response :redirect
     assert_redirected_to "/way/1"
 
     get "/browse/relation/1"
-    assert_response :redirect
     assert_redirected_to "/relation/1"
 
     get "/browse/changeset/1"
-    assert_response :redirect
     assert_redirected_to "/changeset/1"
 
     get "/browse/note/1"
-    assert_response :redirect
     assert_redirected_to "/note/1"
   end
 
   def test_browse_history_redirects
     get "/browse/node/1/history"
-    assert_response :redirect
     assert_redirected_to "/node/1/history"
 
     get "/browse/way/1/history"
-    assert_response :redirect
     assert_redirected_to "/way/1/history"
 
     get "/browse/relation/1/history"
-    assert_response :redirect
     assert_redirected_to "/relation/1/history"
   end
 end

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -130,7 +130,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
     post confirmation_url
 
-    assert_response :redirect
     assert_redirected_to welcome_path
 
     user.reload
@@ -250,13 +249,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_uid => "http://localhost:1123/new.tester",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -296,13 +292,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_uid => "http://localhost:1123/new.tester",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to auth_failure_path(:strategy => "openid", :message => "connection_failed", :origin => "/user/new")
           follow_redirect!
           assert_response :redirect
@@ -335,13 +328,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" },
                             :referer => referer }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/new.tester", :origin => "/user/new")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -403,13 +393,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "google",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "google")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -420,7 +407,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => password,
                                        :pass_crypt_confirmation => password },
                             :read_ct => 1, :read_tou => 1 }
-          assert_response :redirect
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -449,13 +435,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "google",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "google")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to auth_failure_path(:strategy => "google", :message => "connection_failed", :origin => "/user/new")
           follow_redirect!
           assert_response :redirect
@@ -489,13 +472,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" },
                             :referer => referer }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "google", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "google")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -557,13 +537,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "facebook",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "facebook")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -574,7 +551,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => password,
                                        :pass_crypt_confirmation => password },
                             :read_ct => 1, :read_tou => 1 }
-          assert_response :redirect
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -603,13 +579,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "facebook",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "facebook")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to auth_failure_path(:strategy => "facebook", :message => "connection_failed", :origin => "/user/new")
           follow_redirect!
           assert_response :redirect
@@ -641,13 +614,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" },
                             :referer => referer }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "facebook", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "facebook")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -709,13 +679,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "microsoft",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "microsoft", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "microsoft")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -726,7 +693,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => password,
                                        :pass_crypt_confirmation => password },
                             :read_ct => 1, :read_tou => 1 }
-          assert_response :redirect
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -755,13 +721,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "microsoft",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "microsoft", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "microsoft")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to auth_failure_path(:strategy => "microsoft", :message => "connection_failed", :origin => "/user/new")
           follow_redirect!
           assert_response :redirect
@@ -793,13 +756,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" },
                             :referer => referer }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "microsoft", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "microsoft")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -861,13 +821,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "github",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "github")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -879,7 +836,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => password },
                             :read_ct => 1,
                             :read_tou => 1 }
-          assert_response :redirect
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -908,13 +864,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "github",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "github")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to auth_failure_path(:strategy => "github", :message => "connection_failed", :origin => "/user/new")
           follow_redirect!
           assert_response :redirect
@@ -946,13 +899,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" },
                             :referer => referer }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "github", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "github")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -1015,13 +965,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "wikipedia",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,
@@ -1033,7 +980,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt_confirmation => password },
                             :read_ct => 1,
                             :read_tou => 1 }
-          assert_response :redirect
           assert_redirected_to welcome_path
           follow_redirect!
         end
@@ -1062,13 +1008,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :auth_provider => "wikipedia",
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" } }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to auth_failure_path(:strategy => "wikipedia", :message => "connection_failed", :origin => "/user/new")
           follow_redirect!
           assert_response :redirect
@@ -1100,13 +1043,10 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => "",
                                        :pass_crypt_confirmation => "" },
                             :referer => referer }
-          assert_response :redirect
           assert_redirected_to auth_path(:provider => "wikipedia", :origin => "/user/new")
           post response.location
-          assert_response :redirect
           assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/user/new")
           follow_redirect!
-          assert_response :redirect
           assert_redirected_to "/user/terms"
           post "/user/save",
                :params => { :user => { :email => new_email,

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -354,13 +354,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:openid, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true, :referer => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -375,13 +373,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:openid, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true, :referer => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -395,13 +391,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:openid, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true, :referer => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -420,13 +414,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:openid, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true, :referer => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/john.doe", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -441,16 +433,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:openid] = :connection_failed
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true, :referer => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "openid", :message => "connection_failed", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -466,16 +455,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:openid] = :invalid_credentials
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true, :referer => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => user.auth_uid, :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "openid", :message => "invalid_credentials", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -490,13 +476,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:openid, :uid => "http://localhost:1123/fred.bloggs")
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true, :referer => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "openid", :openid_url => "http://localhost:1123/fred.bloggs", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "openid", :openid_url => "http://localhost:1123/fred.bloggs", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -513,13 +497,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
                              })
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
     assert_response :redirect
@@ -536,13 +518,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
                              })
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
     assert_response :redirect
@@ -558,13 +538,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
                              })
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
     assert_response :redirect
@@ -585,13 +563,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
                              })
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
     assert_response :redirect
@@ -605,16 +581,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:google] = :connection_failed
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "google", :message => "connection_failed", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -629,16 +602,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:google] = :invalid_credentials
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "google", :message => "invalid_credentials", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -655,13 +625,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
                              })
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
     assert_response :redirect
@@ -678,13 +646,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
                              })
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "google", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "google")
     follow_redirect!
     assert_response :redirect
@@ -703,13 +669,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:facebook, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
     assert_response :redirect
@@ -724,13 +688,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:facebook, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
     assert_response :redirect
@@ -744,13 +706,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:facebook, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
     assert_response :redirect
@@ -769,13 +729,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:facebook, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
     assert_response :redirect
@@ -789,16 +747,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:facebook] = :connection_failed
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "facebook", :message => "connection_failed", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -813,16 +768,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:facebook] = :invalid_credentials
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "facebook", :message => "invalid_credentials", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -837,13 +789,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:facebook, :uid => "987654321")
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "facebook", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "facebook")
     follow_redirect!
     assert_response :redirect
@@ -858,13 +808,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:microsoft, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "microsoft", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "microsoft")
     follow_redirect!
     assert_response :redirect
@@ -879,13 +827,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:microsoft, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "microsoft", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "microsoft")
     follow_redirect!
     assert_response :redirect
@@ -899,13 +845,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:microsoft, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "microsoft", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "microsoft")
     follow_redirect!
     assert_response :redirect
@@ -924,13 +868,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:microsoft, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "microsoft", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "microsoft")
     follow_redirect!
     assert_response :redirect
@@ -944,16 +886,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:microsoft] = :connection_failed
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "microsoft", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "microsoft")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "microsoft", :message => "connection_failed", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -968,16 +907,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:microsoft] = :invalid_credentials
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "microsoft", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "microsoft")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "microsoft", :message => "invalid_credentials", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -992,13 +928,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:microsoft, :uid => "987654321")
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "microsoft", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "microsoft")
     follow_redirect!
     assert_response :redirect
@@ -1013,13 +947,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:github, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
     assert_response :redirect
@@ -1034,13 +966,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:github, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
     assert_response :redirect
@@ -1054,13 +984,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:github, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
     assert_response :redirect
@@ -1079,13 +1007,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:github, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
     assert_response :redirect
@@ -1099,16 +1025,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:github] = :connection_failed
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "github", :message => "connection_failed", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -1123,16 +1046,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:github] = :invalid_credentials
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "github", :message => "invalid_credentials", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -1147,13 +1067,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:github, :uid => "987654321")
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "github", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "github")
     follow_redirect!
     assert_response :redirect
@@ -1168,13 +1086,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:wikipedia, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -1189,13 +1105,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:wikipedia, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -1209,13 +1123,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:wikipedia, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -1234,13 +1146,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:wikipedia, :uid => user.auth_uid)
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -1254,16 +1164,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:wikipedia] = :connection_failed
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "wikipedia", :message => "connection_failed", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -1278,16 +1185,13 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.mock_auth[:wikipedia] = :invalid_credentials
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
-    assert_response :redirect
     assert_redirected_to auth_failure_path(:strategy => "wikipedia", :message => "invalid_credentials", :origin => "/login?referer=%2Fhistory")
     follow_redirect!
     assert_response :redirect
@@ -1302,13 +1206,11 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock(:wikipedia, :uid => "987654321")
 
     get "/login", :params => { :referer => "/history" }
-    assert_response :redirect
     assert_redirected_to login_path("cookie_test" => "true", "referer" => "/history")
     follow_redirect!
     assert_response :success
     assert_template "sessions/new"
     post auth_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
-    assert_response :redirect
     assert_redirected_to auth_success_path(:provider => "wikipedia", :origin => "/login?referer=%2Fhistory", :referer => "/history")
     follow_redirect!
     assert_response :redirect
@@ -1322,7 +1224,6 @@ class UserLoginTest < ActionDispatch::IntegrationTest
 
   def try_password_login(username, password, remember_me = nil)
     get "/login"
-    assert_response :redirect
     assert_redirected_to login_path(:cookie_test => true)
     follow_redirect!
     assert_response :success

--- a/test/integration/user_terms_seen_test.rb
+++ b/test/integration/user_terms_seen_test.rb
@@ -24,7 +24,6 @@ class UserTermsSeenTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     post "/login", :params => { :username => user.email, :password => "test", :referer => "/diary/new" }
-    assert_response :redirect
     # but now we need to look at the terms
     assert_redirected_to :controller => :users, :action => :terms, :referer => "/diary/new"
     follow_redirect!
@@ -49,7 +48,6 @@ class UserTermsSeenTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "sessions/new"
     post "/login", :params => { :username => user.email, :password => "test", :referer => "/diary/new" }
-    assert_response :redirect
     # but now we need to look at the terms
     assert_redirected_to :controller => :users, :action => :terms, :referer => "/diary/new"
 


### PR DESCRIPTION
`assert_redirected_to` does `assert_response` anyway:

https://github.com/rails/rails/blob/6f0d1ad14b92b9f5906e44740fce8b4f1c7075dc/actionpack/lib/action_dispatch/testing/assertions/response.rb#L61