### PR TITLE
Use "emphasis" link color in changeset lists instead of dark text

### DIFF
--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -12,7 +12,7 @@
 
 <%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item" do %>
   <p class="fst-italic">
-    <a class="changeset_id text-dark stretched-link" href="<%= changeset_path(changeset) %>">
+    <a class="changeset_id link-body-emphasis stretched-link" href="<%= changeset_path(changeset) %>">
       <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>
     </a>
   </p>
@@ -20,7 +20,7 @@
     <div class="col">
       <%= changeset_details(changeset) %>
       &middot;
-      <a class="changeset_id text-dark" href="<%= changeset_path(changeset) %>">
+      <a class="changeset_id link-body-emphasis" href="<%= changeset_path(changeset) %>">
         #<%= changeset.id %>
       </a>
     </div>


### PR DESCRIPTION
Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b97a3019-2d75-44f7-b8a8-6cd73425f685)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/91020792-bf43-4714-8b12-4c7eb7096987)
