### PR TITLE
Count only tbody rows when testing tables

### DIFF
--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -40,14 +40,13 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       create(:note_comment, :note => note, :author => second_user)
     end
 
-    # Note that the table rows include a header row
     get user_notes_path(:display_name => first_user.display_name)
     assert_response :success
-    assert_select "table.note_list tr", :count => 2
+    assert_select "table.note_list tbody tr", :count => 1
 
     get user_notes_path(:display_name => second_user.display_name)
     assert_response :success
-    assert_select "table.note_list tr", :count => 2
+    assert_select "table.note_list tbody tr", :count => 1
 
     get user_notes_path(:display_name => "non-existent")
     assert_response :not_found
@@ -56,11 +55,11 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
 
     get user_notes_path(:display_name => first_user.display_name)
     assert_response :success
-    assert_select "table.note_list tr", :count => 2
+    assert_select "table.note_list tbody tr", :count => 1
 
     get user_notes_path(:display_name => second_user.display_name)
     assert_response :success
-    assert_select "table.note_list tr", :count => 3
+    assert_select "table.note_list tbody tr", :count => 2
 
     get user_notes_path(:display_name => "non-existent")
     assert_response :not_found
@@ -75,11 +74,11 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
 
     get user_notes_path(:display_name => user.display_name)
     assert_response :success
-    assert_select "table.note_list tr", :count => 11
+    assert_select "table.note_list tbody tr", :count => 10
 
     get user_notes_path(:display_name => user.display_name, :page => 2)
     assert_response :success
-    assert_select "table.note_list tr", :count => 11
+    assert_select "table.note_list tbody tr", :count => 10
   end
 
   def test_empty_page

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -88,14 +88,14 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     get user_blocks_path
     assert_response :success
-    assert_select "table#block_list", :count => 1 do
-      assert_select "tr", :count => 21
+    assert_select "table#block_list tbody", :count => 1 do
+      assert_select "tr", :count => 20
     end
 
     get user_blocks_path(:page => 2)
     assert_response :success
-    assert_select "table#block_list", :count => 1 do
-      assert_select "tr", :count => 21
+    assert_select "table#block_list tbody", :count => 1 do
+      assert_select "tr", :count => 20
     end
   end
 
@@ -513,14 +513,14 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     get user_blocks_on_path(:display_name => user.display_name)
     assert_response :success
-    assert_select "table#block_list", :count => 1 do
-      assert_select "tr", :count => 21
+    assert_select "table#block_list tbody", :count => 1 do
+      assert_select "tr", :count => 20
     end
 
     get user_blocks_on_path(:display_name => user.display_name, :page => 2)
     assert_response :success
-    assert_select "table#block_list", :count => 1 do
-      assert_select "tr", :count => 21
+    assert_select "table#block_list tbody", :count => 1 do
+      assert_select "tr", :count => 20
     end
   end
 
@@ -572,14 +572,14 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     get user_blocks_by_path(:display_name => user.display_name)
     assert_response :success
-    assert_select "table#block_list", :count => 1 do
-      assert_select "tr", :count => 21
+    assert_select "table#block_list tbody", :count => 1 do
+      assert_select "tr", :count => 20
     end
 
     get user_blocks_by_path(:display_name => user.display_name, :page => 2)
     assert_response :success
-    assert_select "table#block_list", :count => 1 do
-      assert_select "tr", :count => 21
+    assert_select "table#block_list tbody", :count => 1 do
+      assert_select "tr", :count => 20
     end
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -618,19 +618,19 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get users_path
     assert_response :success
     assert_template :index
-    assert_select "table#user_list tr", :count => 7 + 1
+    assert_select "table#user_list tbody tr", :count => 7
 
     # Should be able to limit by status
     get users_path, :params => { :status => "suspended" }
     assert_response :success
     assert_template :index
-    assert_select "table#user_list tr", :count => 1 + 1
+    assert_select "table#user_list tbody tr", :count => 1
 
     # Should be able to limit by IP address
     get users_path, :params => { :ip => "1.2.3.4" }
     assert_response :success
     assert_template :index
-    assert_select "table#user_list tr", :count => 1 + 1
+    assert_select "table#user_list tbody tr", :count => 1
   end
 
   def test_index_get_paginated
@@ -648,17 +648,17 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get users_path
     assert_response :success
     assert_template :index
-    assert_select "table#user_list tr", :count => 51
+    assert_select "table#user_list tbody tr", :count => 50
 
     get users_path, :params => { :page => 2 }
     assert_response :success
     assert_template :index
-    assert_select "table#user_list tr", :count => 51
+    assert_select "table#user_list tbody tr", :count => 50
 
     get users_path, :params => { :page => 3 }
     assert_response :success
     assert_template :index
-    assert_select "table#user_list tr", :count => 3
+    assert_select "table#user_list tbody tr", :count => 2
   end
 
   def test_index_post_confirm


### PR DESCRIPTION
Avoids adding 1 to expected number of rows.
Was done like this in https://github.com/openstreetmap/openstreetmap-website/commit/b57ed0bf23ba13e9f79bb3ab8f9bda59ee577d4a