### PR TITLE
Remove OAuth 1 ApiCapability user branch

### DIFF
--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -5,7 +5,7 @@ class ApiCapability
 
   def initialize(token)
     if Settings.status != "database_offline"
-      user = (User.find(token.resource_owner_id) if token.respond_to?(:resource_owner_id))
+      user = User.find(token.resource_owner_id)
 
       if user&.active?
         can [:create, :comment, :close, :reopen], Note if scope?(token, :write_notes)

--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -5,11 +5,7 @@ class ApiCapability
 
   def initialize(token)
     if Settings.status != "database_offline"
-      user = if token.respond_to?(:resource_owner_id)
-               User.find(token.resource_owner_id)
-             elsif token.respond_to?(:user)
-               token.user
-             end
+      user = (User.find(token.resource_owner_id) if token.respond_to?(:resource_owner_id))
 
       if user&.active?
         can [:create, :comment, :close, :reopen], Note if scope?(token, :write_notes)

--- a/test/abilities/api_capability_test.rb
+++ b/test/abilities/api_capability_test.rb
@@ -88,12 +88,6 @@ end
 
 class UserApiCapabilityTest < ActiveSupport::TestCase
   test "user preferences" do
-    # a user with no tokens
-    capability = ApiCapability.new nil
-    [:index, :show, :update_all, :update, :destroy].each do |act|
-      assert capability.cannot? act, UserPreference
-    end
-
     # A user with empty tokens
     token = create(:oauth_access_token)
     capability = ApiCapability.new token


### PR DESCRIPTION
I looked at Coveralls and noticed that `token.user` is never accessed:

![image](https://github.com/user-attachments/assets/d48d0d20-6627-41ea-87de-452cb2a4b84c)

I guess this branch is not required after #5058.