### PR TITLE
Redirect to inbox after marking a message as read/unread

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -127,7 +127,7 @@ class MessagesController < ApplicationController
     @message.message_read = message_read
     if @message.save
       flash[:notice] = notice
-      redirect_back_or_to inbox_messages_path, :status => :see_other
+      redirect_to inbox_messages_path, :status => :see_other
     end
   rescue ActiveRecord::RecordNotFound
     @title = t "messages.no_such_message.title"

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -407,14 +407,14 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to inbox_messages_path
     assert_not Message.find(message.id).message_read
 
-    # Check that the marking a message read via XHR works
-    post message_mark_path(:message_id => message, :mark => "read")
-    assert_response :see_other
+    # Check that the marking a message read works and redirects to inbox from the message page
+    post message_mark_path(:message_id => message, :mark => "read"), :headers => { :referer => message_path(message) }
+    assert_redirected_to inbox_messages_path
     assert Message.find(message.id).message_read
 
-    # Check that the marking a message unread via XHR works
-    post message_mark_path(:message_id => message, :mark => "unread")
-    assert_response :see_other
+    # Check that the marking a message unread works and redirects to inbox from the message page
+    post message_mark_path(:message_id => message, :mark => "unread"), :headers => { :referer => message_path(message) }
+    assert_redirected_to inbox_messages_path
     assert_not Message.find(message.id).message_read
 
     # Asking to mark a message with no ID should fail


### PR DESCRIPTION
Fixes #4750 by redirecting when "Mark as unread" is clicked on a message page. For example Github notifications work like that: if you mark a notification as unread it redirects you to the notifications list.

I rename the `unread_message` variable in tests because the message doesn't stay unread.

I reuse the xhr test lines for referer test because xhr is not in use since the Turbo update.