### PR TITLE
Stack preferred auth button over other auth buttons on small screens

### DIFF
--- a/app/assets/javascripts/auth_providers.js
+++ b/app/assets/javascripts/auth_providers.js
@@ -11,7 +11,7 @@ $(document).ready(function () {
   // Add click handler to show OpenID field
   $("#openid_open_url").click(function () {
     $("#openid_url").val("http://");
-    $("#login_auth_buttons").hide().removeClass("d-flex");
+    $("#login_auth_buttons").hide();
     $("#login_openid_url").show();
     $("#openid_login_button").show();
   });

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -1,17 +1,18 @@
-<div>
-  <div class="justify-content-center d-flex align-items-center flex-wrap mb-3" id="login_auth_buttons">
+<% prefered_auth_button_available = false %>
+<% %w[google facebook microsoft github wikipedia].each do |provider| %>
+  <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
+    <% if @preferred_auth_provider == provider %>
+      <% prefered_auth_button_available = true %>
+    <% end %>
+  <% end -%>
+<% end -%>
 
-    <% prefered_auth_button_available = false %>
-    <% %w[google facebook microsoft github wikipedia].each do |provider| %>
-      <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
-        <% if @preferred_auth_provider == provider %>
-          <% prefered_auth_button_available = true %>
-        <% end %>
-      <% end -%>
-    <% end -%>
+<div>
+  <%= tag.div :id => "login_auth_buttons",
+              :class => ["row row-cols-1", { "row-cols-sm-2" => prefered_auth_button_available }, "g-2 mb-3"] do %>
 
     <% if prefered_auth_button_available %>
-      <div class="justify-content-center d-flex align-items-center flex-wrap w-50">
+      <div class="col justify-content-center d-flex align-items-center flex-wrap">
         <% %w[google facebook microsoft github wikipedia].each do |provider| %>
           <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
             <% if @preferred_auth_provider == provider %>
@@ -20,11 +21,9 @@
           <% end -%>
         <% end -%>
       </div>
-      <div class="justify-content-center d-flex align-items-center flex-wrap gap-2 w-50 px-1">
-    <% else %>
-      <div class="justify-content-center d-flex align-items-center flex-wrap gap-2">
     <% end %>
 
+    <div class="col justify-content-center d-flex align-items-center flex-wrap gap-2">
       <%= button_tag image_tag("openid.svg",
                                :alt => t(".openid.alt"),
                                :size => "36"),
@@ -41,7 +40,7 @@
         <% end %>
       <% end -%>
     </div>
-  </div>
+  <% end %>
 
   <%# :tabindex starts high to allow rendering at the bottom of the template %>
   <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>


### PR DESCRIPTION
There's an attempt to wrap auth buttons below the preferred button with `flex-wrap` here:
https://github.com/openstreetmap/openstreetmap-website/blob/bc8ce5729da0a7df4306ae5f785f68980a9bf47b/app/views/application/_auth_providers.html.erb#L2

That's not going to work after the children of this flex container got 50% width in #4849. They always fit in one row, no matter how narrow 50% of that row is.

Here I'm using Bootstrap's grid system with two-column row above the small width breakpoint if there's a preferred auth button.

Before/after:
![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/572c079d-491e-48f1-8c58-9e3369ec7096) ![image](https://github.com/openstreetmap/openstreetmap-website/assets/4158490/24244b16-3bd1-43e8-9e3a-71e0532cb1c3)
