### PR TITLE
Invert trace images in dark mode + blend with background

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1036,4 +1036,12 @@ div.secondary-actions {
   margin-bottom: -1px;
 }
 
+/* Rules for traces */
+
+@include color-mode(dark) {
+  img.trace_image {
+    filter: invert(1);
+  }
+}
+
 @import 'browse';

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1038,9 +1038,14 @@ div.secondary-actions {
 
 /* Rules for traces */
 
+img.trace_image {
+  mix-blend-mode: darken;
+}
+
 @include color-mode(dark) {
   img.trace_image {
     filter: invert(1);
+    mix-blend-mode: lighten;
   }
 }
 

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -2,7 +2,7 @@
   <td>
     <% if Settings.status != "gpx_offline" %>
       <% if trace.inserted %>
-        <%= link_to image_tag(trace_icon_path(trace.user, trace), :alt => ""), show_trace_path(trace.user, trace) %>
+        <%= link_to image_tag(trace_icon_path(trace.user, trace), :alt => "", :class => "trace_image"), show_trace_path(trace.user, trace) %>
       <% else %>
         <span class="text-danger"><%= t ".pending" %></span>
       <% end %>

--- a/app/views/traces/edit.html.erb
+++ b/app/views/traces/edit.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t ".heading", :name => @trace.name %></h1>
 <% end %>
 
-<%= image_tag trace_picture_path(@trace.user, @trace) %>
+<%= image_tag trace_picture_path(@trace.user, @trace), :class => "trace_image" %>
 
 <%= bootstrap_form_for @trace do |f| %>
   <%= f.text_field :name, :disabled => true %>

--- a/app/views/traces/show.html.erb
+++ b/app/views/traces/show.html.erb
@@ -4,7 +4,7 @@
 
 <% if Settings.status != "gpx_offline" %>
   <% if @trace.inserted %>
-    <%= image_tag trace_picture_path(@trace.user, @trace) %>
+    <%= image_tag trace_picture_path(@trace.user, @trace), :class => "trace_image" %>
   <% else %>
     <span class="text-danger"><%= t ".pending" %></span>
   <% end %>


### PR DESCRIPTION
An alternative to #4679 which also changes light mode.

Trace images have white background which they probably shouldn't have, it should be transparent. Besides dark mode, this white background shows up in striped tables:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/017b8fda-813c-41e4-9590-c6733cb1fcbf)

But we can make it behave as transparent by using blend modes:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/85e86ba9-c92e-4812-abf4-a75ef8dcc553)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7a6bfd65-4b0b-4a72-abfb-54d80b09416e)
