### PR TITLE
Move element history actions to old element controllers

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -4,10 +4,8 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    can [:relation, :relation_history, :way, :way_history, :node, :node_history, :query], :browse
-    can [:show], OldNode
-    can [:show], OldWay
-    can [:show], OldRelation
+    can [:relation, :way, :node, :query], :browse
+    can [:index, :show], [OldNode, OldWay, OldRelation]
     can [:show, :new], Note
     can :search, :direction
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :communities, :preview, :copyright, :key, :id], :site

--- a/app/controllers/old_nodes_controller.rb
+++ b/app/controllers/old_nodes_controller.rb
@@ -11,6 +11,14 @@ class OldNodesController < ApplicationController
   before_action :require_moderator_for_unredacted_history
   around_action :web_timeout
 
+  def index
+    @type = "node"
+    @feature = Node.preload(:node_tags, :old_nodes => [:old_tags, { :changeset => [:changeset_tags, :user] }]).find(params[:id])
+    render "browse/history"
+  rescue ActiveRecord::RecordNotFound
+    render "browse/not_found", :status => :not_found
+  end
+
   def show
     @type = "node"
     @feature = OldNode.preload(:old_tags, :changeset => [:changeset_tags, :user]).find([params[:id], params[:version]])

--- a/app/controllers/old_relations_controller.rb
+++ b/app/controllers/old_relations_controller.rb
@@ -11,6 +11,14 @@ class OldRelationsController < ApplicationController
   before_action :require_moderator_for_unredacted_history
   around_action :web_timeout
 
+  def index
+    @type = "relation"
+    @feature = Relation.preload(:relation_tags, :old_relations => [:old_tags, { :changeset => [:changeset_tags, :user], :old_members => :member }]).find(params[:id])
+    render "browse/history"
+  rescue ActiveRecord::RecordNotFound
+    render "browse/not_found", :status => :not_found
+  end
+
   def show
     @type = "relation"
     @feature = OldRelation.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_members => :member).find([params[:id], params[:version]])

--- a/app/controllers/old_ways_controller.rb
+++ b/app/controllers/old_ways_controller.rb
@@ -11,6 +11,14 @@ class OldWaysController < ApplicationController
   before_action :require_moderator_for_unredacted_history
   around_action :web_timeout
 
+  def index
+    @type = "way"
+    @feature = Way.preload(:way_tags, :old_ways => [:old_tags, { :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:node_tags, :ways] } }]).find(params[:id])
+    render "browse/history"
+  rescue ActiveRecord::RecordNotFound
+    render "browse/not_found", :status => :not_found
+  end
+
   def show
     @type = "way"
     @feature = OldWay.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:node_tags, :ways] }).find([params[:id], params[:version]])

--- a/app/views/browse/_version_actions.erb
+++ b/app/views/browse/_version_actions.erb
@@ -21,7 +21,7 @@
     <% end %>
     &middot;
   <% end %>
-  <%= link_to t("browse.view_history"), :controller => :browse, :action => "#{@type}_history" %>
+  <%= link_to t("browse.view_history"), :action => :index %>
   <% unless @feature.latest_version? %>
     &middot;
     <%= link_to({ :version => @feature.version + 1 }, { :class => "icon-link" }) do %>

--- a/app/views/browse/feature.html.erb
+++ b/app/views/browse/feature.html.erb
@@ -17,10 +17,10 @@
     <% end %>
     &middot;
   <% end %>
-    <%= link_to t("browse.view_history"), :action => "#{@type}_history" %>
+    <%= link_to t("browse.view_history"), :controller => "old_#{@type.pluralize}" %>
   <% if current_user&.moderator? %>
     &middot;
-    <%= link_to(t("browse.view_unredacted_history"), :action => "#{@type}_history", :params => { :show_redactions => true }) %>
+    <%= link_to(t("browse.view_unredacted_history"), :controller => "old_#{@type.pluralize}", :params => { :show_redactions => true }) %>
   <% end %>
   <% if @feature.version > 1 %>
     &middot;

--- a/app/views/browse/history.html.erb
+++ b/app/views/browse/history.html.erb
@@ -2,17 +2,17 @@
 
 <%= render "sidebar_header", :title => t("browse.#{@type}.history_title_html", :name => printable_element_name(@feature)) %>
 
-<%= render :partial => @type, :collection => @feature.send(:"old_#{@type}s").reverse %>
+<%= render :partial => "browse/#{@type}", :collection => @feature.send(:"old_#{@type}s").reverse %>
 
 <div class='secondary-actions'>
