### PR TITLE
Remove unused no_iframe_support message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2206,7 +2206,6 @@ en:
       anon_edits_link: "https://wiki.openstreetmap.org/wiki/Disabling_anonymous_edits"
       anon_edits_link_text: "Find out why this is the case."
       id_not_configured: "iD has not been configured"
-      no_iframe_support: "Your browser doesn't support HTML iframes, which are necessary for this feature."
     export:
       title: "Export"
       manually_select: "Manually select a different area"


### PR DESCRIPTION
Added for `app/views/site/_josm.html.erb` in https://github.com/openstreetmap/openstreetmap-website/commit/cd66a5db99fda4920ed559ec71163d5d01ba1f4a which was removed in https://github.com/openstreetmap/openstreetmap-website/commit/c3453cf57df864b008dca6479f84504f81c0b131 a few hours later.