### PR TITLE
Write directions sidebar header using .erb template

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -133,7 +133,7 @@ OSM.Directions = function (map) {
     // copy loading item to sidebar and display it. we copy it, rather than
     // just using it in-place and replacing it in case it has to be used
     // again.
-    $("#sidebar_content").html($(".directions_form .loader_copy").html());
+    $("#directions_content").html($(".directions_form .loader_copy").html());
     map.setSidebarOverlaid(false);
 
     routeRequest = chosenEngine.getRoute([o, d], function (err, route) {
@@ -143,7 +143,7 @@ OSM.Directions = function (map) {
         map.removeLayer(polyline);
 
         if (reportErrors) {
-          $("#sidebar_content").html("<div class=\"alert alert-danger\">" + I18n.t("javascripts.directions.errors.no_route") + "</div>");
+          $("#directions_content").html("<div class=\"alert alert-danger\">" + I18n.t("javascripts.directions.errors.no_route") + "</div>");
         }
 
         return;
@@ -169,16 +169,10 @@ OSM.Directions = function (map) {
 
       var turnByTurnTable = $("<table class='table table-hover table-sm mb-3'>")
         .append($("<tbody>"));
-      var directionsCloseButton = $("<button type='button' class='btn-close'>")
-        .attr("aria-label", I18n.t("javascripts.close"));
 
-      $("#sidebar_content")
+      $("#directions_content")
         .empty()
         .append(
-          $("<div class='d-flex'>").append(
-            $("<h2 class='flex-grow-1 text-break'>")
-              .text(I18n.t("javascripts.directions.directions")),
-            $("<div>").append(directionsCloseButton)),
           distanceText,
           turnByTurnTable
         );
@@ -226,17 +220,18 @@ OSM.Directions = function (map) {
         turnByTurnTable.append(row);
       });
 
-      $("#sidebar_content").append("<p class=\"text-center\">" +
+      $("#directions_content").append("<p class=\"text-center\">" +
         I18n.t("javascripts.directions.instructions.courtesy", { link: chosenEngine.creditline }) +
         "</p>");
-
-      directionsCloseButton.on("click", function () {
-        map.removeLayer(polyline);
-        $("#sidebar_content").html("");
-        map.setSidebarOverlaid(true);
-        // TODO: collapse width of sidebar back to previous
-      });
     });
+  }
+
+  function hideRoute(e) {
+    e.stopPropagation();
+    map.removeLayer(polyline);
+    $("#directions_content").html("");
+    map.setSidebarOverlaid(true);
+    // TODO: collapse width of sidebar back to previous
   }
 
   var chosenEngineIndex = findEngine("fossgis_osrm_car");
@@ -270,8 +265,18 @@ OSM.Directions = function (map) {
   var page = {};
 
   page.pushstate = page.popstate = function () {
+    if ($("#directions_content").length) {
+      page.load();
+    } else {
+      OSM.loadSidebarContent("/directions", page.load);
+    }
+  };
+
+  page.load = function () {
     $(".search_form").hide();
     $(".directions_form").show();
+
+    $("#sidebar_content").on("click", ".btn-close", hideRoute);
 
     $("#map").on("dragend dragover", function (e) {
       e.preventDefault();
@@ -312,13 +317,10 @@ OSM.Directions = function (map) {
     map.setSidebarOverlaid(!from || !to);
   };
 
-  page.load = function () {
-    page.pushstate();
-  };
-
   page.unload = function () {
     $(".search_form").show();
     $(".directions_form").hide();
+    $("#sidebar_content").off("click", ".btn-close", hideRoute);
     $("#map").off("dragend dragover drop");
 
     endpoints[0].disable();

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -269,6 +269,7 @@ OSM.Directions = function (map) {
       page.load();
     } else {
       OSM.loadSidebarContent("/directions", page.load);
+      // TODO predict if both endpoints will have latlng on load and set map.setSidebarOverlaid() accordingly
     }
   };
 

--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -1,1 +1,5 @@
 <% content_for(:content_class) { "overlay-sidebar" } %>
+
+<%= render "sidebar_header", :title => t("javascripts.directions.directions") %>
+
+<div id="directions_content"></div>


### PR DESCRIPTION
Other sidebar pages have at least a heading and some placeholder in their `.html.erb` template, for example [geocoder search](https://github.com/openstreetmap/openstreetmap-website/blob/84aa7f455ae58b4b051368e35dbc43f780b3aa0f/app/views/geocoder/search.html.erb). Directions search is the exception, it's template is [essentially empty](https://github.com/openstreetmap/openstreetmap-website/blob/84aa7f455ae58b4b051368e35dbc43f780b3aa0f/app/views/directions/search.html.erb). Instead everything is written by `directions.js`.

Here I'm moving the directions heading to `.html.erb`. Actually I'm doing this to add more things to `.html.erb` later. Preview: #4901.