### PR TITLE
Fully encode wikipedia tag values

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -85,20 +85,15 @@ module BrowseTagsHelper
       title_section = value
     end
 
-    if title_section =~ /^([^#]*)#(.*)/
-      # Contains a reference to a section of the wikipedia article
-      # Must break it up to correctly build the url
-      title = Regexp.last_match(1)
-      encoded_section = "##{CGI.escape(Regexp.last_match(2).gsub(/ +/, '_'))}"
-    else
-      title = title_section
-      encoded_section = ""
-    end
+    title, section = title_section.split("#", 2)
+    url = "https://#{lang}.wikipedia.org/wiki/#{wiki_encode(title)}?uselang=#{I18n.locale}"
+    url += "##{wiki_encode(section)}" if section
 
-    {
-      :url => "https://#{lang}.wikipedia.org/wiki/#{title}?uselang=#{I18n.locale}#{encoded_section}",
-      :title => value
-    }
+    { :url => url, :title => value }
+  end
+
+  def wiki_encode(s)
+    u s.tr(" ", "_")
   end
 
   def wikidata_links(key, value)

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -198,16 +198,20 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_equal "de:Test", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Englischer Garten (München)#Japanisches Teehaus")
-    assert_equal "https://de.wikipedia.org/wiki/Englischer Garten (München)?uselang=en#Japanisches_Teehaus", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/Englischer_Garten_%28M%C3%BCnchen%29?uselang=en#Japanisches_Teehaus", link[:url]
     assert_equal "de:Englischer Garten (München)#Japanisches Teehaus", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Alte Brücke (Heidelberg)#Brückenaffe")
-    assert_equal "https://de.wikipedia.org/wiki/Alte Brücke (Heidelberg)?uselang=en#Br%C3%BCckenaffe", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/Alte_Br%C3%BCcke_%28Heidelberg%29?uselang=en#Br%C3%BCckenaffe", link[:url]
     assert_equal "de:Alte Brücke (Heidelberg)#Brückenaffe", link[:title]
 
     link = wikipedia_link("wikipedia", "de:Liste der Baudenkmäler in Eichstätt#Brückenstraße 1, Ehemaliges Bauernhaus")
-    assert_equal "https://de.wikipedia.org/wiki/Liste der Baudenkmäler in Eichstätt?uselang=en#Br%C3%BCckenstra%C3%9Fe_1%2C_Ehemaliges_Bauernhaus", link[:url]
+    assert_equal "https://de.wikipedia.org/wiki/Liste_der_Baudenkm%C3%A4ler_in_Eichst%C3%A4tt?uselang=en#Br%C3%BCckenstra%C3%9Fe_1%2C_Ehemaliges_Bauernhaus", link[:url]
     assert_equal "de:Liste der Baudenkmäler in Eichstätt#Brückenstraße 1, Ehemaliges Bauernhaus", link[:title]
+
+    link = wikipedia_link("wikipedia", "en:Are Years What? (for Marianne Moore)")
+    assert_equal "https://en.wikipedia.org/wiki/Are_Years_What%3F_%28for_Marianne_Moore%29?uselang=en", link[:url]
+    assert_equal "en:Are Years What? (for Marianne Moore)", link[:title]
 
     I18n.with_locale "pt-BR" do
       link = wikipedia_link("wikipedia", "zh-classical:Test#Section")
@@ -216,7 +220,7 @@ class BrowseTagsHelperTest < ActionView::TestCase
     end
 
     link = wikipedia_link("subject:wikipedia", "en:Catherine McAuley")
-    assert_equal "https://en.wikipedia.org/wiki/Catherine McAuley?uselang=en", link[:url]
+    assert_equal "https://en.wikipedia.org/wiki/Catherine_McAuley?uselang=en", link[:url]
     assert_equal "en:Catherine McAuley", link[:title]
 
     link = wikipedia_link("foo", "Test")


### PR DESCRIPTION
Fix https://github.com/openstreetmap/openstreetmap-website/issues/4851 by using the opposite approach to #4855 and what's currently deployed: urlencode everything unless it needs to be unencoded. Things that are not urlencoded:
- `:` in language prefix
- `#` before article section name

Urls will get uglier, especially non-English ones.