### PR TITLE
Simplify creation of bearer authorization headers

### DIFF
--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -303,11 +303,11 @@ module Api
     # But writing oauth tests is hard, and so it's easier to put in a controller test.)
     def test_api_write_and_terms_agreed_via_token
       user = create(:user, :terms_agreed => nil)
-      token = create(:oauth_access_token, :resource_owner_id => user.id, :scopes => %w[write_api])
+      auth_header = bearer_authorization_header(user, :scopes => %w[write_api])
       changeset = create(:changeset, :closed)
 
       assert_difference "ChangesetComment.count", 0 do
-        post changeset_comment_path(changeset), :params => { :text => "This is a comment" }, :headers => bearer_authorization_header(token.token)
+        post changeset_comment_path(changeset), :params => { :text => "This is a comment" }, :headers => auth_header
       end
       assert_response :forbidden
 
@@ -316,7 +316,7 @@ module Api
       user.save!
 
       assert_difference "ChangesetComment.count", 1 do
-        post changeset_comment_path(changeset), :params => { :text => "This is a comment" }, :headers => bearer_authorization_header(token.token)
+        post changeset_comment_path(changeset), :params => { :text => "This is a comment" }, :headers => auth_header
       end
       assert_response :success
     end

--- a/test/controllers/api/messages_controller_test.rb
+++ b/test/controllers/api/messages_controller_test.rb
@@ -59,10 +59,7 @@ module Api
       recipient = create(:user)
       sender = create(:user)
 
-      sender_token = create(:oauth_access_token,
-                            :resource_owner_id => sender.id,
-                            :scopes => %w[send_messages consume_messages])
-      sender_auth = bearer_authorization_header(sender_token.token)
+      sender_auth = bearer_authorization_header(sender, :scopes => %w[send_messages consume_messages])
 
       msg = build(:message)
 
@@ -101,10 +98,7 @@ module Api
       recipient = create(:user)
 
       sender = create(:user)
-      sender_token = create(:oauth_access_token,
-                            :resource_owner_id => sender.id,
-                            :scopes => %w[send_messages consume_messages])
-      sender_auth = bearer_authorization_header(sender_token.token)
+      sender_auth = bearer_authorization_header(sender, :scopes => %w[send_messages consume_messages])
 
       assert_no_difference "Message.count" do
         assert_no_difference "ActionMailer::Base.deliveries.size" do
@@ -160,20 +154,9 @@ module Api
       sender = create(:user)
       user3 = create(:user)
 
-      sender_token = create(:oauth_access_token,
-                            :resource_owner_id => sender.id,
-                            :scopes => %w[consume_messages])
-      sender_auth = bearer_authorization_header(sender_token.token)
-
-      recipient_token = create(:oauth_access_token,
-                               :resource_owner_id => recipient.id,
-                               :scopes => %w[consume_messages])
-      recipient_auth = bearer_authorization_header(recipient_token.token)
-
-      user3_token = create(:oauth_access_token,
-                           :resource_owner_id => user3.id,
-                           :scopes => %w[send_messages consume_messages])
-      user3_auth = bearer_authorization_header(user3_token.token)
+      sender_auth = bearer_authorization_header(sender, :scopes => %w[consume_messages])
+      recipient_auth = bearer_authorization_header(recipient, :scopes => %w[consume_messages])
+      user3_auth = bearer_authorization_header(user3, :scopes => %w[send_messages consume_messages])
 
       msg = create(:message, :unread, :sender => sender, :recipient => recipient)
 
@@ -264,15 +247,8 @@ module Api
       sender = create(:user)
       user3 = create(:user)
 
-      recipient_token = create(:oauth_access_token,
-                               :resource_owner_id => recipient.id,
-                               :scopes => %w[consume_messages])
-      recipient_auth = bearer_authorization_header(recipient_token.token)
-
-      user3_token = create(:oauth_access_token,
-                           :resource_owner_id => user3.id,
-                           :scopes => %w[send_messages consume_messages])
-      user3_auth = bearer_authorization_header(user3_token.token)
+      recipient_auth = bearer_authorization_header(recipient, :scopes => %w[consume_messages])
+      user3_auth = bearer_authorization_header(user3, :scopes => %w[send_messages consume_messages])
 
       msg = create(:message, :unread, :sender => sender, :recipient => recipient)
 
@@ -339,22 +315,13 @@ module Api
 
     def test_delete
       recipient = create(:user)
-      recipient_token = create(:oauth_access_token,
-                               :resource_owner_id => recipient.id,
-                               :scopes => %w[consume_messages])
-      recipient_auth = bearer_authorization_header(recipient_token.token)
+      recipient_auth = bearer_authorization_header(recipient, :scopes => %w[consume_messages])
 
       sender = create(:user)
