### PR TITLE
Simplify handling of geocoder URLs

### DIFF
--- a/app/views/geocoder/search.html.erb
+++ b/app/views/geocoder/search.html.erb
@@ -4,8 +4,7 @@
 
 <% @sources.each do |source| %>
   <h4>
-    <%= t(".title.results_from_html", :results_link => link_to(t(".title.#{source[:name]}"),
-                                                               t(".title.#{source[:name]}_url").to_s + source[:parameters].to_s)) %>
+    <%= t(".title.results_from_html", :results_link => link_to(t(".title.#{source[:name]}"), source[:url].to_s)) %>
   </h4>
   <div class="search_results_entry mx-n3" data-href="<%= url_for @params.merge(:action => "search_#{source[:name]}") %>">
     <div class="text-center loader">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -671,11 +671,8 @@ en:
       title:
         results_from_html: 'Results from %{results_link}'
         latlon: Internal
-        latlon_url: https://openstreetmap.org/
         osm_nominatim: OpenStreetMap Nominatim
-        osm_nominatim_url: https://nominatim.openstreetmap.org/
         osm_nominatim_reverse: OpenStreetMap Nominatim
-        osm_nominatim_reverse_url: https://nominatim.openstreetmap.org/
     search_osm_nominatim:
       prefix_format: "%{name}"
       prefix:

--- a/test/http/nominatim.yml
+++ b/test/http/nominatim.yml
@@ -16,7 +16,7 @@
       <place place_id='109724' osm_type='node' osm_id='17044599' place_rank='30' boundingbox="51.7418469,51.7518469,-0.0156773,-0.0056773" lat='51.7468469' lon='-0.0106773' display_name='Broxbourne, Stafford Drive, Broxbourne, Hertfordshire, East of England, England, United Kingdom' class='railway' type='station' importance='0.111' icon='http://nominatim.openstreetmap.org/images/mapicons/transport_train_station2.p.20.png'><extratags></extratags></place>
     </searchresults>
 
-/reverse?accept-language=&lat=51.7632&lon=-0.0076&zoom=15:
+/reverse?accept-language=&format=xml&lat=51.7632&lon=-0.0076&zoom=15:
   code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8"?>
@@ -33,7 +33,7 @@
       </addressparts>
     </reversegeocode>
 
-/reverse?accept-language=&lat=51.7632&lon=-0.0076&zoom=17:
+/reverse?accept-language=&format=xml&lat=51.7632&lon=-0.0076&zoom=17:
   code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8"?>
@@ -52,7 +52,7 @@
       </addressparts>
     </reversegeocode>
 
-/reverse?accept-language=&lat=13.7709&lon=100.50507&zoom=19:
+/reverse?accept-language=&format=xml&lat=13.7709&lon=100.50507&zoom=19:
   code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8" ?>


### PR DESCRIPTION
This avoids having to build them in multiple places and also ensures we link to what was actually searched rather than some random string from the locale file.