### PR TITLE
Make blank role icons transparent

### DIFF
--- a/app/helpers/user_roles_helper.rb
+++ b/app/helpers/user_roles_helper.rb
@@ -32,8 +32,11 @@ module UserRolesHelper
     path_data = "M 10,2 8.125,8 2,8 6.96875,11.71875 5,18 10,14 15,18 13.03125,11.71875 18,8 11.875,8 10,2 z"
     tag.svg(:width => 20, :height => 20, **options) do
       concat tag.title(title)
-      concat tag.path(:d => path_data, :fill => color, :stroke => color, "stroke-width" => 2, "stroke-linejoin" => "round")
-      concat tag.path(:d => path_data, :fill => "#fff") if blank
+      concat tag.path(:d => path_data,
+                      :fill => blank ? "none" : color,
+                      :stroke => color,
+                      "stroke-width" => blank ? 1.5 : 2,
+                      "stroke-linejoin" => "round")
     end
   end
 end


### PR DESCRIPTION
Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/4fc55385-a754-4d42-9278-78b24f78ea94)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/da822dbe-5d99-4b96-b8ff-d7d943058b70)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/bdc74100-394d-4e51-955a-ff87974b6321)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/91eb89e9-a7be-4465-8af0-0f55249d4831)
