### PR TITLE
Be paranoid when sending password reset emails

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -43,12 +43,10 @@ class PasswordsController < ApplicationController
     if user
       token = user.generate_token_for(:password_reset)
       UserMailer.lost_password(user, token).deliver_later
-      flash[:notice] = t ".notice email on way"
-      redirect_to login_path
-    else
-      flash.now[:error] = t ".notice email cannot find"
-      render :new
     end
+
+    flash[:notice] = t ".send_paranoid_instructions"
+    redirect_to login_path
   end
 
   def update

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1777,7 +1777,7 @@ en:
       wrong_user: "You are logged in as `%{user}' but the message you have asked to read was not sent by or to that user. Please login as the correct user in order to read it."
     sent_message_summary:
       destroy_button: "Delete"
-    heading: 
+    heading:
       my_inbox: "My Inbox"
       my_outbox: "My Outbox"
       muted_messages: "Muted messages"
@@ -1797,8 +1797,7 @@ en:
       new password button: "Reset password"
       help_text: "Enter the email address you used to sign up, we will send a link to it that you can use to reset your password."
     create:
-      notice email on way: "Sorry you lost it :-( but an email is on its way so you can reset it soon."
-      notice email cannot find: "Could not find that email address, sorry."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
     edit:
       title: "Reset password"
       heading: "Reset Password for %{user}"


### PR DESCRIPTION
This implements what is known as "paranoid" password reset flash messages ([using the terminology from Devise](https://github.com/heartcombo/devise/blob/bb18f4d3805be0bf5f45e21be39625c7cfd9c1d6/config/locales/en.yml#L36)). It avoids revealing whether the supplied email address is already registered.

Added an explicit test for this situation, so that the test for email non-existance is separate from the duplicate-case tests.

(I originally planned to move the entire passwords_controller to use `Devise::Recoverable`, but that was more challenging than I first thought.)