### PR TITLE
Remove inbox template and anchor id

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -83,7 +83,9 @@
       <div class='d-inline-flex dropdown user-menu logged-in'>
         <button class='dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
           <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
-          <%= render :partial => "layouts/inbox" %>
+          <% if current_user.new_messages.size > 0 %>
+            <span class="badge count-number m-1"><%= current_user.new_messages.size %></span>
+          <% end %>
           <span class="user-button">
             <span class='username'>
               <%= current_user.display_name %>

--- a/app/views/layouts/_inbox.html.erb
+++ b/app/views/layouts/_inbox.html.erb
@@ -1,3 +1,0 @@
-<% if current_user.new_messages.size > 0 %>
-<span id="inboxanchor" class="badge count-number m-1"><%= current_user.new_messages.size %></span>
-<% end %>


### PR DESCRIPTION
This partial template used to be included from different places, but now it's included only from header. I want to make changes to it that are specific to the account button. It would make no sense for them to be in a different file.

Also `id="inboxanchor"` is not necessary after Turbo updates.