### PR TITLE
Infinite scroll - Issues page

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -57,7 +57,7 @@ class Ability
 
         if user.moderator?
           can [:hide, :unhide], [DiaryEntry, DiaryComment]
-          can [:index, :show, :resolve, :ignore, :reopen], Issue
+          can [:index, :show, :resolve, :ignore, :reopen, :page], Issue
           can :create, IssueComment
           can [:new, :create, :edit, :update, :destroy], Redaction
           can [:new, :edit, :create, :update, :revoke, :revoke_all], UserBlock
@@ -65,7 +65,7 @@ class Ability
 
         if user.administrator?
           can [:hide, :unhide], [DiaryEntry, DiaryComment]
-          can [:index, :show, :resolve, :ignore, :reopen], Issue
+          can [:index, :show, :resolve, :ignore, :reopen, :page], Issue
           can :create, IssueComment
           can [:set_status, :destroy, :index], User
           can [:grant, :revoke], UserRole

--- a/app/assets/javascripts/issues.js
+++ b/app/assets/javascripts/issues.js
@@ -1,0 +1,48 @@
+$(document).ready(function () {
+  let beforeInput;
+
+  function fetchIssues() {
+    const data = {
+      limit: 50
+    };
+
+    if (beforeInput) {
+      data.before = beforeInput.value;
+      beforeInput.remove();
+    }
+
+    $.ajax({
+      oauth: true,
+      url:
+        window.location.origin +
+        window.location.pathname +
+        "/page" +
+        window.location.search,
+      data,
+      cache: false
+    }).done(function (result) {
+      $("#reports_table").append($(result));
+      beforeInput = $("input[name='before']")[0];
+
+      if (!beforeInput) {
+        $("#reports_loading").remove();
+      }
+    });
+  }
+
+  let options = {
+    root: null,
+    threshold: 0.1
+  };
+
+  function handleIntersect(entries) {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        fetchIssues();
+      }
+    });
+  }
+
+  const observer = new IntersectionObserver(handleIntersect, options);
+  observer.observe($("#reports_loading")[0]);
+});

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -1,0 +1,27 @@
+<% @issues.each do |issue| %>
+    <tr>
+        <td><%= t ".states.#{issue.status}" %></td>
+        <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
+        <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
+        <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
+        <td>
+        <% if issue.user_updated %>
+            <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated), :time_ago => friendly_date_ago(issue.updated_at) %>
+        <% else %>
+            <%= friendly_date_ago(issue.updated_at) %>
+        <% end %>
+        </td>
+    </tr>
+<% end %>
+
+<% if @issues.length != 0 && @older_issues_id != nil %>
+    <tr class="d-none">
+        <td>
+            <input type="hidden" name="before" value="<%= @older_issues_id %>" disabled>
+        </td>
+    </tr>
+<% elsif @issues.length == 0 && @older_issues_id == nil && params[:before] == nil %>
+    <tr>
+        <td colspan="5" class="text-center border-bottom-0"><%= @user_not_found_error || (t ".issues_not_found") %></td>
+    </tr>
+<% end %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for :heading do %>
+  <%= javascript_include_tag "issues" %>
   <h1><%= t ".title" %></h1>
 <% end %>
 
@@ -40,36 +41,21 @@
   </div>
 <% end %>
 
-<% if @issues.length == 0 %>
-  <p><%= t ".issues_not_found" %></p>
-<% else %>
-  <table class="table table-sm">
-    <thead>
-      <tr>
-        <th><%= t ".status" %></th>
-        <th><%= t ".reports" %></th>
-        <th><%= t ".reported_item" %></th>
-        <th><%= t ".reported_user" %></th>
-        <th><%= t ".last_updated" %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @issues.each do |issue| %>
-        <tr>
-          <td><%= t ".states.#{issue.status}" %></td>
-          <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
-          <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
-          <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
-          <td>
-            <% if issue.user_updated %>
-              <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),
-                                                        :time_ago => friendly_date_ago(issue.updated_at) %>
-            <% else %>
-              <%= friendly_date_ago(issue.updated_at) %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th><%= t ".status" %></th>
+      <th><%= t ".reports" %></th>
+      <th><%= t ".reported_item" %></th>
+      <th><%= t ".reported_user" %></th>
+      <th><%= t ".last_updated" %></th>
+    </tr>
+  </thead>
+  <tbody id="reports_table">
+  </tbody>
+</table>
+<div id="reports_loading" class="d-flex justify-content-center">
+  <div class="spinner-border" role="status">
+    <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1465,17 +1465,22 @@ en:
       not_updated: Not Updated
       search: Search
       search_guidance: "Search Issues:"
