### PR TITLE
Added link to nominatim results in searching results

### DIFF
--- a/app/views/geocoder/search.html.erb
+++ b/app/views/geocoder/search.html.erb
@@ -4,10 +4,10 @@
 
 <% @sources.each do |source| %>
   <h4>
-    <%= t(".title.results_from_html", :results_link => link_to(t(".title.#{source}"),
-                                                               t(".title.#{source}_url"))) %>
+    <%= t(".title.results_from_html", :results_link => link_to(t(".title.#{source[:name]}"),
+                                                               t(".title.#{source[:name]}_url").to_s + source[:parameters].to_s)) %>
   </h4>
-  <div class="search_results_entry mx-n3" data-href="<%= url_for @params.merge(:action => "search_#{source}") %>">
+  <div class="search_results_entry mx-n3" data-href="<%= url_for @params.merge(:action => "search_#{source[:name]}") %>">
     <div class="text-center loader">
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -364,7 +364,7 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template :search
     assert_template :layout => "map"
-    assert_equal %w[latlon osm_nominatim_reverse], assigns(:sources)
+    assert_equal %w[latlon osm_nominatim_reverse], assigns(:sources).pluck(:name)
     assert_nil @controller.params[:query]
     assert_in_delta lat, @controller.params[:lat]
     assert_in_delta lon, @controller.params[:lon]
@@ -373,7 +373,7 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template :search
     assert_template :layout => "xhr"
-    assert_equal %w[latlon osm_nominatim_reverse], assigns(:sources)
+    assert_equal %w[latlon osm_nominatim_reverse], assigns(:sources).pluck(:name)
     assert_nil @controller.params[:query]
     assert_in_delta lat, @controller.params[:lat]
     assert_in_delta lon, @controller.params[:lon]
@@ -384,13 +384,13 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template :search
     assert_template :layout => "map"
-    assert_equal sources, assigns(:sources)
+    assert_equal sources, assigns(:sources).pluck(:name)
 
     get search_path(:query => query), :xhr => true
     assert_response :success
     assert_template :search
     assert_template :layout => "xhr"
-    assert_equal sources, assigns(:sources)
+    assert_equal sources, assigns(:sources).pluck(:name)
   end
 
   def results_check(*results)


### PR DESCRIPTION
This PR addresses "Link to nominatim including search query" issue mentioned in the #3205 

Fixes #3205. Added caching of nominatim URL query parameters in GeocoderController#search for both direct and reverse geocoding. In app/views/geocoder/search.html.erb added displaying cached URL as forwarding link when clicked on "OpenStreetMap Nominatim" label.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/7002343f-6ae0-4b0e-a8e5-31644fae0edd)
