### PR TITLE
Set layer button size in rems

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -22,7 +22,7 @@ L.OSM.layers = function (options) {
         .prop("checked", map.hasLayer(layer))
         .appendTo(buttonContainer);
 
-      var item = $("<label class='btn btn-outline-primary border-4 rounded-3 bg-transparent position-absolute top-0 start-0 bottom-0 end-0 m-n1 overflow-hidden'>")
+      var item = $("<label class='btn btn-outline-primary border-4 rounded-3 bg-transparent position-absolute p-0 h-100 w-100 overflow-hidden'>")
         .prop("for", id)
         .append($("<span class='badge position-absolute top-0 start-0 rounded-top-0 rounded-start-0 py-1 px-2 bg-body bg-opacity-75 text-body text-wrap text-start fs-6 lh-base'>").append(layer.options.name))
         .appendTo(buttonContainer);

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -415,6 +415,9 @@ body.small-nav {
     height: 3.5rem;
 
     > .btn {
+      box-sizing: content-box;
+      top: - map.get($border-widths, 4);
+      left: - map.get($border-widths, 4);
       --bs-btn-border-color: var(--bs-body-bg);
     }
     > .btn:hover {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -412,7 +412,7 @@ body.small-nav {
 
 .layers-ui {
   .base-layers > * {
-    height: 56px;
+    height: 3.5rem;
 
     > .btn {
       --bs-btn-border-color: var(--bs-body-bg);


### PR DESCRIPTION
Probably fixes #5066.

Before:

150% zoom / 150% text-only zoom:
![image](https://github.com/user-attachments/assets/f50fb1f9-c85a-40e0-bf19-ecea253f481d) ![image](https://github.com/user-attachments/assets/401a3a53-4ace-4a70-9661-d2793be8f481)

After:

150% zoom / 150% text-only zoom:
![image](https://github.com/user-attachments/assets/134efc24-e3ac-4607-a0a2-4092bf626124) ![image](https://github.com/user-attachments/assets/809bd85a-02e1-4c6f-ab41-8408e5261923)
