### PR TITLE
Show edit and export on small screens

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -79,8 +79,11 @@ $(document).ready(function () {
 
     if (windowWidth < compactWidth) {
       $("body").removeClass("compact-nav").addClass("small-nav");
+      // Toggling the classes is needed until https://github.com/twbs/bootstrap/issues/39213 is added
+      $("nav.primary > .btn-group").removeClass("btn-group").addClass("btn-group-vertical");
     } else if (windowWidth < headerWidth) {
       $("body").addClass("compact-nav").removeClass("small-nav");
+      $("nav.primary > .btn-group").removeClass("btn-group-vertical").addClass("btn-group");
     } else {
       $("body").removeClass("compact-nav").removeClass("small-nav");
     }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -199,9 +199,7 @@ body.small-nav {
     }
   }
 
-  #sidebar .search_forms,
-  #edit_tab,
-  #export_tab {
+  #sidebar .search_forms {
     display: none;
   }
 
@@ -209,9 +207,18 @@ body.small-nav {
     margin-right: 0;
     padding: 0;
 
-    .btn-group {
+    > .btn-group,
+    > .btn-group-vertical {
       width: 100%;
       padding: 10px;
+    }
+
+    // Fix Bootstrap 5 bug, see https://github.com/twbs/bootstrap/pull/40488
+    .btn-group-vertical>.btn-group:not(:first-child)>.btn,
+    .btn-group-vertical>.btn:nth-child(n+3),
+    .btn-group-vertical>:not(.btn-check)+.btn {
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
     }
   }
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,14 +8,14 @@
   <a href="#" id="menu-icon"></a>
   <nav class='primary'>
     <%= content_for :header %>
-    <div class="btn-group">
-      <div id="edit_tab" class="btn-group">
+    <div class="btn-group" role="group">
+      <div id="edit_tab" class="btn-group" role="group">
         <%= link_to t("layouts.edit"),
                     edit_path,
-                    :class => "btn btn-outline-primary geolink editlink",
+                    :class => "btn btn-outline-primary geolink editlink w-100",
                     :id => "editanchor",
                     :data => { :editor => preferred_editor } %>
-        <button class='btn btn-outline-primary dropdown-toggle dropdown-toggle-split' type='button' data-bs-toggle='dropdown'></button>
+        <button class='btn btn-outline-primary dropdown-toggle dropdown-toggle-split px-3 px-md-2' type='button' data-bs-toggle='dropdown'></button>
         <ul class='dropdown-menu'>
           <% Editors::RECOMMENDED_EDITORS.each do |editor| %>
             <li>


### PR DESCRIPTION
I looked into making the edit button visible on small screen https://github.com/openstreetmap/openstreetmap-website/issues/2233 and ran into a few issues that are making this less straight forward than I was hoping it to be.

1. Bootstrap does not provide responsive classes to change the button group to vertical. 
    - There is an issue on this at https://github.com/twbs/bootstrap/issues/39213
    - We could change the layout of course. 
    - We could also change the classes in JavaScript, which I did for this draft.
3. Bootstrap has a bug with vertical button list when the first button is a dropdown. 
   - I reported this in https://github.com/twbs/bootstrap/issues/40487 and my PR https://github.com/twbs/bootstrap/pull/40488 might fix it. 
   - I added this fix as a workaround to our css for this draft.
5. Bootstrap does not support vertical button groups with split buttons ATM. 
   - See https://getbootstrap.com/docs/5.2/components/button-group/#vertical-variation _"Split button dropdowns are not supported here."_. 
   - We can work around this by adding a few utility classes, which I did for this draft. 
   - But since the way we do responsive design on the website is a bit special, there are slight changes to what we have right now in certain edge case screen sizes. We could use more JS to fix this if needed…
7. Bootstrap does not handle hidden items in a group.
   - We are hiding the "Export" Page on the button group via CSS ATM and Bootstrap does not handle the case of hidden elements, so the button group borders are wrong. 
   - For this solution I made all menu items visible. Following the logic that the reason why we have an export page so prominently on the page at all is to showcase the story of OSM, which is just as true on mobile. Hiding part of the story is worse than showing it so users can learn about it an realize they need a different device to use this part of the website. – We could continue hiding the page, of course, but need to add more custom css or JS to make bootstrap work.

**This is what it looks like:**

**Logged out:**

<img width="601" alt="image" src="https://github.com/openstreetmap/openstreetmap-website/assets/111561/7f1e4fb8-e330-4fa5-bc73-1069d0b80c91">

<img width="720" alt="image" src="https://github.com/openstreetmap/openstreetmap-website/assets/111561/a1657b76-d981-4f1b-9862-fb9d532711ab">

**Logged in:**


<img width="711" alt="Bildschirmfoto 2024-05-26 um 07 17 19" src="https://github.com/openstreetmap/openstreetmap-website/assets/111561/b73b8915-214d-41d9-baf4-d760ce0c4282">

<img width="713" alt="Bildschirmfoto 2024-05-26 um 07 17 27" src="https://github.com/openstreetmap/openstreetmap-website/assets/111561/a5304607-d591-4ae7-bb22-977f81dddd67">

<img width="1057" alt="Bildschirmfoto 2024-05-26 um 07 17 37" src="https://github.com/openstreetmap/openstreetmap-website/assets/111561/4275eaa7-4272-4b96-b202-2069afc379a2">


---

**Where do go from here?**

I consider hiding the Edit button in 2024 a bug which we should fix. And this PR is a way to do this.

In the near future we will need to reconsider this part of the menu, especially the screen usually visible on mobile to incorporate editors in the menu (https://github.com/openstreetmap/operations/issues/877#issuecomment-2130858478).

---

**Open issues:**

- [ ] When changing the screen width without reload, the class change from "button group" to "vertical button group" is not applied. 
    <img width="728" alt="image" src="https://github.com/openstreetmap/openstreetmap-website/assets/111561/35686c72-cc83-4aa2-a7a4-392f71cd15c4">
    I can fix since depending on the feedback on this PR.


---

Closes https://github.com/openstreetmap/openstreetmap-website/issues/2233