### PR TITLE
Drop support for basic authentication

### DIFF
--- a/app/controllers/api/permissions_controller.rb
+++ b/app/controllers/api/permissions_controller.rb
@@ -9,13 +9,10 @@ module Api
     # External apps that use the api are able to query which permissions
     # they have. This currently returns a list of permissions granted to the current user:
     # * if authenticated via OAuth, this list will contain all permissions granted by the user to the access_token.
-    # * if authenticated via basic auth all permissions are granted, so the list will contain all permissions.
     # * unauthenticated users have no permissions, so the list will be empty.
     def show
       @permissions = if doorkeeper_token.present?
                        doorkeeper_token.scopes.map { |s| :"allow_#{s}" }
-                     elsif current_user
-                       Oauth.scopes.map { |s| :"allow_#{s.name}" }
                      else
                        []
                      end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -323,20 +323,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # extract authorisation credentials from headers, returns user = nil if none
-  def auth_data
-    if request.env.key? "X-HTTP_AUTHORIZATION" # where mod_rewrite might have put it
-      authdata = request.env["X-HTTP_AUTHORIZATION"].to_s.split
-    elsif request.env.key? "REDIRECT_X_HTTP_AUTHORIZATION" # mod_fcgi
-      authdata = request.env["REDIRECT_X_HTTP_AUTHORIZATION"].to_s.split
-    elsif request.env.key? "HTTP_AUTHORIZATION" # regular location
-      authdata = request.env["HTTP_AUTHORIZATION"].to_s.split
-    end
-    # only basic authentication supported
-    user, pass = Base64.decode64(authdata[1]).split(":", 2) if authdata && authdata[0] == "Basic"
-    [user, pass]
-  end
-
   # clean any referer parameter
   def safe_referer(referer)
     begin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2580,8 +2580,6 @@ en:
         other: "GPX file with %{count} points from %{user}"
       description_without_count: "GPX file from %{user}"
   application:
-    basic_auth_disabled: "HTTP Basic Authentication is disabled: %{link}"
-    auth_disabled_link: "https://wiki.openstreetmap.org/wiki/2024_authentication_update"
     permission_denied: You do not have permission to access that action
     require_cookies:
       cookies_needed: "You appear to have cookies disabled - please enable cookies in your browser before continuing."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -106,8 +106,6 @@ attachments_dir: ":rails_root/public/attachments"
 #logstash_path: ""
 # List of memcache servers to use for caching
 #memcache_servers: []
-# Enable HTTP basic authentication support
-basic_auth_support: true
 # URL of Nominatim instance to use for geocoding
 nominatim_url: "https://nominatim.openstreetmap.org/"
 # Default editor

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -55,7 +55,7 @@ module Api
       assert_response :unauthorized, "node upload did not return unauthorized status"
 
       ## Now try with the user which doesn't have their data public
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # create a minimal xml file
       xml = "<osm><node lat='#{lat}' lon='#{lon}' changeset='#{private_changeset.id}'/></osm>"
@@ -66,7 +66,7 @@ module Api
       assert_require_public_data "node create did not return forbidden status"
 
       ## Now try with the user that has the public data
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # create a minimal xml file
       xml = "<osm><node lat='#{lat}' lon='#{lon}' changeset='#{changeset.id}'/></osm>"
@@ -92,7 +92,7 @@ module Api
       user = create(:user)
       changeset = create(:changeset, :user => user)
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
       lat = 3.434
       lon = 3.23
 
@@ -178,7 +178,7 @@ module Api
       assert_response :unauthorized
 
       ## now set auth for the non-data public user
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # try to delete with an invalid (closed) changeset
       xml = update_changeset(xml_for_node(private_node), private_user_closed_changeset.id)
@@ -226,7 +226,7 @@ module Api
       changeset = create(:changeset, :user => user)
       closed_changeset = create(:changeset, :closed, :user => user)
       node = create(:node, :changeset => changeset)
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # try to delete with an invalid (closed) changeset
       xml = update_changeset(xml_for_node(node), closed_changeset.id)
@@ -314,7 +314,7 @@ module Api
       ## Second test with the private user
 
       # setup auth
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       ## trying to break changesets
 
@@ -356,7 +356,7 @@ module Api
       assert_response :forbidden
 
       # setup auth
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       ## trying to break changesets
 
