### PR TITLE
Shorten user path helper calls in tests

### DIFF
--- a/test/controllers/friendships_controller_test.rb
+++ b/test/controllers/friendships_controller_test.rb
@@ -32,7 +32,7 @@ class FriendshipsControllerTest < ActionDispatch::IntegrationTest
 
     # When not logged in a GET should ask us to login
     get make_friend_path(friend)
-    assert_redirected_to login_path(:referer => make_friend_path(:display_name => friend.display_name))
+    assert_redirected_to login_path(:referer => make_friend_path(friend))
 
     # When not logged in a POST should error
     post make_friend_path(friend)
@@ -113,7 +113,7 @@ class FriendshipsControllerTest < ActionDispatch::IntegrationTest
   def test_make_friend_unknown_user
     # Should error when a bogus user is specified
     session_for(create(:user))
-    get make_friend_path(:display_name => "No Such User")
+    get make_friend_path("No Such User")
     assert_response :not_found
     assert_template :no_such_user
   end
@@ -129,7 +129,7 @@ class FriendshipsControllerTest < ActionDispatch::IntegrationTest
 
     # When not logged in a GET should ask us to login
     get remove_friend_path(friend)
-    assert_redirected_to login_path(:referer => remove_friend_path(:display_name => friend.display_name))
+    assert_redirected_to login_path(:referer => remove_friend_path(friend))
 
     # When not logged in a POST should error
     post remove_friend_path, :params => { :display_name => friend.display_name }
@@ -191,7 +191,7 @@ class FriendshipsControllerTest < ActionDispatch::IntegrationTest
   def test_remove_friend_unknown_user
     # Should error when a bogus user is specified
     session_for(create(:user))
-    get remove_friend_path(:display_name => "No Such User")
+    get remove_friend_path("No Such User")
     assert_response :not_found
     assert_template :no_such_user
   end

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -47,8 +47,8 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
   def test_new_no_login
     # Check that the new message page requires us to login
     user = create(:user)
-    get new_message_path(:display_name => user.display_name)
-    assert_redirected_to login_path(:referer => new_message_path(:display_name => user.display_name))
+    get new_message_path(user)
+    assert_redirected_to login_path(:referer => new_message_path(user))
   end
 
   ##
@@ -60,7 +60,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     session_for(user)
 
     # Check that the new message page loads
-    get new_message_path(:display_name => recipient_user.display_name)
+    get new_message_path(recipient_user)
     assert_response :success
     assert_template "new"
     assert_select "title", "Send message | OpenStreetMap"
@@ -84,8 +84,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_difference "ActionMailer::Base.deliveries.size", 0 do
       assert_difference "Message.count", 0 do
         perform_enqueued_jobs do
-          get new_message_path(:display_name => recipient_user.display_name,
-                               :message => { :title => "Test Message", :body => "Test message body" })
+          get new_message_path(recipient_user, :message => { :title => "Test Message", :body => "Test message body" })
         end
       end
     end
@@ -197,7 +196,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "markdown", m.body_format
 
     # Asking to send a message with a bogus user name should fail
-    get new_message_path(:display_name => "non_existent_user")
+    get new_message_path("non_existent_user")
     assert_response :not_found
     assert_template "users/no_such_user"
     assert_select "h1", "The user non_existent_user does not exist"

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -40,28 +40,28 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       create(:note_comment, :note => note, :author => second_user)
     end
 
-    get user_notes_path(:display_name => first_user.display_name)
+    get user_notes_path(first_user)
     assert_response :success
     assert_select "table.note_list tbody tr", :count => 1
 
-    get user_notes_path(:display_name => second_user.display_name)
+    get user_notes_path(second_user)
     assert_response :success
     assert_select "table.note_list tbody tr", :count => 1
 
-    get user_notes_path(:display_name => "non-existent")
+    get user_notes_path("non-existent")
     assert_response :not_found
 
     session_for(moderator_user)
 
-    get user_notes_path(:display_name => first_user.display_name)
+    get user_notes_path(first_user)
     assert_response :success
     assert_select "table.note_list tbody tr", :count => 1
 
-    get user_notes_path(:display_name => second_user.display_name)
+    get user_notes_path(second_user)
     assert_response :success
     assert_select "table.note_list tbody tr", :count => 2
 
