### PR TITLE
Add oldest/newest links to shared pagination - with gaps around "newer" and "older" v2

### DIFF
--- a/app/controllers/concerns/pagination_methods.rb
+++ b/app/controllers/concerns/pagination_methods.rb
@@ -6,8 +6,8 @@ module PaginationMethods
   ##
   # limit selected items to one page, get ids of first item before/after the page
   def get_page_items(items, includes: [], limit: 20, cursor_column: :id)
-    param! :before, Integer, :min => 1
-    param! :after, Integer, :min => 1
+    param! :before, Integer, :min => 0
+    param! :after, Integer, :min => 0
 
     qualified_cursor_column = "#{items.table_name}.#{cursor_column}"
     page_items = if params[:before]

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,17 @@
+module PaginationHelper
+  def pagination_item(params, &)
+    link_class = "page-link icon-link text-center"
+    page_link_content = capture(&)
+    if params
+      page_link = link_to page_link_content,
+                          params,
+                          :class => link_class,
+                          :data => { "turbo" => true, "turbo-frame" => "pagination", "turbo-action" => "advance" }
+      tag.li page_link, :class => "page-item d-flex"
+    else
+      page_link = tag.span page_link_content,
+                           :class => link_class
+      tag.li page_link, :class => "page-item d-flex disabled"
+    end
+  end
+end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,11 +1,12 @@
 module PaginationHelper
-  def pagination_item(params, &)
+  def pagination_item(params, title, &)
     link_class = "page-link icon-link text-center"
     page_link_content = capture(&)
     if params
       page_link = link_to page_link_content,
                           params,
                           :class => link_class,
+                          :title => title,
                           :data => { "turbo" => true, "turbo-frame" => "pagination", "turbo-action" => "advance" }
       tag.li page_link, :class => "page-item d-flex"
     else

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -2,35 +2,15 @@
 
 <% translation_scope ||= "shared.pagination.#{controller.controller_name}" %>
 <nav>
-  <% link_class = "page-link icon-link text-center" %>
   <ul class="pagination">
-    <% newer_link_content = capture do %>
+    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
       <%= t :newer, :scope => translation_scope %>
     <% end %>
-    <% if newer_id -%>
-      <li class="page-item d-flex">
-        <%= link_to newer_link_content, @params.merge(:before => nil, :after => newer_id), :class => link_class, :data => { "turbo" => true, "turbo-frame" => "pagination", "turbo-action" => "advance" } %>
-      </li>
-    <% else -%>
-      <li class="page-item d-flex disabled">
-        <%= tag.span newer_link_content, :class => link_class %>
-      </li>
-    <% end -%>
-
-    <% older_link_content = capture do %>
+    <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
       <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
     <% end %>
-    <% if older_id -%>
-      <li class="page-item d-flex">
-        <%= link_to older_link_content, @params.merge(:before => older_id, :after => nil), :class => link_class, :data => { "turbo" => true, "turbo-frame" => "pagination", "turbo-action" => "advance" } %>
-      </li>
-    <% else -%>
-      <li class="page-item d-flex disabled">
-        <%= tag.span older_link_content, :class => link_class %>
-      </li>
-    <% end -%>
   </ul>
 </nav>
 

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -3,24 +3,26 @@
 <% translation_scope ||= "shared.pagination.#{controller.controller_name}" %>
 <nav class="d-flex justify-content-between gap-2">
   <ul class="pagination">
-    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
+    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil),
+                        t(:newest, :scope => translation_scope)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
-      <span class="d-none d-md-block"><%= t :newest, :scope => translation_scope %></span>
     <% end %>
   </ul>
   <ul class="pagination">
-    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
+    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id),
+                        t(:newer, :scope => translation_scope)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0" %>
       <span class="d-none d-sm-block"><%= t :newer, :scope => translation_scope %></span>
     <% end %>
-    <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
+    <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil),
+                        t(:older, :scope => translation_scope)) do %>
       <span class="d-none d-sm-block"><%= t :older, :scope => translation_scope %></span>
       <%= next_page_svg_tag :class => "flex-shrink-0" %>
     <% end %>
   </ul>
   <ul class="pagination">
-    <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0)) do %>
-      <span class="d-none d-md-block"><%= t :oldest, :scope => translation_scope %></span>
+    <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0),
+                        t(:oldest, :scope => translation_scope)) do %>
       <%= next_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
     <% end %>
   </ul>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,12 +1,14 @@
 <% if older_id || newer_id %>
 
 <% translation_scope ||= "shared.pagination.#{controller.controller_name}" %>
-<nav>
+<nav class="d-flex justify-content-between gap-2">
   <ul class="pagination">
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
       <span class="d-none d-md-block"><%= t :newest, :scope => translation_scope %></span>
     <% end %>
+  </ul>
+  <ul class="pagination">
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0" %>
       <span class="d-none d-sm-block"><%= t :newer, :scope => translation_scope %></span>
