### PR TITLE
Prevent reactivating inactive blocks

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2950,6 +2950,7 @@ en:
     update:
       only_creator_can_edit: "Only the moderator who created this block can edit it."
       only_creator_or_revoker_can_edit: "Only the moderators who created or revoked this block can edit it."
+      inactive_block_cannot_be_reactivated: "This block is inactive and cannot be reactivated."
       success: "Block updated."
     index:
       title: "User blocks"


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/pull/5069/files#r1715714691

Let's disable block reactivations first.

![image](https://github.com/user-attachments/assets/3aab7677-517f-4df3-9c4a-c2fed3024c9b)
