### PR TITLE
Define fixed size for trace images

### DIFF
--- a/app/helpers/trace_helper.rb
+++ b/app/helpers/trace_helper.rb
@@ -2,4 +2,12 @@ module TraceHelper
   def link_to_tag(tag)
     link_to(tag, :tag => tag, :page => nil)
   end
+
+  def trace_icon(trace, options = {})
+    options[:class] ||= "trace_image"
+    options[:alt] ||= ""
+
+    image_tag trace_icon_path(trace.user, trace),
+              options.merge(:size => 50)
+  end
 end

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -2,7 +2,7 @@
   <td>
     <% if Settings.status != "gpx_offline" %>
       <% if trace.inserted %>
-        <%= link_to image_tag(trace_icon_path(trace.user, trace), :alt => "", :class => "trace_image"),
+        <%= link_to trace_icon(trace),
                     show_trace_path(trace.user, trace),
                     :class => "d-inline-block" %>
       <% else %>


### PR DESCRIPTION
Since [loading trace images](https://www.openstreetmap.org/traces) from AWS S3 might take a bit, users are currently experiencing a re-rendering of the page. I found this a bit annoying, and added a fixed 50x50 size for the trace png now. With the change in place, the re-rendering of the page no longer happens. The trace png is shown initially as a blank spot.

### Situation before:
#### First rendering (w/o images)
![image](https://github.com/user-attachments/assets/4632f6cf-c9b8-429b-ae5f-45144671f24b)

#### Second rendering (w/ images)
![image](https://github.com/user-attachments/assets/03aeab0e-6a3a-4f76-b4bc-2965c9ba32db)

### Situation with PR:
#### Blank spot with 50x50 shown as long as image hasn't been loaded yet. No re-rendering of the page
![image](https://github.com/user-attachments/assets/b916dd02-46b6-4cfb-887e-1a914e238363)