-      user_not_found: User does not exist
-      issues_not_found: No such issues found
       status: Status
       reports: Reports
       last_updated: Last Updated
-      last_updated_time_ago_user_html: "%{time_ago} by %{user}"
+      states:
+        ignored: Ignored
+        open: Open
+        resolved: Resolved
       link_to_reports: View Reports
+      reported_item: Reported Item
+    page:
+      user_not_found: User does not exist
+      issues_not_found: No such issues found
+      last_updated_time_ago_user_html: "%{time_ago} by %{user}"
       reports_count:
         one: "%{count} Report"
         other: "%{count} Reports"
-      reported_item: Reported Item
       states:
         ignored: Ignored
         open: Open

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,6 +335,9 @@ OpenStreetMap::Application.routes.draw do
       post "ignore"
       post "reopen"
     end
+    collection do
+      get "page"
+    end
   end
 
   resources :reports

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -19,7 +19,7 @@ class IssuesTest < ApplicationSystemTestCase
     sign_in_as(create(:moderator_user))
 
     visit issues_path
-    assert_content I18n.t("issues.index.issues_not_found")
+    assert_content I18n.t("issues.page.issues_not_found")
   end
 
   def test_view_issues
@@ -81,22 +81,22 @@ class IssuesTest < ApplicationSystemTestCase
     visit issues_path
     fill_in "search_by_user", :with => good_user.display_name
     click_on "Search"
-    assert_no_content I18n.t("issues.index.user_not_found")
-    assert_content I18n.t("issues.index.issues_not_found")
+    assert_no_content I18n.t("issues.page.user_not_found")
+    assert_content I18n.t("issues.page.issues_not_found")
 
     # User doesn't exist
     visit issues_path
     fill_in "search_by_user", :with => "Nonexistent User"
     click_on "Search"
-    assert_content I18n.t("issues.index.user_not_found")
-    assert_content I18n.t("issues.index.issues_not_found")
+    assert_content I18n.t("issues.page.user_not_found")
+    assert_no_content I18n.t("issues.page.issues_not_found")
 
     # Find Issue against bad_user
     visit issues_path
     fill_in "search_by_user", :with => bad_user.display_name
     click_on "Search"
-    assert_no_content I18n.t("issues.index.user_not_found")
-    assert_no_content I18n.t("issues.index.issues_not_found")
+    assert_no_content I18n.t("issues.page.user_not_found")
+    assert_no_content I18n.t("issues.page.issues_not_found")
   end
 
   def test_commenting
@@ -158,7 +158,22 @@ class IssuesTest < ApplicationSystemTestCase
 
     visit issues_path
 
-    assert_link I18n.t("issues.index.reports_count", :count => issue1.reports_count), :href => issue_path(issue1)
-    assert_link I18n.t("issues.index.reports_count", :count => issue2.reports_count), :href => issue_path(issue2)
+    assert_link I18n.t("issues.page.reports_count", :count => issue1.reports_count), :href => issue_path(issue1)
+    assert_link I18n.t("issues.page.reports_count", :count => issue2.reports_count), :href => issue_path(issue2)
+  end
+
+  def test_infinite_scroll_issues
+    1.upto(100).each do
+      user = create(:user)
+      create(:issue, :reportable => user, :reported_user => user, :assigned_role => "administrator")
+    end
+
+    sign_in_as(create(:administrator_user))
+
+    visit issues_path
+
+    assert_no_content I18n.t("issues.page.user_not_found")
+    assert_no_content I18n.t("issues.page.issues_not_found")
+    assert_css "tr", :count => 51
   end
 end


### PR DESCRIPTION
This PR addresses heavy calls and long load time of the Issues page. Problem was mentioned in https://github.com/openstreetmap/openstreetmap-website/pull/4990 by @AntonKhorev.

Added infinite scroll functionality. On the first load, there will be only loader and after that, every time loader will be shown on the screen, new 50 issues will be called and displayed. In terms of performance, locally I have 1000 users and 1000 issues. First load time was decreased from ~8s to ~1s, and after that every call for the next 50 issues takes ~150ms. In real environment, it will have much better improvement, as instead of searching for 30000 issues, it will take only 50 (in theory, the difference should be 30x better in the real environment, then it is on my local machine).

Video:

https://github.com/user-attachments/assets/33254baf-f553-4a27-8b3e-9ce651a08c53

Issues not found:

![image](https://github.com/user-attachments/assets/ea28ad5e-aeb0-4ae9-aa64-e337e1c72b6f)

User not found:

![image](https://github.com/user-attachments/assets/95695949-3136-4e41-a9c5-e91de6e8c3e5)

