### PR TITLE
Reduce test run time portion of build process (8:31 reduced to 3:51)

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,6 +11,9 @@ Rails.application.configure do
   # While tests run files are not watched, reloading is not necessary.
   config.enable_reloading = false
 
+  # disable logging in tests, for speed increases. Set to :info to bring back logging
+  config.log_level = :warn
+
   # Eager loading loads your entire application. When running a single test locally,
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
     sequence(:display_name) { |n| "User #{n}" }
-    pass_crypt { PasswordHash.create("test").first }
+    pass_crypt { "$argon2id$v=19$m=65536,t=3,p=4$M+oP6KQOdFLDeiYa/gbzAg$pULNwXgKt2sEmTxMXxt298skEqc8MjnPwGsk075jLrk" }
 
     # These attributes are not the defaults, but in most tests we want
     # a 'normal' user who can log in without being redirected etc.

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,8 +1,10 @@
+pass_crypt = PasswordHash.create("test").first 
+
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
     sequence(:display_name) { |n| "User #{n}" }
-    pass_crypt { "$argon2id$v=19$m=65536,t=3,p=4$M+oP6KQOdFLDeiYa/gbzAg$pULNwXgKt2sEmTxMXxt298skEqc8MjnPwGsk075jLrk" }
+    pass_crypt { pass_crypt }
 
     # These attributes are not the defaults, but in most tests we want
     # a 'normal' user who can log in without being redirected etc.


### PR DESCRIPTION
update: This is now ready to merge!

Doing a quick audit of the test harness, to see where time is being spent, and to try side-stepping some of it. 

I'm doing lots of this work locally, but defer to using Github Actions timing data as the gold standard for if I'm successful or not. 

[I have some live, detailed, time-stamped stream-of-consciousness notes here](https://gist.github.com/josh-works/552c7db716372431d5b181f19ee36804), might be helpful to future me or others.

I am primarily investigating 'just' the tests, rather than tweaking the build pipeline at all. Faster/easier tests are so low-risk, high-reward. 

Here's the test suite on `main`, right now, as I open this PR:

![2024-04-16 at 10 24 AM](https://github.com/openstreetmap/openstreetmap-website/assets/5198260/618f204c-bd97-44d5-a569-21e2bac96ad7)

here's the detailed results on tests as being run on another PR: https://github.com/openstreetmap/openstreetmap-website/actions/runs/8708315212/job/23885377955?pr=4706

You can drill into the details, and see the tests take times like:

- 7m 0s
- 8m 0s
- 7m 26s
- 8m 13s
- 8m 7s
- 8m 31s

## the finished results

the current PR, with logging turned off, stubbing out the password hash process in the user factory returns, in the same order, much improved results:

- 3:50 (improvement of 4:10, 58% faster)
- 3:42 (improvement of 4:20 , 73% faster)
- 3:49 (improvement of 3:20 64% faster)
- 4:12  (improvement of 4m, 52% faster)
- 3:58 (improvement of 4:10, 56% faster)
- 3:55 (improvement of 4:30, 62% faster)

## change 1, turn off logging, minor

I expect 'turning off logging' to lead to a 6% decrease in test time. That would be each of these figures going down by about 30 seconds. (this is something [Vladimir Dementyev](https://github.com/palkan) said on a [codewithjason podcast episode](https://www.codewithjason.com/podcast/12948312-185-test-suite-performance-with-vladimir-dementyev/)


## change 2, eliminate 4000 calls to `PasswordHash.create`, meaningful

the next iteration of the PR, in addition to turning off logging, eliminates the `PasswordHash.create` call, on each the ~1000 users set up across each thread. 

There's 4 threads, usually, 1000 users each, or 4000 total users. Doesn't seem like calling a single method 4000 times would be super expensive, but it seems to account for *three or four total minutes of the 8 minute test run time.* (Makes sense, I suppose, as that function is intended to be arbitrarily expensive). I just hard-coded the value to a valid string.

I ended up with this fix after noticing a LOT of time being spent in the `user` factory. [detailed notes here](https://gist.github.com/josh-works/552c7db716372431d5b181f19ee36804#let_it_be-as-a-strategy)

Current test run time is: 4:52 total (sometimes lower), down from 9:30, _on my machine_. 

Questions? Any reasons to not merge this? 

I cannot see the exact credit 'cost' of each build, I'd love to see that figure, if it's available, to also know how this change lowers the 'credits per build'. 

