### PR TITLE
Add a template for failed new diary comment validation

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -153,7 +153,7 @@ class DiaryEntriesController < ApplicationController
 
       redirect_to diary_entry_path(@entry.user, @entry)
     else
-      render :action => "show"
+      render :action => "newcomment"
     end
   rescue ActiveRecord::RecordNotFound
     render :action => "no_such_entry", :status => :not_found

--- a/app/views/diary_entries/newcomment.html.erb
+++ b/app/views/diary_entries/newcomment.html.erb
@@ -1,0 +1,12 @@
+<% content_for :heading do %>
+  <h1><%= t ".heading" %></h1>
+<% end %>
+
+<%= render :partial => "diary_entry_heading", :object => @entry, :as => "diary_entry" %>
+
+<h3 id="newcomment"><%= t "diary_entries.show.leave_a_comment" %></h3>
+
+<%= bootstrap_form_for @diary_comment, :url => { :action => "comment" } do |f| %>
+  <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
+  <%= f.primary %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -598,6 +598,8 @@ en:
     unsubscribe:
       heading: Unsubscribe from the following diary entry discussion?
       button: Unsubscribe from discussion
+    newcomment:
+      heading: Add a comment to the following diary entry discussion?
   diary_comments:
     index:
       title: "Diary Comments added by %{user}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,7 +237,8 @@ OpenStreetMap::Application.routes.draw do
   scope "/user/:display_name" do
     resources :diary_entries, :path => "diary", :only => [:edit, :update, :show], :id => /\d+/
   end
-  post "/user/:display_name/diary/:id/newcomment" => "diary_entries#comment", :id => /\d+/, :as => :comment_diary_entry
+  get "/user/:display_name/diary/:id/comments", :id => /\d+/, :to => redirect(:path => "/user/%{display_name}/diary/%{id}", :anchor => "comments")
+  post "/user/:display_name/diary/:id/comments" => "diary_entries#comment", :id => /\d+/, :as => :comment_diary_entry
   post "/user/:display_name/diary/:id/hide" => "diary_entries#hide", :id => /\d+/, :as => :hide_diary_entry
   post "/user/:display_name/diary/:id/unhide" => "diary_entries#unhide", :id => /\d+/, :as => :unhide_diary_entry
   post "/user/:display_name/diary/:id/hidecomment/:comment" => "diary_comments#hide", :id => /\d+/, :comment => /\d+/, :as => :hide_diary_comment

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -70,7 +70,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
       { :controller => "diary_entries", :action => "update", :display_name => "username", :id => "1" }
     )
     assert_routing(
-      { :path => "/user/username/diary/1/newcomment", :method => :post },
+      { :path => "/user/username/diary/1/comments", :method => :post },
       { :controller => "diary_entries", :action => "comment", :display_name => "username", :id => "1" }
     )
     assert_routing(
@@ -370,7 +370,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
       end
     end
     assert_response :success
-    assert_template :show
+    assert_template :newcomment
 
     # Now try again with the right id
     assert_difference "ActionMailer::Base.deliveries.size", entry.subscribers.count do


### PR DESCRIPTION
Here's a problem* that I came across when trying to create a controller for diary comments.

You write a comment for a diary entry, submit it and it fails the validation. Currently it's difficult to fail the validation, because empty comments are prevented client-side and it's difficult to type special characters that are disallowed. But let's suppose the validation failed. We have a branch for it:

https://github.com/openstreetmap/openstreetmap-website/blob/50df5eefcc5c45a47e1fcac50fe3ad6af6245819/app/controllers/diary_entries_controller.rb#L154

It just renders the diary entry page again. You'll be looking at the top of the page, not where the comment form is. And the entered comment is reset:

https://github.com/openstreetmap/openstreetmap-website/blob/50df5eefcc5c45a47e1fcac50fe3ad6af6245819/app/views/diary_entries/show.html.erb#L37

Here I'm showing a different page instead. It is similar to subscribe/unsubscribe pages and has a comment form that keeps the previously entered comment.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/abbacc48-efc7-48eb-b451-a70b0e59b62d)

---

\* The actual problem was that with a diary comments controller I'd have to render the show action of another controller.