### PR TITLE
Use .icon-link to align logo

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -107,14 +107,8 @@ header {
     padding: $lineheight * 0.5;
   }
 
-  img.logo {
-    margin-top: -2px;
-  }
-
   h1 {
     font-size: 18px;
-    line-height: 1.2;
-    padding-top: 15px;
   }
 
   .btn {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="d-flex bg-body text-nowrap closed z-3">
-  <h1 class="m-0 fw-semibold">
-    <a href="<%= root_path %>" class="text-body-emphasis text-decoration-none geolink">
-      <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :width => 30, :height => 30, :class => "logo" %>
+  <h1 class="d-flex m-0 fw-semibold">
+    <a href="<%= root_path %>" class="icon-link gap-1 text-body-emphasis text-decoration-none geolink">
+      <%= image_tag "osm_logo.png", :srcset => image_path("osm_logo.svg"), :alt => t("layouts.logo.alt_text"), :size => 30 %>
       <%= t "layouts.project_name.h1" %>
     </a>
   </h1>


### PR DESCRIPTION
Removes pixel sizes specific to the logo.

`.icon-link` also makes the gap between the logo and "OpenStreetMap" slightly bigger:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/631bcbb3-6769-4867-a68a-2683b0e3b39f)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/e7fc94e3-21dc-4285-af73-939f3bdd1c0b)
