### PR TITLE
Edit unrevoked block

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -60,7 +60,10 @@ class Ability
           can [:index, :show, :resolve, :ignore, :reopen], Issue
           can :create, IssueComment
           can [:new, :create, :edit, :update, :destroy], Redaction
-          can [:new, :edit, :create, :update, :revoke, :revoke_all], UserBlock
+          can [:new, :create, :revoke, :revoke_all], UserBlock
+          can :update, UserBlock, :creator => user
+          can :update, UserBlock, :revoker => user
+          can :update, UserBlock, :active? => true
         end
 
         if user.administrator?

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -15,8 +15,7 @@
     <% end %>
   </td>
   <td><%= link_to t(".show"), block %></td>
-  <td><% if current_user && (current_user.id == block.creator_id ||
-                             current_user.id == block.revoker_id) %><%= link_to t(".edit"), edit_user_block_path(block) %><% end %></td>
+  <td><% if can?(:edit, block) %><%= link_to t(".edit"), edit_user_block_path(block) %><% end %></td>
   <% if can?(:revoke, UserBlock) %>
   <td><% if block.active? %><%= link_to t(".revoke"), revoke_user_block_path(block) %><% end %></td>
   <% end %>

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -9,7 +9,7 @@
 <%= bootstrap_form_for(@user_block) do |f| %>
   <%= f.richtext_field :reason, :cols => 80, :rows => 20, :format => @user_block.reason_format %>
 
-  <% if @user_block.active? %>
+  <% if @user_block.active? && @user_block.creator == current_user %>
     <%= f.form_group do %>
       <%= label_tag "user_block_period", t(".period"), :class => "form-label" %>
       <%= select_tag "user_block_period",
@@ -23,11 +23,15 @@
     <% end %>
   <% else %>
     <div class="alert alert-info">
-      <%= t "user_blocks.update.inactive_block_cannot_be_reactivated" %>
+      <% if @user_block.active? %>
+        <%= t "user_blocks.update.only_creator_can_edit_without_revoking" %>
+      <% else %>
+        <%= t "user_blocks.update.inactive_block_cannot_be_reactivated" %>
+      <% end %>
     </div>
 
     <%= hidden_field_tag "user_block_period", 0 %>
-    <%= f.hidden_field :needs_view %>
+    <%= hidden_field_tag "user_block[needs_view]", false %>
   <% end %>
 
   <%= f.primary %>

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -21,6 +21,8 @@
     <%= f.form_group :needs_view do %>
       <%= f.check_box :needs_view %>
     <% end %>
+
+    <%= f.primary %>
   <% else %>
     <div class="alert alert-info">
       <% if @user_block.active? %>
@@ -32,7 +34,11 @@
 
     <%= hidden_field_tag "user_block_period", 0 %>
     <%= hidden_field_tag "user_block[needs_view]", false %>
-  <% end %>
 
-  <%= f.primary %>
+    <% if @user_block.active? %>
+      <%= f.submit t(".revoke"), :class => "btn btn-danger" %>
+    <% else %>
+      <%= f.primary %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/user_blocks/show.html.erb
+++ b/app/views/user_blocks/show.html.erb
@@ -30,8 +30,7 @@
                        current_user.id == @user_block.revoker_id) ||
       can?(:revoke, UserBlock) && @user_block.active? %>
   <div>
-    <% if current_user && (current_user.id == @user_block.creator_id ||
-                           current_user.id == @user_block.revoker_id) %>
+    <% if can?(:edit, @user_block) %>
       <%= link_to t(".edit"), edit_user_block_path(@user_block), :class => "btn btn-outline-primary" %>
     <% end %>
     <% if can?(:revoke, UserBlock) && @user_block.active? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2949,6 +2949,7 @@ en:
       flash: "Created a block on user %{name}."
     update:
       only_creator_can_edit: "Only the moderator who created this block can edit it."
+      only_creator_can_edit_without_revoking: "Only the moderator who created this block can edit it without revoking."
       only_creator_or_revoker_can_edit: "Only the moderators who created or revoked this block can edit it."
       inactive_block_cannot_be_reactivated: "This block is inactive and cannot be reactivated."
       success: "Block updated."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2943,6 +2943,7 @@ en:
       title: "Editing block on %{name}"
       heading_html: "Editing block on %{name}"
       period: "How long, starting now, the user will be blocked from the API for."
+      revoke: "Revoke block"
     filter:
       block_period: "The blocking period must be one of the values selectable in the drop-down list."
     create:

--- a/test/abilities/abilities_test.rb
+++ b/test/abilities/abilities_test.rb
@@ -95,6 +95,53 @@ class ModeratorAbilityTest < AbilityTest
       assert ability.can?(action, DiaryComment), "should be able to #{action} DiaryComment"
     end
   end
