### PR TITLE
Avoid use of scientific notation in geocoder results

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,7 +24,7 @@ FactoryBot/ExcessiveCreateList:
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
 # URISchemes: http, https
 Layout/LineLength:
-  Max: 248
+  Max: 266
 
 # Offense count: 29
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -226,18 +226,18 @@ class GeocoderController < ApplicationController
 
   def to_decdeg(captures)
     ns = captures.fetch("ns").casecmp("s").zero? ? -1 : 1
-    nsd = captures.fetch("nsd", "0").to_f
-    nsm = captures.fetch("nsm", "0").to_f
-    nss = captures.fetch("nss", "0").to_f
+    nsd = BigDecimal(captures.fetch("nsd", "0"))
+    nsm = BigDecimal(captures.fetch("nsm", "0"))
+    nss = BigDecimal(captures.fetch("nss", "0"))
 
     ew = captures.fetch("ew").casecmp("w").zero? ? -1 : 1
-    ewd = captures.fetch("ewd", "0").to_f
-    ewm = captures.fetch("ewm", "0").to_f
-    ews = captures.fetch("ews", "0").to_f
+    ewd = BigDecimal(captures.fetch("ewd", "0"))
+    ewm = BigDecimal(captures.fetch("ewm", "0"))
+    ews = BigDecimal(captures.fetch("ews", "0"))
 
     lat = ns * (nsd + (nsm / 60) + (nss / 3600))
     lon = ew * (ewd + (ewm / 60) + (ews / 3600))
 
-    { :lat => lat, :lon => lon }
+    { :lat => lat.round(6).to_s("F"), :lon => lon.round(6).to_s("F") }
   end
 end

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -206,20 +206,16 @@ class GeocoderController < ApplicationController
     if query = params[:query]
       query.strip!
 
