### PR TITLE
When downloading image by "Share", allow other map styles with static image APIs

### DIFF
--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -160,6 +160,7 @@ L.OSM.share = function (options) {
     $("<div>")
       .appendTo($form)
       .attr("class", "row mb-3")
+      .attr("id", "mapnik_scale_row")
       .append($("<label>")
         .attr("for", "mapnik_scale")
         .attr("class", "col-auto col-form-label")
@@ -195,7 +196,7 @@ L.OSM.share = function (options) {
             .attr("class", "form-check-input")
             .bind("change", toggleFilter))));
 
-    ["minlon", "minlat", "maxlon", "maxlat"].forEach(function (name) {
+    ["minlon", "minlat", "maxlon", "maxlat", "lat", "lon"].forEach(function (name) {
       $("<input>")
         .attr("id", "mapnik_" + name)
         .attr("name", name)
@@ -204,8 +205,30 @@ L.OSM.share = function (options) {
     });
 
     $("<input>")
+      .attr("id", "map_format")
       .attr("name", "format")
       .attr("value", "mapnik")
+      .attr("type", "hidden")
+      .appendTo($form);
+
+    $("<input>")
+      .attr("id", "map_zoom")
+      .attr("name", "zoom")
+      .attr("value", map.getZoom())
+      .attr("type", "hidden")
+      .appendTo($form);
+
+    $("<input>")
+      .attr("id", "map_width")
+      .attr("name", "width")
+      .attr("value", 0)
+      .attr("type", "hidden")
+      .appendTo($form);
+
+    $("<input>")
+      .attr("id", "map_height")
+      .attr("name", "height")
+      .attr("value", 0)
       .attr("type", "hidden")
       .appendTo($form);
 
@@ -219,6 +242,7 @@ L.OSM.share = function (options) {
       .appendTo($form);
 
     var args = {
+      layer: "<span id=\"mapnik_image_layer\"></span>",
       width: "<span id=\"mapnik_image_width\"></span>",
       height: "<span id=\"mapnik_image_height\"></span>"
     };
@@ -381,11 +405,34 @@ L.OSM.share = function (options) {
         $("#mapnik_scale").val(scale);
       }
 
-      $("#mapnik_image_width").text(Math.round(size.x / scale / 0.00028));
-      $("#mapnik_image_height").text(Math.round(size.y / scale / 0.00028));
+      const mapWidth = Math.round(size.x / scale / 0.00028);
+      const mapHeight = Math.round(size.y / scale / 0.00028);
+      $("#mapnik_image_width").text(mapWidth);
+      $("#mapnik_image_height").text(mapHeight);
 
-      if (map.getMapBaseLayerId() === "mapnik") {
+      const layer = map.getMapBaseLayerId();
+      const layerKeys = new Map([
+        ["mapnik", "standard"],
+        ["cyclemap", "cycle_map"],
+        ["transportmap", "transport_map"]
+      ]);
+
+      $("#mapnik_image_layer").text(layerKeys.has(layer) ? I18n.t(`javascripts.map.base.${layerKeys.get(layer)}`) : "");
+      $("#map_format").val(layer);
+
+      $("#map_zoom").val(map.getZoom());
+      $("#mapnik_lon").val(map.getCenter().lng);
+      $("#mapnik_lat").val(map.getCenter().lat);
+      $("#map_width").val(mapWidth);
+      $("#map_height").val(mapHeight);
+
+      if (["cyclemap", "transportmap"].includes(map.getMapBaseLayerId())) {
         $("#export-image").show();
+        $("#mapnik_scale_row").hide();
+        $("#export-warning").hide();
+      } else if (map.getMapBaseLayerId() === "mapnik") {
+        $("#export-image").show();
+        $("#mapnik_scale_row").show();
         $("#export-warning").hide();
       } else {
         $("#export-image").hide();

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -13,19 +13,27 @@ class ExportController < ApplicationController
   # When the user clicks 'Export' we redirect to a URL which generates the export download
   def finish
     bbox = BoundingBox.from_lon_lat_params(params)
-    format = params[:format]
+    style = params[:format]
+    format = params[:mapnik_format]
 
-    case format
+    case style
     when "osm"
       # redirect to API map get
       redirect_to :controller => "api/map", :action => "index", :bbox => bbox
 
     when "mapnik"
       # redirect to a special 'export' cgi script
-      format = params[:mapnik_format]
       scale = params[:mapnik_scale]
 
       redirect_to "https://render.openstreetmap.org/cgi-bin/export?bbox=#{bbox}&scale=#{scale}&format=#{format}", :allow_other_host => true
+    when "cyclemap", "transportmap"
+      zoom = params[:zoom]
+      lat = params[:lat]
+      lon = params[:lon]
+      width = params[:width]
+      height = params[:height]
+
+      redirect_to "https://tile.thunderforest.com/static/#{style[..-4]}/#{lon},#{lat},#{zoom}/#{width}x#{height}.#{format}?apikey=#{Settings.thunderforest_key}", :allow_other_host => true
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3111,14 +3111,14 @@ en:
       custom_dimensions: "Set custom dimensions"
       format: "Format:"
       scale: "Scale:"
-      image_dimensions: "Image will show standard layer at %{width} x %{height}"
+      image_dimensions: "Image will show %{layer} layer at %{width} x %{height}"
       download: "Download"
       short_url: "Short URL"
       include_marker: "Include marker"
       center_marker: "Center map on marker"
       paste_html: "Paste HTML to embed in website"
       view_larger_map: "View Larger Map"
-      only_standard_layer: "Only the standard layer can be exported as an image"
+      only_standard_layer: "Only the Standard, Cycle Map and Transport layers can be exported as an image"
     embed:
       report_problem: "Report a problem"
     key:

--- a/test/controllers/export_controller_test.rb
+++ b/test/controllers/export_controller_test.rb
@@ -28,6 +28,20 @@ class ExportControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to "https://render.openstreetmap.org/cgi-bin/export?bbox=0.0,50.0,1.0,51.0&scale=12&format=test"
   end
 
+  ###
+  # test the finish action for cyclemap images
+  def test_finish_cyclemap
+    post export_finish_path(:minlon => 0, :minlat => 50, :maxlon => 1, :maxlat => 51, :format => "cyclemap", :mapnik_scale => 12, :mapnik_format => "png", :zoom => 17, :lat => 1, :lon => 2, :width => 400, :height => 300)
+    assert_redirected_to "https://tile.thunderforest.com/static/cycle/2,1,17/400x300.png?apikey=#{Settings.thunderforest_key}"
+  end
+
+  ###
+  # test the finish action for transport images
+  def test_finish_transport
+    post export_finish_path(:minlon => 0, :minlat => 50, :maxlon => 1, :maxlat => 51, :format => "transportmap", :mapnik_scale => 12, :mapnik_format => "png", :zoom => 17, :lat => 1, :lon => 2, :width => 400, :height => 300)
+    assert_redirected_to "https://tile.thunderforest.com/static/transport/2,1,17/400x300.png?apikey=#{Settings.thunderforest_key}"
+  end
+
   ##
   # test the embed action
   def test_embed


### PR DESCRIPTION
This PR addresses "When downloading image by 'Share', allow other map styles with static image APIs" issue mentioned in the https://github.com/openstreetmap/openstreetmap-website/issues/1886

Added API for downloading Transport and Cycle Map images, as they are supported by the [ThunderForest](https://www.thunderforest.com/docs/static-maps-api/). Also changed unsupported map text to show that not only Standard, but Transport and Cycle Map layers also have downloading capability. Fixes https://github.com/openstreetmap/openstreetmap-website/issues/1886

Transport layer:
![Screenshot 2024-07-10 140949](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/6ebd6d04-026e-4ef1-81cf-cbc6a3dcc6ab)

Cycle Map layer:
![Screenshot 2024-07-10 141009](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/022bb17a-35f8-4619-af1c-be6f3697066d)

Unsupported Humanitarian layer:
![Screenshot 2024-07-10 141024](https://github.com/openstreetmap/openstreetmap-website/assets/55288419/98c9ae8a-f93d-4a3f-b075-a05bf8be6c9b)
