### PR TITLE
Adapt Leaflet context menus to dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -460,8 +460,14 @@ body.small-nav {
 }
 
 .leaflet-popup-content-wrapper,
-.leaflet-popup-tip {
+.leaflet-popup-tip,
+.leaflet-contextmenu,
+.leaflet-contextmenu-item {
   @extend .bg-body, .text-body;
+}
+
+.leaflet-contextmenu-item.over {
+  @extend .bg-body-secondary, .border-secondary, .border-opacity-10;
 }
 
 .leaflet-popup-content-wrapper {


### PR DESCRIPTION
Before in light and dark mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/1b15c6c5-c209-4376-92a5-f7770219dfa6)

After in light mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/2b13d3b7-d1c9-4f3b-86ea-32a028d16a3c)

After in dark mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/06ea0f3e-42fb-4310-ae5a-7a6ebc2eb030)
