### PR TITLE
Share button unusable on a cell phone

### DIFF
--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -8,6 +8,7 @@ L.OSM.share = function (options) {
 
   control.onAddPane = function (map, button, $ui) {
     // Link / Embed
+    $("#content").addClass("overlay-right-sidebar");
 
     var $linkSection = $("<div>")
       .attr("class", "share-link p-3 border-bottom border-secondary-subtle")

--- a/app/assets/javascripts/leaflet.sidebar.js
+++ b/app/assets/javascripts/leaflet.sidebar.js
@@ -31,9 +31,11 @@ L.OSM.sidebar = function (selector) {
         map.panBy([-paneWidth, 0], { animate: false });
       }
       $(sidebar).hide();
+      $("#content").addClass("overlay-right-sidebar");
       current = currentButton = $();
     } else {
       $(sidebar).show();
+      $("#content").removeClass("overlay-right-sidebar");
       current = pane;
       currentButton = button || $();
       if ($("html").attr("dir") === "rtl") {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -395,7 +395,7 @@ body.small-nav {
       overflow-y: scroll;
     }
 
-    .overlay-sidebar {
+    .overlay-sidebar.overlay-right-sidebar {
       #sidebar {
         position: absolute;
         width: 350px;
@@ -403,7 +403,7 @@ body.small-nav {
         overflow: hidden;
       }
 
-      #map, #map-ui {
+      #map {
         height: 100%;
       }
     }

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -1,6 +1,41 @@
 require "application_system_test_case"
 
 class IndexTest < ApplicationSystemTestCase
+  test "should remove and add an overlay on share button click" do
+    node = create(:node)
+    visit node_path(node)
+    assert_selector "#content.overlay-right-sidebar"
+    find(".icon.share").click
+    assert_no_selector "#content.overlay-right-sidebar"
+    find(".icon.share").click
+    assert_selector "#content.overlay-right-sidebar"
+  end
+
+  test "should add an overlay on close" do
+    node = create(:node)
+    visit node_path(node)
+    find(".icon.share").click
+    assert_no_selector "#content.overlay-right-sidebar"
+    find(".share-ui .btn-close").click
+    assert_selector "#content.overlay-right-sidebar"
+  end
+
+  test "should not add overlay when not closing right menu popup" do
+    node = create(:node)
+    visit node_path(node)
+    find(".icon.share").click
+
+    find(".icon.key").click
+    assert_no_selector "#content.overlay-right-sidebar"
+    find(".icon.layers").click
+    assert_no_selector "#content.overlay-right-sidebar"
+    find(".icon.key").click
+    assert_no_selector "#content.overlay-right-sidebar"
+
+    find(".icon.key").click
+    assert_selector "#content.overlay-right-sidebar"
+  end
+
   test "node included in edit link" do
     node = create(:node)
     visit node_path(node)


### PR DESCRIPTION
This PR addresses "Share button unusable on a cell phone" issue mentioned in the #3988 

Added class to track if "Share", "Layer" and "Map Key" buttons have been clicked. Fixes #3988  

Change affects "Share" button, "Map Key" button and "Layer" button.

To follow the style of the website, all of them have the same visual as "Add a note to the map" button had.

Add a note to the map:
![Screenshot 2024-07-04 162504](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/80ca05e8-8ccb-4008-92dc-f58c182b88f2)

Share:
![Screenshot 2024-07-04 162231](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/a9af9c48-e9fb-4426-b310-01914ee2664e)

Map Key:
![Screenshot 2024-07-04 162203](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/a987983b-76ff-437c-bfe9-ad936f9f3885)

Layer:
![Screenshot 2024-07-04 162153](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/135ed0ee-9047-4580-afc9-397bdc3344ff)

When both "Add a note to the map" and "Share" are displayed, their visual is same as before:
![Screenshot 2024-07-04 162659](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/0302e460-9bb4-4104-81ba-726cb340e727)
