### PR TITLE
Remove old note api endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,12 +99,6 @@ OpenStreetMap::Application.routes.draw do
       end
     end
 
-    post "notes/addPOIexec" => "notes#create"
-    post "notes/closePOIexec" => "notes#close"
-    post "notes/editPOIexec" => "notes#comment"
-    get "notes/getGPX" => "notes#index", :format => "gpx"
-    get "notes/getRSSfeed" => "notes#feed", :format => "rss"
-
     resources :user_blocks, :only => [:show], :constraints => { :id => /\d+/ }, :controller => "user_blocks", :as => :api_user_blocks
   end
 

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -99,27 +99,6 @@ module Api
         { :path => "/api/0.6/notes/feed", :method => :get },
         { :controller => "api/notes", :action => "feed", :format => "rss" }
       )
-
-      assert_recognizes(
-        { :controller => "api/notes", :action => "create" },
-        { :path => "/api/0.6/notes/addPOIexec", :method => :post }
-      )
-      assert_recognizes(
-        { :controller => "api/notes", :action => "close" },
-        { :path => "/api/0.6/notes/closePOIexec", :method => :post }
-      )
-      assert_recognizes(
-        { :controller => "api/notes", :action => "comment" },
-        { :path => "/api/0.6/notes/editPOIexec", :method => :post }
-      )
-      assert_recognizes(
-        { :controller => "api/notes", :action => "index", :format => "gpx" },
-        { :path => "/api/0.6/notes/getGPX", :method => :get }
-      )
-      assert_recognizes(
-        { :controller => "api/notes", :action => "feed", :format => "rss" },
-        { :path => "/api/0.6/notes/getRSSfeed", :method => :get }
-      )
     end
 
     def test_create_success


### PR DESCRIPTION
Remove endpoints listed in #4588.

- they are undocumented
- they don't do anything that documented endpoints can't
- [nobody seems to be using them](https://github.com/openstreetmap/openstreetmap-website/issues/4588#issuecomment-2004302883)
- you can't easily move their routes inside resources because they'll overwrite path helpers of documented endpoints