### PR TITLE
Remove name argument from auth button helpers

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -52,29 +52,29 @@ module UserHelper
 
   # External authentication support
 
-  def auth_button(name, provider, options = {})
+  def auth_button(provider, options = {})
     link_to(
-      image_tag("#{name}.svg",
-                :alt => t("application.auth_providers.#{name}.alt"),
+      image_tag("#{provider}.svg",
+                :alt => t("application.auth_providers.#{provider}.alt"),
                 :class => "rounded-1",
                 :size => "36"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
       :class => "auth_button btn btn-light p-2",
-      :title => t("application.auth_providers.#{name}.title")
+      :title => t("application.auth_providers.#{provider}.title")
     )
   end
 
-  def auth_button_preferred(name, provider, options = {})
+  def auth_button_preferred(provider, options = {})
     link_to(
-      image_tag("#{name}.svg",
-                :alt => t("application.auth_providers.#{name}.alt"),
+      image_tag("#{provider}.svg",
+                :alt => t("application.auth_providers.#{provider}.alt"),
                 :class => "rounded-1 me-3",
-                :size => "36") + t("application.auth_providers.#{name}.title"),
+                :size => "36") + t("application.auth_providers.#{provider}.title"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
       :class => "auth_button btn btn-outline-secondary border py-2 px-4 d-flex justify-content-center align-items-center",
-      :title => t("application.auth_providers.#{name}.title")
+      :title => t("application.auth_providers.#{provider}.title")
     )
   end
 

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -16,7 +16,7 @@
         <% %w[google facebook microsoft github wikipedia].each do |provider| %>
           <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
             <% if @preferred_auth_provider == provider %>
-              <%= auth_button_preferred provider, provider %>
+              <%= auth_button_preferred provider %>
             <% end %>
           <% end -%>
         <% end -%>
@@ -35,7 +35,7 @@
       <% %w[google facebook microsoft github wikipedia].each do |provider| %>
         <% unless @preferred_auth_provider == provider %>
           <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
-            <%= auth_button provider, provider %>
+            <%= auth_button provider %>
           <% end -%>
         <% end %>
       <% end -%>

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -110,7 +110,7 @@ class UserHelperTest < ActionView::TestCase
   end
 
   def test_auth_button
-    button = auth_button("google", "google")
+    button = auth_button("google")
     img_tag = "<img alt=\"Google logo\" class=\"rounded-1\" src=\"/images/google.svg\" width=\"36\" height=\"36\" />"
     assert_equal("<a class=\"auth_button btn btn-light p-2\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
   end


### PR DESCRIPTION
`auth_button` and `auth_button_preferred` helpers have the following first two arguments:
- `name`, which is an auth provider name
- `provider`, which is also an auth provider name, exactly the same

They used to be different [at some point](https://github.com/openstreetmap/openstreetmap-website/commit/e434cb154c5ccecd7fc0ce672e4de79bd9e7e06f), but not anymore. Now the calls look like `auth_button provider, provider`.

We can remove the `name` argument.