-    get user_notes_path(:display_name => "non-existent")
+    get user_notes_path("non-existent")
     assert_response :not_found
   end
 
@@ -72,18 +72,18 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       create(:note_comment, :note => note, :author => user)
     end
 
-    get user_notes_path(:display_name => user.display_name)
+    get user_notes_path(user)
     assert_response :success
     assert_select "table.note_list tbody tr", :count => 10
 
-    get user_notes_path(:display_name => user.display_name, :page => 2)
+    get user_notes_path(user, :page => 2)
     assert_response :success
     assert_select "table.note_list tbody tr", :count => 10
   end
 
   def test_empty_page
     user = create(:user)
-    get user_notes_path(:display_name => user.display_name)
+    get user_notes_path(user)
     assert_response :success
     assert_select "h4", :html => "No notes"
   end

--- a/test/controllers/oauth_clients_controller_test.rb
+++ b/test/controllers/oauth_clients_controller_test.rb
@@ -39,12 +39,12 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     create_list(:client_application, 2, :user => user)
     create_list(:access_token, 2, :user => user)
 
-    get oauth_clients_path(:display_name => user.display_name)
-    assert_redirected_to login_path(:referer => oauth_clients_path(:display_name => user.display_name))
+    get oauth_clients_path(user)
+    assert_redirected_to login_path(:referer => oauth_clients_path(user))
 
     session_for(user)
 
-    get oauth_clients_path(:display_name => user.display_name)
+    get oauth_clients_path(user)
     assert_response :success
     assert_template "index"
     assert_select "li.client_application", 2
@@ -53,12 +53,12 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
   def test_new
     user = create(:user)
 
-    get new_oauth_client_path(:display_name => user.display_name)
-    assert_redirected_to login_path(:referer => new_oauth_client_path(:display_name => user.display_name))
+    get new_oauth_client_path(user)
+    assert_redirected_to login_path(:referer => new_oauth_client_path(user))
 
     session_for(user)
 
-    get new_oauth_client_path(:display_name => user.display_name)
+    get new_oauth_client_path(user)
     assert_response :success
     assert_template "new"
     assert_select "form", 1 do
@@ -76,13 +76,13 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
 
     with_settings(:oauth_10_registration => false) do
-      get new_oauth_client_path(:display_name => user.display_name)
-      assert_redirected_to login_path(:referer => new_oauth_client_path(:display_name => user.display_name))
+      get new_oauth_client_path(user)
+      assert_redirected_to login_path(:referer => new_oauth_client_path(user))
 
       session_for(user)
 
-      get new_oauth_client_path(:display_name => user.display_name)
-      assert_redirected_to oauth_clients_path(:display_name => user.display_name)
+      get new_oauth_client_path(user)
+      assert_redirected_to oauth_clients_path(user)
     end
   end
 
@@ -90,23 +90,21 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
 
     assert_difference "ClientApplication.count", 0 do
-      post oauth_clients_path(:display_name => user.display_name)
+      post oauth_clients_path(user)
     end
     assert_response :forbidden
 
     session_for(user)
 
     assert_difference "ClientApplication.count", 0 do
-      post oauth_clients_path(:display_name => user.display_name,
-                              :client_application => { :name => "Test Application" })
+      post oauth_clients_path(user, :client_application => { :name => "Test Application" })
     end
     assert_response :success
     assert_template "new"
 
     assert_difference "ClientApplication.count", 1 do
-      post oauth_clients_path(:display_name => user.display_name,
-                              :client_application => { :name => "Test Application",
-                                                       :url => "http://test.example.com/" })
+      post oauth_clients_path(user, :client_application => { :name => "Test Application",
+                                                             :url => "http://test.example.com/" })
     end
     assert_redirected_to oauth_client_path(:id => ClientApplication.find_by(:name => "Test Application").id)
   end
@@ -116,16 +114,16 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     client = create(:client_application, :user => user)
     other_client = create(:client_application)
 
-    get oauth_client_path(:display_name => user.display_name, :id => client)
-    assert_redirected_to login_path(:referer => oauth_client_path(:display_name => user.display_name, :id => client.id))
+    get oauth_client_path(user, client)
+    assert_redirected_to login_path(:referer => oauth_client_path(user, client.id))
 
     session_for(user)
 
