### PR TITLE
Use https links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 * https://www.ruby-lang.org/ - The homepage of Ruby which has more links and some great tutorials.
-* http://rubyonrails.org/ - The homepage of Rails, also has links and tutorials
+* https://rubyonrails.org/ - The homepage of Rails, also has links and tutorials.
 
 ## Coding style
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,7 +125,7 @@ If you want to add in the full history later on, perhaps to run `git blame` or `
 
 ## Ruby gems
 
-We use [Bundler](http://gembundler.com/) to manage the rubygems required for the project.
+We use [Bundler](https://bundler.io/) to manage the rubygems required for the project.
 
 ```
 cd openstreetmap-website

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests](https://github.com/openstreetmap/openstreetmap-website/workflows/Tests/badge.svg?branch=master&event=push)](https://github.com/openstreetmap/openstreetmap-website/actions?query=workflow%3ATests%20branch%3Amaster%20event%3Apush)
 [![Coverage Status](https://coveralls.io/repos/openstreetmap/openstreetmap-website/badge.svg?branch=master)](https://coveralls.io/r/openstreetmap/openstreetmap-website?branch=master)
 
-This is `openstreetmap-website`, the [Ruby on Rails](http://rubyonrails.org/)
+This is `openstreetmap-website`, the [Ruby on Rails](https://rubyonrails.org/)
 application that powers the [OpenStreetMap](https://www.openstreetmap.org) website and API.
 
 This repository consists of:

--- a/config/locales/README
+++ b/config/locales/README
@@ -10,4 +10,4 @@ errors, as there is at least one test that makes sure that all translations are
 valid (we'll makes sure that they won't cause the site to not work).
 
 There is more information about translating the website on the wiki at
-http://wiki.openstreetmap.org/wiki/Website_Internationalization.
+https://wiki.openstreetmap.org/wiki/Website_internationalization.


### PR DESCRIPTION
There's also a gembundler.com link in INSTALL.md, is it supposed to be bundler.io?