### PR TITLE
Simplify api element paths in tests

### DIFF
--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -2436,7 +2436,7 @@ module Api
         assert_response :success, "can't create a new node"
         node_id = @response.body.to_i
 
-        get api_node_path(:id => node_id)
+        get api_node_path(node_id)
         assert_response :success, "can't read back new node"
         node_doc = XML::Parser.string(@response.body).parse
         node_xml = node_doc.find("//osm/node").first
@@ -2447,7 +2447,7 @@ module Api
           node_xml["lon"] = rand.to_s
           node_xml["version"] = (i + 1).to_s
 
-          put api_node_path(:id => node_id), :params => node_doc.to_s, :headers => auth_header
+          put api_node_path(node_id), :params => node_doc.to_s, :headers => auth_header
           assert_response :success, "attempt #{i} should have succeeded"
         end
 
@@ -2456,7 +2456,7 @@ module Api
         node_xml["lon"] = rand.to_s
         node_xml["version"] = offset.to_s
 
-        put api_node_path(:id => node_id), :params => node_doc.to_s, :headers => auth_header
+        put api_node_path(node_id), :params => node_doc.to_s, :headers => auth_header
         assert_response :conflict, "final attempt should have failed"
       end
 

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -456,11 +456,11 @@ module Api
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get nodes_path, :params => { :nodes => "" }
+      get nodes_path(:nodes => "")
       assert_response :bad_request
 
       # test a working call
-      get nodes_path, :params => { :nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}" }
+      get nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}")
       assert_response :success
       assert_select "osm" do
         assert_select "node", :count => 5
@@ -472,7 +472,7 @@ module Api
       end
 
       # test a working call with json format
-      get nodes_path, :params => { :nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}", :format => "json" }
+      get nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}", :format => "json")
 
       js = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil js
@@ -485,7 +485,7 @@ module Api
       assert_equal 1, (js["elements"].count { |a| a["id"] == node5.id && a["visible"] == false })
 
       # check error when a non-existent node is included
-      get nodes_path, :params => { :nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id},0" }
+      get nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id},0")
       assert_response :not_found
     end
 

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -151,7 +151,7 @@ module Api
       assert_response :gone
 
       # check chat a non-existent node is not returned
-      get api_node_path(:id => 0)
+      get api_node_path(0)
       assert_response :not_found
     end
 
@@ -201,7 +201,7 @@ module Api
       assert_require_public_data
 
       # this won't work since the node never existed
-      delete api_node_path(:id => 0), :headers => auth_header
+      delete api_node_path(0), :headers => auth_header
       assert_require_public_data
 
       ## these test whether nodes which are in-use can be deleted:
@@ -241,7 +241,7 @@ module Api
       # try to delete a node with a different ID
       other_node = create(:node)
       xml = xml_for_node(other_node)
-      delete api_node_path(node.id), :params => xml.to_s, :headers => auth_header
+      delete api_node_path(node), :params => xml.to_s, :headers => auth_header
       assert_response :bad_request,
                       "should not be able to delete a node with a different ID from the XML"
 
@@ -266,7 +266,7 @@ module Api
       assert_response :gone
 
       # this won't work since the node never existed
-      delete api_node_path(:id => 0), :headers => auth_header
+      delete api_node_path(0), :headers => auth_header
       assert_response :not_found
 
       ## these test whether nodes which are in-use can be deleted:
@@ -360,7 +360,7 @@ module Api
       # try and update a node without authorisation
       # first try to update node without auth
       xml = xml_for_node(node)
-      put api_node_path(node.id), :params => xml.to_s, :headers => auth_header
+      put api_node_path(node), :params => xml.to_s, :headers => auth_header
       assert_response :forbidden
 
       # setup auth
@@ -548,7 +548,7 @@ module Api
       assert_not_nil checknode, "node not found in data base after upload"
 
       # and grab it using the api
-      get api_node_path(:id => nodeid)
+      get api_node_path(nodeid)
       assert_response :success
       apinode = Node.from_xml(@response.body)
       assert_not_nil apinode, "downloaded node is nil, but shouldn't be"

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -68,7 +68,7 @@ module Api
         xml_node["lat"] = precision((rand * 180) - 90).to_s
         xml_node["lon"] = precision((rand * 360) - 180).to_s
         with_controller(NodesController.new) do
