### PR TITLE
Remove node.tags_as_hash method

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -199,10 +199,6 @@ class Node < ApplicationRecord
     save_with_history!
   end
 
-  def tags_as_hash
-    tags
-  end
-
   def tags
     @tags ||= node_tags.to_h { |t| [t.k, t.v] }
   end

--- a/app/models/old_node.rb
+++ b/app/models/old_node.rb
@@ -85,10 +85,6 @@ class OldNode < ApplicationRecord
 
   attr_writer :tags
 
-  def tags_as_hash
-    tags
-  end
-
   # Pretend we're not in any ways
   def ways
     []


### PR DESCRIPTION
Not used, was last used for Potlatch undelete that was removed in  #3038.

`node.tags` is a hash anyway.
