### PR TITLE
Remove unused includes of ConsistencyValidations

### DIFF
--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -16,9 +16,6 @@ class ChangesetsController < ApplicationController
 
   around_action :web_timeout
 
-  # Helper methods for checking consistency
-  include ConsistencyValidations
-
   ##
   # list non-empty changesets in reverse chronological order
   def index

--- a/app/models/old_node.rb
+++ b/app/models/old_node.rb
@@ -26,7 +26,6 @@
 
 class OldNode < ApplicationRecord
   include GeoRecord
-  include ConsistencyValidations
 
   self.table_name = "nodes"
 

--- a/app/models/old_relation.rb
+++ b/app/models/old_relation.rb
@@ -21,8 +21,6 @@
 #
 
 class OldRelation < ApplicationRecord
-  include ConsistencyValidations
-
   self.table_name = "relations"
 
   # NOTE: this needs to be included after the table name changes, or

--- a/app/models/old_way.rb
+++ b/app/models/old_way.rb
@@ -21,8 +21,6 @@
 #
 
 class OldWay < ApplicationRecord
-  include ConsistencyValidations
-
   self.table_name = "ways"
 
   # NOTE: this needs to be included after the table name changes, or

--- a/lib/diff_reader.rb
+++ b/lib/diff_reader.rb
@@ -4,8 +4,6 @@
 # Uses the streaming LibXML "Reader" interface to cut down on memory
 # usage, so hopefully we can process fairly large diffs.
 class DiffReader
-  include ConsistencyValidations
-
   # maps each element type to the model class which handles it
   MODELS = {
     "node" => Node,


### PR DESCRIPTION
Why is ConsistencyValidations a model concern? It raises API exceptions.