### PR TITLE
Add deactivates_at date to user blocks

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -26,6 +26,7 @@ class UserBlocksController < ApplicationController
   def show
     if current_user && current_user == @user_block.user
       @user_block.needs_view = false
+      @user_block.deactivates_at = [@user_block.ends_at, Time.now.utc].max
       @user_block.save!
     end
   end
@@ -49,6 +50,7 @@ class UserBlocksController < ApplicationController
         :ends_at => now + @block_period.hours,
         :needs_view => params[:user_block][:needs_view]
       )
+      @user_block.deactivates_at = @user_block.ends_at unless @user_block.needs_view
 
       if @user_block.save
         flash[:notice] = t(".flash", :name => @user.display_name)
@@ -72,11 +74,16 @@ class UserBlocksController < ApplicationController
         @user_block.reason = params[:user_block][:reason]
         @user_block.needs_view = params[:user_block][:needs_view]
         @user_block.ends_at = Time.now.utc + @block_period.hours
+        @user_block.deactivates_at = (@user_block.ends_at unless @user_block.needs_view)
         if !user_block_was_active && @user_block.active?
           flash.now[:error] = t(".inactive_block_cannot_be_reactivated")
           render :action => "edit"
         else
-          @user_block.ends_at = @user_block.ends_at_was unless user_block_was_active
+          unless user_block_was_active
+            @user_block.ends_at = @user_block.ends_at_was
+            @user_block.deactivates_at = @user_block.deactivates_at_was
+            @user_block.deactivates_at = [@user_block.ends_at, @user_block.updated_at].max unless @user_block.deactivates_at # take updated_at into account before deactivates_at is backfilled
+          end
           if @user_block.save
             flash[:notice] = t(".success")
             redirect_to @user_block

--- a/app/helpers/user_blocks_helper.rb
+++ b/app/helpers/user_blocks_helper.rb
@@ -20,7 +20,7 @@ module UserBlocksHelper
       # the max of the last update time or the ends_at time is when this block finished
       # either because the user viewed the block (updated_at) or it expired or was
       # revoked (ends_at)
-      last_time = [block.ends_at, block.updated_at].max
+      last_time = block.deactivates_at || [block.ends_at, block.updated_at].max
       t("user_blocks.helper.time_past_html", :time => friendly_date_ago(last_time))
     end
   end

--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -2,16 +2,17 @@
 #
 # Table name: user_blocks
 #
-#  id            :integer          not null, primary key
-#  user_id       :bigint(8)        not null
-#  creator_id    :bigint(8)        not null
-#  reason        :text             not null
-#  ends_at       :datetime         not null
-#  needs_view    :boolean          default(FALSE), not null
-#  revoker_id    :bigint(8)
-#  created_at    :datetime
-#  updated_at    :datetime
-#  reason_format :enum             default("markdown"), not null
+#  id             :integer          not null, primary key
+#  user_id        :bigint(8)        not null
+#  creator_id     :bigint(8)        not null
+#  reason         :text             not null
+#  ends_at        :datetime         not null
+#  needs_view     :boolean          default(FALSE), not null
+#  revoker_id     :bigint(8)
+#  created_at     :datetime
+#  updated_at     :datetime
+#  reason_format  :enum             default("markdown"), not null
+#  deactivates_at :datetime
 #
 # Indexes
 #
@@ -28,6 +29,8 @@
 class UserBlock < ApplicationRecord
   validate :moderator_permissions
   validates :reason, :characters => true
+  validates :deactivates_at, :comparison => { :greater_than_or_equal_to => :ends_at }, :unless => -> { needs_view }
+  validates :deactivates_at, :absence => true, :if => -> { needs_view }
 
   belongs_to :user, :class_name => "User"
   belongs_to :creator, :class_name => "User"
@@ -67,6 +70,7 @@ class UserBlock < ApplicationRecord
   def revoke!(revoker)
     update(
       :ends_at => Time.now.utc,
+      :deactivates_at => Time.now.utc,
       :revoker_id => revoker.id,
       :needs_view => false
     )

--- a/db/migrate/20240813070506_add_deactivates_at_to_user_blocks.rb
+++ b/db/migrate/20240813070506_add_deactivates_at_to_user_blocks.rb
@@ -1,0 +1,5 @@
+class AddDeactivatesAtToUserBlocks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_blocks, :deactivates_at, :timestamp
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1488,7 +1488,8 @@ CREATE TABLE public.user_blocks (
     revoker_id bigint,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    reason_format public.format_enum DEFAULT 'markdown'::public.format_enum NOT NULL
+    reason_format public.format_enum DEFAULT 'markdown'::public.format_enum NOT NULL,
+    deactivates_at timestamp without time zone
 );
 
 
@@ -3578,6 +3579,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20240813070506'),
 ('20240618193051'),
 ('20240605134916'),
 ('20240405083825'),

--- a/test/factories/user_blocks.rb
+++ b/test/factories/user_blocks.rb
@@ -2,12 +2,14 @@ FactoryBot.define do
   factory :user_block do
     sequence(:reason) { |n| "User Block #{n}" }
     ends_at { Time.now.utc + 1.day }
+    deactivates_at { ends_at }
 
     user
     creator :factory => :moderator_user
 
     trait :needs_view do
       needs_view { true }
+      deactivates_at { nil }
     end
 
     trait :expired do

--- a/test/integration/user_blocks_test.rb
+++ b/test/integration/user_blocks_test.rb
@@ -15,7 +15,8 @@ class UserBlocksTest < ActionDispatch::IntegrationTest
       :user_id => blocked_user.id,
       :creator_id => create(:moderator_user).id,
       :reason => "testing",
-      :ends_at => Time.now.utc + 5.minutes
+      :ends_at => Time.now.utc + 5.minutes,
+      :deactivates_at => Time.now.utc + 5.minutes
     )
     get "/api/#{Settings.api_version}/user/details", :headers => basic_authorization_header(blocked_user.display_name, "test")
     assert_response :forbidden
@@ -29,7 +30,8 @@ class UserBlocksTest < ActionDispatch::IntegrationTest
       :user_id => blocked_user.id,
       :creator_id => moderator.id,
       :reason => "testing",
-      :ends_at => Time.now.utc + 5.minutes
+      :ends_at => Time.now.utc + 5.minutes,
+      :deactivates_at => Time.now.utc + 5.minutes
     )
     get "/api/#{Settings.api_version}/user/details", :headers => basic_authorization_header(blocked_user.display_name, "test")
     assert_response :forbidden


### PR DESCRIPTION
Block deactivation dates that take needs_view-block views into account were derived using updated_at. This was possible because inactive blocks couldn't be edited and their updated_at date wouldn't change. The logic is explained here:

https://github.com/openstreetmap/openstreetmap-website/blob/e0e6c7f1c26fcddff883dad38a6207475150f323/app/helpers/user_blocks_helper.rb#L20-L24

With editing of inactive blocks enabled deactivation date needs to be saved explicitly. It is defined for blocks that don't have `needs_view` and will time out even if the user doesn't look at them. Block with `needs_view` don't have a defined deactivation date. It's going to be set as soon as the user views the block and clears `needs_view`. Its value is going to be either the block end date if it's in the future or the current date.

---

After creating `deactivates_at` we no longer need `needs_view`. A block with `needs_view` is just a block without `deactivates_at`. But I can't remove `needs_view` right away because strong_migrations won't let me to drop the column without extra steps.