### PR TITLE
Remove strings unused since Oct 2013 frontpage redesign

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1573,16 +1573,12 @@ en:
     history: History
     export: Export
     issues: Issues
-    data: Data
-    export_data: Export Data
     gps_traces: GPS Traces
     gps_traces_tooltip: Manage GPS traces
     user_diaries: User Diaries
     edit_with: Edit with %{editor}
-    tag_line: The Free Wiki World Map
     intro_header: Welcome to OpenStreetMap!
     intro_text: OpenStreetMap is a map of the world, created by people like you and free to use under an open license.
-    intro_2_create_account: "Create a user account"
     hosting_partners_2024_html: "Hosting is supported by %{fastly}, %{corpmembers}, and other %{partners}."
     partners_fastly: "Fastly"
     partners_corpmembers: "OSMF corporate members"
@@ -1596,9 +1592,6 @@ en:
     about: About
     copyright: Copyright
     communities: Communities
-    community: Community
-    community_blogs: "Community Blogs"
-    community_blogs_title: "Blogs from members of the OpenStreetMap community"
     learn_more: "Learn More"
     more: More
   user_mailer:


### PR DESCRIPTION
The redesign happened in https://github.com/openstreetmap/openstreetmap-website/commit/6adcce4e5d75fa21dea85742fa36ee3b97247b01. Some of the texts went to the *About* page in https://github.com/openstreetmap/openstreetmap-website/commit/3ebad9ec2f59f2ba5716952f6169cdbb4972f931.