### PR TITLE
Clear endpoint values when leaving directions page

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -27,6 +27,9 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
 
     if (endpoint.geocodeRequest) endpoint.geocodeRequest.abort();
     delete endpoint.geocodeRequest;
+    removeLatLng();
+    delete endpoint.value;
+    input.val("");
     map.removeLayer(endpoint.marker);
   };
 


### PR DESCRIPTION
Originally was in #5064 but I took it out because it solves a different problem.

The problem is:
1. right-click somewhere on the map, select "Directions from here": a starting marker appears on the map
2. right-click some other place, select "Directions to here": first, another marker appears, then a route
3. close the directions form so you're no longer on the directions page but don't do a full page reload
  ![image](https://github.com/user-attachments/assets/cbecff06-79c5-4154-a1ad-025d38086093)
4. scroll to a different place on the map
5. right-click and select "Directions from here"

What do you expect to happen after step 5? Probably the same thing that happened after step 1: a starting marker appearing. But that's not what's going to happen. A route is going to be built from your new start to an old destination you picked in step 2. This will likely be accompanied by an annoying zoom-out to fit the route if you scrolled far away in step 4.

This PR clears endpoint values when leaving the directions page. This prevents building a route to an old endpoint in step 5.