### PR TITLE
Move Export button to secondary nav

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -412,6 +412,9 @@ $(document).ready(function () {
 
     if (OSM.router.route(this.pathname + this.search + this.hash)) {
       e.preventDefault();
+      if (this.pathname !== "/directions") {
+        $("header").addClass("closed");
+      }
     }
   });
 

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -32,6 +32,7 @@ OSM.Search = function (map) {
 
   $(".describe_location").on("click", function (e) {
     e.preventDefault();
+    $("header").addClass("closed");
     var center = map.getCenter().wrap(),
         precision = OSM.zoomPrecision(map.getZoom()),
         lat = center.lat.toFixed(precision),

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -101,6 +101,16 @@ OSM.Router = function (map, rts) {
 
   var router = {};
 
+  function updateSecondaryNav() {
+    $("header nav.secondary > ul > li > a").each(function () {
+      var active = $(this).attr("href") === window.location.pathname;
+
+      $(this)
+        .toggleClass("text-secondary", !active)
+        .toggleClass("text-secondary-emphasis", active);
+    });
+  }
+
   $(window).on("popstate", function (e) {
     if (!e.originalEvent.state) return; // Is it a real popstate event or just a hash change?
     var path = window.location.pathname + window.location.search,
@@ -110,6 +120,7 @@ OSM.Router = function (map, rts) {
     currentPath = path;
     currentRoute = route;
     currentRoute.run("popstate", currentPath);
+    updateSecondaryNav();
     map.setState(e.originalEvent.state, { animate: false });
   });
 
@@ -124,6 +135,7 @@ OSM.Router = function (map, rts) {
     currentPath = path;
     currentRoute = route;
     currentRoute.run("pushstate", currentPath);
+    updateSecondaryNav();
     return true;
   };
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -197,9 +197,7 @@ body.small-nav {
     }
   }
 
-  #sidebar .search_forms,
-  #edit_tab,
-  #export_tab {
+  #sidebar .search_forms {
     display: none;
   }
 
@@ -207,7 +205,7 @@ body.small-nav {
     margin-right: 0;
     padding: 0;
 
-    .btn-group {
+    > .btn-group {
       width: 100%;
       padding: 10px;
     }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,13 +9,13 @@
   <nav class='primary'>
     <%= content_for :header %>
     <div class="btn-group">
-      <div id="edit_tab" class="btn-group">
+      <div id="edit_tab" class="btn-group flex-grow-1">
         <%= link_to t("layouts.edit"),
                     edit_path,
                     :class => "btn btn-outline-primary geolink editlink",
                     :id => "editanchor",
                     :data => { :editor => preferred_editor } %>
-        <button class='btn btn-outline-primary dropdown-toggle dropdown-toggle-split' type='button' data-bs-toggle='dropdown'></button>
+        <button class='btn btn-outline-primary dropdown-toggle dropdown-toggle-split flex-grow-0' type='button' data-bs-toggle='dropdown'></button>
         <ul class='dropdown-menu'>
           <% Editors::RECOMMENDED_EDITORS.each do |editor| %>
             <li>
@@ -27,8 +27,7 @@
           <% end %>
         </ul>
       </div>
-      <%= link_to t("layouts.history"), history_path, :class => "btn btn-outline-primary geolink flex-grow-1", :id => "history_tab" %>
-      <%= link_to t("layouts.export"), export_path, :class => "btn btn-outline-primary geolink", :id => "export_tab" %>
+      <%= link_to t("layouts.history"), history_path, :class => "btn btn-outline-primary geolink flex-grow-1" %>
     </div>
   </nav>
   <nav class='secondary d-flex gap-2 align-items-center'>
@@ -41,6 +40,9 @@
           <% end -%>
         </li>
       <% end %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.export"), export_path, :class => header_nav_link_class(export_path) %>
+      </li>
       <li class="compact-hide nav-item">
         <%= link_to t("layouts.gps_traces"), traces_path, :class => header_nav_link_class(traces_path) %>
       </li>
@@ -70,6 +72,7 @@
               <% end -%>
             </li>
           <% end %>
+          <li><%= link_to t("layouts.export"), export_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.gps_traces"), traces_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.user_diaries"), diary_entries_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.communities"), communities_path, :class => "dropdown-item" %></li>


### PR DESCRIPTION
*Export* is no longer a green outline button but rather a gray secondary navigation item.

The main reason for this is to allow *Export* to collapse into *More*. This lets the header to be narrower in *compact mode*. Hopefully then *compact mode* will be available above the Bootstrap medium breakpoint of 768px, which then can be made a fixed breakpoint for going between *small* and *compact* modes. (If not, maybe try moving the *History* button next.) See #4130.

I also don't hide the *Edit* button because it's easier not to hide it. If I kept it hidden exactly like it was before, the *History* button in the small mode menu would have had rounded borders only on one side. So coincidentally I also do here what #4839 tried to do except I don't need a vertical button group for edit-history-export. There's no *Export* in the group and *Edit*+*History* should fit horizontally.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/328c1f25-9755-4647-8a9d-72b3eaba06c1)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/44a9fa59-e182-48d7-8588-afc27844052d)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9c582ba9-a112-40f7-ba00-1572469782be)

