### PR TITLE
Remove bs-custom-file-input javascript plugin

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,8 +16,6 @@
 //= require matomo
 //= require richtext
 //= require qs/dist/qs
-//= require bs-custom-file-input
-//= require bs-custom-file-input-init
 
 /*
  * Called as the user scrolls/zooms around to manipulate hrefs of the

--- a/app/assets/javascripts/bs-custom-file-input-init.js
+++ b/app/assets/javascripts/bs-custom-file-input-init.js
@@ -1,5 +1,0 @@
-/* global bsCustomFileInput */
-
-$(document).ready(function () {
-  bsCustomFileInput.init();
-});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "openstreetmap",
   "private": true,
   "dependencies": {
-    "bs-custom-file-input": "^1.3.4",
     "jquery-simulate": "^1.0.2",
     "js-cookie": "^3.0.0",
     "leaflet": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,11 +134,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-bs-custom-file-input@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/bs-custom-file-input/-/bs-custom-file-input-1.3.4.tgz#c275cb8d4f1c02ba026324292509fa9a747dbda8"
-  integrity sha512-NBsQzTnef3OW1MvdKBbMHAYHssCd613MSeJV7z2McXznWtVMnJCy7Ckyc+PwxV6Pk16cu6YBcYWh/ZE0XWNKCA==
-
 call-bind@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"


### PR DESCRIPTION
That was a [Bootstrap 4 plugin](https://getbootstrap.com/docs/4.6/components/forms/#file-browser). Bootstrap 5 docs [no longer recommend it](https://getbootstrap.com/docs/5.3/forms/form-control/#file-input). It doesn't do anything because there are no inputs matching [its selector](https://github.com/Johann-S/bs-custom-file-input/blob/a4cb893188f06e94c811bac1e5c3682bb4b0e459/src/selector.js#L2).