### PR TITLE
Use Bootstrap hoverable rows in directions tables

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -268,7 +268,7 @@ OSM.Directions = function (map) {
           I18n.t("javascripts.directions.descend") + ": " + formatHeight(route.descend) + ".");
       }
 
-      var turnByTurnTable = $("<table class='table table-sm mb-3'>")
+      var turnByTurnTable = $("<table class='table table-hover table-sm mb-3'>")
         .append($("<tbody>"));
       var directionsCloseButton = $("<button type='button' class='btn-close'>")
         .attr("aria-label", I18n.t("javascripts.close"));

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -570,9 +570,6 @@ td.distance {
 tr.turn {
     cursor: pointer;
 }
-tr.turn:hover {
-    background: $list-highlight;
-}
 
 .routing_marker { width: 15px; cursor: move; }
 


### PR DESCRIPTION
There was a hover effect on rows in directions tables. It got broken probably when Bootstrap started setting background directly on table cells instead of table rows.

Here I'm using their standard hoverable rows. The color is different. We used to have a yellow highlight, but that one would have to be adapted to dark mode while the standard highlight works fine.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c3420d39-f833-4275-b34b-af2b89b1a63a)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/002b4b72-08ea-423f-ab59-6c5f82a570a3)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/130abf53-232d-4f64-a99c-b991ea1ad92a)
