### PR TITLE
Redirect from old diary comments pagination

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,8 +236,8 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/diary/rss" => "diary_entries#rss", :defaults => { :format => :rss }
   get "/diary/:language/rss" => "diary_entries#rss", :defaults => { :format => :rss }
   get "/diary/rss" => "diary_entries#rss", :defaults => { :format => :rss }
-  get "/user/:display_name/diary/comments/:page" => "diary_entries#comments", :page => /[1-9][0-9]*/
-  get "/user/:display_name/diary/comments/" => "diary_entries#comments", :as => :diary_comments
+  get "/user/:display_name/diary/comments/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/user/%{display_name}/diary/comments")
+  get "/user/:display_name/diary/comments" => "diary_entries#comments", :as => :diary_comments
   get "/user/:display_name/diary" => "diary_entries#index"
   get "/diary/:language" => "diary_entries#index"
   scope "/user/:display_name" do

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -53,10 +53,6 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
       { :path => "/user/username/diary/comments", :method => :get },
       { :controller => "diary_entries", :action => "comments", :display_name => "username" }
     )
-    assert_routing(
-      { :path => "/user/username/diary/comments/1", :method => :get },
-      { :controller => "diary_entries", :action => "comments", :display_name => "username", :page => "1" }
-    )
 
     assert_routing(
       { :path => "/diary/new", :method => :get },
@@ -114,6 +110,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
       { :path => "/user/username/diary/1/unsubscribe", :method => :post },
       { :controller => "diary_entries", :action => "unsubscribe", :display_name => "username", :id => "1" }
     )
+
+    get "/user/username/diary/comments/1"
+    assert_redirected_to "/user/username/diary/comments"
   end
 
   def test_new_no_login


### PR DESCRIPTION
Like was done in https://github.com/openstreetmap/openstreetmap-website/commit/c909b29c35b32be6f918f4393692033b40c303ea for trace pagination.

`/user/username/diary/comments/123` -> `/user/username/diary/comments` because page numbers no longer exist
