### PR TITLE
Refactor login form to use form helpers for password field

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -33,15 +33,12 @@
 
     <%= f.text_field :username, :label => t(".email or username"), :autofocus => true, :tabindex => 1, :value => params[:username] %>
 
-    <div class="row">
-      <div class="col">
-        <%= f.label :password, t(".password"), :class => "form-label" %>
-      </div>
-      <div class="col text-end">
-        <small><%= link_to(t(".lost password link"), user_forgot_password_path) %></small>
-      </div>
+    <div class="d-flex flex-wrap column-gap-3 justify-content-between align-items-baseline">
+      <%= f.label :password, t(".password"), :class => "my-2" %>
+      <small><%= link_to(t(".lost password link"), user_forgot_password_path) %></small>
     </div>
-    <input class="form-control mb-3" type="password" name="password" id="password" tabindex="2" value="" autocomplete="on" />
+
+    <%= f.password_field :password, :autocomplete => "on", :tabindex => 2, :value => "", :skip_label => true %>
 
     <%= f.form_group do %>
       <%= f.check_box :remember_me, { :label => t(".remember"), :tabindex => 3, :checked => (params[:remember_me] == "yes") }, "yes" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -33,8 +33,8 @@
 
     <%= f.text_field :username, :label => t(".email or username"), :autofocus => true, :tabindex => 1, :value => params[:username] %>
 
-    <div class="d-flex flex-wrap column-gap-3 justify-content-between align-items-baseline">
-      <%= f.label :password, t(".password"), :class => "my-2" %>
+    <div class="d-flex flex-wrap column-gap-3 justify-content-between align-items-baseline mb-2">
+      <%= f.label :password, t(".password") %>
       <small><%= link_to(t(".lost password link"), user_forgot_password_path) %></small>
     </div>
 


### PR DESCRIPTION
This PR addresses issue #4773: "Raw HTML input used for password field." The login form previously used raw HTML for the password input field, which bypassed the automatic HTML attribute generation and site-wide overrides provided by form helpers.

- Replaced the raw HTML input for the password field with the f.password_field helper.
- Ensured the alignment of the password label and the "forgot password" link using Bootstrap classes.