### PR TITLE
Remove .message-summary css classes and selectors

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -5,7 +5,7 @@ $(document).ready(function () {
     }
   });
 
-  $(".messages-table .message-summary").on("turbo:before-morph-element", function (event) {
+  $(".messages-table tbody tr").on("turbo:before-morph-element", function (event) {
     if ($(event.target).find("[data-is-destroyed]").length > 0) {
       event.preventDefault(); // NB: prevent Turbo from morhping/removing this element
       $(event.target).fadeOut(800, "linear", function () {

--- a/app/views/messages/_message_summary.html.erb
+++ b/app/views/messages/_message_summary.html.erb
@@ -1,4 +1,4 @@
-<%= tag.tr(:id => "inbox-#{message.id}", :class => { "message-summary" => true, "table-success" => !message.message_read? }) do %>
+<%= tag.tr(:id => "inbox-#{message.id}", :class => { "table-success" => !message.message_read? }) do %>
   <td><%= link_to message.sender.display_name, user_path(message.sender) %></td>
   <td><%= link_to message.title, message_path(message) %></td>
   <td class="text-nowrap"><%= l message.sent_on, :format => :friendly %></td>

--- a/app/views/messages/_sent_message_summary.html.erb
+++ b/app/views/messages/_sent_message_summary.html.erb
@@ -1,4 +1,4 @@
-<%= tag.tr(:id => "outbox-#{message.id}", :class => { "message-summary" => true }) do %>
+<%= tag.tr(:id => "outbox-#{message.id}") do %>
   <td><%= link_to message.recipient.display_name, user_path(message.recipient) %></td>
   <td><%= link_to message.title, message_path(message) %></td>
   <td class="text-nowrap"><%= l message.sent_on, :format => :friendly %></td>


### PR DESCRIPTION
They are not necessary because they select every table body row, and the table already has its own class.

They were added in #4562 to set up listeners that start fadeout deletion animations.