### PR TITLE
Map Data checkbox: perhaps use toggle slider instead

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -89,6 +89,15 @@ OSM.initializeDataLayer = function (map) {
 
     if (dataLoader) dataLoader.abort();
 
+    $("#layers-data-loading").remove();
+
+    const spanLoading = $("<span>")
+      .attr("id", "layers-data-loading")
+      .attr("class", "spinner-border spinner-border-sm ms-1")
+      .attr("role", "status")
+      .html("<span class='visually-hidden'>" + I18n.t("browse.start_rjs.loading") + "</span>")
+      .appendTo($("#label-layers-data"));
+
     dataLoader = new AbortController();
     fetch(url, { signal: dataLoader.signal })
       .then(response => {
@@ -131,7 +140,10 @@ OSM.initializeDataLayer = function (map) {
           $("#browse_status").empty();
         });
       })
-      .finally(() => dataLoader = null);
+      .finally(() => {
+        dataLoader = null;
+        spanLoading.remove();
+      });
   }
 
   function onSelect(layer) {

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -100,6 +100,7 @@ L.OSM.layers = function (options) {
 
         const label = $("<label>")
           .attr("class", "form-check-label")
+          .attr("id", `label-layers-${name}`)
           .appendTo(item);
 
         let checked = map.hasLayer(layer);
@@ -114,10 +115,15 @@ L.OSM.layers = function (options) {
 
         input.on("change", function () {
           checked = input.is(":checked");
+          if (layer.cancelLoading) {
+            layer.cancelLoading();
+          }
+
           if (checked) {
             map.addLayer(layer);
           } else {
             map.removeLayer(layer);
+            $(`#layers-${name}-loading`).remove();
           }
         });
 

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -47,7 +47,7 @@ L.OSM.Map = L.Map.extend({
     this.noteLayer = new L.FeatureGroup();
     this.noteLayer.options = { code: "N" };
 
-    this.dataLayer = new L.OSM.DataLayer(null);
+    this.dataLayer = new L.OSM.DataLayer(null, { asynchronous: true });
     this.dataLayer.options.code = "D";
 
     this.gpsLayer = new L.OSM.GPS({
@@ -306,7 +306,8 @@ L.OSM.Map = L.Map.extend({
               way: objectStyle,
               area: objectStyle,
               changeset: changesetStyle
-            }
+            },
+            asynchronous: true
           });
 
           map._objectLayer.interestingNode = function (node, wayNodes, relationNodes) {

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -104,6 +104,13 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
     }
   },
 
+  loadingLayers: [],
+
+  cancelLoading: function () {
+    this.loadingLayers.forEach(layer => clearTimeout(layer));
+    this.loadingLayers = [];
+  },
+
   addData: function (features) {
     if (!(features instanceof Array)) {
       features = this.buildFeatures(features);
@@ -220,9 +227,11 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
   eachLayer: function (method, context, asynchronous = false) {
     for (let i in this._layers) {
       if (asynchronous) {
-        setTimeout(() => {
-          method.call(context, this._layers[i]);
-        });
+        this.loadingLayers.push(
+          setTimeout(() => {
+            method.call(context, this._layers[i]);
+          })
+        );
       } else {
         method.call(context, this._layers[i]);
       }


### PR DESCRIPTION
This PR addresses "Map Data checkbox: perhaps use toggle slider instead" issue mentioned in the https://github.com/openstreetmap/openstreetmap-website/issues/4931

Several changes were made to the data loading functionality:

1. Clicking "Map Data" checkbox will add loading spinner to the label. It will be shown until back end collects and returns all the information (see "Loading Video"). After all the information is returned, spinner will be removed.
2. After getting information and agreeing to show it on the map, rendering process will be asynchronous. Therefore, there will be no more browser or page freezes and it will have animation like visual (see "Render Video").
3. If user unchecks "Map Data" checkbox, removing process will be also asynchronous and there won't be any freezes. It will also have animation like visual (see "Remove Video").

- Checkbox state will be updated as soon as it is clicked, so changing it to the toggle one has no more benefits.
- If the user decides to uncheck "Map Data" while back end collects information, loading spinner will disappear.
- If the user decides to uncheck "Map Data" while objects is rendered, it won't trigger change until the rendering process is done. After the process, application will check and if "Map Data" is unchecked, it will start removing rendered objects.

Connected to the PR https://github.com/openstreetmap/leaflet-osm/pull/38
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/4931

### Videos:

Loading Video

https://github.com/user-attachments/assets/4b8a9245-4847-4a2f-8c40-ad16ce933e05

Render Video

https://github.com/user-attachments/assets/8e11fc5f-1d9c-4458-a5a8-96479627d5ff

Remove Video

https://github.com/user-attachments/assets/0743916d-353e-4717-8600-c74937b6f2fe

