### PR TITLE
Allows sending follow-ups for sent messages

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -89,6 +89,16 @@ class MessagesController < ApplicationController
       @title = @message.title
 
       render :action => "new"
+    elsif message.sender == current_user
+      @message = Message.new(
+        :recipient => message.recipient,
+        :title => "Re: #{message.title.sub(/^Re:\s*/, '')}",
+        :body => "On #{message.sent_on} #{message.sender.display_name} wrote:\n\n#{message.body.gsub(/^/, '> ')}"
+      )
+
+      @title = @message.title
+
+      render :action => "new"
     else
       flash[:notice] = t ".wrong_user", :user => current_user.display_name
       redirect_to login_path(:referer => request.fullpath)

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -18,8 +18,8 @@
 <div class="richtext text-break"><%= @message.body.to_html %></div>
 
 <div>
+  <%= link_to t(".reply_button"), message_reply_path(@message), :class => "btn btn-primary" %>
   <% if current_user == @message.recipient %>
-    <%= link_to t(".reply_button"), message_reply_path(@message), :class => "btn btn-primary" %>
     <%= link_to t(".unread_button"), message_mark_path(@message, :mark => "unread"), :method => "post", :class => "btn btn-primary" %>
     <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>
   <% else %>


### PR DESCRIPTION
PR adds Reply button when displaying sent messages, so users can send follow-ups
 
Fixes #3497. Adds Reply button when displaying sent messages (app/views/messages/show.html.erb) and allows replying to messages for which sender is current user (app/controllers/messages_controller.rb).

![image](https://github.com/user-attachments/assets/71ad4e45-cfa7-4b70-bccd-002ce42f1a2c)
