### PR TITLE
Add gap between rows of auth buttons

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -64,7 +64,7 @@ module UserHelper
                 :size => "36"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
-      :class => "auth_button btn btn-light mx-1 p-2 d-block",
+      :class => "auth_button btn btn-light p-2 d-block",
       :title => t("application.auth_providers.#{name}.title")
     )
   end

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -20,9 +20,9 @@
           <% end -%>
         <% end -%>
       </div>
-      <div class="list-inline justify-content-center d-flex align-items-center flex-wrap w-50">
+      <div class="list-inline justify-content-center d-flex align-items-center flex-wrap gap-2 w-50 px-1">
     <% else %>
-      <div class="list-inline justify-content-center d-flex align-items-center flex-wrap w-100">
+      <div class="list-inline justify-content-center d-flex align-items-center flex-wrap gap-2 w-100">
     <% end %>
 
       <%= link_to image_tag("openid.svg",
@@ -31,7 +31,7 @@
                   "#",
                   :id => "openid_open_url",
                   :title => t("application.auth_providers.openid.title"),
-                  :class => "btn btn-light mx-1 p-2 d-block" %>
+                  :class => "btn btn-light p-2 d-block" %>
 
       <% %w[google facebook microsoft github wikipedia].each do |provider| %>
         <% unless @preferred_auth_provider == provider %>

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -117,7 +117,7 @@ class UserHelperTest < ActionView::TestCase
   def test_auth_button
     button = auth_button("google", "google")
     img_tag = "<img alt=\"Google logo\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"36\" height=\"36\" />"
-    assert_equal("<a class=\"auth_button btn btn-light mx-1 p-2 d-block\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
+    assert_equal("<a class=\"auth_button btn btn-light p-2 d-block\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
   end
 
   private


### PR DESCRIPTION
Currently auth buttons have horizontal margins that create horizontal gaps and nothing to create vertical gaps. It's easier to set the gap class on their flex container and get gaps in both directions.

Before/after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/c5af4ebc-cddd-4ed6-805f-106777fc3152) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/2df3a10c-71e8-4d17-9d78-835b24433f12)
