### PR TITLE
Switch vagrant to use Debian 12

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,9 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  # use official ubuntu image for virtualbox
+  # use official debian image
+  config.vm.box = "debian/bookworm64"
+
+  # configure virtualbox provider
   config.vm.provider "virtualbox" do |vb, override|
-    override.vm.box = "ubuntu/noble64"
     override.vm.synced_folder ".", "/srv/openstreetmap-website"
     vb.customize ["modifyvm", :id, "--memory", "4096"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]
@@ -14,16 +16,16 @@ Vagrant.configure("2") do |config|
   # Use sshfs sharing if available, otherwise NFS sharing
   sharing_type = Vagrant.has_plugin?("vagrant-sshfs") ? "sshfs" : "nfs"
 
-  # use third party image and sshfs or NFS sharing for lxc
+  # configure lxc provider
   config.vm.provider "lxc" do |_, override|
-    override.vm.box = "generic/ubuntu2404"
     override.vm.synced_folder ".", "/srv/openstreetmap-website", :type => sharing_type
   end
 
-  # use third party image and sshfs or NFS sharing for libvirt
-  config.vm.provider "libvirt" do |_, override|
-    override.vm.box = "generic/ubuntu2404"
+  # configure libvirt provider
+  config.vm.provider "libvirt" do |libvirt, override|
     override.vm.synced_folder ".", "/srv/openstreetmap-website", :type => sharing_type
+    libvirt.memory = 4096
+    libvirt.cpus = 2
   end
 
   # configure shared package cache if possible

--- a/script/vagrant/setup/provision.sh
+++ b/script/vagrant/setup/provision.sh
@@ -3,12 +3,6 @@
 # abort on error
 set -e
 
-# set locale to UTF-8 compatible. apologies to non-english speakers...
-locale-gen en_GB.utf8
-update-locale LANG=en_GB.utf8 LC_ALL=en_GB.utf8
-export LANG=en_GB.utf8
-export LC_ALL=en_GB.utf8
-
 # make sure we have up-to-date packages
 apt-get update
 
@@ -18,7 +12,7 @@ apt-get upgrade -y
 # install packages as explained in INSTALL.md
 apt-get install -y ruby ruby-dev ruby-bundler \
                      libxml2-dev libxslt1-dev nodejs npm \
-                     build-essential git-core \
+                     build-essential git-core firefox-esr \
                      postgresql postgresql-contrib libpq-dev libvips-dev libyaml-dev \
                      libsasl2-dev libffi-dev libgd-dev libarchive-dev libbz2-dev
 npm install --global yarn


### PR DESCRIPTION
Similar to #5157 this switches the vagrant configuration to use Debian 12 instead of Ubuntu.

Only tested with the libvirt provider at the moment.