### PR TITLE
Disable Rails/BulkChangeTable cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,10 @@ Naming/FileName:
 Naming/MethodParameterName:
   Enabled: false
 
+# This conflicts with Strong Migrations, which can't check `change_table`
+Rails/BulkChangeTable:
+  Enabled: false
+
 Rails/CreateTableWithTimestamps:
   Enabled: false
 


### PR DESCRIPTION
If you have multiple alter commands in a migration (like adding two columns to an existing table) this cop will suggest combining them using `change_table :foo, :bulk => true`.

However, Strong Migrations can't inspect `change_table` blocks, and therefore suggests using `safety_assured`, which mostly defeats the purpose of using Strong Migrations in the first place.

Instead, we should stick with the individual alter commands. Since postgres runs DDL changes in a transaction anyway, there is not enough benefit from the `change_table` approach to be worth losing the safety net of the Strong Migrations checks.

* Refs https://github.com/ankane/strong_migrations/issues/204
* Refs https://github.com/openstreetmap/openstreetmap-website/pull/4481