### PR TITLE
Add oldest/newest links to shared pagination

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,13 @@
+module PaginationHelper
+  def pagination_item(params, &block)
+    link_class = "page-link icon-link text-center"
+    page_link_content = capture(&block)
+    if params
+      page_link = link_to page_link_content, params, :class => link_class
+      tag.li page_link, :class => "page-item d-flex"
+    else
+      page_link = tag.span page_link_content, :class => link_class
+      tag.li page_link, :class => "page-item d-flex disabled"
+    end
+  end
+end

--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -27,8 +27,7 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "diary_entries.comments.newer_comments",
-             :older_key => "diary_entries.comments.older_comments",
+             :translation_scope => "diary_entries.comments_pagination",
              :newer_id => @newer_comments_id,
              :older_id => @older_comments_id %>
 <% end -%>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -41,8 +41,7 @@
   <%= render @entries %>
 
   <%= render "shared/pagination",
-             :newer_key => "diary_entries.index.newer_entries",
-             :older_key => "diary_entries.index.older_entries",
+             :translation_scope => "diary_entries.pagination",
              :newer_id => @newer_entries_id,
              :older_id => @older_entries_id %>
 <% end %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,5 +1,9 @@
 <nav>
   <ul class="pagination">
+    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
+      <%= t :newest, :scope => translation_scope %>
+    <% end %>
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
       <%= t :newer, :scope => translation_scope %>
@@ -7,6 +11,10 @@
     <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
       <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
+    <% end %>
+    <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0)) do %>
+      <%= t :oldest, :scope => translation_scope %>
+      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
     <% end %>
   </ul>
 </nav>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,20 +1,20 @@
 <nav>
   <ul class="pagination">
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
-      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
-      <%= t :newest, :scope => translation_scope %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
+      <span class="d-none d-md-block"><%= t :newest, :scope => translation_scope %></span>
     <% end %>
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
-      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
-      <%= t :newer, :scope => translation_scope %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0" %>
+      <span class="d-none d-sm-block"><%= t :newer, :scope => translation_scope %></span>
     <% end %>
     <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
-      <%= t :older, :scope => translation_scope %>
-      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
+      <span class="d-none d-sm-block"><%= t :older, :scope => translation_scope %></span>
+      <%= next_page_svg_tag :class => "flex-shrink-0" %>
     <% end %>
     <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0)) do %>
-      <%= t :oldest, :scope => translation_scope %>
-      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
+      <span class="d-none d-md-block"><%= t :oldest, :scope => translation_scope %></span>
+      <%= next_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
     <% end %>
   </ul>
 </nav>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,32 +1,12 @@
 <nav>
-  <% link_class = "page-link icon-link text-center" %>
   <ul class="pagination">
-    <% newer_link_content = capture do %>
+    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
       <%= t :newer, :scope => translation_scope %>
     <% end %>
-    <% if newer_id -%>
-      <li class="page-item d-flex">
-        <%= link_to newer_link_content, @params.merge(:before => nil, :after => newer_id), :class => link_class %>
-      </li>
-    <% else -%>
-      <li class="page-item d-flex disabled">
-        <%= tag.span newer_link_content, :class => link_class %>
-      </li>
-    <% end -%>
-
-    <% older_link_content = capture do %>
+    <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
       <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
     <% end %>
-    <% if older_id -%>
-      <li class="page-item d-flex">
-        <%= link_to older_link_content, @params.merge(:before => older_id, :after => nil), :class => link_class %>
-      </li>
-    <% else -%>
-      <li class="page-item d-flex disabled">
-        <%= tag.span older_link_content, :class => link_class %>
-      </li>
-    <% end -%>
   </ul>
 </nav>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -3,7 +3,7 @@
   <ul class="pagination">
     <% newer_link_content = capture do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
-      <%= t(newer_key) %>
+      <%= t :newer, :scope => translation_scope %>
     <% end %>
     <% if newer_id -%>
       <li class="page-item d-flex">
@@ -16,7 +16,7 @@
     <% end -%>
 
     <% older_link_content = capture do %>
-      <%= t(older_key) %>
+      <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
     <% end %>
     <% if older_id -%>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -70,8 +70,7 @@
 
 <% if @traces.size > 0 %>
   <%= render "shared/pagination",
-             :newer_key => "traces.trace_paging_nav.newer",
-             :older_key => "traces.trace_paging_nav.older",
+             :translation_scope => "traces.pagination",
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 
@@ -82,8 +81,7 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "traces.trace_paging_nav.newer",
-             :older_key => "traces.trace_paging_nav.older",
+             :translation_scope => "traces.pagination",
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 <% else %>

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -21,7 +21,6 @@
 </table>
 
 <%= render "shared/pagination",
-           :newer_key => "user_blocks.blocks.newer",
-           :older_key => "user_blocks.blocks.older",
+           :translation_scope => "user_blocks.pagination",
            :newer_id => @newer_user_blocks_id,
            :older_id => @older_user_blocks_id %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,8 +13,7 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :newer_key => "users.index.newer",
-                   :older_key => "users.index.older",
+                   :translation_scope => "users.pagination",
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>
@@ -42,8 +41,7 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :newer_key => "users.index.newer",
-                   :older_key => "users.index.older",
+                   :translation_scope => "users.pagination",
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -535,8 +535,9 @@ en:
       my_diary: My Diary
       no_entries: No diary entries
       recent_entries: "Recent diary entries"
-      older_entries: Older Entries
-      newer_entries: Newer Entries
+    pagination:
+      older: Older Entries
+      newer: Newer Entries
     edit:
       title: Edit Diary Entry
       marker_text: Diary entry location
@@ -594,8 +595,9 @@ en:
       post: Post
       when: When
       comment: Comment
