### PR TITLE
Rename api OldController to OldElementsController

### DIFF
--- a/app/controllers/api/old_elements_controller.rb
+++ b/app/controllers/api/old_elements_controller.rb
@@ -2,7 +2,7 @@
 # into one place. as it turns out, the API methods for historical
 # nodes, ways and relations are basically identical.
 module Api
-  class OldController < ApiController
+  class OldElementsController < ApiController
     before_action :check_api_readable
     before_action :check_api_writable, :only => [:redact]
     before_action :setup_user_auth, :only => [:history, :show]

--- a/app/controllers/api/old_nodes_controller.rb
+++ b/app/controllers/api/old_nodes_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class OldNodesController < OldController
+  class OldNodesController < OldElementsController
     private
 
     def lookup_old_element

--- a/app/controllers/api/old_relations_controller.rb
+++ b/app/controllers/api/old_relations_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class OldRelationsController < OldController
+  class OldRelationsController < OldElementsController
     private
 
     def lookup_old_element

--- a/app/controllers/api/old_ways_controller.rb
+++ b/app/controllers/api/old_ways_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class OldWaysController < OldController
+  class OldWaysController < OldElementsController
     private
 
     def lookup_old_element


### PR DESCRIPTION
#3715 adds `ElementsController`. When I originally did it, I didn't notice that a similar superclass already exists for old elements because it's not named after elements.

The name "OldController" is not specific enough because there are other "old" things besides old elements like old tags or old relation members.