### PR TITLE
Trace image cleanups

### DIFF
--- a/app/controllers/traces/icons_controller.rb
+++ b/app/controllers/traces/icons_controller.rb
@@ -6,21 +6,17 @@ module Traces
     authorize_resource :trace
 
     def show
-      trace = Trace.visible.find(params[:trace_id])
+      trace = Trace.visible.imported.find(params[:trace_id])
 
-      if trace.inserted?
-        if trace.public? || (current_user && current_user == trace.user)
-          if trace.icon.attached?
-            redirect_to rails_blob_path(trace.icon, :disposition => "inline")
-          else
-            expires_in 7.days, :private => !trace.public?, :public => trace.public?
-            send_file(trace.icon_picture_name, :filename => "#{trace.id}_icon.gif", :type => "image/gif", :disposition => "inline")
-          end
+      if trace.public? || (current_user && current_user == trace.user)
+        if trace.icon.attached?
+          redirect_to rails_blob_path(trace.icon, :disposition => "inline")
         else
-          head :forbidden
+          expires_in 7.days, :private => !trace.public?, :public => trace.public?
+          send_file(trace.icon_picture_name, :filename => "#{trace.id}_icon.gif", :type => "image/gif", :disposition => "inline")
         end
       else
-        head :not_found
+        head :forbidden
       end
     rescue ActiveRecord::RecordNotFound
       head :not_found

--- a/app/controllers/traces/icons_controller.rb
+++ b/app/controllers/traces/icons_controller.rb
@@ -9,12 +9,7 @@ module Traces
       trace = Trace.visible.imported.find(params[:trace_id])
 
       if trace.public? || (current_user && current_user == trace.user)
-        if trace.icon.attached?
-          redirect_to rails_blob_path(trace.icon, :disposition => "inline")
-        else
-          expires_in 7.days, :private => !trace.public?, :public => trace.public?
-          send_file(trace.icon_picture_name, :filename => "#{trace.id}_icon.gif", :type => "image/gif", :disposition => "inline")
-        end
+        redirect_to rails_blob_path(trace.icon, :disposition => "inline")
       else
         head :forbidden
       end

--- a/app/controllers/traces/pictures_controller.rb
+++ b/app/controllers/traces/pictures_controller.rb
@@ -6,21 +6,17 @@ module Traces
     authorize_resource :trace
 
     def show
-      trace = Trace.visible.find(params[:trace_id])
+      trace = Trace.visible.imported.find(params[:trace_id])
 
-      if trace.inserted?
-        if trace.public? || (current_user && current_user == trace.user)
-          if trace.icon.attached?
-            redirect_to rails_blob_path(trace.image, :disposition => "inline")
-          else
-            expires_in 7.days, :private => !trace.public?, :public => trace.public?
-            send_file(trace.large_picture_name, :filename => "#{trace.id}.gif", :type => "image/gif", :disposition => "inline")
-          end
+      if trace.public? || (current_user && current_user == trace.user)
+        if trace.icon.attached?
+          redirect_to rails_blob_path(trace.image, :disposition => "inline")
         else
-          head :forbidden
+          expires_in 7.days, :private => !trace.public?, :public => trace.public?
+          send_file(trace.large_picture_name, :filename => "#{trace.id}.gif", :type => "image/gif", :disposition => "inline")
         end
       else
-        head :not_found
+        head :forbidden
       end
     rescue ActiveRecord::RecordNotFound
       head :not_found

--- a/app/controllers/traces/pictures_controller.rb
+++ b/app/controllers/traces/pictures_controller.rb
@@ -9,12 +9,7 @@ module Traces
       trace = Trace.visible.imported.find(params[:trace_id])
 
       if trace.public? || (current_user && current_user == trace.user)
-        if trace.icon.attached?
-          redirect_to rails_blob_path(trace.image, :disposition => "inline")
-        else
-          expires_in 7.days, :private => !trace.public?, :public => trace.public?
-          send_file(trace.large_picture_name, :filename => "#{trace.id}.gif", :type => "image/gif", :disposition => "inline")
-        end
+        redirect_to rails_blob_path(trace.image, :disposition => "inline")
       else
         head :forbidden
       end

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -38,6 +38,7 @@ class Trace < ApplicationRecord
   scope :visible_to, ->(u) { visible.where(:visibility => %w[public identifiable]).or(visible.where(:user => u)) }
   scope :visible_to_all, -> { where(:visibility => %w[public identifiable]) }
   scope :tagged, ->(t) { joins(:tags).where(:gpx_file_tags => { :tag => t }) }
+  scope :imported, -> { where(:inserted => true) }
 
   has_one_attached :file, :service => Settings.trace_file_storage
   has_one_attached :image, :service => Settings.trace_image_storage


### PR DESCRIPTION
This further simplifies the trace image controllers by adding an `imported` scope to the trace model which eliminates a duplicate "not found" branch.

It also drops some redundant code for handling legacy traces that should have been removed in #3491.