### PR TITLE
Don't skip heading levels on "fixthemap" page

### DIFF
--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -13,14 +13,14 @@
 
 <div class='row'>
   <div class='col-sm'>
-    <h5><%= t ".how_to_help.join_the_community.title" %></h5>
+    <h3 class='fs-5'><%= t ".how_to_help.join_the_community.title" %></h3>
     <p><%= t ".how_to_help.join_the_community.explanation_html" %></p>
     <p class='text-center'>
       <a class="btn btn-primary" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
     </p>
   </div>
   <div class='col-sm'>
-    <h5><%= t "site.welcome.add_a_note.title" %></h5>
+    <h3 class='fs-5'><%= t "site.welcome.add_a_note.title" %></h3>
     <p><%= t "site.welcome.add_a_note.para_1" %></p>
     <p><%= t ".how_to_help.add_a_note.instructions_1_html", :note_icon => tag.a(:class => "icon note bg-dark rounded-1") %></p>
   </div>


### PR DESCRIPTION
[
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/084d61cd-524f-473a-8ba7-168a5e8cc8b7)
](https://validator.w3.org/nu/?showoutline=yes&doc=https%3A%2F%2Fwww.openstreetmap.org%2Ffixthemap#headingoutline)