### PR TITLE
Trace import: remove activerecord-import gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ gem "file_exists"
 
 # Load rails plugins
 gem "actionpack-page_caching", ">= 1.2.0"
-gem "activerecord-import"
 gem "active_record_union"
 gem "bootstrap", "~> 5.3.2"
 gem "bootstrap_form", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,6 @@ GEM
       activemodel (= 7.2.1.2)
       activesupport (= 7.2.1.2)
       timeout (>= 0.4.0)
-    activerecord-import (1.8.1)
-      activerecord (>= 4.2)
     activestorage (7.2.1.2)
       actionpack (= 7.2.1.2)
       activejob (= 7.2.1.2)
@@ -667,7 +665,6 @@ DEPENDENCIES
   aasm
   actionpack-page_caching (>= 1.2.0)
   active_record_union
-  activerecord-import
   addressable (~> 2.8)
   annotate
   argon2

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -230,16 +230,17 @@ class Trace < ApplicationRecord
           tp.timestamp = point.timestamp
           tp.gpx_id = id
           tp.trackid = point.segment
+          tp.validate!
           tracepoints << tp
         end
 
-        # Run the before_save and before_create callbacks, and then import them in bulk with activerecord-import
+        # Run the before_save and before_create callbacks, and then do a bulk insert
         tracepoints.each do |tp|
           tp.run_callbacks(:save) { false }
           tp.run_callbacks(:create) { false }
         end
 
-        Tracepoint.import!(tracepoints)
+        Tracepoint.insert_all!(tracepoints.map(&:attributes)) # rubocop:disable Rails::SkipsModelValidations
       end
 
       if gpx.actual_points.positive?


### PR DESCRIPTION
This PR removes the activerecord-import dependency and changes the tracepoint import to use `import_all!` instead.

I hope I didn't miss anything here. In particular `Tracepoint.insert_all!(tracepoints.map(&:attributes))` would need a review if that's the proper way to import Tracepoint instances. 

Fixes #4994