### PR TITLE
Parse og:image urls using Addressable::URI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem "validates_email_format_of", ">= 1.5.1"
 gem "quad_tile", "~> 1.0.1"
 
 # Sanitise URIs
+gem "addressable", "~> 2.8"
 gem "rack-uri_sanitizer"
 
 # Omniauth for authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -602,6 +602,7 @@ DEPENDENCIES
   actionpack-page_caching (>= 1.2.0)
   active_record_union
   activerecord-import
+  addressable (~> 2.8)
   annotate
   argon2
   autoprefixer-rails

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -1,10 +1,12 @@
 module OpenGraphHelper
+  require "addressable/uri"
+
   def opengraph_tags(title = nil, og_image = nil)
     tags = {
       "og:site_name" => t("layouts.project_name.title"),
       "og:title" => title || t("layouts.project_name.title"),
       "og:type" => "website",
-      "og:image" => og_image ? URI.join(root_url, og_image) : image_url("osm_logo_256.png"),
+      "og:image" => og_image ? Addressable::URI.join(root_url, og_image).normalize : image_url("osm_logo_256.png"),
       "og:url" => url_for(:only_path => false),
       "og:description" => t("layouts.intro_text")
     }

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -6,7 +6,7 @@ module OpenGraphHelper
       "og:site_name" => t("layouts.project_name.title"),
       "og:title" => title || t("layouts.project_name.title"),
       "og:type" => "website",
-      "og:image" => og_image ? Addressable::URI.join(root_url, og_image).normalize : image_url("osm_logo_256.png"),
+      "og:image" => og_image_url(og_image),
       "og:url" => url_for(:only_path => false),
       "og:description" => t("layouts.intro_text")
     }
@@ -14,5 +14,16 @@ module OpenGraphHelper
     safe_join(tags.map do |property, content|
       tag.meta(:property => property, :content => content)
     end, "\n")
+  end
+
+  private
+
+  def og_image_url(og_image)
+    begin
+      return Addressable::URI.join(root_url, og_image).normalize if og_image
+    rescue Addressable::URI::InvalidURIError
+      # return default image
+    end
+    image_url("osm_logo_256.png")
   end
 end

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -766,6 +766,28 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_show_og_image_with_spaces
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :body => "![some picture](https://example.com/the picture.jpg)")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='og:image']" do
+      assert_dom "> @content", "https://example.com/the%20picture.jpg"
+    end
+  end
+
+  def test_show_og_image_with_relative_uri_and_spaces
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :body => "![some local picture](/the picture.jpg)")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='og:image']" do
+      assert_dom "> @content", "#{root_url}the%20picture.jpg"
+    end
+  end
+
   def test_hide
     user = create(:user)
     diary_entry = create(:diary_entry, :user => user)

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -744,6 +744,17 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_show_og_image_with_no_image
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :body => "nothing")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='og:image']" do
+      assert_dom "> @content", ActionController::Base.helpers.image_url("osm_logo_256.png", :host => root_url)
+    end
+  end
+
   def test_show_og_image
     user = create(:user)
     diary_entry = create(:diary_entry, :user => user, :body => "![some picture](https://example.com/picture.jpg)")
@@ -785,6 +796,17 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_dom "head meta[property='og:image']" do
       assert_dom "> @content", "#{root_url}the%20picture.jpg"
+    end
+  end
+
+  def test_show_og_image_with_invalid_uri
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :body => "![](:)")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='og:image']" do
+      assert_dom "> @content", ActionController::Base.helpers.image_url("osm_logo_256.png", :host => root_url)
     end
   end
 


### PR DESCRIPTION
Fixes #4890.

I used an URI parser to construct absolute URIs, but that thing is stricter than browsers.

<s>Now I only parse urls that don't start with http[s]: and catch invalid URI exceptions.</s>