-      newer_comments: "Newer Comments"
-      older_comments: "Older Comments"
+    comments_pagination:
+      older: "Older Comments"
+      newer: "Newer Comments"
     subscribe:
       heading: Subscribe to the following diary entry discussion?
       button: Subscribe to discussion
@@ -2533,7 +2535,7 @@ en:
       trace_not_found: "Trace not found!"
       visibility: "Visibility:"
       confirm_delete: "Delete this trace?"
-    trace_paging_nav:
+    pagination:
       older: "Older Traces"
       newer: "Newer Traces"
     trace:
@@ -2840,8 +2842,6 @@ en:
     index:
       title: Users
       heading: Users
-      older: "Older Users"
-      newer: "Newer Users"
       found_users:
         one: "%{count} user found"
         other: "%{count} users found"
@@ -2850,6 +2850,9 @@ en:
       confirm: Confirm Selected Users
       hide: Hide Selected Users
       empty: No matching users found
+    pagination:
+      older: "Older Users"
+      newer: "Newer Users"
     suspended:
       title: Account Suspended
       heading: Account Suspended
@@ -2991,6 +2994,7 @@ en:
       reason: "Reason for block"
       status: "Status"
       revoker_name: "Revoked by"
+    pagination:
       older: "Older Blocks"
       newer: "Newer Blocks"
     navigation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,6 +538,8 @@ en:
     pagination:
       older: Older Entries
       newer: Newer Entries
+      oldest: Oldest Entries
+      newest: Newest Entries
     edit:
       title: Edit Diary Entry
       marker_text: Diary entry location
@@ -598,6 +600,8 @@ en:
     comments_pagination:
       older: "Older Comments"
       newer: "Newer Comments"
+      oldest: "Oldest Comments"
+      newest: "Newest Comments"
     subscribe:
       heading: Subscribe to the following diary entry discussion?
       button: Subscribe to discussion
@@ -2538,6 +2542,8 @@ en:
     pagination:
       older: "Older Traces"
       newer: "Newer Traces"
+      oldest: "Oldest Traces"
+      newest: "Newest Traces"
     trace:
       pending: "PENDING"
       count_points:
@@ -2853,6 +2859,8 @@ en:
     pagination:
       older: "Older Users"
       newer: "Newer Users"
+      oldest: "Oldest Users"
+      newest: "Newest Users"
     suspended:
       title: Account Suspended
       heading: Account Suspended
@@ -2997,6 +3005,8 @@ en:
     pagination:
       older: "Older Blocks"
       newer: "Newer Blocks"
+      oldest: "Oldest Blocks"
+      newest: "Newest Blocks"
     navigation:
       all_blocks: "All Blocks"
       blocks_on_me: "Blocks on Me"

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -553,42 +553,57 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
   def test_index_paged
     # Create several pages worth of diary entries
     create_list(:diary_entry, 50)
+    next_path = diary_entries_path
 
     # Try and get the index
-    get diary_entries_path
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 20
-    assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Entries", :count => 1
+    check_no_page_link "Newer Entries"
+    next_path = check_page_link "Older Entries"
 
     # Try and get the second page
-    get css_select("li.page-item .page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 20
-    assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
+    check_page_link "Newer Entries"
+    next_path = check_page_link "Older Entries"
 
     # Try and get the third page
-    get css_select("li.page-item .page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 10
-    assert_select "li.page-item.disabled span.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
+    next_path = check_page_link "Newer Entries"
+    check_no_page_link "Older Entries"
 
     # Go back to the second page
-    get css_select("li.page-item .page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 20
-    assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
+    next_path = check_page_link "Newer Entries"
+    check_page_link "Older Entries"
 
     # Go back to the first page
-    get css_select("li.page-item .page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 20
-    assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Entries", :count => 1
+    check_no_page_link "Newer Entries"
+    check_page_link "Older Entries"
   end
+
+  private
+
+  def check_no_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/, :count => 0 }, "unexpected #{name} page link"
+  end
+
+  def check_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/ }, "missing #{name} page link" do |buttons|
+      return buttons.first.attributes["href"].value
+    end
+  end
+
+  public
 
   def test_rss
     create(:language, :code => "de")

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -222,51 +222,52 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
   def test_index_paged
     # Create several pages worth of traces
     create_list(:trace, 50)
+    next_path = traces_path
 
     # Try and get the index
-    get traces_path
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the second page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the third page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 10
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item.disabled span.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_no_page_link "Older Traces"
 
     # Go back to the second page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_page_link "Older Traces"
 
     # Go back to the first page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    check_page_link "Older Traces"
   end
 
   # Check a multi-page index of tagged traces
@@ -275,52 +276,67 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     create_list(:trace, 100) do |trace, index|
       create(:tracetag, :trace => trace, :tag => "London") if index.even?
     end
+    next_path = traces_path :tag => "London"
 
     # Try and get the index
-    get traces_path(:tag => "London")
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the second page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the third page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 10
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item.disabled span.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_no_page_link "Older Traces"
 
     # Go back to the second page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_page_link "Older Traces"
 
     # Go back to the first page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    check_page_link "Older Traces"
   end
+
+  private
+
+  def check_no_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/, :count => 0 }, "unexpected #{name} page link"
+  end
+
+  def check_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/ }, "missing #{name} page link" do |buttons|
+      return buttons.first.attributes["href"].value
+    end
+  end
+
+  public
 
   # Check the RSS feed
   def test_rss


### PR DESCRIPTION
#4707 was intended for this PR and possibly for putting something between </> buttons. We already do it on changeset history pages.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3186013c-afb9-49bb-973f-23c901d3811d)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/2955d782-3a95-4397-bf1a-9a34e4114716)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/00f7cc11-6ace-4e87-aadc-451caeaddb36)
