### PR TITLE
Refactor api actions

### DIFF
--- a/app/controllers/api/capabilities_controller.rb
+++ b/app/controllers/api/capabilities_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class CapabilitiesController < ApiController
+    skip_before_action :check_api_readable
+
     authorize_resource :class => false
 
     before_action :set_request_formats

--- a/app/controllers/api/changeset_comments_controller.rb
+++ b/app/controllers/api/changeset_comments_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class ChangesetCommentsController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable
     before_action :authorize
 

--- a/app/controllers/api/changeset_comments_controller.rb
+++ b/app/controllers/api/changeset_comments_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class ChangesetCommentsController < ApiController
+    before_action :check_api_readable
     before_action :check_api_writable
-    before_action :check_api_readable, :except => [:create]
     before_action :authorize
 
     authorize_resource

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -2,7 +2,6 @@
 
 module Api
   class ChangesetsController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :upload, :subscribe, :unsubscribe]
     before_action :setup_user_auth, :only => [:show]
     before_action :authorize, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -2,8 +2,8 @@
 
 module Api
   class ChangesetsController < ApiController
+    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :upload, :subscribe, :unsubscribe]
-    before_action :check_api_readable, :except => [:index, :create, :update, :upload, :download, :subscribe, :unsubscribe]
     before_action :setup_user_auth, :only => [:show]
     before_action :authorize, :only => [:create, :update, :upload, :close, :subscribe, :unsubscribe]
 

--- a/app/controllers/api/map_controller.rb
+++ b/app/controllers/api/map_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class MapController < ApiController
-    before_action :check_api_readable
-
     authorize_resource :class => false
 
     around_action :api_call_handle_error, :api_call_timeout

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -2,8 +2,8 @@
 
 module Api
   class NodesController < ApiController
+    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :delete]
-    before_action :check_api_readable, :except => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]
 
     authorize_resource

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -2,7 +2,6 @@
 
 module Api
   class NodesController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]
 

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class NotesController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :comment, :close, :reopen, :destroy]
     before_action :setup_user_auth, :only => [:create, :show]
     before_action :authorize, :only => [:close, :reopen, :destroy, :comment]

--- a/app/controllers/api/old_elements_controller.rb
+++ b/app/controllers/api/old_elements_controller.rb
@@ -3,7 +3,6 @@
 # nodes, ways and relations are basically identical.
 module Api
   class OldElementsController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable, :only => [:redact]
     before_action :setup_user_auth, :only => [:history, :show]
     before_action :authorize, :only => [:redact]

--- a/app/controllers/api/permissions_controller.rb
+++ b/app/controllers/api/permissions_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class PermissionsController < ApiController
-    before_action :check_api_readable
-
     authorize_resource :class => false
 
     before_action :setup_user_auth

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class RelationsController < ApiController
+    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :delete]
-    before_action :check_api_readable, :except => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]
 
     authorize_resource

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class RelationsController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]
 

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class TracepointsController < ApiController
-    before_action :check_api_readable
-
     authorize_resource
 
     around_action :api_call_handle_error, :api_call_timeout

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class TracesController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :destroy]
     before_action :set_locale
     before_action :authorize

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -1,14 +1,12 @@
 module Api
   class TracesController < ApiController
-    before_action :check_database_readable, :except => [:show, :data]
-    before_action :check_database_writable, :only => [:create, :update, :destroy]
+    before_action :check_api_readable, :only => [:show, :data]
+    before_action :check_api_writable, :only => [:create, :update, :destroy]
     before_action :set_locale
     before_action :authorize
 
     authorize_resource
 
-    before_action :check_api_readable, :only => [:show, :data]
-    before_action :check_api_writable, :only => [:create, :update, :destroy]
     before_action :offline_error, :only => [:create, :destroy, :data]
     around_action :api_call_handle_error
 

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class TracesController < ApiController
-    before_action :check_api_readable, :only => [:show, :data]
+    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :destroy]
     before_action :set_locale
     before_action :authorize

--- a/app/controllers/api/user_blocks_controller.rb
+++ b/app/controllers/api/user_blocks_controller.rb
@@ -1,7 +1,5 @@
 module Api
   class UserBlocksController < ApiController
-    before_action :check_api_readable
-
     authorize_resource
 
     around_action :api_call_handle_error, :api_call_timeout

--- a/app/controllers/api/user_preferences_controller.rb
+++ b/app/controllers/api/user_preferences_controller.rb
@@ -1,6 +1,8 @@
 # Update and read user preferences, which are arbitrary key/val pairs
 module Api
   class UserPreferencesController < ApiController
+    before_action :check_api_readable
+    before_action :check_api_writable, :only => [:update_all, :update, :destroy]
     before_action :authorize
 
     authorize_resource

