### PR TITLE
Parse lat and lon independently when using dms notation

### DIFF
--- a/test/controllers/geocoder_controller_test.rb
+++ b/test/controllers/geocoder_controller_test.rb
@@ -262,6 +262,17 @@ class GeocoderControllerTest < ActionDispatch::IntegrationTest
   end
 
   #
+  # Test identification of lat/lon pairs with mixed precision
+  def test_identify_latlon_ne_mixed_precision
+    latlon_check "N1 5 E15",    1.083333, 15
+    latlon_check "N1 5 9 E15",  1.085833, 15
+    latlon_check "N1 5 9 E1 5", 1.085833, 1.083333
+    latlon_check "N15 E1 5",    15, 1.083333
+    latlon_check "N15 E1 5 9",  15, 1.085833
+    latlon_check "N1 5 E1 5 9", 1.083333, 1.085833
+  end
+
+  #
   # Test identification of lat/lon pairs with values close to zero
   def test_identify_latlon_close_to_zero
     [


### PR DESCRIPTION
Current parsing tries to have as many numbers in longitude as there are in longitude, sometimes splitting "12" (12 deg) into (1 deg 2 min).

Before/after:
![image](https://github.com/user-attachments/assets/ae08e71d-f35a-4f55-8e80-0fc70a65c1f0) ![image](https://github.com/user-attachments/assets/caffb0c1-043b-443d-8e8b-af4a8e689379)
