### PR TITLE
Move changeset subscribe/unsubscribe to resourceful routes

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -177,7 +177,7 @@ class UserMailer < ApplicationMailer
       @changeset_comment = comment.changeset.tags["comment"].presence
       @time = comment.created_at
       @changeset_author = comment.changeset.user.display_name
-      @unsubscribe_url = changeset_unsubscribe_url(comment.changeset)
+      @unsubscribe_url = unsubscribe_changeset_url(comment.changeset)
       @author = @commenter
 
       subject = if @owner
@@ -193,7 +193,7 @@ class UserMailer < ApplicationMailer
       set_list_headers(
         "#{comment.changeset.id}.changeset.www.openstreetmap.org",
         t(".description", :id => comment.changeset.id),
-        :subscribe => changeset_subscribe_url(comment.changeset),
+        :subscribe => subscribe_changeset_url(comment.changeset),
         :unsubscribe => @unsubscribe_url,
         :archive => @changeset_url
       )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,7 +118,9 @@ OpenStreetMap::Application.routes.draw do
   get "/relation/:id" => "relations#show", :id => /\d+/, :as => :relation
   get "/relation/:id/history" => "old_relations#index", :id => /\d+/, :as => :relation_history
   resources :old_relations, :path => "/relation/:id/history", :id => /\d+/, :version => /\d+/, :param => :version, :only => :show
-  resources :changesets, :path => "changeset", :id => /\d+/, :only => :show
+  resources :changesets, :path => "changeset", :id => /\d+/, :only => :show do
+    match :subscribe, :unsubscribe, :on => :member, :via => [:get, :post]
+  end
   get "/changeset/:id/comments/feed" => "changeset_comments#index", :as => :changeset_comments_feed, :id => /\d*/, :defaults => { :format => "rss" }
   resources :notes, :path => "note", :only => [:show, :new]
 
@@ -127,8 +129,6 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/notes" => "notes#index", :as => :user_notes
   get "/history/friends" => "changesets#index", :friends => true, :as => "friend_changesets", :defaults => { :format => :html }
   get "/history/nearby" => "changesets#index", :nearby => true, :as => "nearby_changesets", :defaults => { :format => :html }
-  match "/changeset/:id/subscribe" => "changesets#subscribe", :via => [:get, :post], :as => "changeset_subscribe"
-  match "/changeset/:id/unsubscribe" => "changesets#unsubscribe", :via => [:get, :post], :as => "changeset_unsubscribe"
 
   get "/browse/way/:id",                :to => redirect(:path => "/way/%{id}")
   get "/browse/way/:id/history",        :to => redirect(:path => "/way/%{id}/history")

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -402,7 +402,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
     other_user = create(:user)
     changeset = create(:changeset, :user => user)
-    path = changeset_subscribe_path(changeset)
+    path = subscribe_changeset_path(changeset)
 
     get path
     assert_redirected_to login_path(:referer => path)
@@ -423,7 +423,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
 
     session_for(other_user)
     assert_difference "changeset.subscribers.count", 1 do
-      post changeset_subscribe_path(changeset)
+      post subscribe_changeset_path(changeset)
     end
     assert_redirected_to changeset_path(changeset)
     assert changeset.reload.subscribed?(other_user)
@@ -437,20 +437,20 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
 
     # not signed in
     assert_no_difference "changeset.subscribers.count" do
-      post changeset_subscribe_path(changeset)
+      post subscribe_changeset_path(changeset)
     end
     assert_response :forbidden
 
     session_for(other_user)
 
     # bad diary id
-    post changeset_subscribe_path(999111)
+    post subscribe_changeset_path(999111)
     assert_response :not_found
 
     # trying to subscribe when already subscribed
-    post changeset_subscribe_path(changeset)
+    post subscribe_changeset_path(changeset)
     assert_no_difference "changeset.subscribers.count" do
-      post changeset_subscribe_path(changeset)
+      post subscribe_changeset_path(changeset)
     end
   end
 
@@ -458,7 +458,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
     other_user = create(:user)
     changeset = create(:changeset, :user => user)
-    path = changeset_unsubscribe_path(changeset)
+    path = unsubscribe_changeset_path(changeset)
 
     get path
     assert_redirected_to login_path(:referer => path)
@@ -481,7 +481,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
 
     session_for(other_user)
     assert_difference "changeset.subscribers.count", -1 do
-      post changeset_unsubscribe_path(changeset)
+      post unsubscribe_changeset_path(changeset)
     end
     assert_redirected_to changeset_path(changeset)
     assert_not changeset.reload.subscribed?(other_user)
@@ -495,19 +495,19 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
 
     # not signed in
     assert_no_difference "changeset.subscribers.count" do
-      post changeset_unsubscribe_path(changeset)
+      post unsubscribe_changeset_path(changeset)
     end
     assert_response :forbidden
 
     session_for(other_user)
 
     # bad diary id
-    post changeset_unsubscribe_path(999111)
+    post unsubscribe_changeset_path(999111)
     assert_response :not_found
 
     # trying to unsubscribe when not subscribed
     assert_no_difference "changeset.subscribers.count" do
-      post changeset_unsubscribe_path(changeset)
+      post unsubscribe_changeset_path(changeset)
     end
   end
 

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -68,4 +68,19 @@ class UserMailerTest < ActionMailer::TestCase
     assert_select body, "a[href^='#{url}']"
     assert_select body, "a[href='#{unsubscribe_url}']", :count => 1
   end
+
+  def test_changeset_comment_notification
+    create(:language, :code => "en")
+    user = create(:user)
+    other_user = create(:user)
+    changeset = create(:changeset, :user => user)
+    changeset_comment = create(:changeset_comment, :changeset => changeset)
+    email = UserMailer.changeset_comment_notification(changeset_comment, other_user)
+    body = Rails::Dom::Testing.html_document_fragment.parse(email.html_part.body)
+
+    url = Rails.application.routes.url_helpers.changeset_url(changeset, :host => Settings.server_url, :protocol => Settings.server_protocol)
+    unsubscribe_url = Rails.application.routes.url_helpers.unsubscribe_changeset_url(changeset, :host => Settings.server_url, :protocol => Settings.server_protocol)
+    assert_select body, "a[href^='#{url}']"
+    assert_select body, "a[href='#{unsubscribe_url}']", :count => 1
+  end
 end


### PR DESCRIPTION
Since changesets are already declared as resources, I moved subscribe/unsubscribe routes under their resources definition. The only problem is that rails named their path helpers differently, `subscribe_changeset_path` etc instead of previous `changeset_subscribe_path`.