### PR TITLE
Don't order by id when getting last records

### DIFF
--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -163,7 +163,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
                                                 :longitude => "2.2", :language_code => "en" })
     end
     assert_redirected_to :action => :index, :display_name => user.display_name
-    entry = DiaryEntry.order(:id).last
+    entry = DiaryEntry.last
     assert_equal user.id, entry.user_id
     assert_equal "New Title", entry.title
     assert_equal "This is a new body for the diary entry", entry.body
@@ -189,7 +189,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
                                                 :longitude => "2.2", :language_code => "de" })
     end
     assert_redirected_to :action => :index, :display_name => user.display_name
-    entry = DiaryEntry.order(:id).last
+    entry = DiaryEntry.last
     assert_equal user.id, entry.user_id
     assert_equal "New Title", entry.title
     assert_equal "This is a new body for the diary entry", entry.body
@@ -217,7 +217,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
                               :diary_entry => { :title => spammy_title, :body => spammy_body, :language_code => "en" })
     end
     assert_redirected_to :action => :index, :display_name => user.display_name
-    entry = DiaryEntry.order(:id).last
+    entry = DiaryEntry.last
     assert_equal user.id, entry.user_id
     assert_equal spammy_title, entry.title
     assert_equal spammy_body, entry.body

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -352,10 +352,9 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
                             :user_block_period => "12",
                             :user_block => { :needs_view => false, :reason => "Vandalism" })
     end
-    id = UserBlock.order(:id).ids.last
-    assert_redirected_to user_block_path(:id => id)
+    b = UserBlock.last
+    assert_redirected_to user_block_path(:id => b.id)
     assert_equal "Created a block on user #{target_user.display_name}.", flash[:notice]
-    b = UserBlock.find(id)
     assert_in_delta Time.now.utc, b.created_at, 1
     assert_in_delta Time.now.utc, b.updated_at, 1
     assert_in_delta Time.now.utc + 12.hours, b.ends_at, 1
@@ -388,7 +387,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
                           :user_block_period => "336",
                           :user_block => { :needs_view => false, :reason => "Vandalism" })
 
-    block = UserBlock.order(:id).last
+    block = UserBlock.last
     assert_equal 1209600, block.ends_at - block.created_at
   end
 


### PR DESCRIPTION
Ordering by id [happens by default](https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-last).

Some more `order(:id)` are removed in #5054.