### PR TITLE
Add oldest/newest links to shared pagination - with gap between "newer" and "older"

### DIFF
--- a/app/controllers/concerns/pagination_methods.rb
+++ b/app/controllers/concerns/pagination_methods.rb
@@ -6,8 +6,8 @@ module PaginationMethods
   ##
   # limit selected items to one page, get ids of first item before/after the page
   def get_page_items(items, includes: [], limit: 20)
-    param! :before, Integer, :min => 1
-    param! :after, Integer, :min => 1
+    param! :before, Integer, :min => 0
+    param! :after, Integer, :min => 0
 
     id_column = "#{items.table_name}.id"
     page_items = if params[:before]

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,13 @@
+module PaginationHelper
+  def pagination_item(params, &block)
+    link_class = "page-link icon-link text-center"
+    page_link_content = capture(&block)
+    if params
+      page_link = link_to page_link_content, params, :class => link_class
+      tag.li page_link, :class => "page-item d-flex"
+    else
+      page_link = tag.span page_link_content, :class => link_class
+      tag.li page_link, :class => "page-item d-flex disabled"
+    end
+  end
+end

--- a/app/views/diary_comments/index.html.erb
+++ b/app/views/diary_comments/index.html.erb
@@ -27,8 +27,7 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "diary_comments.index.newer_comments",
-             :older_key => "diary_comments.index.older_comments",
+             :translation_scope => "diary_comments.pagination",
              :newer_id => @newer_comments_id,
              :older_id => @older_comments_id %>
 <% end -%>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -41,8 +41,7 @@
   <%= render @entries %>
 
   <%= render "shared/pagination",
-             :newer_key => "diary_entries.index.newer_entries",
-             :older_key => "diary_entries.index.older_entries",
+             :translation_scope => "diary_entries.pagination",
              :newer_id => @newer_entries_id,
              :older_id => @older_entries_id %>
 <% end %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,5 +1,9 @@
 <nav>
   <ul class="pagination">
+    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
+      <%= t :newest, :scope => translation_scope %>
+    <% end %>
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
       <%= t :newer, :scope => translation_scope %>
@@ -7,6 +11,10 @@
     <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
       <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
+    <% end %>
+    <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0)) do %>
+      <%= t :oldest, :scope => translation_scope %>
+      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
     <% end %>
   </ul>
 </nav>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,20 +1,20 @@
 <nav>
   <ul class="pagination">
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
-      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
-      <%= t :newest, :scope => translation_scope %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
+      <span class="d-none d-md-block"><%= t :newest, :scope => translation_scope %></span>
     <% end %>
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
-      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
-      <%= t :newer, :scope => translation_scope %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0" %>
+      <span class="d-none d-sm-block"><%= t :newer, :scope => translation_scope %></span>
     <% end %>
     <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
-      <%= t :older, :scope => translation_scope %>
-      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
+      <span class="d-none d-sm-block"><%= t :older, :scope => translation_scope %></span>
+      <%= next_page_svg_tag :class => "flex-shrink-0" %>
     <% end %>
     <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0)) do %>
-      <%= t :oldest, :scope => translation_scope %>
-      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
+      <span class="d-none d-md-block"><%= t :oldest, :scope => translation_scope %></span>
+      <%= next_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
     <% end %>
   </ul>
 </nav>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,32 +1,12 @@
 <nav>
-  <% link_class = "page-link icon-link text-center" %>
   <ul class="pagination">
-    <% newer_link_content = capture do %>
+    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
       <%= t :newer, :scope => translation_scope %>
     <% end %>
-    <% if newer_id -%>
-      <li class="page-item d-flex">
-        <%= link_to newer_link_content, @params.merge(:before => nil, :after => newer_id), :class => link_class %>
-      </li>
-    <% else -%>
-      <li class="page-item d-flex disabled">
-        <%= tag.span newer_link_content, :class => link_class %>
-      </li>
-    <% end -%>
-
-    <% older_link_content = capture do %>
+    <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
       <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
     <% end %>
