### PR TITLE
Increase font size in routing form

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -357,7 +357,7 @@ OSM.Directions = function (map) {
     getRoute(true, true);
   });
 
-  $(".routing_marker").on("dragstart", function (e) {
+  $(".routing_marker_column img").on("dragstart", function (e) {
     var dt = e.originalEvent.dataTransfer;
     dt.effectAllowed = "move";
     var dragData = { type: $(this).data("type") };

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -568,7 +568,13 @@ tr.turn {
     cursor: pointer;
 }
 
-.routing_marker { width: 15px; cursor: move; }
+.routing_marker_column {
+  width: 15px;
+
+  img {
+    cursor: move;
+  }
+}
 
 /* Rules for the history sidebar */
 

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -33,34 +33,26 @@
   <form method="GET" action="<%= directions_path %>" class="directions_form bg-body-secondary pb-3">
     <div class="d-flex flex-row-reverse px-3 py-3"><button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button></div>
 
-    <div class="row gx-2 m-1">
-      <div class="col-1">
-        <%= image_tag "marker-green.png", :class => "routing_marker mx-auto d-block", :data => { :type => "from" }, :draggable => "true" %>
+    <div class="d-flex my-1 mx-2 gap-2 align-items-center">
+      <div class="routing_marker_column flex-shrink-0">
+        <%= image_tag "marker-green.png", :class => "img-fluid", :data => { :type => "from" }, :draggable => "true" %>
       </div>
-      <div class="col">
-        <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
-      </div>
+      <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
     </div>
-    <div class="row gx-2 m-1">
-      <div class="col-1">
-        <%= image_tag "marker-red.png", :class => "routing_marker mx-auto d-block", :data => { :type => "to" }, :draggable => "true" %>
+    <div class="d-flex my-1 mx-2 gap-2 align-items-center">
+      <div class="routing_marker_column flex-shrink-0">
+        <%= image_tag "marker-red.png", :class => "img-fluid", :data => { :type => "to" }, :draggable => "true" %>
       </div>
-      <div class="col">
-        <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
-      </div>
+      <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
     </div>
-    <div class="row gx-2 m-1">
-      <div class="col offset-1">
-        <select class="routing_engines form-select py-1 px-2" name="routing_engines"></select>
-      </div>
-      <div class="col-auto">
-        <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-primary py-1 px-2", :data => { :disable_with => false } %>
-      </div>
+    <div class="d-flex my-1 mx-2 gap-2 align-items-center">
+      <div class="routing_marker_column flex-shrink-0"></div>
+      <select class="routing_engines form-select py-1 px-2" name="routing_engines"></select>
+      <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-primary py-1 px-2", :data => { :disable_with => false } %>
     </div>
-    <div class="row gx-2 m-1">
-      <div class="col offset-1">
-        <button class="btn btn-link py-1 px-2 reverse_directions"><%= t("site.search.reverse_directions_text") %></button>
-      </div>
+    <div class="d-flex my-1 mx-2 gap-2 align-items-center">
+      <div class="routing_marker_column flex-shrink-0"></div>
+      <button class="btn btn-link py-1 px-2 reverse_directions"><%= t("site.search.reverse_directions_text") %></button>
     </div>
 
     <div class="loader_copy d-none">

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -30,7 +30,7 @@
     </div>
   </form>
 
-  <form method="GET" action="<%= directions_path %>" class="directions_form bg-body-secondary pb-3">
+  <form method="GET" action="<%= directions_path %>" class="directions_form bg-body-secondary pb-2">
     <div class="d-flex flex-row-reverse px-3 py-3"><button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button></div>
 
     <div class="d-flex flex-column mx-2 gap-1">

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -38,7 +38,7 @@
         <%= image_tag "marker-green.png", :class => "routing_marker mx-auto d-block", :data => { :type => "from" }, :draggable => "true" %>
       </div>
       <div class="col">
-        <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control form-control-sm", :dir => "auto" %>
+        <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
       </div>
     </div>
     <div class="row gx-2 m-1">
@@ -46,20 +46,20 @@
         <%= image_tag "marker-red.png", :class => "routing_marker mx-auto d-block", :data => { :type => "to" }, :draggable => "true" %>
       </div>
       <div class="col">
-        <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control form-control-sm", :dir => "auto" %>
+        <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
       </div>
     </div>
     <div class="row gx-2 m-1">
       <div class="col offset-1">
-        <select class="routing_engines form-select form-select-sm" name="routing_engines"></select>
+        <select class="routing_engines form-select py-1 px-2" name="routing_engines"></select>
       </div>
       <div class="col-auto">
-        <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-sm btn-primary", :data => { :disable_with => false } %>
+        <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-primary py-1 px-2", :data => { :disable_with => false } %>
       </div>
     </div>
     <div class="row gx-2 m-1">
       <div class="col offset-1">
-        <button class="btn btn-sm btn-link reverse_directions"><%= t("site.search.reverse_directions_text") %></button>
+        <button class="btn btn-link py-1 px-2 reverse_directions"><%= t("site.search.reverse_directions_text") %></button>
       </div>
     </div>
 

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -33,26 +33,28 @@
   <form method="GET" action="<%= directions_path %>" class="directions_form bg-body-secondary pb-3">
     <div class="d-flex flex-row-reverse px-3 py-3"><button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button></div>
 
-    <div class="d-flex my-1 mx-2 gap-2 align-items-center">
-      <div class="routing_marker_column flex-shrink-0">
-        <%= image_tag "marker-green.png", :class => "img-fluid", :data => { :type => "from" }, :draggable => "true" %>
+    <div class="d-flex flex-column mx-2 gap-1">
+      <div class="d-flex gap-2 align-items-center">
+        <div class="routing_marker_column flex-shrink-0">
+          <%= image_tag "marker-green.png", :class => "img-fluid", :data => { :type => "from" }, :draggable => "true" %>
+        </div>
+        <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
       </div>
-      <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
-    </div>
-    <div class="d-flex my-1 mx-2 gap-2 align-items-center">
-      <div class="routing_marker_column flex-shrink-0">
-        <%= image_tag "marker-red.png", :class => "img-fluid", :data => { :type => "to" }, :draggable => "true" %>
+      <div class="d-flex gap-2 align-items-center">
+        <div class="routing_marker_column flex-shrink-0">
+          <%= image_tag "marker-red.png", :class => "img-fluid", :data => { :type => "to" }, :draggable => "true" %>
+        </div>
+        <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
       </div>
-      <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
-    </div>
-    <div class="d-flex my-1 mx-2 gap-2 align-items-center">
-      <div class="routing_marker_column flex-shrink-0"></div>
-      <select class="routing_engines form-select py-1 px-2" name="routing_engines"></select>
-      <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-primary py-1 px-2", :data => { :disable_with => false } %>
-    </div>
-    <div class="d-flex my-1 mx-2 gap-2 align-items-center">
-      <div class="routing_marker_column flex-shrink-0"></div>
-      <button class="btn btn-link py-1 px-2 reverse_directions"><%= t("site.search.reverse_directions_text") %></button>
+      <div class="d-flex gap-2 align-items-center">
+        <div class="routing_marker_column flex-shrink-0"></div>
+        <select class="routing_engines form-select py-1 px-2" name="routing_engines"></select>
+        <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-primary py-1 px-2", :data => { :disable_with => false } %>
+      </div>
+      <div class="d-flex gap-2 align-items-center">
+        <div class="routing_marker_column flex-shrink-0"></div>
+        <button class="btn btn-link py-1 px-2 reverse_directions"><%= t("site.search.reverse_directions_text") %></button>
+      </div>
     </div>
 
     <div class="loader_copy d-none">


### PR DESCRIPTION
Don't use `*-sm` Bootstrap controls to have 16px fonts and avoid auto-zoom on iPhone, see https://github.com/openstreetmap/openstreetmap-website/pull/4866#issuecomment-2143803410.

Before/after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7fe43e77-b3d0-46df-a2a6-5aea101de462) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c2dbfcd3-8662-4b27-8e08-9f0c8df2c431)
