### PR TITLE
Stop using the session to persist the referer during login

### DIFF
--- a/app/controllers/concerns/session_methods.rb
+++ b/app/controllers/concerns/session_methods.rb
@@ -39,7 +39,7 @@ module SessionMethods
     session[:fingerprint] = user.fingerprint
     session_expires_after 28.days if session[:remember_me]
 
-    target = referer || session[:referer] || url_for(:controller => :site, :action => :index)
+    target = referer || url_for(:controller => :site, :action => :index)
 
     # The user is logged in, so decide where to send them:
     #
@@ -56,31 +56,28 @@ module SessionMethods
     end
 
     session.delete(:remember_me)
-    session.delete(:referer)
   end
 
   ##
   # process a failed login
-  def failed_login(message, username = nil)
+  def failed_login(message, username, referer = nil)
     flash[:error] = message
 
-    redirect_to :controller => "sessions", :action => "new", :referer => session[:referer],
+    redirect_to :controller => "sessions", :action => "new", :referer => referer,
                 :username => username, :remember_me => session[:remember_me]
 
     session.delete(:remember_me)
-    session.delete(:referer)
   end
 
   ##
   #
-  def unconfirmed_login(user)
+  def unconfirmed_login(user, referer = nil)
     session[:pending_user] = user.id
 
     redirect_to :controller => "confirmations", :action => "confirm",
-                :display_name => user.display_name, :referer => session[:referer]
+                :display_name => user.display_name, :referer => referer
 
     session.delete(:remember_me)
-    session.delete(:referer)
   end
 
   ##

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -16,7 +16,7 @@
         <%= link_to t("sessions.new.tab_title"), "#", :class => "nav-link active" %>
       </li>
       <li class="nav-item">
-        <%= link_to t("users.new.tab_title"), url_for(:action => :new, :controller => :users), :class => "nav-link" %>
+        <%= link_to t("users.new.tab_title"), url_for(:action => :new, :controller => :users, :referer => params[:referer]), :class => "nav-link" %>
       </li>
     </ul>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -13,7 +13,7 @@
   <div class="header-illustration new-user-main auth-container mx-auto">
     <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
       <li class="nav-item">
-        <%= link_to t("sessions.new.tab_title"), url_for(:action => :new, :controller => :sessions), :class => "nav-link" %>
+        <%= link_to t("sessions.new.tab_title"), url_for(:action => :new, :controller => :sessions, :referer => @referer), :class => "nav-link" %>
       </li>
       <li class="nav-item">
         <%= link_to t("users.new.tab_title"), "#", :class => "nav-link active" %>


### PR DESCRIPTION
Using the session to persist the referer is not necessary and can be problematic in that if a login/signup is aborted partway through then the referer information can persist in the session and be reused during a later attempt.