### PR TITLE
Don't add site name to og:title when page title is provided

### DIFF
--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -2,7 +2,7 @@ module OpenGraphHelper
   def opengraph_tags(title = nil, og_image = nil)
     tags = {
       "og:site_name" => t("layouts.project_name.title"),
-      "og:title" => [title, t("layouts.project_name.title")].compact.join(" | "),
+      "og:title" => title || t("layouts.project_name.title"),
       "og:type" => "website",
       "og:image" => og_image ? URI.join(root_url, og_image) : image_url("osm_logo_256.png"),
       "og:url" => url_for(:only_path => false),


### PR DESCRIPTION
It makes sense to add "OpenStreetMap" to `<title>` of every page, but for Open Graph there's already `og:site_name`. I looked at various sites like github, osm forum, they don't add site name to `og:title`.