### PR TITLE
Remove global "awaiting geocode" routing state

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -3,7 +3,6 @@
 //= require qs/dist/qs
 
 OSM.Directions = function (map) {
-  var awaitingGeocode; // true if the user has requested a route, but we're waiting on a geocode result
   var awaitingRoute; // true if we've asked the engine for a route and are waiting to hear back
   var chosenEngine;
 
@@ -74,8 +73,6 @@ OSM.Directions = function (map) {
     });
 
     input.on("change", function (e) {
-      awaitingGeocode = true;
-
       // make text the same in both text boxes
       var value = e.target.value;
       endpoint.setValue(value);
@@ -118,10 +115,7 @@ OSM.Directions = function (map) {
 
         input.val(json[0].display_name);
 
-        if (awaitingGeocode) {
-          awaitingGeocode = false;
-          getRoute(true, true);
-        }
+        getRoute(true, true);
       });
     };
 
@@ -209,11 +203,9 @@ OSM.Directions = function (map) {
       var endpoint = endpoints[ep_i];
       if (!endpoint.hasGeocode && !endpoint.awaitingGeocode) {
         endpoint.getGeocode();
-        awaitingGeocode = true;
       }
     }
     if (endpoints[0].awaitingGeocode || endpoints[1].awaitingGeocode) {
-      awaitingGeocode = true;
       return;
     }
 


### PR DESCRIPTION
`/directions` javascript has an `awaitingGeocode` state variable, which is true when one of endpoints awaits geocoding results. But each endpoint has its own `awaitingGeocode` state variable too. Endpoint methods manipulate both global and their own state. Why do they need the global state? Only to decide if they need to run `getRoute()`. But `getRoute()` checks `awaitingGeocode` on endpoints anyway. There's no need for the global state.