### PR TITLE
Add more wiki prefixes

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -1,7 +1,7 @@
 module BrowseTagsHelper
   # https://wiki.openstreetmap.org/wiki/Key:wikipedia#Secondary_Wikipedia_links
   # https://wiki.openstreetmap.org/wiki/Key:wikidata#Secondary_Wikidata_links
-  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|name:etymology|network|operator|species|subject".freeze
+  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|manufacturer|model|name:etymology|network|operator|species|subject".freeze
 
   def format_key(key)
     if url = wiki_link("key", key)


### PR DESCRIPTION
Both cases are documented on OSM wiki. See:

- https://wiki.openstreetmap.org/wiki/Key:manufacturer:wikidata
- https://wiki.openstreetmap.org/wiki/Key:manufacturer:wikipedia
- https://wiki.openstreetmap.org/wiki/Key:model:wikidata
- https://wiki.openstreetmap.org/wiki/Key:model:wikipedia