### PR TITLE
Restore constraints on note id parameter, simplify tests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,7 +122,7 @@ OpenStreetMap::Application.routes.draw do
     match :subscribe, :unsubscribe, :on => :member, :via => [:get, :post]
   end
   get "/changeset/:id/comments/feed" => "changeset_comments#index", :as => :changeset_comments_feed, :id => /\d*/, :defaults => { :format => "rss" }
-  resources :notes, :path => "note", :only => [:show, :new]
+  resources :notes, :path => "note", :id => /\d+/, :only => [:show, :new]
 
   get "/user/:display_name/history" => "changesets#index"
   get "/user/:display_name/history/feed" => "changesets#feed", :defaults => { :format => :atom }

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -179,9 +179,9 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       get path_method.call
     end
 
-    # assert_raise ActionController::UrlGenerationError do
-    #   get path_method.call(:id => -10) # we won't have an id that's negative
-    # end
+    assert_raise ActionController::UrlGenerationError do
+      get path_method.call(:id => -10) # we won't have an id that's negative
+    end
 
     get path_method.call(:id => 0)
     assert_response :not_found

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -93,7 +93,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
   def test_read_note
     open_note = create(:note_with_comments)
 
-    browse_check :note_path, open_note.id, "notes/show"
+    sidebar_browse_check :note_path, open_note.id, "notes/show"
   end
 
   def test_read_hidden_note
@@ -111,7 +111,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
 
     session_for(create(:moderator_user))
 
-    browse_check :note_path, hidden_note_with_comment.id, "notes/show"
+    sidebar_browse_check :note_path, hidden_note_with_comment.id, "notes/show"
   end
 
   def test_read_note_hidden_comments
@@ -119,12 +119,12 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       create(:note_comment, :note => note, :visible => false)
     end
 
-    browse_check :note_path, note_with_hidden_comment.id, "notes/show"
+    sidebar_browse_check :note_path, note_with_hidden_comment.id, "notes/show"
     assert_select "div.note-comments ul li", :count => 1
 
     session_for(create(:moderator_user))
 
-    browse_check :note_path, note_with_hidden_comment.id, "notes/show"
+    sidebar_browse_check :note_path, note_with_hidden_comment.id, "notes/show"
     assert_select "div.note-comments ul li", :count => 2
   end
 
@@ -134,12 +134,12 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       create(:note_comment, :note => note, :author => hidden_user)
     end
 
-    browse_check :note_path, note_with_hidden_user_comment.id, "notes/show"
+    sidebar_browse_check :note_path, note_with_hidden_user_comment.id, "notes/show"
     assert_select "div.note-comments ul li", :count => 1
 
     session_for(create(:moderator_user))
 
-    browse_check :note_path, note_with_hidden_user_comment.id, "notes/show"
+    sidebar_browse_check :note_path, note_with_hidden_user_comment.id, "notes/show"
     assert_select "div.note-comments ul li", :count => 1
   end
 
@@ -147,7 +147,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     user = create(:user)
     closed_note = create(:note_with_comments, :closed, :closed_by => user, :comments_count => 2)
 
-    browse_check :note_path, closed_note.id, "notes/show"
+    sidebar_browse_check :note_path, closed_note.id, "notes/show"
     assert_select "div.note-comments ul li", :count => 2
     assert_select "div.details", /Resolved by #{user.display_name}/
 
@@ -155,7 +155,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
 
     reset!
 
-    browse_check :note_path, closed_note.id, "notes/show"
+    sidebar_browse_check :note_path, closed_note.id, "notes/show"
     assert_select "div.note-comments ul li", :count => 1
     assert_select "div.details", /Resolved by deleted/
   end
@@ -164,43 +164,5 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     get new_note_path
     assert_response :success
     assert_template "notes/new"
-  end
-
-  private
-
-  # This is a convenience method for most of the above checks
-  # First we check that when we don't have an id, it will correctly return a 404
-  # then we check that we get the correct 404 when a non-existant id is passed
-  # then we check that it will get a successful response, when we do pass an id
-  def browse_check(path, id, template)
-    path_method = method(path)
-
-    assert_raise ActionController::UrlGenerationError do
-      get path_method.call
-    end
-
-    assert_raise ActionController::UrlGenerationError do
-      get path_method.call(:id => -10) # we won't have an id that's negative
-    end
-
-    get path_method.call(:id => 0)
-    assert_response :not_found
-    assert_template "browse/not_found"
-    assert_template :layout => "map"
-
-    get path_method.call(:id => 0), :xhr => true
-    assert_response :not_found
-    assert_template "browse/not_found"
-    assert_template :layout => "xhr"
-
-    get path_method.call(:id => id)
-    assert_response :success
-    assert_template template
-    assert_template :layout => "map"
-
-    get path_method.call(:id => id), :xhr => true
-    assert_response :success
-    assert_template template
-    assert_template :layout => "xhr"
   end
 end


### PR DESCRIPTION
Elements, changesets, notes had constraints in their id parameter in routes. https://github.com/openstreetmap/openstreetmap-website/commit/9748ce301c9488b9cd32439448770c3d4a38ebd6 removed this constraint for notes for unknown reason. Without this constraint notes controller needs different tests. The part of "browse_check" that checks negative ids had to be commented out.

This PR restores the constraint which allows to use the same "browse_check" as for every other entity formerly handled by browse controller.