### PR TITLE
Replace lookup_user_by_id with load_resource

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -8,7 +8,7 @@ module Api
     authorize_resource
 
     around_action :api_call_handle_error
-    before_action :lookup_user_by_id, :only => [:show]
+    load_resource :only => :show
 
     before_action :set_request_formats, :except => [:gpx_files]
 
@@ -56,14 +56,6 @@ module Api
 
     private
 
-    ##
-    # ensure that there is a "user" instance variable
-    def lookup_user_by_id
-      @user = User.find(params[:id])
-    end
-
-    ##
-    #
     def disable_terms_redirect
       # this is necessary otherwise going to the user terms page, when
       # having not agreed already would cause an infinite redirect loop.


### PR DESCRIPTION
`.find(params[:id])` is exactly what CanCanCan's `load_resource` does:
https://github.com/CanCanCommunity/cancancan/blob/develop/docs/controller_helpers.md#authorize_resource-load_resource-load_and_authorize_resource