### PR TITLE
Set og:image:alt OpenGraph property

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -69,6 +69,7 @@ class DiaryEntriesController < ApplicationController
     if @entry
       @title = t ".title", :user => params[:display_name], :title => @entry.title
       @og_image = @entry.body.image
+      @og_image_alt = @entry.body.image_alt
       @comments = can?(:unhide, DiaryComment) ? @entry.comments : @entry.visible_comments
     else
       @title = t "diary_entries.no_such_entry.title", :id => params[:id]

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -1,15 +1,16 @@
 module OpenGraphHelper
   require "addressable/uri"
 
-  def opengraph_tags(title = nil, og_image = nil)
+  def opengraph_tags(title = nil, og_image = nil, og_image_alt = nil)
     tags = {
       "og:site_name" => t("layouts.project_name.title"),
       "og:title" => title || t("layouts.project_name.title"),
       "og:type" => "website",
-      "og:image" => og_image_url(og_image),
       "og:url" => url_for(:only_path => false),
       "og:description" => t("layouts.intro_text")
-    }
+    }.merge(
+      opengraph_image_properties(og_image, og_image_alt)
+    )
 
     safe_join(tags.map do |property, content|
       tag.meta(:property => property, :content => content)
@@ -18,12 +19,20 @@ module OpenGraphHelper
 
   private
 
-  def og_image_url(og_image)
+  def opengraph_image_properties(og_image, og_image_alt)
     begin
-      return Addressable::URI.join(root_url, og_image).normalize if og_image
+      if og_image
+        properties = {}
+        properties["og:image"] = Addressable::URI.join(root_url, og_image).normalize
+        properties["og:image:alt"] = og_image_alt if og_image_alt
+        return properties
+      end
     rescue Addressable::URI::InvalidURIError
       # return default image
     end
-    image_url("osm_logo_256.png")
+    {
+      "og:image" => image_url("osm_logo_256.png"),
+      "og:image:alt" => t("layouts.logo.alt_text")
+    }
   end
 end

--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -21,7 +21,7 @@
 <% end -%>
 <%= tag.link :rel => "search", :type => "application/opensearchdescription+xml", :title => "OpenStreetMap Search", :href => asset_path("osm.xml") %>
 <%= tag.meta :name => "description", :content => "OpenStreetMap is the free wiki world map." %>
-<%= opengraph_tags(@title, @og_image) %>
+<%= opengraph_tags(@title, @og_image, @og_image_alt) %>
 <% if flash[:matomo_goal] -%>
 <%= tag.meta :name => "matomo-goal", :content => flash[:matomo_goal] %>
 <% end -%>

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -53,6 +53,10 @@ module RichText
       nil
     end
 
+    def image_alt
+      nil
+    end
+
     protected
 
     def simple_format(text)
@@ -92,9 +96,13 @@ module RichText
     end
 
     def image
-      return @image if defined? @image
+      @image_element = first_image_element(document.root) unless defined? @image_element
+      @image_element.attr["src"] if @image_element
+    end
 
-      @image = first_image_element(document.root)&.attr&.[]("src")
+    def image_alt
+      @image_element = first_image_element(document.root) unless defined? @image_element
+      @image_element.attr["alt"] if @image_element
     end
 
     private

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -657,6 +657,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_dom "head meta[property='og:image']" do
       assert_dom "> @content", ActionController::Base.helpers.image_url("osm_logo_256.png", :host => root_url)
     end
+    assert_dom "head meta[property='og:image:alt']" do
+      assert_dom "> @content", "OpenStreetMap logo"
+    end
   end
 
   def test_show_og_image
@@ -667,6 +670,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_dom "head meta[property='og:image']" do
       assert_dom "> @content", "https://example.com/picture.jpg"
+    end
+    assert_dom "head meta[property='og:image:alt']" do
+      assert_dom "> @content", "some picture"
     end
   end
 
@@ -679,6 +685,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_dom "head meta[property='og:image']" do
       assert_dom "> @content", "#{root_url}picture.jpg"
     end
+    assert_dom "head meta[property='og:image:alt']" do
+      assert_dom "> @content", "some local picture"
+    end
   end
 
   def test_show_og_image_with_spaces
@@ -689,6 +698,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_dom "head meta[property='og:image']" do
       assert_dom "> @content", "https://example.com/the%20picture.jpg"
+    end
+    assert_dom "head meta[property='og:image:alt']" do
+      assert_dom "> @content", "some picture"
     end
   end
 
@@ -701,6 +713,9 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_dom "head meta[property='og:image']" do
       assert_dom "> @content", "#{root_url}the%20picture.jpg"
     end
+    assert_dom "head meta[property='og:image:alt']" do
+      assert_dom "> @content", "some local picture"
+    end
   end
 
   def test_show_og_image_with_invalid_uri
@@ -712,6 +727,21 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_dom "head meta[property='og:image']" do
       assert_dom "> @content", ActionController::Base.helpers.image_url("osm_logo_256.png", :host => root_url)
     end
+    assert_dom "head meta[property='og:image:alt']" do
+      assert_dom "> @content", "OpenStreetMap logo"
+    end
+  end
+
+  def test_show_og_image_without_alt
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :body => "<img src='https://example.com/no_alt.gif'>")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='og:image']" do
+      assert_dom "> @content", "https://example.com/no_alt.gif"
+    end
+    assert_dom "head meta[property='og:image:alt']", :count => 0
   end
 
   def test_hide

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -253,61 +253,79 @@ class RichTextTest < ActiveSupport::TestCase
   def test_text_no_image
     r = RichText.new("text", "foo https://example.com/ bar")
     assert_nil r.image
