### PR TITLE
Use button elements that allow word wrap for note controls

### DIFF
--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -36,12 +36,12 @@ OSM.Note = function (map) {
   };
 
   function initialize(path, id, callback) {
-    content.find("input[type=submit]").on("click", function (e) {
+    content.find("button[type=submit]").on("click", function (e) {
       e.preventDefault();
       var data = $(e.target).data();
       var form = e.target.form;
 
-      $(form).find("input[type=submit]").prop("disabled", true);
+      $(form).find("button[type=submit]").prop("disabled", true);
 
       $.ajax({
         url: data.url,
@@ -83,12 +83,12 @@ OSM.Note = function (map) {
   }
 
   function updateButtons(form) {
-    $(form).find("input[type=submit]").prop("disabled", false);
+    $(form).find("button[type=submit]").prop("disabled", false);
     if ($(form.text).val() === "") {
-      $(form.close).val($(form.close).data("defaultActionText"));
+      $(form.close).text($(form.close).data("defaultActionText"));
       $(form.comment).prop("disabled", true);
     } else {
-      $(form.close).val($(form.close).data("commentActionText"));
+      $(form.close).text($(form.close).data("commentActionText"));
       $(form.comment).prop("disabled", false);
     }
   }

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -53,16 +53,16 @@
         </div>
         <div class="d-flex flex-wrap gap-1">
           <% if current_user.moderator? -%>
-            <%= submit_tag t(".hide"), :name => "hide", :class => "btn btn-light",
+            <%= button_tag t(".hide"), :name => "hide", :class => "btn btn-light",
                                        :data => { :method => "DELETE",
                                                   :url => api_note_url(@note, "json") } %>
           <% end -%>
-          <%= submit_tag t(".resolve"), :name => "close", :class => "btn btn-primary",
+          <%= button_tag t(".resolve"), :name => "close", :class => "btn btn-primary",
                                         :data => { :method => "POST",
                                                    :url => close_api_note_url(@note, "json"),
                                                    :default_action_text => t(".resolve"),
                                                    :comment_action_text => t(".comment_and_resolve") } %>
-          <%= submit_tag t(".comment"), :name => "comment", :class => "btn btn-primary", :disabled => true,
+          <%= button_tag t(".comment"), :name => "comment", :class => "btn btn-primary", :disabled => true,
                                         :data => { :method => "POST",
                                                    :url => comment_api_note_url(@note, "json") } %>
         </div>
@@ -79,12 +79,12 @@
       </div>
       <div class="d-flex flex-wrap gap-1">
         <% if @note.status != "hidden" and current_user and current_user.moderator? -%>
-          <%= submit_tag t(".hide"), :name => "hide", :class => "btn btn-light",
+          <%= button_tag t(".hide"), :name => "hide", :class => "btn btn-light",
                                      :data => { :method => "DELETE",
                                                 :url => api_note_url(@note, "json") } %>
         <% end -%>
         <% if current_user -%>
-          <%= submit_tag t(".reactivate"), :name => "reopen", :class => "btn btn-primary",
+          <%= button_tag t(".reactivate"), :name => "reopen", :class => "btn btn-primary",
                                            :data => { :method => "POST",
                                                       :url => reopen_api_note_url(@note, "json") } %>
         <% end -%>


### PR DESCRIPTION
To make sure that #1353 is not a problem even on very narrow screens. `<button>` allows word wrap inside; if you need several words for example for "comment and close", they'll still fit on screen as long as every individual word fits.

Changesets already use `<button>` in discussion forms.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/f02047bd-55fe-4b38-b577-329ad4eaaed3)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/8ca31d78-197d-4661-99e2-cef7b205f03e)

