### PR TITLE
Update hosting partners as per OWG policy

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -44,10 +44,9 @@
       <div class="welcome p-3" hidden>
         <%= render "sidebar_header", :title => t("layouts.intro_header") %>
         <p class="fs-6 fw-light"><%= t "layouts.intro_text" %></p>
-        <p class="fs-6 fw-light"><%= t "layouts.hosting_partners_html",
-                                       :ucl => link_to(t("layouts.partners_ucl"), "https://www.ucl.ac.uk"),
+        <p class="fs-6 fw-light"><%= t "layouts.hosting_partners_2024_html",
                                        :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
-                                       :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
+                                       :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
                                        :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
         </p>
         <div class="d-flex gap-2">

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -66,10 +66,9 @@
       <% end %>
 
       <%= render :layout => "about_section", :locals => { :id => "partners", :icon => "partners", :title => "partners" } do %>
-        <p><%= t "layouts.hosting_partners_html", :ucl => link_to(t("layouts.partners_ucl"), "https://www.ucl.ac.uk"),
-                                                  :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
-                                                  :bytemark => link_to(t("layouts.partners_bytemark"), "https://www.bytemark.co.uk"),
-                                                  :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
+        <p><%= t "layouts.hosting_partners_2024_html", :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
+                                                       :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
+                                                       :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
         </p>
       <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1568,10 +1568,9 @@ en:
     intro_header: Welcome to OpenStreetMap!
     intro_text: OpenStreetMap is a map of the world, created by people like you and free to use under an open license.
     intro_2_create_account: "Create a user account"
-    hosting_partners_html: "Hosting is supported by %{ucl}, %{fastly}, %{bytemark}, and other %{partners}."
-    partners_ucl: "UCL"
+    hosting_partners_2024_html: "Hosting is supported by %{fastly}, %{corpmembers}, and other %{partners}."
     partners_fastly: "Fastly"
-    partners_bytemark: "Bytemark Hosting"
+    partners_corpmembers: "OSMF corporate members"
     partners_partners: "partners"
     tou: "Terms of Use"
     osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."


### PR DESCRIPTION
OWG has changed its [Hosting Provider Credit Policy](https://operations.osmfoundation.org/policies/hosting/). This implements the new policy.

I had to rename the translation string because removing an interpolation from the string caused all kinds of test failures with the yet-to-be-updated translations. Let me know if you prefer a different solution here.