-          put api_node_path(:id => nodeid), :params => xml_doc.to_s, :headers => auth_header
+          put api_node_path(nodeid), :params => xml_doc.to_s, :headers => auth_header
           assert_response :forbidden, "Should have rejected node update"
           xml_node["version"] = @response.body.to_s
         end
@@ -83,7 +83,7 @@ module Api
         xml_tag["v"] = random_string
         xml_node << xml_tag
         with_controller(NodesController.new) do
-          put api_node_path(:id => nodeid), :params => xml_doc.to_s, :headers => auth_header
+          put api_node_path(nodeid), :params => xml_doc.to_s, :headers => auth_header
           assert_response :forbidden,
                           "should have rejected node #{nodeid} (#{@response.body}) with forbidden"
           xml_node["version"] = @response.body.to_s
@@ -116,7 +116,7 @@ module Api
         xml_node["lat"] = precision((rand * 180) - 90).to_s
         xml_node["lon"] = precision((rand * 360) - 180).to_s
         with_controller(NodesController.new) do
-          put api_node_path(:id => nodeid), :params => xml_doc.to_s, :headers => auth_header
+          put api_node_path(nodeid), :params => xml_doc.to_s, :headers => auth_header
           assert_response :success
           xml_node["version"] = @response.body.to_s
         end
@@ -131,7 +131,7 @@ module Api
         xml_tag["v"] = random_string
         xml_node << xml_tag
         with_controller(NodesController.new) do
-          put api_node_path(:id => nodeid), :params => xml_doc.to_s, :headers => auth_header
+          put api_node_path(nodeid), :params => xml_doc.to_s, :headers => auth_header
           assert_response :success,
                           "couldn't update node #{nodeid} (#{@response.body})"
           xml_node["version"] = @response.body.to_s
@@ -456,7 +456,7 @@ module Api
     def check_current_version(node_id)
       # get the current version of the node
       current_node = with_controller(NodesController.new) do
-        get api_node_path(:id => node_id)
+        get api_node_path(node_id)
         assert_response :success, "cant get current node #{node_id}"
         Node.from_xml(@response.body)
       end

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -373,7 +373,7 @@ module Api
       node_v1 = node.old_nodes.find_by(:version => 1)
       node_v1.redact!(create(:redaction))
 
-      post node_version_redact_path(:id => node_v1.node_id, :version => node_v1.version)
+      post node_version_redact_path(node_v1.node_id, node_v1.version)
       assert_response :unauthorized, "should need to be authenticated to unredact."
     end
 
@@ -388,7 +388,7 @@ module Api
 
       auth_header = basic_authorization_header user.email, "test"
 
-      post node_version_redact_path(:id => node_v1.node_id, :version => node_v1.version), :headers => auth_header
+      post node_version_redact_path(node_v1.node_id, node_v1.version), :headers => auth_header
       assert_response :forbidden, "should need to be moderator to unredact."
     end
 
@@ -403,7 +403,7 @@ module Api
 
       auth_header = basic_authorization_header moderator_user.email, "test"
 
-      post node_version_redact_path(:id => node_v1.node_id, :version => node_v1.version), :headers => auth_header
+      post node_version_redact_path(node_v1.node_id, node_v1.version), :headers => auth_header
       assert_response :success, "should be OK to unredact old version as moderator."
 
       # check moderator can now see the redacted data, when not
@@ -450,7 +450,7 @@ module Api
       assert_response :success, "should be able to get version #{node.version} of node #{node.node_id}."
 
       # now redact it
-      post node_version_redact_path(:id => node.node_id, :version => node.version), :params => { :redaction => redaction.id }, :headers => headers
+      post node_version_redact_path(node.node_id, node.version), :params => { :redaction => redaction.id }, :headers => headers
     end
 
     def check_current_version(node_id)

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -36,7 +36,7 @@ module Api
       assert_response :success
 
       # check chat a non-existent relations is not returned
-      get api_relation_history_path(:id => 0)
+      get api_relation_history_path(0)
       assert_response :not_found
     end
 
@@ -138,7 +138,7 @@ module Api
       relation_v1 = relation.old_relations.find_by(:version => 1)
       relation_v1.redact!(create(:redaction))
 
-      get api_relation_history_path(:id => relation_v1.relation_id)
+      get api_relation_history_path(relation)
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 0,
                     "redacted relation #{relation_v1.relation_id} version #{relation_v1.version} shouldn't be present in the history."
