### PR TITLE
Use newer/older pagination on admin users page

### DIFF
--- a/app/controllers/concerns/pagination_methods.rb
+++ b/app/controllers/concerns/pagination_methods.rb
@@ -1,0 +1,27 @@
+module PaginationMethods
+  extend ActiveSupport::Concern
+
+  private
+
+  ##
+  # limit selected items to one page, get ids of first item before/after the page
+  def get_page_items(items, includes)
+    id_column = "#{items.table_name}.id"
+    page_items = if params[:before]
+                   items.where("#{id_column} < ?", params[:before]).order(:id => :desc)
+                 elsif params[:after]
+                   items.where("#{id_column} > ?", params[:after]).order(:id => :asc)
+                 else
+                   items.order(:id => :desc)
+                 end
+
+    page_items = page_items.limit(20)
+    page_items = page_items.includes(includes)
+    page_items = page_items.sort.reverse
+
+    newer_items_id = page_items.first.id if page_items.count.positive? && items.exists?(["#{id_column} > ?", page_items.first.id])
+    older_items_id = page_items.last.id if page_items.count.positive? && items.exists?(["#{id_column} < ?", page_items.last.id])
+
+    [page_items, newer_items_id, older_items_id]
+  end
+end

--- a/app/controllers/concerns/pagination_methods.rb
+++ b/app/controllers/concerns/pagination_methods.rb
@@ -5,7 +5,7 @@ module PaginationMethods
 
   ##
   # limit selected items to one page, get ids of first item before/after the page
-  def get_page_items(items, includes)
+  def get_page_items(items, includes: [], limit: 20)
     id_column = "#{items.table_name}.id"
     page_items = if params[:before]
                    items.where("#{id_column} < ?", params[:before]).order(:id => :desc)
@@ -15,7 +15,7 @@ module PaginationMethods
                    items.order(:id => :desc)
                  end
 
-    page_items = page_items.limit(20)
+    page_items = page_items.limit(limit)
     page_items = page_items.includes(includes)
     page_items = page_items.sort.reverse
 

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -58,7 +58,7 @@ class DiaryEntriesController < ApplicationController
 
     @params = params.permit(:display_name, :friends, :nearby, :language)
 
-    @entries, @newer_entries_id, @older_entries_id = get_page_items(entries, [:user, :language])
+    @entries, @newer_entries_id, @older_entries_id = get_page_items(entries, :includes => [:user, :language])
   end
 
   def show
@@ -247,7 +247,7 @@ class DiaryEntriesController < ApplicationController
 
     @params = params.permit(:display_name, :before, :after)
 
-    @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, [:user])
+    @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, :includes => [:user])
   end
 
   private

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -1,5 +1,6 @@
 class DiaryEntriesController < ApplicationController
   include UserMethods
+  include PaginationMethods
 
   layout "site", :except => :rss
 
@@ -281,25 +282,5 @@ class DiaryEntriesController < ApplicationController
       @lat = current_user.home_lat
       @zoom = 12
     end
-  end
-
-  def get_page_items(items, includes)
-    id_column = "#{items.table_name}.id"
-    page_items = if params[:before]
-                   items.where("#{id_column} < ?", params[:before]).order(:id => :desc)
-                 elsif params[:after]
-                   items.where("#{id_column} > ?", params[:after]).order(:id => :asc)
-                 else
-                   items.order(:id => :desc)
-                 end
-
-    page_items = page_items.limit(20)
-    page_items = page_items.includes(includes)
-    page_items = page_items.sort.reverse
-
-    newer_items_id = page_items.first.id if page_items.count.positive? && items.exists?(["#{id_column} > ?", page_items.first.id])
-    older_items_id = page_items.last.id if page_items.count.positive? && items.exists?(["#{id_column} < ?", page_items.last.id])
-
-    [page_items, newer_items_id, older_items_id]
   end
 end

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -61,7 +61,7 @@ class TracesController < ApplicationController
 
     @params = params.permit(:display_name, :tag, :before, :after)
 
-    @traces, @newer_traces_id, @older_traces_id = get_page_items(traces, [:user, :tags])
+    @traces, @newer_traces_id, @older_traces_id = get_page_items(traces, :includes => [:user, :tags])
 
     # final helper vars for view
     @target_user = target_user

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -1,5 +1,6 @@
 class TracesController < ApplicationController
   include UserMethods
+  include PaginationMethods
 
   layout "site", :except => :georss
 
@@ -60,20 +61,7 @@ class TracesController < ApplicationController
 
     @params = params.permit(:display_name, :tag, :before, :after)
 
