### PR TITLE
Rename map layer javascript files

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -12,9 +12,9 @@
 //= require leaflet.contextmenu
 //= require index/contextmenu
 //= require index/search
-//= require index/browse
+//= require index/layers/data
 //= require index/export
-//= require index/notes
+//= require index/layers/notes
 //= require index/history
 //= require index/note
 //= require index/new_note
@@ -160,12 +160,12 @@ $(document).ready(function () {
   OSM.initializeContextMenu(map);
 
   if (OSM.STATUS !== "api_offline" && OSM.STATUS !== "database_offline") {
-    OSM.initializeNotes(map);
+    OSM.initializeNotesLayer(map);
     if (params.layers.indexOf(map.noteLayer.options.code) >= 0) {
       map.addLayer(map.noteLayer);
     }
 
-    OSM.initializeBrowse(map);
+    OSM.initializeDataLayer(map);
     if (params.layers.indexOf(map.dataLayer.options.code) >= 0) {
       map.addLayer(map.dataLayer);
     }

--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -1,5 +1,5 @@
-OSM.initializeBrowse = function (map) {
-  var browseBounds;
+OSM.initializeDataLayer = function (map) {
+  var loadedBounds;
   var dataLayer = map.dataLayer;
 
   dataLayer.setStyle({
@@ -41,7 +41,7 @@ OSM.initializeBrowse = function (map) {
 
   function updateData() {
     var bounds = map.getBounds();
-    if (!browseBounds || !browseBounds.contains(bounds)) {
+    if (!loadedBounds || !loadedBounds.contains(bounds)) {
       getData();
     }
   }
@@ -96,7 +96,7 @@ OSM.initializeBrowse = function (map) {
         function addFeatures() {
           $("#browse_status").empty();
           dataLayer.addData(features);
-          browseBounds = bounds;
+          loadedBounds = bounds;
         }
 
         function cancelAddFeatures() {

--- a/app/assets/javascripts/index/layers/notes.js
+++ b/app/assets/javascripts/index/layers/notes.js
@@ -1,4 +1,4 @@
-OSM.initializeNotes = function (map) {
+OSM.initializeNotesLayer = function (map) {
   var noteLayer = map.noteLayer,
       notes = {};
 


### PR DESCRIPTION
We have a bunch of things named "browse". On the client side we have the `OSM.Browse` controller for single element pages: https://github.com/openstreetmap/openstreetmap-website/blob/ecd091c976cc8f2a3cf96fe08dc3211aad689ae2/app/assets/javascripts/index.js#L327

But there's also [browse.js](https://github.com/openstreetmap/openstreetmap-website/blob/ecd091c976cc8f2a3cf96fe08dc3211aad689ae2/app/assets/javascripts/index/browse.js). It initializes the data layer:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/058f1c7f-3fbc-46e1-a692-f2eb30917e75)

This is confusing because most of controllers, for example `OSM.Directions`, are in their own javascript files. You'd expect to find `OSM.Browse` in `browse.js` but no, `browse.js` is something completely different.

This pull request renames everything "browse" about `browse.js` and moves the file into the `layers` directory. And it also moves notes layer there.