### PR TITLE
Avoid lego translation in trace time/user/tags string

### DIFF
--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -29,11 +29,13 @@
       </li>
     </ul>
     <p class="text-muted mb-0">
-      <%= friendly_date_ago(trace.timestamp) %>
-      <%= t ".by" %> <%= link_to trace.user.display_name, trace.user %>
-      <% if !trace.tags.empty? %>
-        <%= t ".in" %>
-        <%= safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>
+      <% if trace.tags.empty? %>
+        <%= t ".details_without_tags_html", :time_ago => friendly_date_ago(trace.timestamp),
+                                            :user => link_to(trace.user.display_name, trace.user) %>
+      <% else %>
+        <%= t ".details_with_tags_html", :time_ago => friendly_date_ago(trace.timestamp),
+                                         :user => link_to(trace.user.display_name, trace.user),
+                                         :tags => safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>
       <% end %>
     </p>
     <p class="fst-italic mb-0">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2541,8 +2541,8 @@ en:
       identifiable: "IDENTIFIABLE"
       private: "PRIVATE"
       trackable: "TRACKABLE"
-      by: "by"
-      in: "in"
+      details_with_tags_html: "%{time_ago} by %{user} in %{tags}"
+      details_without_tags_html: "%{time_ago} by %{user}"
     index:
       public_traces: "Public GPS Traces"
       my_gps_traces: "My GPS Traces"


### PR DESCRIPTION
Fixes #4597, but tags are still joined by `,` which might be a problem for some languages.