### PR TITLE
Remove "whereami" search parameter, use "lat" and "lon" instead

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -51,7 +51,7 @@ OSM.initializeContextMenu = function (map) {
           lat = latlng.lat.toFixed(precision),
           lng = latlng.lng.toFixed(precision);
 
-      OSM.router.route("/search?whereami=1&query=" + encodeURIComponent(lat + "," + lng));
+      OSM.router.route("/search?lat=" + encodeURIComponent(lat) + "&lon=" + encodeURIComponent(lng));
     }
   });
 

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -33,10 +33,11 @@ OSM.Search = function (map) {
   $(".describe_location").on("click", function (e) {
     e.preventDefault();
     var center = map.getCenter().wrap(),
-        precision = OSM.zoomPrecision(map.getZoom());
-    OSM.router.route("/search?whereami=1&query=" + encodeURIComponent(
-      center.lat.toFixed(precision) + "," + center.lng.toFixed(precision)
-    ));
+        precision = OSM.zoomPrecision(map.getZoom()),
+        lat = center.lat.toFixed(precision),
+        lng = center.lng.toFixed(precision);
+
+    OSM.router.route("/search?lat=" + encodeURIComponent(lat) + "&lon=" + encodeURIComponent(lng));
   });
 
   $("#sidebar_content")

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -221,7 +221,7 @@ class GeocoderController < ApplicationController
       elsif latlon = query.match(%r{^([+-]?\d+(\.\d*)?)(?:\s+|\s*[,/]\s*)([+-]?\d+(\.\d*)?)$})
         params.merge!(:lat => latlon[1].to_f, :lon => latlon[3].to_f).delete(:query)
 
-        params[:latlon_digits] = true unless params[:whereami]
+        params[:latlon_digits] = true
       end
     end
 


### PR DESCRIPTION
`whereami` was introduced in #1968. It's only used to suppress another parameter `latlon_digits` which indicates that we're not sure if the query string is "lat,lon" or "lon,lat". `whereami=1` says that we know it's "lat,lon". But why don't we use `lat` and `lon` parameters directly?