### PR TITLE
Remove custom small font size

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -15,10 +15,6 @@ p > img {
   max-width: 100%;
 }
 
-small, aside {
-  font-size: 12px;
-}
-
 time[title] {
   text-decoration: underline dotted;
 }


### PR DESCRIPTION
For `<small>` Bootstrap sets the font size to almost the same, 12.25px vs our custom 12px:
https://github.com/twbs/bootstrap/blob/d7b22b77dbe7d1bd8d5cb03cec5d89b480500afb/scss/_reboot.scss#L211

Looks like we don't use `<aside>` anywhere.