### PR TITLE
Fix marking muted messages as read/unread

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -117,7 +117,7 @@ class MessagesController < ApplicationController
 
   # Set the message as being read or unread.
   def mark
-    @message = current_user.messages.find(params[:message_id])
+    @message = current_user.messages.unscope(:where => :muted).find(params[:message_id])
     if params[:mark] == "unread"
       message_read = false
       notice = t ".as_unread"
@@ -128,7 +128,11 @@ class MessagesController < ApplicationController
     @message.message_read = message_read
     if @message.save
       flash[:notice] = notice
-      redirect_to inbox_messages_path, :status => :see_other
+      if @message.muted?
+        redirect_to muted_messages_path, :status => :see_other
+      else
+        redirect_to inbox_messages_path, :status => :see_other
+      end
     end
   rescue ActiveRecord::RecordNotFound
     @title = t "messages.no_such_message.title"

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -424,6 +424,27 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   ##
+  # test the mark action for messages from muted users
+  def test_mark_muted
+    sender_user = create(:user)
+    recipient_user = create(:user)
+    create(:user_mute, :owner => recipient_user, :subject => sender_user)
+    message = create(:message, :unread, :sender => sender_user, :recipient => recipient_user)
+
+    session_for(recipient_user)
+
+    # Check that the marking a message read works
+    post message_mark_path(message, :mark => "read")
+    assert_redirected_to muted_messages_path
+    assert Message.find(message.id).message_read
+
+    # Check that the marking a message unread works
+    post message_mark_path(message, :mark => "unread")
+    assert_redirected_to muted_messages_path
+    assert_not Message.find(message.id).message_read
+  end
+
+  ##
   # test the destroy action
   def test_destroy
     user = create(:user)


### PR DESCRIPTION
Otherwise you get this error:

![image](https://github.com/user-attachments/assets/e2b93301-06aa-4797-8d8f-561a70dfab64)

![image](https://github.com/user-attachments/assets/7b75118f-5098-4537-a9b1-ebcef8bde5cc)
