### PR TITLE
Disable turbo on all links inside pagination frames except older/newer

### DIFF
--- a/app/views/diary_comments/_page.html.erb
+++ b/app/views/diary_comments/_page.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="pagination" target="_top">
+<turbo-frame id="pagination" target="_top" data-turbo="false">
   <table class="table table-striped" width="100%">
     <thead>
       <tr>

--- a/app/views/diary_entries/_page.html.erb
+++ b/app/views/diary_entries/_page.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="pagination" target="_top">
+<turbo-frame id="pagination" target="_top" data-turbo="false">
   <h4><%= t ".recent_entries" %></h4>
 
   <%= render @entries %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -7,7 +7,7 @@
     <% end %>
     <% if newer_id -%>
       <li class="page-item d-flex">
-        <%= link_to newer_link_content, @params.merge(:before => nil, :after => newer_id), :class => link_class, :data => { "turbo-frame" => "pagination", "turbo-action" => "advance" } %>
+        <%= link_to newer_link_content, @params.merge(:before => nil, :after => newer_id), :class => link_class, :data => { "turbo" => true, "turbo-frame" => "pagination", "turbo-action" => "advance" } %>
       </li>
     <% else -%>
       <li class="page-item d-flex disabled">
@@ -21,7 +21,7 @@
     <% end %>
     <% if older_id -%>
       <li class="page-item d-flex">
-        <%= link_to older_link_content, @params.merge(:before => older_id, :after => nil), :class => link_class, :data => { "turbo-frame" => "pagination", "turbo-action" => "advance" } %>
+        <%= link_to older_link_content, @params.merge(:before => older_id, :after => nil), :class => link_class, :data => { "turbo" => true, "turbo-frame" => "pagination", "turbo-action" => "advance" } %>
       </li>
     <% else -%>
       <li class="page-item d-flex disabled">

--- a/app/views/traces/_page.html.erb
+++ b/app/views/traces/_page.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="pagination" target="_top">
+<turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= render "shared/pagination",
              :newer_key => "traces.page.newer",
              :older_key => "traces.page.older",

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="pagination" target="_top">
+<turbo-frame id="pagination" target="_top" data-turbo="false">
   <table id="block_list" class="table table-borderless table-striped table-sm">
     <thead>
       <tr>

--- a/app/views/users/_page.html.erb
+++ b/app/views/users/_page.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id="pagination" target="_top">
+<turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= form_tag do %>
     <div class="row">
       <div class="col">


### PR DESCRIPTION
Something had to break after #4646.

Turbo handles all links inside its frames unless told not to. If any link leads to a page that has some javascript running on load, it's going to be broken. The most common javascript in our case is rich rext controls code. If you go to a diaries page and click "comment", turbo takes you to a diary entry page with broken richtext javascript. And it's not as easy to fix as adding the page onload code to an equivalent turbo event because now you also have to clean up when leaving the page (using a back button for example), something that wasn't possible before (except on our map layout pages with our special router).

I did here the same as in #4565: set `data-turbo="false"` on the entire frame and set it to true just on previous/next page links.