### PR TITLE
Remove unused $offwhite color

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -802,10 +802,6 @@ tr.turn:hover {
 /* Rules for messages pages */
 
 .messages {
-  .inbox-row {
-    background: $offwhite;
-  }
-
   .inbox-row-unread td {
     background: #CBEEA7;
   }

--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -2,7 +2,6 @@
 $lineheight: 20px;
 $typeheight: 14px;
 
-$offwhite: #f8f8ff;
 $blue: #7092FF;
 $secondary: #888;
 $lightblue: #B8C5F0;


### PR DESCRIPTION
It had no effect inside .inbox-row selector because table cells override the background.