### PR TITLE
Improves displaying lat, lon values close to 0.0

### DIFF
--- a/app/helpers/geocoder_helper.rb
+++ b/app/helpers/geocoder_helper.rb
@@ -2,6 +2,37 @@ module GeocoderHelper
   def result_to_html(result)
     html_options = { :class => "set_position stretched-link", :data => {} }
 
+    result.each do |key, value|
+      if key.to_s == "name" && value.match(%r{^([+-]?\d+(\.\d*)?)(([eE][-+]?\d+)?)(?:\s+|\s*[,/]\s*)([+-]?\d+(\.\d*)?)(([eE][-+]?\d+)?)$})
+        lat, lon = value.split(%r{[\/,]})
+
+        if lat.index(".").positive?
+          number_of_decimals = lat.length - lat.index(".") - 1
+          lat = format("%0.#{number_of_decimals}f", lat.to_f)
+        end
+
+        if lon.index(".").positive?
+          number_of_decimals = lon.length - lon.index(".") - 1
+          lon = format("%0.#{number_of_decimals}f", lon.to_f)
+        end
+
+        value = "#{lat}, #{lon}"
+        result[key] = value
+      elsif key.to_s == "lat" || key.to_s == "lon"
+        if value.to_f.abs < 0.0001
+          value_str = value.to_s
+
+          if value_str.index(".").positive?
+            number_of_decimals = value_str.length - value_str.index(".") - 1
+            value = format("%0.#{number_of_decimals}f", value.to_f)
+            result[key] = value
+          end
+        end
+      end
+
+      html_options[:data][key.to_s.tr("_", "-")] = value
+    end
+
     url = if result[:type] && result[:id]
             url_for(:controller => result[:type].pluralize, :action => :show, :id => result[:id])
           elsif result[:min_lon] && result[:min_lat] && result[:max_lon] && result[:max_lat]
@@ -9,10 +40,6 @@ module GeocoderHelper
           else
             "/#map=#{result[:zoom]}/#{result[:lat]}/#{result[:lon]}"
           end
-
-    result.each do |key, value|
-      html_options[:data][key.to_s.tr("_", "-")] = value
-    end
 
     html = []
     html << result[:prefix] if result[:prefix]


### PR DESCRIPTION
This PR addresses issue about using exponential instead of standard notation for latitudes and longitudes close to 0.0 in search results described in #4950

Fixes #4950. Improved result_to_html routine by detecting latitude and longitude values close to 0.0 and replacing their representation (exponential) with standard, by calculating number of required decimals (by looking at the position of decimal point if available) and generating standard representation.

Before:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/90b2de1c-d545-44d5-829f-a07f2c7f2636)
After:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/25298521/0b70c191-b191-4ecb-9980-8b05e38a2c04)