@@ -146,7 +146,7 @@ module Api
       # not even to a logged-in user
       auth_header = basic_authorization_header create(:user).email, "test"
       get api_old_relation_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
-      get api_relation_history_path(:id => relation_v1.relation_id), :headers => auth_header
+      get api_relation_history_path(relation), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 0,
                     "redacted relation #{relation_v1.relation_id} version #{relation_v1.version} shouldn't be present in the history, even when logged in."
@@ -172,11 +172,11 @@ module Api
       assert_response :success, "After redaction, relation should not be gone for moderator, when flag passed."
 
       # and when accessed via history
-      get api_relation_history_path(:id => relation_v3.relation_id), :headers => auth_header
+      get api_relation_history_path(relation), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v3.relation_id}'][version='#{relation_v3.version}']", 0,
                     "relation #{relation_v3.relation_id} version #{relation_v3.version} should not be present in the history for moderators when not passing flag."
-      get api_relation_history_path(:id => relation_v3.relation_id), :params => { :show_redactions => "true" }, :headers => auth_header
+      get api_relation_history_path(relation, :show_redactions => "true"), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v3.relation_id}'][version='#{relation_v3.version}']", 1,
                     "relation #{relation_v3.relation_id} version #{relation_v3.version} should still be present in the history for moderators when passing flag."
@@ -201,7 +201,7 @@ module Api
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
 
       # and when accessed via history
-      get api_relation_history_path(:id => relation_v3.relation_id), :headers => auth_header
+      get api_relation_history_path(relation), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v3.relation_id}'][version='#{relation_v3.version}']", 0,
                     "redacted relation #{relation_v3.relation_id} version #{relation_v3.version} shouldn't be present in the history."
@@ -252,7 +252,7 @@ module Api
       assert_response :success, "After unredaction, relation should not be gone for moderator."
 
       # and when accessed via history
-      get api_relation_history_path(:id => relation_v1.relation_id), :headers => auth_header
+      get api_relation_history_path(relation), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 1,
                     "relation #{relation_v1.relation_id} version #{relation_v1.version} should still be present in the history for moderators."
@@ -264,7 +264,7 @@ module Api
       assert_response :success, "After redaction, node should not be gone for normal user."
 
       # and when accessed via history
-      get api_relation_history_path(:id => relation_v1.relation_id), :headers => auth_header
+      get api_relation_history_path(relation), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 1,
                     "relation #{relation_v1.relation_id} version #{relation_v1.version} should still be present in the history for normal users."

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -215,7 +215,7 @@ module Api
       relation_v1 = relation.old_relations.find_by(:version => 1)
       relation_v1.redact!(create(:redaction))
 
-      post relation_version_redact_path(:id => relation_v1.relation_id, :version => relation_v1.version)
+      post relation_version_redact_path(relation_v1.relation_id, relation_v1.version)
       assert_response :unauthorized, "should need to be authenticated to unredact."
     end
 
@@ -229,7 +229,7 @@ module Api
 
       auth_header = basic_authorization_header create(:user).email, "test"
 
-      post relation_version_redact_path(:id => relation_v1.relation_id, :version => relation_v1.version), :headers => auth_header
+      post relation_version_redact_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       assert_response :forbidden, "should need to be moderator to unredact."
     end
 
@@ -243,7 +243,7 @@ module Api
 
       auth_header = basic_authorization_header create(:moderator_user).email, "test"
 
-      post relation_version_redact_path(:id => relation_v1.relation_id, :version => relation_v1.version), :headers => auth_header
+      post relation_version_redact_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       assert_response :success, "should be OK to unredact old version as moderator."
 
       # check moderator can still see the redacted data, without passing
@@ -333,7 +333,7 @@ module Api
       assert_response :success, "should be able to get version #{relation.version} of relation #{relation.relation_id}."
 
       # now redact it
-      post relation_version_redact_path(:id => relation.relation_id, :version => relation.version), :params => { :redaction => redaction.id }, :headers => headers
+      post relation_version_redact_path(relation.relation_id, relation.version), :params => { :redaction => redaction.id }, :headers => headers
     end
   end
 end

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -122,12 +122,12 @@ module Api
       relation_v1 = relation.old_relations.find_by(:version => 1)
       relation_v1.redact!(create(:redaction))
 
-      get api_old_relation_path(:id => relation_v1.relation_id, :version => relation_v1.version)
+      get api_old_relation_path(relation_v1.relation_id, relation_v1.version)
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
 
       # not even to a logged-in user
       auth_header = basic_authorization_header create(:user).email, "test"
