### PR TITLE
Darken + add transparency to counter badges

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -245,7 +245,7 @@ body.small-nav {
 /* Utility for styling notification numbers */
 
 .count-number {
-  background: lighten($green, 30%);
+  background: transparentize(lighten($green, 25%), .25);
   color: $gray-800;
   font-weight: $font-weight-normal;
 }


### PR DESCRIPTION
We have a custom color for counter badges. But it's too bright for dark mode. It's too bright even for light mode because it's brightness is too close to the header background.

Light mode before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/49cdae5d-3a9a-48cb-aa05-490a3870cb03)

Light mode after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b2d931c1-f2c1-46b0-bee0-cf500b2f8032)

Dark mode before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6c4de753-d888-4b85-b20c-f962166fb996)

Dark mode after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/06ba3274-48b8-4ce0-8bc3-2a49a10ed1a7)
