### PR TITLE
Add planet link and explanation to robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,8 @@
+# OpenStreetMap's data is available for free in bulk from https://planet.openstreetmap.org
+# We encourage you to use these instead of scraping our site.
+# Scraping puts a high load on our donated resources and will lead to your IP being blocked.
+# Please respect our resources, and help us keep the service free and accessible for everyone.
+
 User-agent: *
 Disallow: /user/*/traces/
 Allow: /user/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 # OpenStreetMap's data is available for free in bulk from https://planet.openstreetmap.org
+# For regional extracts and documentation, see https://wiki.openstreetmap.org/wiki/Planet.osm
 # We encourage you to use these instead of scraping our site.
 # Scraping puts a high load on our donated resources and will lead to your IP being blocked.
 # Please respect our resources, and help us keep the service free and accessible for everyone.


### PR DESCRIPTION
Recent scraping incidents have made think that a friendly pointer to planet.osm.org probably wouldn't hurt.