-    get oauth_client_path(:display_name => user.display_name, :id => other_client)
+    get oauth_client_path(user, other_client)
     assert_response :not_found
     assert_template "not_found"
 
-    get oauth_client_path(:display_name => user.display_name, :id => client)
+    get oauth_client_path(user, client)
     assert_response :success
     assert_template "show"
   end
@@ -135,16 +133,16 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     client = create(:client_application, :user => user)
     other_client = create(:client_application)
 
-    get edit_oauth_client_path(:display_name => user.display_name, :id => client)
-    assert_redirected_to login_path(:referer => edit_oauth_client_path(:display_name => user.display_name, :id => client.id))
+    get edit_oauth_client_path(user, client)
+    assert_redirected_to login_path(:referer => edit_oauth_client_path(user, client.id))
 
     session_for(user)
 
-    get edit_oauth_client_path(:display_name => user.display_name, :id => other_client)
+    get edit_oauth_client_path(user, other_client)
     assert_response :not_found
     assert_template "not_found"
 
-    get edit_oauth_client_path(:display_name => user.display_name, :id => client)
+    get edit_oauth_client_path(user, client)
     assert_response :success
     assert_template "edit"
     assert_select "form", 1 do
@@ -163,22 +161,20 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     client = create(:client_application, :user => user)
     other_client = create(:client_application)
 
-    put oauth_client_path(:display_name => user.display_name, :id => client)
+    put oauth_client_path(user, client)
     assert_response :forbidden
 
     session_for(user)
 
-    put oauth_client_path(:display_name => user.display_name, :id => other_client)
+    put oauth_client_path(user, other_client)
     assert_response :not_found
     assert_template "not_found"
 
-    put oauth_client_path(:display_name => user.display_name, :id => client,
-                          :client_application => { :name => "New Name", :url => nil })
+    put oauth_client_path(user, client, :client_application => { :name => "New Name", :url => nil })
     assert_response :success
     assert_template "edit"
 
-    put oauth_client_path(:display_name => user.display_name, :id => client,
-                          :client_application => { :name => "New Name", :url => "http://new.example.com/url" })
+    put oauth_client_path(user, client, :client_application => { :name => "New Name", :url => "http://new.example.com/url" })
     assert_redirected_to oauth_client_path(:id => client.id)
   end
 
@@ -188,21 +184,21 @@ class OauthClientsControllerTest < ActionDispatch::IntegrationTest
     other_client = create(:client_application)
 
     assert_difference "ClientApplication.count", 0 do
-      delete oauth_client_path(:display_name => user.display_name, :id => client)
+      delete oauth_client_path(user, client)
     end
     assert_response :forbidden
 
     session_for(user)
 
     assert_difference "ClientApplication.count", 0 do
-      delete oauth_client_path(:display_name => user.display_name, :id => other_client)
+      delete oauth_client_path(user, other_client)
     end
     assert_response :not_found
     assert_template "not_found"
 
     assert_difference "ClientApplication.count", -1 do
-      delete oauth_client_path(:display_name => user.display_name, :id => client)
+      delete oauth_client_path(user, client)
     end
-    assert_redirected_to oauth_clients_path(:display_name => user.display_name)
+    assert_redirected_to oauth_clients_path(user)
   end
 end

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -374,17 +374,17 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     public_trace_file = create(:trace, :visibility => "public")
 
     # First with no auth, which should work since the trace is public
-    get show_trace_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get show_trace_path(public_trace_file.user, public_trace_file)
     check_trace_show public_trace_file
 
     # Now with some other user, which should work since the trace is public
     session_for(create(:user))
-    get show_trace_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get show_trace_path(public_trace_file.user, public_trace_file)
     check_trace_show public_trace_file
 
     # And finally we should be able to do it with the owner of the trace
     session_for(public_trace_file.user)
-    get show_trace_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get show_trace_path(public_trace_file.user, public_trace_file)
     check_trace_show public_trace_file
   end
 
@@ -393,17 +393,17 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     anon_trace_file = create(:trace, :visibility => "private")
 
     # First with no auth
