### PR TITLE
Show richtext tabs over secondary body background

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -903,10 +903,12 @@ div.secondary-actions {
 
 /* Rules for tabs inside secondary background sections */
 
-.bg-body-secondary .nav-tabs {
-  --bs-border-color: var(--bs-secondary-border-subtle);
-  --bs-secondary-bg: var(--bs-secondary-border-subtle);
-  margin-bottom: -1px;
+.bg-body-secondary {
+  &.nav-tabs, .nav-tabs {
+    --bs-border-color: var(--bs-secondary-border-subtle);
+    --bs-secondary-bg: var(--bs-secondary-border-subtle);
+    margin-bottom: -1px;
+  }
 }
 
 /* Rules for traces */

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= id %>_container" class="row richtext_container">
   <div id="<%= id %>_content" class="col-sm-8 mb-3 mb-sm-0 richtext_content">
-    <ul class="nav nav-tabs mb-3" role="tablist">
+    <ul class="nav nav-tabs mb-3 bg-body-secondary rounded-top-2" role="tablist">
       <li class="nav-item">
         <button type="button" class="nav-link active" data-bs-toggle="tab" data-bs-target="#<%= id %>_edit"><%= t(".edit") %></button>
       </li>


### PR DESCRIPTION
Addresses https://github.com/openstreetmap/openstreetmap-website/pull/5042#issuecomment-2267514649 by using the same background as in content heading.

![image](https://github.com/user-attachments/assets/8257793e-b3b7-4241-971d-a0b28a100272)
![image](https://github.com/user-attachments/assets/249cca34-fdfb-44a3-a355-2c947c3f5edc)
![image](https://github.com/user-attachments/assets/598a1343-ccc0-4334-b6e3-2ccb201f37f1)
