### PR TITLE
Invert trace images in dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1036,4 +1036,12 @@ div.secondary-actions {
   margin-bottom: -1px;
 }
 
+/* Rules for traces */
+
+@include color-mode(dark) {
+  img.trace_image {
+    filter: invert(.85);
+  }
+}
+
 @import 'browse';

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -2,7 +2,7 @@
   <td>
     <% if Settings.status != "gpx_offline" %>
       <% if trace.inserted %>
-        <%= link_to image_tag(trace_icon_path(trace.user, trace), :alt => ""), show_trace_path(trace.user, trace) %>
+        <%= link_to image_tag(trace_icon_path(trace.user, trace), :alt => "", :class => "trace_image"), show_trace_path(trace.user, trace) %>
       <% else %>
         <span class="text-danger"><%= t ".pending" %></span>
       <% end %>

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t ".heading", :name => @trace.name %></h1>
 <% end %>
 
-<%= image_tag trace_picture_path(@trace.user, @trace) %>
+<%= image_tag trace_picture_path(@trace.user, @trace), :class => "trace_image" %>
 
 <%= bootstrap_form_for @trace do |f| %>
   <%= f.text_field :name, :disabled => true %>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -4,7 +4,7 @@
 
 <% if Settings.status != "gpx_offline" %>
   <% if @trace.inserted %>
-    <%= image_tag trace_picture_path(@trace.user, @trace) %>
+    <%= image_tag trace_picture_path(@trace.user, @trace), :class => "trace_image" %>
   <% else %>
     <span class="text-danger"><%= t ".pending" %></span>
   <% end %>


### PR DESCRIPTION
Do 85% invert because the page background is not 100% black.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7ce8471a-b9dc-4dd7-bc9c-6bf01a83eb07)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/92187a4f-0c8b-4824-811a-0586f4d88f5b)