@@ -477,7 +477,7 @@ module Api
       existing_tag = create(:node_tag)
       assert existing_tag.node.changeset.user.data_public
       # setup auth
-      auth_header = basic_authorization_header existing_tag.node.changeset.user.email, "test"
+      auth_header = bearer_authorization_header existing_tag.node.changeset.user
 
       # add an identical tag to the node
       tag_xml = XML::Node.new("tag")
@@ -503,7 +503,7 @@ module Api
       changeset = create(:changeset, :user => user)
 
       ## First try with the non-data public user
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # try and put something into a string that the API might
       # use unquoted and therefore allow code injection...
@@ -514,7 +514,7 @@ module Api
       assert_require_public_data "Shouldn't be able to create with non-public user"
 
       ## Then try with the public data user
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # try and put something into a string that the API might
       # use unquoted and therefore allow code injection...
@@ -552,7 +552,7 @@ module Api
                                      :num_changes => Settings.initial_changes_per_hour - 1)
 
       # create authentication header
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # try creating a node
       xml = "<osm><node lat='0' lon='0' changeset='#{changeset.id}'/></osm>"
@@ -599,7 +599,7 @@ module Api
       end
 
       # create authentication header
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # try creating a node
       xml = "<osm><node lat='0' lon='0' changeset='#{changeset.id}'/></osm>"

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -203,7 +203,7 @@ module Api
     def test_comment_success
       open_note_with_comment = create(:note_with_comments)
       user = create(:user)
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
       assert_difference "NoteComment.count", 1 do
         assert_no_difference "ActionMailer::Base.deliveries.size" do
           perform_enqueued_jobs do
@@ -244,7 +244,7 @@ module Api
         create(:note_comment, :note => note, :author => second_user)
       end
 
-      auth_header = basic_authorization_header third_user.email, "test"
+      auth_header = bearer_authorization_header third_user
 
       assert_difference "NoteComment.count", 1 do
         assert_difference "ActionMailer::Base.deliveries.size", 2 do
@@ -300,7 +300,7 @@ module Api
         assert_response :unauthorized
       end
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       assert_no_difference "NoteComment.count" do
         post comment_api_note_path(open_note_with_comment), :headers => auth_header
@@ -344,7 +344,7 @@ module Api
       post close_api_note_path(open_note_with_comment, :text => "This is a close comment", :format => "json")
       assert_response :unauthorized
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       post close_api_note_path(open_note_with_comment, :text => "This is a close comment", :format => "json"), :headers => auth_header
       assert_response :success
@@ -375,7 +375,7 @@ module Api
       post close_api_note_path(12345)
       assert_response :unauthorized
 
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
 
       post close_api_note_path(12345), :headers => auth_header
       assert_response :not_found
@@ -398,7 +398,7 @@ module Api
       post reopen_api_note_path(closed_note_with_comment, :text => "This is a reopen comment", :format => "json")
       assert_response :unauthorized
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       post reopen_api_note_path(closed_note_with_comment, :text => "This is a reopen comment", :format => "json"), :headers => auth_header
       assert_response :success
@@ -431,7 +431,7 @@ module Api
       post reopen_api_note_path(hidden_note_with_comment)
       assert_response :unauthorized
 
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
 
       post reopen_api_note_path(12345), :headers => auth_header
       assert_response :not_found
@@ -550,12 +550,12 @@ module Api
       delete api_note_path(open_note_with_comment, :text => "This is a hide comment", :format => "json")
       assert_response :unauthorized
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       delete api_note_path(open_note_with_comment, :text => "This is a hide comment", :format => "json"), :headers => auth_header
       assert_response :forbidden
 
-      auth_header = basic_authorization_header moderator_user.email, "test"
+      auth_header = bearer_authorization_header moderator_user
 
       delete api_note_path(open_note_with_comment, :text => "This is a hide comment", :format => "json"), :headers => auth_header
       assert_response :success
@@ -572,7 +572,7 @@ module Api
       get api_note_path(open_note_with_comment, :format => "json"), :headers => auth_header
       assert_response :success
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       get api_note_path(open_note_with_comment, :format => "json"), :headers => auth_header
       assert_response :gone
