### PR TITLE
Test oauth2 application list with moderator permission icon

### DIFF
--- a/test/controllers/oauth2_applications_controller_test.rb
+++ b/test/controllers/oauth2_applications_controller_test.rb
@@ -53,6 +53,16 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "tbody tr", 2
   end
 
+  def test_index_with_moderator_app
+    user = create(:user)
+    create(:oauth_application, :owner => user, :scopes => "write_redactions")
+
+    session_for(user)
+
+    get oauth_applications_path
+    assert_response :success
+  end
+
   def test_new
     user = create(:user)
 


### PR DESCRIPTION
Will fail if #5058 is applied because https://github.com/openstreetmap/openstreetmap-website/pull/5058#pullrequestreview-2272966401.