### PR TITLE
Adapt notes table to dark mode by overriding Bootstrap colors

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -799,6 +799,13 @@ tr.turn:hover {
   }
 }
 
+/* Rules for notes pages */
+
+.notes .table-primary td {
+  --bs-table-bg: rgb(var(--bs-primary-rgb), .25);
+  --bs-table-color: var(--bs-emphasis-color);
+}
+
 /* Rules for messages pages */
 
 .messages {

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -3,7 +3,7 @@
   <p><%= t ".subheading_html",
            :user => link_to(@user.display_name, @user),
            :submitted => tag.span(t(".subheading_submitted"), :class => "px-2 py-1 bg-primary bg-opacity-25"),
-           :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-white") %></p>
+           :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-body") %></p>
 <% end %>
 
 <% if @notes.empty? %>


### PR DESCRIPTION
Version 3 of #4672 and #4693 which slightly changes light mode colors but probably nobody is going to notice it.

`table-*` classes [happen to use "subtle" background colors](https://github.com/openstreetmap/openstreetmap-website/pull/4693#discussion_r1564038196) that look fine in light mode. They [don't adapt to dark mode](https://github.com/openstreetmap/openstreetmap-website/pull/4672#discussion_r1557742890) so we have to override them if we [still want to use them](https://github.com/openstreetmap/openstreetmap-website/pull/4669#issuecomment-2045718454). An obvious override is to set them to "subtle" colors in dark mode, that's what I tried in #4672 and it looks too dark. In this PR I'm doing the same thing I did in the legend abode the table and use the "non-subtle" color with 25% opacity.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/1283617a-6a24-4e5b-a311-14984fb520c6)
