### PR TITLE
Remove unused map link locale strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2173,9 +2173,6 @@ en:
     index:
       js_1: "You are either using a browser that does not support JavaScript, or you have disabled JavaScript."
       js_2: "OpenStreetMap uses JavaScript for its slippy map."
-      permalink: Permalink
-      shortlink: Shortlink
-      createnote: Add a note
       license:
         copyright: "Copyright OpenStreetMap and contributors, under an open license"
         license_url: "https://openstreetmap.org/copyright"


### PR DESCRIPTION
Since https://github.com/openstreetmap/openstreetmap-website/commit/a0a18f428f5e77ad1d1321a1a08fa63bf1a8ba0f