### PR TITLE
Move richtext help to a tab on small screens

### DIFF
--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -11,7 +11,7 @@ $(document).ready(function () {
   /*
    * Install a handler to switch to preview mode
    */
-  $(".richtext_dopreview").on("show.bs.tab", function () {
+  $(".richtext_container button[data-bs-target$='_preview']").on("show.bs.tab", function () {
     var editor = $(this).parents(".richtext_container").find("textarea");
     var preview = $(this).parents(".richtext_container").find(".richtext_preview");
     var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -5,15 +5,18 @@ $(document).ready(function () {
    * the user next switches to it.
    */
   $(".richtext_container textarea").change(function () {
-    $(this).parents(".richtext_container").find(".tab-pane[id$='_preview']").empty();
+    var container = $(this).closest(".richtext_container");
+
+    container.find(".tab-pane[id$='_preview']").empty();
   });
 
   /*
    * Install a handler to switch to preview mode
    */
   $(".richtext_container button[data-bs-target$='_preview']").on("show.bs.tab", function () {
-    var editor = $(this).parents(".richtext_container").find("textarea");
-    var preview = $(this).parents(".richtext_container").find(".tab-pane[id$='_preview']");
+    var container = $(this).closest(".richtext_container");
+    var editor = container.find("textarea");
+    var preview = container.find(".tab-pane[id$='_preview']");
     var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
 
     if (preview.contents().length === 0) {

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -4,7 +4,7 @@ $(document).ready(function () {
    * the associated preview pne so that it will be regenerated when
    * the user next switches to it.
    */
-  $(".richtext_content textarea").change(function () {
+  $(".richtext_container textarea").change(function () {
     $(this).parents(".richtext_container").find(".richtext_preview").empty();
   });
 

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -5,7 +5,7 @@ $(document).ready(function () {
    * the user next switches to it.
    */
   $(".richtext_container textarea").change(function () {
-    $(this).parents(".richtext_container").find(".richtext_preview").empty();
+    $(this).parents(".richtext_container").find(".tab-pane[id$='_preview']").empty();
   });
 
   /*
@@ -13,7 +13,7 @@ $(document).ready(function () {
    */
   $(".richtext_container button[data-bs-target$='_preview']").on("show.bs.tab", function () {
     var editor = $(this).parents(".richtext_container").find("textarea");
-    var preview = $(this).parents(".richtext_container").find(".richtext_preview");
+    var preview = $(this).parents(".richtext_container").find(".tab-pane[id$='_preview']");
     var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
 
     if (preview.contents().length === 0) {

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -41,6 +41,9 @@ $(document).ready(function () {
     $(".richtext_container .richtext_help_sidebar:visible:empty").each(function () {
       var container = $(this).closest(".richtext_container");
       container.find(".tab-pane[id$='_help']").children().appendTo($(this));
+      if (container.find("button[data-bs-target$='_help'].active").length) {
+        container.find("button[data-bs-target$='_edit']").tab("show");
+      }
     });
   };
 

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -32,4 +32,18 @@ $(document).ready(function () {
 
     preview.css("min-height", minHeight + "px");
   });
+
+  var updateHelp = function () {
+    $(".richtext_container .richtext_help_sidebar:not(:visible):not(:empty)").each(function () {
+      var container = $(this).closest(".richtext_container");
+      $(this).children().appendTo(container.find(".tab-pane[id$='_help']"));
+    });
+    $(".richtext_container .richtext_help_sidebar:visible:empty").each(function () {
+      var container = $(this).closest(".richtext_container");
+      container.find(".tab-pane[id$='_help']").children().appendTo($(this));
+    });
+  };
+
+  updateHelp();
+  $(window).on("resize", updateHelp);
 });

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -11,13 +11,25 @@ $(document).ready(function () {
   });
 
   /*
+   * Install a handler to set the minimum preview pane height
+   * when switching away from an edit pane
+   */
+  $(".richtext_container button[data-bs-target$='_edit']").on("hide.bs.tab", function () {
+    var container = $(this).closest(".richtext_container");
+    var editor = container.find("textarea");
+    var preview = container.find(".tab-pane[id$='_preview']");
+    var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
+
+    preview.css("min-height", minHeight + "px");
+  });
+
+  /*
    * Install a handler to switch to preview mode
    */
   $(".richtext_container button[data-bs-target$='_preview']").on("show.bs.tab", function () {
     var container = $(this).closest(".richtext_container");
     var editor = container.find("textarea");
     var preview = container.find(".tab-pane[id$='_preview']");
-    var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
 
     if (preview.contents().length === 0) {
       preview.oneTime(500, "loading", function () {
@@ -29,8 +41,6 @@ $(document).ready(function () {
         preview.removeClass("loading");
       });
     }
-
-    preview.css("min-height", minHeight + "px");
   });
 
   var updateHelp = function () {

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -5,7 +5,7 @@
         <button type="button" class="nav-link active" data-bs-toggle="tab" data-bs-target="#<%= id %>_edit"><%= t(".edit") %></button>
       </li>
       <li class="nav-item">
-        <button type="button" class="nav-link richtext_dopreview" data-bs-toggle="tab" data-bs-target="#<%= id %>_preview"><%= t(".preview") %></button>
+        <button type="button" class="nav-link" data-bs-toggle="tab" data-bs-target="#<%= id %>_preview"><%= t(".preview") %></button>
       </li>
     </ul>
     <div class="tab-content">

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -1,25 +1,29 @@
-<div class="row richtext_container">
-  <div class="col-sm-8 mb-3 mb-sm-0">
-    <ul class="nav nav-tabs mb-3" role="tablist">
-      <li class="nav-item">
-        <button type="button" class="nav-link active" data-bs-toggle="tab" data-bs-target="#<%= id %>_edit"><%= t(".edit") %></button>
-      </li>
-      <li class="nav-item">
-        <button type="button" class="nav-link" data-bs-toggle="tab" data-bs-target="#<%= id %>_preview"><%= t(".preview") %></button>
-      </li>
-    </ul>
-    <div class="tab-content">
+<div class="richtext_container">
+  <ul class="nav nav-tabs mb-3">
+    <li class="nav-item">
+      <button type="button" class="nav-link active" data-bs-toggle="tab" data-bs-target="#<%= id %>_edit"><%= t(".edit") %></button>
+    </li>
+    <li class="nav-item">
+      <button type="button" class="nav-link" data-bs-toggle="tab" data-bs-target="#<%= id %>_preview"><%= t(".preview") %></button>
+    </li>
+    <li class="nav-item">
+      <button type="button" class="nav-link" data-bs-toggle="tab" data-bs-target="#<%= id %>_help"><%= t(".help") %></button>
+    </li>
+  </ul>
+  <div class="row g-3">
+    <div class="tab-content col-sm-8">
       <div id="<%= id %>_edit" class="tab-pane show active">
         <%= builder.text_area(attribute, options.merge(:wrapper => false, "data-preview-url" => preview_url(:type => type))) %>
       </div>
       <div id="<%= id %>_preview" class="tab-pane richtext text-break"></div>
-    </div>
-  </div>
-  <div id="<%= id %>_help" class="col-sm-4 richtext_help">
-    <div class="card bg-body-tertiary h-100">
-      <div class="card-body">
-        <%= render :partial => "shared/#{type}_help" %>
+      <div id="<%= id %>_help" class="tab-pane">
+        <div class="card bg-body-tertiary h-100">
+          <div class="card-body">
+            <%= render :partial => "shared/#{type}_help" %>
+          </div>
+        </div>
       </div>
     </div>
+    <aside class="col-sm-4 d-none d-sm-block"></aside>
   </div>
 </div>

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= id %>_container" class="row richtext_container">
-  <div id="<%= id %>_content" class="col-sm-8 mb-3 mb-sm-0 richtext_content">
+  <div id="<%= id %>_content" class="col-sm-8 mb-3 mb-sm-0">
     <ul class="nav nav-tabs mb-3" role="tablist">
       <li class="nav-item">
         <button type="button" class="nav-link active" data-bs-toggle="tab" data-bs-target="#<%= id %>_edit"><%= t(".edit") %></button>

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -1,5 +1,5 @@
-<div id="<%= id %>_container" class="row richtext_container">
-  <div id="<%= id %>_content" class="col-sm-8 mb-3 mb-sm-0">
+<div class="row richtext_container">
+  <div class="col-sm-8 mb-3 mb-sm-0">
     <ul class="nav nav-tabs mb-3" role="tablist">
       <li class="nav-item">
         <button type="button" class="nav-link active" data-bs-toggle="tab" data-bs-target="#<%= id %>_edit"><%= t(".edit") %></button>

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -12,7 +12,7 @@
       <div id="<%= id %>_edit" class="tab-pane show active">
         <%= builder.text_area(attribute, options.merge(:wrapper => false, "data-preview-url" => preview_url(:type => type))) %>
       </div>
-      <div id="<%= id %>_preview" class="tab-pane richtext_preview richtext text-break"></div>
+      <div id="<%= id %>_preview" class="tab-pane richtext text-break"></div>
     </div>
   </div>
   <div id="<%= id %>_help" class="col-sm-4 richtext_help">

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -6,7 +6,7 @@
     <li class="nav-item">
       <button type="button" class="nav-link" data-bs-toggle="tab" data-bs-target="#<%= id %>_preview"><%= t(".preview") %></button>
     </li>
-    <li class="nav-item">
+    <li class="nav-item d-block d-sm-none">
       <button type="button" class="nav-link" data-bs-toggle="tab" data-bs-target="#<%= id %>_help"><%= t(".help") %></button>
     </li>
   </ul>
@@ -24,6 +24,6 @@
         </div>
       </div>
     </div>
-    <aside class="col-sm-4 d-none d-sm-block"></aside>
+    <aside class="col-sm-4 d-none d-sm-block richtext_help_sidebar"></aside>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1905,6 +1905,7 @@ en:
     richtext_field:
       edit: Edit
       preview: Preview
+      help: Help
   site:
     about:
       next: Next


### PR DESCRIPTION
As I said in #5042 you have to scroll to the end of the help card in order to reach the edit/preview buttons. But you also have to scroll there in order to reach the submit button which is also annoying. What if we don't display the help card on small screens unless the user requests it?

When the screen is wide enough the UI looks like it did before:
![image](https://github.com/user-attachments/assets/1a41df85-1f7a-4f5e-b299-19888597c64c)

When the screen is narrow:
![image](https://github.com/user-attachments/assets/a5e87b81-3f81-4a91-bc71-1d8314942b4f)
![image](https://github.com/user-attachments/assets/8c4b90e1-5a11-4e3b-ac57-04906b0cc2f1)

