### PR TITLE
Add missing graphhopper icons

### DIFF
--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -9,7 +9,9 @@ function GraphHopperEngine(id, vehicleType) {
     "3": 3, // sharp right
     "4": 14, // finish reached
     "5": 14, // via reached
-    "6": 10 // roundabout
+    "6": 10, // roundabout
+    "-7": 19, // keep left
+    "7": 18 // keep right
   };
 
   return {

--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -11,7 +11,10 @@ function GraphHopperEngine(id, vehicleType) {
     "5": 14, // via reached
     "6": 10, // roundabout
     "-7": 19, // keep left
-    "7": 18 // keep right
+    "7": 18, // keep right
+    "-98": 4, // unknown direction u-turn
+    "-8": 4, // left u-turn
+    "8": 4 // right u-turn
   };
 
   return {


### PR DESCRIPTION
GraphHopper's routing icon map is missing some entries that are [possible in the results](https://docs.graphhopper.com/#operation/getRoute!c=200&path=paths/instructions/sign&t=response). They are represented as a straight arrow because this icon is at offset zero in the routing sprite svg.
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d77432db-c63b-43f8-8c88-7fc17d12a0d0)


[Keep left/right](https://www.openstreetmap.org/directions?engine=graphhopper_car&route=53.2390%2C14.0022%3B53.3071%2C13.9935) before/after:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/53e1c0e0-7265-43f4-badd-06a887cc8b7a) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/3c555410-04b8-4ee8-a413-bdcd7c4928c9)

[U-turn](https://www.openstreetmap.org/directions?engine=graphhopper_car&route=59.92761%2C30.29539%3B59.92773%2C30.29552) before/after:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d7c70ebf-5a40-459a-9604-1bd9babebb4e) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d2e02558-34e9-41c5-a6bf-c3e01eb90728)
