### PR TITLE
Make factory-created revoked blocks inactive

### DIFF
--- a/test/factories/user_blocks.rb
+++ b/test/factories/user_blocks.rb
@@ -11,10 +11,12 @@ FactoryBot.define do
     end
 
     trait :expired do
+      created_at { Time.now.utc - 2.days }
       ends_at { Time.now.utc - 1.day }
     end
 
     trait :revoked do
+      expired
       revoker :factory => :moderator_user
     end
   end


### PR DESCRIPTION
While testing you can create a revoked block with `create(:user_block, :revoked)`. However it's going to be active because its expiration date is not set. This can't happen when you normally use the osm website because block model's `revoke!` method expires the block.

Here I make all factory-created revoked blocks also expired. And just in case I also set the creation date earlier than the expiration date.