### PR TITLE
Separate translatable messages for privacy policy link in signup form

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -44,10 +44,10 @@
     <%= f.hidden_field :auth_uid unless current_user.auth_uid.nil? %>
 
     <% if current_user.auth_uid.nil? or @email_hmac.nil? or not current_user.errors[:email].empty? %>
-      <%= f.email_field :email, :help => t(".email_help_html",
-                                           :privacy_policy_link => link_to(t(".privacy_policy"),
-                                                                           t(".privacy_policy_url"),
-                                                                           :title => t(".privacy_policy_title"),
+      <%= f.email_field :email, :help => t(".email_help.html",
+                                           :privacy_policy_link => link_to(t(".email_help.privacy_policy"),
+                                                                           t(".email_help.privacy_policy_url"),
+                                                                           :title => t(".email_help.privacy_policy_title"),
                                                                            :target => :new)),
                                 :autofocus => true,
                                 :tabindex => 1 %>
@@ -68,16 +68,16 @@
       </div>
     <% end %>
 
-    <p class="mb-3 text-body-secondary fs-6"><%= t(".by_signing_up_html",
+    <p class="mb-3 text-body-secondary fs-6"><%= t(".by_signing_up.html",
                                                    :tou_link => link_to(t("layouts.tou"),
                                                                         "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
                                                                         :target => :new),
-                                                   :privacy_policy_link => link_to(t(".privacy_policy"),
-                                                                                   t(".privacy_policy_url"),
-                                                                                   :title => t(".privacy_policy_title"),
+                                                   :privacy_policy_link => link_to(t(".by_signing_up.privacy_policy"),
+                                                                                   t(".by_signing_up.privacy_policy_url"),
+                                                                                   :title => t(".by_signing_up.privacy_policy_title"),
                                                                                    :target => :new),
-                                                   :contributor_terms_link => link_to(t(".contributor_terms"),
-                                                                                      t(".contributor_terms_url"),
+                                                   :contributor_terms_link => link_to(t(".by_signing_up.contributor_terms"),
+                                                                                      t(".by_signing_up.contributor_terms_url"),
                                                                                       :target => :new)) %></p>
     <%= f.form_group do %>
       <%= f.check_box :consider_pd,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2752,17 +2752,22 @@ en:
         welcome: "Welcome to OpenStreetMap"
       duplicate_social_email: "If you already have an OpenStreetMap account and wish to use a 3rd party identity provider, please log in using your password and modify the settings of your account."
       display name description: "Your publicly displayed username. You can change this later in the preferences."
-      by_signing_up_html: "By signing up, you agree to our %{tou_link}, %{privacy_policy_link} and %{contributor_terms_link}."
+      by_signing_up:
+        html: "By signing up, you agree to our %{tou_link}, %{privacy_policy_link} and %{contributor_terms_link}."
+        privacy_policy: privacy policy
+        privacy_policy_url: https://wiki.osmfoundation.org/wiki/Privacy_Policy
+        privacy_policy_title: OSMF privacy policy including section on email addresses
+        contributor_terms_url: "https://wiki.osmfoundation.org/wiki/Licence/Contributor_Terms"
+        contributor_terms: "contributor terms"
       tou: "terms of use"
-      contributor_terms_url: "https://wiki.osmfoundation.org/wiki/Licence/Contributor_Terms"
-      contributor_terms: "contributor terms"
       external auth: "Third Party Authentication:"
       continue: Sign Up
       terms accepted: "Thanks for accepting the new contributor terms!"
-      email_help_html: 'Your address is not displayed publicly, see our %{privacy_policy_link} for more information.'
-      privacy_policy: privacy policy
-      privacy_policy_url: https://wiki.osmfoundation.org/wiki/Privacy_Policy
-      privacy_policy_title: OSMF privacy policy including section on email addresses
+      email_help:
+        privacy_policy: privacy policy
+        privacy_policy_url: https://wiki.osmfoundation.org/wiki/Privacy_Policy
+        privacy_policy_title: OSMF privacy policy including section on email addresses
+        html: 'Your address is not displayed publicly, see our %{privacy_policy_link} for more information.'
       consider_pd_html: "I consider my contributions to be in the %{consider_pd_link}."
       consider_pd: "public domain"
       consider_pd_url: https://wiki.osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain


### PR DESCRIPTION
This PR addresses the need for distinct translatable messages for the privacy policy link in different contexts within the signup form mentioned in #4773.

In the signup form, the privacy_policy_link and its respective label were reused in two different sentences (in email help HTML and by signing up HTML messages). Different contexts may require distinct translations due to language-specific rules, such as declension.
##### Changes Made
- Added separate translation keys for the privacy policy link in the email_help and by_signing_up sections.
- Updated the form to use these new translation keys, ensuring the correct link label is used in each context.

This PR aims to solve the issue of translation nuances by providing separate translatable messages for the privacy policy link in different contexts within the signup form. This approach should enhance localization and ensure accurate translations.

Intuitively this makes sense, but any suggestions for improvements are very welcome.