### PR TITLE
Adapt messages table to dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -810,14 +810,6 @@ tr.turn {
   }
 }
 
-/* Rules for messages pages */
-
-.messages {
-  .inbox-row-unread td {
-    background: #CBEEA7;
-  }
-}
-
 /* Rules for user images */
 
 img.user_image {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -75,7 +75,10 @@ time[title] {
   .table-secondary {
     --bs-table-bg: rgb(var(--bs-secondary-rgb), .25);
   }
-  .table-primary, .table-secondary {
+  .table-success {
+    --bs-table-bg: rgb(var(--bs-success-rgb), .25);
+  }
+  .table-primary, .table-secondary, .table-success {
     --bs-table-color: initial;
     border-color: inherit;
   }

--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -19,4 +19,6 @@ $link-hover-color: #24d;
 $link-decoration: none;
 $link-hover-decoration: underline;
 
+$table-border-factor: .1;
+
 $enable-negative-margins: true;

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -1,4 +1,4 @@
-<tr id="inbox-<%= message.id %>" class="message-summary inbox-row<%= "-unread" unless message.message_read? %>">
+<%= tag.tr(:id => "inbox-#{message.id}", :class => { "message-summary" => true, "table-success" => !message.message_read? }) do %>
   <td><%= link_to message.sender.display_name, user_path(message.sender) %></td>
   <td><%= link_to message.title, message_path(message) %></td>
   <td class="text-nowrap"><%= l message.sent_on, :format => :friendly %></td>
@@ -12,4 +12,4 @@
       <% end %>
     </div>
   </td>
-</tr>
+<% end %>

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -1,4 +1,4 @@
-<tr id="outbox-<%= message.id %>" class="message-summary inbox-row">
+<%= tag.tr(:id => "outbox-#{message.id}", :class => { "message-summary" => true }) do %>
   <td><%= link_to message.recipient.display_name, user_path(message.recipient) %></td>
   <td><%= link_to message.title, message_path(message) %></td>
   <td class="text-nowrap"><%= l message.sent_on, :format => :friendly %></td>
@@ -7,4 +7,4 @@
       <%= button_to t(".destroy_button"), message_path(message, :referer => request.fullpath), :method => :delete, :class => "btn btn-sm btn-danger", :form => { :data => { :turbo => true }, :class => "destroy-message" } %>
     </div>
   </td>
-</tr>
+<% end %>

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -339,8 +339,8 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     get inbox_messages_path
     assert_response :success
     assert_template "inbox"
-    assert_select ".content-inner > table", :count => 1 do
-      assert_select "tr", :count => 2
+    assert_select ".content-inner > table.messages-table > tbody", :count => 1 do
+      assert_select "tr", :count => 1
       assert_select "tr#inbox-#{read_message.id}.inbox-row", :count => 1 do
         assert_select "a[href='#{user_path read_message.sender}']", :text => read_message.sender.display_name
         assert_select "a[href='#{message_path read_message}']", :text => read_message.title
@@ -365,8 +365,8 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     get outbox_messages_path
     assert_response :success
     assert_template "outbox"
-    assert_select ".content-inner > table", :count => 1 do
-      assert_select "tr", :count => 2
+    assert_select ".content-inner > table.messages-table > tbody", :count => 1 do
+      assert_select "tr", :count => 1
       assert_select "tr.inbox-row", :count => 1 do
         assert_select "a[href='#{user_path message.recipient}']", :text => message.recipient.display_name
         assert_select "a[href='#{message_path message}']", :text => message.title

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -341,7 +341,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_template "inbox"
     assert_select ".content-inner > table.messages-table > tbody", :count => 1 do
       assert_select "tr", :count => 1
-      assert_select "tr#inbox-#{read_message.id}.inbox-row", :count => 1 do
+      assert_select "tr#inbox-#{read_message.id}", :count => 1 do
         assert_select "a[href='#{user_path read_message.sender}']", :text => read_message.sender.display_name
         assert_select "a[href='#{message_path read_message}']", :text => read_message.title
       end
@@ -367,7 +367,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_template "outbox"
     assert_select ".content-inner > table.messages-table > tbody", :count => 1 do
       assert_select "tr", :count => 1
-      assert_select "tr.inbox-row", :count => 1 do
+      assert_select "tr#outbox-#{message.id}", :count => 1 do
         assert_select "a[href='#{user_path message.recipient}']", :text => message.recipient.display_name
         assert_select "a[href='#{message_path message}']", :text => message.title
       end


### PR DESCRIPTION
- I remove the custom *unread message* background and replace it with `table-success`. The custom background was applied directly to table cells which we presumably don't want. This changes the green color used in the table.
- I extend dark mode overrides to cover `table-success`.
- I remove the `inbox-row` class. It was also used in the outbox.

Light mode before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d5a83e6b-a985-471f-9c64-0ca66cbf4edc)

Light mode after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6a8e5840-2a05-4118-aab9-3bbf8b3d2149)

Dark mode after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/74200ed6-ca10-4992-98a0-f3b5d7cddf2a)
