### PR TITLE
Remove Open Graph og:image:secure_url property

### DIFF
--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -4,8 +4,7 @@ module OpenGraphHelper
       "og:site_name" => t("layouts.project_name.title"),
       "og:title" => [title, t("layouts.project_name.title")].compact.join(" | "),
       "og:type" => "website",
-      "og:image" => image_url("osm_logo_256.png", :protocol => "http"),
-      "og:image:secure_url" => image_url("osm_logo_256.png", :protocol => "https"),
+      "og:image" => image_url("osm_logo_256.png"),
       "og:url" => url_for(:only_path => false),
       "og:description" => t("layouts.intro_text")
     }


### PR DESCRIPTION
On the actual osm website `og:image:secure_url` is the same as `og:image`, therefore it's not [an alternate url](https://ogp.me/#structured).

~~~
<meta property="og:image" content="https://www.openstreetmap.org/assets/osm_logo_256-ed028f90468224a272961c380ecee0cfb73b8048b34f4b4b204b7f0d1097875d.png">
<meta property="og:image:secure_url" content="https://www.openstreetmap.org/assets/osm_logo_256-ed028f90468224a272961c380ecee0cfb73b8048b34f4b4b204b7f0d1097875d.png">
~~~

Same for OpenHistoricalMap and probably every publicly available openstreetmap-website instance.

Removing `og:image:secure_url` would make it easier to replace the image if necessary, like #1361.