### PR TITLE
Add article:published_time meta tag to diary entries

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -71,7 +71,8 @@ class DiaryEntriesController < ApplicationController
       @opengraph_properties = {
         "og:image" => @entry.body.image,
         "og:image:alt" => @entry.body.image_alt,
-        "og:description" => @entry.body.description
+        "og:description" => @entry.body.description,
+        "article:published_time" => @entry.created_at.xmlschema
       }
       @comments = can?(:unhide, DiaryComment) ? @entry.comments : @entry.visible_comments
     else

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -10,6 +10,8 @@ module OpenGraphHelper
       "og:description" => properties["og:description"] || t("layouts.intro_text")
     }.merge(
       opengraph_image_properties(properties)
+    ).merge(
+      properties.slice("article:published_time")
     )
 
     safe_join(tags.map do |property, content|

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -766,6 +766,17 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_show_article_published_time
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :created_at => "2020-03-04")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='article:published_time']" do
+      assert_dom "> @content", "2020-03-04T00:00:00Z"
+    end
+  end
+
   def test_hide
     user = create(:user)
     diary_entry = create(:diary_entry, :user => user)


### PR DESCRIPTION
Mastodon seems to be using it:
https://en.osm.town/@openstreetmap/112670776752214880