### PR TITLE
Add navigation tabs to new block pages

### DIFF
--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -34,10 +34,16 @@
                   :class => ["nav-link", { :active => action_name == "blocks_by" }] %>
     </li>
   <% end %>
-  <% if @user_block %>
+  <% if @user_block&.persisted? %>
     <li class="nav-item">
       <%= link_to t(".block", :id => @user_block.id),
                   user_block_path(@user_block),
+                  :class => "nav-link active" %>
+    </li>
+  <% elsif @user_block&.new_record? %>
+    <li class="nav-item">
+      <%= link_to t(".new_block"),
+                  new_user_block_path,
                   :class => "nav-link active" %>
     </li>
   <% end %>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -1,7 +1,11 @@
 <% @title = t ".title", :name => @user.display_name %>
+
+<% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html", :name => link_to(@user.display_name, @user)) %></h1>
+  <%= render :partial => "navigation" %>
 <% end %>
+
 <%= bootstrap_form_for(@user_block) do |f| %>
   <%= hidden_field_tag "display_name", @user.display_name, :autocomplete => "off" %>
   <%= f.richtext_field :reason, :cols => 80, :rows => 20 %>
@@ -18,5 +22,4 @@
   <% end %>
 
   <%= f.primary %>
-  <%= link_to t(".back"), user_blocks_path, :class => "btn btn-link" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2936,7 +2936,6 @@ en:
       title: "Creating block on %{name}"
       heading_html: "Creating block on %{name}"
       period: "How long, starting now, the user will be blocked from the API for."
-      back: "View all blocks"
     edit:
       title: "Editing block on %{name}"
       heading_html: "Editing block on %{name}"
@@ -3034,6 +3033,7 @@ en:
       blocks_by_me: "Blocks by Me"
       blocks_by_user: "Blocks by %{user}"
       block: "Block #%{id}"
+      new_block: "New Block"
   user_mutes:
     index:
       title: "Muted Users"


### PR DESCRIPTION
Similar to #5086

Before:
![image](https://github.com/user-attachments/assets/0d3d35c3-5494-472e-b88b-8a69a5145a7e)
...
![image](https://github.com/user-attachments/assets/b1267940-6919-4293-ae5c-a41dd08e437a)

After:
![image](https://github.com/user-attachments/assets/d36aeaa2-da89-49f5-9df5-aa7c52ca0da0)
...
![image](https://github.com/user-attachments/assets/4d4b453c-23df-4b36-a019-92a44a0a4bb7)

Related to #3267 where back buttons get outlines. This PR removes one of these buttons.