+    assert_nil r.image_alt
   end
 
   def test_html_no_image
     r = RichText.new("html", "foo <a href='https://example.com/'>bar</a> baz")
     assert_nil r.image
+    assert_nil r.image_alt
   end
 
   def test_markdown_no_image
     r = RichText.new("markdown", "foo [bar](https://example.com/) baz")
     assert_nil r.image
+    assert_nil r.image_alt
   end
 
   def test_markdown_image
     r = RichText.new("markdown", "foo ![bar](https://example.com/image.jpg) baz")
     assert_equal "https://example.com/image.jpg", r.image
+    assert_equal "bar", r.image_alt
   end
 
   def test_markdown_first_image
     r = RichText.new("markdown", "foo ![bar1](https://example.com/image1.jpg) baz\nfoo ![bar2](https://example.com/image2.jpg) baz")
     assert_equal "https://example.com/image1.jpg", r.image
+    assert_equal "bar1", r.image_alt
   end
 
   def test_markdown_image_with_empty_src
     r = RichText.new("markdown", "![invalid]()")
     assert_nil r.image
+    assert_nil r.image_alt
   end
 
   def test_markdown_skip_image_with_empty_src
     r = RichText.new("markdown", "![invalid]() ![valid](https://example.com/valid.gif)")
     assert_equal "https://example.com/valid.gif", r.image
+    assert_equal "valid", r.image_alt
   end
 
   def test_markdown_html_image
+    r = RichText.new("markdown", "<img src='https://example.com/img_element.png' alt='alt text here'>")
+    assert_equal "https://example.com/img_element.png", r.image
+    assert_equal "alt text here", r.image_alt
+  end
+
+  def test_markdown_html_image_without_alt
     r = RichText.new("markdown", "<img src='https://example.com/img_element.png'>")
     assert_equal "https://example.com/img_element.png", r.image
+    assert_nil r.image_alt
   end
 
   def test_markdown_html_image_with_empty_src
-    r = RichText.new("markdown", "<img src=''>")
+    r = RichText.new("markdown", "<img src='' alt='forgot src'>")
     assert_nil r.image
+    assert_nil r.image_alt
   end
 
   def test_markdown_skip_html_image_with_empty_src
-    r = RichText.new("markdown", "<img src=''> <img src='https://example.com/next_img_element.png'>")
+    r = RichText.new("markdown", "<img src='' alt='forgot src'> <img src='https://example.com/next_img_element.png' alt='have src'>")
     assert_equal "https://example.com/next_img_element.png", r.image
+    assert_equal "have src", r.image_alt
   end
 
   def test_markdown_html_image_without_src
-    r = RichText.new("markdown", "<img>")
+    r = RichText.new("markdown", "<img alt='totally forgot src'>")
     assert_nil r.image
+    assert_nil r.image_alt
   end
 
   def test_markdown_skip_html_image_without_src
-    r = RichText.new("markdown", "<img> <img src='https://example.com/next_img_element.png'>")
+    r = RichText.new("markdown", "<img alt='totally forgot src'> <img src='https://example.com/next_img_element.png' alt='have src'>")
     assert_equal "https://example.com/next_img_element.png", r.image
+    assert_equal "have src", r.image_alt
   end
 
   private


### PR DESCRIPTION
`og:image:alt` is set to
- "OpenStreetMap logo" when the default osm logo image is used as `og:image`, like attempted in #3945
- alt text from the first image of a diary entry when it's use as `og:image`
- nothing with the property skipped if the first image has no `alt` attribute, which is unlikely because you can't do it with markdown syntax
