### PR TITLE
Replace csp_meta_tag with `secure_headers` nonce

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -11,6 +11,6 @@
   <%= yield :head %>
   <%= yield :auto_discovery_link_tag %>
   <%= csrf_meta_tag %>
-  <%= csp_meta_tag %>
+  <meta name="csp-nonce" content="<%= content_security_policy_style_nonce %>" />
   <title><%= "#{@title} | " if @title %><%= t "layouts.project_name.title" %></title>
 <% end %>


### PR DESCRIPTION
## Why are the changes necessary?

Unblocks the PR #4562

The `csp_meta_tag` does not generate a `csp-nonce`-tag since currently the `secure_headers`-gem is responsible to manage the `Content-Security-Policy` directives.

Once `secure_headers`-logic is moved/delegated back to Rails the usage of `csp_meta_tag` is useful again. Otherwise it is a bit confusing.

Once this PR is merged the CSP violation in #4562 will be solved. See more here https://github.com/openstreetmap/openstreetmap-website/pull/4562#discussion_r1532380754