@@ -585,12 +585,12 @@ module Api
       delete api_note_path(12345, :format => "json")
       assert_response :unauthorized
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       delete api_note_path(12345, :format => "json"), :headers => auth_header
       assert_response :forbidden
 
-      auth_header = basic_authorization_header moderator_user.email, "test"
+      auth_header = bearer_authorization_header moderator_user
 
       delete api_note_path(12345, :format => "json"), :headers => auth_header
       assert_response :not_found

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -58,7 +58,7 @@ module Api
       relation = create(:relation, :with_history, :version => 4)
       relation_v3 = relation.old_relations.find_by(:version => 3)
 
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
 
       do_redact_relation(relation_v3, create(:redaction), auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
@@ -71,7 +71,7 @@ module Api
       relation = create(:relation, :with_history, :version => 4)
       relation_latest = relation.old_relations.last
 
-      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+      auth_header = bearer_authorization_header create(:moderator_user)
 
       do_redact_relation(relation_latest, create(:redaction), auth_header)
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
@@ -126,7 +126,7 @@ module Api
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
 
       # not even to a logged-in user
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
       get api_old_relation_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API, even when logged in."
     end
@@ -144,7 +144,7 @@ module Api
                     "redacted relation #{relation_v1.relation_id} version #{relation_v1.version} shouldn't be present in the history."
 
       # not even to a logged-in user
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
       get api_old_relation_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       get api_relation_history_path(relation), :headers => auth_header
       assert_response :success, "Redaction shouldn't have stopped history working."
@@ -159,7 +159,7 @@ module Api
       relation = create(:relation, :with_history, :version => 4)
       relation_v3 = relation.old_relations.find_by(:version => 3)
 
-      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+      auth_header = bearer_authorization_header create(:moderator_user)
 
       do_redact_relation(relation_v3, create(:redaction), auth_header)
       assert_response :success, "should be OK to redact old version as moderator."
@@ -188,13 +188,13 @@ module Api
       relation = create(:relation, :with_history, :version => 4)
       relation_v3 = relation.old_relations.find_by(:version => 3)
 
-      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+      auth_header = bearer_authorization_header create(:moderator_user)
 
       do_redact_relation(relation_v3, create(:redaction), auth_header)
       assert_response :success, "should be OK to redact old version as moderator."
 
       # re-auth as non-moderator
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
 
       # check can't see the redacted data
       get api_old_relation_path(relation_v3.relation_id, relation_v3.version), :headers => auth_header
@@ -227,7 +227,7 @@ module Api
       relation_v1 = relation.old_relations.find_by(:version => 1)
       relation_v1.redact!(create(:redaction))
 
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
 
       post relation_version_redact_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       assert_response :forbidden, "should need to be moderator to unredact."
@@ -241,7 +241,7 @@ module Api
       relation_v1 = relation.old_relations.find_by(:version => 1)
       relation_v1.redact!(create(:redaction))
 
-      auth_header = basic_authorization_header create(:moderator_user).email, "test"
+      auth_header = bearer_authorization_header create(:moderator_user)
 
       post relation_version_redact_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
       assert_response :success, "should be OK to unredact old version as moderator."
@@ -257,7 +257,7 @@ module Api
       assert_select "osm relation[id='#{relation_v1.relation_id}'][version='#{relation_v1.version}']", 1,
                     "relation #{relation_v1.relation_id} version #{relation_v1.version} should still be present in the history for moderators."
 
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
 
       # check normal user can now see the redacted data
       get api_old_relation_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header

--- a/test/controllers/api/permissions_controller_test.rb
+++ b/test/controllers/api/permissions_controller_test.rb
@@ -32,30 +32,6 @@ module Api
       assert_equal 0, js["permissions"].count
     end
 
-    def test_permissions_basic_auth
-      auth_header = basic_authorization_header create(:user).email, "test"
-      get permissions_path, :headers => auth_header
-      assert_response :success
-      assert_select "osm > permissions", :count => 1 do
-        assert_select "permission", :count => Oauth.scopes.size
-        Oauth.scopes.each do |p|
-          assert_select "permission[name='allow_#{p.name}']", :count => 1
-        end
-      end
-
-      # Test json
-      get permissions_path(:format => "json"), :headers => auth_header
-      assert_response :success
-      assert_equal "application/json", @response.media_type
-
-      js = ActiveSupport::JSON.decode(@response.body)
-      assert_not_nil js
-      assert_equal Oauth.scopes.size, js["permissions"].count
-      Oauth.scopes.each do |p|
-        assert_includes js["permissions"], "allow_#{p.name}"
-      end
-    end
-
     def test_permissions_oauth2
       user = create(:user)
       token = create(:oauth_access_token,

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -221,7 +221,7 @@ module Api
       node = create(:node)
       way = create(:way_with_nodes, :nodes_count => 2)
 
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # create an relation without members
       xml = "<osm><relation changeset='#{private_changeset.id}'><tag k='test' v='yes' /></relation></osm>"
@@ -263,7 +263,7 @@ module Api
                       "relation upload did not return success status"
 
       ## Now try with the public user
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # create an relation without members
       xml = "<osm><relation changeset='#{changeset.id}'><tag k='test' v='yes' /></relation></osm>"
@@ -391,7 +391,7 @@ module Api
       relation = create(:relation)
       create_list(:relation_tag, 4, :relation => relation)
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       with_relation(relation.id) do |rel|
         # alter one of the tags
@@ -423,7 +423,7 @@ module Api
       relation = create(:relation)
       create_list(:relation_tag, 4, :relation => relation)
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       with_relation(relation.id) do |rel|
         # alter one of the tags
@@ -450,7 +450,7 @@ module Api
       relation = create(:relation)
       other_relation = create(:relation)
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
       with_relation(relation.id) do |rel|
         update_changeset(rel, changeset.id)
         put api_relation_path(other_relation), :params => rel.to_s, :headers => auth_header
@@ -466,7 +466,7 @@ module Api
       user = create(:user)
       changeset = create(:changeset, :user => user)
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # create a relation with non-existing node as member
       xml = "<osm><relation changeset='#{changeset.id}'>" \
@@ -487,7 +487,7 @@ module Api
       changeset = create(:changeset, :user => user)
       node = create(:node)
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # create some xml that should return an error
       xml = "<osm><relation changeset='#{changeset.id}'>" \
@@ -522,7 +522,7 @@ module Api
       assert_response :unauthorized
 
       ## Then try with the private user, to make sure that you get a forbidden
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # this shouldn't work, as we should need the payload...
       delete api_relation_path(relation), :headers => auth_header
@@ -564,7 +564,7 @@ module Api
       assert_response :forbidden
 
       ## now set auth for the public user
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # this shouldn't work, as we should need the payload...
       delete api_relation_path(relation), :headers => auth_header
@@ -743,7 +743,7 @@ module Api
       way1 = create(:way_with_nodes, :nodes_count => 2)
       way2 = create(:way_with_nodes, :nodes_count => 2)
 
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       doc_str = <<~OSM
         <osm>
@@ -816,13 +816,13 @@ module Api
       doc = XML::Parser.string(doc_str).parse
 
       ## First try with the private user
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       put relation_create_path, :params => doc.to_s, :headers => auth_header
       assert_response :forbidden
 
       ## Now try with the public user
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       put relation_create_path, :params => doc.to_s, :headers => auth_header
       assert_response :success, "can't create a relation: #{@response.body}"
@@ -855,7 +855,7 @@ module Api
         </osm>
       OSM
       doc = XML::Parser.string(doc_str).parse
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       put relation_create_path, :params => doc.to_s, :headers => auth_header
       assert_response :success, "can't create a relation: #{@response.body}"
@@ -922,7 +922,7 @@ module Api
                                      :num_changes => Settings.initial_changes_per_hour - 1)
 
       # create authentication header
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # try creating a relation
       xml = "<osm><relation changeset='#{changeset.id}'>" \
@@ -982,7 +982,7 @@ module Api
       end
 
       # create authentication header
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # try creating a relation
       xml = "<osm><relation changeset='#{changeset.id}'>" \
@@ -1062,7 +1062,7 @@ module Api
     # that the changeset bounding box is +bbox+.
     def check_changeset_modify(bbox)
       ## First test with the private user to check that you get a forbidden
-      auth_header = basic_authorization_header create(:user, :data_public => false).email, "test"
+      auth_header = bearer_authorization_header create(:user, :data_public => false)
 
       # create a new changeset for this operation, so we are assured
       # that the bounding box will be newly-generated.
@@ -1073,7 +1073,7 @@ module Api
       end
 
       ## Now do the whole thing with the public user
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
 
       # create a new changeset for this operation, so we are assured
       # that the bounding box will be newly-generated.

--- a/test/controllers/api/user_preferences_controller_test.rb
+++ b/test/controllers/api/user_preferences_controller_test.rb
@@ -39,7 +39,7 @@ module Api
       assert_response :unauthorized, "should be authenticated"
 
       # authenticate as a user with no preferences
-      auth_header = basic_authorization_header create(:user).email, "test"
+      auth_header = bearer_authorization_header
 
       # try the read again
       get user_preferences_path, :headers => auth_header
@@ -53,7 +53,7 @@ module Api
       user = create(:user)
       user_preference = create(:user_preference, :user => user)
       user_preference2 = create(:user_preference, :user => user)
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header(user)
 
       # try the read again
       get user_preferences_path, :headers => auth_header
@@ -89,7 +89,7 @@ module Api
       assert_response :unauthorized, "should be authenticated"
 
       # authenticate as a user with preferences
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header(user)
 
       # try the read again
       get user_preference_path(:preference_key => "key"), :headers => auth_header
@@ -121,7 +121,7 @@ module Api
       end
 
       # authenticate as a user with preferences
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header(user)
 
       # try the put again
       assert_no_difference "UserPreference.count" do
@@ -181,7 +181,7 @@ module Api
       end
 
       # authenticate as a user with preferences
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header(user)
 
       # try adding a new preference
       assert_difference "UserPreference.count", 1 do
@@ -225,7 +225,7 @@ module Api
       assert_equal "value", UserPreference.find([user.id, "key"]).v
 
       # authenticate as a user with preferences
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header(user)
 
       # try the delete again
       assert_difference "UserPreference.count", -1 do

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -164,7 +164,7 @@ module Api
       assert_response :unauthorized
 
       # check that we get a response when logged in
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
       get user_details_path, :headers => auth_header
       assert_response :success
       assert_equal "application/xml", response.media_type
@@ -173,7 +173,7 @@ module Api
       check_xml_details(user, true, false)
 
       # check that data is returned properly in json
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
       get user_details_path(:format => "json"), :headers => auth_header
       assert_response :success
       assert_equal "application/json", response.media_type
@@ -427,7 +427,7 @@ module Api
       assert_response :unauthorized
 
       # check that we get a response when logged in
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
       get user_gpx_files_path, :headers => auth_header
       assert_response :success
       assert_equal "application/xml", response.media_type

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -146,7 +146,7 @@ module Api
       changeset = create(:changeset, :user => user)
 
       ## First check that it fails when creating a way using a non-public user
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # use the first user's open changeset
       changeset_id = private_changeset.id
@@ -161,7 +161,7 @@ module Api
                       "way upload did not return forbidden status"
 
       ## Now use a public user
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # use the first user's open changeset
       changeset_id = changeset.id
@@ -207,7 +207,7 @@ module Api
       closed_changeset = create(:changeset, :closed, :user => user)
 
       ## First test with a private user to make sure that they are not authorized
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # use the first user's open changeset
       # create a way with non-existing node
@@ -235,7 +235,7 @@ module Api
                       "way upload to closed changeset with a private user did not return 'forbidden'"
 
       ## Now test with a public user
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # use the first user's open changeset
       # create a way with non-existing node
@@ -301,7 +301,7 @@ module Api
       assert_response :unauthorized
 
       # now set auth using the private user
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # this shouldn't work as with the 0.6 api we need pay load to delete
       delete api_way_path(private_way), :headers => auth_header
@@ -350,7 +350,7 @@ module Api
 
       ### Now check with a public user
       # now set auth
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # this shouldn't work as with the 0.6 api we need pay load to delete
       delete api_way_path(way), :headers => auth_header
@@ -419,7 +419,7 @@ module Api
       ## Second test with the private user
 
       # setup auth
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       ## trying to break changesets
 
@@ -457,7 +457,7 @@ module Api
       ## Finally test with the public user
 
       # setup auth
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       ## trying to break changesets
 
@@ -541,7 +541,7 @@ module Api
 
       ## Try with the non-public user
       # setup auth
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # add an identical tag to the way
       tag_xml = XML::Node.new("tag")
@@ -559,7 +559,7 @@ module Api
 
       ## Now try with the public user
       # setup auth
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # add an identical tag to the way
       tag_xml = XML::Node.new("tag")
@@ -589,7 +589,7 @@ module Api
 
       ## Try with the non-public user
       # setup auth
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # add an identical tag to the way
       tag_xml = XML::Node.new("tag")
@@ -607,7 +607,7 @@ module Api
 
       ## Now try with the public user
       # setup auth
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # add an identical tag to the way
       tag_xml = XML::Node.new("tag")
@@ -635,7 +635,7 @@ module Api
 
       ## First test with the non-public user so should be rejected
       # setup auth
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # create duplicate tag
       tag_xml = XML::Node.new("tag")
@@ -655,7 +655,7 @@ module Api
 
       ## Now test with the public user
       # setup auth
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # create duplicate tag
       tag_xml = XML::Node.new("tag")
@@ -687,7 +687,7 @@ module Api
 
       ## First make sure that you can't with a non-public user
       # setup auth
-      auth_header = basic_authorization_header private_user.email, "test"
+      auth_header = bearer_authorization_header private_user
 
       # add the tag into the existing xml
       way_str = "<osm><way changeset='#{private_changeset.id}'>"
@@ -702,7 +702,7 @@ module Api
 
       ## Now do it with a public user
       # setup auth
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # add the tag into the existing xml
       way_str = "<osm><way changeset='#{changeset.id}'>"
@@ -769,7 +769,7 @@ module Api
                                      :num_changes => Settings.initial_changes_per_hour - 1)
 
       # create authentication header
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # try creating a way
       xml = "<osm><way changeset='#{changeset.id}'>" \
