### PR TITLE
Remove duration and needs_view inputs from inactive block edit form

### DIFF
--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -12,16 +12,25 @@
 <%= bootstrap_form_for(@user_block) do |f| %>
   <%= f.richtext_field :reason, :cols => 80, :rows => 20, :format => @user_block.reason_format %>
 
-  <%= f.form_group do %>
-    <%= label_tag "user_block_period", t(".period"), :class => "form-label" %>
-    <%= select_tag("user_block_period",
-                   options_for_select(UserBlock::PERIODS.collect { |h| [block_duration_in_words(h.hours), h.to_s] },
-                                      UserBlock::PERIODS.min_by { |h| (params[:user_block_period].to_i - h).abs }),
-                   :class => "form-select") %>
-  <% end %>
+  <% if @user_block.active? %>
+    <%= f.form_group do %>
+      <%= label_tag "user_block_period", t(".period"), :class => "form-label" %>
+      <%= select_tag "user_block_period",
+                     options_for_select(UserBlock::PERIODS.collect { |h| [block_duration_in_words(h.hours), h.to_s] },
+                                        UserBlock::PERIODS.min_by { |h| (params[:user_block_period].to_i - h).abs }),
+                     :class => "form-select" %>
+    <% end %>
 
-  <%= f.form_group :needs_view do %>
-    <%= f.check_box :needs_view %>
+    <%= f.form_group :needs_view do %>
+      <%= f.check_box :needs_view %>
+    <% end %>
+  <% else %>
+    <div class="alert alert-info">
+      <%= t "user_blocks.update.inactive_block_cannot_be_reactivated" %>
+    </div>
+
+    <%= hidden_field_tag "user_block_period", 0 %>
+    <%= f.hidden_field :needs_view %>
   <% end %>
 
   <%= f.primary %>

--- a/test/system/user_blocks_test.rb
+++ b/test/system/user_blocks_test.rb
@@ -68,4 +68,34 @@ class UserBlocksSystemTest < ApplicationSystemTestCase
     assert_unchecked_field "Are you sure you wish to revoke 2 active blocks?"
     assert_button "Revoke!"
   end
+
+  test "duration controls are present for active blocks" do
+    creator_user = create(:moderator_user)
+    block = create(:user_block, :creator => creator_user, :reason => "Testing editing active blocks", :ends_at => Time.now.utc + 2.days)
+    sign_in_as(creator_user)
+
+    visit edit_user_block_path(block)
+    assert_field "Reason", :with => "Testing editing active blocks"
+    assert_select "user_block_period", :selected => "2 days"
+    assert_unchecked_field "Needs view"
+
+    fill_in "Reason", :with => "Editing active blocks works"
+    click_on "Update block"
+    assert_text(/Reason for block:\s+Editing active blocks works/)
+  end
+
+  test "duration controls are removed for inactive blocks" do
+    creator_user = create(:moderator_user)
+    block = create(:user_block, :expired, :creator => creator_user, :reason => "Testing editing expired blocks")
+    sign_in_as(creator_user)
+
+    visit edit_user_block_path(block)
+    assert_field "Reason", :with => "Testing editing expired blocks"
+    assert_no_select "user_block_period"
+    assert_no_field "Needs view"
+
+    fill_in "Reason", :with => "Editing expired blocks works"
+    click_on "Update block"
+    assert_text(/Reason for block:\s+Editing expired blocks works/)
+  end
 end


### PR DESCRIPTION
Since #5082 removed the ability to reactivate blocks, we can remove the inputs for doing that too. Inactive blocks will have only editable reason input.

![image](https://github.com/user-attachments/assets/72d8c91c-7364-45f8-8604-b35bd71d35f0)
