### PR TITLE
Fix warning on unescaped hyphen in regexp

### DIFF
--- a/test/system/user_email_change_test.rb
+++ b/test/system/user_email_change_test.rb
@@ -21,9 +21,9 @@ class UserEmailChangeTest < ApplicationSystemTestCase
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal "new_tester@example.com", email.to.first
-    assert_match %r{/user/confirm-email\?confirm_string=[A-Za-z0-9-_%]+\s}, email.parts[0].parts[0].decoded
+    assert_match %r{/user/confirm-email\?confirm_string=[A-Za-z0-9\-_%]+\s}, email.parts[0].parts[0].decoded
 
-    if email.parts[0].parts[0].decoded =~ %r{(/user/confirm-email\?confirm_string=[A-Za-z0-9-_%]+)\s}
+    if email.parts[0].parts[0].decoded =~ %r{(/user/confirm-email\?confirm_string=[A-Za-z0-9\-_%]+)\s}
       visit Regexp.last_match(1)
       assert page.has_css?("body.accounts-edit")
     end


### PR DESCRIPTION
```bash
$ bundle exec rails test test/system/user_email_change_test.rb 
/home/andy/src/openstreetmap-website/test/system/user_email_change_test.rb:24: warning: character class has '-' without escape: /\/user\/confirm-email\?confirm_string=[A-Za-z0-9-_%]+\s/
/home/andy/src/openstreetmap-website/test/system/user_email_change_test.rb:26: warning: character class has '-' without escape
/home/andy/.rbenv/versions/3.0.6/lib/ruby/gems/3.0.0/gems/bootsnap-1.18.3/lib/bootsnap/compile_cache/iseq.rb:53: warning: character class has '-' without escape: /\/user\/confirm-email\?confirm_string=[A-Za-z0-9-_%]+\s/
/home/andy/.rbenv/versions/3.0.6/lib/ruby/gems/3.0.0/gems/bootsnap-1.18.3/lib/bootsnap/compile_cache/iseq.rb:53: warning: character class has '-' without escape
```