### PR TITLE
Remove .prose css selector

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -865,8 +865,7 @@ div.secondary-actions {
 
 /* Rules for rich text */
 
-.richtext,
-.prose {
+.richtext {
   code {
     background: var(--bs-secondary-bg);
     padding: 2px 3px;


### PR DESCRIPTION
Not in use since https://github.com/openstreetmap/openstreetmap-website/commit/adfb4dc61945b7b441695885b3b273bfdf712332