--- a/app/controllers/api/user_preferences_controller.rb
+++ b/app/controllers/api/user_preferences_controller.rb
@@ -1,7 +1,6 @@
 # Update and read user preferences, which are arbitrary key/val pairs
 module Api
   class UserPreferencesController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable, :only => [:update_all, :update, :destroy]
     before_action :authorize
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class UsersController < ApiController
-    before_action :check_api_readable
     before_action :disable_terms_redirect, :only => [:details]
     before_action :setup_user_auth, :only => [:show, :index]
     before_action :authorize, :only => [:details, :gpx_files]

--- a/app/controllers/api/versions_controller.rb
+++ b/app/controllers/api/versions_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class VersionsController < ApiController
+    skip_before_action :check_api_readable
     authorize_resource :class => false
 
     before_action :set_request_formats

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class WaysController < ApiController
+    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :delete]
-    before_action :check_api_readable, :except => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]
 
     authorize_resource

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -1,6 +1,5 @@
 module Api
   class WaysController < ApiController
-    before_action :check_api_readable
     before_action :check_api_writable, :only => [:create, :update, :delete]
     before_action :authorize, :only => [:create, :update, :delete]
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,6 +1,8 @@
 class ApiController < ApplicationController
   skip_before_action :verify_authenticity_token
 
+  before_action :check_api_readable
+
   private
 
   ##

--- a/test/controllers/api/capabilities_controller_test.rb
+++ b/test/controllers/api/capabilities_controller_test.rb
@@ -71,5 +71,75 @@ module Api
       assert_equal "online", js["api"]["status"]["gpx"]
       assert_equal Settings.imagery_blacklist.length, js["policy"]["imagery"]["blacklist"].length
     end
+
+    def test_capabilities_api_readonly
+      with_settings(:status => "api_readonly") do
+        get api_capabilities_path
+        assert_response :success
+        assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
+          assert_select "api", :count => 1 do
+            assert_select "status[database='online']", :count => 1
+            assert_select "status[api='readonly']", :count => 1
+            assert_select "status[gpx='online']", :count => 1
+          end
+        end
+      end
+    end
+
+    def test_capabilities_api_offline
+      with_settings(:status => "api_offline") do
+        get api_capabilities_path
+        assert_response :success
+        assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
+          assert_select "api", :count => 1 do
+            assert_select "status[database='online']", :count => 1
+            assert_select "status[api='offline']", :count => 1
+            assert_select "status[gpx='online']", :count => 1
+          end
+        end
+      end
+    end
+
+    def test_capabilities_database_readonly
+      with_settings(:status => "database_readonly") do
+        get api_capabilities_path
+        assert_response :success
+        assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
+          assert_select "api", :count => 1 do
+            assert_select "status[database='readonly']", :count => 1
+            assert_select "status[api='readonly']", :count => 1
+            assert_select "status[gpx='readonly']", :count => 1
+          end
+        end
+      end
+    end
+
+    def test_capabilities_database_offline
+      with_settings(:status => "database_offline") do
+        get api_capabilities_path
+        assert_response :success
+        assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
+          assert_select "api", :count => 1 do
+            assert_select "status[database='offline']", :count => 1
+            assert_select "status[api='offline']", :count => 1
+            assert_select "status[gpx='offline']", :count => 1
+          end
+        end
+      end
+    end
+
+    def test_capabilities_gpx_offline
+      with_settings(:status => "gpx_offline") do
+        get api_capabilities_path
+        assert_response :success
+        assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", :count => 1 do
+          assert_select "api", :count => 1 do
+            assert_select "status[database='online']", :count => 1
+            assert_select "status[api='online']", :count => 1
+            assert_select "status[gpx='offline']", :count => 1
+          end
+        end
+      end
+    end
   end
 end

--- a/test/controllers/api/versions_controller_test.rb
+++ b/test/controllers/api/versions_controller_test.rb
@@ -46,5 +46,17 @@ module Api
       assert_response :success
       assert_select "osm[version]", :count => 0
     end
+
+    def test_versions_available_while_offline
+      with_settings(:status => "api_offline") do
+        get api_versions_path
+        assert_response :success
+        assert_select "osm[generator='#{Settings.generator}']", :count => 1 do
+          assert_select "api", :count => 1 do
+            assert_select "version", Settings.api_version
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR addresses https://github.com/openstreetmap/openstreetmap-website/issues/4858 by standardising on not have `:except` lists for the `_readable` checks.

It also takes things one step further, by moving the before_action into the parent api_controller, and skipping that action in the only two controllers that need to skip it (and adding tests for those).