@@ -826,7 +826,7 @@ module Api
       end
 
       # create authentication header
-      auth_header = basic_authorization_header user.email, "test"
+      auth_header = bearer_authorization_header user
 
       # try creating a way
       xml = "<osm><way changeset='#{changeset.id}'>" \

--- a/test/integration/compressed_requests_test.rb
+++ b/test/integration/compressed_requests_test.rb
@@ -37,10 +37,9 @@ class CompressedRequestsTest < ActionDispatch::IntegrationTest
     # upload it
     post "/api/0.6/changeset/#{changeset.id}/upload",
          :params => diff,
-         :headers => {
-           "HTTP_AUTHORIZATION" => format("Basic %<auth>s", :auth => Base64.encode64("#{user.display_name}:test")),
+         :headers => bearer_authorization_header(user).merge(
            "HTTP_CONTENT_TYPE" => "application/xml"
-         }
+         )
     assert_response :success,
                     "can't upload an uncompressed diff to changeset: #{@response.body}"
 
@@ -86,11 +85,10 @@ class CompressedRequestsTest < ActionDispatch::IntegrationTest
     # upload it
     post "/api/0.6/changeset/#{changeset.id}/upload",
          :params => gzip_content(diff),
-         :headers => {
-           "HTTP_AUTHORIZATION" => format("Basic %<auth>s", :auth => Base64.encode64("#{user.display_name}:test")),
+         :headers => bearer_authorization_header(user).merge(
            "HTTP_CONTENT_ENCODING" => "gzip",
            "HTTP_CONTENT_TYPE" => "application/xml"
-         }
+         )
     assert_response :success,
                     "can't upload a gzip compressed diff to changeset: #{@response.body}"
 
