### PR TITLE
Remove unused user parameter for subscribe/unsubscribe headings

### DIFF
--- a/app/views/diary_entries/subscribe.html.erb
+++ b/app/views/diary_entries/subscribe.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t ".heading", :user => @diary_entry.user.display_name %></h1>
+  <h1><%= t ".heading" %></h1>
 <% end %>
 
 <%= render :partial => "diary_entry_heading", :object => @diary_entry, :as => "diary_entry" %>

--- a/app/views/diary_entries/unsubscribe.html.erb
+++ b/app/views/diary_entries/unsubscribe.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t ".heading", :user => @diary_entry.user.display_name %></h1>
+  <h1><%= t ".heading" %></h1>
 <% end %>
 
 <%= render :partial => "diary_entry_heading", :object => @diary_entry, :as => "diary_entry" %>


### PR DESCRIPTION
I was experimenting with subscribe/unsubscribe to diary entry page headings. I decided not to put username there but forgot to remove it from translation arguments.