### PR TITLE
Add warnings when creating notes anonymously

### DIFF
--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -4,6 +4,11 @@
 
 <div class="note">
   <p class="alert alert-info"><%= t(".intro") %></p>
+  <% if !current_user %>
+    <p class="alert alert-warning"><%= t ".anonymous_warning_html",
+                                         :log_in => link_to(t(".anonymous_warning_log_in"), login_path(:referer => new_note_path)),
+                                         :sign_up => link_to(t(".anonymous_warning_sign_up"), user_new_path) %></p>
+  <% end %>
   <form action="#">
     <input type="hidden" name="lon" autocomplete="off">
     <input type="hidden" name="lat" autocomplete="off">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3081,6 +3081,9 @@ en:
     new:
       title: "New Note"
       intro: "Spotted a mistake or something missing? Let other mappers know so we can fix it. Move the marker to the correct position and type a note to explain the problem."
+      anonymous_warning_html: "You are not logged in. Please %{log_in} or %{sign_up} if you want to receive updates for your note."
+      anonymous_warning_log_in: "log in"
+      anonymous_warning_sign_up: "sign up"
       advice: "Your note is public and may be used to update the map, so don't enter personal information, or information from copyrighted maps or directory listings."
       add: Add Note
   javascripts:

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -160,9 +160,19 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_select "div.details", /Resolved by deleted/
   end
 
-  def test_new_note
+  def test_new_note_anonymous
     get new_note_path
     assert_response :success
     assert_template "notes/new"
+    assert_select "#sidebar_content a[href='#{login_path(:referer => new_note_path)}']", :count => 1
+  end
+
+  def test_new_note
+    session_for(create(:user))
+
+    get new_note_path
+    assert_response :success
+    assert_template "notes/new"
+    assert_select "#sidebar_content a[href='#{login_path(:referer => new_note_path)}']", :count => 0
   end
 end


### PR DESCRIPTION
Fixes #244.

The goal is to:
- tell users who are not registered and add notes why they might want to register
- tell users who forgot to log in that they might want to log in

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/dc0aad38-7d37-4119-aba8-56de0827f9f3)
