### PR TITLE
Use Bootstrap classes for diary navigation icons

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -21,11 +21,6 @@ time[title] {
 
 #container { position: relative; }
 
-.small_icon {
-  vertical-align: middle;
-  margin-right: $lineheight * 0.25;
-}
-
 /* Rules for icons */
 
 .icon {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,11 +10,11 @@ module ApplicationHelper
   end
 
   def rss_link_to(args = {})
-    link_to(image_tag("RSS.png", :size => "16x16"), args, :class => "rsssmall")
+    link_to image_tag("RSS.png", :size => "16x16", :class => "align-text-bottom"), args
   end
 
   def atom_link_to(args = {})
-    link_to(image_tag("RSS.png", :size => "16x16"), args, :class => "rsssmall")
+    link_to image_tag("RSS.png", :size => "16x16", :class => "align-text-bottom"), args
   end
 
   def dir

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,11 +10,11 @@ module ApplicationHelper
   end
 
   def rss_link_to(args = {})
-    link_to(image_tag("RSS.png", :size => "16x16", :border => 0), args, :class => "rsssmall")
+    link_to(image_tag("RSS.png", :size => "16x16"), args, :class => "rsssmall")
   end
 
   def atom_link_to(args = {})
-    link_to(image_tag("RSS.png", :size => "16x16", :border => 0), args, :class => "rsssmall")
+    link_to(image_tag("RSS.png", :size => "16x16"), args, :class => "rsssmall")
   end
 
   def dir

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -25,7 +25,7 @@
           <% end %>
 
           <% if @user && @user == current_user || !@user && current_user %>
-            <li><%= link_to image_tag("new.png", :class => "small_icon") + t(".new"), new_diary_entry_path, :title => t(".new_title") %></li>
+            <li><%= link_to image_tag("new.png") + t(".new"), new_diary_entry_path, :class => "icon-link", :title => t(".new_title") %></li>
           <% end %>
         </ul>
       </nav>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -31,12 +31,12 @@ class ApplicationHelperTest < ActionView::TestCase
 
   def test_rss_link_to
     link = rss_link_to(:controller => :diary_entries, :action => :rss)
-    assert_dom_equal "<a class=\"rsssmall\" href=\"/diary/rss\"><img height=\"16\" src=\"/images/RSS.png\" width=\"16\" /></a>", link
+    assert_dom_equal "<a href=\"/diary/rss\"><img height=\"16\" src=\"/images/RSS.png\" width=\"16\" class=\"align-text-bottom\" /></a>", link
   end
 
   def test_atom_link_to
     link = atom_link_to(:controller => :changesets, :action => :feed)
-    assert_dom_equal "<a class=\"rsssmall\" href=\"/history/feed\"><img height=\"16\" src=\"/images/RSS.png\" width=\"16\" /></a>", link
+    assert_dom_equal "<a href=\"/history/feed\"><img height=\"16\" src=\"/images/RSS.png\" width=\"16\" class=\"align-text-bottom\" /></a>", link
   end
 
   def test_dir

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -31,12 +31,12 @@ class ApplicationHelperTest < ActionView::TestCase
 
   def test_rss_link_to
     link = rss_link_to(:controller => :diary_entries, :action => :rss)
-    assert_dom_equal "<a class=\"rsssmall\" href=\"/diary/rss\"><img border=\"0\" height=\"16\" src=\"/images/RSS.png\" width=\"16\" /></a>", link
+    assert_dom_equal "<a class=\"rsssmall\" href=\"/diary/rss\"><img height=\"16\" src=\"/images/RSS.png\" width=\"16\" /></a>", link
   end
 
   def test_atom_link_to
     link = atom_link_to(:controller => :changesets, :action => :feed)
-    assert_dom_equal "<a class=\"rsssmall\" href=\"/history/feed\"><img border=\"0\" height=\"16\" src=\"/images/RSS.png\" width=\"16\" /></a>", link
+    assert_dom_equal "<a class=\"rsssmall\" href=\"/history/feed\"><img height=\"16\" src=\"/images/RSS.png\" width=\"16\" /></a>", link
   end
 
   def test_dir


### PR DESCRIPTION
Removes custom classes `rsssmall` and `small_icon`.