### PR TITLE
Use .is-invalid to highlight routing inputs with failed geocode lookups

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -70,7 +70,7 @@ OSM.Directions = function (map) {
     });
 
     input.on("keydown", function () {
-      input.removeClass("error");
+      input.removeClass("is-invalid");
     });
 
     input.on("change", function (e) {
@@ -84,7 +84,7 @@ OSM.Directions = function (map) {
     endpoint.setValue = function (value, latlng) {
       endpoint.value = value;
       delete endpoint.latlng;
-      input.removeClass("error");
+      input.removeClass("is-invalid");
       input.val(value);
 
       if (latlng) {
@@ -109,7 +109,7 @@ OSM.Directions = function (map) {
         endpoint.awaitingGeocode = false;
         endpoint.hasGeocode = true;
         if (json.length === 0) {
-          input.addClass("error");
+          input.addClass("is-invalid");
           alert(I18n.t("javascripts.directions.errors.no_place", { place: endpoint.value }));
           return;
         }


### PR DESCRIPTION
Currently `.error` is added to these inputs, but it doesn't make them look any different.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/538d5c7e-05ea-4b6a-9a08-c321d2513e69)
