### PR TITLE
Show/hide entire OpenID form

### DIFF
--- a/app/assets/javascripts/auth_providers.js
+++ b/app/assets/javascripts/auth_providers.js
@@ -12,11 +12,9 @@ $(document).ready(function () {
   $("#openid_open_url").click(function () {
     $("#openid_url").val("http://");
     $("#login_auth_buttons").hide();
-    $("#login_openid_url").show();
-    $("#openid_login_button").show();
+    $("#openid_login_form").show();
   });
 
   // Hide OpenID field for now
-  $("#login_openid_url").hide();
-  $("#openid_login_button").hide();
+  $("#openid_login_form").hide();
 });

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -44,7 +44,7 @@
 
   <%# :tabindex starts high to allow rendering at the bottom of the template %>
   <%= form_tag(auth_path(:provider => "openid"), :id => "openid_login_form") do %>
-    <div id="login_openid_url" class="mb-3">
+    <div class="mb-3">
       <label for="openid_url" class="form-label">
         <%= image_tag "openid.svg", :size => "36", :alt => "", :class => "align-text-bottom" %>
         <%= t ".openid_url" %>
@@ -54,6 +54,6 @@
       <span class="form-text text-body-secondary">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
     </div>
 
-    <%= submit_tag t(".openid_login_button"), :tabindex => 21, :id => "openid_login_button", :class => "btn btn-primary" %>
+    <%= submit_tag t(".openid_login_button"), :tabindex => 21, :class => "btn btn-primary" %>
   <% end %>
 </div>

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -8,4 +8,16 @@ class UserSignupTest < ApplicationSystemTestCase
 
     assert_content "Confirm Password"
   end
+
+  test "Show OpenID form when OpenID provider button is clicked" do
+    visit login_path
+
+    assert_no_field "OpenID URL"
+    assert_no_button "Continue"
+
+    click_on "Log in with OpenID"
+
+    assert_field "OpenID URL"
+    assert_button "Continue"
+  end
 end


### PR DESCRIPTION
When the login page is loaded, this form gets hidden by javascript:
![image](https://github.com/user-attachments/assets/15c43f62-fe6f-4585-9c53-7a46c2d060e2)

Later if the OpenID button is clicked, it gets shown.

Actually not quite. The form is always visible, what's getting shown/hidden are the div containing the url input and the *Continue* button. But there's not reason to show/hide them separately when you can show/hide the entire form.