-    @traces = if params[:before]
-                traces.where("gpx_files.id < ?", params[:before]).order(:id => :desc)
-              elsif params[:after]
-                traces.where("gpx_files.id > ?", params[:after]).order(:id => :asc)
-              else
-                traces.order(:id => :desc)
-              end
-
-    @traces = @traces.limit(20)
-    @traces = @traces.includes(:user, :tags)
-    @traces = @traces.sort.reverse
-
-    @newer_traces = @traces.count.positive? && traces.exists?(["gpx_files.id > ?", @traces.first.id])
-    @older_traces = @traces.count.positive? && traces.exists?(["gpx_files.id < ?", @traces.last.id])
+    @traces, @newer_traces_id, @older_traces_id = get_page_items(traces, [:user, :tags])
 
     # final helper vars for view
     @target_user = target_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,6 +36,7 @@ class UsersController < ApplicationController
       users = users.where(:status => @params[:status]) if @params[:status]
       users = users.where(:creation_ip => @params[:ip]) if @params[:ip]
 
+      @users_count = users.count
       @users, @newer_users_id, @older_users_id = get_page_items(users, :limit => 50)
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   include EmailMethods
   include SessionMethods
   include UserMethods
+  include PaginationMethods
 
   layout "site"
 
@@ -29,16 +30,13 @@ class UsersController < ApplicationController
 
       redirect_to url_for(:status => params[:status], :ip => params[:ip], :page => params[:page])
     else
-      @params = params.permit(:status, :ip)
+      @params = params.permit(:status, :ip, :before, :after)
 
-      conditions = {}
-      conditions[:status] = @params[:status] if @params[:status]
-      conditions[:creation_ip] = @params[:ip] if @params[:ip]
+      users = User.all
+      users = users.where(:status => @params[:status]) if @params[:status]
+      users = users.where(:creation_ip => @params[:ip]) if @params[:ip]
 
-      @user_pages, @users = paginate(:users,
-                                     :conditions => conditions,
-                                     :order => :id,
-                                     :per_page => 50)
+      @users, @newer_users_id, @older_users_id = get_page_items(users, :limit => 50)
     end
   end
 

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -68,8 +68,8 @@
   <%= render "shared/pagination",
              :newer_key => "traces.trace_paging_nav.newer",
              :older_key => "traces.trace_paging_nav.older",
-             :newer_id => @newer_traces && @traces.first.id,
-             :older_id => @older_traces && @traces.last.id %>
+             :newer_id => @newer_traces_id,
+             :older_id => @older_traces_id %>
 
   <table id="trace_list" class="table table-borderless table-striped">
     <tbody>
@@ -80,8 +80,8 @@
   <%= render "shared/pagination",
              :newer_key => "traces.trace_paging_nav.newer",
              :older_key => "traces.trace_paging_nav.older",
-             :newer_id => @newer_traces && @traces.first.id,
-             :older_id => @older_traces && @traces.last.id %>
+             :newer_id => @newer_traces_id,
+             :older_id => @older_traces_id %>
 <% else %>
   <h2><%= t ".empty_title" %></h2>
   <p><%= t ".empty_upload_html", :upload_link => link_to(t(".upload_new"), new_trace_path),

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,11 +10,18 @@
 
 <% unless @users.empty? %>
   <%= form_tag do %>
-    <%= render "shared/pagination",
-               :newer_key => "users.index.newer",
-               :older_key => "users.index.older",
-               :newer_id => @newer_users_id,
-               :older_id => @older_users_id %>
+    <div class="row">
+      <div class="col">
+        <%= render "shared/pagination",
+                   :newer_key => "users.index.newer",
+                   :older_key => "users.index.older",
+                   :newer_id => @newer_users_id,
+                   :older_id => @older_users_id %>
+      </div>
+      <div class="col col-auto">
+        <%= t ".found_users", :count => @users_count %>
+      </div>
+    <div>
 
     <%= hidden_field_tag :status, params[:status] if params[:status] %>
     <%= hidden_field_tag :ip, params[:ip] if params[:ip] %>
@@ -32,11 +39,18 @@
       <%= render @users %>
     </table>
 