-      get api_old_relation_path(:id => relation_v1.relation_id, :version => relation_v1.version), :headers => auth_header
+      get api_old_relation_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API, even when logged in."
     end
 
@@ -145,7 +145,7 @@ module Api
 
       # not even to a logged-in user
       auth_header = basic_authorization_header create(:user).email, "test"
-      get api_old_relation_path(:id => relation_v1.relation_id, :version => relation_v1.version), :headers => auth_header
+      get api_old_relation_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       get api_relation_history_path(:id => relation_v1.relation_id), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 0,
@@ -166,9 +166,9 @@ module Api
 
       # check moderator can still see the redacted data, when passing
       # the appropriate flag
-      get api_old_relation_path(:id => relation_v3.relation_id, :version => relation_v3.version), :headers => auth_header
+      get api_old_relation_path(relation_v3.relation_id, relation_v3.version), :headers => auth_header
       assert_response :forbidden, "After redaction, relation should be gone for moderator, when flag not passed."
-      get api_old_relation_path(:id => relation_v3.relation_id, :version => relation_v3.version), :params => { :show_redactions => "true" }, :headers => auth_header
+      get api_old_relation_path(relation_v3.relation_id, relation_v3.version, :show_redactions => "true"), :headers => auth_header
       assert_response :success, "After redaction, relation should not be gone for moderator, when flag passed."
 
       # and when accessed via history
@@ -197,7 +197,7 @@ module Api
       auth_header = basic_authorization_header create(:user).email, "test"
 
       # check can't see the redacted data
-      get api_old_relation_path(:id => relation_v3.relation_id, :version => relation_v3.version), :headers => auth_header
+      get api_old_relation_path(relation_v3.relation_id, relation_v3.version), :headers => auth_header
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
 
       # and when accessed via history
@@ -248,7 +248,7 @@ module Api
 
       # check moderator can still see the redacted data, without passing
       # the appropriate flag
-      get api_old_relation_path(:id => relation_v1.relation_id, :version => relation_v1.version), :headers => auth_header
+      get api_old_relation_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       assert_response :success, "After unredaction, relation should not be gone for moderator."
 
       # and when accessed via history
@@ -260,7 +260,7 @@ module Api
       auth_header = basic_authorization_header create(:user).email, "test"
 
       # check normal user can now see the redacted data
-      get api_old_relation_path(:id => relation_v1.relation_id, :version => relation_v1.version), :headers => auth_header
+      get api_old_relation_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       assert_response :success, "After redaction, node should not be gone for normal user."
 
       # and when accessed via history
@@ -329,7 +329,7 @@ module Api
     end
 
     def do_redact_relation(relation, redaction, headers = {})
-      get api_old_relation_path(:id => relation.relation_id, :version => relation.version)
+      get api_old_relation_path(relation.relation_id, relation.version)
       assert_response :success, "should be able to get version #{relation.version} of relation #{relation.relation_id}."
 
       # now redact it

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -253,7 +253,7 @@ module Api
       way_v1 = way.old_ways.find_by(:version => 1)
       way_v1.redact!(create(:redaction))
 
-      post way_version_redact_path(:id => way_v1.way_id, :version => way_v1.version)
+      post way_version_redact_path(way_v1.way_id, way_v1.version)
       assert_response :unauthorized, "should need to be authenticated to unredact."
     end
 
@@ -267,7 +267,7 @@ module Api
 
       auth_header = basic_authorization_header create(:user).email, "test"
 
-      post way_version_redact_path(:id => way_v1.way_id, :version => way_v1.version), :headers => auth_header
+      post way_version_redact_path(way_v1.way_id, way_v1.version), :headers => auth_header
       assert_response :forbidden, "should need to be moderator to unredact."
     end
 
@@ -282,7 +282,7 @@ module Api
 
       auth_header = basic_authorization_header moderator_user.email, "test"
 
-      post way_version_redact_path(:id => way_v1.way_id, :version => way_v1.version), :headers => auth_header
+      post way_version_redact_path(way_v1.way_id, way_v1.version), :headers => auth_header
       assert_response :success, "should be OK to unredact old version as moderator."
 
       # check moderator can still see the unredacted data, without passing
@@ -372,7 +372,7 @@ module Api
       assert_response :success, "should be able to get version #{way.version} of way #{way.way_id}."
 
       # now redact it
