### PR TITLE
Remove unused user_diaries_tooltip locale string

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1584,7 +1584,6 @@ en:
     gps_traces: GPS Traces
     gps_traces_tooltip: Manage GPS traces
     user_diaries: User Diaries
-    user_diaries_tooltip: View user diaries
     edit_with: Edit with %{editor}
     tag_line: The Free Wiki World Map
     intro_header: Welcome to OpenStreetMap!


### PR DESCRIPTION
There used to be a tooltip on the diaries tab. Added in https://github.com/openstreetmap/openstreetmap-website/commit/f7985046696958688b8a220a91c4b96ce16d4b65, removed in https://github.com/openstreetmap/openstreetmap-website/commit/6adcce4e5d75fa21dea85742fa36ee3b97247b01.