### PR TITLE
Use shallow routes for diary comments

### DIFF
--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -13,9 +13,9 @@
     <% if can? :hide, DiaryComment %>
       <span>
         <% if diary_comment.visible? %>
-          <%= link_to t(".hide_link"), hide_diary_comment_path(diary_comment.diary_entry.user, diary_comment.diary_entry, diary_comment), :method => :post, :data => { :confirm => t(".confirm") } %>
+          <%= link_to t(".hide_link"), hide_diary_comment_path(diary_comment), :method => :post, :data => { :confirm => t(".confirm") } %>
         <% else %>
-          <%= link_to t(".unhide_link"), unhide_diary_comment_path(diary_comment.diary_entry.user, diary_comment.diary_entry, diary_comment), :method => :post, :data => { :confirm => t(".confirm") } %>
+          <%= link_to t(".unhide_link"), unhide_diary_comment_path(diary_comment), :method => :post, :data => { :confirm => t(".confirm") } %>
         <% end %>
       </span>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,8 +253,8 @@ OpenStreetMap::Application.routes.draw do
   match "/user/:display_name/diary/:id/subscribe" => "diary_entries#subscribe", :via => [:get, :post], :as => :diary_entry_subscribe, :id => /\d+/
   match "/user/:display_name/diary/:id/unsubscribe" => "diary_entries#unsubscribe", :via => [:get, :post], :as => :diary_entry_unsubscribe, :id => /\d+/
   post "/user/:display_name/diary/:id/comments" => "diary_comments#create", :id => /\d+/, :as => :comment_diary_entry
-  post "/user/:display_name/diary/:id/comments/:comment/hide" => "diary_comments#hide", :id => /\d+/, :comment => /\d+/, :as => :hide_diary_comment
-  post "/user/:display_name/diary/:id/comments/:comment/unhide" => "diary_comments#unhide", :id => /\d+/, :comment => /\d+/, :as => :unhide_diary_comment
+  post "/diary_comments/:comment/hide" => "diary_comments#hide", :comment => /\d+/, :as => :hide_diary_comment
+  post "/diary_comments/:comment/unhide" => "diary_comments#unhide", :comment => /\d+/, :as => :unhide_diary_comment
 
   # user pages
   resources :users, :path => "user", :param => :display_name, :only => [:show, :destroy]

--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -17,12 +17,12 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
       { :controller => "diary_comments", :action => "create", :display_name => "username", :id => "1" }
     )
     assert_routing(
-      { :path => "/user/username/diary/1/comments/2/hide", :method => :post },
-      { :controller => "diary_comments", :action => "hide", :display_name => "username", :id => "1", :comment => "2" }
+      { :path => "/diary_comments/2/hide", :method => :post },
+      { :controller => "diary_comments", :action => "hide", :comment => "2" }
     )
     assert_routing(
-      { :path => "/user/username/diary/1/comments/2/unhide", :method => :post },
-      { :controller => "diary_comments", :action => "unhide", :display_name => "username", :id => "1", :comment => "2" }
+      { :path => "/diary_comments/2/unhide", :method => :post },
+      { :controller => "diary_comments", :action => "unhide", :comment => "2" }
     )
 
     get "/user/username/diary/comments/1"
@@ -186,19 +186,19 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
     diary_comment = create(:diary_comment, :diary_entry => diary_entry)
 
     # Try without logging in
-    post hide_diary_comment_path(user, diary_entry, diary_comment)
+    post hide_diary_comment_path(diary_comment)
     assert_response :forbidden
     assert DiaryComment.find(diary_comment.id).visible
 
     # Now try as a normal user
     session_for(user)
-    post hide_diary_comment_path(user, diary_entry, diary_comment)
+    post hide_diary_comment_path(diary_comment)
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert DiaryComment.find(diary_comment.id).visible
 
     # Try as a moderator
     session_for(create(:moderator_user))
-    post hide_diary_comment_path(user, diary_entry, diary_comment)
+    post hide_diary_comment_path(diary_comment)
     assert_redirected_to diary_entry_path(user, diary_entry)
     assert_not DiaryComment.find(diary_comment.id).visible
 
@@ -207,7 +207,7 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
 
     # Finally try as an administrator
     session_for(create(:administrator_user))
-    post hide_diary_comment_path(user, diary_entry, diary_comment)
+    post hide_diary_comment_path(diary_comment)
     assert_redirected_to diary_entry_path(user, diary_entry)
     assert_not DiaryComment.find(diary_comment.id).visible
   end
@@ -218,19 +218,19 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
     diary_comment = create(:diary_comment, :diary_entry => diary_entry, :visible => false)
 
     # Try without logging in
-    post unhide_diary_comment_path(user, diary_entry, diary_comment)
+    post unhide_diary_comment_path(diary_comment)
     assert_response :forbidden
     assert_not DiaryComment.find(diary_comment.id).visible
 
     # Now try as a normal user
     session_for(user)
-    post unhide_diary_comment_path(user, diary_entry, diary_comment)
+    post unhide_diary_comment_path(diary_comment)
     assert_redirected_to :controller => :errors, :action => :forbidden
     assert_not DiaryComment.find(diary_comment.id).visible
 
     # Now try as a moderator
     session_for(create(:moderator_user))
-    post unhide_diary_comment_path(user, diary_entry, diary_comment)
+    post unhide_diary_comment_path(diary_comment)
     assert_redirected_to diary_entry_path(user, diary_entry)
     assert DiaryComment.find(diary_comment.id).visible
 
@@ -239,7 +239,7 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
 
     # Finally try as an administrator
     session_for(create(:administrator_user))
-    post unhide_diary_comment_path(user, diary_entry, diary_comment)
+    post unhide_diary_comment_path(diary_comment)
     assert_redirected_to diary_entry_path(user, diary_entry)
     assert DiaryComment.find(diary_comment.id).visible
   end


### PR DESCRIPTION
Changes routes from 

`/user/:display_name/diary/:id/comments/:comment/hide`

to

`/diary_comments/:comment/hide`

\+ the same for unhide.

This is what you'll get if you define comments as a shallow nested resource like this:

```ruby
  resources :users, :path => "user", :param => :display_name do
    resources :diary_entries, :path => "diary" do
      resources :diary_comments, :shallow => true do
        ...
      end
    end
  end
```

Paths with display_name and diary entry id are too long and these names/ids are not used for anything in the controller.