### PR TITLE
Convert tests using OAuth 1 tokens to use OAuth 2 tokens

### DIFF
--- a/test/abilities/api_capability_test.rb
+++ b/test/abilities/api_capability_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
   test "as a normal user with permissionless token" do
-    token = create(:access_token)
+    token = create(:oauth_access_token)
     capability = ApiCapability.new token
 
     [:create, :destroy, :restore].each do |action|
@@ -12,8 +12,8 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "as a normal user with allow_write_api token" do
-    token = create(:access_token, :allow_write_api => true)
+  test "as a normal user with write_api token" do
+    token = create(:oauth_access_token, :scopes => %w[write_api])
     capability = ApiCapability.new token
 
     [:destroy, :restore].each do |action|
@@ -26,7 +26,7 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with permissionless token" do
-    token = create(:access_token, :user => create(:moderator_user))
+    token = create(:oauth_access_token, :resource_owner_id => create(:moderator_user).id)
     capability = ApiCapability.new token
 
     [:create, :destroy, :restore].each do |action|
@@ -34,8 +34,8 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "as a moderator with allow_write_api token" do
-    token = create(:access_token, :user => create(:moderator_user), :allow_write_api => true)
+  test "as a moderator with write_api token" do
+    token = create(:oauth_access_token, :resource_owner_id => create(:moderator_user).id, :scopes => %w[write_api])
     capability = ApiCapability.new token
 
     [:create, :destroy, :restore].each do |action|
@@ -46,7 +46,7 @@ end
 
 class NoteApiCapabilityTest < ActiveSupport::TestCase
   test "as a normal user with permissionless token" do
-    token = create(:access_token)
+    token = create(:oauth_access_token)
     capability = ApiCapability.new token
 
     [:create, :comment, :close, :reopen, :destroy].each do |action|
@@ -54,8 +54,8 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "as a normal user with allow_write_notes token" do
-    token = create(:access_token, :allow_write_notes => true)
+  test "as a normal user with write_notes token" do
+    token = create(:oauth_access_token, :scopes => %w[write_notes])
     capability = ApiCapability.new token
 
     [:destroy].each do |action|
@@ -68,7 +68,7 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with permissionless token" do
-    token = create(:access_token, :user => create(:moderator_user))
+    token = create(:oauth_access_token, :resource_owner_id => create(:moderator_user).id)
     capability = ApiCapability.new token
 
     [:destroy].each do |action|
@@ -76,8 +76,8 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "as a moderator with allow_write_notes token" do
-    token = create(:access_token, :user => create(:moderator_user), :allow_write_notes => true)
+  test "as a moderator with write_notes token" do
+    token = create(:oauth_access_token, :resource_owner_id => create(:moderator_user).id, :scopes => %w[write_notes])
     capability = ApiCapability.new token
 
     [:destroy].each do |action|
@@ -95,14 +95,14 @@ class UserApiCapabilityTest < ActiveSupport::TestCase
     end
 
     # A user with empty tokens
-    token = create(:access_token)
+    token = create(:oauth_access_token)
     capability = ApiCapability.new token
 
     [:index, :show, :update_all, :update, :destroy].each do |act|
       assert capability.cannot? act, UserPreference
     end
 
-    token = create(:access_token, :allow_read_prefs => true)
+    token = create(:oauth_access_token, :scopes => %w[read_prefs])
     capability = ApiCapability.new token
 
     [:update_all, :update, :destroy].each do |act|
@@ -113,7 +113,7 @@ class UserApiCapabilityTest < ActiveSupport::TestCase
       assert capability.can? act, UserPreference
     end
 
-    token = create(:access_token, :allow_write_prefs => true)
+    token = create(:oauth_access_token, :scopes => %w[write_prefs])
     capability = ApiCapability.new token
 
     [:index, :show].each do |act|

--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -303,11 +303,11 @@ module Api
     # But writing oauth tests is hard, and so it's easier to put in a controller test.)
     def test_api_write_and_terms_agreed_via_token
       user = create(:user, :terms_agreed => nil)
-      token = create(:access_token, :user => user, :allow_write_api => true)
+      token = create(:oauth_access_token, :resource_owner_id => user.id, :scopes => %w[write_api])
       changeset = create(:changeset, :closed)
 
       assert_difference "ChangesetComment.count", 0 do
-        signed_post changeset_comment_path(:id => changeset), :params => { :text => "This is a comment" }, :oauth => { :token => token }
+        post changeset_comment_path(:id => changeset), :params => { :text => "This is a comment" }, :headers => bearer_authorization_header(token.token)
       end
       assert_response :forbidden
 
@@ -316,7 +316,7 @@ module Api
       user.save!
 
       assert_difference "ChangesetComment.count", 1 do
-        signed_post changeset_comment_path(:id => changeset), :params => { :text => "This is a comment" }, :oauth => { :token => token }
+        post changeset_comment_path(:id => changeset), :params => { :text => "This is a comment" }, :headers => bearer_authorization_header(token.token)
       end
       assert_response :success
     end

--- a/test/controllers/api/user_preferences_controller_test.rb
+++ b/test/controllers/api/user_preferences_controller_test.rb
@@ -252,10 +252,10 @@ module Api
     # read preferences
     def test_show_using_token
       user = create(:user)
-      token = create(:access_token, :user => user, :allow_read_prefs => true)
+      token = create(:oauth_access_token, :resource_owner_id => user.id, :scopes => %w[read_prefs])
       create(:user_preference, :user => user, :k => "key", :v => "value")
 
-      signed_get user_preference_path(:preference_key => "key"), :oauth => { :token => token }
+      get user_preference_path(:preference_key => "key"), :headers => bearer_authorization_header(token.token)
       assert_response :success
     end
 
@@ -264,10 +264,10 @@ module Api
     # by other methods.
     def test_show_using_token_fail
       user = create(:user)
-      token = create(:access_token, :user => user, :allow_read_prefs => false)
+      token = create(:oauth_access_token, :resource_owner_id => user.id)
       create(:user_preference, :user => user, :k => "key", :v => "value")
 
-      signed_get user_preference_path(:preference_key => "key"), :oauth => { :token => token }
+      get user_preference_path(:preference_key => "key"), :headers => bearer_authorization_header(token.token)
       assert_response :forbidden
     end
   end

--- a/test/factories/oauth_access_token.rb
+++ b/test/factories/oauth_access_token.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :oauth_access_token, :class => "Doorkeeper::AccessToken" do
     application :factory => :oauth_application
+
+    resource_owner_id { create(:user).id }
   end
 end


### PR DESCRIPTION
This converts some tests which are testing OAuth 1 tokens and which don't have an OAuth 2 equivalent to use OAuth 2 instead.