### PR TITLE
Set og:description meta tag to diary entry description

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -68,8 +68,10 @@ class DiaryEntriesController < ApplicationController
     @entry = entries.find_by(:id => params[:id])
     if @entry
       @title = t ".title", :user => params[:display_name], :title => @entry.title
-      @og_image = @entry.body.image
-      @og_image_alt = @entry.body.image_alt
+      @opengraph_properties = {
+        "og:image" => @entry.body.image,
+        "og:image:alt" => @entry.body.image_alt
+      }
       @comments = can?(:unhide, DiaryComment) ? @entry.comments : @entry.visible_comments
     else
       @title = t "diary_entries.no_such_entry.title", :id => params[:id]

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -70,7 +70,8 @@ class DiaryEntriesController < ApplicationController
       @title = t ".title", :user => params[:display_name], :title => @entry.title
       @opengraph_properties = {
         "og:image" => @entry.body.image,
-        "og:image:alt" => @entry.body.image_alt
+        "og:image:alt" => @entry.body.image_alt,
+        "og:description" => @entry.body.description
       }
       @comments = can?(:unhide, DiaryComment) ? @entry.comments : @entry.visible_comments
     else

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -1,7 +1,7 @@
 module OpenGraphHelper
   require "addressable/uri"
 
-  def opengraph_tags(title = nil, og_image = nil, og_image_alt = nil)
+  def opengraph_tags(title, og_image, og_image_alt)
     tags = {
       "og:site_name" => t("layouts.project_name.title"),
       "og:title" => title || t("layouts.project_name.title"),

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -7,7 +7,7 @@ module OpenGraphHelper
       "og:title" => title || t("layouts.project_name.title"),
       "og:type" => "website",
       "og:url" => url_for(:only_path => false),
-      "og:description" => t("layouts.intro_text")
+      "og:description" => properties["og:description"] || t("layouts.intro_text")
     }.merge(
       opengraph_image_properties(properties)
     )

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -1,7 +1,7 @@
 module OpenGraphHelper
   require "addressable/uri"
 