@@ -136,11 +134,10 @@ class CompressedRequestsTest < ActionDispatch::IntegrationTest
     # upload it
     post "/api/0.6/changeset/#{changeset.id}/upload",
          :params => deflate_content(diff),
-         :headers => {
-           "HTTP_AUTHORIZATION" => format("Basic %<auth>s", :auth => Base64.encode64("#{user.display_name}:test")),
+         :headers => bearer_authorization_header(user).merge(
            "HTTP_CONTENT_ENCODING" => "deflate",
            "HTTP_CONTENT_TYPE" => "application/xml"
-         }
+         )
     assert_response :success,
                     "can't upload a deflate compressed diff to changeset: #{@response.body}"
 
@@ -157,11 +154,10 @@ class CompressedRequestsTest < ActionDispatch::IntegrationTest
     # upload it
     post "/api/0.6/changeset/#{changeset.id}/upload",
          :params => "",
-         :headers => {
-           "HTTP_AUTHORIZATION" => format("Basic %<auth>s", :auth => Base64.encode64("#{user.display_name}:test")),
+         :headers => bearer_authorization_header(user).merge(
            "HTTP_CONTENT_ENCODING" => "unknown",
            "HTTP_CONTENT_TYPE" => "application/xml"
-         }
+         )
     assert_response :unsupported_media_type
   end
 

