### PR TITLE
Remove unused site.about.next string

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1908,7 +1908,6 @@ en:
       help: Help
   site:
     about:
-      next: Next
       heading_html: "%{copyright}OpenStreetMap %{br} contributors"
       copyright_symbol_html: "&copy;"
       used_by_html: "%{name} provides map data for thousands of websites, mobile apps, and hardware devices"


### PR DESCRIPTION
Was used in a photo gallery on the *About* page. The gallery was added in https://github.com/openstreetmap/openstreetmap-website/commit/3ebad9ec2f59f2ba5716952f6169cdbb4972f931, commented out in https://github.com/openstreetmap/openstreetmap-website/commit/0f6ee7407c173fa21075a68b8b99d520ace43225 and removed in https://github.com/openstreetmap/openstreetmap-website/commit/07c6d714c557d79924c09139e875de0f5eb80e81.