### PR TITLE
Remove custom css from "Enable overlays" text

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -84,7 +84,7 @@ L.OSM.layers = function (options) {
 
       $("<p>")
         .text(I18n.t("javascripts.map.layers.overlays"))
-        .attr("class", "text-body-secondary")
+        .attr("class", "text-body-secondary small mb-2")
         .appendTo(overlaySection);
 
       var overlays = $("<ul class='list-unstyled form-check'>")

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -423,10 +423,6 @@ body.small-nav {
   }
 
   .overlay-layers {
-    p {
-      font-size: 13px;
-      margin-bottom: 8px;
-    }
     li.disabled { color: $darkgrey; }
   }
 }


### PR DESCRIPTION
I use `.small` font size from Bootstrap which is slightly smaller than the current custom 13px size.

Before / after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d4e683ac-7139-4bda-9f46-635e1d0ad9ca) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d1d1cd26-0a3c-4c49-8229-44a7343b27a2)
