### PR TITLE
Truncate user menu username

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -106,6 +106,7 @@ $(document).ready(function () {
     $("body").removeClass("compact-nav");
 
     $("header").removeClass("text-nowrap");
+    $("header nav.secondary > ul").removeClass("flex-nowrap");
 
     updateHeader();
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -150,7 +150,7 @@ nav.primary {
 
 nav.secondary {
   .nav-link {
-    padding: 0.2rem;
+    padding: 0.3rem;
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -114,6 +114,10 @@ header {
   nav.primary {
     margin-right: auto;
   }
+
+  .username {
+    max-width: 12em;
+  }
 }
 
 nav.primary {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -98,10 +98,6 @@ header {
   position: relative;
   font-size: 14px;
 
-  h1, nav, nav > ul, nav > ul > li {
-    display: inline-block;
-  }
-
   > * {
     padding: $lineheight * 0.5;
   }
@@ -191,7 +187,7 @@ body.small-nav {
     min-height: $headerHeight;
 
     &.closed nav {
-      display: none;
+      display: none !important;
     }
 
     .search_forms {
@@ -216,6 +212,8 @@ body.small-nav {
   }
 
   nav.secondary {
+    flex-direction: column;
+
     .user-menu, .login-menu {
       width: 100%;
     }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -31,8 +31,8 @@
       <%= link_to t("layouts.export"), export_path, :class => "btn btn-outline-primary geolink", :id => "export_tab" %>
     </div>
   </nav>
-  <nav class='secondary'>
-    <ul class='mx-1 px-0'>
+  <nav class='secondary d-flex gap-2 align-items-center'>
+    <ul class='nav flex-nowrap'>
       <% if Settings.status != "database_offline" && can?(:index, Issue) %>
         <li class="compact-hide nav-item">
           <%= link_to issues_path(:status => "open"), :class => header_nav_link_class(issues_path) do %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -84,9 +84,9 @@
         <button class='dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
           <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
           <% if current_user.new_messages.size > 0 %>
-            <span class="badge count-number m-1"><%= current_user.new_messages.size %></span>
+            <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
           <% end %>
-          <span class='username'>
+          <span class='username align-middle'>
             <%= current_user.display_name %>
           </span>
         </button>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -81,12 +81,12 @@
     </ul>
     <% if current_user && current_user.id %>
       <div class='d-inline-flex dropdown user-menu logged-in'>
-        <button class='dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
+        <button class='d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
           <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
           <% if current_user.new_messages.size > 0 %>
-            <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
+            <span class="badge count-number position-static"><%= current_user.new_messages.size %></span>
           <% end %>
-          <span class='username align-middle'>
+          <span class='username text-truncate'>
             <%= current_user.display_name %>
           </span>
         </button>


### PR DESCRIPTION
Follows #4828. If the username is long, the user menu button won't be oversized and won't trigger *small mode* for the header.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/b9dfdde4-2794-4646-94cf-1833c907a4c4)
