### PR TITLE
Set maximum size limits for user provided content

### DIFF
--- a/app/models/changeset_comment.rb
+++ b/app/models/changeset_comment.rb
@@ -30,7 +30,7 @@ class ChangesetComment < ApplicationRecord
   validates :changeset, :associated => true
   validates :author, :associated => true
   validates :visible, :inclusion => [true, false]
-  validates :body, :characters => true
+  validates :body, :length => { :maximum => 2000 }, :characters => true
 
   # Return the comment text
   def body

--- a/app/models/diary_comment.rb
+++ b/app/models/diary_comment.rb
@@ -28,7 +28,7 @@ class DiaryComment < ApplicationRecord
 
   scope :visible, -> { where(:visible => true) }
 
-  validates :body, :presence => true, :characters => true
+  validates :body, :presence => true, :length => { :maximum => 10000 }, :characters => true
   validates :diary_entry, :user, :associated => true
 
   after_save :spam_check

--- a/app/models/issue_comment.rb
+++ b/app/models/issue_comment.rb
@@ -24,7 +24,7 @@ class IssueComment < ApplicationRecord
   belongs_to :issue
   belongs_to :user
 
-  validates :body, :presence => true, :characters => true
+  validates :body, :presence => true, :length => { :maximum => 2000 }, :characters => true
 
   def body
     RichText.new("markdown", self[:body])

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -25,7 +25,7 @@ class Report < ApplicationRecord
   belongs_to :issue, :counter_cache => true
   belongs_to :user
 
-  validates :details, :presence => true, :characters => true
+  validates :details, :presence => true, :length => { :maximum => 10000 }, :characters => true
   validates :category, :presence => true
 
   def self.categories_for(reportable)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,6 +114,7 @@ class User < ApplicationRecord
                        :uniqueness => { :scope => :auth_provider }
   validates :avatar, :if => proc { |u| u.attachment_changes["avatar"] },
                      :image => true
+  validates :description, :length => { :maximum => 10000 }
 
   validates_email_format_of :email, :if => proc { |u| u.email_changed? }
   validates_email_format_of :new_email, :allow_blank => true, :if => proc { |u| u.new_email_changed? }

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -61,7 +61,7 @@
     <% unless @changeset.open? %>
       <form action="#" class="mb-3">
         <div class="mb-3">
-          <textarea class="form-control" name="text" cols="40" rows="5"></textarea>
+          <textarea class="form-control" name="text" cols="40" rows="5" maxlength="2000"></textarea>
         </div>
         <div id="comment-error" class="alert alert-danger p-2 mb-3" hidden>
         </div>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -35,7 +35,7 @@
     <h3 id="newcomment"><%= t ".leave_a_comment" %></h3>
 
     <%= bootstrap_form_for @entry.comments.new, :url => { :action => "comment" } do |f| %>
-      <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
+      <%= f.richtext_field :body, :cols => 80, :rows => 20, :maxlength => 10000, :hide_label => true %>
       <%= f.primary %>
     <% end %>
   <% else %>

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -19,7 +19,7 @@
 
 <div>
   <%= bootstrap_form_for @new_comment, :url => issue_comments_path(@issue) do |f| %>
-    <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
+    <%= f.richtext_field :body, :cols => 80, :rows => 20, :maxlength => 2000, :hide_label => true %>
     <%= f.form_group do %>
       <%= f.check_box :reassign, { :label => t(".reassign_param"), :id => "reassign", :name => "reassign", :checked => false }, true, false %>
     <% end %>


### PR DESCRIPTION
I believe we should continue adding some upper size limits for various input fields, like we already do for [note comments](https://github.com/openstreetmap/openstreetmap-website/commit/d9a48d66f977afbe9d5e196e9e22d882b16b3566). 

Limits in this pull request are a best guess only, and I'm open to make them larger if needed. However, they shouldn't be unlimited as they are today. 

I'm aware that there are existing limits imposed by the web server, but I find them too large for input fields.