### PR TITLE
Always use coordinates when using directions from context menu

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -11,7 +11,7 @@ OSM.initializeContextMenu = function (map) {
 
       OSM.router.route("/directions?" + Qs.stringify({
         from: lat + "," + lng,
-        to: $("#route_to").val()
+        to: getDirectionsEndpointCoordinatesFromInput($("#route_to"))
       }));
     }
   });
@@ -25,7 +25,7 @@ OSM.initializeContextMenu = function (map) {
           lng = latlng.lng.toFixed(precision);
 
       OSM.router.route("/directions?" + Qs.stringify({
-        from: $("#route_from").val(),
+        from: getDirectionsEndpointCoordinatesFromInput($("#route_from")),
         to: lat + "," + lng
       }));
     }
@@ -78,6 +78,14 @@ OSM.initializeContextMenu = function (map) {
     if (e.originalEvent.shiftKey) map.contextmenu.disable();
     else map.contextmenu.enable();
   });
+
+  function getDirectionsEndpointCoordinatesFromInput(input) {
+    if (input.attr("data-lat") && input.attr("data-lon")) {
+      return input.attr("data-lat") + "," + input.attr("data-lon");
+    } else {
+      return $(input).val();
+    }
+  }
 
   var updateMenu = function updateMenu() {
     map.contextmenu.setDisabled(2, map.getZoom() < 12);

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -51,7 +51,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
 
   endpoint.setValue = function (value, latlng) {
     endpoint.value = value;
-    delete endpoint.latlng;
+    removeLatLng();
     input.removeClass("is-invalid");
     input.val(value);
 
@@ -86,10 +86,20 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
   }
 
   function setLatLng(ll) {
+    input
+      .attr("data-lat", ll.lat)
+      .attr("data-lon", ll.lng);
     endpoint.latlng = ll;
     endpoint.marker
       .setLatLng(ll)
       .addTo(map);
+  }
+
+  function removeLatLng() {
+    input
+      .removeAttr("data-lat")
+      .removeAttr("data-lon");
+    delete endpoint.latlng;
   }
 
   function setInputValueFromLatLng(latlng) {

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -31,7 +31,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
   };
 
   function markerDragListener(e) {
-    var latlng = e.target.getLatLng();
+    var latlng = convertLatLngToZoomPrecision(e.target.getLatLng());
 
     setLatLng(latlng);
     setInputValueFromLatLng(latlng);
@@ -93,9 +93,13 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
   }
 
   function setInputValueFromLatLng(latlng) {
+    input.val(latlng.lat + ", " + latlng.lng);
+  }
+
+  function convertLatLngToZoomPrecision(latlng) {
     var precision = OSM.zoomPrecision(map.getZoom());
 
-    input.val(latlng.lat.toFixed(precision) + ", " + latlng.lng.toFixed(precision));
+    return L.latLng(latlng.lat.toFixed(precision), latlng.lng.toFixed(precision));
   }
 
   return endpoint;

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -287,7 +287,8 @@ OSM.Directions = function (map) {
       var ll = map.containerPointToLatLng(pt);
       var precision = OSM.zoomPrecision(map.getZoom());
       var value = ll.lat.toFixed(precision) + ", " + ll.lng.toFixed(precision);
-      endpoints[type === "from" ? 0 : 1].setValue(value, ll);
+      var llWithPrecision = L.latLng(ll.lat.toFixed(precision), ll.lng.toFixed(precision));
+      endpoints[type === "from" ? 0 : 1].setValue(value, llWithPrecision);
     });
 
     endpoints[0].enable();


### PR DESCRIPTION
Part of the problem #5064 tries to solve are the result of the context menu using addresses from endpoint inputs.

You right click somewhere, select "Directions from here" and it goes to and url like this: `/directions?from=51.420436%2C-0.174805&to=`. Then you right click somewhere else, select "Directions to here" and the url becomes something like this: `/directions?from=Park%20Road%2C%20Collier%27s%20Wood%2C%20London%20Borough%20of%20Merton%2C%20London%2C%20Greater%20London%2C%20England%2C%20SW19%202HT%2C%20United%20Kingdom&to=51.420563%2C-0.171007`. The coordinates in `from` got replaced by an address. It's impossible to get the original coordinates from an address.

The solution here is to save the coordinates to `data-lat` and `data-lon` attributes of inputs. The context menu then can generate directions urls using the values stored there.

This doesn't solve the entire problem because there's also uncontrolled reverse geocoding decided by Nominatim when using its freeform query.