### PR TITLE
Move edit/revoke block buttons to the bottom of the block page

### DIFF
--- a/app/views/user_blocks/revoke.html.erb
+++ b/app/views/user_blocks/revoke.html.erb
@@ -21,7 +21,7 @@
       </div>
     </div>
 
-    <%= f.primary t(".revoke") %>
+    <%= f.submit t(".revoke"), :class => "btn btn-danger" %>
   <% end %>
 
 <% else %>

--- a/app/views/user_blocks/revoke_all.html.erb
+++ b/app/views/user_blocks/revoke_all.html.erb
@@ -16,7 +16,7 @@
       </div>
     </div>
 
-    <%= f.primary t(".revoke") %>
+    <%= f.submit t(".revoke"), :class => "btn btn-danger" %>
   <% end %>
 
 <% else %>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -8,14 +8,6 @@
             :block_by => link_to(@user_block.creator.display_name, @user_block.creator)) %></h1>
   <nav class='secondary-actions'>
     <ul class='clearfix'>
-      <% if @user_block.ends_at > Time.now.getutc %>
-        <% if current_user and current_user.id == @user_block.creator_id %>
-          <li><%= link_to t(".edit"), edit_user_block_path(@user_block) %></li>
-        <% end %>
-        <% if can?(:revoke, UserBlock) %>
-          <li><%= link_to t(".revoke"), revoke_user_block_path(@user_block) %></li>
-        <% end %>
-      <% end %>
       <li><%= link_to t(".back"), user_blocks_path %></li>
     </ul>
   </nav>
@@ -36,3 +28,15 @@
   <dt class="col-sm-3"><%= t ".reason" %></dt>
   <dd class="col-sm-9"><div class="richtext text-break"><%= @user_block.reason.to_html %></div></dd>
 </dl>
+
+<% if @user_block.ends_at > Time.now.getutc && (current_user&.id == @user_block.creator_id ||
+                                                can?(:revoke, UserBlock)) %>
+  <div>
+    <% if current_user&.id == @user_block.creator_id %>
+      <%= link_to t(".edit"), edit_user_block_path(@user_block), :class => "btn btn-outline-primary" %>
+    <% end %>
+    <% if can?(:revoke, UserBlock) %>
+      <%= link_to t(".revoke"), revoke_user_block_path(@user_block), :class => "btn btn-outline-danger" %>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
Currently it's difficult to go between all blocks, blocks on, blocks by pages. For example, it's not obvious where's the link to the *all blocks* page. I want to make some kind of navigation for it. Something like tabs similar to how they are used on gpx traces pages will probably do:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/e37fb173-8bb2-406a-b239-81cdd2604710)

But first I need to make room for tabs. Block pages have *Edit* and *Revoke* links in the heading where the tabs are supposed to be:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/cd532402-c50d-42ef-a7c7-5207f012c547)

But why these links are there? If they are supposed to work on a currently shown block, they should be below the block, again similar to how *Edit*/*Delete* buttons are located on traces pages.

This PR moves the links and styles them similarly to traces buttons:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/5e5711d0-8617-43c6-8ded-22eb93ceb3d9)

Later I'll turn *View all blocks* into a tab and add other tabs.