### PR TITLE
Provide a summary view of recent diaries

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -46,6 +46,14 @@ time[title] {
 .icon.note.grey   { /*rtl:ignore*/ background-position: -240px -20px; }
 .icon.query       { /*rtl:ignore*/ background-position: -260px 0; }
 
+.mh-10-collapsed {
+  transition: none;
+
+  &.collapse:not(.show) {
+    max-height: 10rem;
+  }
+}
+
 /* Utility for de-emphasizing content */
 
 .text-body-secondary a {

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -15,6 +15,10 @@ class DiaryEntriesController < ApplicationController
 
   allow_thirdparty_images :only => [:new, :create, :edit, :update, :index, :show]
 
+  content_security_policy(:only => :index) do |policy|
+    policy.img_src(*policy.img_src, "data:")
+  end
+
   def index
     if params[:display_name]
       @user = User.active.find_by(:display_name => params[:display_name])

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -1,7 +1,6 @@
 <article class='diary_post border-top border-secondary-subtle py-3<%= " text-body-secondary px-3 bg-danger bg-opacity-10" unless diary_entry.visible %> user_<%= diary_entry.user.id %>'>
-  <%= render :partial => "diary_entry_heading", :object => diary_entry, :as => "diary_entry" %>
-
-  <div class="richtext text-break" xml:lang="<%= diary_entry.language_code %>" lang="<%= diary_entry.language_code %>">
+  <%= render :partial => "diary_entry_heading", :object => diary_entry, :as => "diary_entry", :locals => { :show_accordion => defined?(show_accordion) && show_accordion } %>
+  <div class="richtext text-break<%= " h-auto d-block collapse accordion-collapse mh-10-collapsed overflow-hidden" if defined?(show_accordion) && show_accordion %>" id="diary_entry_<%= diary_entry.id.to_s %>" xml:lang="<%= diary_entry.language_code %>" lang="<%= diary_entry.language_code %>">
     <%= diary_entry.body.to_html %>
   </div>
 

--- a/app/views/diary_entries/_diary_entry_heading.html.erb
+++ b/app/views/diary_entries/_diary_entry_heading.html.erb
@@ -1,17 +1,23 @@
 <div class='mb-3'>
-  <% if @user %>
-    <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>
-  <% else %>
-    <div class="row">
-      <div class="col-auto">
-        <%= user_thumbnail diary_entry.user %>
-      </div>
-      <div class="col">
-        <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>
-      </div>
+  <div class="accordion">
+    <div class="accordion-item bg-transparent row w-100 border-0">
+      <% if @user %>
+        <h2 class="col"><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>
+      <% else %>
+        <div class="col-auto">
+          <%= user_thumbnail diary_entry.user %>
+        </div>
+        <div class="col">
+          <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>
+        </div>
+      <% end %>
+      <% if defined?(show_accordion) && show_accordion %>
+        <button class="w-auto accordion-button bg-transparent collapsed shadow-none" type="button" data-bs-toggle="collapse" data-bs-target="#diary_entry_<%= diary_entry.id.to_s %>" aria-expanded="false" aria-controls="diary_entry_<%= diary_entry.id.to_s %>">
+          <span class="visually-hidden"><%= t "diary_entries.diary_entry.toggle_content" %></span>
+        </button>
+      <% end %>
     </div>
-  <% end %>
-
+  </div>
   <small class='text-body-secondary'>
     <%= t("diary_entries.diary_entry.posted_by_html", :link_user => (link_to diary_entry.user.display_name, diary_entry.user), :created => l(diary_entry.created_at, :format => :blog), :language_link => (link_to diary_entry.language.name, :controller => "diary_entries", :action => "index", :display_name => nil, :language => diary_entry.language_code)) %>
     <% if (l(diary_entry.updated_at, :format => :blog) != l(diary_entry.created_at, :format => :blog)) %>

--- a/app/views/diary_entries/_page.html.erb
+++ b/app/views/diary_entries/_page.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <h4><%= t ".recent_entries" %></h4>
 
-  <%= render @entries %>
+  <%= render @entries, :show_accordion => true %>
 
   <%= render "shared/pagination",
              :newer_key => "diary_entries.page.newer_entries",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -572,6 +572,7 @@ en:
       unhide_link: Unhide this entry
       confirm: Confirm
       report: Report this entry
+      toggle_content: Toggle entry content visibility
     diary_comment:
       comment_from_html: "Comment from %{link_user} on %{comment_created_at}"
       hide_link: Hide this comment


### PR DESCRIPTION
This PR addresses "Provide a summary view of recent diaries" issue mentioned in the https://github.com/openstreetmap/openstreetmap-website/issues/3887

[Bootstrap Accordion](https://getbootstrap.com/docs/5.2/components/accordion/) was added to the diary entries list pages. Now the content of the diary entry will be collapsed until toggle button is clicked. View of the diary entry details (show) page remains the same. Fixes https://github.com/openstreetmap/openstreetmap-website/issues/3887

Screenshots:
![Screenshot 2024-08-26 122446](https://github.com/user-attachments/assets/aaefa241-9f48-4474-8061-73e22d40ae3e)
![Screenshot 2024-08-26 122459](https://github.com/user-attachments/assets/32076fb2-f92d-46c2-8e7c-170b204cb6bc)
![Screenshot 2024-08-26 122517](https://github.com/user-attachments/assets/29b902d9-8460-4ba4-a4a1-098e566d057c)