### PR TITLE
Remove color override for user dropdown message count

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -160,10 +160,6 @@ nav.secondary {
   .nav-link {
     padding: 0.2rem;
   }
-
-  #inboxanchor {
-    background-color: lighten($grey, 10%);
-  }
 }
 
 nav.primary, nav.secondary {


### PR DESCRIPTION
There's a message counter in the upper right corner (`#inboxanchor`). It was gray for a long time (https://github.com/openstreetmap/openstreetmap-website/commit/ff752b072f44aad142314a57eed79271928d181a) but why? Other counters are green, including the same counter in the dropdown menu.

Before in light mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/02a31484-a08a-4002-a4b4-95355a9a37f4)

Before in dark mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c08ab083-5685-4789-bdf0-9152bc518bc8)

After in light mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/85946858-5a47-4464-8eb6-d4aef807d65f)

After in dark mode:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/618a00ca-3c92-4f7c-a54f-5003c5de09b4)
