### PR TITLE
Remove unused .browse_status css class

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -580,10 +580,6 @@ tr.turn {
 
 .routing_marker { width: 15px; cursor: move; }
 
-.browse_status {
-  display: none;
-}
-
 /* Rules for the history sidebar */
 
 #sidebar .changesets {


### PR DESCRIPTION
#4835 removes `#browse_status` but there's also `.browse_status`. I can't find any use of this class at any time.