### PR TITLE
Add expiry for OAuth 2 grants and tokens

### DIFF
--- a/script/cleanup
+++ b/script/cleanup
@@ -6,4 +6,7 @@ OauthNonce.where("timestamp < EXTRACT(EPOCH FROM NOW() - INTERVAL '1 day')").del
 OauthToken.where("invalidated_at < NOW() - INTERVAL '28 days'").delete_all
 RequestToken.where("authorized_at IS NULL AND created_at < NOW() - INTERVAL '28 days'").delete_all
 
+Doorkeeper::AccessGrant.where("revoked_at < NOW() - INTERVAL '28 days' OR (created_at + expires_in * INTERVAL '1 second') < NOW() - INTERVAL '28 days'").delete_all
+Doorkeeper::AccessToken.where("revoked_at < NOW() - INTERVAL '28 days' OR (created_at + expires_in * INTERVAL '1 second') < NOW() - INTERVAL '28 days'").delete_all
+
 exit 0


### PR DESCRIPTION
This extends the existing cleanup script that runs every night in production to deal with OAuth 2 grants and tokens.