### PR TITLE
Larger font size in search form, svg icon for "Go" button

### DIFF
--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -3,12 +3,12 @@
     <div class="row gx-2 mx-0">
       <div class="col">
         <div class="input-group flex-nowrap">
-          <%= text_field_tag "query", params[:query], :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control form-control-sm z-0", :dir => "auto" %>
+          <%= text_field_tag "query", params[:query], :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control z-0 py-1 px-2", :dir => "auto" %>
           <div class="input-group-text border-start-0 p-0 position-relative">
-            <%= button_tag t("site.search.where_am_i"), :type => "button", :class => "describe_location position-absolute end-0 me-1 btn btn-sm btn-outline-primary border-0 bg-transparent text-primary link-body-emphasis link-opacity-100-hover", :title => t("site.search.where_am_i_title") %>
+            <%= button_tag t("site.search.where_am_i"), :type => "button", :class => "describe_location position-absolute end-0 top-0 bottom-0 m-1 btn btn-outline-primary border-0 p-1 bg-transparent text-primary link-body-emphasis link-opacity-100-hover", :title => t("site.search.where_am_i_title") %>
           </div>
-          <%= button_tag :class => "btn btn-sm btn-primary p-1", :title => t("site.search.submit_text") do %>
-            <svg width="24" height="20" class="align-bottom">
+          <%= button_tag :class => "btn btn-primary p-1", :title => t("site.search.submit_text") do %>
+            <svg width="24" height="20">
               <circle cx="13" cy="7" r="6.5" fill="#fff8" stroke="#fff" />
               <path d="M9.75 12.629 A6.5 6.5 0 0 1 7.371 10.25" fill="none" stroke="#fff" stroke-width="1.5" />
               <line x1="1" y1="19" x2="1.5" y2="18.5" stroke="#fff8" stroke-width="2" />
@@ -20,8 +20,8 @@
         </div>
       </div>
       <div class="col-auto">
-        <%= link_to directions_path, :class => "btn btn-sm btn-primary px-1 switch_link", :title => t("site.search.get_directions_title") do %>
-          <svg width="28" height="20" class="align-bottom">
+        <%= link_to directions_path, :class => "btn btn-primary p-1 switch_link", :title => t("site.search.get_directions_title") do %>
+          <svg width="28" height="24" viewBox="0 -2 28 24" class="align-bottom">
             <path d="M11.5 9.5 v-3h3v-1l-5 -5l-5 5v1h3v6" fill="none" stroke="#fff8" />
             <path d="M7.5 19.5h4v-5a1 1 0 0 1 1 -1h5v3h1l5 -5l-5 -5h-1v3h-6a4 4 0 0 0 -4 4z" fill="#fff8" stroke="#fff" />
           </svg>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -7,7 +7,16 @@
           <div class="input-group-text border-start-0 p-0 position-relative">
             <%= button_tag t("site.search.where_am_i"), :type => "button", :class => "describe_location position-absolute end-0 me-1 btn btn-sm btn-outline-primary border-0 bg-transparent text-primary link-body-emphasis link-opacity-100-hover", :title => t("site.search.where_am_i_title") %>
           </div>
-          <%= submit_tag t("site.search.submit_text"), :class => "btn btn-sm btn-primary", :data => { :disable_with => false } %>
+          <%= button_tag :class => "btn btn-sm btn-primary p-1", :title => t("site.search.submit_text") do %>
+            <svg width="24" height="20" class="align-bottom">
+              <circle cx="13" cy="7" r="6.5" fill="#fff8" stroke="#fff" />
+              <path d="M9.75 12.629 A6.5 6.5 0 0 1 7.371 10.25" fill="none" stroke="#fff" stroke-width="1.5" />
+              <line x1="1" y1="19" x2="1.5" y2="18.5" stroke="#fff8" stroke-width="2" />
+              <line x1="1.5" y1="18.5" x2="6" y2="14" stroke="#fff" stroke-width="2.5" />
+              <line x1="6" y1="14" x2="6.5" y2="13.5" stroke="#fff8" stroke-width="2" />
+              <line x1="6.5" y1="13.5" x2="8.5" y2="11.5" stroke="#fff" stroke-width="1.5" />
+            </svg>
+          <% end %>
         </div>
       </div>
       <div class="col-auto">


### PR DESCRIPTION
Should fix #1414 according to https://github.com/openstreetmap/openstreetmap-website/issues/1414#issuecomment-2130065798. I can't test it without an iPhone.

Changed small form controls to default ones. This makes font size to be 16px.

But there's another obstacle: the *Go* button. "Go" is short enough in English, but how about other languages. With a larger font it may get too large. To avoid that I replaced "Go" with a magnifying glass icon.

Before/after in English:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/426f8d7d-cb1a-46aa-b451-3f483675af03)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3a63b3ad-2eed-4ea3-a90b-ee092ad75491)

Before/after in Bulgarian (wider labels):
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/cbfdd444-d583-44d4-97d4-1807ef0a310e)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/bf7d983d-6bd6-43ab-bf53-4b0e7820defa)

Before/after in Polish (already trying to replace "Go" with a symbol):
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/15e427df-2985-48e3-9af0-be2b8fa16bfe)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/099eae3e-71ef-4475-994e-b1089ea34b43)

Before/after in Arabic:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/354bf229-80b0-46e2-a858-4829d66df186)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3dcc059f-fe70-4d1b-b3cf-6b37b1e965a0)

200% zoom:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7cc3cfca-d920-467e-9f46-135e9213e4ed)
