### PR TITLE
Dim map tiles in dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -474,6 +474,13 @@ body.small-nav {
   border-radius: 4px !important;
 }
 
+@include color-mode(dark) {
+  .leaflet-tile-container,
+  .mapkey-table-entry td:first-child > * {
+    filter: brightness(.8);
+  }
+}
+
 /* Rules for attribution text under the main map shown on printouts */
 
 .donate-attr { color: darken($green, 10%) !important; }

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -69,7 +69,7 @@
   <div id="map-ui" class="bg-body z-2">
   </div>
 
-  <div id="map" tabindex="2" class="z-0">
+  <div id="map" tabindex="2" class="bg-body-secondary z-0">
   </div>
 
   <div id="attribution" class="d-none">


### PR DESCRIPTION
Map tiles are going to be too bright in dark mode. The question is then what to do with them. There are two options: dim them or invert them, and the existing dark themes like [this one](https://userstyles.world/style/15596/openstreetmap-dark-theme) may offer a choice.

Here I'm making a conservative choice of 80% dimming.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/de1a5883-bcb3-462a-95f2-ce560ea6078f)
