### PR TITLE
Remove messages.message_summary.reply_button string

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1756,7 +1756,6 @@ en:
     message_summary:
       unread_button: "Mark as unread"
       read_button: "Mark as read"
-      reply_button: "Reply"
       destroy_button: "Delete"
       unmute_button: "Move to Inbox"
     new:


### PR DESCRIPTION
Added in https://github.com/openstreetmap/openstreetmap-website/commit/272d73e9a76ff55a05a0889bd02a9e3c31a35910. The button was removed from message lists in https://github.com/openstreetmap/openstreetmap-website/commit/be8617dfdc9fdf941705272ec9ba152b95677249.