### PR TITLE
Added indicator message preview is empty.

### DIFF
--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -43,6 +43,12 @@ $(document).ready(function () {
     var preview = $(this).parents(".richtext_container").find(".richtext_preview");
     var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
 
+    if (editor.val().length === 0) {
+      event.preventDefault();
+      editor[0].reportValidity();
+      return;
+    }
+
     if (preview.contents().length === 0) {
       preview.oneTime(500, "loading", function () {
         preview.addClass("loading");


### PR DESCRIPTION
This PR addresses "Indicate if the message preview is empty" issue mentioned in the #3748

Added check in Preview button click event handler if body (message, diary entry, diary comment) is empty and if positive, performs reporting validity (displays tooltip). Fixes #3748.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/2d380005-17a6-4c65-bab8-918d1d436d1a)