-    <%= render "shared/pagination",
-               :newer_key => "users.index.newer",
-               :older_key => "users.index.older",
-               :newer_id => @newer_users_id,
-               :older_id => @older_users_id %>
+    <div class="row">
+      <div class="col">
+        <%= render "shared/pagination",
+                   :newer_key => "users.index.newer",
+                   :older_key => "users.index.older",
+                   :newer_id => @newer_users_id,
+                   :older_id => @older_users_id %>
+      </div>
+      <div class="col col-auto">
+        <%= t ".found_users", :count => @users_count %>
+      </div>
+    <div>
 
     <div>
       <%= submit_tag t(".confirm"), :name => "confirm", :class => "btn btn-primary" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,6 +10,12 @@
 
 <% unless @users.empty? %>
   <%= form_tag do %>
+    <%= render "shared/pagination",
+               :newer_key => "users.index.newer",
+               :older_key => "users.index.older",
+               :newer_id => @newer_users_id,
+               :older_id => @older_users_id %>
+
     <%= hidden_field_tag :status, params[:status] if params[:status] %>
     <%= hidden_field_tag :ip, params[:ip] if params[:ip] %>
     <%= hidden_field_tag :page, params[:page] if params[:page] %>
@@ -17,15 +23,6 @@
       <thead>
         <tr>
           <td colspan="2">
-            <%= t ".showing",
-                  :page => @user_pages.current_page.number,
-                  :first_item => @user_pages.current_page.first_item,
-                  :last_item => @user_pages.current_page.last_item,
-                  :items => @user_pages.item_count,
-                  :count => @user_pages.current_page.last_item - @user_pages.current_page.first_item + 1 %>
-            <% if @user_pages.page_count > 1 %>
-            | <%= raw pagination_links_each(@user_pages, {}) { |n| link_to n, @params.merge(:page => n) } %>
-            <% end %>
           </td>
           <td>
             <%= check_box_tag "user_all", "1", false %>
@@ -34,6 +31,12 @@
       </thead>
       <%= render @users %>
     </table>
+
+    <%= render "shared/pagination",
+               :newer_key => "users.index.newer",
+               :older_key => "users.index.older",
+               :newer_id => @newer_users_id,
+               :older_id => @older_users_id %>
 
     <div>
       <%= submit_tag t(".confirm"), :name => "confirm", :class => "btn btn-primary" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2832,9 +2832,8 @@ en:
     index:
       title: Users
       heading: Users
-      showing:
-        one: Page %{page} (%{first_item} of %{items})
-        other: Page %{page} (%{first_item}-%{last_item} of %{items})
+      older: "Older Users"
+      newer: "Newer Users"
       summary_html: "%{name} created from %{ip_address} on %{date}"
       summary_no_ip_html: "%{name} created on %{date}"
       confirm: Confirm Selected Users

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2834,6 +2834,9 @@ en:
       heading: Users
       older: "Older Users"
       newer: "Newer Users"
+      found_users:
+        one: "%{count} user found"
+        other: "%{count} users found"
       summary_html: "%{name} created from %{ip_address} on %{date}"
       summary_no_ip_html: "%{name} created on %{date}"
       confirm: Confirm Selected Users

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -644,22 +644,43 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     # 100 examples, an administrator, and a granter for the admin.
     assert_equal 102, User.count
+    next_path = users_path
 
-    get users_path
+    get next_path
     assert_response :success
     assert_template :index
     assert_select "table#user_list tbody tr", :count => 50
+    check_no_page_link "Newer Users"
+    next_path = check_page_link "Older Users"
 
-    get users_path, :params => { :page => 2 }
+    get next_path
     assert_response :success
     assert_template :index
     assert_select "table#user_list tbody tr", :count => 50
+    check_page_link "Newer Users"
+    next_path = check_page_link "Older Users"
 
-    get users_path, :params => { :page => 3 }
+    get next_path
     assert_response :success
     assert_template :index
     assert_select "table#user_list tbody tr", :count => 2
+    check_page_link "Newer Users"
+    check_no_page_link "Older Users"
   end
+
+  private
+
+  def check_no_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/, :count => 0 }, "unexpected #{name} page link"
+  end
+
+  def check_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/ }, "missing #{name} page link" do |buttons|
+      return buttons.first.attributes["href"].value
+    end
+  end
+
+  public
 
   def test_index_post_confirm
     inactive_user = create(:user, :pending)


### PR DESCRIPTION
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/73d57a3d-a113-4abf-b543-5a29d18e1389)

This gets rid of classic pagination on this page. There's going to be only two pages with classic pagination after that: user blocks and changeset elements.

Differences to the previous version:

- Users are listed in the opposite order.
- Of course now there's no page numbers and it's impossible to switch to the nth page, but I don't know if this was ever used.
- Normally with before/after pagination there's no total count. Classic pagination had it, which might be useful when combined with some filter like ip address. I added the count here because there won't be any large traffic to this page.