### PR TITLE
Use before/after pagination on user blocks page

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -1,5 +1,6 @@
 class UserBlocksController < ApplicationController
   include UserMethods
+  include PaginationMethods
 
   layout "site"
 
@@ -16,10 +17,10 @@ class UserBlocksController < ApplicationController
 
   def index
     @params = params.permit
-    @user_blocks_pages, @user_blocks = paginate(:user_blocks,
-                                                :include => [:user, :creator, :revoker],
-                                                :order => "user_blocks.ends_at DESC",
-                                                :per_page => 20)
+
+    user_blocks = UserBlock.all
+
+    @user_blocks, @newer_user_blocks_id, @older_user_blocks_id = get_page_items(user_blocks, :includes => [:user, :creator, :revoker])
   end
 
   def show
@@ -103,22 +104,20 @@ class UserBlocksController < ApplicationController
   # shows a list of all the blocks on the given user
   def blocks_on
     @params = params.permit(:display_name)
-    @user_blocks_pages, @user_blocks = paginate(:user_blocks,
-                                                :include => [:user, :creator, :revoker],
-                                                :conditions => { :user_id => @user.id },
-                                                :order => "user_blocks.ends_at DESC",
-                                                :per_page => 20)
+
+    user_blocks = UserBlock.where(:user => @user)
+
+    @user_blocks, @newer_user_blocks_id, @older_user_blocks_id = get_page_items(user_blocks, :includes => [:user, :creator, :revoker])
   end
 
   ##
   # shows a list of all the blocks by the given user.
   def blocks_by
     @params = params.permit(:display_name)
-    @user_blocks_pages, @user_blocks = paginate(:user_blocks,
-                                                :include => [:user, :creator, :revoker],
-                                                :conditions => { :creator_id => @user.id },
-                                                :order => "user_blocks.ends_at DESC",
-                                                :per_page => 20)
+
+    user_blocks = UserBlock.where(:creator => @user)
+
+    @user_blocks, @newer_user_blocks_id, @older_user_blocks_id = get_page_items(user_blocks, :includes => [:user, :creator, :revoker])
   end
 
   private

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -20,20 +20,8 @@
   <%= render :partial => "block", :locals => { :show_revoke_link => show_revoke_link, :show_user_name => show_user_name, :show_creator_name => show_creator_name }, :collection => @user_blocks %>
 </table>
 
-<nav class='secondary-actions'>
-  <ul>
-    <% if @user_blocks_pages.current_page.number > 1 -%>
-      <li><%= link_to t(".previous"), @params.merge(:page => @user_blocks_pages.current_page.number - 1) %></li>
-    <% else -%>
-      <li><%= t(".previous") %></li>
-    <% end -%>
-
-    <li><%= t(".showing_page", :page => @user_blocks_pages.current_page.number) %></li>
-
-    <% if @user_blocks_pages.current_page.number < @user_blocks_pages.page_count -%>
-      <li><%= link_to t(".next"), @params.merge(:page => @user_blocks_pages.current_page.number + 1) %></li>
-    <% else -%>
-      <li><%= t(".next") %></li>
-    <% end -%>
-  </ul>
-</nav>
+<%= render "shared/pagination",
+           :newer_key => "user_blocks.blocks.newer",
+           :older_key => "user_blocks.blocks.older",
+           :newer_id => @newer_user_blocks_id,
+           :older_id => @older_user_blocks_id %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2984,9 +2984,8 @@ en:
       reason: "Reason for block"
       status: "Status"
       revoker_name: "Revoked by"
-      showing_page: "Page %{page}"
-      next: "Next »"
-      previous: "« Previous"
+      older: "Older Blocks"
+      newer: "Newer Blocks"
   user_mutes:
     index:
       title: "Muted Users"


### PR DESCRIPTION
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/32187d05-bb59-45b0-8e6f-00540837bfd7)

This changes the order of blocks in the table, but:

- The current order (by end date desc) is not very useful, because the beginning of the list is dominated by long-term blocks. You'll have to page through a lot of "Ends in almost 10 years" blocks for throwaway vandalism accounts before you reach "real" blocks for people to pay attention to, those are not 10 years right away.
- There are plans to let the table be reordered, see #4200.