### PR TITLE
Don't call getGeocode from getRoute

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -43,18 +43,12 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
       setLatLng(latlng);
       setInputValueFromLatLng(latlng);
       changeCallback();
-    } else {
+    } else if (endpoint.value) {
       endpoint.getGeocode();
     }
   };
 
   endpoint.getGeocode = function () {
-    // if no one has entered a value yet, then we can't geocode, so don't
-    // even try.
-    if (!endpoint.value) {
-      return;
-    }
-
     endpoint.awaitingGeocode = true;
 
     var viewbox = map.getBounds().toBBoxString(); // <sw lon>,<sw lat>,<ne lon>,<ne lat>

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -61,7 +61,6 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
 
     $.getJSON(OSM.NOMINATIM_URL + "search?q=" + encodeURIComponent(endpoint.value) + "&format=json&viewbox=" + viewbox, function (json) {
       endpoint.awaitingGeocode = false;
-      endpoint.hasGeocode = true;
       if (json.length === 0) {
         input.addClass("is-invalid");
         alert(I18n.t("javascripts.directions.errors.no_place", { place: endpoint.value }));
@@ -77,7 +76,6 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
   };
 
   function setLatLng(ll) {
-    endpoint.hasGeocode = true;
     endpoint.latlng = ll;
     endpoint.marker
       .setLatLng(ll)

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -44,11 +44,11 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
       setInputValueFromLatLng(latlng);
       changeCallback();
     } else if (endpoint.value) {
-      endpoint.getGeocode();
+      getGeocode();
     }
   };
 
-  endpoint.getGeocode = function () {
+  function getGeocode() {
     endpoint.awaitingGeocode = true;
 
     var viewbox = map.getBounds().toBBoxString(); // <sw lon>,<sw lat>,<ne lon>,<ne lat>
@@ -67,7 +67,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
 
       changeCallback();
     });
-  };
+  }
 
   function setLatLng(ll) {
     endpoint.latlng = ll;

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -119,18 +119,6 @@ OSM.Directions = function (map) {
     // Cancel any route that is already in progress
     if (routeRequest) routeRequest.abort();
 
-    // go fetch geocodes for any endpoints which have not already
-    // been geocoded.
-    for (var ep_i = 0; ep_i < 2; ++ep_i) {
-      var endpoint = endpoints[ep_i];
-      if (!endpoint.hasGeocode && !endpoint.awaitingGeocode) {
-        endpoint.getGeocode();
-      }
-    }
-    if (endpoints[0].awaitingGeocode || endpoints[1].awaitingGeocode) {
-      return;
-    }
-
     var o = endpoints[0].latlng,
         d = endpoints[1].latlng;
 


### PR DESCRIPTION
Part of #5064.

`getRoute` shouldn't know anything about geocoding, doesn't need to wait for every kind of geocoding (namely for reverse one), therefore shouldn't command the endpoints to do it. All necessary geocoding is triggered by `endpoint.setValue` and input event listeners.