### PR TITLE
Adapt About page backgrounds to dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -984,8 +984,6 @@ div.secondary-actions {
 }
 
 .site-about #content {
-  background-color: $lightgrey;
-
   .content-inner {
     max-width: 760px;
   }

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:content_class) { "bg-body-secondary" } %>
 <% I18n.with_locale @locale do %>
   <%= tag.div :lang => @locale, :dir => t("html.dir") do %>
     <div class="container-lg attr">
@@ -11,13 +12,13 @@
         </div>
       </div>
       <div class='row'>
-        <div class="px-5 py-4 bg-dark">
+        <div class="px-5 py-4 bg-black bg-opacity-75">
           <h1 class="text-white fw-light"><%= t ".used_by_html", :name => tag.span("OpenStreetMap", :class => "user-name") %></h1>
         </div>
       </div>
     </div>
 
-    <div class='bg-white px-5 py-4'>
+    <div class='bg-body px-5 py-4'>
       <p class="lead"><%= t ".lede_text" %></p>
 
       <%= render :layout => "about_section", :locals => { :icon => "local", :title => "local_knowledge" } do %>


### PR DESCRIPTION
I made the "OpenStreetMap provides map data" section lighter in light mode and darker in dark mode. The previous color, `bg-dark`, is exactly `bg-body` in dark mode. If kept, there would be no visible separation with the next section.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d83e90d7-dda2-4844-9d43-c1d206bbcfba)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/03d8679c-10cb-4dac-869a-8ada3a834dc0)