@@ -15,6 +17,8 @@
       <span class="d-none d-sm-block"><%= t :older, :scope => translation_scope %></span>
       <%= next_page_svg_tag :class => "flex-shrink-0" %>
     <% end %>
+  </ul>
+  <ul class="pagination">
     <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0)) do %>
       <span class="d-none d-md-block"><%= t :oldest, :scope => translation_scope %></span>
       <%= next_page_svg_tag :class => "flex-shrink-0", :count => 2 %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -4,20 +4,20 @@
 <nav>
   <ul class="pagination">
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
-      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
-      <%= t :newest, :scope => translation_scope %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
+      <span class="d-none d-md-block"><%= t :newest, :scope => translation_scope %></span>
     <% end %>
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
-      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
-      <%= t :newer, :scope => translation_scope %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0" %>
+      <span class="d-none d-sm-block"><%= t :newer, :scope => translation_scope %></span>
     <% end %>
     <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
-      <%= t :older, :scope => translation_scope %>
-      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
+      <span class="d-none d-sm-block"><%= t :older, :scope => translation_scope %></span>
+      <%= next_page_svg_tag :class => "flex-shrink-0" %>
     <% end %>
     <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0)) do %>
-      <%= t :oldest, :scope => translation_scope %>
-      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
+      <span class="d-none d-md-block"><%= t :oldest, :scope => translation_scope %></span>
+      <%= next_page_svg_tag :class => "flex-shrink-0", :count => 2 %>
     <% end %>
   </ul>
 </nav>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -3,6 +3,10 @@
 <% translation_scope ||= "shared.pagination.#{controller.controller_name}" %>
 <nav>
   <ul class="pagination">
+    <%= pagination_item(newer_id && @params.merge(:before => nil, :after => nil)) do %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
+      <%= t :newest, :scope => translation_scope %>
+    <% end %>
     <%= pagination_item(newer_id && @params.merge(:before => nil, :after => newer_id)) do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
       <%= t :newer, :scope => translation_scope %>
@@ -10,6 +14,10 @@
     <%= pagination_item(older_id && @params.merge(:before => older_id, :after => nil)) do %>
       <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
+    <% end %>
+    <%= pagination_item(older_id && @params.merge(:before => nil, :after => 0)) do %>
+      <%= t :oldest, :scope => translation_scope %>
+      <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block", :count => 2 %>
     <% end %>
   </ul>
 </nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2064,24 +2064,38 @@ en:
       changeset_comments:
         older: Older Comments
         newer: Newer Comments
+        oldest: Oldest Comments
+        newest: Newest Comments
       diary_comments:
         older: Older Comments
         newer: Newer Comments
+        oldest: Oldest Comments
+        newest: Newest Comments
       diary_entries:
         older: Older Entries
         newer: Newer Entries
+        oldest: Oldest Entries
+        newest: Newest Entries
       issues:
         older: Older Issues
         newer: Newer Issues
+        oldest: Oldest Issues
+        newest: Newest Issues
       traces:
         older: Older Traces
         newer: Newer Traces
+        oldest: Oldest Traces
+        newest: Newest Traces
       user_blocks:
         older: Older Blocks
         newer: Newer Blocks
+        oldest: Oldest Blocks
+        newest: Newest Blocks
       users:
         older: Older Users
         newer: Newer Users
+        oldest: Oldest Users
+        newest: Newest Users
   site:
     about:
       heading_html: "%{copyright}OpenStreetMap %{br} contributors"

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -471,41 +471,42 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
   def test_index_paged
     # Create several pages worth of diary entries
     create_list(:diary_entry, 50)
+    next_path = diary_entries_path
 
     # Try and get the index
-    get diary_entries_path
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 20
-    assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Entries", :count => 1
+    check_no_page_link "Newer Entries"
+    next_path = check_page_link "Older Entries"
 
     # Try and get the second page
