### PR TITLE
Remove unused #container css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -16,8 +16,6 @@ time[title] {
   text-decoration: underline dotted;
 }
 
-#container { position: relative; }
-
 /* Rules for icons */
 
 .icon {


### PR DESCRIPTION
Like #4836 I can't find it ever being used. Maybe it was meant to be `<div id="content">`?