### PR TITLE
Move continue auth/start mapping button to appear fixed to the bottom of the welcome page     

### DIFF
--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -77,17 +77,17 @@
 
 <%= render "any_questions" %>
 
-<div class='text-center mb-3'>
-<% if params[:oauth_return_url] %>
-  <a class="btn btn-primary" href="<%= params[:oauth_return_url] %>"><%= t ".continue_authorization" %></a>
-<% else %>
-  <a class="btn btn-primary start-mapping" href="<%= edit_path %>"><%= t ".start_mapping" %></a>
-<% end %>
-</div>
-
-<div class='alert alert-primary'>
+<div class='alert alert-primary mb-5'>
   <h2><%= t ".add_a_note.title" %></h2>
   <p><%= t ".add_a_note.para_1" %></p>
   <p><%= t ".add_a_note.para_2_html", :map_link => link_to(t(".add_a_note.the_map"), root_path),
                                       :note_icon => tag.span(:class => "icon note bg-dark rounded-1") %></p>
+</div>
+
+<div class='d-flex justify-content-center align-items-center mw-100 fixed-bottom bg-white py-2 border-top'>
+  <% if params[:oauth_return_url] %>
+    <a class="btn btn-primary d-block d-sm-inline-block" href="<%= params[:oauth_return_url] %>"><%= t ".continue_authorization" %></a>
+  <% else %>
+    <a class="btn btn-primary start-mapping d-block d-sm-inline-block" href="<%= edit_path %>"><%= t ".start_mapping" %></a>
+  <% end %>
 </div>


### PR DESCRIPTION
### Move continue auth/start mapping button to appear fixed to the bottom of the welcome page  
  
#### Objective  
To enhance the user experience by pinning the existing "Continue Auth/Start Mapping" button at the bottom of the page. This adjustment is aimed at improving user navigation and simplifying the OAuth process.  
  
<img width="1115" alt="Screenshot 2024-07-03 at 17 16 28" src="https://github.com/openstreetmap/openstreetmap-website/assets/76796906/0367b633-3727-4a02-b8a0-1ace3a3f4147">

#### Key Points  
- **Enhanced UX:** By fixing the button at the bottom, we ensure it’s always visible, making it more prominent for users during signup flow.
- **Simplified OAuth Process:** This change makes the OAuth process more intuitive and seamless, reducing potential user confusion and promoting a smoother transition.  
  
