### PR TITLE
Use Bootstrap actionable items in changeset lists

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -584,8 +584,9 @@ tr.turn {
 
 #sidebar .changesets {
   li {
-    &.selected { background: $list-highlight; }
-    /* color is derived from changeset bbox fillColor in history.js */
+    &.selected {
+      @extend :hover;
+    }
 
     a.stretched-link > span, a:not(.stretched-link), [title] {
       position: relative;

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -10,7 +10,7 @@
      }
    end %>
 
-<%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item" do %>
+<%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item list-group-item-action" do %>
   <p class="fst-italic">
     <a class="changeset_id link-body-emphasis stretched-link" href="<%= changeset_path(changeset) %>">
       <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>


### PR DESCRIPTION
Like #4711 but for changeset history lists.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c4059f68-91a9-4bfc-85ec-ecc9f75e3699)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/18d1ce0d-d813-45f5-9f4f-ccadffb2f812)