-    <% if older_id -%>
-      <li class="page-item d-flex">
-        <%= link_to older_link_content, @params.merge(:before => older_id, :after => nil), :class => link_class %>
-      </li>
-    <% else -%>
-      <li class="page-item d-flex disabled">
-        <%= tag.span older_link_content, :class => link_class %>
-      </li>
-    <% end -%>
   </ul>
 </nav>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -3,7 +3,7 @@
   <ul class="pagination">
     <% newer_link_content = capture do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
-      <%= t(newer_key) %>
+      <%= t :newer, :scope => translation_scope %>
     <% end %>
     <% if newer_id -%>
       <li class="page-item d-flex">
@@ -16,7 +16,7 @@
     <% end -%>
 
     <% older_link_content = capture do %>
-      <%= t(older_key) %>
+      <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
     <% end %>
     <% if older_id -%>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,4 +1,4 @@
-<nav>
+<nav class="d-flex justify-content-between gap-2">
   <ul class="pagination">
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
@@ -8,6 +8,8 @@
       <%= previous_page_svg_tag :class => "flex-shrink-0" %>
       <span class="d-none d-sm-block"><%= t :newer, :scope => translation_scope %></span>
     <% end %>
+  </ul>
+  <ul class="pagination">
     <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
       <span class="d-none d-sm-block"><%= t :older, :scope => translation_scope %></span>
       <%= next_page_svg_tag :class => "flex-shrink-0" %>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -70,8 +70,7 @@
 
 <% if @traces.size > 0 %>
   <%= render "shared/pagination",
-             :newer_key => "traces.trace_paging_nav.newer",
-             :older_key => "traces.trace_paging_nav.older",
+             :translation_scope => "traces.pagination",
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 
@@ -82,8 +81,7 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "traces.trace_paging_nav.newer",
-             :older_key => "traces.trace_paging_nav.older",
+             :translation_scope => "traces.pagination",
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 <% else %>

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -21,7 +21,6 @@
 </table>
 
 <%= render "shared/pagination",
-           :newer_key => "user_blocks.blocks.newer",
-           :older_key => "user_blocks.blocks.older",
+           :translation_scope => "user_blocks.pagination",
            :newer_id => @newer_user_blocks_id,
            :older_id => @older_user_blocks_id %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,8 +13,7 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :newer_key => "users.index.newer",
-                   :older_key => "users.index.older",
+                   :translation_scope => "users.pagination",
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>
@@ -42,8 +41,7 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :newer_key => "users.index.newer",
-                   :older_key => "users.index.older",
+                   :translation_scope => "users.pagination",
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -542,6 +542,8 @@ en:
     pagination:
       older: Older Entries
       newer: Newer Entries
+      oldest: Oldest Entries
+      newest: Newest Entries
     edit:
       title: Edit Diary Entry
       marker_text: Diary entry location
@@ -611,6 +613,8 @@ en:
     pagination:
       older: "Older Comments"
       newer: "Newer Comments"
+      oldest: "Oldest Comments"
+      newest: "Newest Comments"
   doorkeeper:
     errors:
       messages:
@@ -2519,6 +2523,8 @@ en:
     pagination:
       older: "Older Traces"
       newer: "Newer Traces"
+      oldest: "Oldest Traces"
+      newest: "Newest Traces"
     trace:
       pending: "PENDING"
       count_points:
@@ -2880,6 +2886,8 @@ en:
     pagination:
       older: "Older Users"
       newer: "Newer Users"
+      oldest: "Oldest Users"
+      newest: "Newest Users"
     suspended:
       title: Account Suspended
       heading: Account Suspended
@@ -3024,6 +3032,8 @@ en:
     pagination:
       older: "Older Blocks"
       newer: "Newer Blocks"
+      oldest: "Oldest Blocks"
+      newest: "Newest Blocks"
     navigation:
       all_blocks: "All Blocks"
       blocks_on_me: "Blocks on Me"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -539,8 +539,9 @@ en:
       my_diary: My Diary
       no_entries: No diary entries
       recent_entries: "Recent diary entries"
-      older_entries: Older Entries
-      newer_entries: Newer Entries
+    pagination:
+      older: Older Entries
+      newer: Newer Entries
     edit:
       title: Edit Diary Entry
       marker_text: Diary entry location
