### PR TITLE
Use alt text in OpenID image alt attribute

### DIFF
--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -26,7 +26,7 @@
     <% end %>
 
       <%= link_to image_tag("openid.svg",
-                            :alt => t("application.auth_providers.openid.title"),
+                            :alt => t("application.auth_providers.openid.alt"),
                             :size => "36"),
                   "#",
                   :id => "openid_open_url",


### PR DESCRIPTION
Continuing #4941 for OpenID button that had its image alt attribute set to its title text.