### PR TITLE
Added workflow for PR labeling using Danger

### DIFF
--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -1,0 +1,25 @@
+name: Danger
+
+run-name: Updating labels for current PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  danger:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          rubygems: 3.4.10
+          bundler-cache: true
+      - name: Danger
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bundle exec danger --verbose

--- a/Dangerfile
+++ b/Dangerfile
@@ -16,16 +16,16 @@ end
 
 # Report if some translation file (except en.yml) is modified
 if modified_yml_files.empty?
-  auto_label.remove("Compromised Translations")
+  auto_label.remove("Inappropriate Translations")
 else
   modified_files_str = modified_yml_files.map { |file| "`#{file}`" }.join(", ")
   warn("The following YAML files other than `en.yml` have been modified: #{modified_files_str}. Only `en.yml` is allowed to be changed. Translations are updated via Translatewiki, see CONTRIBUTING.md.")
-  auto_label.set(pr_number, "Compromised Translations", "B60205")
+  auto_label.set(pr_number, "Inappropriate Translations", "B60205")
 end
 
 # Report if there are merge-commits in PR
 if git.commits.any? { |c| c.parents.count > 1 }
-  warn("Merge commits are found in PR. Please rebase to get rid of the merge commits in this PR and read CONTRIBUTE.md.")
+  warn("Merge commits are found in PR. Please rebase to get rid of the merge commits in this PR, see CONTRIBUTING.md.")
   auto_label.set(pr_number, "Merge Commits", "D93F0B")
 else
   auto_label.remove("Merge Commits")

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,32 @@
+# Get PR number
+pr_number = github.pr_json["number"]
+
+# Report if number of changed lines is > 500
+if git.lines_of_code > 500
+  warn("Number of updated lines of code is too large to be in one PR. Perhaps it should be separated into two or more?")
+  auto_label.set(pr_number, "Big PR", "FBCA04")
+else
+  auto_label.remove("Big PR")
+end
+
+# Get list of translation files (except en.yml) which are modified
+modified_yml_files = git.modified_files.select do |file|
+  file.start_with?("config/locales") && File.extname(file) == ".yml" && File.basename(file) != "en.yml"
+end
+
+# Report if some translation file (except en.yml) is modified
+if modified_yml_files.empty?
+  auto_label.remove("Compromised Translations")
+else
+  modified_files_str = modified_yml_files.map { |file| "`#{file}`" }.join(", ")
+  warn("The following YAML files other than `en.yml` have been modified: #{modified_files_str}. Only `en.yml` is allowed to be changed. Translations are updated via Translatewiki, see CONTRIBUTING.md.")
+  auto_label.set(pr_number, "Compromised Translations", "B60205")
+end
+
+# Report if there are merge-commits in PR
+if git.commits.any? { |c| c.parents.count > 1 }
+  warn("Merge commits are found in PR. Please rebase to get rid of the merge commits in this PR and read CONTRIBUTE.md.")
+  auto_label.set(pr_number, "Merge Commits", "D93F0B")
+else
+  auto_label.remove("Merge Commits")
+end

--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,8 @@ gem "unicode-display_width"
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "danger"
+  gem "danger-auto_label"
   gem "debug_inspector"
   gem "i18n-tasks"
   gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,16 +150,40 @@ GEM
       xpath (~> 3.2)
     childprocess (5.1.0)
       logger (~> 1.5)
+    claide (1.1.0)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    colored2 (3.1.2)
     concurrent-ruby (1.3.4)
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
     connection_pool (2.4.1)
+    cork (0.3.0)
+      colored2 (~> 3.1)
     crack (1.0.0)
       bigdecimal
       rexml
     crass (1.0.6)
     dalli (3.2.8)
+    danger (9.5.0)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (>= 0.9.0, < 3.0)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.13)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      octokit (>= 4.0)
+      terminal-table (>= 1, < 4)
+    danger-auto_label (1.3.1)
+      danger-plugin-api (~> 1.0)
+    danger-plugin-api (1.0.0)
+      danger (> 2.0)
     dartsass-ruby (3.0.2)
       sass-embedded (~> 1.54, < 1.67)
     dartsass-sprockets (3.0.0)
@@ -240,6 +264,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.4)
       json
       logger
+    faraday-http-cache (2.5.1)
+      faraday (>= 0.8)
     faraday-net_http (3.3.0)
       net-http
     ffi (1.17.0)
@@ -254,6 +280,9 @@ GEM
     fspath (3.1.2)
     gd2-ffij (0.4.0)
       ffi (>= 1.0.0)
+    git (1.19.1)
+      addressable (~> 2.8)
+      rchardet (~> 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.5)
@@ -311,6 +340,8 @@ GEM
     kgio (2.11.4)
     kramdown (2.4.0)
       rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     libv8-node (18.19.0.0)
     libxml-ruby (5.0.3)
@@ -344,6 +375,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
+    nap (1.1.0)
     net-http (0.4.1)
       uri
     net-imap (0.4.16)
@@ -372,6 +404,9 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
+    octokit (9.1.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     omniauth (2.0.4)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -407,6 +442,7 @@ GEM
     omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    open4 (1.3.4)
     openstreetmap-deadlock_retry (1.3.1)
     ostruct (0.6.0)
     overcommit (0.64.0)
@@ -488,6 +524,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rchardet (1.8.0)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -542,6 +579,9 @@ GEM
     sass-embedded (1.64.2)
       google-protobuf (~> 3.23)
       rake (>= 13.0.0)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
     securerandom (0.3.1)
     selenium-webdriver (4.23.0)
       base64 (~> 0.2)
@@ -634,6 +674,8 @@ DEPENDENCIES
   config
   connection_pool
   dalli
+  danger
+  danger-auto_label
   dartsass-sprockets
   debug
   debug_inspector


### PR DESCRIPTION
This PR proposes possible solution for labeling pull requests using Danger described in #4912

Proposed solution introduces new workflow, executed whenever new PR is created or updated. Workflow checks if PR is too big (>500 changed lines) or changes one of translation files (YML, except en.yml) or contains merge-commits and generates appropriate labels using Danger and danger-auto_label plugin. If none of these is found, green "Good PR" is generated.

![image](https://github.com/user-attachments/assets/4d4141e8-a471-4ff8-a842-a831198a4ed8)
