### PR TITLE
Remove unnecessary classes from preferred auth button

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -77,7 +77,7 @@ module UserHelper
                 :size => "36") + t("application.auth_providers.#{name}.title"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
-      :class => "auth_button btn btn-outline-secondary fs-6 border rounded py-2 px-4 d-flex justify-content-center align-items-center",
+      :class => "auth_button btn btn-outline-secondary border py-2 px-4 d-flex justify-content-center align-items-center",
       :title => t("application.auth_providers.#{name}.title")
     )
   end


### PR DESCRIPTION
.rounded is the default rounding for this button type.
.fs-6 is the default font size for this button type.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/170cc7f9-911f-4e18-b068-22b30199f56d)
