### PR TITLE
Add navigation tabs to block list/show pages

### DIFF
--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -26,4 +26,12 @@
                   :class => ["nav-link", { :active => action_name == "blocks_by" && current_user == @user }] %>
     </li>
   <% end %>
+  <% by_user = @user || @user_block&.creator %>
+  <% if by_user != current_user && by_user&.blocks_created&.exists? %>
+    <li class="nav-item">
+      <%= link_to t(".blocks_by_user", :user => by_user.display_name),
+                  user_blocks_by_path(by_user),
+                  :class => ["nav-link", { :active => action_name == "blocks_by" }] %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -4,4 +4,11 @@
                 user_blocks_path,
                 :class => ["nav-link", { :active => action_name == "index" }] %>
   </li>
+  <% if current_user&.blocks&.exists? %>
+    <li class="nav-item">
+      <%= link_to t(".blocks_on_me"),
+                  user_blocks_on_path(current_user),
+                  :class => ["nav-link", { :active => action_name == "blocks_on" && current_user == @user }] %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -1,0 +1,7 @@
+<ul class="nav nav-tabs">
+  <li class="nav-item">
+    <%= link_to t(".all_blocks"),
+                user_blocks_path,
+                :class => ["nav-link", { :active => action_name == "index" }] %>
+  </li>
+</ul>

--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -11,6 +11,14 @@
                   :class => ["nav-link", { :active => action_name == "blocks_on" && current_user == @user }] %>
     </li>
   <% end %>
+  <% on_user = @user || @user_block&.user %>
+  <% if on_user != current_user && on_user&.blocks&.exists? %>
+    <li class="nav-item">
+      <%= link_to t(".blocks_on_user", :user => on_user.display_name),
+                  user_blocks_on_path(on_user),
+                  :class => ["nav-link", { :active => action_name == "blocks_on" }] %>
+    </li>
+  <% end %>
   <% if current_user&.blocks_created&.exists? %>
     <li class="nav-item">
       <%= link_to t(".blocks_by_me"),

--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -11,4 +11,11 @@
                   :class => ["nav-link", { :active => action_name == "blocks_on" && current_user == @user }] %>
     </li>
   <% end %>
+  <% if current_user&.blocks_created&.exists? %>
+    <li class="nav-item">
+      <%= link_to t(".blocks_by_me"),
+                  user_blocks_by_path(current_user),
+                  :class => ["nav-link", { :active => action_name == "blocks_by" && current_user == @user }] %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/user_blocks/blocks_by.html.erb
+++ b/app/views/user_blocks/blocks_by.html.erb
@@ -1,6 +1,9 @@
 <% @title = t(".title", :name => @user.display_name) %>
+
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html", :name => link_to(@user.display_name, @user)) %></h1>
+  <%= render :partial => "navigation" %>
 <% end %>
 
 <% unless @user_blocks.empty? %>

--- a/app/views/user_blocks/blocks_on.html.erb
+++ b/app/views/user_blocks/blocks_on.html.erb
@@ -1,6 +1,9 @@
 <% @title = t(".title", :name => @user.display_name) %>
+
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html", :name => link_to(@user.display_name, @user)) %></h1>
+  <%= render :partial => "navigation" %>
 <% end %>
 
 <% unless @user_blocks.empty? %>

--- a/app/views/user_blocks/index.html.erb
+++ b/app/views/user_blocks/index.html.erb
@@ -1,6 +1,9 @@
 <% @title = t(".title") %>
+
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= t(".heading") %></h1>
+  <%= render :partial => "navigation" %>
 <% end %>
 
 <% unless @user_blocks.empty? %>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -2,15 +2,12 @@
               :block_on => @user_block.user.display_name,
               :block_by => @user_block.creator.display_name) %>
 
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html",
             :block_on => link_to(@user_block.user.display_name, @user_block.user),
             :block_by => link_to(@user_block.creator.display_name, @user_block.creator)) %></h1>
-  <nav class='secondary-actions'>
-    <ul class='clearfix'>
-      <li><%= link_to t(".back"), user_blocks_path %></li>
-    </ul>
-  </nav>
+  <%= render :partial => "navigation" %>
 <% end %>
 
 <dl class="row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2988,6 +2988,7 @@ en:
     navigation:
       all_blocks: "All Blocks"
       blocks_on_me: "Blocks on Me"
+      blocks_on_user: "Blocks on %{user}"
       blocks_by_me: "Blocks by Me"
   user_mutes:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2990,6 +2990,7 @@ en:
       blocks_on_me: "Blocks on Me"
       blocks_on_user: "Blocks on %{user}"
       blocks_by_me: "Blocks by Me"
+      blocks_by_user: "Blocks by %{user}"
   user_mutes:
     index:
       title: "Muted Users"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2988,6 +2988,7 @@ en:
     navigation:
       all_blocks: "All Blocks"
       blocks_on_me: "Blocks on Me"
+      blocks_by_me: "Blocks by Me"
   user_mutes:
     index:
       title: "Muted Users"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2987,6 +2987,7 @@ en:
       newer: "Newer Blocks"
     navigation:
       all_blocks: "All Blocks"
+      blocks_on_me: "Blocks on Me"
   user_mutes:
     index:
       title: "Muted Users"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2970,7 +2970,6 @@ en:
       revoke: "Revoke!"
       confirm: "Are you sure?"
       reason: "Reason for block:"
-      back: "View all blocks"
       revoker: "Revoker:"
       needs_view: "The user needs to log in before this block will be cleared."
     block:
@@ -2986,6 +2985,8 @@ en:
       revoker_name: "Revoked by"
       older: "Older Blocks"
       newer: "Newer Blocks"
+    navigation:
+      all_blocks: "All Blocks"
   user_mutes:
     index:
       title: "Muted Users"


### PR DESCRIPTION
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/2f8b1a53-4001-4bc6-9892-b86ada177eb1)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/91f1f73f-77d5-4761-87ad-ed2006ba2cdb)

There's a potential problem though. Checks if a user has created any blocks are going to be made more often with this navigation, but there's no `creator_id` index on the blocks table. The options are:
- Do nothing because blocks pages are not the most visited and the blocks table is not the most populated.
- Remove `.blocks_created.exists?` checks. That would show more unnecessary and unexpected tabs: blocks by regular users but they can't make any blocks.
- Check if a user can create blocks instead of checking if they have created any. That would remove tabs for blocks by former moderators.
- Add a `creator_id` index on the blocks table.
- Add a `(creator_id, id)` index on the blocks table that will also help with sorting.