### PR TITLE
Change zoom precision function

### DIFF
--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -204,7 +204,9 @@ OSM = {
   },
 
   zoomPrecision: function(zoom) {
-    return Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
+    var pixels = Math.pow(2, 8 + zoom);
+    var degrees = 180;
+    return Math.ceil(Math.log10(pixels / degrees));
   },
 
   locationCookie: function(map) {


### PR DESCRIPTION
This changes the number of fractional digits to log10(pixels / degrees) with pixels = 2**(8 + zoom) and degrees = 180.

---

If you apply the entire #5064, zoom in to the max zoom level, place an endpoint marker and try to drag it around, you'll notice it moves by jumping several pixels. This is because I limit its coordinates to zoom precision and zoom precision is not high enough. Its current version was introduced in https://github.com/openstreetmap/openstreetmap-website/commit/b28511faca45d8d8abc0d3c2fde5a501bbe94062. You can notice something strange about it: the zoom value went from being an argument of `Math.pow` to an argument of `Math.log`. `zoom` is already on a log scale, why do you need to take its log again?

| zoom | old zoomPrecision | new zoomPrecision |
| --- | --- | --- |
| 0 | 0 | 1 |
| 1 | 0 | 1 |
| 2 | 1 | 1 |
| 3 | 2 | 2 |
| 4 | 2 | 2 |
| 5 | 3 | 2 |
| 6 | 3 | 2 |
| 7 | 3 | 3 |
| 8 | 3 | 3 |
| 9 | 4 | 3 |
| 10 | 4 | 4 |
| 11 | 4 | 4 |
| 12 | 4 | 4 |
| 13 | 4 | 5 |
| 14 | 4 | 5 |
| 15 | 4 | 5 |
| 16 | 4 | 5 |
| 17 | 5 | 6 |
| 18 | 5 | 6 |
| 19 | 5 | 6 |
| 20 | 5 | 7 |
| 21 | 5 | 7 |

Some layers go up to zoom 21, precision limits become very noticeable there. Even on level 0 you need at least one digit after `.` to translate -90..+90 to 256 tile pixels.