### PR TITLE
Disable redactions with write_api scope

### DIFF
--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -27,7 +27,7 @@ class ApiCapability
         if user.moderator?
           can [:destroy, :restore], ChangesetComment if scope?(token, :write_api)
           can :destroy, Note if scope?(token, :write_notes)
-          can :redact, [OldNode, OldWay, OldRelation] if user&.terms_agreed? && (scope?(token, :write_api) || scope?(token, :write_redactions))
+          can :redact, [OldNode, OldWay, OldRelation] if user&.terms_agreed? && scope?(token, :write_redactions)
         end
       end
     end

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -238,14 +238,8 @@ module Api
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
     end
 
-    def test_redact_node_by_regular_with_read_prefs_scope
-      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs])
-      do_redact_redactable_node(auth_header)
-      assert_response :forbidden, "should need to be moderator to redact."
-    end
-
-    def test_redact_node_by_regular_with_write_api_scope
-      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_api])
+    def test_redact_node_by_regular_without_write_redactions_scope
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs write_api])
       do_redact_redactable_node(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
@@ -256,17 +250,10 @@ module Api
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
-    def test_redact_node_by_moderator_with_read_prefs_scope
-      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs])
+    def test_redact_node_by_moderator_without_write_redactions_scope
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs write_api])
       do_redact_redactable_node(auth_header)
       assert_response :forbidden, "should need to have write_redactions scope to redact."
-    end
-
-    def test_redact_node_by_moderator_with_write_api_scope
-      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_api])
-      do_redact_redactable_node(auth_header)
-      assert_response :success, "should be OK to redact old version as moderator with write_api scope."
-      # assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_node_by_moderator_with_write_redactions_scope

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -77,14 +77,8 @@ module Api
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
     end
 
-    def test_redact_relation_by_regular_with_read_prefs_scope
-      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs])
-      do_redact_redactable_relation(auth_header)
-      assert_response :forbidden, "should need to be moderator to redact."
-    end
-
-    def test_redact_relation_by_regular_with_write_api_scope
-      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_api])
+    def test_redact_relation_by_regular_without_write_redactions_scope
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs write_api])
       do_redact_redactable_relation(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
@@ -95,17 +89,10 @@ module Api
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
-    def test_redact_relation_by_moderator_with_read_prefs_scope
-      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs])
+    def test_redact_relation_by_moderator_without_write_redactions_scope
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs write_api])
       do_redact_redactable_relation(auth_header)
       assert_response :forbidden, "should need to have write_redactions scope to redact."
-    end
-
-    def test_redact_relation_by_moderator_with_write_api_scope
-      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_api])
-      do_redact_redactable_relation(auth_header)
-      assert_response :success, "should be OK to redact old version as moderator with write_api scope."
-      # assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_relation_by_moderator_with_write_redactions_scope

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -118,14 +118,8 @@ module Api
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
     end
 
-    def test_redact_way_by_regular_with_read_prefs_scope
-      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs])
-      do_redact_redactable_way(auth_header)
-      assert_response :forbidden, "should need to be moderator to redact."
-    end
-
-    def test_redact_way_by_regular_with_write_api_scope
-      auth_header = bearer_authorization_header(create(:user), :scopes => %w[write_api])
+    def test_redact_way_by_regular_without_write_redactions_scope
+      auth_header = bearer_authorization_header(create(:user), :scopes => %w[read_prefs write_api])
       do_redact_redactable_way(auth_header)
       assert_response :forbidden, "should need to be moderator to redact."
     end
@@ -136,17 +130,10 @@ module Api
       assert_response :forbidden, "should need to be moderator to redact."
     end
 
-    def test_redact_way_by_moderator_with_read_prefs_scope
-      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs])
+    def test_redact_way_by_moderator_without_write_redactions_scope
+      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[read_prefs write_api])
       do_redact_redactable_way(auth_header)
       assert_response :forbidden, "should need to have write_redactions scope to redact."
-    end
-
-    def test_redact_way_by_moderator_with_write_api_scope
-      auth_header = bearer_authorization_header(create(:moderator_user), :scopes => %w[write_api])
-      do_redact_redactable_way(auth_header)
-      assert_response :success, "should be OK to redact old version as moderator with write_api scope."
-      # assert_response :forbidden, "should need to have write_redactions scope to redact."
     end
 
     def test_redact_way_by_moderator_with_write_redactions_scope


### PR DESCRIPTION
Continues #4387.

Requires `write_redactions` scope to redact. Previously it was possible to redact with either `write_redactions` or `write_api`.