--- a/test/integration/user_blocks_test.rb
+++ b/test/integration/user_blocks_test.rb
@@ -7,7 +7,7 @@ class UserBlocksTest < ActionDispatch::IntegrationTest
     get "/api/#{Settings.api_version}/user/details"
     assert_response :unauthorized
 
-    get "/api/#{Settings.api_version}/user/details", :headers => basic_authorization_header(blocked_user.display_name, "test")
+    get "/api/#{Settings.api_version}/user/details", :headers => bearer_authorization_header(blocked_user)
     assert_response :success
 
     # now block the user
@@ -18,7 +18,7 @@ class UserBlocksTest < ActionDispatch::IntegrationTest
       :ends_at => Time.now.utc + 5.minutes,
       :deactivates_at => Time.now.utc + 5.minutes
     )
-    get "/api/#{Settings.api_version}/user/details", :headers => basic_authorization_header(blocked_user.display_name, "test")
+    get "/api/#{Settings.api_version}/user/details", :headers => bearer_authorization_header(blocked_user)
     assert_response :forbidden
   end
 
@@ -33,7 +33,7 @@ class UserBlocksTest < ActionDispatch::IntegrationTest
       :ends_at => Time.now.utc + 5.minutes,
       :deactivates_at => Time.now.utc + 5.minutes
     )
