### PR TITLE
Add overcommit to manage git hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .bundle/config
 .idea
+.local-overcommit.yml
 .ruby-gemset
 .ruby-version
 .vagrant

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,45 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+gemfile: Gemfile
+
+PreCommit:
+  ErbLint:
+    enabled: true
+  EsLint:
+    enabled: true
+    command: ["bin/yarn", "eslint", "-c", "config/eslint.js"]
+    exclude:
+      - vendor/**/*.js
+  RailsSchemaUpToDate:
+    enabled: true
+  RuboCop:
+    enabled: true
+    on_warn: fail
+  TrailingWhitespace:
+    enabled: true
+
+PrePush:
+  Brakeman:
+    enabled: true
+
+PostCheckout:
+  BundleInstall:
+    enabled: true
+  YarnInstall:
+    enabled: true
+    required_executable: bin/yarn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ bundle exec rails eslint
 bundle exec erblint .
 ```
 
+You can also install hooks to have git run checks automatically when
+you commit using [overcommit](https://github.com/sds/overcommit) with:
+
+```
+bundle exec overcommit --install
+```
+
 ## Testing
 
 Having a good suite of tests is very important to the stability and

--- a/Gemfile
+++ b/Gemfile
@@ -151,6 +151,7 @@ group :development do
   gem "debug_inspector"
   gem "i18n-tasks"
   gem "listen"
+  gem "overcommit"
   gem "vendorer"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.4)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -292,6 +294,7 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     image_size (3.4.0)
     in_threads (1.6.0)
+    iniparse (1.5.0)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
@@ -406,6 +409,10 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     openstreetmap-deadlock_retry (1.3.1)
+    overcommit (0.64.0)
+      childprocess (>= 0.6.3, < 6)
+      iniparse (~> 1.4)
+      rexml (~> 3.2)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -675,6 +682,7 @@ DEPENDENCIES
   omniauth-openid
   omniauth-rails_csrf_protection (~> 1.0)
   openstreetmap-deadlock_retry (>= 1.3.1)
+  overcommit
   pg
   puma (~> 5.6)
   quad_tile (~> 1.0.1)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "qs": "^6.9.4"
   },
   "devDependencies": {
-    "eslint": "^9.0.0"
+    "eslint": "^9.0.0",
+    "eslint-formatter-compact": "^8.40.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,6 +227,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-formatter-compact@^8.40.0:
+  version "8.40.0"
+  resolved "https://registry.yarnpkg.com/eslint-formatter-compact/-/eslint-formatter-compact-8.40.0.tgz#d7455b2d75fd70e8c0e7a98a5e189f168e9dfe2d"
+  integrity sha512-cwGUs113TgmTQXecx5kfRjB7m0y2wkDLSadPTE2pK6M/wO4N8PjmUaoWOFNCP9MHgsiZwgqd5bZFnDCnszC56Q==
+
 eslint-scope@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.0.2.tgz#5cbb33d4384c9136083a71190d548158fe128f94"


### PR DESCRIPTION
As suggested in https://github.com/openstreetmap/openstreetmap-website/pull/4988#issuecomment-2285568484 this adds support overcommit to install git gooks to run checks.

With this change `bundle exec overcommit --install` will install hooks to run a variety of checks.