### PR TITLE
Fixed "Tab alignment" issue described in #4773

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <div class="header-illustration new-user-main auth-container mx-auto">
-    <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
+    <ul class="nav nav-tabs position-absolute bottom-0 fs-6 w-100">
       <li class="nav-item">
         <%= link_to t("sessions.new.tab_title"), "#", :class => "nav-link active" %>
       </li>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <div class="header-illustration new-user-main auth-container mx-auto">
-    <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
+    <ul class="nav nav-tabs position-absolute bottom-0 fs-6 w-100">
       <li class="nav-item">
         <%= link_to t("sessions.new.tab_title"), url_for(:action => :new, :controller => :sessions, :referer => @referer), :class => "nav-link" %>
       </li>


### PR DESCRIPTION
This PR addresses "Tab alignment" issue mentioned in the #4773

I removed px-3 class from ul tag defining area in which are "Log in" and "Sign up" tabs.