### PR TITLE
Reload only element type sections with Turbo frames

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -396,7 +396,7 @@ $(document).ready(function () {
   OSM.router.load();
 
   $(document).on("click", "a", function (e) {
-    if (e.isDefaultPrevented() || e.isPropagationStopped()) {
+    if (e.isDefaultPrevented() || e.isPropagationStopped() || $(e.target).data("turbo")) {
       return;
     }
 

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -96,7 +96,7 @@ module BrowseHelper
       pagination_items(pages, {}).each do |body, page_or_class|
         linked = !(page_or_class.is_a? String)
         link = if linked
-                 link_to body, url_for(page_param => page_or_class.number), :class => link_classes, :title => yield(page_or_class)
+                 link_to body, url_for(page_param => page_or_class.number), :class => link_classes, **yield(page_or_class)
                else
                  tag.span body, :class => link_classes
                end

--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -70,14 +70,14 @@ module BrowseHelper
     "nofollow" if object.tags.empty?
   end
 
-  def type_and_paginated_count(type, pages)
+  def type_and_paginated_count(type, pages, selected_page = pages.current_page)
     if pages.page_count == 1
       t ".#{type.pluralize}",
         :count => pages.item_count
     else
       t ".#{type.pluralize}_paginated",
-        :x => pages.current_page.first_item,
-        :y => pages.current_page.last_item,
+        :x => selected_page.first_item,
+        :y => selected_page.last_item,
         :count => pages.item_count
     end
   end
@@ -93,14 +93,14 @@ module BrowseHelper
     link_classes = ["page-link", { "px-1" => width > max_width_for_default_padding }]
 
     tag.ul :class => "pagination pagination-sm mb-1 ms-auto" do
-      pagination_items(pages, {}).each do |body, n|
-        linked = !(n.is_a? String)
+      pagination_items(pages, {}).each do |body, page_or_class|
+        linked = !(page_or_class.is_a? String)
         link = if linked
-                 link_to body, url_for(page_param => n), :class => link_classes
+                 link_to body, url_for(page_param => page_or_class.number), :class => link_classes, :title => yield(page_or_class)
                else
                  tag.span body, :class => link_classes
                end
-        concat tag.li link, :class => ["page-item", { n => !linked }]
+        concat tag.li link, :class => ["page-item", { page_or_class => !linked }]
       end
     end
   end

--- a/app/views/changesets/_elements.html.erb
+++ b/app/views/changesets/_elements.html.erb
@@ -1,6 +1,6 @@
-<div>
+<%= turbo_frame_tag "changeset_#{type.pluralize}" do %>
   <%= render :partial => "paging_nav", :locals => { :type => type, :pages => pages } %>
-  <ul class="list-unstyled">
+  <ul class="list-unstyled" data-turbo="false">
     <% elements.each do |element| %>
       <%= element_list_item type, element do
             t "printable_name.current_and_old_links_html",
@@ -9,4 +9,4 @@
           end %>
     <% end %>
   </ul>
-</div>
+<% end %>

--- a/app/views/changesets/_elements.html.erb
+++ b/app/views/changesets/_elements.html.erb
@@ -1,0 +1,12 @@
+<div>
+  <%= render :partial => "paging_nav", :locals => { :type => type, :pages => pages } %>
+  <ul class="list-unstyled">
+    <% elements.each do |element| %>
+      <%= element_list_item type, element do
+            t "printable_name.current_and_old_links_html",
+              :current_link => link_to(printable_element_name(element), :controller => type.pluralize, :action => :show, :id => element.id[0]),
+              :old_link => link_to(printable_element_version(element), :controller => "old_#{type.pluralize}", :action => :show, :id => element.id[0], :version => element.version)
+          end %>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/changesets/_paging_nav.html.erb
+++ b/app/views/changesets/_paging_nav.html.erb
@@ -1,6 +1,11 @@
 <div class="d-flex flex-wrap gap-2">
   <h4 class="fs-5 mb-0"><%= type_and_paginated_count(type, pages) %></h4>
   <% if pages.page_count > 1 %>
-    <%= sidebar_classic_pagination(pages, "#{type}_page") { |page| type_and_paginated_count(type, pages, page) } %>
+    <%= sidebar_classic_pagination(pages, "#{type}_page") do |page|
+          {
+            :title => type_and_paginated_count(type, pages, page),
+            :data => { :turbo => "true" }
+          }
+        end %>
   <% end %>
 </div>

--- a/app/views/changesets/_paging_nav.html.erb
+++ b/app/views/changesets/_paging_nav.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex flex-wrap gap-2">
   <h4 class="fs-5 mb-0"><%= type_and_paginated_count(type, pages) %></h4>
   <% if pages.page_count > 1 %>
-    <%= sidebar_classic_pagination(pages, "#{type}_page") %>
+    <%= sidebar_classic_pagination(pages, "#{type}_page") { |page| type_and_paginated_count(type, pages, page) } %>
   <% end %>
 </div>

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -77,42 +77,15 @@
   <% end %>
 
   <% unless @ways.empty? %>
-    <%= render :partial => "paging_nav", :locals => { :type => "way", :pages => @way_pages } %>
-    <ul class="list-unstyled">
-      <% @ways.each do |way| %>
-        <%= element_list_item "way", way do
-              t "printable_name.current_and_old_links_html",
-                :current_link => link_to(printable_element_name(way), way_path(way.way_id)),
-                :old_link => link_to(printable_element_version(way), old_way_path(way.way_id, way.version))
-            end %>
-      <% end %>
-    </ul>
+    <%= render :partial => "elements", :locals => { :type => "way", :elements => @ways, :pages => @way_pages } %>
   <% end %>
 
   <% unless @relations.empty? %>
-    <%= render :partial => "paging_nav", :locals => { :type => "relation", :pages => @relation_pages } %>
-    <ul class="list-unstyled">
-      <% @relations.each do |relation| %>
-        <%= element_list_item "relation", relation do
-              t "printable_name.current_and_old_links_html",
-                :current_link => link_to(printable_element_name(relation), relation_path(relation.relation_id)),
-                :old_link => link_to(printable_element_version(relation), old_relation_path(relation.relation_id, relation.version))
-            end %>
-      <% end %>
-    </ul>
+    <%= render :partial => "elements", :locals => { :type => "relation", :elements => @relations, :pages => @relation_pages } %>
   <% end %>
 
   <% unless @nodes.empty? %>
-    <%= render :partial => "paging_nav", :locals => { :type => "node", :pages => @node_pages } %>
-    <ul class="list-unstyled">
-      <% @nodes.each do |node| %>
-        <%= element_list_item "node", node do
-              t "printable_name.current_and_old_links_html",
-                :current_link => link_to(printable_element_name(node), node_path(node.node_id), { :rel => link_follow(node) }),
-                :old_link => link_to(printable_element_version(node), old_node_path(node.node_id, node.version), { :rel => link_follow(node) })
-            end %>
-      <% end %>
-    </ul>
+    <%= render :partial => "elements", :locals => { :type => "node", :elements => @nodes, :pages => @node_pages } %>
   <% end %>
 </div>
 

--- a/lib/classic_pagination/pagination_helper.rb
+++ b/lib/classic_pagination/pagination_helper.rb
@@ -145,7 +145,7 @@ module ActionView
         items = []
 
         if always_show_anchors && !(wp_first = window_pages[0]).first?
-          items.push [first.number.to_s, first.number]
+          items.push [first.number.to_s, first]
           items.push ["...", "disabled"] if wp_first.number - first.number > 1
         end
 
@@ -153,13 +153,13 @@ module ActionView
           if current_page == page && !link_to_current_page
             items.push [page.number.to_s, "active"]
           else
-            items.push [page.number.to_s, page.number]
+            items.push [page.number.to_s, page]
           end
         end
 
         if always_show_anchors && !(wp_last = window_pages[-1]).last?
           items.push ["...", "disabled"] if last.number - wp_last.number > 1
-          items.push [last.number.to_s, last.number]
+          items.push [last.number.to_s, last]
         end
 
         items

--- a/test/system/changeset_elements_test.rb
+++ b/test/system/changeset_elements_test.rb
@@ -13,11 +13,39 @@ class ChangesetElementsTest < ApplicationSystemTestCase
     visit changeset_path(changeset)
 
     within_sidebar do
-      assert_one_missing_link way_paths
+      next_page_way_path = assert_one_missing_link way_paths
+      assert_no_link "Ways (1-20 of 21)"
       assert_link "Ways (21-21 of 21)"
 
       assert_one_missing_link node_paths
+      assert_no_link "Nodes (1-20 of 21)"
       assert_link "Nodes (21-21 of 21)"
+
+      fill_in "text", :with => "Comment text we don't want to lose"
+
+      click_on "Ways (21-21 of 21)"
+
+      assert_one_present_link way_paths, next_page_way_path
+      assert_link "Ways (1-20 of 21)"
+      assert_no_link "Ways (21-21 of 21)"
+
+      next_page_node_path = assert_one_missing_link node_paths
+      assert_no_link "Nodes (1-20 of 21)"
+      assert_link "Nodes (21-21 of 21)"
+
+      assert_field "text", :with => "Comment text we don't want to lose"
+
+      click_on "Nodes (21-21 of 21)"
+
+      assert_one_present_link way_paths, next_page_way_path
+      assert_link "Ways (1-20 of 21)"
+      assert_no_link "Ways (21-21 of 21)"
+
+      assert_one_present_link node_paths, next_page_node_path
+      assert_link "Nodes (1-20 of 21)"
+      assert_no_link "Nodes (21-21 of 21)"
+
+      assert_field "text", :with => "Comment text we don't want to lose"
     end
   end
 
@@ -37,5 +65,11 @@ class ChangesetElementsTest < ApplicationSystemTestCase
     end
     assert_not_nil missing_href, "expected one link missing but all are present"
     missing_href
+  end
+
+  def assert_one_present_link(hrefs, present_href)
+    hrefs.each do |href|
+      assert_link :href => href, :count => (href == present_href ? 1 : 0)
+    end
   end
 end

--- a/test/system/changeset_elements_test.rb
+++ b/test/system/changeset_elements_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+class ChangesetElementsTest < ApplicationSystemTestCase
+  test "can navigate between element subpages without losing comment input" do
+    element_page_size = 20
+    changeset = create(:changeset, :closed)
+    ways = create_list(:way, element_page_size + 1, :with_history, :changeset => changeset)
+    way_paths = ways.map { |way| way_path(way) }
+    nodes = create_list(:node, element_page_size + 1, :with_history, :changeset => changeset)
+    node_paths = nodes.map { |node| node_path(node) }
+
+    sign_in_as(create(:user))
+    visit changeset_path(changeset)
+
+    within_sidebar do
+      assert_one_missing_link way_paths
+      assert_link "Ways (21-21 of 21)"
+
+      assert_one_missing_link node_paths
+      assert_link "Nodes (21-21 of 21)"
+    end
+  end
+
+  private
+
+  def assert_one_missing_link(hrefs)
+    missing_href = nil
+    hrefs.each do |href|
+      missing = true
+      assert_link :href => href, :minimum => 0, :maximum => 1 do
+        missing = false
+      end
+      if missing
+        assert_nil missing_href, "unexpected extra missing link '#{href}'"
+        missing_href = href
+      end
+    end
+    assert_not_nil missing_href, "expected one link missing but all are present"
+    missing_href
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/4561. Updated version without doing #4563 first. I don't do the entire sidebar with Turbo. The only change to javascript here is to suppress our router.js when a pagination turbo link is clicked. I have to mark those links explicitly for now with `data-turbo="true"`.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6bf2d5f3-aa41-4ede-ba47-b80fda115892)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/ff4d9f02-5fd8-413d-b07e-73e2ddfd9d02)
