### PR TITLE
Remove unused locale strings for former changeset tables

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,12 +435,6 @@ en:
       anonymous: "Anonymous"
       no_edits: "(no edits)"
       view_changeset_details: "View changeset details"
-    changesets:
-      id: "ID"
-      saved_at: "Saved at"
-      user: "User"
-      comment: "Comment"
-      area: "Area"
     index:
       title: "Changesets"
       title_user: "Changesets by %{user}"


### PR DESCRIPTION
Changeset lists stopped using them in https://github.com/openstreetmap/openstreetmap-website/commit/e098d52424c3a0c8025cb62193a03bb42477c85c but they we also used in note lists, that stopped in https://github.com/openstreetmap/openstreetmap-website/commit/9d3b419aad3069db13fc0169049a30fbc2b2a288.