### PR TITLE
Use bindPopup options to set min width of user popup

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -121,7 +121,7 @@ $(document).ready(function () {
         var user = $(this).data("user");
         if (user.lon && user.lat) {
           L.marker([user.lat, user.lon], { icon: OSM.getUserIcon(user.icon) }).addTo(map)
-            .bindPopup(user.description);
+            .bindPopup(user.description, { minWidth: 200 });
         }
       });
     }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -769,7 +769,6 @@ tr.turn {
 /* Rules for user popups on maps */
 
 .user_popup {
-  min-width: 200px;
   p {
     padding: 0 0 5px 0;
     margin: 0 0 0 60px;


### PR DESCRIPTION
Leaflet may get confused if you use css `min-width` property on popup contents.

Examples in Chromium where scrollbars always take width.

Here I made the contents longer and limited the popup height while keeping css `min-width`:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3aea1c01-fb3a-4124-b646-4ab580d27680)

This is with `minWidth` `.bindPopup` option, no horizontal scrollbars appear:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/06872411-228b-418d-9414-c51cc61c0049)
