### PR TITLE
Move search form css to correct section

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -513,6 +513,12 @@ header .search_forms,
   display: none;
 }
 
+.search_form {
+  .describe_location {
+    font-size: 10px;
+  }
+}
+
 /* Rules for search sidebar */
 
 #sidebar .search_results_entry {
@@ -808,12 +814,6 @@ tr.turn:hover {
 
   .inbox-row-unread td {
     background: #CBEEA7;
-  }
-}
-
-.search_form {
-  .describe_location {
-    font-size: 10px;
   }
 }
 


### PR DESCRIPTION
Was in "Rules for messages pages" for some reason.