### PR TITLE
Use secondary body color for export inputs background

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -686,8 +686,6 @@ tr.turn:hover {
   }
 
   .export_boxy {
-    background: $lightgrey;
-
     > * {
         margin: -1px;
     }

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -6,7 +6,7 @@
   <%= hidden_field_tag "format", "osm", :autocomplete => "off" %>
 
   <div class='export_area_inputs'>
-    <div class='export_boxy border border-secondary-subtle rounded'>
+    <div class='export_boxy border border-secondary-subtle rounded bg-body-secondary'>
       <%= text_field_tag("maxlat", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control mx-auto") %>
       <div class="clearfix">
         <%= text_field_tag("minlon", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control my-2") %>


### PR DESCRIPTION
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/852f3459-3eea-46b5-8447-a7304943a030)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/674ea519-b9ec-4187-b0f0-fb212e2df62e)
