### PR TITLE
Add enable/disable endpoint methods

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -14,24 +14,36 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     autoPan: true
   });
 
-  endpoint.marker.on("drag dragend", function (e) {
+  endpoint.enable = function () {
+    endpoint.marker.on("drag dragend", markerDragListener);
+    input.on("keydown", inputKeydownListener);
+    input.on("change", inputChangeListener);
+  };
+
+  endpoint.disable = function () {
+    endpoint.marker.off("drag dragend", markerDragListener);
+    input.off("keydown", inputKeydownListener);
+    input.off("change", inputChangeListener);
+  };
+
+  function markerDragListener(e) {
     var latlng = e.target.getLatLng();
 
     setLatLng(latlng);
     setInputValueFromLatLng(latlng);
     endpoint.value = input.val();
     dragCallback(e.type === "drag");
-  });
+  }
 
-  input.on("keydown", function () {
+  function inputKeydownListener() {
     input.removeClass("is-invalid");
-  });
+  }
 
-  input.on("change", function (e) {
+  function inputChangeListener(e) {
     // make text the same in both text boxes
     var value = e.target.value;
     endpoint.setValue(value);
-  });
+  }
 
   endpoint.setValue = function (value, latlng) {
     endpoint.value = value;

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -24,6 +24,8 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     endpoint.marker.off("drag dragend", markerDragListener);
     input.off("keydown", inputKeydownListener);
     input.off("change", inputChangeListener);
+
+    map.removeLayer(endpoint.marker);
   };
 
   function markerDragListener(e) {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -290,6 +290,9 @@ OSM.Directions = function (map) {
       endpoints[type === "from" ? 0 : 1].setValue(value, ll);
     });
 
+    endpoints[0].enable();
+    endpoints[1].enable();
+
     var params = Qs.parse(location.search.substring(1)),
         route = (params.route || "").split(";"),
         from = route[0] && L.latLng(route[0].split(",")),
@@ -317,6 +320,9 @@ OSM.Directions = function (map) {
     $(".search_form").show();
     $(".directions_form").hide();
     $("#map").off("dragend dragover drop");
+
+    endpoints[0].disable();
+    endpoints[1].disable();
 
     map
       .removeLayer(popup)

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -326,9 +326,7 @@ OSM.Directions = function (map) {
 
     map
       .removeLayer(popup)
-      .removeLayer(polyline)
-      .removeLayer(endpoints[0].marker)
-      .removeLayer(endpoints[1].marker);
+      .removeLayer(polyline);
   };
 
   return page;


### PR DESCRIPTION
Part of #5064. I'm pulling it out because it's also required for #4900.

The noticeable difference after this PR should be geocoding request cancelling when leaving the directions page. Previously you could pick "Directions from/to here" then quickly close the directions form or go to any other map layout page. The geocoding request could terminate after that, placing an endpoint marker on the map despite not being on the directions page.