### PR TITLE
allow data URIs for images in iD

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -18,7 +18,7 @@ class SiteController < ApplicationController
 
   content_security_policy(:only => :id) do |policy|
     policy.connect_src("*")
-    policy.img_src("*", :blob)
+    policy.img_src(*policy.img_src, "*", :blob)
     policy.script_src(*policy.script_src, "dev.virtualearth.net", :unsafe_eval)
     policy.style_src(*policy.style_src, :unsafe_inline)
   end


### PR DESCRIPTION
Fixes problems like https://github.com/openstreetmap/iD/issues/10259.

This is a slight regression in #4627, as the code previously _appended_[^1] the additional CSP rules and now they are overwritten. I assume this was an oversight in the migration process, or was the omission of the existing `img-src` rules there on purpose? In that case, the `:data` type should be added as `policy.img_src("*", :blob, :data)`.


[^1]: see https://github.com/openstreetmap/openstreetmap-website/pull/4627/files#diff-c7e7144de4dcf44dbb148d4acc6aa4a9d8581c6a581966a0bbfb598e79730f14L139
