### PR TITLE
Remove unused reference to missing gps layer name

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -124,8 +124,7 @@ L.OSM.Map = L.Map.extend({
 
     this.gpsLayer = new L.OSM.GPS({
       pane: "overlayPane",
-      code: "G",
-      name: I18n.t("javascripts.map.base.gps")
+      code: "G"
     });
 
     this.on("layeradd", function (event) {


### PR DESCRIPTION
`name: I18n.t("javascripts.map.base.gps")` was added in https://github.com/openstreetmap/openstreetmap-website/commit/df17b997b33fc9d0c60360de7f27aadc76b930a0 without a translation provided. Went unnoticed because the name is not actually used anywhere, see https://github.com/openstreetmap/openstreetmap-website/pull/5133#issuecomment-2323053456.