### PR TITLE
Change auth provider logo alt texts to indicate that these are logos

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2588,22 +2588,22 @@ en:
       openid_login_button: "Continue"
       openid:
         title: Log in with OpenID
-        alt: Log in with an OpenID URL
+        alt: OpenID logo
       google:
         title: Log in with Google
-        alt: Log in with a Google OpenID
+        alt: Google logo
       facebook:
         title: Log in with Facebook
-        alt: Log in with a Facebook Account
+        alt: Facebook logo
       microsoft:
         title: Log in with Microsoft
-        alt: Log in with a Microsoft Account
+        alt: Microsoft logo
       github:
         title: Log in with GitHub
-        alt: Log in with a GitHub Account
+        alt: GitHub logo
       wikipedia:
         title: Log in with Wikipedia
-        alt: Log in with a Wikipedia Account
+        alt: Wikipedia logo
   oauth:
     authorize:
       title: "Authorize access to your account"

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -116,7 +116,7 @@ class UserHelperTest < ActionView::TestCase
 
   def test_auth_button
     button = auth_button("google", "google")
-    img_tag = "<img alt=\"Log in with a Google OpenID\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"36\" height=\"36\" />"
+    img_tag = "<img alt=\"Google logo\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"36\" height=\"36\" />"
     assert_equal("<a class=\"auth_button btn btn-light mx-1 p-2 d-block\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
   end
 


### PR DESCRIPTION
Auth provider images have `alt` attributes that instead of describing the images say what's going to happen when they are clicked. This is wrong and redundant because their buttons already have titles that say "Log in with ...":

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/66029e73-6754-42eb-92f3-a2e7364bffb9)

This PR changes the alt texts to "... logo", similar to the alt text of OSM logo:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/75a01f13-10eb-4e8b-a351-8df48d899400)
