### PR TITLE
Set "login/signup" page width equal to "about" page width

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -677,7 +677,13 @@ tr.turn {
   padding: $lineheight;
 }
 
-/* Overrides for pages that use new layout conventions */
+/* Rules for login and signup pages */
+
+.sessions-new, .users-new, .users-create {
+  #content .content-inner {
+    max-width: 760px;
+  }
+}
 
 .header-illustration {
   background-position: 0 0;
@@ -893,10 +899,6 @@ div.secondary-actions {
       margin-left: -1em;
     }
   }
-}
-
-.auth-container {
-  max-width: 600px;
 }
 
 /* Rules for tabs inside secondary background sections */

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,14 +3,14 @@
   <%= javascript_include_tag "auth_providers" %>
 <% end %>
 
-<% content_for :heading_class, "p-0 mw-100" %>
+<% content_for :heading_class, "pb-0" %>
 
 <% content_for :heading do %>
   <% if @client_app_name %>
     <p class="text-center text-body-secondary fs-6 py-2 mb-0 bg-body"><%= t(".login_to_authorize_html", :client_app_name => @client_app_name) %></p>
   <% end %>
 
-  <div class="header-illustration new-user-main auth-container mx-auto">
+  <div class="header-illustration new-user-main">
     <ul class="nav nav-tabs position-absolute bottom-0 fs-6 w-100">
       <li class="nav-item">
         <%= link_to t("sessions.new.tab_title"), "#", :class => "nav-link active" %>
@@ -22,7 +22,7 @@
   </div>
 <% end %>
 
-<div id="login_login" class="auth-container mx-auto my-0">
+<div id="login_login">
   <% if @preferred_auth_provider %>
     <%= render :partial => "auth_providers" %>
     <%= render :partial => "shared/section_divider", :locals => { :text => t(".or") } %>

--- a/app/views/users/blocked.html.erb
+++ b/app/views/users/blocked.html.erb
@@ -1,6 +1,6 @@
-<% content_for :heading_class, "p-0 mw-100" %>
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
-  <div class="header-illustration new-user-main auth-container mx-auto">
+  <div class="header-illustration new-user-main">
     <ul class="nav nav-tabs position-absolute bottom-0 px-3 fs-6 w-100">
       <li class="nav-item">
         <%= link_to t("sessions.new.tab_title"), url_for(:action => :new, :controller => :sessions), :class => "nav-link" %>
@@ -12,7 +12,7 @@
   </div>
 <% end %>
 
-<div class="auth-container mx-auto my-0">
+<div>
   <p><strong><%= t "users.new.no_auto_account_create" %></strong></p>
   <p><%= t "users.new.please_contact_support_html", :support_link => mail_to(Settings.support_email, t("users.new.support")) %></p>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,14 +3,14 @@
   <%= javascript_include_tag "auth_providers" %>
 <% end %>
 
-<% content_for :heading_class, "p-0 mw-100" %>
+<% content_for :heading_class, "pb-0" %>
 
 <% content_for :heading do %>
   <% if @client_app_name %>
     <p class="text-center text-body-secondary fs-6 py-2 mb-0 bg-body"><%= t(".signup_to_authorize_html", :client_app_name => @client_app_name) %></p>
   <% end %>
 
-  <div class="header-illustration new-user-main auth-container mx-auto">
+  <div class="header-illustration new-user-main">
     <ul class="nav nav-tabs position-absolute bottom-0 fs-6 w-100">
       <li class="nav-item">
         <%= link_to t("sessions.new.tab_title"), url_for(:action => :new, :controller => :sessions, :referer => @referer), :class => "nav-link" %>
@@ -22,7 +22,7 @@
   </div>
 <% end %>
 
-<div class="auth-container mx-auto my-0">
+<div>
   <% if current_user.auth_uid.nil? %>
     <div class="text-body-secondary fs-6">
       <p><strong><%= t ".about.header" %></strong> <%= t ".about.paragraph_1" %></p>


### PR DESCRIPTION
Currently login pages with preferred auth provider look like [this](https://www.openstreetmap.org/login?referer=https%3A%2F%2Fexample.com%2F%3Fpreferred_auth_provider%3Dgoogle):

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/9c45fc8d-9b5f-4ede-b8ae-740c84992796)

The buttons don't fit in one row even on max width. This happens because the page width is still 600px, the logo images were increased to 36px and they are allowed to take only half of the page width.

Now we can remember that 600px is an arbitrary page width (#4773, Page width). It was chosen likely because the standard width is too high for login pages. The other width we use is 760px on [the about page](https://www.openstreetmap.org/about). We can use it for login pages too in exactly the same manner, without special `.auth-container` classes:

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/206461d3-1df1-4b90-815d-a8d0ab778e95)

Now the buttons fit.