### PR TITLE
Switch from ubuntu to debian and refactor Dockerfile

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -75,11 +75,15 @@ Run the Rails database migrations:
 
 Prepare the test database:
 
-     docker compose run --rm web bundle exec rails db:test:prepare
+    docker compose run --rm web bundle exec rails db:test:prepare
 
 Run the test suite:
 
     docker compose run --rm web bundle exec rails test:all
+
+If you encounter errors about missing assets, precompile the assets:
+
+    docker compose run --rm web bundle exec rake assets:precompile
 
 ### Loading an OSM extract
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,39 @@
-FROM ubuntu:22.04
+FROM debian:bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install system packages then clean up to minimize image size
 RUN apt-get update \
- && apt-get install --no-install-recommends -y \
-      build-essential \
-      curl \
-      default-jre-headless \
-      file \
-      git-core \
-      gpg-agent \
-      libarchive-dev \
-      libffi-dev \
-      libgd-dev \
-      libpq-dev \
-      libsasl2-dev \
-      libvips-dev \
-      libxml2-dev \
-      libxslt1-dev \
-      libyaml-dev \
-      locales \
-      postgresql-client \
-      ruby \
-      ruby-dev \
-      ruby-bundler \
-      software-properties-common \
-      tzdata \
-      unzip
-
-# Install Node.js 18 and npm
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
- && apt-get install -y nodejs
+  && apt-get install --no-install-recommends -y \
+  build-essential \
+  curl \
+  default-jre-headless \
+  file \
+  git-core \
+  gpg-agent \
+  libarchive-dev \
+  libffi-dev \
+  libgd-dev \
+  libpq-dev \
+  libsasl2-dev \
+  libvips-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  libyaml-dev \
+  locales \
+  postgresql-client \
+  ruby-dev \
+  ruby-bundler \
+  tzdata \
+  unzip \
+  nodejs \
+  npm \
+  osmosis \
+  ca-certificates \
+  firefox-esr
 
 # Install yarn globally
-RUN npm install --global yarn \
- # We can't use snap packages for firefox inside a container, so we need to get firefox+geckodriver elsewhere
- && add-apt-repository -y ppa:mozillateam/ppa \
- && echo "Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001" > /etc/apt/preferences.d/mozilla-firefox \
- && apt-get install --no-install-recommends -y \
-      firefox-geckodriver \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-# Install compatible Osmosis to help users import sample data in a new instance
-RUN curl -OL https://github.com/openstreetmap/osmosis/releases/download/0.47.2/osmosis-0.47.2.tgz \
- && tar -C /usr/local -xzf osmosis-0.47.2.tgz
+RUN npm install --global yarn
 
 ENV DEBIAN_FRONTEND=dialog
 


### PR DESCRIPTION
Fixes #5010

A few notes regarding this issue and PR:

- Since @tomhughes mentioned in this [comment](https://github.com/openstreetmap/openstreetmap-website/pull/5070#issuecomment-2329719170) that all the production and development servers are now on Debian 12, I thought this would be a good time to sync the Docker image and revisit the previous work.
- The issues noted in this [comment](https://github.com/openstreetmap/openstreetmap-website/issues/5010#issuecomment-2261537069) have been resolved. These were likely caused by geckodriver v0.34 being incompatible with the newer version of Firefox, which was reflected in the test logs afterwards.
- Node.js and osmosis are now installed as a system packages, and ESLint is working correctly out of the box again.
- I encountered an issue when running tests for the first time inside the Docker container, where some assets were missing. Running `bundle exec rake assets:precompile` resolved these errors.
- Everything seems to be working fine now, but it would be helpful if a few of us could test this locally before merging.

Let me know if you have any feedback or suggestions!