### PR TITLE
Don't update ends_at when editing inactive blocks

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -75,11 +75,14 @@ class UserBlocksController < ApplicationController
         if !user_block_was_active && @user_block.active?
           flash.now[:error] = t(".inactive_block_cannot_be_reactivated")
           render :action => "edit"
-        elsif @user_block.save
-          flash[:notice] = t(".success")
-          redirect_to @user_block
         else
-          render :action => "edit"
+          @user_block.ends_at = @user_block.ends_at_was unless user_block_was_active
+          if @user_block.save
+            flash[:notice] = t(".success")
+            redirect_to @user_block
+          else
+            render :action => "edit"
+          end
         end
       end
     else

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -799,6 +799,8 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   end
 
   def check_inactive_block_updates(block)
+    original_ends_at = block.ends_at
+
     put user_block_path(block,
                         :user_block_period => "0",
                         :user_block => { :needs_view => false, :reason => "Updated Reason" })
@@ -807,6 +809,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     block.reload
     assert_not_predicate block, :active?
     assert_equal "Updated Reason", block.reason
+    assert_equal original_ends_at, block.ends_at
 
     put user_block_path(block,
                         :user_block_period => "0",
@@ -816,6 +819,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     block.reload
     assert_not_predicate block, :active?
     assert_equal "Updated Reason", block.reason
+    assert_equal original_ends_at, block.ends_at
 
     put user_block_path(block,
                         :user_block_period => "1",
@@ -825,6 +829,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     block.reload
     assert_not_predicate block, :active?
     assert_equal "Updated Reason", block.reason
+    assert_equal original_ends_at, block.ends_at
 
     put user_block_path(block,
                         :user_block_period => "0",
@@ -834,6 +839,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     block.reload
     assert_not_predicate block, :active?
     assert_equal "Updated Reason Again", block.reason
+    assert_equal original_ends_at, block.ends_at
   end
 
   def check_user_blocks_table(user_blocks)


### PR DESCRIPTION
If you edit an inactive block, you can change its text but you can't reactivate it. You are prevented from reactivating it by keeping the block duration at 0. But even setting the duration to 0 changes the block end time, because it's set to now + duration. This in turn affects the duration as reported on the block show page, that shows duration = end_at - created_at. You wanted to just update the text, yet you altered the duration too. That's not something you expect to happen.

This PR keeps old ends_at time when updating inactive blocks.

Example with 0-hour block edited months later:

Before:
![image](https://github.com/user-attachments/assets/0a094d09-6e3a-4e21-9a08-9590a7f6d1ee)

After:
![image](https://github.com/user-attachments/assets/0c579a2f-ec8b-4af3-abea-2557c22efe96)
