### PR TITLE
Set search input value to 'lat, lon' params if query param is missing

### DIFF
--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -118,8 +118,13 @@ OSM.Search = function (map) {
 
   page.pushstate = page.popstate = function (path) {
     var params = Qs.parse(path.substring(path.indexOf("?") + 1));
-    $(".search_form input[name=query]").val(params.query);
-    $(".describe_location").hide();
+    if (params.query) {
+      $(".search_form input[name=query]").val(params.query);
+      $(".describe_location").hide();
+    } else if (params.lat && params.lon) {
+      $(".search_form input[name=query]").val(params.lat + ", " + params.lon);
+      $(".describe_location").hide();
+    }
     OSM.loadSidebarContent(path, page.load);
   };
 

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -1,0 +1,14 @@
+require "application_system_test_case"
+
+class SearchTest < ApplicationSystemTestCase
+  test "click on 'where is this' sets search input value" do
+    stub_request(:get, %r{^https://nominatim\.openstreetmap\.org/reverse\?})
+      .to_return(:status => 404)
+
+    visit "/#map=7/1.234/6.789"
+
+    assert_field "Search", :with => ""
+    click_on "Where is this?"
+    assert_field "Search", :with => "1.234, 6.789"
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/pull/4959#issuecomment-2232620015

Fixes #4997