### PR TITLE
Compacted repeated "Results" into one sentence

### DIFF
--- a/app/views/geocoder/search.html.erb
+++ b/app/views/geocoder/search.html.erb
@@ -4,7 +4,7 @@
 
 <% @sources.each do |source| %>
   <h4>
-    <%= t(".title.results_from_html", :results_link => link_to(t(".title.#{source[:name]}"), source[:url].to_s)) %>
+    <%= link_to t(".title.#{source[:name]}"), source[:url].to_s %>
   </h4>
   <div class="search_results_entry mx-n3" data-href="<%= url_for @params.merge(:action => "search_#{source[:name]}") %>">
     <div class="text-center loader">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -674,7 +674,6 @@ en:
   geocoder:
     search:
       title:
-        results_from_html: 'Results from %{results_link}'
         latlon: Internal
         osm_nominatim: OpenStreetMap Nominatim
         osm_nominatim_reverse: OpenStreetMap Nominatim


### PR DESCRIPTION
PR addresses repeated "Results" in sidebar described in #5065 

Fixes #5065. Replaced "Search Results" with "Search".

Before
![image](https://github.com/user-attachments/assets/047ee979-8ce2-4b94-add3-f3e4102b9149)

After
![image](https://github.com/user-attachments/assets/45a9925e-d471-4fdf-83f8-9101dd137135)

Before
![image](https://github.com/user-attachments/assets/f7743498-9c6d-4e79-9809-de8134801370)

After
![image](https://github.com/user-attachments/assets/0a475c4e-582f-4bc1-a1ae-73fe6bbfac55)
