### PR TITLE
Remove unused donation strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1606,9 +1606,6 @@ en:
     community: Community
     community_blogs: "Community Blogs"
     community_blogs_title: "Blogs from members of the OpenStreetMap community"
-    make_a_donation:
-      title: Support OpenStreetMap with a monetary donation
-      text: Make a Donation
     learn_more: "Learn More"
     more: More
   user_mailer:


### PR DESCRIPTION
There was a donation link in the footer but it was removed in https://github.com/openstreetmap/openstreetmap-website/commit/6d5ce8d49293afa79a86300f38d698426557b9a8 because there's one in the map corner now.