### PR TITLE
Fix CSP failures for Microsoft social sign-in

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -17,7 +17,7 @@ class AccountsController < ApplicationController
     @tokens = current_user.oauth_tokens.authorized
 
     append_content_security_policy_directives(
-      :form_action => %w[accounts.google.com *.facebook.com login.live.com github.com meta.wikimedia.org]
+      :form_action => %w[accounts.google.com *.facebook.com login.live.com login.microsoftonline.com github.com meta.wikimedia.org]
     )
 
     if errors = session.delete(:user_errors)
@@ -32,7 +32,7 @@ class AccountsController < ApplicationController
     @tokens = current_user.oauth_tokens.authorized
 
     append_content_security_policy_directives(
-      :form_action => %w[accounts.google.com *.facebook.com login.live.com github.com meta.wikimedia.org]
+      :form_action => %w[accounts.google.com *.facebook.com login.live.com login.microsoftonline.com github.com meta.wikimedia.org]
     )
 
     user_params = params.require(:user).permit(:display_name, :new_email, :pass_crypt, :pass_crypt_confirmation, :auth_provider)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,7 +63,7 @@ class UsersController < ApplicationController
     parse_oauth_referer @referer
 
     append_content_security_policy_directives(
-      :form_action => %w[accounts.google.com *.facebook.com login.live.com github.com meta.wikimedia.org]
+      :form_action => %w[accounts.google.com *.facebook.com login.live.com login.microsoftonline.com github.com meta.wikimedia.org]
     )
 
     if current_user


### PR DESCRIPTION
Add login.microsoftonline.com to CSP allow list for `/account/new`, `/account/edit` and `/users/new`

To reproduce:
`/account/edit`
- Login as existing user
- go to "My Settings"
- change "External Authentication" to Microsoft
- click "Save Changes"
- Page fails to load due to CSP violation

`/account/update` ?

`/users/new`
- Login to https://login.live.com with your existing MS account
- navigate to https://www.openstreetmap.com/login
- click on Microsoft Icon to use social account
- on `/user/new` page click "Sign up"
- Page fails to load due to CSP violation