### PR TITLE
Remove assert_method from api controllers

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -40,8 +40,6 @@ module Api
 
     # Create a changeset from XML.
     def create
-      assert_method :put
-
       cs = Changeset.from_xml(request.raw_post, :create => true)
 
       # Assume that Changeset.from_xml has thrown an exception if there is an error parsing the xml
@@ -58,8 +56,6 @@ module Api
     # marks a changeset as closed. this may be called multiple times
     # on the same changeset, so is idempotent.
     def close
-      assert_method :put
-
       changeset = Changeset.find(params[:id])
       check_changeset_consistency(changeset, current_user)
 
@@ -85,12 +81,6 @@ module Api
     # Returns: a diffResult document, as described in
     # http://wiki.openstreetmap.org/wiki/OSM_Protocol_Version_0.6
     def upload
-      # only allow POST requests, as the upload method is most definitely
-      # not idempotent, as several uploads with placeholder IDs will have
-      # different side-effects.
-      # see http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.1.2
-      assert_method :post
-
       changeset = Changeset.find(params[:id])
       check_changeset_consistency(changeset, current_user)
 
@@ -205,9 +195,6 @@ module Api
     #
     # after succesful update, returns the XML of the changeset.
     def update
-      # request *must* be a PUT.
-      assert_method :put
-
       @changeset = Changeset.find(params[:id])
       new_changeset = Changeset.from_xml(request.raw_post)
 

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -52,8 +52,6 @@ module Api
 
     # Create a node from XML.
     def create
-      assert_method :put
-
       node = Node.from_xml(request.raw_post, :create => true)
 
       # Assume that Node.from_xml has thrown an exception if there is an error parsing the xml

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -45,8 +45,6 @@ module Api
     end
 
     def create
-      assert_method :put
-
       relation = Relation.from_xml(request.raw_post, :create => true)
 
       # Assume that Relation.from_xml has thrown an exception if there is an error parsing the xml

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -47,8 +47,6 @@ module Api
     end
 
     def create
-      assert_method :put
-
       way = Way.from_xml(request.raw_post, :create => true)
 
       # Assume that Way.from_xml has thrown an exception if there is an error parsing the xml

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -165,14 +165,6 @@ class ApiController < ApplicationController
   end
 
   ##
-  # asserts that the request method is the +method+ given as a parameter
-  # or raises a suitable error. +method+ should be a symbol, e.g: :put or :get.
-  def assert_method(method)
-    ok = request.send(:"#{method.to_s.downcase}?")
-    raise OSM::APIBadMethodError, method unless ok
-  end
-
-  ##
   # wrap an api call in a timeout
   def api_call_timeout(&block)
     Timeout.timeout(Settings.api_timeout, &block)


### PR DESCRIPTION
- The name is confusing. It looks like a test assertion, but it's not.
- This check is unnecessary. You're only routed to actions if you use correct http verbs. If you reached the action method, you know that the verb is correct.

When `assert_method` was added in https://github.com/openstreetmap/openstreetmap-website/commit/3d0ca940d26bdc23aa791178b01b816185c5a086, [most of routes didn't check http methods](https://github.com/openstreetmap/openstreetmap-website/blob/3d0ca940d26bdc23aa791178b01b816185c5a086/config/routes.rb). That's why this check was necessary.