### PR TITLE
Remove unused fail locale strings from user role grant/revoke

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2930,13 +2930,11 @@ en:
       heading: Confirm role granting
       are_you_sure: "Are you sure you want to grant the role `%{role}' to the user `%{name}'?"
       confirm: "Confirm"
-      fail: "Could not grant role `%{role}' to user `%{name}'. Please check that the user and role are both valid."
     revoke:
       title: Confirm role revoking
       heading: Confirm role revoking
       are_you_sure: "Are you sure you want to revoke the role `%{role}' from the user `%{name}'?"
       confirm: "Confirm"
-      fail: "Could not revoke role `%{role}' from user `%{name}'. Please check that the user and role are both valid."
   user_blocks:
     model:
       non_moderator_update: "Must be a moderator to create or update a block."


### PR DESCRIPTION
They were replaced by more specific messages in https://github.com/openstreetmap/openstreetmap-website/commit/1e3b3c1f10213c48a40083e8bbca1429d9f819d6.