-  def opengraph_tags(title, og_image, og_image_alt)
+  def opengraph_tags(title, properties)
     tags = {
       "og:site_name" => t("layouts.project_name.title"),
       "og:title" => title || t("layouts.project_name.title"),
@@ -9,7 +9,7 @@ module OpenGraphHelper
       "og:url" => url_for(:only_path => false),
       "og:description" => t("layouts.intro_text")
     }.merge(
-      opengraph_image_properties(og_image, og_image_alt)
+      opengraph_image_properties(properties)
     )
 
     safe_join(tags.map do |property, content|
@@ -19,13 +19,13 @@ module OpenGraphHelper
 
   private
 
-  def opengraph_image_properties(og_image, og_image_alt)
+  def opengraph_image_properties(properties)
     begin
-      if og_image
-        properties = {}
-        properties["og:image"] = Addressable::URI.join(root_url, og_image).normalize
-        properties["og:image:alt"] = og_image_alt if og_image_alt
-        return properties
+      if properties["og:image"]
+        image_properties = {}
+        image_properties["og:image"] = Addressable::URI.join(root_url, properties["og:image"]).normalize
+        image_properties["og:image:alt"] = properties["og:image:alt"] if properties["og:image:alt"]
+        return image_properties
       end
     rescue Addressable::URI::InvalidURIError
       # return default image

--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -21,7 +21,7 @@
 <% end -%>
 <%= tag.link :rel => "search", :type => "application/opensearchdescription+xml", :title => "OpenStreetMap Search", :href => asset_path("osm.xml") %>
 <%= tag.meta :name => "description", :content => "OpenStreetMap is the free wiki world map." %>
-<%= opengraph_tags(@title, "og:image" => @og_image, "og:image:alt" => @og_image_alt) %>
+<%= opengraph_tags(@title, @opengraph_properties || {}) %>
 <% if flash[:matomo_goal] -%>
 <%= tag.meta :name => "matomo-goal", :content => flash[:matomo_goal] %>
 <% end -%>

--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -21,7 +21,7 @@
 <% end -%>
 <%= tag.link :rel => "search", :type => "application/opensearchdescription+xml", :title => "OpenStreetMap Search", :href => asset_path("osm.xml") %>
 <%= tag.meta :name => "description", :content => "OpenStreetMap is the free wiki world map." %>
-<%= opengraph_tags(@title, @og_image, @og_image_alt) %>
+<%= opengraph_tags(@title, "og:image" => @og_image, "og:image:alt" => @og_image_alt) %>
 <% if flash[:matomo_goal] -%>
 <%= tag.meta :name => "matomo-goal", :content => flash[:matomo_goal] %>
 <% end -%>

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -57,6 +57,10 @@ module RichText
       nil
     end
 
+    def description
+      nil
+    end
+
     protected
 
     def simple_format(text)

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -112,8 +112,9 @@ module RichText
     end
 
     def description
-      @paragraph_element = first_paragraph_element(document.root) unless defined? @paragraph_element
-      truncated_text_content(@paragraph_element) if @paragraph_element
+      return @description if defined? @description
+
+      @description = first_truncated_text_content(document.root)
     end
 
     private
@@ -131,12 +132,14 @@ module RichText
       end
     end
 
-    def first_paragraph_element(element)
-      return element if paragraph?(element)
-
-      element.children.find do |child|
-        nested_paragraph = first_paragraph_element(child)
-        break nested_paragraph if nested_paragraph
+    def first_truncated_text_content(element)
+      if paragraph?(element)
+        truncated_text_content(element)
+      else
+        element.children.find do |child|
+          text = first_truncated_text_content(child)
+          break text unless text.nil?
+        end
       end
     end
 
@@ -154,6 +157,8 @@ module RichText
         end
       end
       append_text.call(element)
+
+      return nil if text.blank?
 
       text.truncate(MAX_DESCRIPTION_LENGTH)
     end

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -158,7 +158,7 @@ module RichText
     end
 
     def paragraph?(element)
-      element.type == :p
+      element.type == :p || (element.type == :html_element && element.value == "p")
     end
   end
 

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -109,6 +109,11 @@ module RichText
       @image_element.attr["alt"] if @image_element
     end
 
+    def description
+      @paragraph_element = first_paragraph_element(document.root) unless defined? @paragraph_element
+      text_content(@paragraph_element) if @paragraph_element
+    end
+
     private
 
     def document
@@ -124,8 +129,36 @@ module RichText
       end
     end
 
+    def first_paragraph_element(element)
+      return element if paragraph?(element)
+
+      element.children.find do |child|
+        nested_paragraph = first_paragraph_element(child)
+        break nested_paragraph if nested_paragraph
+      end
+    end
+
+    def text_content(element)
+      text = ""
+
+      append_text = lambda do |child|
+        if child.type == :text
+          text << child.value
+        else
+          child.children.each { |c| append_text.call(c) }
+        end
+      end
+      append_text.call(element)
+
+      text
+    end
+
     def image?(element)
       element.type == :img || (element.type == :html_element && element.value == "img")
+    end
+
+    def paragraph?(element)
+      element.type == :p
     end
   end
 

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -744,6 +744,28 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_dom "head meta[property='og:image:alt']", :count => 0
   end
 
+  def test_show_no_og_description
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :body => "![nope](https://example.com/nope.jpg)")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='og:description']" do
+      assert_dom "> @content", I18n.t("layouts.intro_text")
+    end
+  end
+
+  def test_show_og_description
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :body => "# Hello\n\n![hello](https://example.com/hello.jpg)\n\nFirst paragraph.\n\nSecond paragraph.")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='og:description']" do
+      assert_dom "> @content", "First paragraph."
+    end
+  end
+
   def test_hide
     user = create(:user)
     diary_entry = create(:diary_entry, :user => user)

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -345,6 +345,16 @@ class RichTextTest < ActiveSupport::TestCase
     assert_equal "Here starts the text.", r.description
   end
 
