### PR TITLE
Fix exception uploading a unicode preference value

### DIFF
--- a/app/controllers/api/user_preferences_controller.rb
+++ b/app/controllers/api/user_preferences_controller.rb
@@ -66,7 +66,7 @@ module Api
         pref.k = params[:preference_key]
       end
 
-      pref.v = request.raw_post.chomp
+      pref.v = request.raw_post.chomp.force_encoding("UTF-8")
       pref.save!
 
       render :plain => ""


### PR DESCRIPTION
Anonymised log extract for an error captured in production:

```
Started PUT "/api/0.6/user/preferences/key" for a.b.c.d at 2024-05-16 15:53:45 +0000
Processing by Api::UserPreferencesController#update as */*
   Parameters: {"preference_key"=>"key"}
API threw unexpected Encoding::CompatibilityError exception: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)
/srv/www.openstreetmap.org/rails/app/validators/characters_validator.rb:6:in `match?'
/srv/www.openstreetmap.org/rails/app/validators/characters_validator.rb:6:in `validate_each'
/var/lib/gems/3.0.0/gems/activemodel-7.1.3.2/lib/active_model/validator.rb:155:in `block in validate'
/var/lib/gems/3.0.0/gems/activemodel-7.1.3.2/lib/active_model/validator.rb:151:in `each'
/var/lib/gems/3.0.0/gems/activemodel-7.1.3.2/lib/active_model/validator.rb:151:in `validate'
```

The problem is that user_preferences#upload is weird and uses the raw request body as the value but that does not have a well defined encoding and rails treats it as ASCII which causes the above exception when the model tries to validate it.

This PR simply forces the body to be treated as UTF-8 instead, and adds tests.