### PR TITLE
Remove .btn-sm from changeset comment button

### DIFF
--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -66,7 +66,7 @@
         <div id="comment-error" class="alert alert-danger p-2 mb-3" hidden>
         </div>
         <div>
-          <button name="comment" data-method="POST" data-url="<%= changeset_comment_url(@changeset) %>" disabled class="btn btn-sm btn-primary"><%= t("javascripts.changesets.show.comment") %></button>
+          <button name="comment" data-method="POST" data-url="<%= changeset_comment_url(@changeset) %>" disabled class="btn btn-primary"><%= t("javascripts.changesets.show.comment") %></button>
         </div>
       </form>
     <% else %>


### PR DESCRIPTION
Note comment buttons are not small:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/5d2a7c08-2e2d-4d66-bd45-5d64e2e04eed)

But changeset comment buttons are. This makes them larger.

Before/after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9506abcb-5dc9-4b69-872c-72d2aa1dd198) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7cad5de5-3870-4f64-9b5c-680f12f2e637)
