### PR TITLE
Fix setting "From" in directions form based on search query

### DIFF
--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -9,9 +9,9 @@ OSM.Search = function (map) {
     }
   });
 
-  $(".search_form a.button.switch_link").on("click", function (e) {
+  $(".search_form a.btn.switch_link").on("click", function (e) {
     e.preventDefault();
-    var query = $(e.target).parent().parent().find("input[name=query]").val();
+    var query = $(this).closest("form").find("input[name=query]").val();
     if (query) {
       OSM.router.route("/directions?from=" + encodeURIComponent(query) + OSM.formatHash(map));
     } else {


### PR DESCRIPTION
When you type a search query and click directions button, the *From* field is supposed to be filled based on your query.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/20032d17-2099-4cfc-a379-dda500c59c88)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/554beaf1-c4f7-4ad6-a188-5ee956115f3a)

This has been broken since at least https://github.com/openstreetmap/openstreetmap-website/commit/f7b8b114a63f58015a8f0645cda6e0578cbe9f42 when the button css classes changed.