### PR TITLE
Replace deprecated text-muted class with text-body-secondary

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -307,7 +307,7 @@ OSM.Directions = function (map) {
         var row = $("<tr class='turn'/>");
         row.append("<td class='border-0'><div class='direction i" + direction + "'/></td> ");
         row.append("<td>" + instruction);
-        row.append("<td class='distance text-muted text-end'>" + dist);
+        row.append("<td class='distance text-body-secondary text-end'>" + dist);
 
         row.on("click", function () {
           popup

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -84,7 +84,7 @@ L.OSM.layers = function (options) {
 
       $("<p>")
         .text(I18n.t("javascripts.map.layers.overlays"))
-        .attr("class", "text-muted")
+        .attr("class", "text-body-secondary")
         .appendTo(overlaySection);
 
       var overlays = $("<ul class='list-unstyled form-check'>")

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -98,7 +98,7 @@ L.OSM.share = function (options) {
           .on("click", select))
       .append(
         $("<p>")
-          .attr("class", "text-muted")
+          .attr("class", "text-body-secondary")
           .text(I18n.t("javascripts.share.paste_html")));
 
     // Geo URI
@@ -128,7 +128,7 @@ L.OSM.share = function (options) {
 
     $("<div>")
       .attr("id", "export-warning")
-      .attr("class", "text-muted")
+      .attr("class", "text-body-secondary")
       .text(I18n.t("javascripts.share.only_standard_layer"))
       .appendTo($imageSection);
 
@@ -223,7 +223,7 @@ L.OSM.share = function (options) {
     };
 
     $("<p>")
-      .attr("class", "text-muted")
+      .attr("class", "text-body-secondary")
       .html(I18n.t("javascripts.share.image_dimensions", args))
       .appendTo($form);
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -50,7 +50,7 @@ time[title] {
 
 /* Utility for de-emphasizing content */
 
-.text-muted a {
+.text-body-secondary a {
   color: $blue;
 }
 

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -77,7 +77,7 @@ module UserHelper
                 :size => "24") + t("application.auth_providers.#{name}.title"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
-      :class => "auth_button fs-6 border rounded text-muted text-decoration-none py-2 px-4 d-flex justify-content-center align-items-center",
+      :class => "auth_button fs-6 border rounded text-body-secondary text-decoration-none py-2 px-4 d-flex justify-content-center align-items-center",
       :title => t("application.auth_providers.#{name}.title")
     )
   end

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -22,12 +22,12 @@
       <%= f.select(:auth_provider, Auth.providers, :hide_label => true, :wrapper => { :class => "col-auto mb-0" }) %>
       <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }) %>
     </div>
-    <small class="form-text text-muted">(<a href="<%= t ".openid.link" %>" target="_new"><%= t ".openid.link text" %></a>)</small>
+    <small class="form-text text-body-secondary">(<a href="<%= t ".openid.link" %>" target="_new"><%= t ".openid.link text" %></a>)</small>
   </fieldset>
 
   <div class="mb-3">
     <label class="form-label"><%= t ".public editing.heading" %></label>
-    <span class="form-text text-muted">
+    <span class="form-text text-body-secondary">
       <% if current_user.data_public? %>
         <%= t ".public editing.enabled" %>
         (<a href="<%= t ".public editing.enabled link" %>" target="_new"><%= t ".public editing.enabled link text" %></a>)
@@ -40,7 +40,7 @@
 
   <div class="mb-3">
     <label class="form-label"><%= t ".contributor terms.heading" %></label>
-    <span class="form-text text-muted">
+    <span class="form-text text-body-secondary">
       <% if current_user.terms_agreed? %>
         <%= t ".contributor terms.agreed" %>
         (<a href="<%= t ".contributor terms.link" %>" target="_new"><%= t ".contributor terms.link text" %></a>)

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -36,7 +36,7 @@
       <label for="openid_url" class="form-label"><%= t ".openid_html", :logo => openid_logo %></label>
       <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>
       <%= text_field_tag("openid_url", "", :tabindex => 20, :autocomplete => "on", :class => "openid_url form-control") %>
-      <span class="form-text text-muted">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
+      <span class="form-text text-body-secondary">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
     </div>
 
     <%= submit_tag t(".openid_login_button"), :tabindex => 21, :id => "openid_login_button", :class => "btn btn-primary" %>

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -7,7 +7,7 @@
                                        :id => node.redaction.id), node.redaction) %>
   </div>
 <% else %>
-  <%= tag.div :class => ["browse-section", "browse-node", { "text-muted" => node.redacted? }] do %>
+  <%= tag.div :class => ["browse-section", "browse-node", { "text-body-secondary" => node.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => node %>
 
     <% unless node.ways.empty? and node.containing_relation_members.empty? %>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -7,7 +7,7 @@
                                        :id => relation.redaction.id), relation.redaction) %>
   </div>
 <% else %>
-  <%= tag.div :class => ["browse-section", "browse-relation", { "text-muted" => relation.redacted? }] do %>
+  <%= tag.div :class => ["browse-section", "browse-relation", { "text-body-secondary" => relation.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => relation %>
 
     <% unless relation.containing_relation_members.empty? %>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -7,7 +7,7 @@
                                        :id => way.redaction.id), way.redaction) %>
   </div>
 <% else %>
-  <%= tag.div :class => ["browse-section", "browse-way", { "text-muted" => way.redacted? }] do %>
+  <%= tag.div :class => ["browse-section", "browse-way", { "text-body-secondary" => way.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => way %>
 
     <% unless way.containing_relation_members.empty? %>

--- a/app/views/changesets/_heading.html.erb
+++ b/app/views/changesets/_heading.html.erb
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <small class='text-muted'>
+  <small class='text-body-secondary'>
     <%= t(".created_by_html", :link_user => link_to(changeset.user.display_name, changeset.user), :created => l(changeset.created_at, :format => :blog)) %>
   </small>
 </div>

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -31,7 +31,7 @@
       <% @comments.each do |comment| %>
         <% next unless comment.visible || current_user&.moderator? %>
         <li id="c<%= comment.id %>">
-          <small class='text-muted'>
+          <small class='text-body-secondary'>
             <%= t comment.visible ? ".comment_by_html" : ".hidden_comment_by_html",
                   :time_ago => friendly_date_ago(comment.created_at),
                   :user => link_to(comment.author.display_name, comment.author) %>

--- a/app/views/confirmations/confirm.html.erb
+++ b/app/views/confirmations/confirm.html.erb
@@ -22,12 +22,12 @@
 <% else %>
   <h1>
     <%= t ".introduction_1" %>
-    <span class="text-muted">
+    <span class="text-body-secondary">
       <%= t ".introduction_2" %>
     </span>
   </h1>
 
-  <p class='text-muted'>
+  <p class='text-body-secondary'>
     <%= t ".resend_html",
           :reconfirm_link => link_to(t(".click_here"), url_for(:action => "confirm_resend")) %>
   </p>

--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -9,7 +9,7 @@
     <%= user_thumbnail contact %>
   </div>
   <div class="col">
-    <p class='text-muted mb-0'>
+    <p class='text-body-secondary mb-0'>
       <%= link_to contact.display_name, contact %>
       <% if @user.home_location? and contact.home_location? %>
         <% distance = @user.distance(contact) %>
@@ -32,7 +32,7 @@
     </p>
 
     <nav class='secondary-actions'>
-      <ul class='clearfix text-muted'>
+      <ul class='clearfix text-body-secondary'>
         <li><%= link_to t("users.show.send message"), new_message_path(contact) %></li>
         <li>
           <% if current_user.friends_with?(contact) %>

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -1,9 +1,9 @@
-<div class="row diary-comment border-bottom py-3<%= " text-muted bg-danger bg-opacity-10" unless diary_comment.visible? %>">
+<div class="row diary-comment border-bottom py-3<%= " text-body-secondary bg-danger bg-opacity-10" unless diary_comment.visible? %>">
   <div class="col-auto pe-0 text-center">
     <%= user_thumbnail diary_comment.user %>
   </div>
   <div class="col">
-    <p class="text-muted m-0" id="comment<%= diary_comment.id %>"><%= t(".comment_from_html", :link_user => (link_to diary_comment.user.display_name, diary_comment.user), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}")) %>
+    <p class="text-body-secondary m-0" id="comment<%= diary_comment.id %>"><%= t(".comment_from_html", :link_user => (link_to diary_comment.user.display_name, diary_comment.user), :comment_created_at => link_to(l(diary_comment.created_at, :format => :friendly), :anchor => "comment#{diary_comment.id}")) %>
       <% if current_user and diary_comment.user.id != current_user.id %>
         | <%= report_link(t(".report"), diary_comment) %>
       <% end %>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -1,4 +1,4 @@
-<article class='diary_post border-top border-secondary-subtle py-3<%= " text-muted px-3 bg-danger bg-opacity-10" unless diary_entry.visible %> user_<%= diary_entry.user.id %>'>
+<article class='diary_post border-top border-secondary-subtle py-3<%= " text-body-secondary px-3 bg-danger bg-opacity-10" unless diary_entry.visible %> user_<%= diary_entry.user.id %>'>
   <%= render :partial => "diary_entry_heading", :object => diary_entry, :as => "diary_entry" %>
 
   <div class="richtext text-break" xml:lang="<%= diary_entry.language_code %>" lang="<%= diary_entry.language_code %>">

--- a/app/views/diary_entries/_diary_entry_heading.html.erb
+++ b/app/views/diary_entries/_diary_entry_heading.html.erb
@@ -12,7 +12,7 @@
     </div>
   <% end %>
 
-  <small class='text-muted'>
+  <small class='text-body-secondary'>
     <%= t("diary_entries.diary_entry.posted_by_html", :link_user => (link_to diary_entry.user.display_name, diary_entry.user), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to diary_entry.language.name, :controller => "diary_entries", :action => "index", :display_name => nil, :language => diary_entry.language_code)) %>
     <% if (l(diary_entry.updated_at, :format => :blog) != l(diary_entry.created_at, :format => :blog)) %>
       <%= t("diary_entries.diary_entry.updated_at_html", :updated => l(diary_entry.updated_at, :format => :blog)) %>

--- a/app/views/diary_entries/comments.html.erb
+++ b/app/views/diary_entries/comments.html.erb
@@ -17,11 +17,11 @@
     </thead>
     <% @comments.each do |comment| -%>
     <tr>
-      <td width="25%" class="<%= "text-muted" unless comment.visible? %>"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
-      <td width="25%" class="<%= "text-muted" unless comment.visible? %>">
+      <td width="25%" class="<%= "text-body-secondary" unless comment.visible? %>"><%= link_to comment.diary_entry.title, diary_entry_path(comment.diary_entry.user, comment.diary_entry) %></td>
+      <td width="25%" class="<%= "text-body-secondary" unless comment.visible? %>">
         <%= friendly_date_ago(comment.created_at) %>
       </td>
-      <td width="50%" class="richtext text-break<%= " text-muted" unless comment.visible? %>"><%= comment.body.to_html %></td>
+      <td width="50%" class="richtext text-break<%= " text-body-secondary" unless comment.visible? %>"><%= comment.body.to_html %></td>
     </tr>
     <% end -%>
   </table>

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -5,7 +5,7 @@
         <%= link_to user_thumbnail(comment.user), comment.user %>
       </div>
       <div class="col">
-        <p class="text-muted">
+        <p class="text-body-secondary">
           <%= t ".comment_from_html", :user_link => link_to(comment.user.display_name, comment.user),
                                       :comment_created_at => tag.time(l(comment.created_at.to_datetime, :format => :friendly),
                                                                       :datetime => comment.created_at.xmlschema) %>

--- a/app/views/issues/_reports.html.erb
+++ b/app/views/issues/_reports.html.erb
@@ -4,7 +4,7 @@
       <%= link_to user_thumbnail(report.user), report.user %>
     </div>
     <div class="col">
-      <p class="text-muted">
+      <p class="text-body-secondary">
         <%= t ".reported_by_html", :category => report.category,
                                    :user => link_to(report.user.display_name, report.user),
                                    :updated_at => tag.time(l(report.updated_at.to_datetime, :format => :friendly),

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :heading do %>
 <h1><%= t ".title", :status => @issue.status.humanize, :issue_id => @issue.id %></h1>
 <p><%= @issue.reportable.model_name.human %> : <%= link_to reportable_title(@issue.reportable), reportable_url(@issue.reportable) %></p>
-<p class="text-muted">
+<p class="text-body-secondary">
   <small>
     <%= @issue.assigned_role %>
     <% if @issue.reports.count > 0 %>
@@ -45,7 +45,7 @@
     <h3><%= t ".reports_of_this_issue" %></h3>
 
     <% if @read_reports.present? %>
-    <div class="bg-body-tertiary text-muted">
+    <div class="bg-body-tertiary text-body-secondary">
       <h4><%= t ".read_reports" %></h4>
       <%= render "reports", :reports => @read_reports %>
     </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -33,7 +33,7 @@
       <ul class="list-unstyled">
         <% @note_comments.drop(1).each do |comment| %>
           <li id="c<%= comment.id %>">
-            <small class='text-muted'><%= note_event(comment.event, comment.created_at, comment.author) %></small>
+            <small class='text-body-secondary'><%= note_event(comment.event, comment.created_at, comment.author) %></small>
             <div class="mx-2">
               <%= comment.body.to_html %>
             </div>
@@ -90,7 +90,7 @@
 
   <% if current_user && current_user != @note.author %>
     <p>
-      <small class="text-muted">
+      <small class="text-body-secondary">
         <%= t ".report_link_html", :link => report_link(t(".report"), @note) %>
         <% if @note.status == "open" %>
           <%= t ".other_problems_resolve", :link => report_link(t(".report"), @note) %>
@@ -102,7 +102,7 @@
   <% end %>
 
   <% if @note.freshly_closed? %>
-    <small class="text-muted">
+    <small class="text-body-secondary">
       <%= t ".disappear_date_html", :disappear_in => friendly_date(@note.freshly_closed_until) %>
     </small>
   <% end %>

--- a/app/views/oauth2_applications/_application.html.erb
+++ b/app/views/oauth2_applications/_application.html.erb
@@ -3,14 +3,14 @@
     <ul class="list-unstyled mb-0">
       <li><%= link_to application.name, oauth_application_path(application) %></li>
       <% application.redirect_uri.split.each do |uri| -%>
-        <li class="text-muted"><%= uri %></li>
+        <li class="text-body-secondary"><%= uri %></li>
       <% end -%>
     </ul>
   </td>
   <td class="align-middle">
     <ul class="list-unstyled mb-0">
       <% application.scopes.each do |scope| -%>
-        <li><%= authorization_scope(scope) %> <code class="text-muted">(<%= scope %>)</code></li>
+        <li><%= authorization_scope(scope) %> <code class="text-body-secondary">(<%= scope %>)</code></li>
       <% end -%>
     </ul>
   </td>

--- a/app/views/oauth2_applications/show.html.erb
+++ b/app/views/oauth2_applications/show.html.erb
@@ -28,7 +28,7 @@
     <td>
       <ul class="list-unstyled mb-0">
         <% @application.scopes.each do |scope| -%>
-          <li><%= t "oauth.scopes.#{scope}" %> <code class="text-muted">(<%= scope %>)</code></li>
+          <li><%= t "oauth.scopes.#{scope}" %> <code class="text-body-secondary">(<%= scope %>)</code></li>
         <% end -%>
       </ul>
     </td>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -42,7 +42,7 @@
 
   <fieldset>
     <legend><%= t ".home location" -%></legend>
-    <p id="home_message" class="text-muted m-0<% if current_user.home_location? %> invisible<% end %>"><%= t ".no home location" %></p>
+    <p id="home_message" class="text-body-secondary m-0<% if current_user.home_location? %> invisible<% end %>"><%= t ".no home location" %></p>
     <div class="row">
       <%= f.text_field :home_lat, :wrapper_class => "col-sm-4 d-flex flex-column", :class => "mt-auto", :id => "home_lat" %>
       <%= f.text_field :home_lon, :wrapper_class => "col-sm-4 d-flex flex-column", :class => "mt-auto", :id => "home_lon" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :heading do %>
   <% if @client_app_name %>
-    <p class="text-center text-muted fs-6 py-2 mb-0 bg-body"><%= t(".login_to_authorize_html", :client_app_name => @client_app_name) %></p>
+    <p class="text-center text-body-secondary fs-6 py-2 mb-0 bg-body"><%= t(".login_to_authorize_html", :client_app_name => @client_app_name) %></p>
   <% end %>
 
   <div class="header-illustration new-user-main auth-container mx-auto">

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -30,7 +30,7 @@
         <span class="badge bg-<%= badge_class %> text-white"><%= t(".#{trace.visibility}") %></span>
       </li>
     </ul>
-    <p class="text-muted mb-0">
+    <p class="text-body-secondary mb-0">
       <% if trace.tags.empty? %>
         <%= t ".details_without_tags_html", :time_ago => friendly_date_ago(trace.timestamp),
                                             :user => link_to(trace.user.display_name, trace.user) %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :heading do %>
   <% if @client_app_name %>
-    <p class="text-center text-muted fs-6 py-2 mb-0 bg-body"><%= t(".signup_to_authorize_html", :client_app_name => @client_app_name) %></p>
+    <p class="text-center text-body-secondary fs-6 py-2 mb-0 bg-body"><%= t(".signup_to_authorize_html", :client_app_name => @client_app_name) %></p>
   <% end %>
 
   <div class="header-illustration new-user-main auth-container mx-auto">
@@ -24,7 +24,7 @@
 
 <div class="auth-container mx-auto my-0">
   <% if current_user.auth_uid.nil? %>
-    <div class="text-muted fs-6">
+    <div class="text-body-secondary fs-6">
       <p><strong><%= t ".about.header" %></strong> <%= t ".about.paragraph_1" %></p>
       <p><%= t ".about.paragraph_2" %></p>
     </div>
@@ -71,17 +71,17 @@
       </div>
     <% end %>
 
-    <p class="mb-3 text-muted fs-6"><%= t(".by_signing_up_html",
-                                          :tou_link => link_to(t("layouts.tou"),
-                                                               "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
-                                                               :target => :new),
-                                          :privacy_policy_link => link_to(t(".privacy_policy"),
-                                                                          t(".privacy_policy_url"),
-                                                                          :title => t(".privacy_policy_title"),
-                                                                          :target => :new),
-                                          :contributor_terms_link => link_to(t(".contributor_terms"),
-                                                                             t(".contributor_terms_url"),
-                                                                             :target => :new)) %></p>
+    <p class="mb-3 text-body-secondary fs-6"><%= t(".by_signing_up_html",
+                                                   :tou_link => link_to(t("layouts.tou"),
+                                                                        "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
+                                                                        :target => :new),
+                                                   :privacy_policy_link => link_to(t(".privacy_policy"),
+                                                                                   t(".privacy_policy_url"),
+                                                                                   :title => t(".privacy_policy_title"),
+                                                                                   :target => :new),
+                                                   :contributor_terms_link => link_to(t(".contributor_terms"),
+                                                                                      t(".contributor_terms_url"),
+                                                                                      :target => :new)) %></p>
     <%= f.form_group do %>
       <%= f.check_box :consider_pd,
                       :tabindex => 5,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -132,7 +132,7 @@
         </nav>
       <% end %>
 
-      <div class='text-muted'>
+      <div class='text-body-secondary'>
         <small>
           <dl class="list-inline">
             <dt class="list-inline-item m-0"><%= t ".mapper since" %></dt>
@@ -206,7 +206,7 @@
       <% end %>
 
       <% if current_user and current_user.administrator? -%>
-        <div class='text-muted'>
+        <div class='text-body-secondary'>
           <small>
             <dl class="list-inline">
               <dt class="list-inline-item m-0"><%= t ".email address" %></dt>

--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -11,11 +11,11 @@
 
 <%= form_tag({ :action => "save" }) do %>
   <!-- legale is <%= @legale %> -->
-  <p class="text-muted"><%= t ".read and accept with tou" %></p>
+  <p class="text-body-secondary"><%= t ".read and accept with tou" %></p>
   <h4>
     <%= t ".heading_ct" %>
   </h4>
-  <p class="text-muted"><%= t ".contributor_terms_explain" %></p>
+  <p class="text-body-secondary"><%= t ".contributor_terms_explain" %></p>
   <label class="form-label">
     <%= t ".legale_select" %>
   </label>
@@ -35,7 +35,7 @@
   </div>
 
   <div>
-    <p id="contributorGuidance" class="text-muted">
+    <p id="contributorGuidance" class="text-body-secondary">
       <%= t ".guidance_info_html",
             :readable_summary_link => link_to(t(".readable_summary"),
                                               "https://www.osmfoundation.org/wiki/License/Contributor_Terms_Summary"),
@@ -55,7 +55,7 @@
   <h4>
     <%= t "layouts.tou" %>
   </h4>
-  <p class="text-muted"><%= t ".tou_explain_html", :tou_link => link_to(t("layouts.tou"), "https://wiki.osmfoundation.org/wiki/Terms_of_Use", :target => :new) %></p>
+  <p class="text-body-secondary"><%= t ".tou_explain_html", :tou_link => link_to(t("layouts.tou"), "https://wiki.osmfoundation.org/wiki/Terms_of_Use", :target => :new) %></p>
 
   <div class="mb-3">
     <div class="form-check">


### PR DESCRIPTION
The `text-muted` class is [deprecated](https://getbootstrap.com/docs/5.3/migration/#utilities-1) and will be removed in bootstrap 6.