### PR TITLE
JSON partial rendering in loop

### DIFF
--- a/app/views/api/changesets/index.json.jbuilder
+++ b/app/views/api/changesets/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.partial! "api/root_attributes"
 
-json.changesets(@changesets) do |changeset|
-  json.partial! changeset
+json.changesets do
+  json.array! @changesets, :partial => "changeset", :as => :changeset
 end

--- a/app/views/api/messages/inbox.json.jbuilder
+++ b/app/views/api/messages/inbox.json.jbuilder
@@ -1,5 +1,5 @@
 json.partial! "api/root_attributes"
 
-json.messages(@messages) do |message|
-  json.partial! message
+json.messages do
+  json.array! @messages, :partial => "message", :as => :message
 end

--- a/app/views/api/messages/outbox.json.jbuilder
+++ b/app/views/api/messages/outbox.json.jbuilder
@@ -1,5 +1,5 @@
 json.partial! "api/root_attributes"
 
-json.messages(@messages) do |message|
-  json.partial! message
+json.messages do
+  json.array! @messages, :partial => "message", :as => :message
 end

--- a/app/views/api/notes/index.json.jbuilder
+++ b/app/views/api/notes/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.type "FeatureCollection"
 
-json.features(@notes) do |note|
-  json.partial! note
+json.features do
+  json.array! @notes, :partial => "note", :as => :note
 end

--- a/app/views/api/users/index.json.jbuilder
+++ b/app/views/api/users/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.partial! "api/root_attributes"
 
-json.users(@users) do |user|
-  json.partial! user
+json.users do
+  json.array! @users, :partial => "user", :as => :user
 end


### PR DESCRIPTION
Similar to the change in #4958, this PR addresses the remaining locations where JSON partials were rendered in a loop, instead of using collections.

~NB: 6268335ccdcdcb6629f32e5cae0d182c05b5593a has a typo in the description, it should read "Notes".~

 I split this up into multiple commits, since the changes are in different parts of the API. If that's not needed, please Squash&merge instead.