### PR TITLE
Adding information about Croatia sources

### DIFF
--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -141,6 +141,14 @@
               :france => tag.strong(t(".legal_babble.contributors_fr_france")) %>
       </li>
       <li>
+        <%= t ".legal_babble.contributors_hr_credit_html",
+              :croatia => tag.strong(t(".legal_babble.contributors_hr_croatia")),
+              :dgu_link => link_to(t(".legal_babble.contributors_hr_dgu"),
+                                   t(".legal_babble.contributors_hr_dgu_url")),
+              :open_data_portal => link_to(t(".legal_babble.contributors_hr_open_data_portal"),
+                                           t(".legal_babble.contributors_hr_open_data_portal_url")) %>
+      </li>
+      <li>
         <%= t ".legal_babble.contributors_nl_credit_html",
               :netherlands => tag.strong(t(".legal_babble.contributors_nl_netherlands")),
               :and_link => link_to(t(".legal_babble.contributors_nl_and"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2099,6 +2099,14 @@ en:
           %{france}: Contains data sourced from
           Direction Générale des Impôts.
         contributors_fr_france: France
+        contributors_hr_credit_html: |
+          %{croatia}: Contains data from the %{dgu_link} and %{open_data_portal}
+          (public information of Croatia).
+        contributors_hr_croatia: Croatia
+        contributors_hr_dgu: State Geodetic Administration of Croatia
+        contributors_hr_dgu_url: https://dgu.gov.hr/
+        contributors_hr_open_data_portal: National Open Data Portal
+        contributors_hr_open_data_portal_url: https://data.gov.hr/
         contributors_nl_credit_html: |
           %{netherlands}: Contains &copy; AND data, 2007 (%{and_link})
         contributors_nl_netherlands: Netherlands


### PR DESCRIPTION
We are required to cite the source of open data in accordance with the Croatian Open License (Otvorena dozvola). This PR is adding proper copyright text for Croatia official sources.

Here is the license described in Croatian law: https://narodne-novine.nn.hr/clanci/sluzbeni/2017_07_67_1577.html

And here is the official English translation of the license: https://prod-data.gov.hr/en/open-license