### PR TITLE
Always do reverse geocoding when routing

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -55,7 +55,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     endpoint.setValue(value);
   }
 
-  endpoint.setValue = function (value, latlng) {
+  endpoint.setValue = function (value) {
     endpoint.value = value;
     removeLatLng();
     input.removeClass("is-invalid");
@@ -63,6 +63,9 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
 
     if (endpoint.geocodeRequest) endpoint.geocodeRequest.abort();
     delete endpoint.geocodeRequest;
+
+    var coordinatesMatch = value.match(/^\s*([+-]?\d+(?:\.\d*)?)(?:\s+|\s*[/,]\s*)([+-]?\d+(?:\.\d*)?)\s*$/);
+    var latlng = coordinatesMatch && L.latLng(coordinatesMatch[1], coordinatesMatch[2]);
 
     if (latlng) {
       setLatLng(latlng);

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -86,6 +86,15 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     }
   };
 
+  endpoint.swapCachedReverseGeocodes = function (otherEndpoint) {
+    var g0 = endpoint.cachedReverseGeocode;
+    var g1 = otherEndpoint.cachedReverseGeocode;
+    delete endpoint.cachedReverseGeocode;
+    delete otherEndpoint.cachedReverseGeocode;
+    if (g0) otherEndpoint.cachedReverseGeocode = g0;
+    if (g1) endpoint.cachedReverseGeocode = g1;
+  };
+
   function getGeocode() {
     var viewbox = map.getBounds().toBBoxString(); // <sw lon>,<sw lat>,<ne lon>,<ne lat>
     var geocodeUrl = OSM.NOMINATIM_URL + "search?q=" + encodeURIComponent(endpoint.value) + "&format=json&viewbox=" + viewbox;

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -66,7 +66,12 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
 
     if (latlng && endpoint.cachedReverseGeocode && endpoint.cachedReverseGeocode.latlng.equals(latlng)) {
       setLatLng(latlng);
-      endpoint.value = endpoint.cachedReverseGeocode.value;
+      if (endpoint.cachedReverseGeocode.notFound) {
+        endpoint.value = value;
+        input.addClass("is-invalid");
+      } else {
+        endpoint.value = endpoint.cachedReverseGeocode.value;
+      }
       input.val(endpoint.value);
       changeCallback();
       return;
@@ -123,6 +128,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     endpoint.geocodeRequest = $.getJSON(reverseGeocodeUrl, function (json) {
       delete endpoint.geocodeRequest;
       if (!json || !json.display_name) {
+        endpoint.cachedReverseGeocode = { latlng: latlng, notFound: true };
         return;
       }
 

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -70,6 +70,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     if (latlng) {
       setLatLng(latlng);
       setInputValueFromLatLng(latlng);
+      getReverseGeocode();
       changeCallback();
     } else if (endpoint.value) {
       getGeocode();
@@ -93,6 +94,20 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
       input.val(json[0].display_name);
 
       changeCallback();
+    });
+  }
+
+  function getReverseGeocode() {
+    var reverseGeocodeUrl = OSM.NOMINATIM_URL + "reverse?lat=" + endpoint.latlng.lat + "&lon=" + endpoint.latlng.lng + "&format=json";
+
+    endpoint.geocodeRequest = $.getJSON(reverseGeocodeUrl, function (json) {
+      delete endpoint.geocodeRequest;
+      if (!json || !json.display_name) {
+        return;
+      }
+
+      endpoint.value = json.display_name;
+      input.val(json.display_name);
     });
   }
 

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -36,6 +36,9 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
   function markerDragListener(e) {
     var latlng = convertLatLngToZoomPrecision(e.target.getLatLng());
 
+    if (endpoint.geocodeRequest) endpoint.geocodeRequest.abort();
+    delete endpoint.geocodeRequest;
+
     setLatLng(latlng);
     setInputValueFromLatLng(latlng);
     endpoint.value = input.val();
@@ -58,6 +61,9 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     input.removeClass("is-invalid");
     input.val(value);
 
+    if (endpoint.geocodeRequest) endpoint.geocodeRequest.abort();
+    delete endpoint.geocodeRequest;
+
     if (latlng) {
       setLatLng(latlng);
       setInputValueFromLatLng(latlng);
@@ -71,7 +77,6 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     var viewbox = map.getBounds().toBBoxString(); // <sw lon>,<sw lat>,<ne lon>,<ne lat>
     var geocodeUrl = OSM.NOMINATIM_URL + "search?q=" + encodeURIComponent(endpoint.value) + "&format=json&viewbox=" + viewbox;
 
-    if (endpoint.geocodeRequest) endpoint.geocodeRequest.abort();
     endpoint.geocodeRequest = $.getJSON(geocodeUrl, function (json) {
       delete endpoint.geocodeRequest;
       if (json.length === 0) {

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -42,6 +42,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     setLatLng(latlng);
     setInputValueFromLatLng(latlng);
     endpoint.value = input.val();
+    if (e.type === "dragend") getReverseGeocode();
     dragCallback(e.type === "drag");
   }
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -287,17 +287,14 @@ OSM.Directions = function (map) {
       var ll = map.containerPointToLatLng(pt);
       var precision = OSM.zoomPrecision(map.getZoom());
       var value = ll.lat.toFixed(precision) + ", " + ll.lng.toFixed(precision);
-      var llWithPrecision = L.latLng(ll.lat.toFixed(precision), ll.lng.toFixed(precision));
-      endpoints[type === "from" ? 0 : 1].setValue(value, llWithPrecision);
+      endpoints[type === "from" ? 0 : 1].setValue(value);
     });
 
     endpoints[0].enable();
     endpoints[1].enable();
 
     var params = Qs.parse(location.search.substring(1)),
-        route = (params.route || "").split(";"),
-        from = route[0] && L.latLng(route[0].split(",")),
-        to = route[1] && L.latLng(route[1].split(","));
+        route = (params.route || "").split(";");
 
     if (params.engine) {
       var engineIndex = findEngine(params.engine);
@@ -307,10 +304,10 @@ OSM.Directions = function (map) {
       }
     }
 
-    endpoints[0].setValue(params.from || "", from);
-    endpoints[1].setValue(params.to || "", to);
+    endpoints[0].setValue(params.from || route[0] || "");
+    endpoints[1].setValue(params.to || route[1] || "");
 
-    map.setSidebarOverlaid(!from || !to);
+    map.setSidebarOverlaid(!endpoints[0].latlng || !endpoints[1].latlng);
   };
 
   page.load = function () {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -65,10 +65,9 @@ OSM.Directions = function (map) {
     if (coordTo) {
       routeTo = coordTo.lat + "," + coordTo.lng;
     }
+    endpoints[0].swapCachedReverseGeocodes(endpoints[1]);
 
     OSM.router.route("/directions?" + Qs.stringify({
-      from: $("#route_to").val(),
-      to: $("#route_from").val(),
       route: routeTo + ";" + routeFrom
     }));
   });


### PR DESCRIPTION
There was a number of bugs related to route endpoint locations caused by various reasons. Some of there reasons were already addressed. The one left is Nominatim deciding to do reverse geocoding when receiving something that looks like coordinates in its freeform query. The query itself is *not* a reverse geocoding query (`/reverse?...`), yet Nominatim will do reverse geocoding if it consists of two floating point numbers.

The problem is that we have inputs that can contain either addresses or coordinates. Then the seemingly obvious thing to get coordinates is to pass this input contents to Nominatim. And this is how you get bugs. It the input already contained coordinates, Nominatim would reverse-geocode them to some place and return the coordinates of that place that are different from the coordinates input already had. And then the endpoint marker would jump somewhere.

If we want to prevent this, we have to check ourselves if we already have two floating point numbers. If we do, we shouldn't make Nominatim's freeform geocoding query. Since we're going to parse coordinates inside the endpoint module to make that check, `endpoint.setValue` doesn't need its `latlng` argument and it is removed.

Since users probably expect reverse geocoding to be happening even if we had coordinates, `endpoint.setValue` is going to make a reverse-geocoding query explicitly, without overwriting the original coordinates. With changes here, `endpoint.setValue` works like this:
- The `value` parameter is checked if it's coordinates.
- If not, geocoding is performed. 
- If yes, reverse geocoding is done.

Reverse geocoding is also done on marker drag end.

Another thing that's done is caching of reverse geocoding results. The reason is that there are common scenarios when you get the same coordinates that were reverse-geocoded. For example, you set the starting point using the context menu, then you add the ending point. The context menu will open a directions url containing the same starting point coordinates, they were looked up already.

Another common scenario is swapping the route start/end. To avoid reverse-geocoding both ends again we can also swap their reverse-geocoding results. That's what `endpoint.swapCachedReverseGeocodes` does.

---

This should fix #1874 and #2982.

Also addresses #1910 to some extent. But if we want to get back "Paris" from the coordinates and not some address inside Paris, we'd need to pass along a zoom level. Nominatim [supposedly can use it](https://nominatim.org/release-docs/develop/api/Reverse/#result-restriction). Or pass search queries along. Presumably that wasn't done to [keep urls short](https://github.com/openstreetmap/openstreetmap-website/issues/1910#issuecomment-399255834), but we can pass only short queries for example.

Also should fix #1911 if the problem is markers moving from clicked locations to geocoding locations. In this case it's the step 3 of https://github.com/openstreetmap/openstreetmap-website/issues/2982#issuecomment-734512269.

May close #1754 because everything was rewritten.