### PR TITLE
Use font size instead of italic for changeset/trace descriptions

### DIFF
--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -7,7 +7,7 @@
   #<%= link_to_unless_current common_details.version, :controller => "old_#{@type.pluralize}", :action => :show, :version => common_details.version %>
 </h4>
 
-<p class="fs-6">
+<p class="fs-6 overflow-x-auto">
   <% if common_details.changeset.tags["comment"].present? %>
     <%= linkify(common_details.changeset.tags["comment"]) %>
   <% else %>

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -7,7 +7,7 @@
   #<%= link_to_unless_current common_details.version, :controller => "old_#{@type.pluralize}", :action => :show, :version => common_details.version %>
 </h4>
 
-<p class="fst-italic">
+<p class="fs-6">
   <% if common_details.changeset.tags["comment"].present? %>
     <%= linkify(common_details.changeset.tags["comment"]) %>
   <% else %>

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -11,7 +11,7 @@
    end %>
 
 <%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item list-group-item-action" do %>
-  <p class="fs-6">
+  <p class="fs-6 text-truncate text-wrap">
     <a class="changeset_id link-body-emphasis stretched-link" href="<%= changeset_path(changeset) %>">
       <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>
     </a>

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -11,7 +11,7 @@
    end %>
 
 <%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item list-group-item-action" do %>
-  <p class="fst-italic">
+  <p class="fs-6">
     <a class="changeset_id link-body-emphasis stretched-link" href="<%= changeset_path(changeset) %>">
       <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>
     </a>

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -3,7 +3,7 @@
 <%= render "sidebar_header", :title => t(".title", :id => @changeset.id) %>
 
 <div class="browse-section">
-  <p class="fs-6">
+  <p class="fs-6 overflow-x-auto">
     <%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %>
   </p>
   <p class="details"><%= changeset_details(@changeset) %></p>

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -3,7 +3,7 @@
 <%= render "sidebar_header", :title => t(".title", :id => @changeset.id) %>
 
 <div class="browse-section">
-  <p class="fst-italic">
+  <p class="fs-6">
     <%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %>
   </p>
   <p class="details"><%= changeset_details(@changeset) %></p>

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -40,7 +40,7 @@
                                          :tags => safe_join(trace.tags.collect { |tag| link_to_tag tag.tag }, ", ") %>
       <% end %>
     </p>
-    <p class="fst-italic mb-0">
+    <p class="fs-6 mb-0">
       <%= trace.description %>
     </p>
   </td>


### PR DESCRIPTION
The problem and links to previous solutions are in #2869. Changeset descriptions were made to use italics "to make them look more like quotes" but that doesn't work well with Chinese and maybe other writing systems and large blocks of italics don't look good. How else can the descriptions be rendered? I tried a few options:

- Bold font: looks too bold. Intermediate font weights: not clear if they are going to be available with every font and writing system that might be in use.
- Decorations like underline: can't use them because descriptions sometimes are links, sometimes are not links, sometimes they contain links inside.
- Colors: also don't look right. Primary color is blue, that looks like a link. Secondary is gray we use for deemphasising. Other colors we mostly don't use, they stick out too much.

How about font size then? Let's make the font slightly bigger.

However that may make another problem worse. The text is now more likely not to fit horizontally. You can't always force words to wrap, but then horizontal scrolling should work fine just for the overflowing descriptions. Except it won't work fine when stretched links are used, and they are used in changeset lists. In this case let's truncate the text while still letting it to wrap if possible.

Screenshots in Chromium, because it shows scrollbars:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3a771cc2-2e4d-4dd3-9171-32f429e1d557)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/5659446b-9a5e-4855-aceb-b373eae464b6)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/a52611ca-9be5-4570-989e-9c7b12e1b4ae)
