### PR TITLE
Switch to edit pane if rich text field validation fails

### DIFF
--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -8,6 +8,10 @@ $(document).ready(function () {
     var container = $(this).closest(".richtext_container");
 
     container.find(".tab-pane[id$='_preview']").empty();
+  }).on("invalid", function () {
+    var container = $(this).closest(".richtext_container");
+
+    container.find("button[data-bs-target$='_edit']").tab("show");
   });
 
   /*

--- a/test/system/rich_text_test.rb
+++ b/test/system/rich_text_test.rb
@@ -1,0 +1,16 @@
+require "application_system_test_case"
+
+class RichTextSystemTest < ApplicationSystemTestCase
+  def setup
+    create(:language, :code => "en")
+  end
+
+  test "switches to edit pane on validation failure" do
+    sign_in_as create(:user)
+    visit new_diary_entry_path
+    fill_in "Subject", :with => "My Diary Entry Title"
+    click_on "Preview"
+    click_on "Publish"
+    assert_field "Body"
+  end
+end


### PR DESCRIPTION
Before you'd click the submit button and nothing would happen if the text is invalid:
![image](https://github.com/user-attachments/assets/579ee9fc-2173-4d79-a152-4207d0746cb0)

With this PR the *Edit* pane shows which lets you see the validation message:
![image](https://github.com/user-attachments/assets/60691d63-0782-49c6-a5b5-7154d870bd4d)
