### PR TITLE
Add pagination to Issues page

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,4 +1,6 @@
 class IssuesController < ApplicationController
+  include PaginationMethods
+
   layout "site"
 
   before_action :authorize_web
@@ -11,6 +13,8 @@ class IssuesController < ApplicationController
   before_action :check_database_writable, :only => [:resolve, :ignore, :reopen]
 
   def index
+    @params = params.permit(:before, :after, :limit, :status, :search_by_user, :issue_type, :last_updated_by)
+    @params[:limit] ||= 50
     @title = t ".title"
 
     @issue_types = []
@@ -18,7 +22,7 @@ class IssuesController < ApplicationController
     @issue_types.push("DiaryEntry", "DiaryComment", "User") if current_user.administrator?
 
     @users = User.joins(:roles).where(:user_roles => { :role => current_user.roles.map(&:role) }).distinct
-    @issues = Issue.visible_to(current_user).order(:updated_at => :desc)
+    @issues = Issue.visible_to(current_user)
 
     # If search
     if params[:search_by_user].present?
@@ -39,6 +43,8 @@ class IssuesController < ApplicationController
       last_updated_by = params[:last_updated_by].to_s == "nil" ? nil : params[:last_updated_by].to_i
       @issues = @issues.where(:updated_by => last_updated_by)
     end
+
+    @issues, @newer_issues_id, @older_issues_id = get_page_items(@issues, :limit => @params[:limit])
   end
 
   def show

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -45,6 +45,7 @@ class IssuesController < ApplicationController
     end
 
     @issues, @newer_issues_id, @older_issues_id = get_page_items(@issues, :limit => @params[:limit])
+    render :partial => "page" if turbo_frame_request_id == "pagination"
   end
 
   def show

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -1,34 +1,36 @@
-<table class="table table-sm">
-  <thead>
-    <tr>
-      <th><%= t ".status" %></th>
-      <th><%= t ".reports" %></th>
-      <th><%= t ".reported_item" %></th>
-      <th><%= t ".reported_user" %></th>
-      <th><%= t ".last_updated" %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @issues.each do |issue| %>
+<turbo-frame id="pagination" target="_top">
+  <table class="table table-sm">
+    <thead>
       <tr>
-        <td><%= t ".states.#{issue.status}" %></td>
-        <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
-        <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
-        <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
-        <td>
-          <% if issue.user_updated %>
-            <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),
-                                                      :time_ago => friendly_date_ago(issue.updated_at) %>
-          <% else %>
-            <%= friendly_date_ago(issue.updated_at) %>
-          <% end %>
-        </td>
+        <th><%= t ".status" %></th>
+        <th><%= t ".reports" %></th>
+        <th><%= t ".reported_item" %></th>
+        <th><%= t ".reported_user" %></th>
+        <th><%= t ".last_updated" %></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
-<%= render "shared/pagination",
-           :newer_key => "issues.page.newer_issues",
-           :older_key => "issues.page.older_issues",
-           :newer_id => @newer_issues_id,
-           :older_id => @older_issues_id %>
+    </thead>
+    <tbody>
+      <% @issues.each do |issue| %>
+        <tr>
+          <td><%= t ".states.#{issue.status}" %></td>
+          <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
+          <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
+          <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
+          <td>
+            <% if issue.user_updated %>
+              <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),
+                                                        :time_ago => friendly_date_ago(issue.updated_at) %>
+            <% else %>
+              <%= friendly_date_ago(issue.updated_at) %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <%= render "shared/pagination",
+             :newer_key => "issues.page.newer_issues",
+             :older_key => "issues.page.older_issues",
+             :newer_id => @newer_issues_id,
+             :older_id => @older_issues_id %>
+</turbo-frame>

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -1,0 +1,34 @@
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th><%= t ".status" %></th>
+      <th><%= t ".reports" %></th>
+      <th><%= t ".reported_item" %></th>
+      <th><%= t ".reported_user" %></th>
+      <th><%= t ".last_updated" %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @issues.each do |issue| %>
+      <tr>
+        <td><%= t ".states.#{issue.status}" %></td>
+        <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
+        <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
+        <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
+        <td>
+          <% if issue.user_updated %>
+            <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),
+                                                      :time_ago => friendly_date_ago(issue.updated_at) %>
+          <% else %>
+            <%= friendly_date_ago(issue.updated_at) %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= render "shared/pagination",
+           :newer_key => "issues.page.newer_issues",
+           :older_key => "issues.page.older_issues",
+           :newer_id => @newer_issues_id,
+           :older_id => @older_issues_id %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -43,33 +43,5 @@
 <% if @issues.length == 0 %>
   <p><%= t ".issues_not_found" %></p>
 <% else %>
-  <table class="table table-sm">
-    <thead>
-      <tr>
-        <th><%= t ".status" %></th>
-        <th><%= t ".reports" %></th>
-        <th><%= t ".reported_item" %></th>
-        <th><%= t ".reported_user" %></th>
-        <th><%= t ".last_updated" %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @issues.each do |issue| %>
-        <tr>
-          <td><%= t ".states.#{issue.status}" %></td>
-          <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
-          <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
-          <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
-          <td>
-            <% if issue.user_updated %>
-              <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),
-                                                        :time_ago => friendly_date_ago(issue.updated_at) %>
-            <% else %>
-              <%= friendly_date_ago(issue.updated_at) %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <%= render :partial => "page" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1469,11 +1469,17 @@ en:
       search_guidance: "Search Issues:"
       user_not_found: User does not exist
       issues_not_found: No such issues found
