### PR TITLE
Fix whitespace in changeset element lists

### DIFF
--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -80,11 +80,11 @@
     <%= render :partial => "paging_nav", :locals => { :type => "way", :pages => @way_pages } %>
     <ul class="list-unstyled">
       <% @ways.each do |way| %>
-        <%= element_list_item "way", way do %>
-          <%= t "printable_name.current_and_old_links_html",
+        <%= element_list_item "way", way do
+              t "printable_name.current_and_old_links_html",
                 :current_link => link_to(printable_element_name(way), way_path(way.way_id)),
-                :old_link => link_to(printable_element_version(way), old_way_path(way.way_id, way.version)) %>
-        <% end %>
+                :old_link => link_to(printable_element_version(way), old_way_path(way.way_id, way.version))
+            end %>
       <% end %>
     </ul>
   <% end %>
@@ -93,11 +93,11 @@
     <%= render :partial => "paging_nav", :locals => { :type => "relation", :pages => @relation_pages } %>
     <ul class="list-unstyled">
       <% @relations.each do |relation| %>
-        <%= element_list_item "relation", relation do %>
-          <%= t "printable_name.current_and_old_links_html",
+        <%= element_list_item "relation", relation do
+              t "printable_name.current_and_old_links_html",
                 :current_link => link_to(printable_element_name(relation), relation_path(relation.relation_id)),
-                :old_link => link_to(printable_element_version(relation), old_relation_path(relation.relation_id, relation.version)) %>
-        <% end %>
+                :old_link => link_to(printable_element_version(relation), old_relation_path(relation.relation_id, relation.version))
+            end %>
       <% end %>
     </ul>
   <% end %>
@@ -106,11 +106,11 @@
     <%= render :partial => "paging_nav", :locals => { :type => "node", :pages => @node_pages } %>
     <ul class="list-unstyled">
       <% @nodes.each do |node| %>
-        <%= element_list_item "node", node do %>
-          <%= t "printable_name.current_and_old_links_html",
+        <%= element_list_item "node", node do
+              t "printable_name.current_and_old_links_html",
                 :current_link => link_to(printable_element_name(node), node_path(node.node_id), { :rel => link_follow(node) }),
-                :old_link => link_to(printable_element_version(node), old_node_path(node.node_id, node.version), { :rel => link_follow(node) }) %>
-        <% end %>
+                :old_link => link_to(printable_element_version(node), old_node_path(node.node_id, node.version), { :rel => link_follow(node) })
+            end %>
       <% end %>
     </ul>
   <% end %>


### PR DESCRIPTION
Whitespace at the start of a list item becomes significant when element icons are added using `::before` pseudoelement. You can see the extra space when elements with/without icons are next to each other. I'm removing unnecessary whitespace inside `<li>` here.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/37604b72-d796-4909-9100-923b1f584ee8)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c602ec1a-3b9a-40f6-b6b4-0ba78c76a43d)
