### PR TITLE
Remove unnecessary user menu wrapper

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -86,10 +86,8 @@
           <% if current_user.new_messages.size > 0 %>
             <span class="badge count-number m-1"><%= current_user.new_messages.size %></span>
           <% end %>
-          <span class="user-button">
-            <span class='username'>
-              <%= current_user.display_name %>
-            </span>
+          <span class='username'>
+            <%= current_user.display_name %>
           </span>
         </button>
         <div class='dropdown-menu dropdown-menu-end'>


### PR DESCRIPTION
Was used to replace the inbox counter before Turbo:
https://github.com/openstreetmap/openstreetmap-website/commit/1a7b7f5d18931f60f4171b7ac410ea4434828dd1#diff-305c268f66d28c4cd669b9a69449100d2de05f2b61da1e58914295c1eea45e16L22

`<span class='username'>` is also unnecessary but I'm going to use it later to limit the username width.