+  def test_markdown_description_after_image
+    r = RichText.new("markdown", "![bar](https://example.com/image.jpg)\n\nThis is below the image.")
+    assert_equal "This is below the image.", r.description
+  end
+
+  def test_markdown_description_only_first_paragraph
+    r = RichText.new("markdown", "This thing.\n\nMaybe also that thing.")
+    assert_equal "This thing.", r.description
+  end
+
   def test_markdown_description_elements
     r = RichText.new("markdown", "*Something* **important** [here](https://example.com/).")
     assert_equal "Something important here.", r.description

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -335,6 +335,21 @@ class RichTextTest < ActiveSupport::TestCase
     assert_nil r.description
   end
 
+  def test_markdown_description
+    r = RichText.new("markdown", "This is an article about something.")
+    assert_equal "This is an article about something.", r.description
+  end
+
+  def test_markdown_description_after_heading
+    r = RichText.new("markdown", "#Heading\n\nHere starts the text.")
+    assert_equal "Here starts the text.", r.description
+  end
+
+  def test_markdown_description_elements
+    r = RichText.new("markdown", "*Something* **important** [here](https://example.com/).")
+    assert_equal "Something important here.", r.description
+  end
+
   private
 
   def assert_html(richtext, &block)

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -355,6 +355,17 @@ class RichTextTest < ActiveSupport::TestCase
     assert_equal "Can use HTML tags.", r.description
   end
 
+  def test_markdown_description_max_length
+    r = RichText.new("markdown", "x" * RichText::MAX_DESCRIPTION_LENGTH)
+    assert_equal "x" * RichText::MAX_DESCRIPTION_LENGTH, r.description
+
+    r = RichText.new("markdown", "y" * (RichText::MAX_DESCRIPTION_LENGTH + 1))
+    assert_equal "#{'y' * (RichText::MAX_DESCRIPTION_LENGTH - 3)}...", r.description
+
+    r = RichText.new("markdown", "*zzzzzzzzz*z" * ((RichText::MAX_DESCRIPTION_LENGTH + 1) / 10.0).ceil)
+    assert_equal "#{'z' * (RichText::MAX_DESCRIPTION_LENGTH - 3)}...", r.description
+  end
+
   private
 
   def assert_html(richtext, &block)

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -250,16 +250,18 @@ class RichTextTest < ActiveSupport::TestCase
     assert_equal 141, r.spam_score.round
   end
 
-  def test_text_no_image
+  def test_text_no_opengraph_properties
     r = RichText.new("text", "foo https://example.com/ bar")
     assert_nil r.image
     assert_nil r.image_alt
+    assert_nil r.description
   end
 
-  def test_html_no_image
+  def test_html_no_opengraph_properties
     r = RichText.new("html", "foo <a href='https://example.com/'>bar</a> baz")
     assert_nil r.image
     assert_nil r.image_alt
+    assert_nil r.description
   end
 
   def test_markdown_no_image
@@ -326,6 +328,11 @@ class RichTextTest < ActiveSupport::TestCase
     r = RichText.new("markdown", "<img alt='totally forgot src'> <img src='https://example.com/next_img_element.png' alt='have src'>")
     assert_equal "https://example.com/next_img_element.png", r.image
     assert_equal "have src", r.image_alt
+  end
+
+  def test_markdown_no_description
+    r = RichText.new("markdown", "#Nope")
+    assert_nil r.description
   end
 
   private

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -350,6 +350,11 @@ class RichTextTest < ActiveSupport::TestCase
     assert_equal "Something important here.", r.description
   end
 
+  def test_markdown_html_description
+    r = RichText.new("markdown", "<p>Can use HTML tags.</p>")
+    assert_equal "Can use HTML tags.", r.description
+  end
+
   private
 
   def assert_html(richtext, &block)


### PR DESCRIPTION
Uses the first paragraph with text truncated to 500 characters as an OpenGraph description on diary entry pages. Uses the default text on other pages or if no paragraph with text is found.

Fixes #1361