### PR TITLE
Move History and Export buttons to secondary nav

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -412,6 +412,9 @@ $(document).ready(function () {
 
     if (OSM.router.route(this.pathname + this.search + this.hash)) {
       e.preventDefault();
+      if (this.pathname !== "/directions") {
+        $("header").addClass("closed");
+      }
     }
   });
 

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -32,6 +32,7 @@ OSM.Search = function (map) {
 
   $(".describe_location").on("click", function (e) {
     e.preventDefault();
+    $("header").addClass("closed");
     var center = map.getCenter().wrap(),
         precision = OSM.zoomPrecision(map.getZoom()),
         lat = center.lat.toFixed(precision),

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -101,6 +101,16 @@ OSM.Router = function (map, rts) {
 
   var router = {};
 
+  function updateSecondaryNav() {
+    $("header nav.secondary > ul > li > a").each(function () {
+      var active = $(this).attr("href") === window.location.pathname;
+
+      $(this)
+        .toggleClass("text-secondary", !active)
+        .toggleClass("text-secondary-emphasis", active);
+    });
+  }
+
   $(window).on("popstate", function (e) {
     if (!e.originalEvent.state) return; // Is it a real popstate event or just a hash change?
     var path = window.location.pathname + window.location.search,
@@ -110,6 +120,7 @@ OSM.Router = function (map, rts) {
     currentPath = path;
     currentRoute = route;
     currentRoute.run("popstate", currentPath);
+    updateSecondaryNav();
     map.setState(e.originalEvent.state, { animate: false });
   });
 
@@ -124,6 +135,7 @@ OSM.Router = function (map, rts) {
     currentPath = path;
     currentRoute = route;
     currentRoute.run("pushstate", currentPath);
+    updateSecondaryNav();
     return true;
   };
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -197,9 +197,7 @@ body.small-nav {
     }
   }
 
-  #sidebar .search_forms,
-  #edit_tab,
-  #export_tab {
+  #sidebar .search_forms {
     display: none;
   }
 
@@ -207,7 +205,7 @@ body.small-nav {
     margin-right: 0;
     padding: 0;
 
-    .btn-group {
+    > .btn-group {
       width: 100%;
       padding: 10px;
     }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -119,7 +119,7 @@ header {
 }
 
 nav.primary {
-  & > .btn-group .btn-outline-primary {
+  #edit_tab .btn-outline-primary {
     @include button-outline-variant($green, $color-hover: $white, $active-color: $white);
   }
 
@@ -205,7 +205,7 @@ body.small-nav {
     margin-right: 0;
     padding: 0;
 
-    > .btn-group {
+    #edit_tab {
       width: 100%;
       padding: 10px;
     }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -27,7 +27,6 @@
           <% end %>
         </ul>
       </div>
-      <%= link_to t("layouts.history"), history_path, :class => "btn btn-outline-primary geolink flex-grow-1" %>
     </div>
   </nav>
   <nav class='secondary d-flex gap-2 align-items-center'>
@@ -40,6 +39,9 @@
           <% end -%>
         </li>
       <% end %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.history"), history_path, :class => header_nav_link_class(history_path) %>
+      </li>
       <li class="compact-hide nav-item">
         <%= link_to t("layouts.export"), export_path, :class => header_nav_link_class(export_path) %>
       </li>
@@ -72,6 +74,7 @@
               <% end -%>
             </li>
           <% end %>
+          <li><%= link_to t("layouts.history"), history_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.export"), export_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.gps_traces"), traces_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.user_diaries"), diary_entries_path, :class => "dropdown-item" %></li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,25 +8,23 @@
   <a href="#" id="menu-icon"></a>
   <nav class='primary'>
     <%= content_for :header %>
-    <div class="btn-group">
-      <div id="edit_tab" class="btn-group flex-grow-1">
-        <%= link_to t("layouts.edit"),
-                    edit_path,
-                    :class => "btn btn-outline-primary geolink editlink",
-                    :id => "editanchor",
-                    :data => { :editor => preferred_editor } %>
-        <button class='btn btn-outline-primary dropdown-toggle dropdown-toggle-split flex-grow-0' type='button' data-bs-toggle='dropdown'></button>
-        <ul class='dropdown-menu'>
-          <% Editors::RECOMMENDED_EDITORS.each do |editor| %>
-            <li>
-              <%= link_to t("layouts.edit_with", :editor => t("editor.#{editor}.description")),
-                          edit_path(:editor => editor),
-                          :data => { :editor => editor },
-                          :class => "geolink editlink dropdown-item" %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
+    <div id="edit_tab" class="btn-group">
+      <%= link_to t("layouts.edit"),
+                  edit_path,
+                  :class => "btn btn-outline-primary geolink editlink",
+                  :id => "editanchor",
+                  :data => { :editor => preferred_editor } %>
+      <button class='btn btn-outline-primary dropdown-toggle dropdown-toggle-split flex-grow-0' type='button' data-bs-toggle='dropdown'></button>
+      <ul class='dropdown-menu'>
+        <% Editors::RECOMMENDED_EDITORS.each do |editor| %>
+          <li>
+            <%= link_to t("layouts.edit_with", :editor => t("editor.#{editor}.description")),
+                        edit_path(:editor => editor),
+                        :data => { :editor => editor },
+                        :class => "geolink editlink dropdown-item" %>
+          </li>
+        <% end %>
+      </ul>
     </div>
   </nav>
   <nav class='secondary d-flex gap-2 align-items-center'>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,13 +9,13 @@
   <nav class='primary'>
     <%= content_for :header %>
     <div class="btn-group">
-      <div id="edit_tab" class="btn-group">
+      <div id="edit_tab" class="btn-group flex-grow-1">
         <%= link_to t("layouts.edit"),
                     edit_path,
                     :class => "btn btn-outline-primary geolink editlink",
                     :id => "editanchor",
                     :data => { :editor => preferred_editor } %>
-        <button class='btn btn-outline-primary dropdown-toggle dropdown-toggle-split' type='button' data-bs-toggle='dropdown'></button>
+        <button class='btn btn-outline-primary dropdown-toggle dropdown-toggle-split flex-grow-0' type='button' data-bs-toggle='dropdown'></button>
         <ul class='dropdown-menu'>
           <% Editors::RECOMMENDED_EDITORS.each do |editor| %>
             <li>
@@ -27,8 +27,7 @@
           <% end %>
         </ul>
       </div>
-      <%= link_to t("layouts.history"), history_path, :class => "btn btn-outline-primary geolink flex-grow-1", :id => "history_tab" %>
-      <%= link_to t("layouts.export"), export_path, :class => "btn btn-outline-primary geolink", :id => "export_tab" %>
+      <%= link_to t("layouts.history"), history_path, :class => "btn btn-outline-primary geolink flex-grow-1" %>
     </div>
   </nav>
   <nav class='secondary d-flex gap-2 align-items-center'>
@@ -41,6 +40,9 @@
           <% end -%>
         </li>
       <% end %>
+      <li class="compact-hide nav-item">
+        <%= link_to t("layouts.export"), export_path, :class => header_nav_link_class(export_path) %>
+      </li>
       <li class="compact-hide nav-item">
         <%= link_to t("layouts.gps_traces"), traces_path, :class => header_nav_link_class(traces_path) %>
       </li>
@@ -70,6 +72,7 @@
               <% end -%>
             </li>
           <% end %>
+          <li><%= link_to t("layouts.export"), export_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.gps_traces"), traces_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.user_diaries"), diary_entries_path, :class => "dropdown-item" %></li>
           <li><%= link_to t("layouts.communities"), communities_path, :class => "dropdown-item" %></li>


### PR DESCRIPTION
Version of #4854 that also moves *History* to secondary navigation.

![image](https://github.com/user-attachments/assets/8010aea1-48ec-43d4-bd7a-b00526d48c40)
![image](https://github.com/user-attachments/assets/e6f5997a-c49e-4a97-88ef-774c46fb4508)
![image](https://github.com/user-attachments/assets/5bc34510-764e-4c48-bc03-2afaefd2b99b)
