### PR TITLE
Have two columns for layer buttons between small and medium screen widths

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -5,14 +5,21 @@ L.OSM.layers = function (options) {
     var layers = options.layers;
 
     var baseSection = $("<div>")
-      .attr("class", "base-layers d-grid gap-3 p-3 border-bottom border-secondary-subtle")
+      .attr("class", "base-layers container-fluid p-3 border-bottom border-secondary-subtle")
       .appendTo($ui);
+
+    var baseSectionRow = $("<div>")
+      .attr("class", "row row-cols-1 row-cols-sm-2 row-cols-md-1 g-3")
+      .appendTo(baseSection);
 
     layers.forEach(function (layer, i) {
       var id = "map-ui-layer-" + i;
 
+      var baseSectionCol = $("<div class='col'>")
+        .appendTo(baseSectionRow);
+
       var buttonContainer = $("<div class='position-relative'>")
-        .appendTo(baseSection);
+        .appendTo(baseSectionCol);
 
       var mapContainer = $("<div class='position-absolute top-0 start-0 bottom-0 end-0 z-0'>")
         .appendTo(buttonContainer);

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -417,7 +417,7 @@ body.small-nav {
 }
 
 .layers-ui {
-  .base-layers > * {
+  .base-layers .col > * {
     height: 56px;
 
     > .btn {


### PR DESCRIPTION
[Originally](https://github.com/openstreetmap/openstreetmap-website/pull/3620) I wanted smaller buttons but that's not easy to do if I'm not allowed to check their widths. Then let's at least not have overly wide buttons when the screen is about 700px wide.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/8ed26af6-5e74-4d6c-9192-99b7fce2c2fb)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/143cda67-3783-49e5-beb6-a27b5f74e953)
