### PR TITLE
Detect <img> images in markdown rich text

### DIFF
--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -104,13 +104,16 @@ module RichText
     end
 
     def first_image_element(element)
-      return element if element.type == :img ||
-                        (element.type == :html_element && element.value == "img")
+      return element if image?(element) && element.attr["src"].present?
 
       element.children.find do |child|
         nested_image = first_image_element(child)
         break nested_image if nested_image
       end
+    end
+
+    def image?(element)
+      element.type == :img || (element.type == :html_element && element.value == "img")
     end
   end
 

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -104,7 +104,8 @@ module RichText
     end
 
     def first_image_element(element)
-      return element if element.type == :img
+      return element if element.type == :img ||
+                        (element.type == :html_element && element.value == "img")
 
       element.children.find do |child|
         nested_image = first_image_element(child)

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -275,9 +275,39 @@ class RichTextTest < ActiveSupport::TestCase
     assert_equal "https://example.com/image1.jpg", r.image
   end
 
+  def test_markdown_image_with_empty_src
+    r = RichText.new("markdown", "![invalid]()")
+    assert_nil r.image
+  end
+
+  def test_markdown_skip_image_with_empty_src
+    r = RichText.new("markdown", "![invalid]() ![valid](https://example.com/valid.gif)")
+    assert_equal "https://example.com/valid.gif", r.image
+  end
+
   def test_markdown_html_image
     r = RichText.new("markdown", "<img src='https://example.com/img_element.png'>")
     assert_equal "https://example.com/img_element.png", r.image
+  end
+
+  def test_markdown_html_image_with_empty_src
+    r = RichText.new("markdown", "<img src=''>")
+    assert_nil r.image
+  end
+
+  def test_markdown_skip_html_image_with_empty_src
+    r = RichText.new("markdown", "<img src=''> <img src='https://example.com/next_img_element.png'>")
+    assert_equal "https://example.com/next_img_element.png", r.image
+  end
+
+  def test_markdown_html_image_without_src
+    r = RichText.new("markdown", "<img>")
+    assert_nil r.image
+  end
+
+  def test_markdown_skip_html_image_without_src
+    r = RichText.new("markdown", "<img> <img src='https://example.com/next_img_element.png'>")
+    assert_equal "https://example.com/next_img_element.png", r.image
   end
 
   private

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -275,6 +275,11 @@ class RichTextTest < ActiveSupport::TestCase
     assert_equal "https://example.com/image1.jpg", r.image
   end
 
+  def test_markdown_html_image
+    r = RichText.new("markdown", "<img src='https://example.com/img_element.png'>")
+    assert_equal "https://example.com/img_element.png", r.image
+  end
+
   private
 
   def assert_html(richtext, &block)


### PR DESCRIPTION
It's possible to add images to markdown rich text without the `![]()` syntax, by using html `<img ...>`. Such images are not detected by #4882 because they have a different type in the kramdown parse tree. This PR enables detection of `<img ...>`.