-      post way_version_redact_path(:id => way.way_id, :version => way.version), :params => { :redaction => redaction.id }, :headers => headers
+      post way_version_redact_path(way.way_id, way.version), :params => { :redaction => redaction.id }, :headers => headers
     end
 
     def propagate_tags(way, old_way)

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -45,7 +45,7 @@ module Api
 
     def test_history_invalid
       # check chat a non-existent way is not returned
-      get api_way_history_path(:id => 0)
+      get api_way_history_path(0)
       assert_response :not_found
     end
 
@@ -179,14 +179,14 @@ module Api
       way_v1 = way.old_ways.find_by(:version => 1)
       way_v1.redact!(create(:redaction))
 
-      get api_way_history_path(:id => way_v1.way_id)
+      get api_way_history_path(way)
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 0,
                     "redacted way #{way_v1.way_id} version #{way_v1.version} shouldn't be present in the history."
 
       # not even to a logged-in user
       auth_header = basic_authorization_header create(:user).email, "test"
-      get api_way_history_path(:id => way_v1.way_id), :headers => auth_header
+      get api_way_history_path(way), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 0,
                     "redacted node #{way_v1.way_id} version #{way_v1.version} shouldn't be present in the history, even when logged in."
@@ -211,11 +211,11 @@ module Api
       assert_response :success, "After redaction, node should not be gone for moderator, when flag passed."
 
       # and when accessed via history
-      get api_way_history_path(:id => way_v3.way_id), :headers => auth_header
+      get api_way_history_path(way), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v3.way_id}'][version='#{way_v3.version}']", 0,
                     "way #{way_v3.way_id} version #{way_v3.version} should not be present in the history for moderators when not passing flag."
-      get api_way_history_path(:id => way_v3.way_id), :params => { :show_redactions => "true" }, :headers => auth_header
+      get api_way_history_path(way, :show_redactions => "true"), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v3.way_id}'][version='#{way_v3.version}']", 1,
                     "way #{way_v3.way_id} version #{way_v3.version} should still be present in the history for moderators when passing flag."
@@ -239,7 +239,7 @@ module Api
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
 
       # and when accessed via history
-      get api_way_history_path(:id => way_v3.way_id), :headers => auth_header
+      get api_way_history_path(way), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v3.way_id}'][version='#{way_v3.version}']", 0,
                     "redacted way #{way_v3.way_id} version #{way_v3.version} shouldn't be present in the history."
@@ -291,7 +291,7 @@ module Api
       assert_response :success, "After unredaction, node should not be gone for moderator."
 
       # and when accessed via history
-      get api_way_history_path(:id => way_v1.way_id), :headers => auth_header
+      get api_way_history_path(way), :headers => auth_header
       assert_response :success, "Unredaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 1,
                     "way #{way_v1.way_id} version #{way_v1.version} should still be present in the history for moderators."
@@ -303,7 +303,7 @@ module Api
       assert_response :success, "After redaction, node should not be gone for moderator, when flag passed."
 
       # and when accessed via history
-      get api_way_history_path(:id => way_v1.way_id), :headers => auth_header
+      get api_way_history_path(way), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_select "osm way[id='#{way_v1.way_id}'][version='#{way_v1.version}']", 1,
                     "way #{way_v1.way_id} version #{way_v1.version} should still be present in the history for normal users."
@@ -336,7 +336,7 @@ module Api
     # look at all the versions of the way in the history and get each version from
     # the versions call. check that they're the same.
     def check_history_equals_versions(way_id)
-      get api_way_history_path(:id => way_id)
+      get api_way_history_path(way_id)
       assert_response :success, "can't get way #{way_id} from API"
       history_doc = XML::Parser.string(@response.body).parse
       assert_not_nil history_doc, "parsing way #{way_id} history failed"

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -163,12 +163,12 @@ module Api
       way_v1 = way.old_ways.find_by(:version => 1)
       way_v1.redact!(create(:redaction))
 
-      get api_old_way_path(:id => way_v1.way_id, :version => way_v1.version)
+      get api_old_way_path(way_v1.way_id, way_v1.version)
       assert_response :forbidden, "Redacted way shouldn't be visible via the version API."
 
       # not even to a logged-in user
       auth_header = basic_authorization_header create(:user).email, "test"
