### PR TITLE
Use secondary text color in header menu

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -150,11 +150,6 @@ nav.primary {
 nav.secondary {
   .nav-link {
     padding: 0.2rem;
-    color: $darkgrey;
-  }
-
-  > ul li.current a {
-    color: darken($darkgrey, 25%);
   }
 
   #inboxanchor {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,8 +41,8 @@ module ApplicationHelper
     end
   end
 
-  def current_page_class(path)
-    :current if current_page?(path)
+  def header_nav_link_class(path)
+    ["nav-link", current_page?(path) ? "text-secondary-emphasis" : "text-secondary"]
   end
 
   def application_data

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -34,48 +34,48 @@
   <nav class='secondary'>
     <ul class='mx-1 px-0'>
       <% if Settings.status != "database_offline" && can?(:index, Issue) %>
-        <li class="compact-hide nav-item <%= current_page_class(issues_path) %>">
-          <%= link_to issues_path(:status => "open"), :class => "nav-link" do %>
+        <li class="compact-hide nav-item">
+          <%= link_to issues_path(:status => "open"), :class => header_nav_link_class(issues_path) do %>
             <%= t("layouts.issues") %>
             <%= open_issues_count %>
           <% end -%>
         </li>
       <% end %>
-      <li class="compact-hide nav-item <%= current_page_class(traces_path) %>">
-        <%= link_to t("layouts.gps_traces"), traces_path, :class => "nav-link" %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.gps_traces"), traces_path, :class => header_nav_link_class(traces_path) %>
       </li>
-      <li class="compact-hide nav-item <%= current_page_class(diary_entries_path) %>">
-        <%= link_to t("layouts.user_diaries"), diary_entries_path, :class => "nav-link" %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.user_diaries"), diary_entries_path, :class => header_nav_link_class(diary_entries_path) %>
       </li>
-      <li class="compact-hide nav-item <%= current_page_class(communities_path) %>">
-        <%= link_to t("layouts.communities"), communities_path, :class => "nav-link" %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.communities"), communities_path, :class => header_nav_link_class(communities_path) %>
       </li>
-      <li class="compact-hide nav-item <%= current_page_class(copyright_path) %>">
-        <%= link_to t("layouts.copyright"), copyright_path, :class => "nav-link" %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.copyright"), copyright_path, :class => header_nav_link_class(copyright_path) %>
       </li>
-      <li class="compact-hide nav-item <%= current_page_class(help_path) %>">
-        <%= link_to t("layouts.help"), help_path, :class => "nav-link" %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.help"), help_path, :class => header_nav_link_class(help_path) %>
       </li>
-      <li class="compact-hide nav-item <%= current_page_class(about_path) %>">
-        <%= link_to t("layouts.about"), about_path, :class => "nav-link" %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.about"), about_path, :class => header_nav_link_class(about_path) %>
       </li>
       <li id="compact-secondary-nav" class="dropdown nav-item">
         <button class="dropdown-toggle nav-link btn btn-outline-secondary border-0 bg-white text-secondary" type="button" data-bs-toggle="dropdown"><%= t "layouts.more" %></button>
         <ul class="dropdown-menu">
           <% if Settings.status != "database_offline" && can?(:index, Issue) %>
-            <li class="<%= current_page_class(issues_path) %>">
+            <li>
               <%= link_to issues_path(:status => "open"), :class => "dropdown-item" do %>
                 <%= t("layouts.issues") %>
                 <%= open_issues_count %>
               <% end -%>
             </li>
           <% end %>
-          <li class="<%= current_page_class(traces_path) %>"><%= link_to t("layouts.gps_traces"), traces_path, :class => "dropdown-item" %></li>
-          <li class="<%= current_page_class(diary_entries_path) %>"><%= link_to t("layouts.user_diaries"), diary_entries_path, :class => "dropdown-item" %></li>
-          <li class="<%= current_page_class(communities_path) %>"><%= link_to t("layouts.communities"), communities_path, :class => "dropdown-item" %></li>
-          <li class="<%= current_page_class(copyright_path) %>"><%= link_to t("layouts.copyright"), copyright_path, :class => "dropdown-item" %></li>
-          <li class="<%= current_page_class(help_path) %>"><%= link_to t("layouts.help"), help_path, :class => "dropdown-item" %></li>
-          <li class="<%= current_page_class(about_path) %>"><%= link_to t("layouts.about"), about_path, :class => "dropdown-item" %></li>
+          <li><%= link_to t("layouts.gps_traces"), traces_path, :class => "dropdown-item" %></li>
+          <li><%= link_to t("layouts.user_diaries"), diary_entries_path, :class => "dropdown-item" %></li>
+          <li><%= link_to t("layouts.communities"), communities_path, :class => "dropdown-item" %></li>
+          <li><%= link_to t("layouts.copyright"), copyright_path, :class => "dropdown-item" %></li>
+          <li><%= link_to t("layouts.help"), help_path, :class => "dropdown-item" %></li>
+          <li><%= link_to t("layouts.about"), about_path, :class => "dropdown-item" %></li>
         </ul>
       </li>
     </ul>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -91,5 +91,5 @@ class ApplicationHelperTest < ActionView::TestCase
 
   def test_body_class; end
 
-  def test_current_page_class; end
+  def test_header_nav_link_class; end
 end


### PR DESCRIPTION
Uses `text-secondary` or `text-secondary-emphasis` if it's a current page.
Replaces: 
- `$darkgrey`: `text-secondary` matches it
- `darken($darkgrey, 25%)`: in dark mode it shouldn't be darkened

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b02c5688-f069-4137-b6fd-b1932aaba7d4)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/4d3825c6-a62c-4d8b-85e5-719748ec8d96)

I also removed the current page color change in the "more" dropdown because it worked in the opposite direction, making the text lighter. Also there's no similar color change in the user menu dropdown.

Before, with "Communities" as the current page:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/802f9d86-57e1-4a91-bbde-6b81ca4f55e5)
