### PR TITLE
Prevent default event when clicking OpenID button

### DIFF
--- a/app/assets/javascripts/login.js
+++ b/app/assets/javascripts/login.js
@@ -14,7 +14,8 @@ $(document).ready(function () {
   });
 
   // Add click handler to show OpenID field
-  $("#openid_open_url").click(function () {
+  $("#openid_open_url").click(function (e) {
+    e.preventDefault();
     $("#openid_url").val("http://");
     $("#login_auth_buttons").hide();
     $("#login_openid_url").show();


### PR DESCRIPTION
Fixes this:

Open a window with small height, go to the login page, scroll down to the OpenId button.
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/27dcfeef-c95f-4303-bbad-bb2de2e13239)

Press the button. The view scrolls to the top, away from the revealed OpenId form.
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/f03a2d7e-2076-4eb9-a701-9e1f1ebe8655)

The same is happening in #4455.