### PR TITLE
Remove require "xml/libxml" from controllers

### DIFF
--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -2,8 +2,6 @@
 
 module Api
   class ChangesetsController < ApiController
-    require "xml/libxml"
-
     before_action :check_api_writable, :only => [:create, :update, :upload, :subscribe, :unsubscribe]
     before_action :check_api_readable, :except => [:create, :update, :upload, :download, :query, :subscribe, :unsubscribe]
     before_action :setup_user_auth, :only => [:show]

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -2,8 +2,6 @@
 
 module Api
   class NodesController < ApiController
-    require "xml/libxml"
-
     before_action :check_api_writable, :only => [:create, :update, :delete]
     before_action :check_api_readable, :except => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]

--- a/app/controllers/api/old_controller.rb
+++ b/app/controllers/api/old_controller.rb
@@ -3,8 +3,6 @@
 # nodes, ways and relations are basically identical.
 module Api
   class OldController < ApiController
-    require "xml/libxml"
-
     before_action :check_api_readable
     before_action :check_api_writable, :only => [:redact]
     before_action :setup_user_auth, :only => [:history, :show]

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class RelationsController < ApiController
-    require "xml/libxml"
-
     before_action :check_api_writable, :only => [:create, :update, :delete]
     before_action :check_api_readable, :except => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class WaysController < ApiController
-    require "xml/libxml"
-
     before_action :check_api_writable, :only => [:create, :update, :delete]
     before_action :check_api_readable, :except => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -4,7 +4,6 @@ class ChangesetsController < ApplicationController
   include UserMethods
 
   layout "site"
-  require "xml/libxml"
 
   before_action :authorize_web
   before_action :set_locale


### PR DESCRIPTION
They don't even use it, and it's included in `lib/osm.rb` anyway.