### PR TITLE
Change content heading background to bg-body-tertiary

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -726,10 +726,6 @@ tr.turn:hover {
 
 /* Rules for non-map content pages */
 
-.content-heading {
-  background: $lightgrey;
-}
-
 .content-inner {
   position: relative;
   max-width: 960px;

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -4,7 +4,7 @@
   <% else %>
     <%= render :partial => "layouts/flash", :locals => { :flash => flash } %>
     <% if content_for? :heading %>
-      <div class="content-heading">
+      <div class="content-heading bg-body-tertiary">
         <div class="content-inner <%= yield :heading_class %>">
           <%= yield :heading %>
         </div>


### PR DESCRIPTION
This is related to #4645 where I wanted to make the background of one element to match exactly the heading background in order to make other element below it invisible. Then I discovered that the heading background color is not a standard Bootstrap color and therefore I'd have to do more custom css if I wanted to reproduce this color.

Why not pick some standard color for the heading background? One advantage for it can be seen here: https://github.com/openstreetmap/openstreetmap-website/issues/2332#issuecomment-1728044333. If dark mode is enabled, the current color doesn't match the theme and you'd have to come up with another custom background color for heading sections. Standard colors have dark mode versions predefined.

Which [standard color](https://getbootstrap.com/docs/5.3/utilities/background/#background-color) is it better to use? The closest one seems to be `bg-body-secondary` but I'm using here `bg-body-tertiary` which is noticeably lighter. That's because there's another problem with the current color which becomes worse with `bg-body-secondary`.

Sometimes we display tabs over the heading background. Those tabs have a border when hovered. However the color of that border is very close to the background color, making it difficult to see it:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/91cbdf85-b695-41c2-ab56-51b2731811a6)

With `bg-body-secondary` you won't be able to see the border at all. But with a lighter background that I set in this PR it's easier to see the border:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/ddeaee50-914d-46d4-80a8-f4cba35d08db)
