### PR TITLE
Add title to copyright page

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -110,6 +110,7 @@ class SiteController < ApplicationController
   end
 
   def copyright
+    @title = t ".title"
     @locale = params[:copyright_locale] || I18n.locale
   end
 

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -32,7 +32,7 @@
 
   <% I18n.with_locale @locale do %>
     <%= tag.h1 :lang => @locale, :dir => t("html.dir") do %>
-      <%= t ".legal_babble.title_html" %>
+      <%= t ".title" %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1960,6 +1960,7 @@ en:
       legal_2_2_registered_trademarks_url: https://wiki.osmfoundation.org/wiki/Trademark_Policy
       partners_title: Partners
     copyright:
+      title: Copyright and License
       foreign:
         title: About this translation
         html: In the event of a conflict between this translated page and %{english_original_link}, the English page shall take precedence
@@ -1970,7 +1971,6 @@ en:
         native_link: THIS_LANGUAGE_NAME_HERE version
         mapping_link: start mapping
       legal_babble:
-        title_html: Copyright and License
         introduction_1_html: |
           OpenStreetMap%{registered_trademark_link} is %{open_data}, licensed under the
           %{odc_odbl_link} (ODbL) by the %{osm_foundation_link} (OSMF).


### PR DESCRIPTION
I'm moving the title string from `.legal_babble.title_html` to `.title` because it's not in that section and not html.