### PR TITLE
Adjust vertical alignment of secondary header navigation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -106,6 +106,7 @@ $(document).ready(function () {
     $("body").removeClass("compact-nav");
 
     $("header").removeClass("text-nowrap");
+    $("header nav.secondary > ul").removeClass("flex-nowrap");
 
     updateHeader();
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -150,7 +150,7 @@ nav.primary {
 
 nav.secondary {
   .nav-link {
-    padding: 0.2rem;
+    padding: 0.3rem;
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -98,10 +98,6 @@ header {
   position: relative;
   font-size: 14px;
 
-  h1, nav, nav > ul, nav > ul > li {
-    display: inline-block;
-  }
-
   > * {
     height: 100%;
     padding: $lineheight * 0.5;
@@ -191,7 +187,7 @@ body.small-nav {
     min-height: $headerHeight;
 
     &.closed nav {
-      display: none;
+      display: none !important;
     }
 
     .search_forms {
@@ -216,6 +212,8 @@ body.small-nav {
   }
 
   nav.secondary {
+    flex-direction: column;
+
     .user-menu, .login-menu {
       width: 100%;
     }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -31,8 +31,8 @@
       <%= link_to t("layouts.export"), export_path, :class => "btn btn-outline-primary geolink", :id => "export_tab" %>
     </div>
   </nav>
-  <nav class='secondary'>
-    <ul class='mx-1 px-0'>
+  <nav class='secondary d-flex gap-2 align-items-center'>
+    <ul class='nav flex-nowrap'>
       <% if Settings.status != "database_offline" && can?(:index, Issue) %>
         <li class="compact-hide nav-item">
           <%= link_to issues_path(:status => "open"), :class => header_nav_link_class(issues_path) do %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -84,9 +84,9 @@
         <button class='dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
           <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
           <% if current_user.new_messages.size > 0 %>
-            <span class="badge count-number m-1"><%= current_user.new_messages.size %></span>
+            <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
           <% end %>
-          <span class='username'>
+          <span class='username align-middle'>
             <%= current_user.display_name %>
           </span>
         </button>


### PR DESCRIPTION
Like #4723 + adjustments inside the user button + increased horizontal spacing between menu items (in #4723 the spacing decreased because with `display: flex` whitespace between items gets removed).

I get rid of `h1, nav, nav > ul, nav > ul > li` selector and do other changes in order to switch later to Bootstrap navbar and decrease the number of menu/sidebar visibility modes.

Before / after when not logged in:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c1ed847c-a110-4505-983b-d70cf106ef33)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/e41554d5-491e-4869-9f5b-81543da883da)

Before / after with issues counter:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/58f03eb8-1c3c-4471-8e3e-00941cf8bdbd)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/93ae91e9-0224-49dc-b210-184b8da650f9)

Before / after with message counter:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/fca587c3-995c-4ca0-b131-f1bc631349e9)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/15b33c81-3065-46ec-bc30-d01053a9b165)
