### PR TITLE
Replace .btn-wrapper with Bootstrap gutters/gaps

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -637,16 +637,6 @@ tr.turn {
   }
 }
 
-/* Bootstrap buttons don't have any vertical margin, so
-   they touch when adjacent buttons wrap onto a new line
-   e.g. wide form buttons on a narrow sidebar */
-
-.btn-wrapper {
-  > .btn {
-    margin-bottom: $spacer * 0.25;
-  }
-}
-
 /* Force LTR/RTL alignment for placeholder text */
 
 .form-control::placeholder {

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -54,11 +54,11 @@
     </span>
   </div>
 
-  <div class="row justify-content-between">
-    <div class="col-auto btn-wrapper">
+  <div class="row justify-content-between g-1">
+    <div class="col-auto">
       <%= f.primary t(".save changes button") %>
     </div>
-    <div class="col-auto btn-wrapper">
+    <div class="col-auto">
       <%= link_to t(".delete_account"), account_deletion_path, :class => "btn btn-outline-danger" %>
     </div>
   </div>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -15,7 +15,7 @@
     <div class="mb-3">
       <textarea class="form-control" name="text" cols="40" rows="10" maxlength="2000" placeholder="<%= t(".advice") %>"></textarea>
     </div>
-    <div class="btn-wrapper">
+    <div>
       <input type="submit" name="add" value="<%= t(".add") %>" disabled="1" class="btn btn-primary">
     </div>
   </form>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -51,7 +51,7 @@
         </div>
         <div id="comment-error" class="alert alert-danger p-2 mb-3" hidden>
         </div>
-        <div class="btn-wrapper">
+        <div class="d-flex flex-wrap gap-1">
           <% if current_user.moderator? -%>
             <%= submit_tag t(".hide"), :name => "hide", :class => "btn btn-light",
                                        :data => { :method => "DELETE",
@@ -77,7 +77,7 @@
       <input type="hidden" name="text" value="" autocomplete="off">
       <div id="comment-error" class="alert alert-danger p-2 mb-3" hidden>
       </div>
-      <div class="btn-wrapper">
+      <div class="d-flex flex-wrap gap-1">
         <% if @note.status != "hidden" and current_user and current_user.moderator? -%>
           <input type="submit" name="hide" value="<%= t(".hide") %>" class="btn btn-light" data-method="DELETE" data-url="<%= api_note_url(@note, "json") %>">
         <% end -%>


### PR DESCRIPTION
See the deleted css comment for why it was used. You can achieve the same effect with [gutters](https://getbootstrap.com/docs/5.3/layout/gutters/) when using Bootstrap rows or with `.d-flex` + [gaps](https://getbootstrap.com/docs/5.3/utilities/spacing/#gap).

Account settings in a very narrow window:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3741bb50-d2fc-4e01-af11-dae68a49c19c)

Note edit buttons:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/749bab5d-191d-4e22-9d1f-7cb52ab48801)