-    get show_trace_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get show_trace_path(anon_trace_file.user, anon_trace_file)
     assert_redirected_to :action => :index
 
     # Now with some other user, which should not work since the trace is anon
     session_for(create(:user))
-    get show_trace_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get show_trace_path(anon_trace_file.user, anon_trace_file)
     assert_redirected_to :action => :index
 
     # And finally we should be able to do it with the owner of the trace
     session_for(anon_trace_file.user)
-    get show_trace_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get show_trace_path(anon_trace_file.user, anon_trace_file)
     check_trace_show anon_trace_file
   end
 
@@ -412,12 +412,12 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     deleted_trace_file = create(:trace, :deleted)
 
     # First with a trace that has never existed
-    get show_trace_path(:display_name => create(:user).display_name, :id => 0)
+    get show_trace_path(create(:user), 0)
     assert_redirected_to :action => :index
 
     # Now with a trace that has been deleted
     session_for(deleted_trace_file.user)
-    get show_trace_path(:display_name => deleted_trace_file.user.display_name, :id => deleted_trace_file)
+    get show_trace_path(deleted_trace_file.user, deleted_trace_file)
     assert_redirected_to :action => :index
   end
 
@@ -505,17 +505,17 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     public_trace_file = create(:trace, :visibility => "public", :fixture => "a")
 
     # First with no auth, which should work since the trace is public
-    get trace_picture_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get trace_picture_path(public_trace_file.user, public_trace_file)
     check_trace_picture public_trace_file
 
     # Now with some other user, which should work since the trace is public
     session_for(create(:user))
-    get trace_picture_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get trace_picture_path(public_trace_file.user, public_trace_file)
     check_trace_picture public_trace_file
 
     # And finally we should be able to do it with the owner of the trace
     session_for(public_trace_file.user)
-    get trace_picture_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get trace_picture_path(public_trace_file.user, public_trace_file)
     check_trace_picture public_trace_file
   end
 
@@ -524,17 +524,17 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     anon_trace_file = create(:trace, :visibility => "private", :fixture => "b")
 
     # First with no auth
-    get trace_picture_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get trace_picture_path(anon_trace_file.user, anon_trace_file)
     assert_response :forbidden
 
     # Now with some other user, which shouldn't work since the trace is anon
     session_for(create(:user))
-    get trace_picture_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get trace_picture_path(anon_trace_file.user, anon_trace_file)
     assert_response :forbidden
 
     # And finally we should be able to do it with the owner of the trace
     session_for(anon_trace_file.user)
-    get trace_picture_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get trace_picture_path(anon_trace_file.user, anon_trace_file)
     check_trace_picture anon_trace_file
   end
 
@@ -543,12 +543,12 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     deleted_trace_file = create(:trace, :deleted)
 
     # First with a trace that has never existed
-    get trace_picture_path(:display_name => create(:user).display_name, :id => 0)
+    get trace_picture_path(create(:user), 0)
     assert_response :not_found
 
     # Now with a trace that has been deleted
     session_for(deleted_trace_file.user)
-    get trace_picture_path(:display_name => deleted_trace_file.user.display_name, :id => deleted_trace_file)
+    get trace_picture_path(deleted_trace_file.user, deleted_trace_file)
     assert_response :not_found
   end
 
@@ -557,17 +557,17 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     public_trace_file = create(:trace, :visibility => "public", :fixture => "a")
 
     # First with no auth, which should work since the trace is public
-    get trace_icon_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get trace_icon_path(public_trace_file.user, public_trace_file)
     check_trace_icon public_trace_file
 
     # Now with some other user, which should work since the trace is public
     session_for(create(:user))
-    get trace_icon_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get trace_icon_path(public_trace_file.user, public_trace_file)
     check_trace_icon public_trace_file
 
     # And finally we should be able to do it with the owner of the trace
     session_for(public_trace_file.user)
-    get trace_icon_path(:display_name => public_trace_file.user.display_name, :id => public_trace_file)
+    get trace_icon_path(public_trace_file.user, public_trace_file)
     check_trace_icon public_trace_file
   end
 
@@ -576,17 +576,17 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     anon_trace_file = create(:trace, :visibility => "private", :fixture => "b")
 
     # First with no auth
