### PR TITLE
Rename geocodeCallback to changeCallback, call it from latlon setValue

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -1,4 +1,4 @@
-OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, geocodeCallback) {
+OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, changeCallback) {
   var endpoint = {};
 
   endpoint.marker = L.marker([0, 0], {
@@ -42,6 +42,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
     if (latlng) {
       setLatLng(latlng);
       setInputValueFromLatLng(latlng);
+      changeCallback();
     } else {
       endpoint.getGeocode();
     }
@@ -71,7 +72,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ge
 
       input.val(json[0].display_name);
 
-      geocodeCallback();
+      changeCallback();
     });
   };
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -28,13 +28,13 @@ OSM.Directions = function (map) {
 
     getRoute(false, !dragging);
   };
-  var endpointGeocodeCallback = function () {
+  var endpointChangeCallback = function () {
     getRoute(true, true);
   };
 
   var endpoints = [
-    OSM.DirectionsEndpoint(map, $("input[name='route_from']"), OSM.MARKER_GREEN, endpointDragCallback, endpointGeocodeCallback),
-    OSM.DirectionsEndpoint(map, $("input[name='route_to']"), OSM.MARKER_RED, endpointDragCallback, endpointGeocodeCallback)
+    OSM.DirectionsEndpoint(map, $("input[name='route_from']"), OSM.MARKER_GREEN, endpointDragCallback, endpointChangeCallback),
+    OSM.DirectionsEndpoint(map, $("input[name='route_to']"), OSM.MARKER_RED, endpointDragCallback, endpointChangeCallback)
   ];
 
   var expiry = new Date();
@@ -303,7 +303,6 @@ OSM.Directions = function (map) {
       var precision = OSM.zoomPrecision(map.getZoom());
       var value = ll.lat.toFixed(precision) + ", " + ll.lng.toFixed(precision);
       endpoints[type === "from" ? 0 : 1].setValue(value, ll);
-      getRoute(true, true);
     });
 
     var params = Qs.parse(location.search.substring(1)),
@@ -323,8 +322,6 @@ OSM.Directions = function (map) {
     endpoints[1].setValue(params.to || "", to);
 
     map.setSidebarOverlaid(!from || !to);
-
-    getRoute(true, true);
   };
 
   page.load = function () {


### PR DESCRIPTION
Another piece of #5064 which changes how callbacks work. The code outside endpoints module shouldn't care if geocoding was performed or not. Previously there was a special callback for completed geocoding, you waited for it and then you built the route. But if you passed coordinates to endpoint.setValue you knew that geocoding may not happen therefore you had to try to build the route right away. Now you just always wait for a callback because it happens even without geocoding.