-      get api_old_way_path(:id => way_v1.way_id, :version => way_v1.version), :headers => auth_header
+      get api_old_way_path(way_v1.way_id, way_v1.version), :headers => auth_header
       assert_response :forbidden, "Redacted way shouldn't be visible via the version API, even when logged in."
     end
 
@@ -205,9 +205,9 @@ module Api
 
       # check moderator can still see the redacted data, when passing
       # the appropriate flag
-      get api_old_way_path(:id => way_v3.way_id, :version => way_v3.version), :headers => auth_header
+      get api_old_way_path(way_v3.way_id, way_v3.version), :headers => auth_header
       assert_response :forbidden, "After redaction, node should be gone for moderator, when flag not passed."
-      get api_old_way_path(:id => way_v3.way_id, :version => way_v3.version), :params => { :show_redactions => "true" }, :headers => auth_header
+      get api_old_way_path(way_v3.way_id, way_v3.version, :show_redactions => "true"), :headers => auth_header
       assert_response :success, "After redaction, node should not be gone for moderator, when flag passed."
 
       # and when accessed via history
@@ -235,7 +235,7 @@ module Api
       auth_header = basic_authorization_header create(:user).email, "test"
 
       # check can't see the redacted data
-      get api_old_way_path(:id => way_v3.way_id, :version => way_v3.version), :headers => auth_header
+      get api_old_way_path(way_v3.way_id, way_v3.version), :headers => auth_header
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
 
       # and when accessed via history
@@ -287,7 +287,7 @@ module Api
 
       # check moderator can still see the unredacted data, without passing
       # the appropriate flag
-      get api_old_way_path(:id => way_v1.way_id, :version => way_v1.version), :headers => auth_header
+      get api_old_way_path(way_v1.way_id, way_v1.version), :headers => auth_header
       assert_response :success, "After unredaction, node should not be gone for moderator."
 
       # and when accessed via history
@@ -299,7 +299,7 @@ module Api
       auth_header = basic_authorization_header create(:user).email, "test"
 
       # check normal user can now see the unredacted data
-      get api_old_way_path(:id => way_v1.way_id, :version => way_v1.version), :headers => auth_header
+      get api_old_way_path(way_v1.way_id, way_v1.version), :headers => auth_header
       assert_response :success, "After redaction, node should not be gone for moderator, when flag passed."
 
       # and when accessed via history
@@ -324,7 +324,7 @@ module Api
       assert_not_nil current_way, "getting way #{way_id} returned nil"
 
       # get the "old" version of the way from the version method
-      get api_old_way_path(:id => way_id, :version => current_way.version)
+      get api_old_way_path(way_id, current_way.version)
       assert_response :success, "can't get old way #{way_id}, v#{current_way.version}"
       old_way = Way.from_xml(@response.body)
 
@@ -345,7 +345,7 @@ module Api
         history_way = Way.from_xml_node(way_doc)
         assert_not_nil history_way, "parsing way #{way_id} version failed"
 
-        get api_old_way_path(:id => way_id, :version => history_way.version)
+        get api_old_way_path(way_id, history_way.version)
         assert_response :success, "couldn't get way #{way_id}, v#{history_way.version}"
         version_way = Way.from_xml(@response.body)
         assert_not_nil version_way, "failed to parse #{way_id}, v#{history_way.version}"
@@ -368,7 +368,7 @@ module Api
     end
 
     def do_redact_way(way, redaction, headers = {})
-      get api_old_way_path(:id => way.way_id, :version => way.version)
+      get api_old_way_path(way.way_id, way.version)
       assert_response :success, "should be able to get version #{way.version} of way #{way.way_id}."
 
       # now redact it

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -82,7 +82,7 @@ module Api
       assert_response :gone
 
       # check chat a non-existent relation is not returned
-      get api_relation_path(:id => 0)
+      get api_relation_path(0)
       assert_response :not_found
     end
 
@@ -286,7 +286,7 @@ module Api
       assert checkrelation.visible,
              "saved relation is not visible"
       # ok the relation is there but can we also retrieve it?
-      get api_relation_path(:id => relationid)
+      get api_relation_path(relationid)
       assert_response :success
 
       ###
@@ -315,7 +315,7 @@ module Api
              "saved relation is not visible"
       # ok the relation is there but can we also retrieve it?
 
-      get api_relation_path(:id => relationid)
+      get api_relation_path(relationid)
       assert_response :success
 
       ###