+
+  test "Active block update permissions" do
+    creator_user = create(:moderator_user)
+    other_moderator_user = create(:moderator_user)
+    block = create(:user_block, :creator => creator_user)
+
+    creator_ability = Ability.new creator_user
+    assert creator_ability.can?(:edit, block)
+    assert creator_ability.can?(:update, block)
+
+    other_moderator_ability = Ability.new other_moderator_user
+    assert other_moderator_ability.can?(:edit, block)
+    assert other_moderator_ability.can?(:update, block)
+  end
+
+  test "Expired block update permissions" do
+    creator_user = create(:moderator_user)
+    other_moderator_user = create(:moderator_user)
+    block = create(:user_block, :expired, :creator => creator_user)
+
+    creator_ability = Ability.new creator_user
+    assert creator_ability.can?(:edit, block)
+    assert creator_ability.can?(:update, block)
+
+    other_moderator_ability = Ability.new other_moderator_user
+    assert other_moderator_ability.cannot?(:edit, block)
+    assert other_moderator_ability.cannot?(:update, block)
+  end
+
+  test "Revoked block update permissions" do
+    creator_user = create(:moderator_user)
+    revoker_user = create(:moderator_user)
+    other_moderator_user = create(:moderator_user)
+    block = create(:user_block, :revoked, :creator => creator_user, :revoker => revoker_user)
+
+    creator_ability = Ability.new creator_user
+    assert creator_ability.can?(:edit, block)
+    assert creator_ability.can?(:update, block)
+
+    revoker_ability = Ability.new revoker_user
+    assert revoker_ability.can?(:edit, block)
+    assert revoker_ability.can?(:update, block)
+
+    other_moderator_ability = Ability.new other_moderator_user
+    assert other_moderator_ability.cannot?(:edit, block)
+    assert other_moderator_ability.cannot?(:update, block)
+  end
 end
 
 class AdministratorAbilityTest < AbilityTest

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -278,9 +278,10 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
       assert_select "textarea#user_block_reason", :count => 1
       assert_select "select#user_block_period", :count => 0
       assert_select "input#user_block_needs_view[type='checkbox']", :count => 0
+      assert_select "input[type='submit'][value='Update block']", :count => 0
       assert_select "input#user_block_period[type='hidden']", :count => 1
       assert_select "input#user_block_needs_view[type='hidden']", :count => 1
-      assert_select "input[type='submit'][value='Update block']", :count => 1
+      assert_select "input[type='submit'][value='Revoke block']", :count => 1
     end
 
     # Login as the block creator
@@ -294,9 +295,10 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
       assert_select "textarea#user_block_reason", :count => 1
       assert_select "select#user_block_period", :count => 1
       assert_select "input#user_block_needs_view[type='checkbox']", :count => 1
+      assert_select "input[type='submit'][value='Update block']", :count => 1
       assert_select "input#user_block_period[type='hidden']", :count => 0
       assert_select "input#user_block_needs_view[type='hidden']", :count => 0
-      assert_select "input[type='submit'][value='Update block']", :count => 1
+      assert_select "input[type='submit'][value='Revoke block']", :count => 0
     end
 
     # We should get an error if the user doesn't exist

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -173,7 +173,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     block = create(:user_block, :creator => creator_user)
 
     session_for(other_moderator_user)
-    check_block_buttons block, :revoke => 1
+    check_block_buttons block, :edit => 1, :revoke => 1
 
     session_for(creator_user)
     check_block_buttons block, :edit => 1, :revoke => 1

--- a/test/factories/user_blocks.rb
+++ b/test/factories/user_blocks.rb
@@ -7,6 +7,12 @@ FactoryBot.define do
     user
     creator :factory => :moderator_user
 
+    trait :zero_hour do
+      now = Time.now.utc
+      created_at { now }
+      ends_at { now }
+    end
+
     trait :needs_view do
       needs_view { true }
       deactivates_at { nil }

--- a/test/system/user_blocks_test.rb
+++ b/test/system/user_blocks_test.rb
@@ -111,7 +111,7 @@ class UserBlocksSystemTest < ApplicationSystemTestCase
     assert_no_field "Needs view"
 
     fill_in "Reason", :with => "Revoking 0-hour blocks works"
-    click_on "Update block"
+    click_on "Revoke block"
     assert_text(/Revoker:\s+#{Regexp.escape other_moderator_user.display_name}/)
     assert_text(/Status:\s+Ended/)
     assert_text(/Reason for block:\s+Revoking 0-hour blocks works/)

--- a/test/system/user_blocks_test.rb
+++ b/test/system/user_blocks_test.rb
@@ -98,4 +98,22 @@ class UserBlocksSystemTest < ApplicationSystemTestCase
     click_on "Update block"
     assert_text(/Reason for block:\s+Editing expired blocks works/)
   end
+
+  test "other moderator can revoke 0-hour blocks" do
+    creator_user = create(:moderator_user)
+    other_moderator_user = create(:moderator_user)
+    block = create(:user_block, :zero_hour, :needs_view, :creator => creator_user, :reason => "Testing revoking 0-hour blocks")
+    sign_in_as(other_moderator_user)
+
+    visit edit_user_block_path(block)
+    assert_field "Reason", :with => "Testing revoking 0-hour blocks"
+    assert_no_select "user_block_period"
+    assert_no_field "Needs view"
+
+    fill_in "Reason", :with => "Revoking 0-hour blocks works"
+    click_on "Update block"
+    assert_text(/Revoker:\s+#{Regexp.escape other_moderator_user.display_name}/)
+    assert_text(/Status:\s+Ended/)
+    assert_text(/Reason for block:\s+Revoking 0-hour blocks works/)
+  end
 end


### PR DESCRIPTION
Continues #5094.

Moderators who didn't create an active block can open its edit page and the form for them will look like this:
![image](https://github.com/user-attachments/assets/6b4ef935-ae22-4783-848f-cfa9c3e1505a)

They can update the reason and click revoke. They'll be recorded as revokers and the block will be deactivated.