### PR TITLE
Use Bootstrap .icon-link in shared pagination

### DIFF
--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,5 +1,5 @@
 <nav>
-  <% link_class = "page-link d-flex align-items-center gap-2 text-center" %>
+  <% link_class = "page-link icon-link text-center" %>
   <ul class="pagination">
     <% newer_link_content = capture do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>


### PR DESCRIPTION
There is a [Bootstrap class](https://getbootstrap.com/docs/5.3/helpers/icon-link/) for displaying icons next to links. Shared pagination has "<"/">" icons which could be attached using this class. But initially I didn't use it because it's named a bit deceptively.

When we're on the first page, there's no link to the previous page yet we still want to attach the icon to the text in the disabled page item. Will `.icon-link` work in this case, without a link? Yes it will, Bootstrap [doesn't check](https://github.com/twbs/bootstrap/blob/ad0cc68b7e226d9e1c1feb39ca68c0404c304365/scss/helpers/_icon-link.scss#L1) if `.icon-link` is used on a link or on anything else.