### PR TITLE
Remove setLatLng() from directions endpoint interface

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -17,7 +17,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
   endpoint.marker.on("drag dragend", function (e) {
     var latlng = e.target.getLatLng();
 
-    endpoint.setLatLng(latlng);
+    setLatLng(latlng);
     setInputValueFromLatLng(latlng);
     endpoint.value = input.val();
     dragCallback(e.type === "drag");
@@ -40,7 +40,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
     input.val(value);
 
     if (latlng) {
-      endpoint.setLatLng(latlng);
+      setLatLng(latlng);
       setInputValueFromLatLng(latlng);
     } else {
       endpoint.getGeocode();
@@ -67,7 +67,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
         return;
       }
 
-      endpoint.setLatLng(L.latLng(json[0]));
+      setLatLng(L.latLng(json[0]));
 
       input.val(json[0].display_name);
 
@@ -75,13 +75,13 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
     });
   };
 
-  endpoint.setLatLng = function (ll) {
+  function setLatLng(ll) {
     endpoint.hasGeocode = true;
     endpoint.latlng = ll;
     endpoint.marker
       .setLatLng(ll)
       .addTo(map);
-  };
+  }
 
   function setInputValueFromLatLng(latlng) {
     var precision = OSM.zoomPrecision(map.getZoom());

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -15,7 +15,11 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
   });
 
   endpoint.marker.on("drag dragend", function (e) {
-    endpoint.setLatLng(e.target.getLatLng());
+    var latlng = e.target.getLatLng();
+
+    endpoint.setLatLng(latlng);
+    setInputValueFromLatLng(latlng);
+    endpoint.value = input.val();
     dragCallback(e.type === "drag");
   });
 
@@ -37,6 +41,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
 
     if (latlng) {
       endpoint.setLatLng(latlng);
+      setInputValueFromLatLng(latlng);
     } else {
       endpoint.getGeocode();
     }
@@ -71,14 +76,18 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
   };
 
   endpoint.setLatLng = function (ll) {
-    var precision = OSM.zoomPrecision(map.getZoom());
-    input.val(ll.lat.toFixed(precision) + ", " + ll.lng.toFixed(precision));
     endpoint.hasGeocode = true;
     endpoint.latlng = ll;
     endpoint.marker
       .setLatLng(ll)
       .addTo(map);
   };
+
+  function setInputValueFromLatLng(latlng) {
+    var precision = OSM.zoomPrecision(map.getZoom());
+
+    input.val(latlng.lat.toFixed(precision) + ", " + latlng.lng.toFixed(precision));
+  }
 
   return endpoint;
 };

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -300,7 +300,9 @@ OSM.Directions = function (map) {
       var pt = L.DomEvent.getMousePosition(oe, map.getContainer()); // co-ordinates of the mouse pointer at present
       pt.y += 20;
       var ll = map.containerPointToLatLng(pt);
-      endpoints[type === "from" ? 0 : 1].setLatLng(ll);
+      var precision = OSM.zoomPrecision(map.getZoom());
+      var value = ll.lat.toFixed(precision) + ", " + ll.lng.toFixed(precision);
+      endpoints[type === "from" ? 0 : 1].setValue(value, ll);
       getRoute(true, true);
     });
 


### PR DESCRIPTION
This is a smaller part of #5064 that can be applied independently.

Instead of two methods to pass values/positions to endpoint (`setValue`, `setLatLng`) you get one, `setValue`. `setValue` after this PR has two arguments, `value` and `latlng`, and the next step is to remove `latlng` and let the endpoint figure out itself if `value` contains coordinates or if it doesn't.