### PR TITLE
Adapt Leaflet popups to dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -473,8 +473,17 @@ body.small-nav {
   border-top: 0px !important;
 }
 
+.leaflet-popup-content-wrapper,
+.leaflet-popup-tip {
+  @extend .bg-body, .text-body;
+}
+
 .leaflet-popup-content-wrapper {
-  border-radius: 4px !important;
+  @extend .rounded-1;
+
+  a {
+    color: var(--bs-link-color) !important;
+  }
 }
 
 /* Rules for attribution text under the main map shown on printouts */


### PR DESCRIPTION
Before in dark mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/ae6ed35b-c6b2-4acd-ae6d-119e3c821882)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/68fde236-afaf-43c3-9450-9d6c1edd6895)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/536c541f-7d37-4876-afe5-d6420c88414c)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/622756fb-e319-40b7-b14d-1ba196edfe07)
