### PR TITLE
Use turbo for pagination

### DIFF
--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -7,28 +7,30 @@
   <h4><%= t ".no_comments" %></h4>
 
 <% else %>
-  <table class="table table-striped" width="100%">
-    <thead>
+  <turbo-frame id="pagination" target="_top">
+    <table class="table table-striped" width="100%">
+      <thead>
+        <tr>
+          <th width="25%"><%= t ".post" %></th>
+          <th width="25%"><%= t ".when" %></th>
+          <th width="50%"><%= t ".comment" %></th>
+        </tr>
+      </thead>
+      <% @comments.each do |comment| -%>
       <tr>
-        <th width="25%"><%= t ".post" %></th>
-        <th width="25%"><%= t ".when" %></th>
-        <th width="50%"><%= t ".comment" %></th>
+        <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
+        <td width="25%" class="<%= "text-muted" unless comment.visible? %>">
+          <%= friendly_date_ago(comment.created_at) %>
+        </td>
+        <td width="50%" class="richtext text-break<%= " text-muted" unless comment.visible? %>"><%= comment.body.to_html %></td>
       </tr>
-    </thead>
-    <% @comments.each do |comment| -%>
-    <tr>
-      <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
-      <td width="25%" class="<%= "text-muted" unless comment.visible? %>">
-        <%= friendly_date_ago(comment.created_at) %>
-      </td>
-      <td width="50%" class="richtext text-break<%= " text-muted" unless comment.visible? %>"><%= comment.body.to_html %></td>
-    </tr>
-    <% end -%>
-  </table>
+      <% end -%>
+    </table>
 
-  <%= render "shared/pagination",
-             :newer_key => "diary_entries.comments.newer_comments",
-             :older_key => "diary_entries.comments.older_comments",
-             :newer_id => @newer_comments_id,
-             :older_id => @older_comments_id %>
+    <%= render "shared/pagination",
+               :newer_key => "diary_entries.comments.newer_comments",
+               :older_key => "diary_entries.comments.older_comments",
+               :newer_id => @newer_comments_id,
+               :older_id => @older_comments_id %>
+  <turbo-frame>
 <% end -%>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -33,22 +33,24 @@
   </div>
 <% end %>
 
-<% if @entries.empty? %>
-  <h4><%= t ".no_entries" %></h4>
-<% else %>
-  <h4><%= t ".recent_entries" %></h4>
+<turbo-frame id="pagination" target="_top">
+  <% if @entries.empty? %>
+    <h4><%= t ".no_entries" %></h4>
+  <% else %>
+    <h4><%= t ".recent_entries" %></h4>
 
-  <%= render @entries %>
+    <%= render @entries %>
 
-  <%= render "shared/pagination",
-             :newer_key => "diary_entries.index.newer_entries",
-             :older_key => "diary_entries.index.older_entries",
-             :newer_id => @newer_entries_id,
-             :older_id => @older_entries_id %>
-<% end %>
+    <%= render "shared/pagination",
+               :newer_key => "diary_entries.index.newer_entries",
+               :older_key => "diary_entries.index.older_entries",
+               :newer_id => @newer_entries_id,
+               :older_id => @older_entries_id %>
+  <% end %>
 
-<% unless params[:friends] or params[:nearby] -%>
-  <% content_for :auto_discovery_link_tag do -%>
-  <%= auto_discovery_link_tag :rss, :action => "rss", :language => params[:language] %>
+  <% unless params[:friends] or params[:nearby] -%>
+    <% content_for :auto_discovery_link_tag do -%>
+    <%= auto_discovery_link_tag :rss, :action => "rss", :language => params[:language] %>
+    <% end -%>
   <% end -%>
-<% end -%>
+</turbo-frame>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -7,7 +7,7 @@
     <% end %>
     <% if newer_id -%>
       <li class="page-item d-flex">
-        <%= link_to newer_link_content, @params.merge(:before => nil, :after => newer_id), :class => link_class %>
+        <%= link_to newer_link_content, @params.merge(:before => nil, :after => newer_id), :class => link_class, :data => { :turbo => { :frame => "pagination", :action => "advance" } } %>
       </li>
     <% else -%>
       <li class="page-item d-flex disabled">