-  <%= link_to(t("browse.download_xml"), :controller => "api/old_#{@type.pluralize}", :action => "history") %>
+  <%= link_to t("browse.download_xml"), :controller => "api/old_#{@type.pluralize}", :action => "history" %>
   &middot;
-  <%= link_to(t("browse.view_details"), :action => @type) %>
+  <%= link_to t("browse.view_details"), :controller => "browse", :action => @type %>
   <% if params[:show_redactions] %>
     &middot;
-    <%= link_to(t("browse.view_history"), :action => "#{@type}_history") %>
+    <%= link_to t("browse.view_history") %>
   <% elsif current_user&.moderator? %>
     &middot;
-    <%= link_to(t("browse.view_unredacted_history"), :action => "#{@type}_history", :params => { :show_redactions => true }) %>
+    <%= link_to t("browse.view_unredacted_history"), :params => { :show_redactions => true } %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,13 +110,13 @@ OpenStreetMap::Application.routes.draw do
 
   # Data browsing
   get "/way/:id" => "browse#way", :id => /\d+/, :as => :way
-  get "/way/:id/history" => "browse#way_history", :id => /\d+/, :as => :way_history
+  get "/way/:id/history" => "old_ways#index", :id => /\d+/, :as => :way_history
   resources :old_ways, :path => "/way/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show
   get "/node/:id" => "browse#node", :id => /\d+/, :as => :node
-  get "/node/:id/history" => "browse#node_history", :id => /\d+/, :as => :node_history
+  get "/node/:id/history" => "old_nodes#index", :id => /\d+/, :as => :node_history
   resources :old_nodes, :path => "/node/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show
   get "/relation/:id" => "browse#relation", :id => /\d+/, :as => :relation
-  get "/relation/:id/history" => "browse#relation_history", :id => /\d+/, :as => :relation_history
+  get "/relation/:id/history" => "old_relations#index", :id => /\d+/, :as => :relation_history
   resources :old_relations, :path => "/relation/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show
   resources :changesets, :path => "changeset", :id => /\d+/, :only => :show
   get "/changeset/:id/comments/feed" => "changeset_comments#index", :as => :changeset_comments_feed, :id => /\d*/, :defaults => { :format => "rss" }

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -9,24 +9,12 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
       { :controller => "browse", :action => "node", :id => "1" }
     )
     assert_routing(
-      { :path => "/node/1/history", :method => :get },
-      { :controller => "browse", :action => "node_history", :id => "1" }
-    )
-    assert_routing(
       { :path => "/way/1", :method => :get },
       { :controller => "browse", :action => "way", :id => "1" }
     )
     assert_routing(
-      { :path => "/way/1/history", :method => :get },
-      { :controller => "browse", :action => "way_history", :id => "1" }
-    )
-    assert_routing(
       { :path => "/relation/1", :method => :get },
       { :controller => "browse", :action => "relation", :id => "1" }
-    )
-    assert_routing(
-      { :path => "/relation/1/history", :method => :get },
-      { :controller => "browse", :action => "relation_history", :id => "1" }
     )
     assert_routing(
       { :path => "/query", :method => :get },
@@ -53,14 +41,6 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 2}']", :count => 1
   end
 
-  def test_read_relation_history
-    relation = create(:relation, :with_history)
-    sidebar_browse_check :relation_history_path, relation.id, "browse/history"
-    assert_select "h4", /^Version/ do
-      assert_select "a[href='#{old_relation_path relation, 1}']", :text => "1", :count => 1
-    end
-  end
-
   def test_read_way
     way = create(:way)
     sidebar_browse_check :way_path, way.id, "browse/feature"
@@ -78,14 +58,6 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 2}']", :count => 1
-  end
-
-  def test_read_way_history
-    way = create(:way, :with_history)
-    sidebar_browse_check :way_history_path, way.id, "browse/history"
-    assert_select "h4", /^Version/ do
-      assert_select "a[href='#{old_way_path way, 1}']", :text => "1", :count => 1
-    end
   end
 
   def test_read_node
@@ -116,14 +88,6 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{api_node_path node}']", :count => 0
   end
 
-  def test_read_node_history
-    node = create(:node, :with_history)
-    sidebar_browse_check :node_history_path, node.id, "browse/history"
-    assert_select "h4", /^Version/ do
-      assert_select "a[href='#{old_node_path node, 1}']", :text => "1", :count => 1
-    end
-  end
-
   ##
   #  Methods to check redaction.
   #
