### PR TITLE
Drop unused oauth_10a_disabled translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2581,7 +2581,6 @@ en:
       description_without_count: "GPX file from %{user}"
   application:
     basic_auth_disabled: "HTTP Basic Authentication is disabled: %{link}"
-    oauth_10a_disabled: "OAuth 1.0 and 1.0a are disabled: %{link}"
     auth_disabled_link: "https://wiki.openstreetmap.org/wiki/2024_authentication_update"
     permission_denied: You do not have permission to access that action
     require_cookies:


### PR DESCRIPTION
This got left in when dropping OAuth 1 support...