### PR TITLE
Add note and comment counts to the user profile

### DIFF
--- a/app/models/diary_comment.rb
+++ b/app/models/diary_comment.rb
@@ -23,7 +23,7 @@
 #
 
 class DiaryComment < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, :counter_cache => true
   belongs_to :diary_entry
 
   scope :visible, -> { where(:visible => true) }

--- a/app/models/note_comment.rb
+++ b/app/models/note_comment.rb
@@ -26,7 +26,7 @@
 
 class NoteComment < ApplicationRecord
   belongs_to :note, :touch => true
-  belongs_to :author, :class_name => "User", :optional => true
+  belongs_to :author, :class_name => "User", :optional => true, :counter_cache => true
 
   validates :id, :uniqueness => true, :presence => { :on => :update },
                  :numericality => { :on => :update, :only_integer => true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,35 +2,37 @@
 #
 # Table name: users
 #
-#  email               :string           not null
-#  id                  :bigint(8)        not null, primary key
-#  pass_crypt          :string           not null
-#  creation_time       :datetime         not null
-#  display_name        :string           default(""), not null
-#  data_public         :boolean          default(FALSE), not null
-#  description         :text             default(""), not null
-#  home_lat            :float
-#  home_lon            :float
-#  home_zoom           :integer          default(3)
-#  pass_salt           :string
-#  email_valid         :boolean          default(FALSE), not null
-#  new_email           :string
-#  creation_ip         :string
-#  languages           :string
-#  status              :enum             default("pending"), not null
-#  terms_agreed        :datetime
-#  consider_pd         :boolean          default(FALSE), not null
-#  auth_uid            :string
-#  preferred_editor    :string
-#  terms_seen          :boolean          default(FALSE), not null
-#  description_format  :enum             default("markdown"), not null
-#  changesets_count    :integer          default(0), not null
-#  traces_count        :integer          default(0), not null
-#  diary_entries_count :integer          default(0), not null
-#  image_use_gravatar  :boolean          default(FALSE), not null
-#  auth_provider       :string
-#  home_tile           :bigint(8)
-#  tou_agreed          :datetime
+#  email                :string           not null
+#  id                   :bigint(8)        not null, primary key
+#  pass_crypt           :string           not null
+#  creation_time        :datetime         not null
+#  display_name         :string           default(""), not null
+#  data_public          :boolean          default(FALSE), not null
+#  description          :text             default(""), not null
+#  home_lat             :float
+#  home_lon             :float
+#  home_zoom            :integer          default(3)
+#  pass_salt            :string
+#  email_valid          :boolean          default(FALSE), not null
+#  new_email            :string
+#  creation_ip          :string
+#  languages            :string
+#  status               :enum             default("pending"), not null
+#  terms_agreed         :datetime
+#  consider_pd          :boolean          default(FALSE), not null
+#  auth_uid             :string
+#  preferred_editor     :string
+#  terms_seen           :boolean          default(FALSE), not null
+#  description_format   :enum             default("markdown"), not null
+#  changesets_count     :integer          default(0), not null
+#  traces_count         :integer          default(0), not null
+#  diary_entries_count  :integer          default(0), not null
+#  image_use_gravatar   :boolean          default(FALSE), not null
+#  auth_provider        :string
+#  home_tile            :bigint(8)
+#  tou_agreed           :datetime
+#  diary_comments_count :integer          default(0)
+#  note_comments_count  :integer          default(0)
 #
 # Indexes
 #

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,7 +14,8 @@
               <span class='badge count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
             </li>
             <li>
-              <%= link_to t(".my notes"), user_notes_path(@user) %>
+              <%= link_to t(".my notes"), user_notes_path(current_user) %>
+              <span class='badge count-number'><%= number_with_delimiter(current_user.note_comments.size) %></span>
             </li>
             <li>
               <%= link_to t(".my traces"), :controller => "traces", :action => "mine" %>
@@ -26,6 +27,7 @@
             </li>
             <li>
               <%= link_to t(".my comments"), diary_comments_path(current_user) %>
+              <span class='badge count-number'><%= number_with_delimiter(current_user.diary_comments.size) %></span>
             </li>
             <li>
               <%= link_to t(".my settings"), edit_account_path %>
@@ -59,6 +61,7 @@
             </li>
             <li>
               <%= link_to t(".notes"), user_notes_path(@user) %>
+              <span class='badge count-number'><%= number_with_delimiter(@user.note_comments.size) %></span>
             </li>
             <li>
               <%= link_to t(".traces"), :controller => "traces", :action => "index", :display_name => @user.display_name %>
@@ -76,6 +79,7 @@
             </li>
             <li>
               <%= link_to t(".comments"), diary_comments_path(@user) %>
+              <span class='badge count-number'><%= number_with_delimiter(@user.diary_comments.size) %></span>
             </li>
             <li>
               <% if current_user and current_user.friends_with?(@user) %>

--- a/db/migrate/20240605134916_add_notes_and_diary_comments_counter_caches.rb
+++ b/db/migrate/20240605134916_add_notes_and_diary_comments_counter_caches.rb
@@ -1,0 +1,30 @@
+class AddNotesAndDiaryCommentsCounterCaches < ActiveRecord::Migration[7.1]
+  class DiaryComment < ApplicationRecord
+  end
+
+  class NoteComment < ApplicationRecord
+  end
+
+  class User < ApplicationRecord
+  end
+
+  def self.up
+    add_column :users, :diary_comments_count, :integer, :default => 0
+    add_column :users, :note_comments_count, :integer, :default => 0
+
+    users_with_diary_comments = DiaryComment.distinct.pluck(:user_id)
+    users_with_diary_comments.each do |user_id|
+      User.reset_counters(user_id, :diary_comments)
+    end
+
+    users_with_note_comments = NoteComment.where.not(:author_id => nil).distinct.pluck(:author_id)
+    users_with_note_comments.each do |author_id|
+      User.reset_counters(author_id, :note_comments)
+    end
+  end
+
+  def self.down
+    remove_column :users, :diary_comments_count
+    remove_column :users, :note_comments_count
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1565,7 +1565,9 @@ CREATE TABLE public.users (
     image_use_gravatar boolean DEFAULT false NOT NULL,
     auth_provider character varying,
     home_tile bigint,
-    tou_agreed timestamp without time zone
+    tou_agreed timestamp without time zone,
+    diary_comments_count integer DEFAULT 0,
+    note_comments_count integer DEFAULT 0
 );
 
 
@@ -3519,6 +3521,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20240605134916'),
 ('20240405083825'),
 ('20240307181018'),
 ('20240307180830'),


### PR DESCRIPTION
This PR addresses "Add note and comment counts too the user profile" issue mentioned in the #1643 

In app\views\users\show.html.erb added displaying notes and diary comments counts for both cases when displaying user's own profile page and when displaying user's profile page to the public. Also, added using built-in cached counts for displayed counts.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/c7d5e99e-3347-4920-968b-2cd785642bc9)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/4593451f-46f8-450e-b4d2-f4c92ba9bc64)
