### PR TITLE
Increase default wait time for capybara

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 ENV.delete("http_proxy")
 
+Capybara.default_max_wait_time = 5
+
 ActiveSupport.on_load(:action_dispatch_system_test_case) do
   ActionDispatch::SystemTesting::Server.silence_puma = true
 end


### PR DESCRIPTION
This attempts to fix #5127 by increasing the default wait time to 5s.

I've only seen this fail locally on my machine once so it's hard to say if this is enough to fix it or not...