### PR TITLE
Fix right sidebar background

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -66,7 +66,7 @@
     </div>
   </noscript>
 
-  <div id="map-ui">
+  <div id="map-ui" class="bg-body">
   </div>
 
   <div id="map" tabindex="2">


### PR DESCRIPTION
Fixes this:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/53567133-17e9-45f2-afa7-8e49d06014a3)

I thought it wouldn't happen because sidebars are become full-width only in small layouts. But the right sidebar has its own logic when to go full width. It's possible to have an intermediate screen width which is both wide enough to have a floating search panel and narrow enough to have full-width right sidebar.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7dbf4acd-8f21-4c2a-96bd-47e51042c6de)
