### PR TITLE
Sticky close button

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -401,7 +401,7 @@ $(document).ready(function () {
     }
   });
 
-  $(document).on("click", "#sidebar_content .btn-close", function () {
+  $(document).on("click", "#sidebar_close button", function () {
     OSM.router.route("/" + OSM.formatHash(map));
   });
 });

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -20,14 +20,9 @@ L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
     var $ui = $("<div>")
       .attr("class", uiClass + "-ui");
 
-    $("<div class='d-flex p-3 pb-0'>")
-      .appendTo($ui)
-      .append($("<h2 class='flex-grow-1 text-break'>")
-        .text(I18n.t(paneTitle)))
-      .append($("<div>")
-        .append($("<button type='button' class='btn-close'>")
-          .attr("aria-label", I18n.t("javascripts.close"))
-          .bind("click", toggle)));
+    $("<h2 class='p-3 pb-0 pe-5 text-break'>")
+      .text(I18n.t(paneTitle))
+      .appendTo($ui);
 
     options.sidebar.addPane($ui);
 

--- a/app/assets/javascripts/leaflet.sidebar.js
+++ b/app/assets/javascripts/leaflet.sidebar.js
@@ -1,6 +1,7 @@
 L.OSM.sidebar = function (selector) {
   var control = {},
       sidebar = $(selector),
+      closeButton = sidebar.find(".btn-close"),
       current = $(),
       currentButton = $(),
       map;
@@ -52,6 +53,10 @@ L.OSM.sidebar = function (selector) {
     currentButton
       .addClass("active");
   };
+
+  closeButton.click(function () {
+    control.togglePane(current, currentButton);
+  });
 
   return control;
 };

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -359,6 +359,7 @@ body.small-nav {
       display: block;
     }
 
+    #sidebar_close,
     #sidebar_content {
       display: none;
     }

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -1,6 +1,1 @@
-<div class="d-flex">
-  <h2 class="flex-grow-1 text-break"><%= title %></h2>
-  <div>
-    <button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button>
-  </div>
-</div>
+<h2 class="text-break pe-4"><%= title %></h2>

--- a/app/views/layouts/_sticky_close.html.erb
+++ b/app/views/layouts/_sticky_close.html.erb
@@ -1,0 +1,5 @@
+<%= tag.div :id => id, :class => "position-sticky top-0 z-3" do %>
+  <div class="position-absolute end-0 d-flex p-3 bg-body bg-opacity-50 rounded-5">
+    <button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button>
+  </div>
+<% end %>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -72,6 +72,7 @@
   </noscript>
 
   <div id="map-ui" class="bg-body z-2">
+    <%= render :partial => "layouts/sticky_close", :locals => { :id => nil } %>
   </div>
 
   <div id="map" tabindex="2" class="bg-body-secondary z-0">

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -36,22 +36,27 @@
       </div>
     </div>
 
+    <%= render :partial => "layouts/sticky_close", :locals => { :id => "sidebar_close" } %>
+
     <div id="sidebar_content" class="p-3">
       <%= yield %>
     </div>
 
     <% unless current_user %>
-      <div class="welcome p-3" hidden>
-        <%= render "sidebar_header", :title => t("layouts.intro_header") %>
-        <p class="fs-6 fw-light"><%= t "layouts.intro_text" %></p>
-        <p class="fs-6 fw-light"><%= t "layouts.hosting_partners_2024_html",
-                                       :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
-                                       :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
-                                       :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
-        </p>
-        <div class="d-flex gap-2">
-          <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
-          <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= new_user_path %>"><%= t("layouts.start_mapping") %></a>
+      <div class="welcome" hidden>
+        <%= render :partial => "layouts/sticky_close", :locals => { :id => nil } %>
+        <div class="p-3">
+          <h2 class="pe-4 text-break"><%= t("layouts.intro_header") %></h2>
+          <p class="fs-6 fw-light"><%= t "layouts.intro_text" %></p>
+          <p class="fs-6 fw-light"><%= t "layouts.hosting_partners_2024_html",
+                                         :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
+                                         :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
+                                         :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
+          </p>
+          <div class="d-flex gap-2">
+            <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
+            <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= new_user_path %>"><%= t("layouts.start_mapping") %></a>
+          </div>
         </div>
       </div>
     <% end %>

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -16,7 +16,7 @@ class IndexTest < ApplicationSystemTestCase
     visit node_path(node)
     find(".icon.share").click
     assert_no_selector "#content.overlay-right-sidebar"
-    find(".share-ui .btn-close").click
+    find("#map-ui .btn-close").click
     assert_selector "#content.overlay-right-sidebar"
   end
 


### PR DESCRIPTION
Allows close buttons to stay visible when sidebar contents is scrolled.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b359a643-b39c-4a36-bd87-eeb63b57bd0b) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/aa30a1e5-3f45-43b8-9e00-4434adcdb119)

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7e85620f-59ac-4723-8ad3-a9662035ef2d) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/0e7d3ea4-e5a4-4e67-be56-c533d8733b5d)

Fixes #2174.

Also related to [this](https://github.com/openstreetmap/openstreetmap-website/pull/4647#issuecomment-2123124562) because the button is not inside `sidebar_content` and is not being resent with page templates.