### PR TITLE
Change "people mapping nearby" empty inbox link to dashboard

### DIFF
--- a/app/views/messages/inbox.html.erb
+++ b/app/views/messages/inbox.html.erb
@@ -9,5 +9,5 @@
 <% if current_user.messages.size > 0 %>
   <%= render :partial => "messages_table", :locals => { :columns => %w[from subject date], :messages => current_user.messages, :inner_partial => "message_summary" } %>
 <% else %>
-  <div><%= t(".no_messages_yet_html", :people_mapping_nearby_link => link_to(t(".people_mapping_nearby"), user_path(current_user))) %></div>
+  <div><%= t(".no_messages_yet_html", :people_mapping_nearby_link => link_to(t(".people_mapping_nearby"), dashboard_path)) %></div>
 <% end %>

--- a/app/views/messages/outbox.html.erb
+++ b/app/views/messages/outbox.html.erb
@@ -9,5 +9,5 @@
 <% if current_user.sent_messages.size > 0 %>
   <%= render :partial => "messages_table", :locals => { :columns => %w[to subject date], :messages => current_user.sent_messages, :inner_partial => "sent_message_summary" } %>
 <% else %>
-  <div class="messages"><%= t(".no_sent_messages_html", :people_mapping_nearby_link => link_to(t(".people_mapping_nearby"), user_path(current_user))) %></div>
+  <div class="messages"><%= t(".no_sent_messages_html", :people_mapping_nearby_link => link_to(t(".people_mapping_nearby"), dashboard_path)) %></div>
 <% end %>


### PR DESCRIPTION
If your inbox or outbox is empty, you'll see this message

> You have no messages yet. Why not get in touch with some of the _people mapping nearby_?

with a link to your profile page. But you won't find anything about _people mapping nearby_ in your profile, this information was moved to the dashboard page in https://github.com/openstreetmap/openstreetmap-website/commit/cb7b79a58f0337ab28b41ed5105215de302d3f73.
