### PR TITLE
Home Location page

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -29,7 +29,7 @@ class Ability
 
     if user&.active?
       can :welcome, :site
-      can :read, [:deletion, :account_terms, :account_pd_declaration]
+      can :read, [:deletion, :account_terms, :account_pd_declaration, :account_home]
 
       if Settings.status != "database_offline"
         can [:read, :create, :destroy], :changeset_subscription

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -21,6 +21,7 @@
 //= require index/directions
 //= require index/changeset
 //= require index/query
+//= require index/home
 //= require router
 
 $(document).ready(function () {
@@ -356,7 +357,8 @@ $(document).ready(function () {
     "/relation/:id(/history)": OSM.Browse(map, "relation"),
     "/relation/:id/history/:version": OSM.OldBrowse(),
     "/changeset/:id": OSM.Changeset(map),
-    "/query": OSM.Query(map)
+    "/query": OSM.Query(map),
+    "/account/home": OSM.Home(map)
   });
 
   if (OSM.preferred_editor === "remote" && document.location.pathname === "/edit") {

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -214,16 +214,6 @@ $(document).ready(function () {
     L.marker([params.mlat, params.mlon]).addTo(map);
   }
 
-  $("#homeanchor").on("click", function (e) {
-    e.preventDefault();
-
-    var data = $(this).data(),
-        center = L.latLng(data.lat, data.lon);
-
-    map.setView(center, data.zoom);
-    L.marker(center, { icon: OSM.getUserIcon() }).addTo(map);
-  });
-
   function remoteEditHandler(bbox, object) {
     var remoteEditHost = "http://127.0.0.1:8111",
         osmHost = location.protocol + "//" + location.host,

--- a/app/assets/javascripts/index/home.js
+++ b/app/assets/javascripts/index/home.js
@@ -12,17 +12,26 @@ OSM.Home = function (map) {
     map.setSidebarOverlaid(true);
     clearMarker();
 
-    OSM.router.withoutMoveListener(function () {
-      map.setView(OSM.home, 15, { reset: true });
-    });
-    marker = L.marker(OSM.home, {
-      icon: OSM.getUserIcon(),
-      title: I18n.t("javascripts.home.marker_title")
-    }).addTo(map);
+    if (OSM.home) {
+      OSM.router.withoutMoveListener(function () {
+        map.setView(OSM.home, 15, { reset: true });
+      });
+      marker = L.marker(OSM.home, {
+        icon: OSM.getUserIcon(),
+        title: I18n.t("javascripts.home.marker_title")
+      }).addTo(map);
+    } else {
+      $("#browse_status").html(
+        $("<div class='m-2 alert alert-warning'>").text(
+          I18n.t("javascripts.home.not_set")
+        )
+      );
+    }
   };
 
   page.unload = function () {
     clearMarker();
+    $("#browse_status").empty();
   };
 
   return page;

--- a/app/assets/javascripts/index/home.js
+++ b/app/assets/javascripts/index/home.js
@@ -1,8 +1,28 @@
 OSM.Home = function (map) {
+  let marker;
+
+  function clearMarker() {
+    if (marker) map.removeLayer(marker);
+    marker = null;
+  }
+
   const page = {};
 
   page.pushstate = page.popstate = page.load = function () {
     map.setSidebarOverlaid(true);
+    clearMarker();
+
+    OSM.router.withoutMoveListener(function () {
+      map.setView(OSM.home, 15, { reset: true });
+    });
+    marker = L.marker(OSM.home, {
+      icon: OSM.getUserIcon(),
+      title: I18n.t("javascripts.home.marker_title")
+    }).addTo(map);
+  };
+
+  page.unload = function () {
+    clearMarker();
   };
 
   return page;

--- a/app/assets/javascripts/index/home.js
+++ b/app/assets/javascripts/index/home.js
@@ -1,0 +1,9 @@
+OSM.Home = function (map) {
+  const page = {};
+
+  page.pushstate = page.popstate = page.load = function () {
+    map.setSidebarOverlaid(true);
+  };
+
+  return page;
+};

--- a/app/controllers/accounts/homes_controller.rb
+++ b/app/controllers/accounts/homes_controller.rb
@@ -1,0 +1,13 @@
+module Accounts
+  class HomesController < ApplicationController
+    layout :map_layout
+
+    before_action :authorize_web
+    before_action :set_locale
+    before_action :require_oauth
+
+    authorize_resource :class => :account_home
+
+    def show; end
+  end
+end

--- a/app/views/accounts/homes/show.html.erb
+++ b/app/views/accounts/homes/show.html.erb
@@ -1,0 +1,1 @@
+<% content_for(:content_class) { "overlay-sidebar" } %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -88,7 +88,9 @@
           <%= link_to t("users.show.my settings"), edit_account_path, :class => "dropdown-item" %>
           <%= link_to t("users.show.my_preferences"), preferences_path, :class => "dropdown-item" %>
           <div class="dropdown-divider"></div>
-          <%= yield :greeting %>
+          <% if current_user.home_location? %>
+            <%= link_to t("layouts.home"), account_home_path, :class => "dropdown-item" %>
+          <% end %>
           <%= link_to t("layouts.logout"), logout_path(:referer => request.fullpath), :method => "post", :class => "geolink dropdown-item" %>
         </div>
       </div>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -4,18 +4,6 @@
 
 <% content_for(:body_class) { "map-layout" } %>
 
-<% if current_user&.home_location? %>
-  <% content_for :greeting do %>
-    <%= link_to t("layouts.home"),
-                "#",
-                :id => "homeanchor",
-                :class => "set_position dropdown-item",
-                :data => { :lat => current_user.home_lat,
-                           :lon => current_user.home_lon,
-                           :zoom => 15 } %>
-  <% end %>
-<% end %>
-
 <% content_for :header do %>
   <%= render :partial => "layouts/search", :locals => { :autofocus => false } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3318,6 +3318,7 @@ en:
       centre_map: Centre map here
     home:
       marker_title: My home location
+      not_set: Home location is not set for your account
   redactions:
     edit:
       heading: "Edit Redaction"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3316,6 +3316,8 @@ en:
       show_address: Show address
       query_features: Query features
       centre_map: Centre map here
+    home:
+      marker_title: My home location
   redactions:
     edit:
       heading: "Edit Redaction"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -300,6 +300,7 @@ OpenStreetMap::Application.routes.draw do
       resource :terms, :only => [:show, :update]
       resource :pd_declaration, :only => [:show, :create]
       resource :deletion, :only => :show
+      resource :home, :only => :show
     end
   end
 

--- a/test/system/account_home_test.rb
+++ b/test/system/account_home_test.rb
@@ -45,4 +45,13 @@ class AccountHomeTest < ApplicationSystemTestCase
     click_on "test user"
     assert_no_link "Go to Home Location"
   end
+
+  test "account home page shows a warning when visited by users without home location" do
+    user = create(:user, :display_name => "test user")
+    sign_in_as(user)
+
+    visit account_home_path
+    assert_no_selector "img.leaflet-marker-icon"
+    assert_text "Home location is not set"
+  end
 end

--- a/test/system/account_home_test.rb
+++ b/test/system/account_home_test.rb
@@ -1,0 +1,48 @@
+require "application_system_test_case"
+
+class AccountHomeTest < ApplicationSystemTestCase
+  test "Go to Home Location works on map layout pages" do
+    user = create(:user, :display_name => "test user", :home_lat => 60, :home_lon => 30)
+    sign_in_as(user)
+
+    visit root_path
+    assert_no_selector "img.leaflet-marker-icon"
+
+    click_on "test user"
+    click_on "Go to Home Location"
+    all "img.leaflet-marker-icon", :count => 1 do |marker|
+      assert_equal "My home location", marker["title"]
+    end
+
+    click_on "OpenStreetMap logo"
+    assert_no_selector "img.leaflet-marker-icon"
+  end
+
+  test "Go to Home Location works on non-map layout pages" do
+    user = create(:user, :display_name => "test user", :home_lat => 60, :home_lon => 30)
+    sign_in_as(user)
+
+    visit about_path
+    assert_no_selector "img.leaflet-marker-icon"
+
+    click_on "test user"
+    click_on "Go to Home Location"
+    all "img.leaflet-marker-icon", :count => 1 do |marker|
+      assert_equal "My home location", marker["title"]
+    end
+
+    click_on "OpenStreetMap logo"
+    assert_no_selector "img.leaflet-marker-icon"
+  end
+
+  test "Go to Home Location is not available for users without home location" do
+    user = create(:user, :display_name => "test user")
+    sign_in_as(user)
+
+    visit root_path
+    assert_no_selector "img.leaflet-marker-icon"
+
+    click_on "test user"
+    assert_no_link "Go to Home Location"
+  end
+end


### PR DESCRIPTION
This adds a home location page with its own URL similar to what's suggested in https://github.com/openstreetmap/openstreetmap-website/issues/670#issuecomment-31867047, without sidebar and extra controls. Instead of `/:username/home` I use the path `/account/home` because it's easier to implement, no need to check `:username`.

A link to this page is available on every other page with the user dropdown menu. This fixes #1810.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/fe4a4e8e-9931-4946-9e36-0e15acbfa6ab)

It's possible to leave this page for another map page. In this case the javascript controller removes the home location marker. This fixes #669 and #670.