### PR TITLE
Preload element tags when showing changesets

### DIFF
--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -84,9 +84,9 @@ class ChangesetsController < ApplicationController
                 else
                   @changeset.comments.includes(:author)
                 end
-    @node_pages, @nodes = paginate(:old_nodes, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "node_page")
-    @way_pages, @ways = paginate(:old_ways, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "way_page")
-    @relation_pages, @relations = paginate(:old_relations, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "relation_page")
+    @node_pages, @nodes = paginate(:old_nodes, :include => :old_tags, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "node_page")
+    @way_pages, @ways = paginate(:old_ways, :include => :old_tags, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "way_page")
+    @relation_pages, @relations = paginate(:old_relations, :include => :old_tags, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "relation_page")
     if @changeset.user.active? && @changeset.user.data_public?
       @next_by_user = @changeset.user.changesets.where("id > ?", @changeset.id).reorder(:id => :asc).first
       @prev_by_user = @changeset.user.changesets.where("id < ?", @changeset.id).reorder(:id => :desc).first


### PR DESCRIPTION
Changeset show action generates a sql query for each element to get its tags:

```
  OldWayTag Load (0.5ms)  SELECT "way_tags".* FROM "way_tags" WHERE "way_tags"."way_id" = $1 AND "way_tags"."version" = $2  [["way_id", 52], ["version", 1]]
  ↳ app/models/old_way.rb:82:in `to_h'
  OldWayTag Load (0.4ms)  SELECT "way_tags".* FROM "way_tags" WHERE "way_tags"."way_id" = $1 AND "way_tags"."version" = $2  [["way_id", 53], ["version", 1]]
  ↳ app/models/old_way.rb:82:in `to_h'
  OldWayTag Load (0.3ms)  SELECT "way_tags".* FROM "way_tags" WHERE "way_tags"."way_id" = $1 AND "way_tags"."version" = $2  [["way_id", 54], ["version", 1]]
  ↳ app/models/old_way.rb:82:in `to_h'
  OldWayTag Load (0.3ms)  SELECT "way_tags".* FROM "way_tags" WHERE "way_tags"."way_id" = $1 AND "way_tags"."version" = $2  [["way_id", 55], ["version", 1]]
  ↳ app/models/old_way.rb:82:in `to_h'
  OldWayTag Load (0.4ms)  SELECT "way_tags".* FROM "way_tags" WHERE "way_tags"."way_id" = $1 AND "way_tags"."version" = $2  [["way_id", 56], ["version", 1]]
  ↳ app/models/old_way.rb:82:in `to_h'
  OldWayTag Load (0.3ms)  SELECT "way_tags".* FROM "way_tags" WHERE "way_tags"."way_id" = $1 AND "way_tags"."version" = $2  [["way_id", 57], ["version", 1]]
  ↳ app/models/old_way.rb:82:in `to_h'
  OldWayTag Load (0.3ms)  SELECT "way_tags".* FROM "way_tags" WHERE "way_tags"."way_id" = $1 AND "way_tags"."version" = $2  [["way_id", 58], ["version", 1]]
  ↳ app/models/old_way.rb:82:in `to_h'
```

It's possible to roll them into one query. Classic pagination has a parameter for that.

```
  OldWayTag Load (0.3ms)  SELECT "way_tags".* FROM "way_tags" WHERE "way_tags"."way_id" IN ($1, $2, $3, $4, $5, $6, $7) AND "way_tags"."version" = $8  [["way_id", 52], ["way_id", 53], ["way_id", 54], ["way_id", 55], ["way_id", 56], ["way_id", 57], ["way_id", 58], ["version", 1]]
  ↳ app/views/changesets/show.html.erb:82
```