@@ -343,7 +343,7 @@ module Api
              "saved relation is not visible"
       # ok the relation is there but can we also retrieve it?
 
-      get api_relation_path(:id => relationid)
+      get api_relation_path(relationid)
       assert_response :success
 
       ###
@@ -371,7 +371,7 @@ module Api
       assert checkrelation.visible,
              "saved relation is not visible"
       # ok the relation is there but can we also retrieve it?
-      get api_relation_path(:id => relationid)
+      get api_relation_path(relationid)
       assert_response :success
     end
 
@@ -453,7 +453,7 @@ module Api
       auth_header = basic_authorization_header user.email, "test"
       with_relation(relation.id) do |rel|
         update_changeset(rel, changeset.id)
-        put api_relation_path(:id => other_relation.id), :params => rel.to_s, :headers => auth_header
+        put api_relation_path(other_relation), :params => rel.to_s, :headers => auth_header
         assert_response :bad_request
       end
     end
@@ -560,7 +560,7 @@ module Api
       assert_response :forbidden
 
       # this won't work since the relation never existed
-      delete api_relation_path(:id => 0), :headers => auth_header
+      delete api_relation_path(0), :headers => auth_header
       assert_response :forbidden
 
       ## now set auth for the public user
@@ -632,7 +632,7 @@ module Api
                       "should be able to delete a relation used in an old relation (#{@response.body})"
 
       # this won't work since the relation never existed
-      delete api_relation_path(:id => 0), :headers => auth_header
+      delete api_relation_path(0), :headers => auth_header
       assert_response :not_found
     end
 
@@ -695,7 +695,7 @@ module Api
           update_changeset(relation_xml, changeset_id)
 
           # upload the change
-          put api_relation_path(:id => relation.id), :params => relation_xml.to_s, :headers => auth_header
+          put api_relation_path(relation), :params => relation_xml.to_s, :headers => auth_header
           assert_response :success, "can't update relation for add #{element.class}/bbox test: #{@response.body}"
 
           # get it back and check the ordering
@@ -762,7 +762,7 @@ module Api
       relation_id = @response.body.to_i
 
       # get it back and check the ordering
-      get api_relation_path(:id => relation_id)
+      get api_relation_path(relation_id)
       assert_response :success, "can't read back the relation: #{@response.body}"
       check_ordering(doc, @response.body)
 
@@ -777,12 +777,12 @@ module Api
       doc.find("//osm/relation").first["version"] = 1.to_s
 
       # upload the next version of the relation
-      put api_relation_path(:id => relation_id), :params => doc.to_s, :headers => auth_header
+      put api_relation_path(relation_id), :params => doc.to_s, :headers => auth_header
       assert_response :success, "can't update relation: #{@response.body}"
       assert_equal 2, @response.body.to_i
 
       # get it back again and check the ordering again
-      get api_relation_path(:id => relation_id)
+      get api_relation_path(relation_id)
       assert_response :success, "can't read back the relation: #{@response.body}"
       check_ordering(doc, @response.body)
 
@@ -829,7 +829,7 @@ module Api
       relation_id = @response.body.to_i
 
       # get it back and check the ordering
-      get api_relation_path(:id => relation_id)
+      get api_relation_path(relation_id)
       assert_response :success, "can't read back the relation: #{relation_id}"
       check_ordering(doc, @response.body)
     end
@@ -862,7 +862,7 @@ module Api
       relation_id = @response.body.to_i
 
       # check the ordering in the current tables:
-      get api_relation_path(:id => relation_id)
+      get api_relation_path(relation_id)
       assert_response :success, "can't read back the relation: #{@response.body}"
       check_ordering(doc, @response.body)
 
@@ -1106,7 +1106,7 @@ module Api
     # doc is returned.
     def with_relation(id, ver = nil)
       if ver.nil?
-        get api_relation_path(:id => id)
+        get api_relation_path(id)
       else
         with_controller(OldRelationsController.new) do
           get api_old_relation_path(:id => id, :version => ver)
@@ -1122,12 +1122,12 @@ module Api
     # the parsed XML doc is returned.
     def with_update(rel, headers)
       rel_id = rel.find("//osm/relation").first["id"].to_i
-      put api_relation_path(:id => rel_id), :params => rel.to_s, :headers => headers
+      put api_relation_path(rel_id), :params => rel.to_s, :headers => headers
       assert_response :success, "can't update relation: #{@response.body}"
       version = @response.body.to_i
 
       # now get the new version
