### PR TITLE
Update Docker Image to use Node.js v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,14 @@ RUN apt-get update \
       ruby-bundler \
       software-properties-common \
       tzdata \
-      unzip \
-      nodejs \
-      npm \
- && npm install --global yarn \
+      unzip
+
+# Install Node.js 18 and npm
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+ && apt-get install -y nodejs
+
+# Install yarn globally
+RUN npm install --global yarn \
  # We can't use snap packages for firefox inside a container, so we need to get firefox+geckodriver elsewhere
  && add-apt-repository -y ppa:mozillateam/ppa \
  && echo "Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001" > /etc/apt/preferences.d/mozilla-firefox \


### PR DESCRIPTION
This PR addresses #4989. 
Errors is encountered when attempting to run `bundle exec rails eslint` inside the Docker container terminal,after following the instructions in the `DOCKER.md` file.

After updating `Dockerfile` to use Node.js v18, we can rebuild the container using `docker compose up --build -d ` command; resulting in expected result when running `bundle exec rails eslint`

```bash
$ bundle exec rails eslint
warning: parser/current is loading parser/ruby30, which recognizes 3.0.7-compliant syntax, but you are running 3.0.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
yarn run v1.22.22
$ /app/node_modules/.bin/eslint -c /app/config/eslint.js /app/app/assets/config/manifest.js /app/app/assets/javascripts/application.js /app/app/assets/javascripts/auth_providers.js /app/app/assets/javascripts/diary_entry.js /app/app/assets/javascripts/fixthemap.js /app/app/assets/javascripts/id.js /app/app/assets/javascripts/index/changeset.js /app/app/assets/javascripts/index/contextmenu.js /app/app/assets/javascripts/index/directions/fossgis_osrm.js /app/app/assets/javascripts/index/directions/fossgis_valhalla.js /app/app/assets/javascripts/index/directions/graphhopper.js /app/app/assets/javascripts/index/directions.js /app/app/assets/javascripts/index/export.js /app/app/assets/javascripts/index/history.js /app/app/assets/javascripts/index/layers/data.js /app/app/assets/javascripts/index/layers/notes.js /app/app/assets/javascripts/index/new_note.js /app/app/assets/javascripts/index/note.js /app/app/assets/javascripts/index/query.js /app/app/assets/javascripts/index/search.js /app/app/assets/javascripts/index.js /app/app/assets/javascripts/leaflet.key.js /app/app/assets/javascripts/leaflet.layers.js /app/app/assets/javascripts/leaflet.locate.js /app/app/assets/javascripts/leaflet.map.js /app/app/assets/javascripts/leaflet.note.js /app/app/assets/javascripts/leaflet.query.js /app/app/assets/javascripts/leaflet.share.js /app/app/assets/javascripts/leaflet.sidebar-pane.js /app/app/assets/javascripts/leaflet.sidebar.js /app/app/assets/javascripts/leaflet.zoom.js /app/app/assets/javascripts/login.js /app/app/assets/javascripts/matomo.js /app/app/assets/javascripts/messages.js /app/app/assets/javascripts/oauth.js /app/app/assets/javascripts/richtext.js /app/app/assets/javascripts/router.js /app/app/assets/javascripts/user.js /app/app/assets/javascripts/welcome.js /app/config/eslint.js

/app/app/assets/javascripts/index.js
  267:9  warning  Unexpected alert  no-alert

/app/app/assets/javascripts/index/directions.js
  117:11  warning  Unexpected alert                                                         no-alert
  337:9   warning  Unexpected 'todo' comment: 'TODO: collapse width of sidebar back to...'  no-warning-comments

/app/app/assets/javascripts/index/directions/fossgis_osrm.js
  4:1  warning  Unexpected function declaration in the global scope, wrap in an IIFE for a local variable, assign as global property for a global variable  no-implicit-globals

/app/app/assets/javascripts/index/directions/fossgis_valhalla.js
  1:1  warning  Unexpected function declaration in the global scope, wrap in an IIFE for a local variable, assign as global property for a global variable  no-implicit-globals

/app/app/assets/javascripts/index/directions/graphhopper.js
   1:1   warning  Unexpected function declaration in the global scope, wrap in an IIFE for a local variable, assign as global property for a global variable  no-implicit-globals
  68:17  warning  Unexpected 'todo' comment: 'TODO does graphhopper map instructions...'                                                                      no-warning-comments

✖ 7 problems (0 errors, 7 warnings)

Done in 0.99s.
# 
```