### PR TITLE
Browse node version coordinates

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -327,17 +327,17 @@ $(document).ready(function () {
   OSM.Browse = function (map, type) {
     var page = {};
 
-    page.pushstate = page.popstate = function (path, id) {
+    page.pushstate = page.popstate = function (path, id, version) {
       OSM.loadSidebarContent(path, function () {
-        addObject(type, id);
+        addObject(type, id, version);
       });
     };
 
-    page.load = function (path, id) {
-      addObject(type, id, true);
+    page.load = function (path, id, version) {
+      addObject(type, id, version, true);
     };
 
-    function addObject(type, id, center) {
+    function addObject(type, id, version, center) {
       var object = { type: type, id: parseInt(id, 10) },
           data;
 
@@ -346,6 +346,10 @@ $(document).ready(function () {
         if (data && data.coordinates) {
           object.latLng = L.latLng(data.coordinates.split(","));
         }
+      }
+
+      if (version && !(type === "node" && object.latLng)) {
+        return;
       }
 
       map.addObject(object, function (bounds) {
@@ -365,16 +369,6 @@ $(document).ready(function () {
     return page;
   };
 
-  OSM.OldBrowse = function () {
-    var page = {};
-
-    page.pushstate = page.popstate = function (path) {
-      OSM.loadSidebarContent(path);
-    };
-
-    return page;
-  };
-
   var history = OSM.History(map);
 
   OSM.router = OSM.Router(map, {
@@ -389,11 +383,11 @@ $(document).ready(function () {
     "/user/:display_name/history": history,
     "/note/:id": OSM.Note(map),
     "/node/:id(/history)": OSM.Browse(map, "node"),
-    "/node/:id/history/:version": OSM.OldBrowse(),
+    "/node/:id/history/:version": OSM.Browse(map, "node"),
     "/way/:id(/history)": OSM.Browse(map, "way"),
-    "/way/:id/history/:version": OSM.OldBrowse(),
+    "/way/:id/history/:version": OSM.Browse(map, "way"),
     "/relation/:id(/history)": OSM.Browse(map, "relation"),
-    "/relation/:id/history/:version": OSM.OldBrowse(),
+    "/relation/:id/history/:version": OSM.Browse(map, "relation"),
     "/changeset/:id": OSM.Changeset(map),
     "/query": OSM.Query(map)
   });

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -338,7 +338,17 @@ $(document).ready(function () {
     };
 
     function addObject(type, id, center) {
-      map.addObject({ type: type, id: parseInt(id, 10) }, function (bounds) {
+      var object = { type: type, id: parseInt(id, 10) },
+          data;
+
+      if (type === "node") {
+        data = $(".details").data();
+        if (data && data.coordinates) {
+          object.latLng = L.latLng(data.coordinates.split(","));
+        }
+      }
+
+      map.addObject(object, function (bounds) {
         if (!window.location.hash && bounds.isValid() &&
             (center || !map.getBounds().contains(bounds))) {
           OSM.router.withoutMoveListener(function () {

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -272,21 +272,6 @@ L.OSM.Map = L.Map.extend({
   },
 
   addObject: function (object, callback) {
-    var objectStyle = {
-      color: "#FF6200",
-      weight: 4,
-      opacity: 1,
-      fillOpacity: 0.5
-    };
-
-    var changesetStyle = {
-      weight: 4,
-      color: "#FF9500",
-      opacity: 1,
-      fillOpacity: 0,
-      interactive: false
-    };
-
     var haloStyle = {
       weight: 2.5,
       radius: 20,
@@ -322,35 +307,55 @@ L.OSM.Map = L.Map.extend({
         dataType: "xml",
         success: function (xml) {
           map._object = object;
-
-          map._objectLayer = new L.OSM.DataLayer(null, {
-            styles: {
-              node: objectStyle,
-              way: objectStyle,
-              area: objectStyle,
-              changeset: changesetStyle
-            }
-          });
-
-          map._objectLayer.interestingNode = function (node, ways, relations) {
-            if (object.type === "node") {
-              return true;
-            } else if (object.type === "relation") {
-              for (var i = 0; i < relations.length; i++) {
-                if (relations[i].members.indexOf(node) !== -1) return true;
-              }
-            } else {
-              return false;
-            }
-          };
-
-          map._objectLayer.addData(xml);
-          map._objectLayer.addTo(map);
+          map._objectLayer = map.makeObjectLayer(object, xml);
 
           if (callback) callback(map._objectLayer.getBounds());
         }
       });
     }
+  },
+
+  makeObjectLayer: function (object, features) {
+    var objectStyle = {
+      color: "#FF6200",
+      weight: 4,
+      opacity: 1,
+      fillOpacity: 0.5
+    };
+
+    var changesetStyle = {
+      weight: 4,
+      color: "#FF9500",
+      opacity: 1,
+      fillOpacity: 0,
+      interactive: false
+    };
+
+    var objectLayer = new L.OSM.DataLayer(null, {
+      styles: {
+        node: objectStyle,
+        way: objectStyle,
+        area: objectStyle,
+        changeset: changesetStyle
+      }
+    });
+
+    objectLayer.interestingNode = function (node, ways, relations) {
+      if (object.type === "node") {
+        return true;
+      } else if (object.type === "relation") {
+        for (var i = 0; i < relations.length; i++) {
+          if (relations[i].members.indexOf(node) !== -1) return true;
+        }
+      } else {
+        return false;
+      }
+    };
+
+    objectLayer.addData(features);
+    objectLayer.addTo(this);
+
+    return objectLayer;
   },
 
   removeObject: function () {

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -302,16 +302,24 @@ L.OSM.Map = L.Map.extend({
       if (callback) callback(this._objectLayer.getBounds());
     } else { // element or changeset handled by L.OSM.DataLayer
       var map = this;
-      this._objectLoader = $.ajax({
-        url: OSM.apiUrl(object),
-        dataType: "xml",
-        success: function (xml) {
-          map._object = object;
-          map._objectLayer = map.makeObjectLayer(object, xml);
 
-          if (callback) callback(map._objectLayer.getBounds());
-        }
-      });
+      if (object.type === "node" && object.latLng) {
+        map._object = object;
+        map._objectLayer = map.makeObjectLayer(object, [object]);
+
+        if (callback) callback(map._objectLayer.getBounds());
+      } else {
+        this._objectLoader = $.ajax({
+          url: OSM.apiUrl(object),
+          dataType: "xml",
+          success: function (xml) {
+            map._object = object;
+            map._objectLayer = map.makeObjectLayer(object, xml);
+
+            if (callback) callback(map._objectLayer.getBounds());
+          }
+        });
+      }
     }
   },
 

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -15,26 +15,28 @@
   <% end %>
 </p>
 
-<ul class="list-unstyled">
-  <li>
-    <%= t "browse.#{common_details.visible? ? :edited : :deleted}_ago_by_html",
-          :time_ago => friendly_date_ago(common_details.timestamp),
-          :user => changeset_user_link(common_details.changeset) %>
-  </li>
-  <li>
-    <%= t "browse.in_changeset" %>
-    #<%= link_to common_details.changeset_id, changeset_path(common_details.changeset) %>
-  </li>
-
-  <% if @type == "node" and common_details.visible? %>
+<%= tag.div :class => "details" do %>
+  <ul class="list-unstyled">
     <li>
-      <%= t "browse.location" %>
-      <%= link_to(t(".coordinates_html",
-                    :latitude => tag.span(number_with_delimiter(common_details.lat), :class => "latitude"),
-                    :longitude => tag.span(number_with_delimiter(common_details.lon), :class => "longitude")),
-                  root_path(:anchor => "map=18/#{common_details.lat}/#{common_details.lon}")) %>
+      <%= t "browse.#{common_details.visible? ? :edited : :deleted}_ago_by_html",
+            :time_ago => friendly_date_ago(common_details.timestamp),
+            :user => changeset_user_link(common_details.changeset) %>
     </li>
-  <% end %>
-</ul>
+    <li>
+      <%= t "browse.in_changeset" %>
+      #<%= link_to common_details.changeset_id, changeset_path(common_details.changeset) %>
+    </li>
+
+    <% if @type == "node" and common_details.visible? %>
+      <li>
+        <%= t "browse.location" %>
+        <%= link_to(t(".coordinates_html",
+                      :latitude => tag.span(number_with_delimiter(common_details.lat), :class => "latitude"),
+                      :longitude => tag.span(number_with_delimiter(common_details.lon), :class => "longitude")),
+                    root_path(:anchor => "map=18/#{common_details.lat}/#{common_details.lon}")) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
 
 <%= render :partial => "browse/tag_details", :object => common_details.tags %>

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -15,7 +15,9 @@
   <% end %>
 </p>
 
-<%= tag.div :class => "details" do %>
+<% coordinates = { :lat => common_details.lat, :lon => common_details.lon } if @type == "node" && common_details.visible? %>
+
+<%= tag.div :class => "details", :data => { :coordinates => coordinates && "#{coordinates[:lat]},#{coordinates[:lon]}" } do %>
   <ul class="list-unstyled">
     <li>
       <%= t "browse.#{common_details.visible? ? :edited : :deleted}_ago_by_html",
@@ -27,13 +29,13 @@
       #<%= link_to common_details.changeset_id, changeset_path(common_details.changeset) %>
     </li>
 
-    <% if @type == "node" and common_details.visible? %>
+    <% if coordinates %>
       <li>
         <%= t "browse.location" %>
         <%= link_to(t(".coordinates_html",
-                      :latitude => tag.span(number_with_delimiter(common_details.lat), :class => "latitude"),
-                      :longitude => tag.span(number_with_delimiter(common_details.lon), :class => "longitude")),
-                    root_path(:anchor => "map=18/#{common_details.lat}/#{common_details.lon}")) %>
+                      :latitude => tag.span(number_with_delimiter(coordinates[:lat]), :class => "latitude"),
+                      :longitude => tag.span(number_with_delimiter(coordinates[:lon]), :class => "longitude")),
+                    root_path(:anchor => "map=18/#{coordinates[:lat]}/#{coordinates[:lon]}")) %>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
It's now possible to see node locations on node version pages for visible versions:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/77d8daad-5068-41d9-825f-58d394497344)
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c86a8762-3b55-45c6-ae9c-618ac1d7a0b1)

Also no extra api requests to fetch node coordinates for map markers.
Before (XHR) / after (no XHR):
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/59f63d84-73e6-4630-a4e4-c772fd2851e9) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/eb8298f7-6d97-490e-9943-0877a3a18fa2)