### PR TITLE
Fix header background

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="d-flex text-nowrap closed">
+<header class="d-flex bg-body text-nowrap closed">
   <h1 class="m-0 fw-semibold">
     <a href="<%= root_path %>" class="text-body-emphasis text-decoration-none geolink">
       <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :width => 30, :height => 30, :class => "logo" %>


### PR DESCRIPTION
Not sure when the header background got broken:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d2495fbb-ec66-48fc-9ebd-bdca0a235e4a)

It was working when I made #4667 with screenshots.

Testing again:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/08409d03-92d7-445e-b794-79f6bda32b50)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/31de104d-a835-4ffe-b7b7-d6dae11538ce)
