### PR TITLE
Set OpenID URL input value in html instead of javascript

### DIFF
--- a/app/assets/javascripts/auth_providers.js
+++ b/app/assets/javascripts/auth_providers.js
@@ -10,7 +10,6 @@ $(document).ready(function () {
 
   // Add click handler to show OpenID field
   $("#openid_open_url").click(function () {
-    $("#openid_url").val("http://");
     $("#login_auth_buttons").hide();
     $("#openid_login_form").show();
   });

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -50,7 +50,7 @@
         <%= t ".openid_url" %>
       </label>
       <%= hidden_field_tag("referer", params[:referer], :autocomplete => "off") %>
-      <%= text_field_tag("openid_url", "", :tabindex => 20, :autocomplete => "on", :class => "form-control") %>
+      <%= text_field_tag("openid_url", "https://", :tabindex => 20, :autocomplete => "on", :class => "form-control") %>
       <span class="form-text text-body-secondary">(<a href="<%= t "accounts.edit.openid.link" %>" target="_new"><%= t "accounts.edit.openid.link text" %></a>)</span>
     </div>
 


### PR DESCRIPTION
That javascript comes from [ages ago](https://github.com/openstreetmap/openstreetmap-website/commit/ebd109c946d71b3ccc616ea3966e56ae019638d7) when each auth provider button was setting its own value.