### PR TITLE
Change OpenID provider link to button

### DIFF
--- a/app/assets/javascripts/auth_providers.js
+++ b/app/assets/javascripts/auth_providers.js
@@ -9,8 +9,7 @@ $(document).ready(function () {
   });
 
   // Add click handler to show OpenID field
-  $("#openid_open_url").click(function (e) {
-    e.preventDefault();
+  $("#openid_open_url").click(function () {
     $("#openid_url").val("http://");
     $("#login_auth_buttons").hide().removeClass("d-flex");
     $("#login_openid_url").show();

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -25,13 +25,13 @@
       <div class="justify-content-center d-flex align-items-center flex-wrap gap-2">
     <% end %>
 
-      <%= link_to image_tag("openid.svg",
-                            :alt => t("application.auth_providers.openid.alt"),
-                            :size => "36"),
-                  "#",
-                  :id => "openid_open_url",
-                  :title => t("application.auth_providers.openid.title"),
-                  :class => "btn btn-light p-2" %>
+      <%= button_tag image_tag("openid.svg",
+                               :alt => t(".openid.alt"),
+                               :size => "36"),
+                     :type => "button",
+                     :id => "openid_open_url",
+                     :title => t(".openid.title"),
+                     :class => "btn btn-light p-2" %>
 
       <% %w[google facebook microsoft github wikipedia].each do |provider| %>
         <% unless @preferred_auth_provider == provider %>


### PR DESCRIPTION
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/7fe16dd5-4743-4e36-aa85-eeb60e929533)

It's not a link. It doesn't have a proper href, that's why `#` was used.