### PR TITLE
Change diary comment post paths

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,13 +237,13 @@ OpenStreetMap::Application.routes.draw do
   scope "/user/:display_name" do
     resources :diary_entries, :path => "diary", :only => [:edit, :update, :show], :id => /\d+/
   end
-  post "/user/:display_name/diary/:id/newcomment" => "diary_comments#create", :id => /\d+/, :as => :comment_diary_entry
   post "/user/:display_name/diary/:id/hide" => "diary_entries#hide", :id => /\d+/, :as => :hide_diary_entry
   post "/user/:display_name/diary/:id/unhide" => "diary_entries#unhide", :id => /\d+/, :as => :unhide_diary_entry
-  post "/user/:display_name/diary/:id/hidecomment/:comment" => "diary_comments#hide", :id => /\d+/, :comment => /\d+/, :as => :hide_diary_comment
-  post "/user/:display_name/diary/:id/unhidecomment/:comment" => "diary_comments#unhide", :id => /\d+/, :comment => /\d+/, :as => :unhide_diary_comment
   match "/user/:display_name/diary/:id/subscribe" => "diary_entries#subscribe", :via => [:get, :post], :as => :diary_entry_subscribe, :id => /\d+/
   match "/user/:display_name/diary/:id/unsubscribe" => "diary_entries#unsubscribe", :via => [:get, :post], :as => :diary_entry_unsubscribe, :id => /\d+/
+  post "/user/:display_name/diary/:id/comments" => "diary_comments#create", :id => /\d+/, :as => :comment_diary_entry
+  post "/user/:display_name/diary/:id/comments/:comment/hide" => "diary_comments#hide", :id => /\d+/, :comment => /\d+/, :as => :hide_diary_comment
+  post "/user/:display_name/diary/:id/comments/:comment/unhide" => "diary_comments#unhide", :id => /\d+/, :comment => /\d+/, :as => :unhide_diary_comment
 
   # user pages
   resources :users, :path => "user", :param => :display_name, :only => [:show, :destroy]

--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -13,15 +13,15 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
       { :controller => "diary_comments", :action => "index", :display_name => "username" }
     )
     assert_routing(
-      { :path => "/user/username/diary/1/newcomment", :method => :post },
+      { :path => "/user/username/diary/1/comments", :method => :post },
       { :controller => "diary_comments", :action => "create", :display_name => "username", :id => "1" }
     )
     assert_routing(
-      { :path => "/user/username/diary/1/hidecomment/2", :method => :post },
+      { :path => "/user/username/diary/1/comments/2/hide", :method => :post },
       { :controller => "diary_comments", :action => "hide", :display_name => "username", :id => "1", :comment => "2" }
     )
     assert_routing(
-      { :path => "/user/username/diary/1/unhidecomment/2", :method => :post },
+      { :path => "/user/username/diary/1/comments/2/unhide", :method => :post },
       { :controller => "diary_comments", :action => "unhide", :display_name => "username", :id => "1", :comment => "2" }
     )
 


### PR DESCRIPTION
This is how path are going to look if comments are turned into nested resources of diary entries:

- `newcomment` => POST on `comments`
- `hidecomment/:comment` => `comments/:comment/hide`
- `unhidecomment/:comment` => `comments/:comment/unhide`

All changed paths are POST paths, changing them shouldn't break anything.