### PR TITLE
Arrange button sizes to default size of 36px

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -53,7 +53,7 @@ module UserHelper
   # External authentication support
 
   def openid_logo
-    image_tag "openid.svg", :size => "24", :alt => t("application.auth_providers.openid_logo_alt"), :class => "align-text-bottom"
+    image_tag "openid.svg", :size => "36", :alt => t("application.auth_providers.openid_logo_alt"), :class => "align-text-bottom"
   end
 
   def auth_button(name, provider, options = {})
@@ -61,7 +61,7 @@ module UserHelper
       image_tag("#{name}.svg",
                 :alt => t("application.auth_providers.#{name}.alt"),
                 :class => "rounded-1",
-                :size => "24"),
+                :size => "36"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
       :class => "auth_button p-2 d-block",
@@ -74,7 +74,7 @@ module UserHelper
       image_tag("#{name}.svg",
                 :alt => t("application.auth_providers.#{name}.alt"),
                 :class => "rounded-1 me-3",
-                :size => "24") + t("application.auth_providers.#{name}.title"),
+                :size => "36") + t("application.auth_providers.#{name}.title"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
       :class => "auth_button fs-6 border rounded text-body-secondary text-decoration-none py-2 px-4 d-flex justify-content-center align-items-center",

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -27,7 +27,7 @@
 
       <%= link_to image_tag("openid.png",
                             :alt => t("application.auth_providers.openid.title"),
-                            :size => "24"),
+                            :size => "36"),
                   "#",
                   :id => "openid_open_url",
                   :title => t("application.auth_providers.openid.title"),

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -116,7 +116,7 @@ class UserHelperTest < ActionView::TestCase
 
   def test_auth_button
     button = auth_button("google", "google")
-    img_tag = "<img alt=\"Log in with a Google OpenID\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"24\" height=\"24\" />"
+    img_tag = "<img alt=\"Log in with a Google OpenID\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"36\" height=\"36\" />"
     assert_equal("<a class=\"auth_button p-2 d-block\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
   end
 


### PR DESCRIPTION
As discussed in #4773, in auth button sizes section it was proposed that 36px should remain as the default size for the auth buttons. This PR addresses that comment.

