### PR TITLE
Adapt striped table override to dark mode

### DIFF
--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -21,6 +21,6 @@ $link-hover-color: #24d;
 $link-decoration: none;
 $link-hover-decoration: underline;
 
-$table-striped-bg: $offwhite;
+$table-striped-bg: rgba(#77f, 0.05);
 
 $enable-negative-margins: true;


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/issues/2332#issuecomment-1728044333 for how striped tables currently look in dark mode.

This change keeps the current "striped" color in light mode, while in dark mode it looks like this:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/e0b7b851-c060-4cc8-8975-9999afd8d3d7)