-    get trace_icon_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get trace_icon_path(anon_trace_file.user, anon_trace_file)
     assert_response :forbidden
 
     # Now with some other user, which shouldn't work since the trace is anon
     session_for(create(:user))
-    get trace_icon_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get trace_icon_path(anon_trace_file.user, anon_trace_file)
     assert_response :forbidden
 
     # And finally we should be able to do it with the owner of the trace
     session_for(anon_trace_file.user)
-    get trace_icon_path(:display_name => anon_trace_file.user.display_name, :id => anon_trace_file)
+    get trace_icon_path(anon_trace_file.user, anon_trace_file)
     check_trace_icon anon_trace_file
   end
 
@@ -595,12 +595,12 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     deleted_trace_file = create(:trace, :deleted)
 
     # First with a trace that has never existed
-    get trace_icon_path(:display_name => create(:user).display_name, :id => 0)
+    get trace_icon_path(create(:user), 0)
     assert_response :not_found
 
     # Now with a trace that has been deleted
     session_for(deleted_trace_file.user)
-    get trace_icon_path(:display_name => deleted_trace_file.user.display_name, :id => deleted_trace_file)
+    get trace_icon_path(deleted_trace_file.user, deleted_trace_file)
     assert_response :not_found
   end
 

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -140,21 +140,21 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     target_user = create(:user)
 
     # Check that the block creation page requires us to login
-    get new_user_block_path(:display_name => target_user.display_name)
-    assert_redirected_to login_path(:referer => new_user_block_path(:display_name => target_user.display_name))
+    get new_user_block_path(target_user)
+    assert_redirected_to login_path(:referer => new_user_block_path(target_user))
 
     # Login as a normal user
     session_for(create(:user))
 
     # Check that normal users can't load the block creation page
-    get new_user_block_path(:display_name => target_user.display_name)
+    get new_user_block_path(target_user)
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as a moderator
     session_for(create(:moderator_user))
 
     # Check that the block creation page loads for moderators
-    get new_user_block_path(:display_name => target_user.display_name)
+    get new_user_block_path(target_user)
     assert_response :success
     assert_select "form#new_user_block", :count => 1 do
       assert_select "textarea#user_block_reason", :count => 1
@@ -232,7 +232,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
       post user_blocks_path(:display_name => target_user.display_name,
                             :user_block_period => "99")
     end
-    assert_redirected_to new_user_block_path(:display_name => target_user.display_name)
+    assert_redirected_to new_user_block_path(target_user)
     assert_equal "The blocking period must be one of the values selectable in the drop-down list.", flash[:error]
 
     # Check that creating a block works
@@ -396,7 +396,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     create(:user_block, :user => blocked_user)
 
     # Asking for the revoke all blocks page with a bogus user name should fail
-    get user_blocks_on_path(:display_name => "non_existent_user")
+    get user_blocks_on_path("non_existent_user")
     assert_response :not_found
 
     # Check that the revoke all blocks page requires us to login
@@ -476,19 +476,19 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     expired_block = create(:user_block, :expired, :user => unblocked_user)
 
     # Asking for a list of blocks with a bogus user name should fail
-    get user_blocks_on_path(:display_name => "non_existent_user")
+    get user_blocks_on_path("non_existent_user")
     assert_response :not_found
     assert_template "users/no_such_user"
     assert_select "h1", "The user non_existent_user does not exist"
 
     # Check the list of blocks for a user that has never been blocked
-    get user_blocks_on_path(:display_name => normal_user.display_name)
+    get user_blocks_on_path(normal_user)
     assert_response :success
     assert_select "table#block_list", false
     assert_select "p", "#{normal_user.display_name} has not been blocked yet."
 
     # Check the list of blocks for a user that is currently blocked
-    get user_blocks_on_path(:display_name => blocked_user.display_name)
+    get user_blocks_on_path(blocked_user)
     assert_response :success
     assert_select "table#block_list", :count => 1 do
       assert_select "tr", 3
@@ -497,7 +497,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Check the list of blocks for a user that has previously been blocked
-    get user_blocks_on_path(:display_name => unblocked_user.display_name)
+    get user_blocks_on_path(unblocked_user)
     assert_response :success
     assert_select "table#block_list", :count => 1 do
       assert_select "tr", 2
