### PR TITLE
Move next page button of shared pagination to the right side

### DIFF
--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -20,11 +20,11 @@
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
     <% end %>
     <% if older_id -%>
-      <li class="page-item d-flex">
+      <li class="page-item d-flex ms-auto">
         <%= link_to older_link_content, @params.merge(:before => older_id, :after => nil), :class => link_class %>
       </li>
     <% else -%>
-      <li class="page-item d-flex disabled">
+      <li class="page-item d-flex ms-auto disabled">
         <%= tag.span older_link_content, :class => link_class %>
       </li>
     <% end -%>


### PR DESCRIPTION
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/a16985d1-e73d-4e5e-827f-bc727600aa9f)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/96c9ea10-6c59-4fbb-8f08-9f46ae37924a)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/51200ca5-445f-4a37-80a0-ab97af39dfc6)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/187772cc-cb82-4183-b4a7-591533707ee5)
