### PR TITLE
Fix "blocked" user signup page layout

### DIFF
--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -3,10 +3,9 @@
   <div class='header-illustration new-user-main'>
     <h1><%= t "users.new.title" %></h1>
   </div>
-  <div class='header-illustration new-user-arm'></div>
 <% end %>
 
-<div class="message">
-  <h1><%= t "users.new.no_auto_account_create" %></h1>
-  <h2><%= t "users.new.please_contact_support_html", :support_link => mail_to(Settings.support_email, t("users.new.support")) %></h2>
+<div class="mx-auto my-0">
+  <p><strong><%= t "users.new.no_auto_account_create" %></strong></p>
+  <p><%= t "users.new.please_contact_support_html", :support_link => mail_to(Settings.support_email, t("users.new.support")) %></p>
 </div>


### PR DESCRIPTION
Split away from #4455, result of discussion https://github.com/openstreetmap/openstreetmap-website/pull/4455#discussion_r1519599220:

- Remove hanging arm
- Remove `<h1>` and `<h2>` tags for main text.
- Emphasize1st paragraph with `<strong>`