### PR TITLE
Truncate long usernames in blocks tables

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -904,6 +904,12 @@ div.secondary-actions {
   }
 }
 
+/* Rules for block pages */
+
+#block_list .username {
+  max-width: 20em;
+}
+
 /* Rules for tabs inside secondary background sections */
 
 .bg-body-secondary .nav-tabs {

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -1,9 +1,9 @@
 <tr>
   <% if show_user_name %>
-  <td><%= link_to block.user.display_name, block.user %></td>
+  <td><%= link_to block.user.display_name, block.user, :class => "username d-inline-block text-truncate text-wrap" %></td>
   <% end %>
   <% if show_creator_name %>
-  <td><%= link_to block.creator.display_name, block.creator %></td>
+  <td><%= link_to block.creator.display_name, block.creator, :class => "username d-inline-block text-truncate text-wrap" %></td>
   <% end %>
   <td><%= h truncate(block.reason) %></td>
   <td><%= h block_status(block) %></td>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/c14900a2-65cf-43bb-8cd2-365955e42a26)

After:
![image](https://github.com/user-attachments/assets/30809711-76d8-4bcf-90f0-f072d808386c)
