### PR TITLE
Update OpenID input label

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -52,10 +52,6 @@ module UserHelper
 
   # External authentication support
 
-  def openid_logo
-    image_tag "openid.svg", :size => "36", :alt => t("application.auth_providers.openid_logo_alt"), :class => "align-text-bottom"
-  end
-
   def auth_button(name, provider, options = {})
     link_to(
       image_tag("#{name}.svg",

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -47,7 +47,7 @@
   <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
     <div id="login_openid_url" class="mb-3">
       <label for="openid_url" class="form-label">
-        <%= image_tag "openid.svg", :size => "36", :alt => t(".openid_logo_alt"), :class => "align-text-bottom" %>
+        <%= image_tag "openid.svg", :size => "36", :alt => "", :class => "align-text-bottom" %>
         <%= t ".openid_url" %>
       </label>
       <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -46,7 +46,10 @@
   <%# :tabindex starts high to allow rendering at the bottom of the template %>
   <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
     <div id="login_openid_url" class="mb-3">
-      <label for="openid_url" class="form-label"><%= t ".openid_html", :logo => openid_logo %></label>
+      <label for="openid_url" class="form-label">
+        <%= openid_logo %>
+        <%= t ".openid_url" %>
+      </label>
       <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>
       <%= text_field_tag("openid_url", "", :tabindex => 20, :autocomplete => "on", :class => "form-control") %>
       <span class="form-text text-body-secondary">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -47,7 +47,7 @@
   <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
     <div id="login_openid_url" class="mb-3">
       <label for="openid_url" class="form-label">
-        <%= openid_logo %>
+        <%= image_tag "openid.svg", :size => "36", :alt => t(".openid_logo_alt"), :class => "align-text-bottom" %>
         <%= t ".openid_url" %>
       </label>
       <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2584,7 +2584,7 @@ en:
       muted_users: Muted Users
     auth_providers:
       openid_logo_alt: "Log in with an OpenID"
-      openid_html: "%{logo} OpenID"
+      openid_html: "%{logo} OpenID URL"
       openid_login_button: "Continue"
       openid:
         title: Log in with OpenID

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2584,7 +2584,7 @@ en:
       muted_users: Muted Users
     auth_providers:
       openid_logo_alt: "Log in with an OpenID"
-      openid_html: "%{logo} OpenID URL"
+      openid_url: "OpenID URL"
       openid_login_button: "Continue"
       openid:
         title: Log in with OpenID

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2583,7 +2583,6 @@ en:
       oauth2_authorizations: OAuth 2 authorizations
       muted_users: Muted Users
     auth_providers:
-      openid_logo_alt: "Log in with an OpenID"
       openid_url: "OpenID URL"
       openid_login_button: "Continue"
       openid:

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -109,11 +109,6 @@ class UserHelperTest < ActionView::TestCase
     assert_match %r{^<img .* width="50" height="50" .* />$}, thumbnail
   end
 
-  def test_openid_logo
-    logo = openid_logo
-    assert_match %r{^<img .* src="/images/openid.svg" .* />$}, logo
-  end
-
   def test_auth_button
     button = auth_button("google", "google")
     img_tag = "<img alt=\"Google logo\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"36\" height=\"36\" />"


### PR DESCRIPTION
- Get rid of html locale string `openid_html: "%{logo} OpenID"` just to prepend the logo image.
- Make the label read "OpenID URL", which includes removing the logo alt text inside the label. In this case the logo is just a visual cue, you don't want screen readers to read its alt text and then read the actual label. I added "URL" because it's present on [the livejournal login page](https://www.livejournal.com/identity/login.bml), where OpenID originated.

![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/10b88bce-59c5-4d97-a90e-7d0690d139e2)
