### PR TITLE
Order of comments in changeset comments feeds

### DIFF
--- a/app/controllers/changeset_comments_controller.rb
+++ b/app/controllers/changeset_comments_controller.rb
@@ -18,7 +18,7 @@ class ChangesetCommentsController < ApplicationController
       changeset = Changeset.find(id)
 
       # Return comments for this changeset only
-      @comments = changeset.comments.includes(:author, :changeset).limit(comments_limit)
+      @comments = changeset.comments.includes(:author, :changeset).reverse_order.limit(comments_limit)
     else
       # Return comments
       @comments = ChangesetComment.includes(:author, :changeset).where(:visible => true).order("created_at DESC").limit(comments_limit).preload(:changeset)

--- a/test/controllers/changeset_comments_controller_test.rb
+++ b/test/controllers/changeset_comments_controller_test.rb
@@ -46,6 +46,23 @@ class ChangesetCommentsControllerTest < ActionDispatch::IntegrationTest
         assert_select "item", :count => 3
       end
     end
+    # Rails::Dom::Testing.html_document_fragment.parse(icons)
+    # Gets comment Ids from HTML and checks that they are in descending order
+
+    last_comment_id = -1
+    assert_select "rss", :count => 1 do
+      assert_select "description", :count => 3 do |descriptions|
+        descriptions.children.each do |description|
+          changeset_dom = Rails::Dom::Testing.html_document_fragment.parse(description.content)
+          comment = changeset_dom.at_css(".changeset-comment-text")
+          next unless comment
+
+          id = comment.content.split[-1].to_i
+          assert_operator id, "<", last_comment_id if last_comment_id != -1
+          last_comment_id = id
+        end
+      end
+    end
   end
 
   ##


### PR DESCRIPTION
This PR addresses "Order of comments in changeset comments feeds" issue mentioned in the [#4613](https://github.com/openstreetmap/openstreetmap-website/issues/4613)
 
Reverse the output of the changeset comments feed from "created_at" ascending order to descending. Fixes [#4613](https://github.com/openstreetmap/openstreetmap-website/issues/4613)

![Screenshot 2024-07-03 133736](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/8b0c4c44-0596-4963-a4a5-c769ae38d064)
