### PR TITLE
Use turbo to update issue search results

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -27,12 +27,11 @@ class IssuesController < ApplicationController
     # If search
     if params[:search_by_user].present?
       @find_user = User.find_by(:display_name => params[:search_by_user])
-      if @find_user
-        @issues = @issues.where(:reported_user => @find_user)
-      else
-        @issues = @issues.none
-        flash.now[:warning] = t(".user_not_found")
-      end
+      @issues = if @find_user
+                  @issues.where(:reported_user => @find_user)
+                else
+                  @issues.none
+                end
     end
 
     @issues = @issues.where(:status => params[:status]) if params[:status].present?

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -1,36 +1,44 @@
 <turbo-frame id="pagination" target="_top">
-  <table class="table table-sm">
-    <thead>
-      <tr>
-        <th><%= t ".status" %></th>
-        <th><%= t ".reports" %></th>
-        <th><%= t ".reported_item" %></th>
-        <th><%= t ".reported_user" %></th>
-        <th><%= t ".last_updated" %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @issues.each do |issue| %>
+  <% if @issues.length == 0 %>
+    <% if params[:search_by_user].present? && !@find_user %>
+      <p><%= t ".user_not_found" %></p>
+    <% else %>
+      <p><%= t ".issues_not_found" %></p>
+    <% end %>
+  <% else %>
+    <table class="table table-sm">
+      <thead>
         <tr>
-          <td><%= t ".states.#{issue.status}" %></td>
-          <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
-          <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
-          <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
-          <td>
-            <% if issue.user_updated %>
-              <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),
-                                                        :time_ago => friendly_date_ago(issue.updated_at) %>
-            <% else %>
-              <%= friendly_date_ago(issue.updated_at) %>
-            <% end %>
-          </td>
+          <th><%= t ".status" %></th>
+          <th><%= t ".reports" %></th>
+          <th><%= t ".reported_item" %></th>
+          <th><%= t ".reported_user" %></th>
+          <th><%= t ".last_updated" %></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
-  <%= render "shared/pagination",
-             :newer_key => "issues.page.newer_issues",
-             :older_key => "issues.page.older_issues",
-             :newer_id => @newer_issues_id,
-             :older_id => @older_issues_id %>
+      </thead>
+      <tbody>
+        <% @issues.each do |issue| %>
+          <tr>
+            <td><%= t ".states.#{issue.status}" %></td>
+            <td class="text-nowrap"><%= link_to t(".reports_count", :count => issue.reports_count), issue %></td>
+            <td><%= link_to reportable_title(issue.reportable), reportable_url(issue.reportable) %></td>
+            <td><%= link_to issue.reported_user.display_name, issue.reported_user if issue.reported_user %></td>
+            <td>
+              <% if issue.user_updated %>
+                <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),
+                                                          :time_ago => friendly_date_ago(issue.updated_at) %>
+              <% else %>
+                <%= friendly_date_ago(issue.updated_at) %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= render "shared/pagination",
+               :newer_key => "issues.page.newer_issues",
+               :older_key => "issues.page.older_issues",
+               :newer_id => @newer_issues_id,
+               :older_id => @older_issues_id %>
+  <% end %>
 </turbo-frame>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -4,7 +4,7 @@
 
 <p><%= t ".search_guidance" %></p>
 
-<%= form_tag(issues_path, :method => :get) do %>
+<%= form_tag(issues_path, :method => :get, :data => { "turbo" => true, "turbo-frame" => "pagination", "turbo-action" => "advance" }) do %>
   <div class="row gx-1">
     <div class="mb-3 col-md-auto">
       <%= select_tag :status,
@@ -40,8 +40,4 @@
   </div>
 <% end %>
 
-<% if @issues.length == 0 %>
-  <p><%= t ".issues_not_found" %></p>
-<% else %>
-  <%= render :partial => "page" %>
-<% end %>
+<%= render :partial => "page" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1467,14 +1467,14 @@ en:
       not_updated: Not Updated
       search: Search
       search_guidance: "Search Issues:"
-      user_not_found: User does not exist
-      issues_not_found: No such issues found
       link_to_reports: View Reports
       states:
         ignored: Ignored
         open: Open
         resolved: Resolved
     page:
+      user_not_found: User does not exist
+      issues_not_found: No such issues found
       reported_user: Reported User
       status: Status
       reports: Reports

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -19,7 +19,7 @@ class IssuesTest < ApplicationSystemTestCase
     sign_in_as(create(:moderator_user))
 
     visit issues_path
-    assert_content I18n.t("issues.index.issues_not_found")
+    assert_content I18n.t("issues.page.issues_not_found")
   end
 
   def test_view_issues
@@ -81,22 +81,22 @@ class IssuesTest < ApplicationSystemTestCase
     visit issues_path
     fill_in "search_by_user", :with => good_user.display_name
     click_on "Search"
-    assert_no_content I18n.t("issues.index.user_not_found")
-    assert_content I18n.t("issues.index.issues_not_found")
+    assert_no_content I18n.t("issues.page.user_not_found")
+    assert_content I18n.t("issues.page.issues_not_found")
 
     # User doesn't exist
     visit issues_path
     fill_in "search_by_user", :with => "Nonexistent User"
     click_on "Search"
-    assert_content I18n.t("issues.index.user_not_found")
-    assert_content I18n.t("issues.index.issues_not_found")
+    assert_content I18n.t("issues.page.user_not_found")
+    assert_no_content I18n.t("issues.page.issues_not_found")
 
     # Find Issue against bad_user
     visit issues_path
     fill_in "search_by_user", :with => bad_user.display_name
     click_on "Search"
-    assert_no_content I18n.t("issues.index.user_not_found")
-    assert_no_content I18n.t("issues.index.issues_not_found")
+    assert_no_content I18n.t("issues.page.user_not_found")
+    assert_no_content I18n.t("issues.page.issues_not_found")
   end
 
   def test_commenting
@@ -173,20 +173,20 @@ class IssuesTest < ApplicationSystemTestCase
     visit issues_path
 
     # First Page
-    assert_no_content I18n.t("issues.index.user_not_found")
-    assert_no_content I18n.t("issues.index.issues_not_found")
+    assert_no_content I18n.t("issues.page.user_not_found")
+    assert_no_content I18n.t("issues.page.issues_not_found")
     assert_css "tr", :count => 51
 
     # Second Page
     click_on I18n.t("issues.page.older_issues")
-    assert_no_content I18n.t("issues.index.user_not_found")
-    assert_no_content I18n.t("issues.index.issues_not_found")
+    assert_no_content I18n.t("issues.page.user_not_found")
+    assert_no_content I18n.t("issues.page.issues_not_found")
     assert_css "tr", :count => 31
 
     # Back to First Page
     click_on I18n.t("issues.page.newer_issues")
-    assert_no_content I18n.t("issues.index.user_not_found")
-    assert_no_content I18n.t("issues.index.issues_not_found")
+    assert_no_content I18n.t("issues.page.user_not_found")
+    assert_no_content I18n.t("issues.page.issues_not_found")
     assert_css "tr", :count => 51
   end
 end


### PR DESCRIPTION
This extends #5057 to use turbo when changing search parameters on the issue list.

The user not found message when searching for an unknown user has been moved from the flash message into the results pane to ensure it can be updated when a search is done.