### PR TITLE
update script-src CSP rules for iD

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -19,7 +19,6 @@ class SiteController < ApplicationController
   content_security_policy(:only => :id) do |policy|
     policy.connect_src("*")
     policy.img_src("*", :blob)
-    policy.script_src(*policy.script_src, "dev.virtualearth.net", :unsafe_eval)
     policy.style_src(*policy.style_src, :unsafe_inline)
   end
 


### PR DESCRIPTION
* by now, all used Bing services are queried directly via REST APIs, so `dev.virtualearth.net` should not be required anymore
* `unsafe-eval` was added with 527ec293c2cd84e777e8f05b4bdcf2b3b611a5e0, but as far as I can see, neither the current mapillary SDK nor any other parts of iD perform any dirty tricks with `eval` & co.