-    get "/api/#{Settings.api_version}/user/details", :headers => basic_authorization_header(blocked_user.display_name, "test")
+    get "/api/#{Settings.api_version}/user/details", :headers => bearer_authorization_header(blocked_user)
     assert_response :forbidden
 
     # revoke the ban
@@ -53,7 +53,7 @@ class UserBlocksTest < ActionDispatch::IntegrationTest
     reset!
 
     # access the API again. this time it should work
-    get "/api/#{Settings.api_version}/user/details", :headers => basic_authorization_header(blocked_user.display_name, "test")
+    get "/api/#{Settings.api_version}/user/details", :headers => bearer_authorization_header(blocked_user)
     assert_response :success
   end
 end

--- a/test/integration/user_terms_seen_test.rb
+++ b/test/integration/user_terms_seen_test.rb
@@ -4,14 +4,14 @@ class UserTermsSeenTest < ActionDispatch::IntegrationTest
   def test_api_blocked
     user = create(:user, :terms_seen => false, :terms_agreed => nil)
 
-    get "/api/#{Settings.api_version}/user/preferences", :headers => auth_header(user.display_name, "test")
+    get "/api/#{Settings.api_version}/user/preferences", :headers => bearer_authorization_header(user)
     assert_response :forbidden
 
     # touch it so that the user has seen the terms
     user.terms_seen = true
     user.save
 
-    get "/api/#{Settings.api_version}/user/preferences", :headers => auth_header(user.display_name, "test")
+    get "/api/#{Settings.api_version}/user/preferences", :headers => bearer_authorization_header(user)
     assert_response :success
   end
 
@@ -57,11 +57,5 @@ class UserTermsSeenTest < ActionDispatch::IntegrationTest
     assert_redirected_to :controller => :users, :action => :terms, :referer => "/traces/mine"
     get "/traces/mine", :params => { :referer => "/diary/new" }
     assert_redirected_to :controller => :users, :action => :terms, :referer => "/diary/new"
-  end
-
-  private
-
-  def auth_header(user, pass)
-    { "HTTP_AUTHORIZATION" => format("Basic %<auth>s", :auth => Base64.encode64("#{user}:#{pass}")) }
   end
 end


### PR DESCRIPTION
This drops support for basic authentication and converts all tests which used it to use OAuth instead.