### PR TITLE
Simplify links on trace pages

### DIFF
--- a/app/views/traces/_description.html.erb
+++ b/app/views/traces/_description.html.erb
@@ -1,4 +1,4 @@
-<%= image_tag(url_for(:controller => :traces, :action => :icon, :id => description.id, :display_name => description.user.display_name)) %>
+<%= image_tag trace_icon_path(description.user, description.id) %>
 <% if description.size -%>
 <%= t ".description_with_count", :count => description.size, :user => description.user.display_name %>
 <% else -%>

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -2,7 +2,7 @@
   <td>
     <% if Settings.status != "gpx_offline" %>
       <% if trace.inserted %>
-        <a href="<%= url_for :controller => "traces", :action => "show", :id => trace.id, :display_name => trace.user.display_name %>"><img src="<%= url_for :controller => "traces", :action => "icon", :id => trace.id, :display_name => trace.user.display_name %>" border="0" alt="" /></a>
+        <%= link_to image_tag(trace_icon_path(trace.user, trace), :alt => ""), show_trace_path(trace.user, trace) %>
       <% else %>
         <span class="text-danger"><%= t ".pending" %></span>
       <% end %>
@@ -11,7 +11,7 @@
   <td>
     <ul class="list-inline mb-0">
       <li class="list-inline-item">
-        <%= link_to trace.name, :controller => "traces", :action => "show", :display_name => trace.user.display_name, :id => trace.id %>
+        <%= link_to trace.name, show_trace_path(trace.user, trace) %>
       </li>
 
       <% if trace.inserted? %>
@@ -30,7 +30,7 @@
     </ul>
     <p class="text-muted mb-0">
       <%= friendly_date_ago(trace.timestamp) %>
-      <%= t ".by" %> <%= link_to trace.user.display_name, user_path(trace.user) %>
+      <%= t ".by" %> <%= link_to trace.user.display_name, trace.user %>
       <% if !trace.tags.empty? %>
         <%= t ".in" %>
         <%= safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>
@@ -45,10 +45,10 @@
       <nav class="secondary-actions">
         <ul>
           <li>
-            <%= link_to t(".view_map"), { :controller => "site", :action => "index", :mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}" } %>
+            <%= link_to t(".view_map"), root_path(:mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}") %>
           </li>
           <li>
-            <%= link_to t(".edit_map"), { :controller => "site", :action => "edit", :gpx => trace.id } %>
+            <%= link_to t(".edit_map"), edit_path(:gpx => trace.id) %>
           </li>
         </ul>
       </nav>

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t ".heading", :name => @trace.name %></h1>
 <% end %>
 
-<img src="<%= url_for :controller => "traces", :action => "picture", :id => @trace.id, :display_name => @trace.user.display_name %>">
+<%= image_tag trace_picture_path(@trace.user, @trace) %>
 
 <%= bootstrap_form_for @trace do |f| %>
   <%= f.text_field :name, :disabled => true %>

--- a/app/views/traces/georss.rss.builder
+++ b/app/views/traces/georss.rss.builder
@@ -21,8 +21,8 @@ xml.rss("version" => "2.0",
       xml.item do
         xml.title trace.name
 
-        xml.link url_for(:controller => :traces, :action => :show, :id => trace.id, :display_name => trace.user.display_name, :only_path => false)
-        xml.guid url_for(:controller => :traces, :action => :show, :id => trace.id, :display_name => trace.user.display_name, :only_path => false)
+        xml.link show_trace_url(trace.user, trace)
+        xml.guid show_trace_url(trace.user, trace)
 
         xml.description do
           xml.cdata! render(:partial => "description", :object => trace, :formats => [:html])

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -4,7 +4,7 @@
 
 <% if Settings.status != "gpx_offline" %>
   <% if @trace.inserted %>
-    <img src="<%= url_for :controller => "traces", :action => "picture", :id => @trace.id, :display_name => @trace.user.display_name %>">
+    <%= image_tag trace_picture_path(@trace.user, @trace) %>
   <% else %>
     <span class="text-danger"><%= t ".pending" %></span>
   <% end %>
@@ -31,12 +31,12 @@
               :latitude => tag.span(number_with_delimiter(@trace.latitude), :class => "latitude"),
               :longitude => tag.span(number_with_delimiter(@trace.longitude), :class => "longitude") %>
       </div>
-      (<%= link_to t(".map"), :controller => "site", :action => "index", :mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %> / <%= link_to t(".edit"), :controller => "site", :action => "edit", :gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}" %>)</td>
+      (<%= link_to t(".map"), root_path(:mlat => @trace.latitude, :mlon => @trace.longitude, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}") %> / <%= link_to t(".edit"), edit_path(:gpx => @trace.id, :anchor => "map=14/#{@trace.latitude}/#{@trace.longitude}") %>)</td>
   </tr>
   <% end %>
   <tr>
     <th><%= t ".owner" %></th>
-    <td><%= link_to @trace.user.display_name, user_path(@trace.user) %></td>
+    <td><%= link_to @trace.user.display_name, @trace.user %></td>
   </tr>
   <tr>
     <th><%= t ".description" %></th>
@@ -63,6 +63,6 @@
     <% if current_user == @trace.user %>
       <%= link_to t(".edit_trace"), edit_trace_path(@trace), :class => "btn btn-outline-primary" %>
     <% end %>
-    <%= link_to t(".delete_trace"), { :controller => "traces", :action => "destroy", :id => @trace.id }, { :method => :delete, :class => "btn btn-outline-danger", :data => { :confirm => t(".confirm_delete") } } %>
+    <%= link_to t(".delete_trace"), @trace, { :method => :delete, :class => "btn btn-outline-danger", :data => { :confirm => t(".confirm_delete") } } %>
   </div>
 <% end %>

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -833,6 +833,7 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
             assert_select row, "li", Regexp.new(Regexp.escape("#{trace.size} points")) if trace.inserted?
             assert_select row, "td", Regexp.new(Regexp.escape(trace.description))
             assert_select row, "td", Regexp.new(Regexp.escape("by #{trace.user.display_name}"))
+            assert_select row, "a[href='#{user_path trace.user}']", :text => trace.user.display_name
           end
         end
       end
@@ -845,7 +846,7 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "table", :count => 1 do
       assert_select "td", /^#{Regexp.quote(trace.name)} /
-      assert_select "td", trace.user.display_name
+      assert_select "td a[href='#{user_path trace.user}']", :text => trace.user.display_name
       assert_select "td", trace.description
     end
   end


### PR DESCRIPTION
for `link_to`, `url_for`, `image_tag` pointing to traces, users, map locations, edit locations