### PR TITLE
Replace secondary actions nav with tag badge on trace list pages

### DIFF
--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -36,6 +36,7 @@ class TracesController < ApplicationController
                t ".public_traces_from", :user => target_user.display_name
              end
 
+    @untagged_title = @title
     @title += t ".tagged_with", :tags => params[:tag] if params[:tag]
 
     # four main cases:

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -1,18 +1,14 @@
 <% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
-  <h1><%= @title %></h1>
-  <nav class="secondary-actions mb-3">
-    <ul>
-      <li>
-        <%= t(".description") %>
-      </li>
-      <% if params[:tag] %>
-        <li>
-          <%= link_to t(".remove_tag_filter", :tag => params[:tag]), { :controller => "traces", :action => "index", :tag => nil } %>
-        </li>
-      <% end %>
-    </ul>
-  </nav>
+  <h1>
+    <%= @untagged_title %>
+    <% if params[:tag] %>
+      <span class="badge border border-secondary-subtle py-1 ps-2 pe-1 align-middle fs-6 fw-normal bg-body text-body icon-link">
+        <%= tag.span params[:tag], :title => t(".tagged_with", :tags => params[:tag]) %>
+        <%= link_to "", { :controller => "traces", :action => "index", :tag => nil }, :class => "btn-close", :title => t(".remove_tag_filter") %>
+      </span>
+    <% end %>
+  </h1>
 
   <div class="d-flex flex-column flex-md-row-reverse align-items-md-end">
     <div class="pb-1 ps-1 d-flex flex-wrap flex-shrink-0 gap-1 justify-content-end">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2555,7 +2555,6 @@ en:
       public_traces: "Public GPS Traces"
       my_gps_traces: "My GPS Traces"
       public_traces_from: "Public GPS Traces from %{user}"
-      description: "Browse recent GPS trace uploads"
       tagged_with: " tagged with %{tags}"
       empty_title: Nothing here yet
       empty_upload_html: "%{upload_link} or learn more about GPS tracing on the %{wiki_link}."


### PR DESCRIPTION
Earlier I copied some of the navigation elements from traces traces to blocks:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/5a033d62-35e5-4396-813b-0e55cfcc366d)

Now I want to copy in the opposite direction. Individual block pages have navigation tabs, while individual trace pages don't:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b67742d2-2d7b-4a4e-b227-28af3b6d00d9)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/17e5ca83-cfa7-4502-b26d-7d1b161a8e24)

So I want to take the navigation from trace lists and put it also on individual trace pages:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/139844e6-02d5-45c2-971d-908bfdc94644)

Here's a problem: the phrase "Browse recent GPS trace uploads" won't make sense on a single trace page. Let's suppose I remove this phrase. Then there's going to be just the "Remove Tag Filter" link if the filter is enabled. I tried to find a better place for this link, but it didn't fit next to tabs or rss/upload buttons.

But the tag is already mentioned in the heading. Maybe I can place the remove link there? That's what I did in this PR, with link turned into the x button:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6a7d27e1-8f32-4021-8f7a-69df44be1960)