-      sender_token = create(:oauth_access_token,
-                            :resource_owner_id => sender.id,
-                            :scopes => %w[send_messages consume_messages])
-      sender_auth = bearer_authorization_header(sender_token.token)
+      sender_auth = bearer_authorization_header(sender, :scopes => %w[send_messages consume_messages])
 
       user3 = create(:user)
-      user3_token = create(:oauth_access_token,
-                           :resource_owner_id => user3.id,
-                           :scopes => %w[send_messages consume_messages])
-      user3_auth = bearer_authorization_header(user3_token.token)
+      user3_auth = bearer_authorization_header(user3, :scopes => %w[send_messages consume_messages])
 
       msg = create(:message, :read, :sender => sender, :recipient => recipient)
 
@@ -407,22 +374,13 @@ module Api
 
     def test_list_messages
       user1 = create(:user)
-      user1_token = create(:oauth_access_token,
-                           :resource_owner_id => user1.id,
-                           :scopes => %w[send_messages consume_messages])
-      user1_auth = bearer_authorization_header(user1_token.token)
+      user1_auth = bearer_authorization_header(user1, :scopes => %w[send_messages consume_messages])
 
       user2 = create(:user)
-      user2_token = create(:oauth_access_token,
-                           :resource_owner_id => user2.id,
-                           :scopes => %w[send_messages consume_messages])
-      user2_auth = bearer_authorization_header(user2_token.token)
+      user2_auth = bearer_authorization_header(user2, :scopes => %w[send_messages consume_messages])
 
       user3 = create(:user)
-      user3_token = create(:oauth_access_token,
-                           :resource_owner_id => user3.id,
-                           :scopes => %w[send_messages consume_messages])
-      user3_auth = bearer_authorization_header(user3_token.token)
+      user3_auth = bearer_authorization_header(user3, :scopes => %w[send_messages consume_messages])
 
       # create some messages between users
       # user | inbox | outbox
@@ -523,10 +481,7 @@ module Api
 
     def test_paged_list_messages_asc
       recipient = create(:user)
-      recipient_token = create(:oauth_access_token,
-                               :resource_owner_id => recipient.id,
-                               :scopes => %w[consume_messages])
-      recipient_auth = bearer_authorization_header(recipient_token.token)
+      recipient_auth = bearer_authorization_header(recipient, :scopes => %w[consume_messages])
 
       sender = create(:user)
 
@@ -559,10 +514,7 @@ module Api
 
     def test_paged_list_messages_desc
       recipient = create(:user)
-      recipient_token = create(:oauth_access_token,
-                               :resource_owner_id => recipient.id,
-                               :scopes => %w[consume_messages])
-      recipient_auth = bearer_authorization_header(recipient_token.token)
+      recipient_auth = bearer_authorization_header(recipient, :scopes => %w[consume_messages])
 
       sender = create(:user)
 

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -239,38 +239,38 @@ module Api
     end
 
     def test_redact_node_by_regular_with_read_prefs_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[read_prefs])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs])
       do_redact_redactable_node(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_node_by_regular_with_write_api_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[write_api])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_api])
       do_redact_redactable_node(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_node_by_regular_with_write_redactions_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[write_redactions])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_redactions])
       do_redact_redactable_node(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_node_by_moderator_with_read_prefs_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[read_prefs])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs])
       do_redact_redactable_node(auth_header)
       assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_node_by_moderator_with_write_api_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_api])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_api])
       do_redact_redactable_node(auth_header)
       assert_response :success, "should be OK to redact old version as moderator with write_api scope."
       # assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_node_by_moderator_with_write_redactions_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_redactions])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_redactions])
       do_redact_redactable_node(auth_header)
       assert_response :success, "should be OK to redact old version as moderator with write_redactions scope."
     end
@@ -431,13 +431,6 @@ module Api
     end
 
     private
-
-    def create_bearer_auth_header(user, scopes)
-      token = create(:oauth_access_token,
-                     :resource_owner_id => user.id,
-                     :scopes => scopes)
-      bearer_authorization_header(token.token)
-    end
 
     def do_redact_redactable_node(headers = {})
       node = create(:node, :with_history, :version => 4)

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -78,38 +78,38 @@ module Api
     end
 
     def test_redact_relation_by_regular_with_read_prefs_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[read_prefs])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs])
       do_redact_redactable_relation(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_relation_by_regular_with_write_api_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[write_api])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_api])
       do_redact_redactable_relation(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_relation_by_regular_with_write_redactions_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[write_redactions])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_redactions])
       do_redact_redactable_relation(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_relation_by_moderator_with_read_prefs_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[read_prefs])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs])
       do_redact_redactable_relation(auth_header)
       assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_relation_by_moderator_with_write_api_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_api])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_api])
       do_redact_redactable_relation(auth_header)
       assert_response :success, "should be OK to redact old version as moderator with write_api scope."
       # assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_relation_by_moderator_with_write_redactions_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_redactions])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_redactions])
       do_redact_redactable_relation(auth_header)
       assert_response :success, "should be OK to redact old version as moderator with write_redactions scope."
     end
