### PR TITLE
Added bootstrap alert when body preview is empty

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -138,7 +138,12 @@ class SiteController < ApplicationController
   end
 
   def preview
-    render :html => RichText.new(params[:type], params[:text]).to_html
+    if params[:text].blank?
+      flash.now[:warning] = t("layouts.nothing_to_preview")
+      render :partial => "layouts/flash"
+    else
+      render :html => RichText.new(params[:type], params[:text]).to_html
+    end
   end
 
   def id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1586,6 +1586,7 @@ en:
     tou: "Terms of Use"
     osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."
     osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential database maintenance work is carried out."
+    nothing_to_preview: "Nothing to preview."
     donate: "Support OpenStreetMap by %{link} to the Hardware Upgrade Fund."
     help: Help
     about: About


### PR DESCRIPTION
PR is alternative to #4894 for displaying indicator, using bootstrap alerts, if (message, diary entry, diary entry comment) body is empty and user selects Preview button.

Fixes #3748. Added check to SiteController#preview to detect if (message, diary entry, diary entry comment) body is empty and if positive, returns rendered bootstrap alert "Nothing to preview" to be displayed in richtext_field.

After:
![image](https://github.com/user-attachments/assets/24e3cfd7-53c5-4d14-afe6-103ca7944988)

