### PR TITLE
Refactor error layout with small styling enchancments

### DIFF
--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -4,14 +4,19 @@
     <meta charset="utf-8">
     <title>OpenStreetMap</title>
     <%= stylesheet_link_tag "errors", :media => "screen" %>
-    <%= render :partial => "layouts/meta" %>
+    <%= render :partial => "layouts/head" %>
   </head>
-  <body>
-    <a href="<%= root_path %>">
-      <%= image_tag "osm_logo.svg", :alt => t("layouts.logo.alt_text"), :class => "logo" %>
-    </a>
-    <div class="details">
-      <%= yield %>
-    </div>
+   <body class="container">
+    <main class="mt-4">
+      <a href="<%= root_path %>">
+        <%= image_tag "osm_logo.svg", :alt => t("layouts.logo.alt_text"), :class => "logo" %>
+      </a>
+      <div class="details">
+        <%= yield %>
+        <a href="<%= root_path %>" class="btn btn-primary">
+          <%= t("layouts.home") %>
+        </a>
+      </div>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
This PR addresses parts of [#3532](https://github.com/openstreetmap/openstreetmap-website/issues/3532) by making the error layout more consistent with the rest of the site's UI.

**Changes:**

- Encapsulated meta tags into the `layouts/head` partial for better organization.
- Applied Bootstrap's `container` class to the `<body>` for a consistent layout.
- Added a `main` element with `mt-4` to improve spacing.
- Introduced a "Home" button with `btn btn-primary` to facilitate easier navigation.

These updates enhance the overall design and user experience of the error pages.

### Screenshots:
#### Before
<img width="1468" alt="Screenshot 2024-08-29 at 20 34 27" src="https://github.com/user-attachments/assets/49d5b06a-d09f-4955-8ab9-f52d9d6706c5">

#### After
<img width="1464" alt="Screenshot 2024-08-29 at 20 35 04" src="https://github.com/user-attachments/assets/105f2d75-0d19-4a47-ae62-60108884d2b1">
<img width="1465" alt="Screenshot 2024-08-29 at 20 35 19" src="https://github.com/user-attachments/assets/5a856faa-7916-4a91-8c50-b1a5797d436f">

