### PR TITLE
Fixed "Add last edited date to user profile" issue described in #3437

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -137,6 +137,8 @@
           <dl class="list-inline">
             <dt class="list-inline-item m-0"><%= t ".mapper since" %></dt>
             <dd class="list-inline-item"><%= l @user.created_at.to_date, :format => :long %></dd>
+            <dt class="list-inline-item m-0"><%= t ".last map edit" %></dt>
+            <dd class="list-inline-item"><%= l @user.changesets.first&.created_at&.to_date, :format => :long, :default => t(".no activity yet") %></dd>
             <% unless @user.terms_agreed %>
               <dt class="list-inline-item m-0"><%= t ".ct status" %></dt>
               <dd class="list-inline-item">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2828,6 +2828,8 @@ en:
       remove as friend: Unfriend
       add as friend: Add Friend
       mapper since: "Mapper since:"
+      last map edit: "Last map edit:"
+      no activity yet: "No activity yet"
       uid: "User id:"
       ct status: "Contributor terms:"
       ct undecided: Undecided


### PR DESCRIPTION
This PR addresses "Add last edited date to user profile" issue mentioned in the #3437 

In app/views/users/show.html.erb added new definition for "Last map edit" as date of the user's last changeset modification or "No activity yet" label if user has not edited map yet (previously mentioned '-' could be misunderstood as website error). Also, added labels to translation files.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/009e23a3-3029-441c-b9ca-d50fb5e50ff5)
After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/00319b26-c851-4e6a-b756-f96d407c34ed)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/027327bf-a259-4c42-9ec6-80845d453be5)
