### PR TITLE
Remove padding around tabs on blocked signup page

### DIFF
--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -1,7 +1,7 @@
 <% content_for :heading_class, "p-0 mw-100" %>
 <% content_for :heading do %>
   <div class="header-illustration new-user-main auth-container mx-auto">
-    <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
+    <ul class="nav nav-tabs position-absolute bottom-0 fs-6 w-100">
       <li class="nav-item">
         <%= link_to t("sessions.new.tab_title"), url_for(:action => :new, :controller => :sessions), :class => "nav-link" %>
       </li>


### PR DESCRIPTION
#4826 didn't remove `px-3` from all pages. One more page with login/signup tabs is the blocked signup page.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/a309a52b-47cd-459b-8253-a041d79753bf)

After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/43c4b8aa-889f-42e4-9e19-b598dbb980d7)