### PR TITLE
Write closed note controls using submit_tag

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -79,10 +79,14 @@
       </div>
       <div class="d-flex flex-wrap gap-1">
         <% if @note.status != "hidden" and current_user and current_user.moderator? -%>
-          <input type="submit" name="hide" value="<%= t(".hide") %>" class="btn btn-light" data-method="DELETE" data-url="<%= api_note_url(@note, "json") %>">
+          <%= submit_tag t(".hide"), :name => "hide", :class => "btn btn-light",
+                                     :data => { :method => "DELETE",
+                                                :url => api_note_url(@note, "json") } %>
         <% end -%>
         <% if current_user -%>
-          <input type="submit" name="reopen" value="<%= t(".reactivate") %>" class="btn btn-primary" data-method="POST" data-url="<%= reopen_api_note_url(@note, "json") %>">
+          <%= submit_tag t(".reactivate"), :name => "reopen", :class => "btn btn-primary",
+                                           :data => { :method => "POST",
+                                                      :url => reopen_api_note_url(@note, "json") } %>
         <% end -%>
       </div>
     </form>


### PR DESCRIPTION
https://github.com/openstreetmap/openstreetmap-website/commit/c276625e7f35a1f9c31fe95325e150879f0b9a73 replaced html + interpolated attributes with `submit_tag`, but only for open note buttons. This PR does the same for closed note buttons.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/98054cf3-e94e-4507-9932-050f3b555012)
