### PR TITLE
Improved error messages and UI when importing GPS trace files

### DIFF
--- a/app/views/traces/new.html.erb
+++ b/app/views/traces/new.html.erb
@@ -3,7 +3,8 @@
 <% end %>
 
 <%= bootstrap_form_for @trace, :url => { :action => "create" }, :html => { :multipart => true } do |f| %>
-  <%= f.file_field :gpx_file, :placeholder => t("helpers.file.prompt") %>
+  <%= f.file_field :gpx_file, :placeholder => t("helpers.file.prompt"),
+                              :help => ".gpx, .tar.gz, .tar.bz2, .tar, .zip, .gpx.gz, .gpx.bz2" %>
   <%= f.text_field :description, :maxlength => 255 %>
   <%= f.text_field :tagstring %>
   <%= f.select :visibility,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,7 +124,7 @@ en:
         longitude: "Longitude"
         public: "Public"
         description: "Description"
-        gpx_file: Upload GPX File
+        gpx_file: Choose GPS Trace File
         visibility: Visibility
         tagstring: Tags
       message:
@@ -1627,13 +1627,13 @@ en:
       befriend_them: "You can also add them as a friend at %{befriendurl}."
       befriend_them_html: "You can also add them as a friend at %{befriendurl}."
     gpx_description:
-      description_with_tags: "It looks like your GPX file %{trace_name} with the description %{trace_description} and the following tags: %{tags}"
-      description_with_tags_html: "It looks like your GPX file %{trace_name} with the description %{trace_description} and the following tags: %{tags}"
-      description_with_no_tags: "It looks like your GPX file %{trace_name} with the description %{trace_description} and no tags"
-      description_with_no_tags_html: "It looks like your GPX file %{trace_name} with the description %{trace_description} and no tags"
+      description_with_tags: "It looks like your file %{trace_name} with the description %{trace_description} and the following tags: %{tags}"
+      description_with_tags_html: "It looks like your file %{trace_name} with the description %{trace_description} and the following tags: %{tags}"
+      description_with_no_tags: "It looks like your file %{trace_name} with the description %{trace_description} and no tags"
+      description_with_no_tags_html: "It looks like your file %{trace_name} with the description %{trace_description} and no tags"
     gpx_failure:
       hi: "Hi %{to_user},"
-      failed_to_import: "failed to import. Here is the error:"
+      failed_to_import: "failed to be imported as a GPS trace file. Please verify that your file is a valid GPX file or an archive containing GPX file(s) in the supported format (.tar.gz, .tar.bz2, .tar, .zip, .gpx.gz, .gpx.bz2). Could there be a format or syntax issue with your file? Here is the importing error:"
       more_info: "More information about GPX import failures and how to avoid them can be found at %{url}."
       more_info_html: "More information about GPX import failures and how to avoid them can be found at %{url}."
       import_failures_url: "https://wiki.openstreetmap.org/wiki/GPX_Import_Failures"


### PR DESCRIPTION
PR adds client and server side checking if supplied trace file has GPX extension

Adds "GPX File (*.gpx)" filter to Open File dialog. Adds checking to TracesController#create if sent file has "gpx" extension (before parsing) by first converting file name to lowercase and then checking if it ends with .gpx. In case of failure, it reports error using bootstrap alert:

![image](https://github.com/user-attachments/assets/5b786adf-1351-4064-b5a2-45ea4a0dacf0)
