### PR TITLE
Add navigation tabs to edit block pages

### DIFF
--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -38,7 +38,7 @@
     <li class="nav-item">
       <%= link_to t(".block", :id => @user_block.id),
                   user_block_path(@user_block),
-                  :class => ["nav-link", { :active => action_name == "show" }] %>
+                  :class => "nav-link active" %>
     </li>
   <% end %>
 </ul>

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -1,12 +1,9 @@
 <% @title = t ".title", :name => @user_block.user.display_name %>
+
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html", :name => link_to(@user_block.user.display_name, @user_block.user)) %></h1>
-  <nav class='secondary-actions'>
-    <ul class='clearfix'>
-      <li><%= link_to t(".show"), @user_block %></li>
-      <li><%= link_to t(".back"), user_blocks_path %></li>
-    </ul>
-  </nav>
+  <%= render :partial => "navigation" %>
 <% end %>
 
 <%= bootstrap_form_for(@user_block) do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2941,8 +2941,6 @@ en:
       title: "Editing block on %{name}"
       heading_html: "Editing block on %{name}"
       period: "How long, starting now, the user will be blocked from the API for."
-      show: "View this block"
-      back: "View all blocks"
     filter:
       block_period: "The blocking period must be one of the values selectable in the drop-down list."
     create:


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/14f467eb-b74c-45c4-bc0a-8087aec402ba)

After:
![image](https://github.com/user-attachments/assets/4ce2ceed-5d48-4c2d-bcc3-3605274fe45c)

The last tab leads to the block show page and is selected even if we're on edit page. I don't think it's worth it to add another tab just for the edit page.