### PR TITLE
Don't pass paths to element_single_current_link helper

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -1,6 +1,6 @@
 module BrowseHelper
-  def element_single_current_link(type, object, url)
-    link_to url, { :class => element_class(type, object), :title => element_title(object), :rel => (link_follow(object) if type == "node") } do
+  def element_single_current_link(type, object)
+    link_to object, { :class => element_class(type, object), :title => element_title(object), :rel => (link_follow(object) if type == "node") } do
       element_strikethrough object do
         printable_element_name object
       end

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -17,7 +17,7 @@
           <summary><%= t "browse.part_of_ways", :count => node.ways.uniq.count %></summary>
           <ul class="list-unstyled">
             <% node.ways.uniq.each do |way| %>
-              <li><%= element_single_current_link "way", way, way_path(way) %></li>
+              <li><%= element_single_current_link "way", way %></li>
             <% end %>
           </ul>
         </details>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -27,12 +27,12 @@
         <ul class="list-unstyled">
           <% way.way_nodes.each do |wn| %>
             <li>
-              <%= element_single_current_link "node", wn.node, node_path(wn.node) %>
+              <%= element_single_current_link "node", wn.node %>
               <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
               <% if related_ways.size > 0 then %>
                 (<%= t ".also_part_of_html",
                        :count => related_ways.size,
-                       :related_ways => to_sentence(related_ways.map { |w| element_single_current_link "way", w, way_path(w) }) %>)
+                       :related_ways => to_sentence(related_ways.map { |w| element_single_current_link "way", w }) %>)
               <% end %>
             </li>
           <% end %>


### PR DESCRIPTION
`link_to` can often be simplified by passing to it just an object instead of a path or a controller name. This may help with refactoring. The simplification can be done in many other places in addition to what's in this PR, but just in case I'll do it in small steps, at least until #4581 is merged.