### PR TITLE
Collect node/way/relation CanCanCan subjects into arrays

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -5,9 +5,7 @@ class Ability
 
   def initialize(user)
     can [:relation, :relation_history, :way, :way_history, :node, :node_history, :query], :browse
-    can [:show], OldNode
-    can [:show], OldWay
-    can [:show], OldRelation
+    can [:show], [OldNode, OldWay, OldRelation]
     can [:show, :new], Note
     can :search, :direction
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :communities, :preview, :copyright, :key, :id], :site

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -29,20 +29,14 @@ class ApiAbility
         if user.terms_agreed?
           can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset
           can :create, ChangesetComment
-          can [:create, :update, :delete], Node
-          can [:create, :update, :delete], Way
-          can [:create, :update, :delete], Relation
+          can [:create, :update, :delete], [Node, Way, Relation]
         end
 
         if user.moderator?
           can [:destroy, :restore], ChangesetComment
           can :destroy, Note
 
-          if user.terms_agreed?
-            can :redact, OldNode
-            can :redact, OldWay
-            can :redact, OldRelation
-          end
+          can :redact, [OldNode, OldWay, OldRelation] if user.terms_agreed?
         end
       end
     end

--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -23,19 +23,13 @@ class ApiCapability
         if user.terms_agreed?
           can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset if scope?(token, :write_api)
           can :create, ChangesetComment if scope?(token, :write_api)
-          can [:create, :update, :delete], Node if scope?(token, :write_api)
-          can [:create, :update, :delete], Way if scope?(token, :write_api)
-          can [:create, :update, :delete], Relation if scope?(token, :write_api)
+          can [:create, :update, :delete], [Node, Way, Relation] if scope?(token, :write_api)
         end
 
         if user.moderator?
           can [:destroy, :restore], ChangesetComment if scope?(token, :write_api)
           can :destroy, Note if scope?(token, :write_notes)
-          if user&.terms_agreed?
-            can :redact, OldNode if scope?(token, :write_api) || scope?(token, :write_redactions)
-            can :redact, OldWay if scope?(token, :write_api) || scope?(token, :write_redactions)
-            can :redact, OldRelation if scope?(token, :write_api) || scope?(token, :write_redactions)
-          end
+          can :redact, [OldNode, OldWay, OldRelation] if user&.terms_agreed? && (scope?(token, :write_api) || scope?(token, :write_redactions))
         end
       end
     end


### PR DESCRIPTION
Different element types usually have the same actions with three very similar lines in ability files. It's possible to turn them into one line, also decreasing the complexity Rubocop complains about. I still have PRs where I need to increase complexity limits like #4301. After this change I won't have to do it.