### PR TITLE
Remove custom right sidebar section class

### DIFF
--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -3,7 +3,7 @@ L.OSM.key = function (options) {
 
   control.onAddPane = function (map, button, $ui) {
     var $section = $("<div>")
-      .attr("class", "section")
+      .attr("class", "p-3")
       .appendTo($ui);
 
     $ui

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -5,7 +5,7 @@ L.OSM.layers = function (options) {
     var layers = options.layers;
 
     var baseSection = $("<div>")
-      .attr("class", "section base-layers d-grid gap-3")
+      .attr("class", "base-layers d-grid gap-3 p-3 border-bottom border-secondary-subtle")
       .appendTo($ui);
 
     layers.forEach(function (layer, i) {
@@ -79,7 +79,7 @@ L.OSM.layers = function (options) {
 
     if (OSM.STATUS !== "api_offline" && OSM.STATUS !== "database_offline") {
       var overlaySection = $("<div>")
-        .attr("class", "section overlay-layers")
+        .attr("class", "overlay-layers p-3")
         .appendTo($ui);
 
       $("<p>")

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -10,7 +10,7 @@ L.OSM.share = function (options) {
     // Link / Embed
 
     var $linkSection = $("<div>")
-      .attr("class", "section share-link")
+      .attr("class", "share-link p-3 border-bottom border-secondary-subtle")
       .appendTo($ui);
 
     $("<h4>")
@@ -104,7 +104,7 @@ L.OSM.share = function (options) {
     // Geo URI
 
     var $geoUriSection = $("<div>")
-      .attr("class", "section share-geo-uri")
+      .attr("class", "share-geo-uri p-3 border-bottom border-secondary-subtle")
       .appendTo($ui);
 
     $("<h4>")
@@ -119,7 +119,7 @@ L.OSM.share = function (options) {
     // Image
 
     var $imageSection = $("<div>")
-      .attr("class", "section share-image")
+      .attr("class", "share-image p-3")
       .appendTo($ui);
 
     $("<h4>")

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -383,11 +383,6 @@ body.small-nav {
     width: 250px;
     height: 100%;
     overflow: auto;
-
-    .section {
-      border-bottom: 1px solid $grey;
-      padding: $spacer;
-    }
   }
 }
 


### PR DESCRIPTION
Uses `border-secondary-subtle` if there's a border between section, like in #4654.

Dark mode before, the border is too bright:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c10738c9-2411-4cae-ae5e-a4d429dbe13d)

Dark mode after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/23796bef-f565-422f-8930-ddc56fc4ccae)
