### PR TITLE
reintroduce unsafe-eval CSP rule for iD (Mapillary layer)

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -19,6 +19,7 @@ class SiteController < ApplicationController
   content_security_policy(:only => :id) do |policy|
     policy.connect_src("*")
     policy.img_src(*policy.img_src, "*", :blob)
+    policy.script_src(*policy.script_src, :unsafe_eval)
     policy.style_src(*policy.style_src, :unsafe_inline)
   end
 


### PR DESCRIPTION
Fixes a regression introduced by me in #4841. Fixes https://github.com/openstreetmap/iD/issues/10265