-    get css_select("li.page-item .page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 20
-    assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
+    check_page_link "Newer Entries"
+    next_path = check_page_link "Older Entries"
 
     # Try and get the third page
-    get css_select("li.page-item .page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 10
-    assert_select "li.page-item.disabled span.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
+    next_path = check_page_link "Newer Entries"
+    check_no_page_link "Older Entries"
 
     # Go back to the second page
-    get css_select("li.page-item .page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 20
-    assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item a.page-link", :text => "Newer Entries", :count => 1
+    next_path = check_page_link "Newer Entries"
+    check_page_link "Older Entries"
 
     # Go back to the first page
-    get css_select("li.page-item .page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "article.diary_post", :count => 20
-    assert_select "li.page-item a.page-link", :text => "Older Entries", :count => 1
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Entries", :count => 1
+    check_no_page_link "Newer Entries"
+    check_page_link "Older Entries"
   end
 
   def test_index_invalid_paged
@@ -993,6 +994,16 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
 
     entries.each do |entry|
       assert_select "a[href=?]", "/user/#{ERB::Util.u(entry.user.display_name)}/diary/#{entry.id}"
+    end
+  end
+
+  def check_no_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/, :count => 0 }, "unexpected #{name} page link"
+  end
+
+  def check_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/ }, "missing #{name} page link" do |buttons|
+      return buttons.first.attributes["href"].value
     end
   end
 end

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -510,7 +510,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
 
   def test_index_invalid_paged
     # Try some invalid paged accesses
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get diary_entries_path(:before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -299,7 +299,7 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
 
   def test_index_invalid_paged
     # Try some invalid paged accesses
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get traces_path(:before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -197,51 +197,52 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
   def test_index_paged
     # Create several pages worth of traces
     create_list(:trace, 50)
+    next_path = traces_path
 
     # Try and get the index
-    get traces_path
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the second page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the third page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 10
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item.disabled span.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_no_page_link "Older Traces"
 
     # Go back to the second page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_page_link "Older Traces"
 
     # Go back to the first page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    check_page_link "Older Traces"
   end
 
   # Check a multi-page index of tagged traces
@@ -250,51 +251,52 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     create_list(:trace, 100) do |trace, index|
       create(:tracetag, :trace => trace, :tag => "London") if index.even?
     end
+    next_path = traces_path :tag => "London"
 
     # Try and get the index
-    get traces_path(:tag => "London")
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the second page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_page_link "Newer Traces"
+    next_path = check_page_link "Older Traces"
 
     # Try and get the third page
-    get css_select("li.page-item a.page-link").last["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 10
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item.disabled span.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_no_page_link "Older Traces"
 
     # Go back to the second page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item a.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    next_path = check_page_link "Newer Traces"
+    check_page_link "Older Traces"
 
     # Go back to the first page
-    get css_select("li.page-item a.page-link").first["href"]
+    get next_path
     assert_response :success
     assert_select "table#trace_list tbody", :count => 1 do
       assert_select "tr", :count => 20
     end
-    assert_select "li.page-item.disabled span.page-link", :text => "Newer Traces", :count => 2
-    assert_select "li.page-item a.page-link", :text => "Older Traces", :count => 2
+    check_no_page_link "Newer Traces"
+    check_page_link "Older Traces"
   end
 
   def test_index_invalid_paged
@@ -580,6 +582,16 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
           end
         end
       end
+    end
+  end
+
+  def check_no_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/, :count => 0 }, "unexpected #{name} page link"
+  end
+
+  def check_page_link(name)
+    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/ }, "missing #{name} page link" do |buttons|
+      return buttons.first.attributes["href"].value
     end
   end
 

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -92,7 +92,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   ##
   # test the index action with invalid pages
   def test_index_invalid_paged
-    %w[-1 0 fred].each do |id|
+    %w[-1 fred].each do |id|
       get user_blocks_path(:before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
 

--- a/test/controllers/users/diary_comments_controller_test.rb
+++ b/test/controllers/users/diary_comments_controller_test.rb
@@ -58,7 +58,7 @@ module Users
     def test_index_invalid_paged
       user = create(:user)
 
-      %w[-1 0 fred].each do |id|
+      %w[-1 fred].each do |id|
         get user_diary_comments_path(user, :before => id)
         assert_redirected_to :controller => "/errors", :action => :bad_request
 

--- a/test/controllers/users/issued_blocks_controller_test.rb
+++ b/test/controllers/users/issued_blocks_controller_test.rb
@@ -83,7 +83,7 @@ module Users
     def test_show_invalid_paged
       user = create(:moderator_user)
 
-      %w[-1 0 fred].each do |id|
+      %w[-1 fred].each do |id|
         get user_issued_blocks_path(user, :before => id)
         assert_redirected_to :controller => "/errors", :action => :bad_request
 

--- a/test/controllers/users/lists_controller_test.rb
+++ b/test/controllers/users/lists_controller_test.rb
@@ -190,7 +190,7 @@ module Users
     def test_show_invalid_paginated
       session_for(create(:administrator_user))
 
-      %w[-1 0 fred].each do |id|
+      %w[-1 fred].each do |id|
         get users_list_path(:before => id)
         assert_redirected_to :controller => "/errors", :action => :bad_request
 

--- a/test/controllers/users/received_blocks_controller_test.rb
+++ b/test/controllers/users/received_blocks_controller_test.rb
@@ -91,7 +91,7 @@ module Users
     def test_show_invalid_paged
       user = create(:user)
 
-      %w[-1 0 fred].each do |id|
+      %w[-1 fred].each do |id|
         get user_received_blocks_path(user, :before => id)
         assert_redirected_to :controller => "/errors", :action => :bad_request
 


### PR DESCRIPTION
#4733 without "oldest"/"newest" button text on any screen width and with `title` tooltips.

![image](https://github.com/user-attachments/assets/329f4ae4-64b8-413a-bc21-088ac0323be7)
![image](https://github.com/user-attachments/assets/75872045-2513-4c3a-9065-fa266406414b)

Partly addresses #2387 ("No way to jump to the last page").