### PR TITLE
Always set z-index of embedded maps

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -19,7 +19,7 @@
              :icon => image_path("marker-red.png"),
              :description => render(:partial => "popup", :object => current_user, :locals => { :type => "your location" })
            } %>
-        <%= tag.div "", :id => "map", :class => "content_map border border-secondary-subtle rounded", :data => { :user => user_data } %>
+        <%= tag.div "", :id => "map", :class => "content_map border border-secondary-subtle rounded z-0", :data => { :user => user_data } %>
       <% end %>
 
       <% friends = @user.friends %>

--- a/app/views/diary_entries/_form.html.erb
+++ b/app/views/diary_entries/_form.html.erb
@@ -5,7 +5,7 @@
 <fieldset>
   <legend><%= t ".location" -%></legend>
 
-  <%= tag.div "", :id => "map", :class => "border border-secondary-subtle rounded mb-3", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
+  <%= tag.div "", :id => "map", :class => "border border-secondary-subtle rounded mb-3 z-0", :data => { :lat => @lat, :lon => @lon, :zoom => @zoom } %>
 
   <div class="row mb-3">
     <%= f.text_field :latitude, :wrapper_class => "col-sm-4 d-flex flex-column", :class => "mt-auto", :id => "latitude" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -56,7 +56,7 @@
       <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.home_location? %> checked <% end %> id="updatehome" />
       <label class="form-check-label" for="updatehome"><%= t ".update home location on click" %></label>
     </div>
-    <%= tag.div "", :id => "map", :class => "content_map set_location border border-secondary-subtle rounded" %>
+    <%= tag.div "", :id => "map", :class => "content_map set_location border border-secondary-subtle rounded z-0" %>
   </fieldset>
 
   <%= f.primary t(".save") %>


### PR DESCRIPTION
Fixes possible overlap of dropdown menus and maps, most likely on `/dashboard` page.

Before/after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/6806eac4-20b5-4ed9-b57b-40d9553afcbc) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/681d7baf-4ae2-4496-8979-8f59f7856243)
