### PR TITLE
Lighten moderator icon color

### DIFF
--- a/app/helpers/user_roles_helper.rb
+++ b/app/helpers/user_roles_helper.rb
@@ -24,7 +24,7 @@ module UserRolesHelper
   def role_icon_svg_tag(role, blank, title, **options)
     role_colors = {
       "administrator" => "#f69e42",
-      "moderator" => "#0606ff",
+      "moderator" => "#447eff",
       "importer" => "#38e13a"
     }
     color = role_colors[role] || "currentColor"


### PR DESCRIPTION
Before:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/a6f28b0d-e4ee-432d-9dad-d45dfad31a25)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7dabcb57-3675-462d-bc45-0eed8034f720)

You can see that the moderator star is significantly darker than the others and it is too dark for dark mode.

After:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/bf6a867c-40a7-441f-a8f8-b73bded78100)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/65352160-b859-4dd3-9415-ef9abe9e2509)
