### PR TITLE
Use callbacks instead of direct getRoute() calls from route endpoints

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -20,9 +20,15 @@ OSM.Directions = function (map) {
     weight: 12
   });
 
+  var endpointDragCallback = function (dragging) {
+    if (map.hasLayer(polyline)) {
+      getRoute(false, !dragging);
+    }
+  };
+
   var endpoints = [
-    Endpoint($("input[name='route_from']"), OSM.MARKER_GREEN),
-    Endpoint($("input[name='route_to']"), OSM.MARKER_RED)
+    Endpoint($("input[name='route_from']"), OSM.MARKER_GREEN, endpointDragCallback),
+    Endpoint($("input[name='route_to']"), OSM.MARKER_RED, endpointDragCallback)
   ];
 
   var expiry = new Date();
@@ -42,7 +48,7 @@ OSM.Directions = function (map) {
     select.append("<option value='" + i + "'>" + I18n.t("javascripts.directions.engines." + engine.id) + "</option>");
   });
 
-  function Endpoint(input, iconUrl) {
+  function Endpoint(input, iconUrl, dragCallback) {
     var endpoint = {};
 
     endpoint.marker = L.marker([0, 0], {
@@ -63,9 +69,7 @@ OSM.Directions = function (map) {
       if (dragging && !chosenEngine.draggable) return;
       if (dragging && awaitingRoute) return;
       endpoint.setLatLng(e.target.getLatLng());
-      if (map.hasLayer(polyline)) {
-        getRoute(false, !dragging);
-      }
+      dragCallback(dragging);
     });
 
     input.on("keydown", function () {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -25,10 +25,13 @@ OSM.Directions = function (map) {
       getRoute(false, !dragging);
     }
   };
+  var endpointGeocodeCallback = function () {
+    getRoute(true, true);
+  };
 
   var endpoints = [
-    Endpoint($("input[name='route_from']"), OSM.MARKER_GREEN, endpointDragCallback),
-    Endpoint($("input[name='route_to']"), OSM.MARKER_RED, endpointDragCallback)
+    Endpoint($("input[name='route_from']"), OSM.MARKER_GREEN, endpointDragCallback, endpointGeocodeCallback),
+    Endpoint($("input[name='route_to']"), OSM.MARKER_RED, endpointDragCallback, endpointGeocodeCallback)
   ];
 
   var expiry = new Date();
@@ -48,7 +51,7 @@ OSM.Directions = function (map) {
     select.append("<option value='" + i + "'>" + I18n.t("javascripts.directions.engines." + engine.id) + "</option>");
   });
 
-  function Endpoint(input, iconUrl, dragCallback) {
+  function Endpoint(input, iconUrl, dragCallback, geocodeCallback) {
     var endpoint = {};
 
     endpoint.marker = L.marker([0, 0], {
@@ -119,7 +122,7 @@ OSM.Directions = function (map) {
 
         input.val(json[0].display_name);
 
-        getRoute(true, true);
+        geocodeCallback();
       });
     };
 


### PR DESCRIPTION
Directions page javascript controller has two route endpoint objects. They manage from/to inputs and markers. When inputs and markers are updated, endpoint objects call `getRoute` method of the controller to redraw the route. But why should endpoints know anything about the entire route? They only need to report that an input or a marker was updated and let the outside code decide what to do in response.