### PR TITLE
Use Bootstrap utilities to set z-indexes of map ui and fix some bugs

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -90,7 +90,6 @@ time[title] {
 header {
   height: $headerHeight;
   position: relative;
-  z-index: 1001;
   font-size: 14px;
 
   h1, nav, nav > ul, nav > ul > li {
@@ -329,7 +328,6 @@ body.small-nav {
 
   .overlay-sidebar #sidebar {
     position: absolute;
-    z-index: 1000;
     height: auto;
     overflow: hidden;
 
@@ -396,7 +394,6 @@ body.small-nav {
     }
 
     #map-ui {
-      z-index: 9999;
       width: 100%;
       height: 50%;
       overflow-y: scroll;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="d-flex bg-body text-nowrap closed">
+<header class="d-flex bg-body text-nowrap closed z-3">
   <h1 class="m-0 fw-semibold">
     <a href="<%= root_path %>" class="text-body-emphasis text-decoration-none geolink">
       <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :width => 30, :height => 30, :class => "logo" %>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -21,7 +21,7 @@
 <% end %>
 
 <% content_for :content do %>
-  <div id="sidebar" class="bg-body">
+  <div id="sidebar" class="bg-body z-1">
     <%= render :partial => "layouts/search", :locals => { :autofocus => true } %>
 
     <div id="flash">
@@ -66,7 +66,7 @@
     </div>
   </noscript>
 
-  <div id="map-ui" class="bg-body">
+  <div id="map-ui" class="bg-body z-2">
   </div>
 
   <div id="map" tabindex="2" class="z-0">

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -69,7 +69,7 @@
   <div id="map-ui" class="bg-body">
   </div>
 
-  <div id="map" tabindex="2">
+  <div id="map" tabindex="2" class="z-0">
   </div>
 
   <div id="attribution" class="d-none">


### PR DESCRIPTION
## bug 1

Open the right sidebar, then open a dropdown menu ("more" or user menu):

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9607c116-1646-4ffb-afdc-341cac581fc6)

Seems to work fine. Now make the screen smaller. If you get the intermediate width like in #4675, the dropdown menu will be covered by the sidebar:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/61efe369-b73f-4584-9a0b-fc58d87137ae)

Bootstrap sets z-index to 1000 on dropdowns which should be high enough, but we use even higher z-indexes on map ui elements. We do this to keep them above Leaflet's range of z-indexes. What we could do instead and what this PR does is to isolate Leaflet in its own [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context). Here I set the entire map at z-0 with a Bootstrap utility class. The right sidebar gets z-2 to stay above the floating left sidebar, which gets z-1.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6820ddc4-88ca-4315-8bc3-1341f9ed85f1)

## bug 2

Open the right sidebar on a small screen then try to open the menu:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6c84b873-bb44-4a15-876b-4d8091426006)

The menu is a part of the header, with z-index below the right sidebar. In addition to the fixes above I set the header at z-3:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3fd36ba8-72aa-4097-9b28-6e7d4ae72c23)
