### PR TITLE
Use section elements instead of div.section on about page

### DIFF
--- a/app/views/site/_about_section.html.erb
+++ b/app/views/site/_about_section.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div :class => "section", :id => local_assigns[:id] do %>
+<%= tag.section :id => local_assigns[:id] do %>
   <div class='d-flex align-items-center gap-2 mb-2'>
     <div class='flex-shrink-0 icon <%= icon %>'></div>
     <h2 class='flex-grow-1 mb-0'><%= t "site.about.#{title}_title" %></h2>


### PR DESCRIPTION
`section` class is not in use since https://github.com/openstreetmap/openstreetmap-website/commit/304deb3ca7adb17b412b0fda4fad10d73d0b90b6#diff-e86a39e6d0b163f152db8843fc7d647a3f5d648de4a74f1732bef4474b6e5bc8L2693-L2699

But those are actually sections and can be replaced with `<section>` elements.