### PR TITLE
Remove Oauth::OAUTH2_SCOPES

### DIFF
--- a/app/views/oauth2_applications/_form.html.erb
+++ b/app/views/oauth2_applications/_form.html.erb
@@ -3,5 +3,5 @@
 <%= f.form_group :confidential do %>
   <%= f.check_box :confidential %>
 <% end %>
-<%= f.collection_check_boxes :scopes, Oauth.scopes(:oauth2 => true, :privileged => current_user.administrator?), :name, :description %>
+<%= f.collection_check_boxes :scopes, Oauth.scopes(:privileged => current_user.administrator?), :name, :description %>
 <%= f.primary %>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -225,7 +225,7 @@ Doorkeeper.configure do
   # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
 
   # default_scopes  :public
-  optional_scopes(*Oauth::SCOPES, *Oauth::PRIVILEGED_SCOPES, *Oauth::OAUTH2_SCOPES)
+  optional_scopes(*Oauth::SCOPES, *Oauth::PRIVILEGED_SCOPES)
 
   # Allows to restrict only certain scopes for grant_type.
   # By default, all the scopes will be available for all the grant types.

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -1,8 +1,11 @@
 module Oauth
-  SCOPES = %w[read_prefs write_prefs write_diary write_api read_gpx write_gpx write_notes].freeze
+  SCOPES = %w[
+    read_prefs write_prefs write_diary
+    write_api read_gpx write_gpx write_notes write_redactions
+    consume_messages send_messages openid
+  ].freeze
   PRIVILEGED_SCOPES = %w[read_email skip_authorization].freeze
   MODERATOR_SCOPES = %w[write_redactions].freeze
-  OAUTH2_SCOPES = %w[write_redactions consume_messages send_messages openid].freeze
 
   class Scope
     attr_reader :name
@@ -16,10 +19,9 @@ module Oauth
     end
   end
 
-  def self.scopes(oauth2: false, privileged: false)
+  def self.scopes(privileged: false)
     scopes = SCOPES
     scopes += PRIVILEGED_SCOPES if privileged
-    scopes += OAUTH2_SCOPES if oauth2
     scopes.collect { |s| Scope.new(s) }
   end
 end


### PR DESCRIPTION
After OAuth1 was removed, all scopes are OAuth2 scopes. Former OAuth2-only scopes now can be combined with the rest.