### PR TITLE
Don't pass width/height to user menu thumbnail

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -82,7 +82,7 @@
     <% if current_user && current_user.id %>
       <div class='d-inline-flex dropdown user-menu logged-in'>
         <button class='d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
-          <%= user_thumbnail_tiny(current_user, :width => 25, :height => 25, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
+          <%= user_thumbnail_tiny(current_user, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
           <% if current_user.new_messages.size > 0 %>
             <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
           <% end %>


### PR DESCRIPTION
We have user image helpers:
https://github.com/openstreetmap/openstreetmap-website/blob/bbd6140f4bdc7746ecbd4d109316b2dd0b6d047f/app/helpers/user_helper.rb#L4-L41

But there's something suspicious in their code. `options` has different keys merged in different places: sometimes it's `:size`, sometimes it's `:width`/`:height`. Are we supposed to be able to pass our own size to the helpers? If yes, which keys should we use?

Easier question is *do we actually try to pass our own size*? There's only one place where we do, the one I remove in this pull request. Does it have any effect, given that helpers sometimes overwrite it? There are different code paths depending on the type of the image. The only path that uses those `:width => 25, :height => 25` is unprocessed attached image, when this overwrite doesn't happen because we don't yet know the actual image size:
https://github.com/openstreetmap/openstreetmap-website/blob/bbd6140f4bdc7746ecbd4d109316b2dd0b6d047f/app/helpers/user_helper.rb#L91-L92

But we don't really need to set this image size because we override it with css:
https://github.com/openstreetmap/openstreetmap-website/blob/bbd6140f4bdc7746ecbd4d109316b2dd0b6d047f/app/assets/stylesheets/common.scss#L789-L803

It's easier not to pass image sizes to helpers. We won't have then to think whether it's `:size`, `:width`/`:height` or [all of them](https://github.com/openstreetmap/openstreetmap-website/commit/4ef7b2c651e20f147719f3ff0bec0dc6bfd7ea2c).