### PR TITLE
Accept coordinates with a slash in search

### DIFF
--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -218,7 +218,7 @@ class GeocoderController < ApplicationController
                      query.match(/^(\d{1,3})°?\s*(\d{1,2})['′]?(?:\s*(\d{1,3}(\.\d*)?)?["″]?)?\s*([NS])\W*(\d{1,3})°?\s*(\d{1,2})['′]?(?:\s*(\d{1,3}(\.\d*)?)?["″]?)?\s*([EW])$/).try(:captures)    # degrees, minutes, decimal seconds [NSEW]
         params.merge!(dms_to_decdeg(latlon)).delete(:query)
 
-      elsif latlon = query.match(/^([+-]?\d+(\.\d*)?)(?:\s+|\s*,\s*)([+-]?\d+(\.\d*)?)$/)
+      elsif latlon = query.match(%r{^([+-]?\d+(\.\d*)?)(?:\s+|\s*[,/]\s*)([+-]?\d+(\.\d*)?)$})
         params.merge!(:lat => latlon[1].to_f, :lon => latlon[3].to_f).delete(:query)
 
         params[:latlon_digits] = true unless params[:whereami]

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -37,9 +37,11 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
   def test_identify_latlon_basic
     [
       "50.06773 14.37742",
+      "50.06773/14.37742",
       "50.06773, 14.37742",
       "+50.06773 +14.37742",
-      "+50.06773, +14.37742"
+      "+50.06773, +14.37742",
+      "+50.06773/+14.37742"
     ].each do |code|
       latlon_check code, 50.06773, 14.37742
     end


### PR DESCRIPTION
This PR addresses "Accept coordinates with a slash in search" issue mentioned in the [#4285](https://github.com/openstreetmap/openstreetmap-website/issues/4285)
 
Added '/' (slash) as an option in the validation and split regex of the search input. Fixes [#4285](https://github.com/openstreetmap/openstreetmap-website/issues/4285)

![Screenshot 2024-07-02 142603](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/e85cc2cf-85ff-43e5-b07a-6d5d5f5d77ad)
