### PR TITLE
Link to previous/next nonempty user's changeset on changeset pages

### DIFF
--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -84,8 +84,9 @@ class ChangesetsController < ApplicationController
     @way_pages, @ways = paginate(:old_ways, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "way_page")
     @relation_pages, @relations = paginate(:old_relations, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "relation_page")
     if @changeset.user.active? && @changeset.user.data_public?
-      @next_by_user = @changeset.user.changesets.where("id > ?", @changeset.id).reorder(:id => :asc).first
-      @prev_by_user = @changeset.user.changesets.where("id < ?", @changeset.id).reorder(:id => :desc).first
+      changesets = conditions_nonempty(@changeset.user.changesets)
+      @next_by_user = changesets.where("id > ?", @changeset.id).reorder(:id => :asc).first
+      @prev_by_user = changesets.where("id < ?", @changeset.id).reorder(:id => :desc).first
     end
     render :layout => map_layout
   rescue ActiveRecord::RecordNotFound

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -321,11 +321,24 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
 
   def test_show_adjacent_changesets
     user = create(:user)
-    changesets = create_list(:changeset, 3, :user => user)
+    changesets = create_list(:changeset, 3, :user => user, :num_changes => 1)
 
     sidebar_browse_check :changeset_path, changesets[1].id, "changesets/show"
     assert_dom "a[href='#{changeset_path changesets[0]}']", :count => 1
     assert_dom "a[href='#{changeset_path changesets[2]}']", :count => 1
+  end
+
+  def test_show_adjacent_nonempty_changesets
+    user = create(:user)
+    changeset1 = create(:changeset, :user => user, :num_changes => 1)
+    create(:changeset, :user => user, :num_changes => 0)
+    changeset3 = create(:changeset, :user => user, :num_changes => 1)
+    create(:changeset, :user => user, :num_changes => 0)
+    changeset5 = create(:changeset, :user => user, :num_changes => 1)
+
+    sidebar_browse_check :changeset_path, changeset3.id, "changesets/show"
+    assert_dom "a[href='#{changeset_path changeset1}']", :count => 1
+    assert_dom "a[href='#{changeset_path changeset5}']", :count => 1
   end
 
   ##


### PR DESCRIPTION
Fixes #450, hiding previous/next empty changesets.

There's also an opposite request #3592.