@@ -607,8 +608,9 @@ en:
       post: Post
       when: When
       comment: Comment
-      newer_comments: "Newer Comments"
-      older_comments: "Older Comments"
+    pagination:
+      older: "Older Comments"
+      newer: "Newer Comments"
   doorkeeper:
     errors:
       messages:
@@ -2514,7 +2516,7 @@ en:
       trace_not_found: "Trace not found!"
       visibility: "Visibility:"
       confirm_delete: "Delete this trace?"
-    trace_paging_nav:
+    pagination:
       older: "Older Traces"
       newer: "Newer Traces"
     trace:
@@ -2867,8 +2869,6 @@ en:
     index:
       title: Users
       heading: Users
-      older: "Older Users"
-      newer: "Newer Users"
       found_users:
         one: "%{count} user found"
         other: "%{count} users found"
@@ -2877,6 +2877,9 @@ en:
       confirm: Confirm Selected Users
       hide: Hide Selected Users
       empty: No matching users found
+    pagination:
+      older: "Older Users"
+      newer: "Newer Users"
     suspended:
       title: Account Suspended
       heading: Account Suspended
@@ -3018,6 +3021,7 @@ en:
       reason: "Reason for block"
       status: "Status"
       revoker_name: "Revoked by"
+    pagination:
       older: "Older Blocks"
       newer: "Newer Blocks"
     navigation:

--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -52,7 +52,7 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
   def test_index_invalid_paged
     user = create(:user)
 
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get diary_comments_path(:display_name => user.display_name, :before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -584,7 +584,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
 
   def test_index_invalid_paged
     # Try some invalid paged accesses
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get diary_entries_path(:before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -324,7 +324,7 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
 
   def test_index_invalid_paged
     # Try some invalid paged accesses
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get traces_path(:before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -222,51 +222,52 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
   def test_index_paged
     # Create several pages worth of traces
     create_list(:trace, 50)
+    next_path = traces_path
 
     # Try and get the index
-    get traces_path
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the second page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the third page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 10
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item.disabled span.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_no_page_link "Older Traces"
 
     # Go back to the second page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_page_link "Older Traces"
 
     # Go back to the first page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    check_page_link "Older Traces"
   end
 
   # Check a multi-page index of tagged traces
@@ -275,51 +276,52 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     create_list(:trace, 100) do |trace, index|
       create(:tracetag, :trace => trace, :tag => "London") if index.even?
     end
+    next_path = traces_path :tag => "London"
 
     # Try and get the index
-    get traces_path(:tag => "London")
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the second page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the third page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 10
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item.disabled span.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_no_page_link "Older Traces"
 
     # Go back to the second page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_page_link "Older Traces"
 
     # Go back to the first page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    check_page_link "Older Traces"
   end
 
   def test_index_invalid_paged
@@ -332,6 +334,20 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
       assert_redirected_to :controller => :errors, :action => :bad_request
     end
   end
+
+  private
+
+  def check_no_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/, :count => 0 }, "unexpected #{name} page link"
+  end
+
+  def check_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/ }, "missing #{name} page link" do |buttons|
+      return buttons.first.attributes["href"].value
+    end
+  end
+
+  public
 
   # Check the RSS feed
   def test_rss

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -118,7 +118,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   ##
   # test the index action with invalid pages
   def test_index_invalid_paged
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get user_blocks_path(:before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 
@@ -577,7 +577,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   def test_blocks_on_invalid_paged
     user = create(:user)
 
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get user_blocks_on_path(user, :before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 
@@ -659,7 +659,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   def test_blocks_by_invalid_paged
     user = create(:moderator_user)
 
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get user_blocks_by_path(user, :before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -561,7 +561,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_index_get_invalid_paginated
     session_for(create(:administrator_user))
 
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get users_path(:before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 


### PR DESCRIPTION
#4710 + #4707 + all borders rounded. With this rounding the buttons won't be able to collapse into one block, there will always be a gap between "newer" and "older".

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/bc682324-44f8-435d-ae4d-cdb3794ffc22)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/4cbd2796-5530-44b3-be36-6b82e6f83b44)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c297922b-26a2-4462-9d41-67f924984d30)
