### PR TITLE
Use assert_not_predicate instead of assert_not next to assert_predicate

### DIFF
--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -87,7 +87,7 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:administrator_user))
     post resolve_issue_path(:id => issue)
     assert_redirected_to :controller => :errors, :action => :not_found
-    assert_not issue.reload.resolved?
+    assert_not_predicate issue.reload, :resolved?
 
     # Resolve issue as moderator
     session_for(create(:moderator_user))
@@ -113,7 +113,7 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:moderator_user))
     post resolve_issue_path(:id => issue)
     assert_redirected_to :controller => :errors, :action => :not_found
-    assert_not issue.reload.resolved?
+    assert_not_predicate issue.reload, :resolved?
 
     # Resolve issue as administrator
     session_for(create(:administrator_user))
@@ -139,7 +139,7 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:administrator_user))
     post ignore_issue_path(:id => issue)
     assert_redirected_to :controller => :errors, :action => :not_found
-    assert_not issue.reload.ignored?
+    assert_not_predicate issue.reload, :ignored?
 
     # Ignore issue as moderator
     session_for(create(:moderator_user))
@@ -165,7 +165,7 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:moderator_user))
     post ignore_issue_path(:id => issue)
     assert_redirected_to :controller => :errors, :action => :not_found
-    assert_not issue.reload.ignored?
+    assert_not_predicate issue.reload, :ignored?
 
     # Ignore issue as administrator
     session_for(create(:administrator_user))
@@ -193,7 +193,7 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:administrator_user))
     post reopen_issue_path(:id => issue)
     assert_redirected_to :controller => :errors, :action => :not_found
-    assert_not issue.reload.open?
+    assert_not_predicate issue.reload, :open?
 
     # Reopen issue as moderator
     session_for(create(:moderator_user))
@@ -221,7 +221,7 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
     session_for(create(:moderator_user))
     post reopen_issue_path(:id => issue)
     assert_redirected_to :controller => :errors, :action => :not_found
-    assert_not issue.reload.open?
+    assert_not_predicate issue.reload, :open?
 
     # Reopen issue as administrator
     session_for(create(:administrator_user))

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -111,10 +111,10 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user)
 
     user.display_name = "user_#{existing_user.id}"
-    assert_not user.valid?, "user_<id> name is valid for existing user id when it shouldn't be"
+    assert_not_predicate user, :valid?, "user_<id> name is valid for existing user id when it shouldn't be"
 
     user.display_name = "user_#{existing_user.id + 1}"
-    assert_not user.valid?, "user_<id> name is valid for new user id when it shouldn't be"
+    assert_not_predicate user, :valid?, "user_<id> name is valid for new user id when it shouldn't be"
   end
 
   def test_display_name_user_id_rename
@@ -122,7 +122,7 @@ class UserTest < ActiveSupport::TestCase
     user = create(:user)
 
     user.display_name = "user_#{existing_user.id}"
-    assert_not user.valid?, "user_<id> name is valid for existing user id when it shouldn't be"
+    assert_not_predicate user, :valid?, "user_<id> name is valid for existing user id when it shouldn't be"
 
     user.display_name = "user_#{user.id}"
     assert_predicate user, :valid?, "user_<id> name is invalid for own id, when it should be"


### PR DESCRIPTION
Rubocop would complain about something like `assert issue.open?` and it gets changed to `assert_predicate`, but `assert_not issue.open?` is left alone for some reason.

I already did this change in #4454. I guess I missed some.