### PR TITLE
Remove unused site.search.get_directions string

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2289,7 +2289,6 @@ en:
       close: Close
     search:
       search: Search
-      get_directions: "Get directions"
       get_directions_title: "Find directions between two points"
       from: "From"
       to: "To"


### PR DESCRIPTION
Not in use since this text was replaced by an icon in https://github.com/openstreetmap/openstreetmap-website/commit/3a9db4cf30899d256558f2e03a7c4c30d66669fd