### PR TITLE
Show/hide "Where is this?" when setting search value from directions

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -75,6 +75,7 @@ OSM.Directions = function (map) {
 
   $(".directions_form .btn-close").on("click", function (e) {
     e.preventDefault();
+    $(".describe_location").toggle(!endpoints[0].value);
     $(".search_form input[name='query']").val(endpoints[0].value);
     OSM.router.route("/" + OSM.formatHash(map));
   });


### PR DESCRIPTION
Fix for #5088.

If the "From" value is long enough [like this](https://www.openstreetmap.org/directions?from=7%2C%20Bell%20Yard%2C%20Gray%27s%20Inn%2C%20Holborn%2C%20London%2C%20Greater%20London%2C%20England%2C%20WC2A%202JR%2C%20United%20Kingdom) and you close the directions form, you'll get the search value overlapping with "Where is this?".

![image](https://github.com/user-attachments/assets/712dae62-4e43-4032-b27f-92da4aa9ec1f)
![image](https://github.com/user-attachments/assets/568f98b2-07ab-4a72-af5f-dd71cbcb7e51)

Also sometimes it's possible to delete the value, close the directions and get a blank search input without "Where is this?".
