### PR TITLE
Don't change display property of messages table header cell

### DIFF
--- a/app/views/messages/_messages_table.html.erb
+++ b/app/views/messages/_messages_table.html.erb
@@ -4,7 +4,7 @@
       <% columns.each do |column| %>
       <th><%= t ".#{column}" %></th>
       <% end %>
-      <th class="d-flex justify-content-end"><%= t ".actions" %></th>
+      <th class="text-end"><%= t ".actions" %></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
I accidentally changed display properties of table cells by using `.d-flex`, then I fixed it in #4702. However by that time `.d-flex` spread to more table cells in https://github.com/openstreetmap/openstreetmap-website/commit/3e69a4512f2d1b39f48719882a0d112d042da73a. Here I'm removing it from message actions header cell.