+      link_to_reports: View Reports
+      states:
+        ignored: Ignored
+        open: Open
+        resolved: Resolved
+    page:
+      reported_user: Reported User
       status: Status
       reports: Reports
       last_updated: Last Updated
       last_updated_time_ago_user_html: "%{time_ago} by %{user}"
-      link_to_reports: View Reports
       reports_count:
         one: "%{count} Report"
         other: "%{count} Reports"
@@ -1482,6 +1488,8 @@ en:
         ignored: Ignored
         open: Open
         resolved: Resolved
+      older_issues: Older Issues
+      newer_issues: Newer Issues
     show:
       title: "%{status} Issue #%{issue_id}"
       reports:

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -181,12 +181,12 @@ class IssuesTest < ApplicationSystemTestCase
     click_on I18n.t("issues.page.older_issues")
     assert_no_content I18n.t("issues.index.user_not_found")
     assert_no_content I18n.t("issues.index.issues_not_found")
-    assert_css "tr", :count => 31, :wait => 1
+    assert_css "tr", :count => 31
 
     # Back to First Page
     click_on I18n.t("issues.page.newer_issues")
     assert_no_content I18n.t("issues.index.user_not_found")
     assert_no_content I18n.t("issues.index.issues_not_found")
-    assert_css "tr", :count => 51, :wait => 1
+    assert_css "tr", :count => 51
   end
 end

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -158,7 +158,35 @@ class IssuesTest < ApplicationSystemTestCase
 
     visit issues_path
 
-    assert_link I18n.t("issues.index.reports_count", :count => issue1.reports_count), :href => issue_path(issue1)
-    assert_link I18n.t("issues.index.reports_count", :count => issue2.reports_count), :href => issue_path(issue2)
+    assert_link I18n.t("issues.page.reports_count", :count => issue1.reports_count), :href => issue_path(issue1)
+    assert_link I18n.t("issues.page.reports_count", :count => issue2.reports_count), :href => issue_path(issue2)
+  end
+
+  def test_issues_pagination
+    1.upto(80).each do
+      user = create(:user)
+      create(:issue, :reportable => user, :reported_user => user, :assigned_role => "administrator")
+    end
+
+    sign_in_as(create(:administrator_user))
+
+    visit issues_path
+
+    # First Page
+    assert_no_content I18n.t("issues.index.user_not_found")
+    assert_no_content I18n.t("issues.index.issues_not_found")
+    assert_css "tr", :count => 51
+
+    # Second Page
+    click_on I18n.t("issues.page.older_issues")
+    assert_no_content I18n.t("issues.index.user_not_found")
+    assert_no_content I18n.t("issues.index.issues_not_found")
+    assert_css "tr", :count => 31, :wait => 1
+
+    # Back to First Page
+    click_on I18n.t("issues.page.newer_issues")
+    assert_no_content I18n.t("issues.index.user_not_found")
+    assert_no_content I18n.t("issues.index.issues_not_found")
+    assert_css "tr", :count => 51, :wait => 1
   end
 end


### PR DESCRIPTION
This PR addresses heavy calls and long load time of the Issues page. Problem was mentioned in https://github.com/openstreetmap/openstreetmap-website/pull/4990 by @AntonKhorev.

Added pagination functionality. When pagination buttons will be clicked, next or previous 50 issues will be called and displayed without a page refresh (Turbo will make a call and render returned Turbo Frame). In terms of performance, on the local environment I have 1000 users and 1000 issues. Initial loading time was decreased from ~8s to ~1s and after that every pagination needs ~150ms. In the real environment, it will have much better improvement, as instead of searching for 30000 issues, it will take only 50 (in theory, the difference should be 30x better in the real environment, then it is on my local machine). Because of the pagination functionality, now issues are sorted according to IDs (it should be the same sort as creation time sort).

To address @AntonKhorev 's [comment](https://github.com/openstreetmap/openstreetmap-website/pull/4990#issuecomment-2248072093) about browser built-in search, user now can change `?limit=50` query parameter in the url to any number. Therefore, if any user wants to use browser built-in search, he can just change it, for example, to `?limit=10000` and 10000 issues will be rendered.

To address @nertc 's [comment](https://github.com/openstreetmap/openstreetmap-website/pull/5033#issuecomment-2260783731) about clicking `go back` button of the browser, now every page is added to the browser history. Therefore, `go back` button will work fine, if user enters any report and then decides to go back to the list.

Video:

https://github.com/user-attachments/assets/b16f08f8-1e2a-472e-9a38-fb77e84bffac

Issues not found:

![image](https://github.com/user-attachments/assets/deb4e6c5-d594-4f68-90ba-c86044d0688c)

User not found:

![Screenshot 2024-08-19 220613](https://github.com/user-attachments/assets/770c0edf-ebac-4502-983d-5b89959ff341)
