### PR TITLE
Add white shadow to browse icons

### DIFF
--- a/app/assets/stylesheets/browse.scss
+++ b/app/assets/stylesheets/browse.scss
@@ -8,6 +8,7 @@
     display: inline-block;
     width: 25px;
     margin-left: -25px;
+    filter: drop-shadow(0 0 2px white);
   }
 
   .node, .way, .relation {


### PR DESCRIPTION
It's difficult to see some of the browse icons in dark mode. There are various ways to fix it. The simplest one I came up with is to add white drop shadows.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/f3ad8c50-d293-43a4-9be5-db7ccaa1acab)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7baab579-552e-4d95-97c2-142efa5bbd00)

Some icons look worse with it, for example "bar", but "place of worship" improves.