### PR TITLE
Pin browser to versions that support ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ gem "gd2-ffij", ">= 0.4.0"
 gem "marcel"
 
 # Used for browser detection
-gem "browser"
+gem "browser", "< 6" # for ruby 3.0 support
 
 # Used for S3 object storage
 gem "aws-sdk-s3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     brakeman (6.1.2)
       racc
     brotli (0.5.0)
-    browser (6.0.0)
+    browser (5.3.1)
     builder (3.2.4)
     bzip2-ffi (1.1.1)
       ffi (~> 1.0)
@@ -336,8 +336,7 @@ GEM
       minitest (>= 4, < 6)
     msgpack (1.7.2)
     multi_json (1.15.0)
-    multi_xml (0.7.1)
-      bigdecimal (~> 3.1)
+    multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
@@ -613,7 +612,7 @@ DEPENDENCIES
   bootstrap (~> 5.3.2)
   bootstrap_form (~> 5.0)
   brakeman
-  browser
+  browser (< 6)
   bzip2-ffi
   cancancan
   canonical-rails


### PR DESCRIPTION
The latest release of the `browser` gem, version 6.0.0, dropped support for ruby 3.0 and ruby 3.1. Ruby 3.0 is our minimum supported version, at least until we drop support for Ubuntu 20.04.

This PR constrains `browser` to "< 6" in order to keep supporting ruby 3.0
