### PR TITLE
Add block tab to show block pages

### DIFF
--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -34,4 +34,11 @@
                   :class => ["nav-link", { :active => action_name == "blocks_by" }] %>
     </li>
   <% end %>
+  <% if @user_block %>
+    <li class="nav-item">
+      <%= link_to t(".block", :id => @user_block.id),
+                  user_block_path(@user_block),
+                  :class => ["nav-link", { :active => action_name == "show" }] %>
+    </li>
+  <% end %>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2991,6 +2991,7 @@ en:
       blocks_on_user: "Blocks on %{user}"
       blocks_by_me: "Blocks by Me"
       blocks_by_user: "Blocks by %{user}"
+      block: "Block #%{id}"
   user_mutes:
     index:
       title: "Muted Users"


### PR DESCRIPTION
To have an active tab on a block page - see https://github.com/openstreetmap/openstreetmap-website/pull/4644#issuecomment-2041438566

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/8c46cf32-1a56-4abf-aba2-8fc29de3988c)