@@ -313,13 +313,6 @@ module Api
 
         assert_relations_are_equal history_relation, version_relation
       end
-    end
-
-    def create_bearer_auth_header(user, scopes)
-      token = create(:oauth_access_token,
-                     :resource_owner_id => user.id,
-                     :scopes => scopes)
-      bearer_authorization_header(token.token)
     end
 
     def do_redact_redactable_relation(headers = {})

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -119,38 +119,38 @@ module Api
     end
 
     def test_redact_way_by_regular_with_read_prefs_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[read_prefs])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs])
       do_redact_redactable_way(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_way_by_regular_with_write_api_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[write_api])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_api])
       do_redact_redactable_way(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_way_by_regular_with_write_redactions_scope
-      auth_header = create_bearer_auth_header(create(:user), %w[write_redactions])
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_redactions])
       do_redact_redactable_way(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
     def test_redact_way_by_moderator_with_read_prefs_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[read_prefs])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs])
       do_redact_redactable_way(auth_header)
       assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_way_by_moderator_with_write_api_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_api])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_api])
       do_redact_redactable_way(auth_header)
       assert_response :success, "should be OK to redact old version as moderator with write_api scope."
       # assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_way_by_moderator_with_write_redactions_scope
-      auth_header = create_bearer_auth_header(create(:moderator_user), %w[write_redactions])
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_redactions])
       do_redact_redactable_way(auth_header)
       assert_response :success, "should be OK to redact old version as moderator with write_redactions scope."
     end
@@ -352,13 +352,6 @@ module Api
 
         assert_ways_are_equal history_way, version_way
       end
-    end
-
-    def create_bearer_auth_header(user, scopes)
-      token = create(:oauth_access_token,
-                     :resource_owner_id => user.id,
-                     :scopes => scopes)
-      bearer_authorization_header(token.token)
     end
 
     def do_redact_redactable_way(headers = {})

--- a/test/controllers/api/permissions_controller_test.rb
+++ b/test/controllers/api/permissions_controller_test.rb
@@ -34,10 +34,8 @@ module Api
 
     def test_permissions_oauth2
       user = create(:user)
-      token = create(:oauth_access_token,
-                     :resource_owner_id => user.id,
-                     :scopes => %w[read_prefs write_api])
-      get permissions_path, :headers => bearer_authorization_header(token.token)
+      auth_header = bearer_authorization_header(user, :scopes => %w[read_prefs write_api])
+      get permissions_path, :headers => auth_header
       assert_response :success
       assert_select "osm > permissions", :count => 1 do
         assert_select "permission", :count => 2

--- a/test/controllers/api/user_preferences_controller_test.rb
+++ b/test/controllers/api/user_preferences_controller_test.rb
@@ -252,10 +252,10 @@ module Api
     # read preferences
     def test_show_using_token
       user = create(:user)
-      token = create(:oauth_access_token, :resource_owner_id => user.id, :scopes => %w[read_prefs])
+      auth_header = bearer_authorization_header(user, :scopes => %w[read_prefs])
       create(:user_preference, :user => user, :k => "key", :v => "value")
 
-      get user_preference_path(:preference_key => "key"), :headers => bearer_authorization_header(token.token)
+      get user_preference_path(:preference_key => "key"), :headers => auth_header
       assert_response :success
     end
 
@@ -264,10 +264,10 @@ module Api
     # by other methods.
     def test_show_using_token_fail
       user = create(:user)
-      token = create(:oauth_access_token, :resource_owner_id => user.id)
+      auth_header = bearer_authorization_header(user, :scopes => %w[])
       create(:user_preference, :user => user, :k => "key", :v => "value")
 
-      get user_preference_path(:preference_key => "key"), :headers => bearer_authorization_header(token.token)
+      get user_preference_path(:preference_key => "key"), :headers => auth_header
       assert_response :forbidden
     end
   end


### PR DESCRIPTION
Uses the new features added to the bearer_authorization_header while dropping basic authentication support to simplify the creation of bearer authorization headers for API tests.

This is an alternative to #5154 that goes further in simplifying things.