### PR TITLE
Use Auth.providers in auth providers template

### DIFF
--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -19,7 +19,7 @@
   <fieldset class="mb-3">
     <label for="user_auth_provider" class="form-label"><%= t(".external auth") %></label>
     <div class="row">
-      <%= f.select(:auth_provider, Auth.providers, :hide_label => true, :wrapper => { :class => "col-auto mb-0" }) %>
+      <%= f.select(:auth_provider, { t("auth.providers.none") => "" }.merge(Auth.providers), :hide_label => true, :wrapper => { :class => "col-auto mb-0" }) %>
       <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }) %>
     </div>
     <small class="form-text text-body-secondary">(<a href="<%= t ".openid.link" %>" target="_new"><%= t ".openid.link text" %></a>)</small>

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -1,11 +1,4 @@
-<% prefered_auth_button_available = false %>
-<% %w[google facebook microsoft github wikipedia].each do |provider| %>
-  <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
-    <% if @preferred_auth_provider == provider %>
-      <% prefered_auth_button_available = true %>
-    <% end %>
-  <% end -%>
-<% end -%>
+<% prefered_auth_button_available = @preferred_auth_provider != "openid" && Auth.providers.value?(@preferred_auth_provider) %>
 
 <div>
   <%= tag.div :id => "login_auth_buttons",
@@ -18,20 +11,18 @@
     <% end %>
 
     <div class="col justify-content-center d-flex align-items-center flex-wrap gap-2">
-      <%= button_tag image_tag("openid.svg",
-                               :alt => t(".openid.alt"),
-                               :size => "36"),
-                     :type => "button",
-                     :id => "openid_open_url",
-                     :title => t(".openid.title"),
-                     :class => "btn btn-light p-2" %>
-
-      <% %w[google facebook microsoft github wikipedia].each do |provider| %>
-        <% unless @preferred_auth_provider == provider %>
-          <% if Settings.key?("#{provider}_auth_id".to_sym) -%>
-            <%= auth_button provider %>
-          <% end -%>
-        <% end %>
+      <% Auth.providers.each_value do |provider| %>
+        <% if provider == "openid" %>
+          <%= button_tag image_tag("openid.svg",
+                                   :alt => t(".openid.alt"),
+                                   :size => "36"),
+                         :type => "button",
+                         :id => "openid_open_url",
+                         :title => t(".openid.title"),
+                         :class => "btn btn-light p-2" %>
+        <% elsif provider != @preferred_auth_provider %>
+          <%= auth_button provider %>
+        <% end -%>
       <% end -%>
     </div>
   <% end %>

--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -3,7 +3,6 @@ module Auth
 
   def self.providers
     @providers[I18n.locale] ||= {
-      I18n.t("auth.providers.none") => "",
       I18n.t("auth.providers.openid") => "openid"
     }.tap do |providers|
       providers[I18n.t("auth.providers.google")] = "google" if Settings.key?(:google_auth_id)


### PR DESCRIPTION
`_auth_providers.html.erb` iterates over `%w[google facebook microsoft github wikipedia]` and checks which provider is available. But the `Auth` module already does that. `Auth` is only used on account settings pages and has a "provider" "None" specific to these pages. If "None" is removed, `Auth` can be reused in `_auth_providers.html.erb`.