@@ -146,109 +110,6 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".browse-section.browse-node", 1
     assert_select ".browse-section.browse-node .latitude", 0
     assert_select ".browse-section.browse-node .longitude", 0
-  end
-
-  def test_redacted_node_history
-    node = create(:node, :with_history, :deleted, :version => 2)
-    node_v1 = node.old_nodes.find_by(:version => 1)
-    node_v1.redact!(create(:redaction))
-
-    get node_history_path(:id => node)
-    assert_response :success
-    assert_template "browse/history"
-
-    # there are 2 revisions of the redacted node, but only one
-    # should be showing details here.
-    assert_select ".browse-section", 2
-    assert_select ".browse-section.browse-redacted", 1
-    assert_select ".browse-section.browse-node", 1
-    assert_select ".browse-section.browse-node .latitude", 0
-    assert_select ".browse-section.browse-node .longitude", 0
-  end
-
-  def test_redacted_node_unredacted_history
-    session_for(create(:moderator_user))
-    node = create(:node, :with_history, :deleted, :version => 2)
-    node_v1 = node.old_nodes.find_by(:version => 1)
-    node_v1.redact!(create(:redaction))
-
-    get node_history_path(:id => node, :params => { :show_redactions => true })
-    assert_response :success
-    assert_template "browse/history"
-
-    assert_select ".browse-section", 2
-    assert_select ".browse-section.browse-redacted", 0
-    assert_select ".browse-section.browse-node", 2
-  end
-
-  def test_redacted_way_history
-    way = create(:way, :with_history, :version => 4)
-    way_v1 = way.old_ways.find_by(:version => 1)
-    way_v1.redact!(create(:redaction))
-    way_v3 = way.old_ways.find_by(:version => 3)
-    way_v3.redact!(create(:redaction))
-
-    get way_history_path(:id => way)
-    assert_response :success
-    assert_template "browse/history"
-
-    # there are 4 revisions of the redacted way, but only 2
-    # should be showing details here.
-    assert_select ".browse-section", 4
-    assert_select ".browse-section.browse-redacted", 2
-    assert_select ".browse-section.browse-way", 2
-  end
-
-  def test_redacted_way_unredacted_history
-    session_for(create(:moderator_user))
-    way = create(:way, :with_history, :version => 4)
-    way_v1 = way.old_ways.find_by(:version => 1)
-    way_v1.redact!(create(:redaction))
-    way_v3 = way.old_ways.find_by(:version => 3)
-    way_v3.redact!(create(:redaction))
-
-    get way_history_path(:id => way, :params => { :show_redactions => true })
-    assert_response :success
-    assert_template "browse/history"
-
-    assert_select ".browse-section", 4
-    assert_select ".browse-section.browse-redacted", 0
-    assert_select ".browse-section.browse-way", 4
-  end
-
-  def test_redacted_relation_history
-    relation = create(:relation, :with_history, :version => 4)
-    relation_v1 = relation.old_relations.find_by(:version => 1)
-    relation_v1.redact!(create(:redaction))
-    relation_v3 = relation.old_relations.find_by(:version => 3)
-    relation_v3.redact!(create(:redaction))
-
-    get relation_history_path(:id => relation)
-    assert_response :success
-    assert_template "browse/history"
-
-    # there are 4 revisions of the redacted relation, but only 2
-    # should be showing details here.
-    assert_select ".browse-section", 4
-    assert_select ".browse-section.browse-redacted", 2
-    assert_select ".browse-section.browse-relation", 2
-  end
-
-  def test_redacted_relation_unredacted_history
-    session_for(create(:moderator_user))
-    relation = create(:relation, :with_history, :version => 4)
-    relation_v1 = relation.old_relations.find_by(:version => 1)
-    relation_v1.redact!(create(:redaction))
-    relation_v3 = relation.old_relations.find_by(:version => 3)
-    relation_v3.redact!(create(:redaction))
-
-    get relation_history_path(:id => relation, :params => { :show_redactions => true })
-    assert_response :success
-    assert_template "browse/history"
-
-    assert_select ".browse-section", 4
-    assert_select ".browse-section.browse-redacted", 0
-    assert_select ".browse-section.browse-relation", 4
   end
 
   def test_query