@@ -21,7 +21,7 @@
     <% end %>
     <% if older_id -%>
       <li class="page-item d-flex">
-        <%= link_to older_link_content, @params.merge(:before => older_id, :after => nil), :class => link_class %>
+        <%= link_to older_link_content, @params.merge(:before => older_id, :after => nil), :class => link_class, :data => { :turbo => { :frame => "pagination", :action => "advance" } } %>
       </li>
     <% else -%>
       <li class="page-item d-flex disabled">

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -65,23 +65,25 @@
 <% end %>
 
 <% if @traces.size > 0 %>
-  <%= render "shared/pagination",
-             :newer_key => "traces.trace_paging_nav.newer",
-             :older_key => "traces.trace_paging_nav.older",
-             :newer_id => @newer_traces_id,
-             :older_id => @older_traces_id %>
+  <turbo-frame id="pagination" target="_top">
+    <%= render "shared/pagination",
+               :newer_key => "traces.trace_paging_nav.newer",
+               :older_key => "traces.trace_paging_nav.older",
+               :newer_id => @newer_traces_id,
+               :older_id => @older_traces_id %>
 
-  <table id="trace_list" class="table table-borderless table-striped">
-    <tbody>
-      <%= render @traces %>
-    </tbody>
-  </table>
+    <table id="trace_list" class="table table-borderless table-striped">
+      <tbody>
+        <%= render @traces %>
+      </tbody>
+    </table>
 
-  <%= render "shared/pagination",
-             :newer_key => "traces.trace_paging_nav.newer",
-             :older_key => "traces.trace_paging_nav.older",
-             :newer_id => @newer_traces_id,
-             :older_id => @older_traces_id %>
+    <%= render "shared/pagination",
+               :newer_key => "traces.trace_paging_nav.newer",
+               :older_key => "traces.trace_paging_nav.older",
+               :newer_id => @newer_traces_id,
+               :older_id => @older_traces_id %>
+  </turbo-frame id="pagination">
 <% else %>
   <h2><%= t ".empty_title" %></h2>
   <p><%= t ".empty_upload_html", :upload_link => link_to(t(".upload_new"), new_trace_path),

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -1,27 +1,29 @@
-<table id="block_list" class="table table-borderless table-striped table-sm">
-  <thead>
-    <tr>
-      <% if show_user_name %>
-      <th><%= t ".display_name" %></th>
-      <% end %>
-      <% if show_creator_name %>
-      <th><%= t ".creator_name" %></th>
-      <% end %>
-      <th><%= t ".reason" %></th>
-      <th><%= t ".status" %></th>
-      <th><%= t ".revoker_name" %></th>
-      <th></th>
-      <th></th>
-      <% if show_revoke_link %>
-      <th></th>
-      <% end %>
-    </tr>
-  </thead>
-  <%= render :partial => "block", :locals => { :show_revoke_link => show_revoke_link, :show_user_name => show_user_name, :show_creator_name => show_creator_name }, :collection => @user_blocks %>
-</table>
+<turbo-frame id="pagination" target="_top">
+  <table id="block_list" class="table table-borderless table-striped table-sm">
+    <thead>
+      <tr>
+        <% if show_user_name %>
+        <th><%= t ".display_name" %></th>
+        <% end %>
+        <% if show_creator_name %>
+        <th><%= t ".creator_name" %></th>
+        <% end %>
+        <th><%= t ".reason" %></th>
+        <th><%= t ".status" %></th>
+        <th><%= t ".revoker_name" %></th>
+        <th></th>
+        <th></th>
+        <% if show_revoke_link %>
+        <th></th>
+        <% end %>
+      </tr>
+    </thead>
+    <%= render :partial => "block", :locals => { :show_revoke_link => show_revoke_link, :show_user_name => show_user_name, :show_creator_name => show_creator_name }, :collection => @user_blocks %>
+  </table>
 
