### PR TITLE
Set trace thumbnail link display property to inline-block, fixing focus outline

### DIFF
--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -2,7 +2,9 @@
   <td>
     <% if Settings.status != "gpx_offline" %>
       <% if trace.inserted %>
-        <%= link_to image_tag(trace_icon_path(trace.user, trace), :alt => "", :class => "trace_image"), show_trace_path(trace.user, trace) %>
+        <%= link_to image_tag(trace_icon_path(trace.user, trace), :alt => "", :class => "trace_image"),
+                    show_trace_path(trace.user, trace),
+                    :class => "d-inline-block" %>
       <% else %>
         <span class="text-danger"><%= t ".pending" %></span>
       <% end %>


### PR DESCRIPTION
Try to move keyboard focus to a trace thumbnail while on a trace list page. This is what you'll see in Firefox:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/8edcd640-1c5a-4959-b578-03dc8943cc99)

After the fix:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/4eef8a52-abef-4669-b831-7fd4ece321bf)

`<img>` is an inline element by default, `<a>` is also an inline element, so a link with a thumbnail inside is as tall as a line of text. And it's shorter than the actual image size. You can see this in browser dev tools, both in Firefox and in Chrome. Chrome still draws the outline around the image but Firefox doesn't.