### PR TITLE
Changeset: avoid XML rendering in loop

### DIFF
--- a/app/views/api/changesets/index.xml.builder
+++ b/app/views/api/changesets/index.xml.builder
@@ -1,7 +1,4 @@
 xml.instruct! :xml, :version => "1.0"
-
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  @changesets.each do |changeset|
-    osm << render(changeset)
-  end
+  osm << (render(@changesets) || "")
 end


### PR DESCRIPTION
XML rendering is much more consistent already. I only found one location where we are still calling `render` inside a loop.