### PR TITLE
Remove custom css applied to images inside paragraphs

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -10,11 +10,6 @@ body {
   font-size: $typeheight;
 }
 
-p > img {
-  width: auto;
-  max-width: 100%;
-}
-
 time[title] {
   text-decoration: underline dotted;
 }


### PR DESCRIPTION
- Many images are not inside `<p>`, this css doesn't apply to them.
- `width: auto` is a default width
- `max-width: 100%` shrinks images that are too wide to fit on the screen. Images inside rich text (diaries, comments) already have this set elsewhere.
- It affects image on the [copyright](https://www.openstreetmap.org/copyright) page, but that image is narrow enough. If there's any wide image that requires shrinking, [`.img-fluid`](https://getbootstrap.com/docs/5.3/content/images/#responsive-images) can be used instead.
  ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9c04130f-a133-4e5b-b5f1-d9456388a46a)

