### PR TITLE
I18N: messages: avoid dynamic translation keys

### DIFF
--- a/app/views/messages/_heading.html.erb
+++ b/app/views/messages/_heading.html.erb
@@ -3,14 +3,14 @@
 <% content_for :heading do %>
   <h1><%= t("users.show.my messages") %></h1>
   <ul class="nav nav-tabs">
-    <% { ".my_inbox" => inbox_messages_path, ".my_outbox" => outbox_messages_path, ".muted_messages" => muted_messages_path }.each do |i18n_key, path| %>
+    <% { t(".my_inbox") => inbox_messages_path, t(".my_outbox") => outbox_messages_path, t(".muted_messages") => muted_messages_path }.each do |label, path| %>
     <% next if path == muted_messages_path && current_user.muted_messages.none? %>
 
     <li class="nav-item">
       <% if path == active_link_path %>
-        <a class="nav-link active"><%= t(i18n_key) %></a>
+        <a class="nav-link active"><%= label %></a>
       <% else %>
-        <%= link_to t(i18n_key), path, :class => "nav-link" %>
+        <%= link_to label, path, :class => "nav-link" %>
       <% end %>
     </li>
     <% end %>


### PR DESCRIPTION
By moving the translation outside the loop and calling t(...) with explicitly stated keys, `bundle exec i18n-tasks unused` no longer reports the keys as unused.

Should we rename `i18n_key` to something different as well?