### PR TITLE
Copy "From" endpoint value to search input when closing directions

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -75,12 +75,8 @@ OSM.Directions = function (map) {
 
   $(".directions_form .btn-close").on("click", function (e) {
     e.preventDefault();
-    var route_from = endpoints[0].value;
-    if (route_from) {
-      OSM.router.route("/?query=" + encodeURIComponent(route_from) + OSM.formatHash(map));
-    } else {
-      OSM.router.route("/" + OSM.formatHash(map));
-    }
+    $(".search_form input[name='query']").val(endpoints[0].value);
+    OSM.router.route("/" + OSM.formatHash(map));
   });
 
   function formatDistance(m) {


### PR DESCRIPTION
When you close the directions form there's this code that tries to use the "From" value for searching.
![image](https://github.com/user-attachments/assets/01b267fa-2db9-4631-866c-076919d1b6ef)

It does so by opening the url `/?query=...`. The url is wrong, it should be `/search?query=...`, thus nothing happens.

I could have fixed it by using `/search?query=...`, but I don't like that it runs the search right away, when the close button is clicked. Instead I set the search input value.

![image](https://github.com/user-attachments/assets/6cddbbc6-64b1-4892-9574-3fca69c5f337)
