### PR TITLE
Allow to edit inactive blocks

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -142,9 +142,6 @@ class UserBlocksController < ApplicationController
     if UserBlock::PERIODS.exclude?(@block_period)
       flash[:error] = t("user_blocks.filter.block_period")
 
-    elsif @user_block && !@user_block.active?
-      flash[:error] = t("user_blocks.filter.block_expired")
-
     else
       @valid_params = true
     end

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -15,7 +15,7 @@
     <% end %>
   </td>
   <td><%= link_to t(".show"), block %></td>
-  <td><% if current_user and current_user.id == block.creator_id and block.active? %><%= link_to t(".edit"), edit_user_block_path(block) %><% end %></td>
+  <td><% if current_user and current_user.id == block.creator_id %><%= link_to t(".edit"), edit_user_block_path(block) %><% end %></td>
   <% if show_revoke_link %>
   <td><% if block.active? %><%= link_to t(".revoke"), revoke_user_block_path(block) %><% end %></td>
   <% end %>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -26,13 +26,12 @@
   <dd class="col-sm-9"><div class="richtext text-break"><%= @user_block.reason.to_html %></div></dd>
 </dl>
 
-<% if @user_block.ends_at > Time.now.getutc && (current_user&.id == @user_block.creator_id ||
-                                                can?(:revoke, UserBlock)) %>
+<% if current_user&.id == @user_block.creator_id || can?(:revoke, UserBlock) && @user_block.active? %>
   <div>
     <% if current_user&.id == @user_block.creator_id %>
       <%= link_to t(".edit"), edit_user_block_path(@user_block), :class => "btn btn-outline-primary" %>
     <% end %>
-    <% if can?(:revoke, UserBlock) %>
+    <% if can?(:revoke, UserBlock) && @user_block.active? %>
       <%= link_to t(".revoke"), revoke_user_block_path(@user_block), :class => "btn btn-outline-danger" %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2935,7 +2935,6 @@ en:
       show: "View this block"
       back: "View all blocks"
     filter:
-      block_expired: "The block has already expired and cannot be edited."
       block_period: "The blocking period must be one of the values selectable in the drop-down list."
     create:
       flash: "Created a block on user %{name}."

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -170,6 +170,63 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   end
 
   ##
+  # test edit/revoke link for active blocks
+  def test_active_block_buttons
+    creator_user = create(:moderator_user)
+    other_moderator_user = create(:moderator_user)
+    block = create(:user_block, :creator => creator_user)
+
+    session_for(other_moderator_user)
+    check_block_buttons block, :revoke => 1
+
+    session_for(creator_user)
+    check_block_buttons block, :edit => 1, :revoke => 1
+  end
+
+  ##
+  # test the edit link for expired blocks
+  def test_expired_block_buttons
+    creator_user = create(:moderator_user)
+    other_moderator_user = create(:moderator_user)
+    block = create(:user_block, :expired, :creator => creator_user)
+
+    session_for(other_moderator_user)
+    check_block_buttons block
+
+    session_for(creator_user)
+    check_block_buttons block, :edit => 1
+  end
+
+  ##
+  # test the edit link for revoked blocks
+  def test_revoked_block_buttons
+    creator_user = create(:moderator_user)
+    revoker_user = create(:moderator_user)
+    other_moderator_user = create(:moderator_user)
+    block = create(:user_block, :revoked, :creator => creator_user, :revoker => revoker_user)
+
+    session_for(other_moderator_user)
+    check_block_buttons block
+
+    session_for(creator_user)
+    check_block_buttons block, :edit => 1
+
+    session_for(revoker_user)
+    check_block_buttons block
+  end
+
+  private
+
+  def check_block_buttons(block, edit: 0, revoke: 0)
+    get user_blocks_path
+    assert_response :success
+    assert_select "a[href='#{edit_user_block_path block}']", :count => edit
+    assert_select "a[href='#{revoke_user_block_path block}']", :count => revoke
+  end
+
+  public
+
+  ##
   # test the new action
   def test_new
     target_user = create(:user)

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -218,10 +218,12 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   private
 
   def check_block_buttons(block, edit: 0, revoke: 0)
-    get user_blocks_path
-    assert_response :success
-    assert_select "a[href='#{edit_user_block_path block}']", :count => edit
-    assert_select "a[href='#{revoke_user_block_path block}']", :count => revoke
+    [user_blocks_path, user_block_path(block)].each do |path|
+      get path
+      assert_response :success
+      assert_select "a[href='#{edit_user_block_path block}']", :count => edit
+      assert_select "a[href='#{revoke_user_block_path block}']", :count => revoke
+    end
   end
 
   public


### PR DESCRIPTION
Expired/revoked blocks have no edit links. Editing them results in "The block has already expired and cannot be edited."

This PR removes the `active?` check on update actions which allows editing inactive blocks.

## Why?

Some block are issued automatically and there are false positives among them. Any moderator can revoke erroneous blocks but it's also desirable to edit the block messages. This may be impossible for two reasons:
1. Revoked block is already expired.
2. Revoked block was created by a different moderator.

This PR removes reason 1.