@@ -511,13 +511,13 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
     create_list(:user_block, 50, :user => user)
 
-    get user_blocks_on_path(:display_name => user.display_name)
+    get user_blocks_on_path(user)
     assert_response :success
     assert_select "table#block_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
 
-    get user_blocks_on_path(:display_name => user.display_name, :page => 2)
+    get user_blocks_on_path(user, :page => 2)
     assert_response :success
     assert_select "table#block_list tbody", :count => 1 do
       assert_select "tr", :count => 20
@@ -535,13 +535,13 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     revoked_block = create(:user_block, :revoked, :creator => second_moderator_user)
 
     # Asking for a list of blocks with a bogus user name should fail
-    get user_blocks_by_path(:display_name => "non_existent_user")
+    get user_blocks_by_path("non_existent_user")
     assert_response :not_found
     assert_template "users/no_such_user"
     assert_select "h1", "The user non_existent_user does not exist"
 
     # Check the list of blocks given by one moderator
-    get user_blocks_by_path(:display_name => moderator_user.display_name)
+    get user_blocks_by_path(moderator_user)
     assert_response :success
     assert_select "table#block_list", :count => 1 do
       assert_select "tr", 2
@@ -549,7 +549,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Check the list of blocks given by a different moderator
-    get user_blocks_by_path(:display_name => second_moderator_user.display_name)
+    get user_blocks_by_path(second_moderator_user)
     assert_response :success
     assert_select "table#block_list", :count => 1 do
       assert_select "tr", 3
@@ -558,7 +558,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Check the list of blocks (not) given by a normal user
-    get user_blocks_by_path(:display_name => normal_user.display_name)
+    get user_blocks_by_path(normal_user)
     assert_response :success
     assert_select "table#block_list", false
     assert_select "p", "#{normal_user.display_name} has not made any blocks yet."
@@ -570,13 +570,13 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     user = create(:moderator_user)
     create_list(:user_block, 50, :creator => user)
 
-    get user_blocks_by_path(:display_name => user.display_name)
+    get user_blocks_by_path(user)
     assert_response :success
     assert_select "table#block_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
 
-    get user_blocks_by_path(:display_name => user.display_name, :page => 2)
+    get user_blocks_by_path(user, :page => 2)
     assert_response :success
     assert_select "table#block_list tbody", :count => 1 do
       assert_select "tr", :count => 20

--- a/test/controllers/user_roles_controller_test.rb
+++ b/test/controllers/user_roles_controller_test.rb
@@ -23,14 +23,14 @@ class UserRolesControllerTest < ActionDispatch::IntegrationTest
     super_user = create(:super_user)
 
     # Granting should fail when not logged in
-    post grant_role_path(:display_name => target_user.display_name, :role => "moderator")
+    post grant_role_path(target_user, "moderator")
     assert_response :forbidden
 
     # Login as an unprivileged user
     session_for(normal_user)
 
     # Granting should still fail
-    post grant_role_path(:display_name => target_user.display_name, :role => "moderator")
+    post grant_role_path(target_user, "moderator")
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Login as an administrator
@@ -39,7 +39,7 @@ class UserRolesControllerTest < ActionDispatch::IntegrationTest
     UserRole::ALL_ROLES.each do |role|
       # Granting a role to a non-existent user should fail
       assert_difference "UserRole.count", 0 do
-        post grant_role_path(:display_name => "non_existent_user", :role => role)
+        post grant_role_path("non_existent_user", role)
       end
       assert_response :not_found
       assert_template "users/no_such_user"
@@ -47,20 +47,20 @@ class UserRolesControllerTest < ActionDispatch::IntegrationTest
 
       # Granting a role to a user that already has it should fail
       assert_no_difference "UserRole.count" do
-        post grant_role_path(:display_name => super_user.display_name, :role => role)
+        post grant_role_path(super_user, role)
       end
       assert_redirected_to user_path(super_user)
       assert_equal "The user already has role #{role}.", flash[:error]
 
       # Granting a role to a user that doesn't have it should work...
       assert_difference "UserRole.count", 1 do
