### PR TITLE
Don't set width of richtext preview

### DIFF
--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -41,7 +41,6 @@ $(document).ready(function () {
   $(".richtext_dopreview").click(function (event) {
     var editor = $(this).parents(".richtext_container").find("textarea");
     var preview = $(this).parents(".richtext_container").find(".richtext_preview");
-    var width = editor.outerWidth() - preview.outerWidth() + preview.width();
     var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
 
     if (preview.contents().length === 0) {
@@ -56,7 +55,6 @@ $(document).ready(function () {
     }
 
     editor.hide();
-    preview.width(width);
     preview.css("min-height", minHeight + "px");
     preview.show();
 


### PR DESCRIPTION
Richtext preview div has its width set to the edit textarea, but why?

Make the browser window wide enough and start editing some text:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/145fc9af-4876-4755-aed7-0be648e936c5)

Click *Preview* and start shrinking the window. You may get something like this because the preview wouldn't shrink:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/99726539-da65-4c5a-af4b-1ae02477d08d)

---

Preview and Help won't overlap if the width setting code is removed:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/be2f4b20-83ed-4677-9bde-b45d5905ccfb)
