### PR TITLE
Fixed bug causing bad error message when requested missing changeset

### DIFF
--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -75,6 +75,7 @@ class ChangesetsController < ApplicationController
   end
 
   def show
+    @type = "changeset"
     @changeset = Changeset.find(params[:id])
     case turbo_frame_request_id
     when "changeset_nodes"


### PR DESCRIPTION
PR fixes bug causing bad error message when requested displaying missing changeset

Fixes #5148. Added forgotten @type = "changeset" in ChangesetsController#show.

Before:
![image](https://github.com/user-attachments/assets/15229387-746a-41e0-84e9-e7f70000f0e4)
After:
![image](https://github.com/user-attachments/assets/4815c9c1-4098-4a6e-a497-d69a5699d236)
