### PR TITLE
Use bg-body in "log in / sign up to access" messages

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :heading do %>
   <% if @client_app_name %>
-    <p class="text-center text-muted fs-6 py-2 mb-0 bg-white"><%= t(".login_to_authorize_html", :client_app_name => @client_app_name) %></p>
+    <p class="text-center text-muted fs-6 py-2 mb-0 bg-body"><%= t(".login_to_authorize_html", :client_app_name => @client_app_name) %></p>
   <% end %>
 
   <div class="header-illustration new-user-main auth-container mx-auto">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :heading do %>
   <% if @client_app_name %>
-    <p class="text-center text-muted fs-6 py-2 mb-0 bg-white"><%= t(".signup_to_authorize_html", :client_app_name => @client_app_name) %></p>
+    <p class="text-center text-muted fs-6 py-2 mb-0 bg-body"><%= t(".signup_to_authorize_html", :client_app_name => @client_app_name) %></p>
   <% end %>
 
   <div class="header-illustration new-user-main auth-container mx-auto">


### PR DESCRIPTION
Fixes "bg-white" from #4773.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c8d251de-4fde-4e94-87a9-283e4ce389cc)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/88b33498-d8a3-4f51-9f14-436c34c849aa)
