### PR TITLE
Update heading, stripes and tab border colors

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1063,4 +1063,11 @@ div.secondary-actions {
   }
 }
 
+/* Rules for tabs inside secondary background sections */
+
+.bg-body-secondary .nav-tabs {
+  --bs-border-color: var(--bs-secondary-border-subtle);
+  --bs-secondary-bg: var(--bs-secondary-border-subtle);
+}
+
 @import 'browse';

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1068,6 +1068,7 @@ div.secondary-actions {
 .bg-body-secondary .nav-tabs {
   --bs-border-color: var(--bs-secondary-border-subtle);
   --bs-secondary-bg: var(--bs-secondary-border-subtle);
+  margin-bottom: -1px;
 }
 
 @import 'browse';

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -719,10 +719,6 @@ tr.turn:hover {
 
 /* Rules for non-map content pages */
 
-.content-heading {
-  background: $lightgrey;
-}
-
 .content-inner {
   position: relative;
   max-width: 960px;

--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -20,6 +20,4 @@ $link-hover-color: #24d;
 $link-decoration: none;
 $link-hover-decoration: underline;
 
-$table-striped-bg: $offwhite;
-
 $enable-negative-margins: true;

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -4,7 +4,7 @@
   <% else %>
     <%= render :partial => "layouts/flash", :locals => { :flash => flash } %>
     <% if content_for? :heading %>
-      <div class="content-heading bg-body-secondary">
+      <div class="content-heading bg-body-secondary border-bottom border-secondary-subtle">
         <div class="content-inner <%= yield :heading_class %>">
           <%= yield :heading %>
         </div>

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -4,7 +4,7 @@
   <% else %>
     <%= render :partial => "layouts/flash", :locals => { :flash => flash } %>
     <% if content_for? :heading %>
-      <div class="content-heading">
+      <div class="content-heading bg-body-secondary">
         <div class="content-inner <%= yield :heading_class %>">
           <%= yield :heading %>
         </div>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -48,7 +48,7 @@
     <% end %>
 
     <li class="nav-item ms-auto">
-      <div class="nav-link pe-0">
+      <div class="nav-link pe-0 border-0">
         <%= link_to({ :action => :georss, :display_name => @target_user&.display_name, :tag => params[:tag] }, { :class => "btn btn-secondary btn-sm my-n2 align-baseline border-0" }) do %>
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" class="align-text-bottom">
             <circle cx="2" cy="14" r="2" fill="white" />


### PR DESCRIPTION
Have to make these changes at the same time to see if they work together:
- `bg-body-secondary` in heading sections instead of #4651
- darker tab borders when they are inside `bg-body-secondary`
- default striped tables instead of #4652

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/4b32abb2-a115-48f4-a313-4da2f2a2389d)

This is how it looks in dark mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/889bc11b-d81c-4787-91e0-d246b08f20b2)
