### PR TITLE
Replace richtext edit/preview buttons with tabs

### DIFF
--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -14,9 +14,6 @@ $(document).ready(function () {
   /* Disable all the edit buttons */
   $(".richtext_doedit").prop("disabled", true);
 
-  /* Enable the preview buttons */
-  $(".richtext_dopreview").prop("disabled", false);
-
   /*
    * Install a click handler to switch to edit mode when the
    * edit button is pressed.
@@ -28,8 +25,8 @@ $(document).ready(function () {
     preview.hide();
     editor.show();
 
-    $(this).siblings(".richtext_dopreview").prop("disabled", false);
-    $(this).prop("disabled", true);
+    $(this).parents(".richtext_container").find(".richtext_dopreview").prop("disabled", false).removeClass("active");
+    $(this).prop("disabled", true).addClass("active");
   });
 
   /*
@@ -56,7 +53,7 @@ $(document).ready(function () {
     preview.css("min-height", minHeight + "px");
     preview.show();
 
-    $(this).siblings(".richtext_doedit").prop("disabled", false);
-    $(this).prop("disabled", true);
+    $(this).parents(".richtext_container").find(".richtext_doedit").prop("disabled", false).removeClass("active");
+    $(this).prop("disabled", true).addClass("active");
   });
 });

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -1,7 +1,4 @@
 $(document).ready(function () {
-  /* Hide the preview panes */
-  $(".richtext_preview").hide();
-
   /*
    * When the text in an edit pane is changed, clear the contents of
    * the associated preview pne so that it will be regenerated when
@@ -11,29 +8,10 @@ $(document).ready(function () {
     $(this).parents(".richtext_container").find(".richtext_preview").empty();
   });
 
-  /* Disable all the edit buttons */
-  $(".richtext_doedit").prop("disabled", true);
-
   /*
-   * Install a click handler to switch to edit mode when the
-   * edit button is pressed.
+   * Install a handler to switch to preview mode
    */
-  $(".richtext_doedit").click(function () {
-    var editor = $(this).parents(".richtext_container").find("textarea");
-    var preview = $(this).parents(".richtext_container").find(".richtext_preview");
-
-    preview.hide();
-    editor.show();
-
-    $(this).parents(".richtext_container").find(".richtext_dopreview").prop("disabled", false).removeClass("active");
-    $(this).prop("disabled", true).addClass("active");
-  });
-
-  /*
-   * Install a click handler to switch to preview mode when the
-   * preview button is pressed.
-   */
-  $(".richtext_dopreview").click(function () {
+  $(".richtext_dopreview").on("show.bs.tab", function () {
     var editor = $(this).parents(".richtext_container").find("textarea");
     var preview = $(this).parents(".richtext_container").find(".richtext_preview");
     var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
@@ -49,11 +27,6 @@ $(document).ready(function () {
       });
     }
 
-    editor.hide();
     preview.css("min-height", minHeight + "px");
-    preview.show();
-
-    $(this).parents(".richtext_container").find(".richtext_doedit").prop("disabled", false).removeClass("active");
-    $(this).prop("disabled", true).addClass("active");
   });
 });

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -21,7 +21,7 @@ $(document).ready(function () {
    * Install a click handler to switch to edit mode when the
    * edit button is pressed.
    */
-  $(".richtext_doedit").click(function (event) {
+  $(".richtext_doedit").click(function () {
     var editor = $(this).parents(".richtext_container").find("textarea");
     var preview = $(this).parents(".richtext_container").find(".richtext_preview");
 
@@ -30,15 +30,13 @@ $(document).ready(function () {
 
     $(this).siblings(".richtext_dopreview").prop("disabled", false);
     $(this).prop("disabled", true);
-
-    event.preventDefault();
   });
 
   /*
    * Install a click handler to switch to preview mode when the
    * preview button is pressed.
    */
-  $(".richtext_dopreview").click(function (event) {
+  $(".richtext_dopreview").click(function () {
     var editor = $(this).parents(".richtext_container").find("textarea");
     var preview = $(this).parents(".richtext_container").find(".richtext_preview");
     var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
@@ -60,7 +58,5 @@ $(document).ready(function () {
 
     $(this).siblings(".richtext_doedit").prop("disabled", false);
     $(this).prop("disabled", true);
-
-    event.preventDefault();
   });
 });

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -7,8 +7,8 @@
     <div class="card bg-body-tertiary h-100">
       <div class="card-body">
         <%= render :partial => "shared/#{type}_help" %>
-        <%= submit_tag t(".edit"), :id => "#{id}_doedit", :class => "richtext_doedit btn btn-primary", :disabled => true %>
-        <%= submit_tag t(".preview"), :id => "#{id}_dopreview", :class => "richtext_dopreview btn btn-primary" %>
+        <%= button_tag t(".edit"), :type => "button", :id => "#{id}_doedit", :class => "richtext_doedit btn btn-primary", :disabled => true %>
+        <%= button_tag t(".preview"), :type => "button", :id => "#{id}_dopreview", :class => "richtext_dopreview btn btn-primary" %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -1,5 +1,13 @@
 <div id="<%= id %>_container" class="row richtext_container">
   <div id="<%= id %>_content" class="col-sm-8 mb-3 mb-sm-0 richtext_content">
+    <ul class="nav nav-tabs mb-3" role="tablist">
+      <li class="nav-item">
+        <button type="button" class="nav-link active richtext_doedit"><%= t(".edit") %></button>
+      </li>
+      <li class="nav-item">
+        <button type="button" class="nav-link richtext_dopreview"><%= t(".preview") %></button>
+      </li>
+    </ul>
     <%= builder.text_area(attribute, options.merge(:wrapper => false, "data-preview-url" => preview_url(:type => type))) %>
     <div id="<%= id %>_preview" class="richtext_preview richtext text-break"></div>
   </div>
@@ -7,8 +15,6 @@
     <div class="card bg-body-tertiary h-100">
       <div class="card-body">
         <%= render :partial => "shared/#{type}_help" %>
-        <%= button_tag t(".edit"), :type => "button", :id => "#{id}_doedit", :class => "richtext_doedit btn btn-primary", :disabled => true %>
-        <%= button_tag t(".preview"), :type => "button", :id => "#{id}_dopreview", :class => "richtext_dopreview btn btn-primary" %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -2,14 +2,18 @@
   <div id="<%= id %>_content" class="col-sm-8 mb-3 mb-sm-0 richtext_content">
     <ul class="nav nav-tabs mb-3" role="tablist">
       <li class="nav-item">
-        <button type="button" class="nav-link active richtext_doedit"><%= t(".edit") %></button>
+        <button type="button" class="nav-link active" data-bs-toggle="tab" data-bs-target="#<%= id %>_edit"><%= t(".edit") %></button>
       </li>
       <li class="nav-item">
-        <button type="button" class="nav-link richtext_dopreview"><%= t(".preview") %></button>
+        <button type="button" class="nav-link richtext_dopreview" data-bs-toggle="tab" data-bs-target="#<%= id %>_preview"><%= t(".preview") %></button>
       </li>
     </ul>
-    <%= builder.text_area(attribute, options.merge(:wrapper => false, "data-preview-url" => preview_url(:type => type))) %>
-    <div id="<%= id %>_preview" class="richtext_preview richtext text-break"></div>
+    <div class="tab-content">
+      <div id="<%= id %>_edit" class="tab-pane show active">
+        <%= builder.text_area(attribute, options.merge(:wrapper => false, "data-preview-url" => preview_url(:type => type))) %>
+      </div>
+      <div id="<%= id %>_preview" class="tab-pane richtext_preview richtext text-break"></div>
+    </div>
   </div>
   <div id="<%= id %>_help" class="col-sm-4 richtext_help">
     <div class="card bg-body-tertiary h-100">

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -119,9 +119,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
         assert_select "input#latitude[name='diary_entry[latitude]']", :count => 1
         assert_select "input#longitude[name='diary_entry[longitude]']", :count => 1
         assert_select "input[name=commit][type=submit][value=Publish]", :count => 1
-        assert_select "input[name=commit][type=submit][value=Edit]", :count => 1
-        assert_select "input[name=commit][type=submit][value=Preview]", :count => 1
-        assert_select "input", :count => 6
+        assert_select "button[type=button]", :text => "Edit", :count => 1
+        assert_select "button[type=button]", :text => "Preview", :count => 1
+        assert_select "input", :count => 4
       end
     end
   end
@@ -272,9 +272,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
         assert_select "input#latitude[name='diary_entry[latitude]']", :count => 1
         assert_select "input#longitude[name='diary_entry[longitude]']", :count => 1
         assert_select "input[name=commit][type=submit][value=Update]", :count => 1
-        assert_select "input[name=commit][type=submit][value=Edit]", :count => 1
-        assert_select "input[name=commit][type=submit][value=Preview]", :count => 1
-        assert_select "input", :count => 7
+        assert_select "button[type=button]", :text => "Edit", :count => 1
+        assert_select "button[type=button]", :text => "Preview", :count => 1
+        assert_select "input", :count => 5
       end
     end
 


### PR DESCRIPTION
Why are the *Edit* and *Preview* buttons inside the help card? The *Preview* button there makes it inconvenient to preview on small screens because you'll have to scroll to the end of the help pane to press the button and then scroll back to see the preview.

Before:
![image](https://github.com/user-attachments/assets/f3b46671-93b1-4b15-8153-753f53dbade5)

After:
![image](https://github.com/user-attachments/assets/5f34545a-e36e-4c88-8762-b3cb30dba400)

Uses https://getbootstrap.com/docs/5.3/components/navs-tabs/#javascript-behavior to switch between tab panes.

Compatible with #5023.