### PR TITLE
Set i18n locale before writing "report a problem" on embed page

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -5,13 +5,13 @@
 //= require i18n
 //= require i18n/embed
 
-window.onload = function () {
-  if (navigator.languages) {
-    I18n.locale = navigator.languages[0];
-  } else if (navigator.language) {
-    I18n.locale = navigator.language;
-  }
+if (navigator.languages) {
+  I18n.locale = navigator.languages[0];
+} else if (navigator.language) {
+  I18n.locale = navigator.language;
+}
 
+window.onload = function () {
   var query = (window.location.search || '?').slice(1),
       args  = {};
 

--- a/test/system/embed_test.rb
+++ b/test/system/embed_test.rb
@@ -1,0 +1,19 @@
+require "application_system_test_case"
+
+class EmbedTest < ApplicationSystemTestCase
+  test "shows localized report link" do
+    visit export_embed_path
+    assert_link "Report a problem"
+  end
+end
+
+class GermanEmbedTest < ApplicationSystemTestCase
+  driven_by :selenium, :using => :headless_firefox, :options => { :name => :selenium_de } do |options|
+    options.add_preference("intl.accept_languages", "de")
+  end
+
+  test "shows localized report link" do
+    visit export_embed_path
+    assert_link "Ein Problem melden"
+  end
+end


### PR DESCRIPTION
`/export/embed` page has the "Report a problem" link which is supposed to be localized depending on the browser's accept-language header. But that doesn't happen because javascript waits for `window.onload` before setting the language. By that time `L.Control.OSMReportAProblem` is already created with a default locale.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/d67e1985-81a1-4e7d-aeba-f0929c0d9262)