@@ -284,57 +145,5 @@ class BrowseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a", :text => "View Details", :count => 0
     assert_select ".secondary-actions a", :text => "View History", :count => 1
     assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 1
-  end
-
-  def test_anonymous_user_history_page_secondary_actions
-    node = create(:node, :with_history)
-    get node_history_path(:id => node)
-    assert_response :success
-    assert_select ".secondary-actions a", :text => "View Details", :count => 1
-    assert_select ".secondary-actions a", :text => "View History", :count => 0
-    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 0
-  end
-
-  def test_regular_user_history_page_secondary_actions
-    session_for(create(:user))
-    node = create(:node, :with_history)
-    get node_history_path(:id => node)
-    assert_response :success
-    assert_select ".secondary-actions a", :text => "View Details", :count => 1
-    assert_select ".secondary-actions a", :text => "View History", :count => 0
-    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 0
-  end
-
-  def test_moderator_user_history_page_secondary_actions
-    session_for(create(:moderator_user))
-    node = create(:node, :with_history)
-    get node_history_path(:id => node)
-    assert_response :success
-    assert_select ".secondary-actions a", :text => "View Details", :count => 1
-    assert_select ".secondary-actions a", :text => "View History", :count => 0
-    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 1
-  end
-
-  def test_anonymous_user_unredacted_history_page_secondary_actions
-    node = create(:node, :with_history)
-    get node_history_path(:id => node, :params => { :show_redactions => true })
-    assert_response :redirect
-  end
-
-  def test_regular_user_unredacted_history_page_secondary_actions
-    session_for(create(:user))
-    node = create(:node, :with_history)
-    get node_history_path(:id => node, :params => { :show_redactions => true })
-    assert_response :redirect
-  end
-
-  def test_moderator_user_unredacted_history_page_secondary_actions
-    session_for(create(:moderator_user))
-    node = create(:node, :with_history)
-    get node_history_path(:id => node, :params => { :show_redactions => true })
-    assert_response :success
-    assert_select ".secondary-actions a", :text => "View Details", :count => 1
-    assert_select ".secondary-actions a", :text => "View History", :count => 1
-    assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 0
   end
 end

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -3,9 +3,56 @@ require "test_helper"
 class OldRelationsControllerTest < ActionDispatch::IntegrationTest
   def test_routes
     assert_routing(
+      { :path => "/relation/1/history", :method => :get },
+      { :controller => "old_relations", :action => "index", :id => "1" }
+    )
+    assert_routing(
       { :path => "/relation/1/history/2", :method => :get },
       { :controller => "old_relations", :action => "show", :id => "1", :version => "2" }
     )
+  end
+
+  def test_history
+    relation = create(:relation, :with_history)
+    sidebar_browse_check :relation_history_path, relation.id, "browse/history"
+    assert_select "h4", /^Version/ do
+      assert_select "a[href='#{old_relation_path relation, 1}']", :text => "1", :count => 1
+    end
+  end
+
+  def test_history_of_redacted
+    relation = create(:relation, :with_history, :version => 4)
+    relation_v1 = relation.old_relations.find_by(:version => 1)
+    relation_v1.redact!(create(:redaction))
+    relation_v3 = relation.old_relations.find_by(:version => 3)
+    relation_v3.redact!(create(:redaction))
+
+    get relation_history_path(:id => relation)
+    assert_response :success
+    assert_template "browse/history"
+
+    # there are 4 revisions of the redacted relation, but only 2
+    # should be showing details here.
+    assert_select ".browse-section", 4
+    assert_select ".browse-section.browse-redacted", 2
+    assert_select ".browse-section.browse-relation", 2
+  end
+
+  def test_unredacted_history_of_redacted
+    session_for(create(:moderator_user))
+    relation = create(:relation, :with_history, :version => 4)
+    relation_v1 = relation.old_relations.find_by(:version => 1)
+    relation_v1.redact!(create(:redaction))
+    relation_v3 = relation.old_relations.find_by(:version => 3)
+    relation_v3.redact!(create(:redaction))
+
+    get relation_history_path(:id => relation, :params => { :show_redactions => true })
+    assert_response :success
+    assert_template "browse/history"
+
+    assert_select ".browse-section", 4
+    assert_select ".browse-section.browse-redacted", 0
+    assert_select ".browse-section.browse-relation", 4
   end
 
   def test_visible_with_one_version


### PR DESCRIPTION
Now they are in `index` actions to match `show` actions from #4480.

Views and path helpers are not changed in this PR.