-<%= render "shared/pagination",
-           :newer_key => "user_blocks.blocks.newer",
-           :older_key => "user_blocks.blocks.older",
-           :newer_id => @newer_user_blocks_id,
-           :older_id => @older_user_blocks_id %>
+  <%= render "shared/pagination",
+             :newer_key => "user_blocks.blocks.newer",
+             :older_key => "user_blocks.blocks.older",
+             :newer_id => @newer_user_blocks_id,
+             :older_id => @older_user_blocks_id %>
+</turbo-frame>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,54 +9,56 @@
 <% end %>
 
 <% unless @users.empty? %>
-  <%= form_tag do %>
-    <div class="row">
-      <div class="col">
-        <%= render "shared/pagination",
-                   :newer_key => "users.index.newer",
-                   :older_key => "users.index.older",
-                   :newer_id => @newer_users_id,
-                   :older_id => @older_users_id %>
-      </div>
-      <div class="col col-auto">
-        <%= t ".found_users", :count => @users_count %>
-      </div>
-    <div>
+  <turbo-frame id="pagination" target="_top">
+    <%= form_tag do %>
+      <div class="row">
+        <div class="col">
+          <%= render "shared/pagination",
+                     :newer_key => "users.index.newer",
+                     :older_key => "users.index.older",
+                     :newer_id => @newer_users_id,
+                     :older_id => @older_users_id %>
+        </div>
+        <div class="col col-auto">
+          <%= t ".found_users", :count => @users_count %>
+        </div>
+      <div>
 
-    <%= hidden_field_tag :status, params[:status] if params[:status] %>
-    <%= hidden_field_tag :ip, params[:ip] if params[:ip] %>
-    <%= hidden_field_tag :page, params[:page] if params[:page] %>
-    <table id="user_list" class="table table-borderless table-striped">
-      <thead>
-        <tr>
-          <td colspan="2">
-          </td>
-          <td>
-            <%= check_box_tag "user_all", "1", false %>
-          </td>
-        </tr>
-      </thead>
-      <%= render @users %>
-    </table>
+      <%= hidden_field_tag :status, params[:status] if params[:status] %>
+      <%= hidden_field_tag :ip, params[:ip] if params[:ip] %>
+      <%= hidden_field_tag :page, params[:page] if params[:page] %>
+      <table id="user_list" class="table table-borderless table-striped">
+        <thead>
+          <tr>
+            <td colspan="2">
+            </td>
+            <td>
+              <%= check_box_tag "user_all", "1", false %>
+            </td>
+          </tr>
+        </thead>
+        <%= render @users %>
+      </table>
 
-    <div class="row">
-      <div class="col">
-        <%= render "shared/pagination",
-                   :newer_key => "users.index.newer",
-                   :older_key => "users.index.older",
-                   :newer_id => @newer_users_id,
-                   :older_id => @older_users_id %>
-      </div>
-      <div class="col col-auto">
-        <%= t ".found_users", :count => @users_count %>
-      </div>
-    <div>
+      <div class="row">
+        <div class="col">
+          <%= render "shared/pagination",
+                     :newer_key => "users.index.newer",
+                     :older_key => "users.index.older",
+                     :newer_id => @newer_users_id,
+                     :older_id => @older_users_id %>
+        </div>
+        <div class="col col-auto">
+          <%= t ".found_users", :count => @users_count %>
+        </div>
+      <div>
 
-    <div>
-      <%= submit_tag t(".confirm"), :name => "confirm", :class => "btn btn-primary" %>
-      <%= submit_tag t(".hide"), :name => "hide", :class => "btn btn-primary" %>
-    </div>
-  <% end %>
+      <div>
+        <%= submit_tag t(".confirm"), :name => "confirm", :class => "btn btn-primary" %>
+        <%= submit_tag t(".hide"), :name => "hide", :class => "btn btn-primary" %>
+      </div>
+    <% end %>
+  </turbo-frame>
 <% else %>
   <p><%= t ".empty" %></p>
 <% end %>


### PR DESCRIPTION
This extends turbo usage to everything that uses the shared pagination helpers, namely:

* Diaries
* User diary comments view
* Traces
* Administrator user listing
* User blocks
