### PR TITLE
Force word wrap in tag table

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -616,6 +616,8 @@ tr.turn {
   .browse-tag-list {
     table-layout: fixed;
     white-space: pre-wrap;
+    word-wrap: break-word;
+    word-break: break-word;
 
     tr:last-child th, tr:last-child td {
       border-bottom: 0;

--- a/app/views/browse/_tag_details.html.erb
+++ b/app/views/browse/_tag_details.html.erb
@@ -1,7 +1,7 @@
 <% unless tag_details.empty? %>
   <h4><%= t ".tags" %></h4>
   <div class='mb-3 border border-secondary-subtle rounded overflow-hidden'>
-    <table class='mb-0 browse-tag-list table align-middle text-break'>
+    <table class='mb-0 browse-tag-list table align-middle'>
       <%= render :partial => "browse/tag", :collection => tag_details.sort %>
     </table>
   </div>


### PR DESCRIPTION
Fixes #4709, kind of.

Aside from differences in browser behavior, there's also a decision by the Bootstrap developers. [They disable `.text-break` in rtl mode](https://getbootstrap.com/docs/5.3/utilities/text/#word-break). They say that rtl is most likely Arabic and word breaks in Arabic are wrong therefore disable word breaks for any rtl. But in our case any long words in tags table are likely not Arabic but rather urls or something similar.

Here I'm putting the css properties that are normally in Bootstrap's `.text-break` to our custom css. This will restore word breaks in rtl tag tables, occasionally with "wrong" Arabic word breaks.

Screenshots in Chrome (Firefox does word wraps anyway for whatever reason):

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/512648a8-22ef-4ce2-9fac-621c38f99ffe)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d4752d94-3e35-40db-94bd-c20e39044638)
