### PR TITLE
Support dark mode in notes and tags tables

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -66,6 +66,21 @@ time[title] {
   color: $blue;
 }
 
+/* Bootstrap contextual table classes overrides in dark mode */
+
+@include color-mode(dark) {
+  .table-primary {
+    --bs-table-bg: rgb(var(--bs-primary-rgb), .25);
+  }
+  .table-secondary {
+    --bs-table-bg: rgb(var(--bs-secondary-rgb), .25);
+  }
+  .table-primary, .table-secondary {
+    --bs-table-color: initial;
+    border-color: inherit;
+  }
+}
+
 /* Rules for the header */
 
 #menu-icon {

--- a/app/views/browse/_tag.html.erb
+++ b/app/views/browse/_tag.html.erb
@@ -1,4 +1,4 @@
 <tr>
-  <th class='py-1 border-secondary-subtle table-light fw-normal' dir='auto'><%= format_key(tag[0]) %></th>
+  <th class='py-1 border-secondary-subtle table-secondary fw-normal' dir='auto'><%= format_key(tag[0]) %></th>
   <td class='py-1 border-secondary-subtle border-start' dir='auto'><%= format_value(tag[0], tag[1]) %></td>
 </tr>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -3,7 +3,7 @@
   <p><%= t ".subheading_html",
            :user => link_to(@user.display_name, @user),
            :submitted => tag.span(t(".subheading_submitted"), :class => "px-2 py-1 bg-primary bg-opacity-25"),
-           :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-white") %></p>
+           :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-body") %></p>
 <% end %>
 
 <% if @notes.empty? %>


### PR DESCRIPTION
Previous attempts:
- #4669
- #4672
- #4693
- #4695

Assumptions:
- We're committed to style tables with `table-*` classes as if Bootstrap supports dark mode.
- Because Bootstrap actually doesn't support dark mode with `table-*` we want some isolated fix that's going to be removed once the support is there.  This fix is in the changes to `common.scss`.
- We don't want classes like `table-light` because we don't want table cells to stay light in dark mode. But this class was used in tags table for tag keys, so it has to be replaced with some other `table-*` class. It's replaced here with `table-secondary` although this makes tag key cells darker in light mode.

---

Tags table in light mode before the changes:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/0b2948db-acc0-4865-ad4c-cbe2fcd43aea)

Tags table in light mode after the changes:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/f7c3c843-d7a3-46bb-96f9-318eb7d94e7c)

Tags table in dark mode after the changes:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/75410ea2-08e1-47c3-913f-1e0a4a4a592f)

---

Notes table doesn't change in light mode.
Notes table in dark mode after the changes:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/8c643b6b-a017-44b8-9ecd-28c21e96bcb2)
