### PR TITLE
Don't include language prefix in wikipedia links

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -69,38 +69,35 @@ module BrowseTagsHelper
 
     case key
     when "wikipedia", /^(#{SECONDARY_WIKI_PREFIXES}):wikipedia/o
-      # This regex should match Wikipedia language codes, everything
-      # from de to zh-classical
-      lang = if value =~ /^([a-z-]{2,12}):(.+)$/i
-               # Value is <lang>:<title> so split it up
-               # Note that value is always left as-is, see: https://trac.openstreetmap.org/ticket/4315
-               Regexp.last_match(1)
-             else
-               # Value is <title> so default to English Wikipedia
-               "en"
-             end
+      lang = "en"
     when /^wikipedia:(\S+)$/
-      # Language is in the key, so assume value is the title
       lang = Regexp.last_match(1)
     else
-      # Not a wikipedia key!
       return nil
     end
 
-    if value =~ /^([^#]*)#(.*)/
+    # This regex should match Wikipedia language codes, everything
+    # from de to zh-classical
+    if value =~ /^([a-z-]{2,12}):(.+)$/i
+      lang = Regexp.last_match(1)
+      title_section = Regexp.last_match(2)
+    else
+      title_section = value
+    end
+
+    if title_section =~ /^([^#]*)#(.*)/
       # Contains a reference to a section of the wikipedia article
       # Must break it up to correctly build the url
-      value = Regexp.last_match(1)
-      section = "##{Regexp.last_match(2)}"
+      title = Regexp.last_match(1)
       encoded_section = "##{CGI.escape(Regexp.last_match(2).gsub(/ +/, '_'))}"
     else
-      section = ""
+      title = title_section
       encoded_section = ""
     end
 
     {
-      :url => "https://#{lang}.wikipedia.org/wiki/#{value}?uselang=#{I18n.locale}#{encoded_section}",
-      :title => value + section
+      :url => "https://#{lang}.wikipedia.org/wiki/#{title}?uselang=#{I18n.locale}#{encoded_section}",
+      :title => value
     }
   end
 

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -186,33 +186,37 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_equal "Test", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Test")
-    assert_equal "https://de.wikipedia.org/wiki/de:Test?uselang=en", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/Test?uselang=en", link[:url]
     assert_equal "de:Test", link[:title]
 
+    link = wikipedia_link("wikipedia:fr", "Portsea")
+    assert_equal "https://fr.wikipedia.org/wiki/Portsea?uselang=en", link[:url]
+    assert_equal "Portsea", link[:title]
+
     link = wikipedia_link("wikipedia:fr", "de:Test")
-    assert_equal "https://fr.wikipedia.org/wiki/de:Test?uselang=en", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/Test?uselang=en", link[:url]
     assert_equal "de:Test", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Englischer Garten (München)#Japanisches Teehaus")
-    assert_equal "https://de.wikipedia.org/wiki/de:Englischer Garten (München)?uselang=en#Japanisches_Teehaus", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/Englischer Garten (München)?uselang=en#Japanisches_Teehaus", link[:url]
     assert_equal "de:Englischer Garten (München)#Japanisches Teehaus", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Alte Brücke (Heidelberg)#Brückenaffe")
-    assert_equal "https://de.wikipedia.org/wiki/de:Alte Brücke (Heidelberg)?uselang=en#Br%C3%BCckenaffe", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/Alte Brücke (Heidelberg)?uselang=en#Br%C3%BCckenaffe", link[:url]
     assert_equal "de:Alte Brücke (Heidelberg)#Brückenaffe", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Liste der Baudenkmäler in Eichstätt#Brückenstraße 1, Ehemaliges Bauernhaus")
-    assert_equal "https://de.wikipedia.org/wiki/de:Liste der Baudenkmäler in Eichstätt?uselang=en#Br%C3%BCckenstra%C3%9Fe_1%2C_Ehemaliges_Bauernhaus", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/Liste der Baudenkmäler in Eichstätt?uselang=en#Br%C3%BCckenstra%C3%9Fe_1%2C_Ehemaliges_Bauernhaus", link[:url]
     assert_equal "de:Liste der Baudenkmäler in Eichstätt#Brückenstraße 1, Ehemaliges Bauernhaus", link[:title]
 
     I18n.with_locale "pt-BR" do
       link = wikipedia_link("wikipedia", "zh-classical:Test#Section")
-      assert_equal "https://zh-classical.wikipedia.org/wiki/zh-classical:Test?uselang=pt-BR#Section", link[:url]
+      assert_equal "https://zh-classical.wikipedia.org/wiki/Test?uselang=pt-BR#Section", link[:url]
       assert_equal "zh-classical:Test#Section", link[:title]
     end
 
     link = wikipedia_link("subject:wikipedia", "en:Catherine McAuley")
-    assert_equal "https://en.wikipedia.org/wiki/en:Catherine McAuley?uselang=en", link[:url]
+    assert_equal "https://en.wikipedia.org/wiki/Catherine McAuley?uselang=en", link[:url]
     assert_equal "en:Catherine McAuley", link[:title]
 
     link = wikipedia_link("foo", "Test")


### PR DESCRIPTION
In links like [https://de.wikipedia.org/wiki/de:Test?uselang=en](https://de.wikipedia.org/wiki/de:Test?uselang=en) what do you need `de:` for? `de` is already in the domain name `de.wikipedia.org`. iD and Overpass Turbo don't include this prefix.

If the prefix in the path differs from domain name, as was in one of the test cases [https://fr.wikipedia.org/wiki/de:Test?uselang=en](https://fr.wikipedia.org/wiki/de:Test?uselang=en), you get a redirect, in this case to [https://de.wikipedia.org/wiki/Test?uselang=en](https://de.wikipedia.org/wiki/Test?uselang=en). Just generate this url instead.