### PR TITLE
Show "reporting user" on "issues" screen

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -816,6 +816,14 @@ tr.turn {
   }
 }
 
+/* Rules for the issues page */
+
+.issues.issues-index {
+  td.reporter_users {
+    max-width: 5rem;
+  }
+}
+
 /* Rules for the account confirmation page */
 
 .accounts-terms-show {

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -44,6 +44,15 @@ class IssuesController < ApplicationController
     end
 
     @issues, @newer_issues_id, @older_issues_id = get_page_items(@issues, :limit => @params[:limit])
+
+    @unique_reporters = @issues.each_with_object({}) do |issue, reporters|
+      user_ids = issue.reports.order(:created_at => :desc).map(&:user_id).uniq
+      reporters[issue.id] = {
+        :count => user_ids.size,
+        :users => User.in_order_of(:id, user_ids.first(3))
+      }
+    end
+
     render :partial => "page" if turbo_frame_request_id == "pagination"
   end
 

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -13,6 +13,7 @@
           <th><%= t ".reports" %></th>
           <th><%= t ".reported_item" %></th>
           <th><%= t ".reported_user" %></th>
+          <th class="reporter_users"><%= t ".reporter_users" %></th>
           <th><%= t ".last_updated" %></th>
         </tr>
       </thead>
@@ -23,6 +24,14 @@
             <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
             <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
             <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
+            <td class="reporter_users text-truncate">
+              <% @unique_reporters[issue.id][:users].each do |reporter| %>
+                <%= link_to reporter.display_name, reporter, :class => "d-block text-truncate", :title => reporter.display_name %>
+              <% end %>
+              <% if @unique_reporters[issue.id][:count] > 3 %>
+                <p class="m-0"><%= t ".more_reporters", :count => @unique_reporters[issue.id][:count] - 3 %></p>
+              <% end %>
+            </td>
             <td>
               <% if issue.user_updated %>
                 <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1509,9 +1509,11 @@ en:
       reports: Reports
       last_updated: Last Updated
       last_updated_time_ago_user_html: "%{time_ago} by %{user}"
+      reporter_users: Reporter Users
       reports_count:
         one: "%{count} Report"
         other: "%{count} Reports"
+      more_reporters: "and %{count} more"
       reported_item: Reported Item
       states:
         ignored: Ignored


### PR DESCRIPTION
This PR addresses "Show 'reporting user' on 'issues' screen" issue mentioned in the https://github.com/openstreetmap/openstreetmap-website/issues/2273

On the issues page, there was added a new column called "Reporter Users". It will show unique reporters of the item. If there are more than reporters for the given item than the size of the block can handle, ellipsis will be shown at the end of the line. Each of user display name will have a link to the user. Fixes https://github.com/openstreetmap/openstreetmap-website/issues/2273

Update:
Added fixed max-width for reporters' column. If the text can't be fitted, ellipsis will be shown. On hover, box shows all the reporters.

Screenshot:
 
![Screenshot 2024-07-18 194055](https://github.com/user-attachments/assets/ef775676-c0c3-419e-91ce-690a1f5ef627)
