### PR TITLE
Replace "Login" labels with "Log in" when used as a verb

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -546,7 +546,7 @@ en:
       discussion: "Discussion"
       leave_a_comment: "Leave a comment"
       login_to_leave_a_comment_html: "%{login_link} to leave a comment"
-      login: "Login"
+      login: "Log in"
     no_such_entry:
       title: "No such diary entry"
       heading: "No entry with the id: %{id}"
@@ -1766,14 +1766,14 @@ en:
         one: "%{count} muted message"
         other: "You have %{count} muted messages"
     reply:
-      wrong_user: "You are logged in as `%{user}' but the message you have asked to reply to was not sent to that user. Please login as the correct user in order to reply."
+      wrong_user: "You are logged in as `%{user}' but the message you have asked to reply to was not sent to that user. Please log in as the correct user in order to reply."
     show:
       title: "Read message"
       reply_button: "Reply"
       unread_button: "Mark as unread"
       destroy_button: "Delete"
       back: "Back"
-      wrong_user: "You are logged in as `%{user}' but the message you have asked to read was not sent by or to that user. Please login as the correct user in order to read it."
+      wrong_user: "You are logged in as `%{user}' but the message you have asked to read was not sent by or to that user. Please log in as the correct user in order to read it."
     sent_message_summary:
       destroy_button: "Delete"
     heading:
@@ -1847,44 +1847,44 @@ en:
       failure: Couldn't update profile.
   sessions:
     new:
-      title: "Login"
-      heading: "Login"
+      title: "Log in"
+      heading: "Log in"
       email or username: "Email Address or Username"
       password: "Password"
       openid_html: "%{logo} OpenID"
       remember: "Remember me"
       lost password link: "Lost your password?"
-      login_button: "Login"
+      login_button: "Log in"
       register now: Register now
-      with external: "Alternatively, use a third party to login:"
+      with external: "Alternatively, use a third party to log in:"
       no account: Don't have an account?
       auth failure: "Sorry, could not log in with those details."
       openid_logo_alt: "Log in with an OpenID"
       auth_providers:
         openid:
-          title: Login with OpenID
-          alt: Login with an OpenID URL
+          title: Log in with OpenID
+          alt: Log in with an OpenID URL
         google:
-          title: Login with Google
-          alt: Login with a Google OpenID
+          title: Log in with Google
+          alt: Log in with a Google OpenID
         facebook:
-          title: Login with Facebook
-          alt: Login with a Facebook Account
+          title: Log in with Facebook
+          alt: Log in with a Facebook Account
         microsoft:
-          title: Login with Microsoft
-          alt: Login with a Microsoft Account
+          title: Log in with Microsoft
+          alt: Log in with a Microsoft Account
         github:
-          title: Login with GitHub
-          alt: Login with a GitHub Account
+          title: Log in with GitHub
+          alt: Log in with a GitHub Account
         wikipedia:
-          title: Login with Wikipedia
-          alt: Login with a Wikipedia Account
+          title: Log in with Wikipedia
+          alt: Log in with a Wikipedia Account
         wordpress:
-          title: Login with Wordpress
-          alt: Login with a Wordpress OpenID
+          title: Log in with Wordpress
+          alt: Log in with a Wordpress OpenID
         aol:
-          title: Login with AOL
-          alt: Login with an AOL OpenID
+          title: Log in with AOL
+          alt: Log in with an AOL OpenID
     destroy:
       title: "Logout"
       heading: "Logout from OpenStreetMap"
@@ -2728,7 +2728,7 @@ en:
         paragraph_2: Sign up to get started contributing. We'll send an email to confirm your account.
       display name description: "Your publicly displayed username. You can change this later in the preferences."
       external auth: "Third Party Authentication:"
-      use external auth: "Alternatively, use a third party to login"
+      use external auth: "Alternatively, use a third party to log in"
       auth no password: "With third party authentication a password is not required, but some extra tools or server may still need one."
       continue: Sign Up
       terms accepted: "Thanks for accepting the new contributor terms!"
@@ -2859,7 +2859,7 @@ en:
         If you are new to OpenStreetMap, please create a new account
         using the form below.
       option_2: |
-        If you already have an account, you can login to your account
+        If you already have an account, you can log in to your account
         using your username and password and then associate the account
         with your ID in your user settings.
   user_role:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -29,7 +29,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     within "form", :text => "Email Address or Username" do
       fill_in "username", :with => user.email
       fill_in "password", :with => "test"
-      click_on "Login"
+      click_on "Log in"
     end
   end
 

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -245,7 +245,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     # Check that we can't reply to somebody else's message
     get message_reply_path(:message_id => unread_message)
     assert_redirected_to login_path(:referer => message_reply_path(:message_id => unread_message.id))
-    assert_equal "You are logged in as `#{other_user.display_name}' but the message you have asked to reply to was not sent to that user. Please login as the correct user in order to reply.", flash[:notice]
+    assert_equal "You are logged in as `#{other_user.display_name}' but the message you have asked to reply to was not sent to that user. Please log in as the correct user in order to reply.", flash[:notice]
 
     # Login as the right user
     session_for(recipient_user)
@@ -291,7 +291,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     # Check that we can't read the message
     get message_path(:id => unread_message)
     assert_redirected_to login_path(:referer => message_path(:id => unread_message.id))
-    assert_equal "You are logged in as `#{other_user.display_name}' but the message you have asked to read was not sent by or to that user. Please login as the correct user in order to read it.", flash[:notice]
+    assert_equal "You are logged in as `#{other_user.display_name}' but the message you have asked to read was not sent by or to that user. Please log in as the correct user in order to read it.", flash[:notice]
 
     # Login as the message sender
     session_for(user)

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -116,7 +116,8 @@ class UserHelperTest < ActionView::TestCase
 
   def test_auth_button
     button = auth_button("google", "google")
-    assert_equal("<a class=\"auth_button\" title=\"Login with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\"><img alt=\"Login with a Google OpenID\" class=\"rounded-3\" src=\"/images/google.svg\" /></a>", button)
+    img_tag = "<img alt=\"Log in with a Google OpenID\" class=\"rounded-3\" src=\"/images/google.svg\" />"
+    assert_equal("<a class=\"auth_button\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
   end
 
   private


### PR DESCRIPTION
Initiated by the following thread https://github.com/openstreetmap/openstreetmap-website/pull/4455#discussion_r1512725362

Split a separate PR from PR #4455.