### PR TITLE
Fixed "or divider" issue described in #4773

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -25,7 +25,7 @@
 <div id="login_login" class="auth-container mx-auto my-0">
   <% if @preferred_auth_provider %>
     <%= render :partial => "auth_providers" %>
-    <div class="d-flex justify-content-center align-items-center">
+    <div class="d-flex justify-content-center align-items-center mb-2">
       <div class="border-bottom border-1 flex-grow-1"></div>
       <div class="text-secondary mx-3"><%= t ".or" %></div>
       <div class="border-bottom border-1 flex-grow-1"></div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -31,7 +31,7 @@
 
     <% unless @preferred_auth_provider.nil? %>
       <%= render :partial => "auth_providers" %>
-      <div class="d-flex justify-content-center align-items-center">
+      <div class="d-flex justify-content-center align-items-center mb-2">
         <div class="border-bottom border-1 flex-grow-1"></div>
         <div class="text-secondary mx-3"><%= t ".or" %></div>
         <div class="border-bottom border-1 flex-grow-1"></div>


### PR DESCRIPTION
This PR addresses "or divider" issue mentioned in the #4773

In app\views\sessions\new.html.erb and app\views\users\new.html.erb added mb-2 after "or" divider.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/661d532e-db21-45f7-87b0-54b6e8c28c7c)
After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/dc84e1a5-3cad-4ca8-a90f-48f2ef83dab4)
