### PR TITLE
Force ltr direction in export inputs

### DIFF
--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -6,7 +6,7 @@
   <%= hidden_field_tag "format", "osm", :autocomplete => "off" %>
 
   <div class='export_area_inputs'>
-    <div class='export_boxy border border-secondary-subtle rounded bg-body-secondary'>
+    <div class='export_boxy border border-secondary-subtle rounded bg-body-secondary' dir='ltr'>
       <%= text_field_tag("maxlat", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control mx-auto") %>
       <div class="clearfix">
         <%= text_field_tag("minlon", nil, :size => 10, :autocomplete => "off", :class => "export_bound form-control my-2") %>


### PR DESCRIPTION
See #4665.

This PR keeps 0123456789 digits with decimal dot and makes `-` always appear on the left side.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/608df12a-9ea1-4d06-80ba-a6a6f07ec412)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/761f063d-11eb-430f-89b2-bbb331cf9fa1)
