### PR TITLE
Remove custom css for note icons on welcome and fixthemap pages

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -929,11 +929,6 @@ div.secondary-actions {
   .sprite.rules {
     /*rtl:ignore*/ background-position: -350px 0;
   }
-
-  .icon.note {
-    background-color: #333;
-    border-radius: 4px;
-  }
 }
 
 .site-about #content {

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -22,7 +22,7 @@
   <div class='col-sm'>
     <h5><%= t "site.welcome.add_a_note.title" %></h5>
     <p><%= t "site.welcome.add_a_note.para_1" %></p>
-    <p><%= t ".how_to_help.add_a_note.instructions_1_html", :note_icon => tag.a(:class => "icon note") %></p>
+    <p><%= t ".how_to_help.add_a_note.instructions_1_html", :note_icon => tag.a(:class => "icon note bg-dark rounded-1") %></p>
   </div>
 </div>
 

--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -73,5 +73,5 @@
   <h2><%= t ".add_a_note.title" %></h2>
   <p><%= t ".add_a_note.para_1" %></p>
   <p><%= t ".add_a_note.para_2_html", :map_link => link_to(t(".add_a_note.the_map"), root_path),
-                                      :note_icon => tag.span(:class => "icon note") %></p>
+                                      :note_icon => tag.span(:class => "icon note bg-dark rounded-1") %></p>
 </div>


### PR DESCRIPTION
The icons should look the same as before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c672275b-5fed-43e5-87e4-1aafce575f18)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/356430e5-1a8b-4db4-a7d4-2b2c10715055)
