### PR TITLE
Add (creator_id, id) index to blocks table

### DIFF
--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -15,7 +15,8 @@
 #
 # Indexes
 #
-#  index_user_blocks_on_user_id  (user_id)
+#  index_user_blocks_on_creator_id_and_id  (creator_id,id)
+#  index_user_blocks_on_user_id            (user_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20240405083825_add_creator_index_to_user_blocks.rb
+++ b/db/migrate/20240405083825_add_creator_index_to_user_blocks.rb
@@ -1,0 +1,7 @@
+class AddCreatorIndexToUserBlocks < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :user_blocks, [:creator_id, :id], :algorithm => :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2729,6 +2729,13 @@ CREATE INDEX index_reports_on_user_id ON public.reports USING btree (user_id);
 
 
 --
+-- Name: index_user_blocks_on_creator_id_and_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_blocks_on_creator_id_and_id ON public.user_blocks USING btree (creator_id, id);
+
+
+--
 -- Name: index_user_blocks_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3512,6 +3519,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20240405083825'),
 ('20240307181018'),
 ('20240307180830'),
 ('20240228205723'),


### PR DESCRIPTION
For #4644 and existing `/user/.../blocks_by` pages.