### PR TITLE
Remove unused messages.outbox.actions string

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1763,7 +1763,6 @@ en:
       body: "Sorry there is no message with that id."
     outbox:
       title: "Outbox"
-      actions: "Actions"
       messages:
         one: "You have %{count} sent message"
         other: "You have %{count} sent messages"


### PR DESCRIPTION
Was added in https://github.com/openstreetmap/openstreetmap-website/commit/3e69a4512f2d1b39f48719882a0d112d042da73a together with `messages.messages_table.actions`, but only the latter is in use.