### PR TITLE
Keep header h1 height equal to default header height

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -103,11 +103,11 @@ header {
   }
 
   > * {
-    height: 100%;
     padding: $lineheight * 0.5;
   }
 
   h1 {
+    height: $headerHeight;
     font-size: 18px;
   }
 


### PR DESCRIPTION
In small mode logo+h1 move up slightly. It seems like they shouldn't because there's `> * { height: 100%; ...}` css, but it doesn't do anything. What actually kept them from moving was `padding-top: 15px;` which I removed in #4823. I'm not going to put this padding back in. Instead I just set their height directly.

Before / after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/2be97da9-afc2-4c62-b53c-b983cf351b93) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/8e0ea2e7-a713-400e-b30e-712e1070e4d3)
