### PR TITLE
Select closest value to remaining duration when editing a block

### DIFF
--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -15,7 +15,8 @@
   <%= f.form_group do %>
     <%= label_tag "user_block_period", t(".period"), :class => "form-label" %>
     <%= select_tag("user_block_period",
-                   options_for_select(UserBlock::PERIODS.collect { |h| [block_duration_in_words(h.hours), h.to_s] }, params[:user_block_period]),
+                   options_for_select(UserBlock::PERIODS.collect { |h| [block_duration_in_words(h.hours), h.to_s] },
+                                      UserBlock::PERIODS.min_by { |h| (params[:user_block_period].to_i - h).abs }),
                    :class => "form-select") %>
   <% end %>
 

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -245,6 +245,34 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   end
 
   ##
+  # test the edit action when the remaining block duration doesn't match the available select options
+  def test_edit_duration
+    moderator_user = create(:moderator_user)
+
+    freeze_time do
+      active_block = create(:user_block, :creator => moderator_user, :ends_at => Time.now.utc + 96.hours)
+
+      session_for(moderator_user)
+      get edit_user_block_path(active_block)
+
+      assert_select "form#edit_user_block_#{active_block.id}", :count => 1 do
+        assert_select "select#user_block_period", :count => 1 do
+          assert_select "option[value='96'][selected]", :count => 1
+        end
+      end
+
+      travel 2.hours
+      get edit_user_block_path(active_block)
+
+      assert_select "form#edit_user_block_#{active_block.id}", :count => 1 do
+        assert_select "select#user_block_period", :count => 1 do
+          assert_select "option[value='96'][selected]", :count => 1
+        end
+      end
+    end
+  end
+
+  ##
   # test the create action
   def test_create
     target_user = create(:user)


### PR DESCRIPTION
Let's suppose you create a block and you set its duration to 12 hours. Then you realize you need to edit this block. You go to `/user_blocks/:id/edit` and you see among other things a duration select set to 12 hours as expected:
![image](https://github.com/user-attachments/assets/550707db-160b-405c-a85e-ecd156d5a4a6)

But what if you come an hour later? Now the remaining duration is 11 hours which is not one of the available select options. The select will look like this, defaulting to 0 hours, probably not the best choice:
![image](https://github.com/user-attachments/assets/6fde232c-a1cb-4f79-83db-b65a308f9a3c)

Here I set the select to the closest available value.