### PR TITLE
Adapt notes table to dark mode by overriding Bootstrap colors

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -799,6 +799,15 @@ tr.turn:hover {
   }
 }
 
+/* Rules for notes pages */
+
+@include color-mode(dark) {
+  .notes .table-primary td {
+    --bs-table-bg: var(--bs-primary-bg-subtle);
+    --bs-table-color: var(--bs-emphasis-color);
+  }
+}
+
 /* Rules for messages pages */
 
 .messages {

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -2,8 +2,8 @@
   <h1><%= t ".heading", :user => @user.display_name %></h1>
   <p><%= t ".subheading_html",
            :user => link_to(@user.display_name, @user),
-           :submitted => tag.span(t(".subheading_submitted"), :class => "px-2 py-1 bg-primary bg-opacity-25"),
-           :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-white") %></p>
+           :submitted => tag.span(t(".subheading_submitted"), :class => "px-2 py-1 bg-primary-subtle"),
+           :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-body") %></p>
 <% end %>
 
 <% if @notes.empty? %>


### PR DESCRIPTION
Alternative version of #4672 where we pretend that Bootstrap's `table-primary` supports dark mode.

`table-primary` is kept in the generated html. For notes table we only have to redefine a couple of colors in dark mode. In general this is not enough because there are variations for stripes, active colors etc but we're not using any of those here.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/0433c94a-c871-4503-9051-91eedd491a77)
