### PR TITLE
Remove custom css from note descriptions

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -636,11 +636,6 @@ tr.turn {
     }
   }
 
-  .note-description {
-    overflow: hidden;
-    margin: 0 0 10px 10px;
-  }
-
   .query-results {
     display: none;
   }

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -4,7 +4,7 @@
 
 <div>
   <h4><%= t(".description") %></h4>
-  <div class="note-description">
+  <div class="overflow-hidden ms-2">
     <%= h(@note_comments.first.body.to_html) %>
   </div>
 


### PR DESCRIPTION
- left margin is similar to what's being used on note comments
- bottom margin - I don't think it's required here because paragraphs inside descriptions already have bottom margins

Before / after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/698a6b19-10d7-4c1c-88ed-6d3ddbbb678a) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d4c65bb1-9606-4b04-9cac-2325be2f2ddb)