-        post grant_role_path(:display_name => target_user.display_name, :role => role)
+        post grant_role_path(target_user, role)
       end
       assert_redirected_to user_path(target_user)
 
       # ...but trying a second time should fail
       assert_no_difference "UserRole.count" do
-        post grant_role_path(:display_name => target_user.display_name, :role => role)
+        post grant_role_path(target_user, role)
       end
       assert_redirected_to user_path(target_user)
       assert_equal "The user already has role #{role}.", flash[:error]
@@ -68,7 +68,7 @@ class UserRolesControllerTest < ActionDispatch::IntegrationTest
 
     # Granting a non-existent role should fail
     assert_difference "UserRole.count", 0 do
-      post grant_role_path(:display_name => target_user.display_name, :role => "no_such_role")
+      post grant_role_path(target_user, "no_such_role")
     end
     assert_redirected_to user_path(target_user)
     assert_equal "The string `no_such_role' is not a valid role.", flash[:error]
@@ -83,14 +83,14 @@ class UserRolesControllerTest < ActionDispatch::IntegrationTest
     super_user = create(:super_user)
 
     # Revoking should fail when not logged in
-    post revoke_role_path(:display_name => target_user.display_name, :role => "moderator")
+    post revoke_role_path(target_user, "moderator")
     assert_response :forbidden
 
     # Login as an unprivileged user
     session_for(normal_user)
 
     # Revoking should still fail
-    post revoke_role_path(:display_name => target_user.display_name, :role => "moderator")
+    post revoke_role_path(target_user, "moderator")
     assert_redirected_to :controller => :errors, :action => :forbidden
 
     # Login as an administrator
@@ -99,7 +99,7 @@ class UserRolesControllerTest < ActionDispatch::IntegrationTest
     UserRole::ALL_ROLES.each do |role|
       # Removing a role from a non-existent user should fail
       assert_difference "UserRole.count", 0 do
-        post revoke_role_path(:display_name => "non_existent_user", :role => role)
+        post revoke_role_path("non_existent_user", role)
       end
       assert_response :not_found
       assert_template "users/no_such_user"
@@ -107,20 +107,20 @@ class UserRolesControllerTest < ActionDispatch::IntegrationTest
 
       # Removing a role from a user that doesn't have it should fail
       assert_no_difference "UserRole.count" do
-        post revoke_role_path(:display_name => target_user.display_name, :role => role)
+        post revoke_role_path(target_user, role)
       end
       assert_redirected_to user_path(target_user)
       assert_equal "The user does not have role #{role}.", flash[:error]
 
       # Removing a role from a user that has it should work...
       assert_difference "UserRole.count", -1 do
-        post revoke_role_path(:display_name => super_user.display_name, :role => role)
+        post revoke_role_path(super_user, role)
       end
       assert_redirected_to user_path(super_user)
 
       # ...but trying a second time should fail
       assert_no_difference "UserRole.count" do
-        post revoke_role_path(:display_name => super_user.display_name, :role => role)
+        post revoke_role_path(super_user, role)
       end
       assert_redirected_to user_path(super_user)
       assert_equal "The user does not have role #{role}.", flash[:error]
@@ -128,13 +128,13 @@ class UserRolesControllerTest < ActionDispatch::IntegrationTest
 
     # Revoking a non-existent role should fail
     assert_difference "UserRole.count", 0 do
-      post revoke_role_path(:display_name => target_user.display_name, :role => "no_such_role")
+      post revoke_role_path(target_user, "no_such_role")
     end
     assert_redirected_to user_path(target_user)
     assert_equal "The string `no_such_role' is not a valid role.", flash[:error]
 
     # Revoking administrator role from current user should fail
-    post revoke_role_path(:display_name => administrator_user.display_name, :role => "administrator")
+    post revoke_role_path(administrator_user, "administrator")
     assert_redirected_to user_path(administrator_user)
     assert_equal "Cannot revoke administrator role from current user.", flash[:error]
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -416,7 +416,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   # information for the user
   def test_show
     # Test a non-existent user
-    get user_path(:display_name => "unknown")
+    get user_path("unknown")
     assert_response :not_found
 
     # Test a normal user


### PR DESCRIPTION
for helpers with `:display_name` argument