### PR TITLE
I18n: ignore unused third party translations

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -122,6 +122,7 @@ search:
 ignore_unused:
   - 'geocoder.search_osm_nominatim.prefix.*'
   - 'javascripts.*'
+  - 'doorkeeper.*'
   - 'activerecord.attributes.*'
   - 'activerecord.models.*'
   - 'activerecord.help.*'


### PR DESCRIPTION
Ignores doorkeeper namespace from reporting in `bundle exec i18n-tasks unused`

Although the translations are part of the osm website repo, we have no real control over how they're being used by third party components (that's at least my conclusion at the moment, I hope this is correct).

They were originally added in e996ee5dbca8b7ed26dbf55fcc116fa947f60188 by moving doorkeeper_openid_connect.en.yml to our own en.yml translation file. I suppose they were automatically added when installing doorkeeper openid connect (link: https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/master/config/locales/en.yml)

 `doorkeeper.flash.applications.create.notice` was originally defined by Doorkeeper in https://github.com/doorkeeper-gem/doorkeeper/blob/main/config/locales/en.yml#L134 and then changed in our own en.yml. It is triggered from within Doorkeeper, outside of our control: https://github.com/doorkeeper-gem/doorkeeper/blob/main/app/controllers/doorkeeper/applications_controller.rb#L34

<!--
Should we exclude it from the list by adding the following namespaces instead?

```
  - 'doorkeeper.errors.messages.*'
  - 'doorkeeper.openid_connect.errors.messages.*'
  - 'doorkeeper.scopes.*'
```
-->

List of ignored keys:
```

|   en   | doorkeeper.errors.messages.account_selection_required                                      | The authorization server requires end-user account selection                                                |
|   en   | doorkeeper.errors.messages.consent_required                                                | The authorization server requires end-user consent                                                          |
|   en   | doorkeeper.errors.messages.interaction_required                                            | The authorization server requires end-user interaction                                                      |
|   en   | doorkeeper.errors.messages.login_required                                                  | The authorization server requires end-user authentication                                                   |
|   en   | doorkeeper.flash.applications.create.notice                                                | Application Registered.                                                                                     |
|   en   | doorkeeper.openid_connect.errors.messages.auth_time_from_resource_owner_not_configured     | Failure due to Doorkeeper::OpenidConnect.configure.auth_time_from_resource_owner missing configuration.     |
|   en   | doorkeeper.openid_connect.errors.messages.reauthenticate_resource_owner_not_configured     | Failure due to Doorkeeper::OpenidConnect.configure.reauthenticate_resource_owner missing configuration.     |
|   en   | doorkeeper.openid_connect.errors.messages.resource_owner_from_access_token_not_configured  | Failure due to Doorkeeper::OpenidConnect.configure.resource_owner_from_access_token missing configuration.  |
|   en   | doorkeeper.openid_connect.errors.messages.select_account_for_resource_owner_not_configured | Failure due to Doorkeeper::OpenidConnect.configure.select_account_for_resource_owner missing configuration. |
|   en   | doorkeeper.openid_connect.errors.messages.subject_not_configured                           | ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.        |
|   en   | doorkeeper.scopes.address                                                                  | View your physical address                                                                                  |
|   en   | doorkeeper.scopes.email                                                                    | View your email address                                                                                     |
|   en   | doorkeeper.scopes.openid                                                                   | Authenticate your account                                                                                   |
|   en   | doorkeeper.scopes.phone                                                                    | View your phone number                                                                                      |
|   en   | doorkeeper.scopes.profile                                                                  | View your profile information                                                                               |

```