-      get api_relation_path(:id => rel_id)
+      get api_relation_path(rel_id)
       assert_response :success
       new_rel = xml_parse(@response.body)
 
@@ -1159,7 +1159,7 @@ module Api
       end
 
       # now get the new version
-      get api_relation_path(:id => rel_id)
+      get api_relation_path(rel_id)
       assert_response :success
       new_rel = xml_parse(@response.body)
 

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -178,11 +178,11 @@ module Api
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get relations_path, :params => { :relations => "" }
+      get relations_path(:relations => "")
       assert_response :bad_request
 
       # test a working call
-      get relations_path, :params => { :relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}" }
+      get relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}")
       assert_response :success
       assert_select "osm" do
         assert_select "relation", :count => 4
@@ -193,7 +193,7 @@ module Api
       end
 
       # test a working call with json format
-      get relations_path, :params => { :relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}", :format => "json" }
+      get relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}", :format => "json")
 
       js = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil js
@@ -205,7 +205,7 @@ module Api
       assert_equal 1, (js["elements"].count { |a| a["id"] == relation4.id && a["visible"].nil? })
 
       # check error when a non-existent relation is included
-      get relations_path, :params => { :relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id},0" }
+      get relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id},0")
       assert_response :not_found
     end
 

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -788,7 +788,7 @@ module Api
 
       # check the ordering in the history tables:
       with_controller(OldRelationsController.new) do
-        get api_old_relation_path(:id => relation_id, :version => 2)
+        get api_old_relation_path(relation_id, 2)
         assert_response :success, "can't read back version 2 of the relation #{relation_id}"
         check_ordering(doc, @response.body)
       end
@@ -868,7 +868,7 @@ module Api
 
       # check the ordering in the history tables:
       with_controller(OldRelationsController.new) do
-        get api_old_relation_path(:id => relation_id, :version => 1)
+        get api_old_relation_path(relation_id, 1)
         assert_response :success, "can't read back version 1 of the relation: #{@response.body}"
         check_ordering(doc, @response.body)
       end
@@ -1109,7 +1109,7 @@ module Api
         get api_relation_path(id)
       else
         with_controller(OldRelationsController.new) do
-          get api_old_relation_path(:id => id, :version => ver)
+          get api_old_relation_path(id, ver)
         end
       end
       assert_response :success

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -57,7 +57,7 @@ module Api
       assert_response :gone
 
       # check chat a non-existent way is not returned
-      get api_way_path(:id => 0)
+      get api_way_path(0)
       assert_response :not_found
     end
 
@@ -345,7 +345,7 @@ module Api
                       "shouldn't be able to delete a way used in a relation (#{@response.body}), when done by a private user"
 
       # this won't work since the way never existed
-      delete api_way_path(:id => 0), :headers => auth_header
+      delete api_way_path(0), :headers => auth_header
       assert_response :forbidden
 
       ### Now check with a public user
@@ -394,7 +394,7 @@ module Api
       assert_equal "Precondition failed: Way #{used_way.id} is still used by relations #{relation.id}.", @response.body
 
       # this won't work since the way never existed
-      delete api_way_path(:id => 0), :params => xml.to_s, :headers => auth_header
+      delete api_way_path(0), :params => xml.to_s, :headers => auth_header
       assert_response :not_found
     end
 

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -102,11 +102,11 @@ module Api
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get ways_path, :params => { :ways => "" }
+      get ways_path(:ways => "")
       assert_response :bad_request
 
       # test a working call
-      get ways_path, :params => { :ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}" }
+      get ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}")
       assert_response :success
       assert_select "osm" do
         assert_select "way", :count => 4
@@ -117,7 +117,7 @@ module Api
       end
 
       # test a working call with json format
-      get ways_path, :params => { :ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}", :format => "json" }
+      get ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}", :format => "json")
 
       js = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil js
@@ -129,7 +129,7 @@ module Api
       assert_equal 1, (js["elements"].count { |a| a["id"] == way4.id && a["visible"].nil? })
 
       # check error when a non-existent way is included
-      get ways_path, :params => { :ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id},0" }
+      get ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id},0")
       assert_response :not_found
     end
 


### PR DESCRIPTION
Like #4591 etc.

One goal was to get rid of explicit `id` parameters because if I make old elements subresources of current elements, rails would want `node_id`/`way_id`/`relation_id` instead of `id`. Old element models already have these fields.