### PR TITLE
Bootstrap notes pagination

### DIFF
--- a/app/views/notes/_notes_paging_nav.html.erb
+++ b/app/views/notes/_notes_paging_nav.html.erb
@@ -1,26 +1,35 @@
 <nav>
+  <% link_class = "page-link icon-link text-center text-nowrap" %>
   <ul class="pagination">
+    <% previous_link_content = capture do %>
+      <%= previous_page_svg_tag :class => "flex-shrink-0" %>
+      <%= t(".previous") %>
+    <% end %>
     <% if @page > 1 %>
       <li class="page-item">
-        <%= link_to t(".previous"), @params.merge(:page => @page - 1), :class => "page-link" %>
+        <%= link_to previous_link_content, @params.merge(:page => @page - 1), :class => link_class %>
       </li>
     <% else %>
       <li class="page-item disabled">
-        <%= tag.span t(".previous"), :class => "page-link" %>
+        <%= tag.span previous_link_content, :class => link_class %>
       </li>
     <% end %>
 
     <li class="page-item active">
-      <%= tag.span t(".showing_page", :page => @page), :class => "page-link" %>
+      <%= tag.span t(".showing_page", :page => @page), :class => link_class %>
     </li>
 
+    <% next_link_content = capture do %>
+      <%= t(".next") %>
+      <%= next_page_svg_tag :class => "flex-shrink-0" %>
+    <% end %>
     <% if @notes.size < @page_size %>
       <li class="page-item disabled">
-        <%= tag.span t(".next"), :class => "page-link" %>
+        <%= tag.span next_link_content, :class => link_class %>
       </li>
     <% else %>
       <li class="page-item">
-        <%= link_to t(".next"), @params.merge(:page => @page + 1), :class => "page-link" %>
+        <%= link_to next_link_content, @params.merge(:page => @page + 1), :class => link_class %>
       </li>
     <% end %>
   </ul>

--- a/app/views/notes/_notes_paging_nav.html.erb
+++ b/app/views/notes/_notes_paging_nav.html.erb
@@ -1,17 +1,27 @@
-<p>
+<nav>
+  <ul class="pagination">
+    <% if @page > 1 %>
+      <li class="page-item">
+        <%= link_to t(".previous"), @params.merge(:page => @page - 1), :class => "page-link" %>
+      </li>
+    <% else %>
+      <li class="page-item disabled">
+        <%= tag.span t(".previous"), :class => "page-link" %>
+      </li>
+    <% end %>
 
-<% if @page > 1 %>
-<%= link_to t(".previous"), @params.merge(:page => @page - 1) %>
-<% else %>
-<%= t(".previous") %>
-<% end %>
+    <li class="page-item active">
+      <%= tag.span t(".showing_page", :page => @page), :class => "page-link" %>
+    </li>
 
-| <%= t(".showing_page", :page => @page) %> |
-
-<% if @notes.size < @page_size %>
-<%= t(".next") %>
-<% else %>
-<%= link_to t(".next"), @params.merge(:page => @page + 1) %>
-<% end %>
-
-</p>
+    <% if @notes.size < @page_size %>
+      <li class="page-item disabled">
+        <%= tag.span t(".next"), :class => "page-link" %>
+      </li>
+    <% else %>
+      <li class="page-item">
+        <%= link_to t(".next"), @params.merge(:page => @page + 1), :class => "page-link" %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/notes/_notes_paging_nav.html.erb
+++ b/app/views/notes/_notes_paging_nav.html.erb
@@ -1,17 +1,17 @@
 <p>
 
 <% if @page > 1 %>
-<%= link_to t("changesets.changeset_paging_nav.previous"), @params.merge(:page => @page - 1) %>
+<%= link_to t(".previous"), @params.merge(:page => @page - 1) %>
 <% else %>
-<%= t("changesets.changeset_paging_nav.previous") %>
+<%= t(".previous") %>
 <% end %>
 
-| <%= t("changesets.changeset_paging_nav.showing_page", :page => @page) %> |
+| <%= t(".showing_page", :page => @page) %> |
 
 <% if @notes.size < @page_size %>
-<%= t("changesets.changeset_paging_nav.next") %>
+<%= t(".next") %>
 <% else %>
-<%= link_to t("changesets.changeset_paging_nav.next"), @params.merge(:page => @page + 1) %>
+<%= link_to t(".next"), @params.merge(:page => @page + 1) %>
 <% end %>
 
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -427,10 +427,6 @@ en:
       timeout:
         sorry: "Sorry, the list of changeset comments you requested took too long to retrieve."
   changesets:
-    changeset_paging_nav:
-      showing_page: "Page %{page}"
-      next: "Next »"
-      previous: "« Previous"
     changeset:
       anonymous: "Anonymous"
       no_edits: "(no edits)"
@@ -3029,6 +3025,10 @@ en:
       anonymous_warning_sign_up: "sign up"
       advice: "Your note is public and may be used to update the map, so don't enter personal information, or information from copyrighted maps or directory listings."
       add: Add Note
+    notes_paging_nav:
+      showing_page: "Page %{page}"
+      next: "Next »"
+      previous: "« Previous"
   javascripts:
     close: Close
     share:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3027,8 +3027,8 @@ en:
       add: Add Note
     notes_paging_nav:
       showing_page: "Page %{page}"
-      next: "Next »"
-      previous: "« Previous"
+      next: "Next"
+      previous: "Previous"
   javascripts:
     close: Close
     share:


### PR DESCRIPTION
Smaller PR compared to #4532. I'm just changing how the paging buttons look on `/user/:name/notes` pages.

Before:
![image](https://github.com/user-attachments/assets/b974aff1-bfcb-41db-9abd-432b3f745908)

After:
![image](https://github.com/user-attachments/assets/b42e1d7b-9576-4639-9aed-7be5c7f8422e)
