### PR TITLE
Record revokers when deactivating blocks by editing

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -72,6 +72,7 @@ class UserBlocksController < ApplicationController
         @user_block.reason = params[:user_block][:reason]
         @user_block.needs_view = params[:user_block][:needs_view]
         @user_block.ends_at = Time.now.utc + @block_period.hours
+        @user_block.revoker = current_user if user_block_was_active && !@user_block.active?
         if !user_block_was_active && @user_block.active?
           flash.now[:error] = t(".inactive_block_cannot_be_reactivated")
           render :action => "edit"

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -494,6 +494,28 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   end
 
   ##
+  # test the update action revoking the block
+  def test_revoke_using_update
+    moderator_user = create(:moderator_user)
+    block = create(:user_block, :creator => moderator_user)
+
+    session_for(moderator_user)
+    put user_block_path(block,
+                        :user_block_period => "24",
+                        :user_block => { :needs_view => false, :reason => "Updated Reason" })
+    block.reload
+    assert_predicate block, :active?
+    assert_nil block.revoker
+
+    put user_block_path(block,
+                        :user_block_period => "0",
+                        :user_block => { :needs_view => false, :reason => "Updated Reason" })
+    block.reload
+    assert_not_predicate block, :active?
+    assert_equal moderator_user, block.revoker
+  end
+
+  ##
   # test the revoke action
   def test_revoke
     active_block = create(:user_block)


### PR DESCRIPTION
You can deactivate a block using the revoke action. But you can also deactivate a block by editing it and setting duration=0 + needs_view=false. The difference is that you're not being recorded as a revoker if you do that. This PR records you as a revoker in this case too.

This kind of editing is only available to you if you're the block creator. The point of this PR is to relax this check later and let any moderator revoke blocks by editing, then remove the revoke action. Instead of first going to the revoke confirmation page with "Are you sure you wish to revoke this block?" and then possibly going to the edit page, moderators will be able to edit the block reason and revoke the block from the same page.