### PR TITLE
Use Bootstrap toggle buttons for layers menu

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -5,26 +5,30 @@ L.OSM.layers = function (options) {
     var layers = options.layers;
 
     var baseSection = $("<div>")
-      .attr("class", "section base-layers")
+      .attr("class", "section base-layers d-grid gap-3")
       .appendTo($ui);
 
-    var baseLayers = $("<ul class='list-unstyled mb-0'>")
-      .appendTo(baseSection);
+    layers.forEach(function (layer, i) {
+      var id = "map-ui-layer-" + i;
 
-    layers.forEach(function (layer) {
-      var item = $("<li>")
-        .attr("class", "rounded-3")
-        .appendTo(baseLayers);
+      var buttonContainer = $("<div class='position-relative'>")
+        .appendTo(baseSection);
 
-      if (map.hasLayer(layer)) {
-        item.addClass("active");
-      }
+      var mapContainer = $("<div class='position-absolute top-0 start-0 bottom-0 end-0 z-0'>")
+        .appendTo(buttonContainer);
 
-      var div = $("<div>")
-        .appendTo(item);
+      var input = $("<input type='radio' class='btn-check' name='layer'>")
+        .prop("id", id)
+        .prop("checked", map.hasLayer(layer))
+        .appendTo(buttonContainer);
+
+      var item = $("<label class='btn btn-outline-primary border-4 rounded-3 bg-transparent position-absolute top-0 start-0 bottom-0 end-0 m-n1 overflow-hidden'>")
+        .prop("for", id)
+        .append($("<span class='badge position-absolute top-0 start-0 rounded-top-0 rounded-start-0 py-1 px-2 bg-body bg-opacity-75 text-body text-wrap text-start fs-6 lh-base'>").append(layer.options.name))
+        .appendTo(buttonContainer);
 
       map.whenReady(function () {
-        var miniMap = L.map(div[0], { attributionControl: false, zoomControl: false, keyboard: false })
+        var miniMap = L.map(mapContainer[0], { attributionControl: false, zoomControl: false, keyboard: false })
           .addLayer(new layer.constructor({ apikey: layer.options.apikey }));
 
         miniMap.dragging.disable();
@@ -55,17 +59,7 @@ L.OSM.layers = function (options) {
         }
       });
 
-      var label = $("<label>")
-        .appendTo(item);
-
-      var input = $("<input>")
-        .attr("type", "radio")
-        .prop("checked", map.hasLayer(layer))
-        .appendTo(label);
-
-      label.append(layer.options.name);
-
-      item.on("click", function () {
+      input.on("click", function () {
         layers.forEach(function (other) {
           if (other === layer) {
             map.addLayer(other);
@@ -79,7 +73,6 @@ L.OSM.layers = function (options) {
       item.on("dblclick", toggle);
 
       map.on("layeradd layerremove", function () {
-        item.toggleClass("active", map.hasLayer(layer));
         input.prop("checked", map.hasLayer(layer));
       });
     });

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -418,43 +418,14 @@ body.small-nav {
 }
 
 .layers-ui {
-  .base-layers {
-    .leaflet-container {
-      width: 100%;
-      height: 50px;
-      cursor: pointer;
+  .base-layers > * {
+    height: 56px;
+
+    > .btn {
+      --bs-btn-border-color: var(--bs-body-bg);
     }
-
-    li  {
-      overflow: hidden;
-      border-radius: 3px;
-      border: 2px solid transparent;
-      margin-bottom: 8px;
-      position: relative;
-      transition: border-color 0.08s ease-in;
-
-      label {
-        position: absolute;
-        top: 0;
-        left: 0;
-        padding: 2px 6px;
-        border-bottom-right-radius: 3px;
-        cursor: pointer;
-        font-weight: 600;
-        font-size: 16px;
-        background-color: var(--bs-body-bg);
-        opacity: 0.9;
-        z-index: 1000;
-        input[type="radio"] {
-          display: none;
-        }
-      }
-
-      &.active { border-color: darken($green, 10%); }
-      &:hover {
-        border-color: $grey;
-        &.active { border-color: darken($green, 20%); }
-      }
+    > .btn:hover {
+      --bs-btn-border-color: var(--bs-primary-border-subtle);
     }
   }
 


### PR DESCRIPTION
Rewrite of #3674 - layer buttons as [Bootstrap radio toggle buttons](https://getbootstrap.com/docs/5.3/forms/checks-radios/#radio-toggle-buttons)

Enables keyboard navigation for layer buttons which is missing now.

The only custom css is to:
- set button heights
- override borders to have hover effects because Bootstrap toggle buttons don't have any hover effect (they'd need another color to tell hover states apart from selected states, they solved it by removing hover states)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c0775b2d-de2b-49d2-992e-93455ed83028)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/fb8c8af0-d742-48f3-b5c4-57bbf25fd34f)
