### PR TITLE
Remove unnecessary site.about locale scopes from About page

### DIFF
--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -27,9 +27,9 @@
             <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
             <path d="m 15,22 c 0,0 5,-4.5199 5,-8 0,-3 -2,-5 -5,-5 -3,0 -5,2 -5,5 0,3.4801 5,8 5,8 z" fill="#c0c0c0" />
           </svg>
-          <h2 class="flex-grow-1 mb-0"><%= t "site.about.local_knowledge_title" %></h2>
+          <h2 class="flex-grow-1 mb-0"><%= t ".local_knowledge_title" %></h2>
         </div>
-        <p><%= t "site.about.local_knowledge_html" %></p>
+        <p><%= t ".local_knowledge_html" %></p>
       </section>
 
       <section>
@@ -38,17 +38,17 @@
             <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
             <path d="m 15,7 -6,6 0,7 4,0 0,-4 4,0 0,4 4,0 0,-7 z" fill="#c0c0c0" />
           </svg>
-          <h2 class="flex-grow-1 mb-0"><%= t "site.about.community_driven_title" %></h2>
+          <h2 class="flex-grow-1 mb-0"><%= t ".community_driven_title" %></h2>
         </div>
         <p>
-          <%= t "site.about.community_driven_1_html", :osm_blog_link => link_to(t("site.about.community_driven_osm_blog"),
-                                                                                t("site.about.community_driven_osm_blog_url")),
-                                                      :user_diaries_link => link_to(t("site.about.community_driven_user_diaries"),
-                                                                                    diary_entries_path),
-                                                      :community_blogs_link => link_to(t("site.about.community_driven_community_blogs"),
-                                                                                       t("site.about.community_driven_community_blogs_url")),
-                                                      :osm_foundation_link => link_to(t("site.about.community_driven_osm_foundation"),
-                                                                                      t("site.about.community_driven_osm_foundation_url")) %>
+          <%= t ".community_driven_1_html", :osm_blog_link => link_to(t(".community_driven_osm_blog"),
+                                                                      t(".community_driven_osm_blog_url")),
+                                            :user_diaries_link => link_to(t(".community_driven_user_diaries"),
+                                                                          diary_entries_path),
+                                            :community_blogs_link => link_to(t(".community_driven_community_blogs"),
+                                                                             t(".community_driven_community_blogs_url")),
+                                            :osm_foundation_link => link_to(t(".community_driven_osm_foundation"),
+                                                                            t(".community_driven_osm_foundation_url")) %>
         </p>
       </section>
 
@@ -58,12 +58,12 @@
             <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
             <path d="M20.196 18 a6 6 0 1 1 0 -6" fill="none" stroke="#c0c0c0" stroke-width="3" />
           </svg>
-          <h2 class="flex-grow-1 mb-0"><%= t "site.about.open_data_title" %></h2>
+          <h2 class="flex-grow-1 mb-0"><%= t ".open_data_title" %></h2>
         </div>
         <p>
-          <%= t "site.about.open_data_1_html", :open_data => tag.i(t("site.about.open_data_open_data")),
-                                               :copyright_license_link => link_to(t("site.about.open_data_copyright_license"),
-                                                                                  copyright_path) %></p>
+          <%= t ".open_data_1_html", :open_data => tag.i(t(".open_data_open_data")),
+                                     :copyright_license_link => link_to(t(".open_data_copyright_license"),
+                                                                        copyright_path) %></p>
       </section>
 
       <section id="legal">
@@ -77,25 +77,25 @@
                     d="M.5 1 a1 1 0 0 0 0 -2 h-2.5 a1 1 0 0 1 0 -2 h.5" />
             </g>
           </svg>
-          <h2 class="flex-grow-1 mb-0"><%= t "site.about.legal_title" %></h2>
+          <h2 class="flex-grow-1 mb-0"><%= t ".legal_title" %></h2>
         </div>
         <p>
-          <%= t "site.about.legal_1_1_html", :openstreetmap_foundation_link => link_to(t("site.about.legal_1_1_openstreetmap_foundation"),
-                                                                                       t("site.about.legal_1_1_openstreetmap_foundation_url")),
-                                             :terms_of_use_link => link_to(t("site.about.legal_1_1_terms_of_use"),
-                                                                           t("site.about.legal_1_1_terms_of_use_url")),
-                                             :aup_link => link_to(t("site.about.legal_1_1_aup"),
-                                                                  t("site.about.legal_1_1_aup_url")),
-                                             :privacy_policy_link => link_to(t("site.about.legal_1_1_privacy_policy"),
-                                                                             t("site.about.legal_1_1_privacy_policy_url")) %>
+          <%= t ".legal_1_1_html", :openstreetmap_foundation_link => link_to(t(".legal_1_1_openstreetmap_foundation"),
+                                                                             t(".legal_1_1_openstreetmap_foundation_url")),
+                                   :terms_of_use_link => link_to(t(".legal_1_1_terms_of_use"),
+                                                                 t(".legal_1_1_terms_of_use_url")),
+                                   :aup_link => link_to(t(".legal_1_1_aup"),
+                                                        t(".legal_1_1_aup_url")),
+                                   :privacy_policy_link => link_to(t(".legal_1_1_privacy_policy"),
+                                                                   t(".legal_1_1_privacy_policy_url")) %>
         </p>
         <p>
-          <%= t "site.about.legal_2_1_html", :contact_the_osmf_link => link_to(t("site.about.legal_2_1_contact_the_osmf"),
-                                                                               t("site.about.legal_2_1_contact_the_osmf_url")) %>
+          <%= t ".legal_2_1_html", :contact_the_osmf_link => link_to(t(".legal_2_1_contact_the_osmf"),
+                                                                     t(".legal_2_1_contact_the_osmf_url")) %>
         </p>
         <p>
-          <%= t "site.about.legal_2_2_html", :registered_trademarks_link => link_to(t("site.about.legal_2_2_registered_trademarks"),
-                                                                                    t("site.about.legal_2_2_registered_trademarks_url")) %>
+          <%= t ".legal_2_2_html", :registered_trademarks_link => link_to(t(".legal_2_2_registered_trademarks"),
+                                                                          t(".legal_2_2_registered_trademarks_url")) %>
         </p>
       </section>
 
@@ -108,7 +108,7 @@
               <line x1="15" y1="11" x2="15" y2="19" />
             </g>
           </svg>
-          <h2 class="flex-grow-1 mb-0"><%= t "site.about.partners_title" %></h2>
+          <h2 class="flex-grow-1 mb-0"><%= t ".partners_title" %></h2>
         </div>
         <p><%= t "layouts.hosting_partners_2024_html", :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
                                                        :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),


### PR DESCRIPTION
They were added together with the section template in https://github.com/openstreetmap/openstreetmap-website/commit/7c4dff7445568b9791f79b5c201c808eb83d100e to support rendering texts from within that template. That template was removed in https://github.com/openstreetmap/openstreetmap-website/commit/459995ab51e9ceb19f12e5baf70d72b2560c9887.