### PR TITLE
Style auth buttons using .btn & .btn-light classes

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -77,7 +77,7 @@ module UserHelper
                 :size => "24") + t("application.auth_providers.#{name}.title"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
-      :class => "auth_button fs-6 border rounded text-body-secondary text-decoration-none py-2 px-4 d-flex justify-content-center align-items-center",
+      :class => "auth_button btn btn-outline-secondary fs-6 border rounded py-2 px-4 d-flex justify-content-center align-items-center",
       :title => t("application.auth_providers.#{name}.title")
     )
   end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -64,7 +64,7 @@ module UserHelper
                 :size => "24"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
-      :class => "auth_button p-2 d-block",
+      :class => "auth_button btn btn-light mx-1 p-2 d-block",
       :title => t("application.auth_providers.#{name}.title")
     )
   end

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -31,7 +31,7 @@
                   "#",
                   :id => "openid_open_url",
                   :title => t("application.auth_providers.openid.title"),
-                  :class => "p-2 d-block" %>
+                  :class => "btn btn-light mx-1 p-2 d-block" %>
 
       <% %w[google facebook microsoft github wikipedia].each do |provider| %>
         <% unless @preferred_auth_provider == provider %>

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -117,7 +117,7 @@ class UserHelperTest < ActionView::TestCase
   def test_auth_button
     button = auth_button("google", "google")
     img_tag = "<img alt=\"Log in with a Google OpenID\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"24\" height=\"24\" />"
-    assert_equal("<a class=\"auth_button p-2 d-block\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
+    assert_equal("<a class=\"auth_button btn btn-light mx-1 p-2 d-block\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
   end
 
   private


### PR DESCRIPTION
This PR addresses #4773  discussion regarding auth_button_preferred css classes section. Auth anchor tags now use button styles as base style which will enforce consistency with other buttons.

The login screen maintains the same ui structure with minor styling enchancments
<img width="902" alt="Screenshot 2024-06-21 at 14 31 26" src="https://github.com/openstreetmap/openstreetmap-website/assets/76796906/014c04c9-e692-476c-84b7-6a234845199f">

