### PR TITLE
Show changeset element counts using badges

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -79,18 +79,6 @@ module BrowseHelper
     "nofollow" if object.tags.empty?
   end
 
-  def type_and_paginated_count(type, pages, selected_page = pages.current_page)
-    if pages.page_count == 1
-      t ".#{type.pluralize}",
-        :count => pages.item_count
-    else
-      t ".#{type.pluralize}_paginated",
-        :x => selected_page.first_item,
-        :y => selected_page.last_item,
-        :count => pages.item_count
-    end
-  end
-
   def sidebar_classic_pagination(pages, page_param)
     max_width_for_default_padding = 35
 

--- a/app/views/changesets/_paging_nav.html.erb
+++ b/app/views/changesets/_paging_nav.html.erb
@@ -1,12 +1,18 @@
 <% if pages.page_count == 1 %>
   <h4 class="fs-5">
-    <%= t ".#{type.pluralize}", :count => pages.item_count %>
+    <%= t ".#{type.pluralize}_title" %>
+    <span class="badge count-number">
+      <%= pages.item_count %>
+    </span>
   </h4>
 <% elsif pages.page_count > 1 %>
   <h4 class="fs-5">
-    <%= t ".#{type.pluralize}_paginated", :x => pages.current_page.first_item,
-                                          :y => pages.current_page.last_item,
-                                          :count => pages.item_count %>
+    <%= t ".#{type.pluralize}_title" %>
+    <span class="badge count-number">
+      <%= t ".range", :x => pages.current_page.first_item,
+                      :y => pages.current_page.last_item,
+                      :count => pages.item_count %>
+    </span>
   </h4>
 
   <%= sidebar_classic_pagination(pages, "#{type}_page") do |page|

--- a/app/views/changesets/_paging_nav.html.erb
+++ b/app/views/changesets/_paging_nav.html.erb
@@ -1,8 +1,19 @@
-<h4 class="fs-5"><%= type_and_paginated_count(type, pages) %></h4>
-<% if pages.page_count > 1 %>
+<% if pages.page_count == 1 %>
+  <h4 class="fs-5">
+    <%= t ".#{type.pluralize}", :count => pages.item_count %>
+  </h4>
+<% elsif pages.page_count > 1 %>
+  <h4 class="fs-5">
+    <%= t ".#{type.pluralize}_paginated", :x => pages.current_page.first_item,
+                                          :y => pages.current_page.last_item,
+                                          :count => pages.item_count %>
+  </h4>
+
   <%= sidebar_classic_pagination(pages, "#{type}_page") do |page|
         {
-          :title => type_and_paginated_count(type, pages, page),
+          :title => t(".#{type.pluralize}_paginated", :x => page.first_item,
+                                                      :y => page.last_item,
+                                                      :count => pages.item_count),
           :data => { :turbo => "true" }
         }
       end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,12 +523,13 @@ en:
       changesetxml: "Changeset XML"
       osmchangexml: "osmChange XML"
     paging_nav:
-      nodes: "Nodes (%{count})"
+      nodes_title: "Nodes"
       nodes_paginated: "Nodes (%{x}-%{y} of %{count})"
-      ways: "Ways (%{count})"
+      ways_title: "Ways"
       ways_paginated: "Ways (%{x}-%{y} of %{count})"
-      relations: "Relations (%{count})"
+      relations_title: "Relations"
       relations_paginated: "Relations (%{x}-%{y} of %{count})"
+      range: "%{x}-%{y} of %{count}"
     not_found_message:
       sorry: "Sorry, changeset #%{id} could not be found."
     timeout:


### PR DESCRIPTION
We use counter badges in other places. We can use them on changeset pages in element headings instead of numbers in ().

Before/after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/55a2742a-b978-4873-8e00-a5a6eb8d4a0c) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/eab29825-edcb-44c2-8096-9689434d6c29)
