### PR TITLE
Remove aol and wordpress auth provider locale strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2604,12 +2604,6 @@ en:
       wikipedia:
         title: Log in with Wikipedia
         alt: Log in with a Wikipedia Account
-      wordpress:
-        title: Log in with Wordpress
-        alt: Log in with a Wordpress OpenID
-      aol:
-        title: Log in with AOL
-        alt: Log in with an AOL OpenID
   oauth:
     authorize:
       title: "Authorize access to your account"


### PR DESCRIPTION
Unused since https://github.com/openstreetmap/openstreetmap-website/commit/a3617b492e67e280790442b77addbd25b896f07e