-      if latlon = query.match(/^([NS])\s*(\d{1,3}(\.\d*)?)\W*([EW])\s*(\d{1,3}(\.\d*)?)$/).try(:captures) || # [NSEW] decimal degrees
-                  query.match(/^(\d{1,3}(\.\d*)?)\s*([NS])\W*(\d{1,3}(\.\d*)?)\s*([EW])$/).try(:captures)    # decimal degrees [NSEW]
-        params.merge!(nsew_to_decdeg(latlon)).delete(:query)
+      if latlon = query.match(/^(?<ns>[NS])\s*(?<nsd>\d{1,3}(?:\.\d+)?)°?\W*(?<ew>[EW])\s*(?<ewd>\d{1,3}(?:\.\d+)?)°?$/) ||                                                                                                     # [NSEW] decimal degrees
+                  query.match(/^(?<nsd>\d{1,3}(?:\.\d+)?)°?\s*(?<ns>[NS])\W*(?<ewd>\d{1,3}(?:\.\d+)?)°?\s*(?<ew>[EW])$/) ||                                                                                                     # decimal degrees [NSEW]
+                  query.match(/^(?<ns>[NS])\s*(?<nsd>\d{1,3})°?(?:\s*(?<nsm>\d{1,3}(?:\.\d+)?)['′]?)\W*(?<ew>[EW])\s*(?<ewd>\d{1,3})°?(?:\s*(?<ewm>\d{1,3}(?:\.\d+)?)['′]?)$/) ||                                               # [NSEW] degrees, decimal minutes
+                  query.match(/^(?<nsd>\d{1,3})°?(?:\s*(?<nsm>\d{1,3}(?:\.\d+)?)['′]?)\s*(?<ns>[NS])\W*(?<ewd>\d{1,3})°?(?:\s*(?<ewm>\d{1,3}(?:\.\d+)?)['′]?)\s*(?<ew>[EW])$/) ||                                               # degrees, decimal minutes [NSEW]
+                  query.match(/^(?<ns>[NS])\s*(?<nsd>\d{1,3})°?\s*(?<nsm>\d{1,2})['′]?(?:\s*(?<nss>\d{1,3}(?:\.\d+)?)["″]?)\W*(?<ew>[EW])\s*(?<ewd>\d{1,3})°?\s*(?<ewm>\d{1,2})['′]?(?:\s*(?<ews>\d{1,3}(?:\.\d+)?)["″]?)$/) || # [NSEW] degrees, minutes, decimal seconds
+                  query.match(/^(?<nsd>\d{1,3})°?\s*(?<nsm>\d{1,2})['′]?(?:\s*(?<nss>\d{1,3}(?:\.\d+)?)["″]?)\s*(?<ns>[NS])\W*(?<ewd>\d{1,3})°?\s*(?<ewm>\d{1,2})['′]?(?:\s*(?<ews>\d{1,3}(?:\.\d+)?)["″]?)\s*(?<ew>[EW])$/)    # degrees, minutes, decimal seconds [NSEW]
+        params.merge!(to_decdeg(latlon.named_captures)).delete(:query)
 
-      elsif latlon = query.match(/^([NS])\s*(\d{1,3})°?(?:\s*(\d{1,3}(\.\d*)?)?['′]?)?\W*([EW])\s*(\d{1,3})°?(?:\s*(\d{1,3}(\.\d*)?)?['′]?)?$/).try(:captures) || # [NSEW] degrees, decimal minutes
-                     query.match(/^(\d{1,3})°?(?:\s*(\d{1,3}(\.\d*)?)?['′]?)?\s*([NS])\W*(\d{1,3})°?(?:\s*(\d{1,3}(\.\d*)?)?['′]?)?\s*([EW])$/).try(:captures)    # degrees, decimal minutes [NSEW]
-        params.merge!(ddm_to_decdeg(latlon)).delete(:query)
-
-      elsif latlon = query.match(/^([NS])\s*(\d{1,3})°?\s*(\d{1,2})['′]?(?:\s*(\d{1,3}(\.\d*)?)?["″]?)?\W*([EW])\s*(\d{1,3})°?\s*(\d{1,2})['′]?(?:\s*(\d{1,3}(\.\d*)?)?["″]?)?$/).try(:captures) || # [NSEW] degrees, minutes, decimal seconds
-                     query.match(/^(\d{1,3})°?\s*(\d{1,2})['′]?(?:\s*(\d{1,3}(\.\d*)?)?["″]?)?\s*([NS])\W*(\d{1,3})°?\s*(\d{1,2})['′]?(?:\s*(\d{1,3}(\.\d*)?)?["″]?)?\s*([EW])$/).try(:captures)    # degrees, minutes, decimal seconds [NSEW]
-        params.merge!(dms_to_decdeg(latlon)).delete(:query)
-
-      elsif latlon = query.match(%r{^([+-]?\d+(\.\d*)?)(?:\s+|\s*[,/]\s*)([+-]?\d+(\.\d*)?)$})
-        params.merge!(:lat => latlon[1], :lon => latlon[3]).delete(:query)
+      elsif latlon = query.match(%r{^(?<lat>[+-]?\d+(?:\.\d+)?)(?:\s+|\s*[,/]\s*)(?<lon>[+-]?\d+(?:\.\d+)?)$})
+        params.merge!(:lat => latlon["lat"], :lon => latlon["lon"]).delete(:query)
 
         params[:latlon_digits] = true
       end
@@ -228,39 +224,20 @@ class GeocoderController < ApplicationController
     params.permit(:query, :lat, :lon, :latlon_digits, :zoom, :minlat, :minlon, :maxlat, :maxlon)
   end
 
-  def nsew_to_decdeg(captures)
-    begin
-      Float(captures[0])
-      lat = captures[2].casecmp("s").zero? ? -captures[0].to_f : captures[0].to_f
-      lon = captures[5].casecmp("w").zero? ? -captures[3].to_f : captures[3].to_f
-    rescue StandardError
-      lat = captures[0].casecmp("s").zero? ? -captures[1].to_f : captures[1].to_f
-      lon = captures[3].casecmp("w").zero? ? -captures[4].to_f : captures[4].to_f
-    end
-    { :lat => lat, :lon => lon }
-  end
+  def to_decdeg(captures)
+    ns = captures.fetch("ns").casecmp("s").zero? ? -1 : 1
+    nsd = captures.fetch("nsd", "0").to_f
+    nsm = captures.fetch("nsm", "0").to_f
+    nss = captures.fetch("nss", "0").to_f
 
-  def ddm_to_decdeg(captures)
-    begin
-      Float(captures[0])
-      lat = captures[3].casecmp("s").zero? ? -(captures[0].to_f + (captures[1].to_f / 60)) : captures[0].to_f + (captures[1].to_f / 60)
-      lon = captures[7].casecmp("w").zero? ? -(captures[4].to_f + (captures[5].to_f / 60)) : captures[4].to_f + (captures[5].to_f / 60)
-    rescue StandardError
-      lat = captures[0].casecmp("s").zero? ? -(captures[1].to_f + (captures[2].to_f / 60)) : captures[1].to_f + (captures[2].to_f / 60)
-      lon = captures[4].casecmp("w").zero? ? -(captures[5].to_f + (captures[6].to_f / 60)) : captures[5].to_f + (captures[6].to_f / 60)
-    end
-    { :lat => lat, :lon => lon }
-  end
+    ew = captures.fetch("ew").casecmp("w").zero? ? -1 : 1
+    ewd = captures.fetch("ewd", "0").to_f
+    ewm = captures.fetch("ewm", "0").to_f
+    ews = captures.fetch("ews", "0").to_f
 
-  def dms_to_decdeg(captures)
-    begin
-      Float(captures[0])
-      lat = captures[4].casecmp("s").zero? ? -(captures[0].to_f + ((captures[1].to_f + (captures[2].to_f / 60)) / 60)) : captures[0].to_f + ((captures[1].to_f + (captures[2].to_f / 60)) / 60)
-      lon = captures[9].casecmp("w").zero? ? -(captures[5].to_f + ((captures[6].to_f + (captures[7].to_f / 60)) / 60)) : captures[5].to_f + ((captures[6].to_f + (captures[7].to_f / 60)) / 60)
-    rescue StandardError
-      lat = captures[0].casecmp("s").zero? ? -(captures[1].to_f + ((captures[2].to_f + (captures[3].to_f / 60)) / 60)) : captures[1].to_f + ((captures[2].to_f + (captures[3].to_f / 60)) / 60)
-      lon = captures[5].casecmp("w").zero? ? -(captures[6].to_f + ((captures[7].to_f + (captures[8].to_f / 60)) / 60)) : captures[6].to_f + ((captures[7].to_f + (captures[8].to_f / 60)) / 60)
-    end
+    lat = ns * (nsd + (nsm / 60) + (nss / 3600))
+    lon = ew * (ewd + (ewm / 60) + (ews / 3600))
+
     { :lat => lat, :lon => lon }
   end
 end

--- a/app/controllers/geocoder_controller.rb
+++ b/app/controllers/geocoder_controller.rb
@@ -35,15 +35,15 @@ class GeocoderController < ApplicationController
       @results = []
 
       if lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
-        @results.push(:lat => lat, :lon => lon,
+        @results.push(:lat => params[:lat], :lon => params[:lon],
                       :zoom => params[:zoom],
-                      :name => "#{lat}, #{lon}")
+                      :name => "#{params[:lat]}, #{params[:lon]}")
       end
 
       if lon >= -90 && lon <= 90 && lat >= -180 && lat <= 180
-        @results.push(:lat => lon, :lon => lat,
+        @results.push(:lat => params[:lon], :lon => params[:lat],
                       :zoom => params[:zoom],
-                      :name => "#{lon}, #{lat}")
+                      :name => "#{params[:lon]}, #{params[:lat]}")
       end
 
       if @results.empty?
@@ -61,9 +61,9 @@ class GeocoderController < ApplicationController
         @error = "Longitude #{lon} out of range"
         render :action => "error"
       else
-        @results = [{ :lat => lat, :lon => lon,
+        @results = [{ :lat => params[:lat], :lon => params[:lon],
                       :zoom => params[:zoom],
-                      :name => "#{lat}, #{lon}" }]
+                      :name => "#{params[:lat]}, #{params[:lon]}" }]
 
         render :action => "results"
       end
@@ -219,7 +219,7 @@ class GeocoderController < ApplicationController
         params.merge!(dms_to_decdeg(latlon)).delete(:query)
 
       elsif latlon = query.match(%r{^([+-]?\d+(\.\d*)?)(?:\s+|\s*[,/]\s*)([+-]?\d+(\.\d*)?)$})
-        params.merge!(:lat => latlon[1].to_f, :lon => latlon[3].to_f).delete(:query)
+        params.merge!(:lat => latlon[1], :lon => latlon[3]).delete(:query)
 
         params[:latlon_digits] = true
       end

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -61,6 +61,19 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
   end
 
   ##
+  # Test identification of integer lat/lon pairs using N/E with degrees
+  def test_identify_latlon_ne_d_int_deg
+    [
+      "N50 E14",
+      "N50° E14°",
+      "50N 14E",
+      "50°N 14°E"
+    ].each do |code|
+      latlon_check code, 50, 14
+    end
+  end
+
+  ##
   # Test identification of lat/lon pairs using N/W with degrees
   def test_identify_latlon_nw_d
     [
@@ -220,6 +233,31 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
       "50°4'3.828\"S 14°22'38.712\"W"
     ].each do |code|
       latlon_check code, -50.06773, -14.37742
+    end
+  end
+
+  ##
+  # Test identification of lat/lon pairs with missing fractions
+  def test_no_identify_latlon_ne_missing_fraction_part
+    [
+      "N50. E14.",
+      "N50.° E14.°",
+      "50.N 14.E",
+      "50.°N 14.°E",
+      "N50 1.' E14 2.'",
+      "N50° 1.' E14° 2.'",
+      "50N 1.' 14 2.'E",
+      "50° 1.'N 14° 2.'E",
+      "N50 1' 3,\" E14 2' 4.\"",
+      "N50° 1' 3.\" E14° 2' 4.\"",
+      "50N 1' 3.\" 14 2' 4.\"E",
+      "50° 1' 3.\"N 14° 2' 4.\"E"
+    ].each do |code|
+      get search_path(:query => code)
+      assert_response :success
+      assert_template :search
+      assert_template :layout => "map"
+      assert_equal %w[osm_nominatim], assigns(:sources).pluck(:name)
     end
   end
 

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -261,6 +261,18 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  #
+  # Test identification of lat/lon pairs with values close to zero
+  def test_identify_latlon_close_to_zero
+    [
+      "0.0000123 -0.0000456",
+      "+0.0000123 -0.0000456",
+      "N 0° 0' 0.4428\", W 0° 0' 1.6416\""
+    ].each do |code|
+      latlon_check code, 0.0000123, -0.0000456
+    end
+  end
+
   ##
   # Test identification of US zipcodes
   def test_identify_us_postcode
@@ -406,6 +418,8 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
     assert_template :layout => "map"
     assert_equal %w[latlon osm_nominatim_reverse], assigns(:sources).pluck(:name)
     assert_nil @controller.params[:query]
+    assert_match(/^[+-]?\d+(?:\.\d*)?$/, @controller.params[:lat])
+    assert_match(/^[+-]?\d+(?:\.\d*)?$/, @controller.params[:lon])
     assert_in_delta lat, @controller.params[:lat].to_f
     assert_in_delta lon, @controller.params[:lon].to_f
 
@@ -415,6 +429,8 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
     assert_template :layout => "xhr"
     assert_equal %w[latlon osm_nominatim_reverse], assigns(:sources).pluck(:name)
     assert_nil @controller.params[:query]
+    assert_match(/^[+-]?\d+(?:\.\d*)?$/, @controller.params[:lat])
+    assert_match(/^[+-]?\d+(?:\.\d*)?$/, @controller.params[:lon])
     assert_in_delta lat, @controller.params[:lat].to_f
     assert_in_delta lon, @controller.params[:lon].to_f
   end

--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -368,8 +368,8 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
     assert_template :layout => "map"
     assert_equal %w[latlon osm_nominatim_reverse], assigns(:sources).pluck(:name)
     assert_nil @controller.params[:query]
-    assert_in_delta lat, @controller.params[:lat]
-    assert_in_delta lon, @controller.params[:lon]
+    assert_in_delta lat, @controller.params[:lat].to_f
+    assert_in_delta lon, @controller.params[:lon].to_f
 
     get search_path(:query => query), :xhr => true
     assert_response :success
@@ -377,8 +377,8 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
     assert_template :layout => "xhr"
     assert_equal %w[latlon osm_nominatim_reverse], assigns(:sources).pluck(:name)
     assert_nil @controller.params[:query]
-    assert_in_delta lat, @controller.params[:lat]
-    assert_in_delta lon, @controller.params[:lon]
+    assert_in_delta lat, @controller.params[:lat].to_f
+    assert_in_delta lon, @controller.params[:lon].to_f
   end
 
   def search_check(query, sources)


### PR DESCRIPTION
This fixes #4950 by modifying the geocoder to avoid printing results in scientific notation.

The main fix is simply to avoid converting the user entered string to numeric format and back but for DMS style inputs we need to convert them to numeric form so we can do calculations so we use bigdecimal rather than float as it can force fixed precision format when converting to a string.