### PR TITLE
Set search input value when searching for coordinates

### DIFF
--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,9 +1,15 @@
+<% search_query = if params[:query]
+                    params[:query]
+                  elsif params[:lat] && params[:lon]
+                    "#{params[:lat]}, #{params[:lon]}"
+                  end %>
+
 <div class="search_forms">
   <form method="GET" action="<%= search_path %>" class="search_form bg-body-secondary px-1 py-2">
     <div class="row gx-2 mx-0">
       <div class="col">
         <div class="input-group flex-nowrap">
-          <%= text_field_tag "query", params[:query], :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control z-0 py-1 px-2", :dir => "auto" %>
+          <%= text_field_tag "query", search_query, :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control z-0 py-1 px-2", :dir => "auto" %>
           <div class="input-group-text border-start-0 p-0 position-relative">
             <%= button_tag t("site.search.where_am_i"), :type => "button", :class => "describe_location position-absolute end-0 top-0 bottom-0 m-1 btn btn-outline-primary border-0 p-1 bg-transparent text-primary link-body-emphasis link-opacity-100-hover", :title => t("site.search.where_am_i_title") %>
           </div>

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -11,4 +11,22 @@ class SearchTest < ApplicationSystemTestCase
     click_on "Where is this?"
     assert_field "Search", :with => "1.234, 6.789"
   end
+
+  test "query search link sets search input value" do
+    stub_request(:get, %r{^https://nominatim\.openstreetmap\.org/reverse\?})
+      .to_return(:status => 404)
+
+    visit search_path(:query => "2.341, 7.896")
+
+    assert_field "Search", :with => "2.341, 7.896"
+  end
+
+  test "latlon search link sets search input value" do
+    stub_request(:get, %r{^https://nominatim\.openstreetmap\.org/reverse\?})
+      .to_return(:status => 404)
+
+    visit search_path(:lat => "4.321", :lon => "9.876")
+
+    assert_field "Search", :with => "4.321, 9.876"
+  end
 end


### PR DESCRIPTION
Fixes setting search input value after full page reloads that only seems to work because of [autocompletion](https://github.com/openstreetmap/openstreetmap-website/pull/4959#issuecomment-2233238733).

`_search.html.erb` fills the input with `params[:query]` which is not going to exist after geocoder's `normalize_params`.