### PR TITLE
Provide a truncated view of recent diaries

### DIFF
--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -2,7 +2,15 @@
   <%= render :partial => "diary_entry_heading", :object => diary_entry, :as => "diary_entry" %>
 
   <div class="richtext text-break" xml:lang="<%= diary_entry.language_code %>" lang="<%= diary_entry.language_code %>">
-    <%= diary_entry.body.to_html %>
+    <% if truncated %>
+      <% truncated_entry = diary_entry.body.truncate_html(2000) %>
+      <%= truncated_entry[:html] %>
+      <% if truncated_entry[:truncated] %>
+        <p>&hellip; <%= link_to t(".full_entry"), diary_entry_path(diary_entry.user, diary_entry) %></p>
+      <% end %>
+    <% else %>
+       <%= diary_entry.body.to_html %>
+    <% end %>
   </div>
 
   <% if diary_entry.latitude and diary_entry.longitude %>

--- a/app/views/diary_entries/_page.html.erb
+++ b/app/views/diary_entries/_page.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <h4><%= t ".recent_entries" %></h4>
 
-  <%= render @entries %>
+  <%= render @entries, :truncated => true %>
 
   <%= render "shared/pagination",
              :newer_id => @newer_entries_id,

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -14,7 +14,7 @@
   </div>
 <% end %>
 
-<%= render @entry %>
+<%= render @entry, :truncated => false %>
 <%= social_share_buttons(:title => @entry.title, :url => diary_entry_url(@entry.user, @entry)) %>
 
 <div id="comments" class="comments mb-3 overflow-hidden">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -608,6 +608,7 @@ en:
     diary_entry:
       posted_by_html: "Posted by %{link_user} on %{created} in %{language_link}."
       updated_at_html: "Last updated on %{updated}."
+      full_entry: See full entry
       comment_link: Comment on this entry
       reply_link: Send a message to the author
       comment_count:

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -74,4 +74,54 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     assert_link "Diary Entries in Portuguese", :href => "/diary/pt"
     assert_no_link "Diary Entries in Russian"
   end
+
+  test "should not be hidden on the list page" do
+    body = SecureRandom.alphanumeric(1998)
+    create(:diary_entry, :body => body)
+
+    visit diary_entries_path
+
+    assert_content body
+    assert_no_content I18n.t("diary_entries.diary_entry.full_entry")
+  end
+
+  test "should be hidden on the list page" do
+    body = SecureRandom.alphanumeric(2000)
+    create(:diary_entry, :body => body)
+
+    visit diary_entries_path
+
+    assert_no_content body
+    assert_content I18n.t("diary_entries.diary_entry.full_entry")
+  end
+
+  test "should be partially hidden on the list page" do
+    text1 = "a" * 500
+    text2 = "b" * 500
+    text3 = "c" * 999
+    text4 = "dd"
+    text5 = "ff"
+
+    body = "<p>#{text1}</p><div><p>#{text2}</p><p>#{text3}<a href='#'>#{text4}</a></p></div><p>#{text5}</p>"
+    create(:diary_entry, :body => body)
+
+    visit diary_entries_path
+
+    assert_content text1
+    assert_content text2
+    assert_no_content text3
+    assert_no_content text4
+    assert_no_content text5
+    assert_content I18n.t("diary_entries.diary_entry.full_entry")
+  end
+
+  test "should not be hidden on the show page" do
+    body = SecureRandom.alphanumeric(2001)
+    diary_entry = create(:diary_entry, :body => body)
+
+    visit diary_entry_path(diary_entry.user, diary_entry)
+
+    assert_content body
+    assert_no_content I18n.t("diary_entries.diary_entry.full_entry")
+  end
 end


### PR DESCRIPTION
This PR is alternative to the https://github.com/openstreetmap/openstreetmap-website/pull/5103.

This PR addresses "Provide a summary view of recent diaries" issue mentioned in the https://github.com/openstreetmap/openstreetmap-website/issues/3887

Diary entries will be truncated after 1000 characters on the list pages. To avoid long diaries with pictures on the list page, every picture is handled as 500 characters. View of the diary entry details (show) page remains the same. "See full entry" button was added to the entry to explicitly mention that full entry is no more visible in the list and enhance UX. Fixes https://github.com/openstreetmap/openstreetmap-website/issues/3887

Screenshots:

![image](https://github.com/user-attachments/assets/44b4774f-39e6-48cd-9d25-f4cf3b9a9b4e)
![image](https://github.com/user-attachments/assets/377c8244-6c3b-4e7d-ad50-9d924f75489a)
![Screenshot 2024-08-27 113359](https://github.com/user-attachments/assets/2cbc9c3e-74a3-4e78-b18a-b68e8203f6e6)
![Screenshot 2024-08-27 113411](https://github.com/user-attachments/assets/1302f0b3-3fe0-416c-8cf7-a0048b172405)
