### PR TITLE
Add debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -180,4 +180,7 @@ end
 
 group :development, :test do
   gem "annotate"
+
+  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem "debug", :require => "debug/prelude"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,9 @@ GEM
       sprockets-rails
       tilt
     date (3.3.4)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
     delayed_job (4.1.11)
@@ -627,6 +630,7 @@ DEPENDENCIES
   connection_pool
   dalli
   dartsass-sprockets
+  debug
   debug_inspector
   delayed_job_active_record
   doorkeeper


### PR DESCRIPTION
This is included in new rails 7+ apps, so let's include it too.

This also means it's available on ruby 3.0, and is automatically updated on newer versions of ruby too.

I've copied this directly from [the upstream `rails new` Gemfile template](https://github.com/rails/rails/blob/eaa74eedba945e1bdcedd7fa6ac38c6493edd735/railties/lib/rails/generators/rails/app/templates/Gemfile.tt#L45-L46).