### PR TITLE
Shared pagination: label instead of i18n key as parameter

### DIFF
--- a/app/views/diary_comments/_page.html.erb
+++ b/app/views/diary_comments/_page.html.erb
@@ -19,8 +19,8 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "diary_comments.page.newer_comments",
-             :older_key => "diary_comments.page.older_comments",
+             :newer_label => t("diary_comments.page.newer_comments"),
+             :older_label => t("diary_comments.page.older_comments"),
              :newer_id => @newer_comments_id,
              :older_id => @older_comments_id %>
 </turbo-frame>

--- a/app/views/diary_entries/_page.html.erb
+++ b/app/views/diary_entries/_page.html.erb
@@ -4,8 +4,8 @@
   <%= render @entries %>
 
   <%= render "shared/pagination",
-             :newer_key => "diary_entries.page.newer_entries",
-             :older_key => "diary_entries.page.older_entries",
+             :newer_label => t("diary_entries.page.newer_entries"),
+             :older_label => t("diary_entries.page.older_entries"),
              :newer_id => @newer_entries_id,
              :older_id => @older_entries_id %>
 </turbo-frame>

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -36,8 +36,8 @@
       </tbody>
     </table>
     <%= render "shared/pagination",
-               :newer_key => "issues.page.newer_issues",
-               :older_key => "issues.page.older_issues",
+               :newer_label => t("issues.page.newer_issues"),
+               :older_label => t("issues.page.older_issues"),
                :newer_id => @newer_issues_id,
                :older_id => @older_issues_id %>
   <% end %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -3,7 +3,7 @@
   <ul class="pagination">
     <% newer_link_content = capture do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
-      <%= t(newer_key) %>
+      <%= newer_label %>
     <% end %>
     <% if newer_id -%>
       <li class="page-item d-flex">
@@ -16,7 +16,7 @@
     <% end -%>
 
     <% older_link_content = capture do %>
-      <%= t(older_key) %>
+      <%= older_label %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
     <% end %>
     <% if older_id -%>

--- a/app/views/traces/_page.html.erb
+++ b/app/views/traces/_page.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= render "shared/pagination",
-             :newer_key => "traces.page.newer",
-             :older_key => "traces.page.older",
+             :newer_label => t("traces.page.newer"),
+             :older_label => t("traces.page.older"),
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 
@@ -12,8 +12,8 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "traces.page.newer",
-             :older_key => "traces.page.older",
+             :newer_label => t("traces.page.newer"),
+             :older_label => t("traces.page.older"),
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 </turbo-frame>

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -19,8 +19,8 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "user_blocks.blocks.newer",
-             :older_key => "user_blocks.blocks.older",
+             :newer_label => t("user_blocks.blocks.newer"),
+             :older_label => t("user_blocks.blocks.older"),
              :newer_id => @newer_user_blocks_id,
              :older_id => @older_user_blocks_id %>
 </turbo-frame>

--- a/app/views/users/_page.html.erb
+++ b/app/views/users/_page.html.erb
@@ -3,8 +3,8 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :newer_key => "users.page.newer",
-                   :older_key => "users.page.older",
+                   :newer_label => t("users.page.newer"),
+                   :older_label => t("users.page.older"),
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>
@@ -32,8 +32,8 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :newer_key => "users.page.newer",
-                   :older_key => "users.page.older",
+                   :newer_label => t("users.page.newer"),
+                   :older_label => t("users.page.older"),
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>


### PR DESCRIPTION
Pass translated label to shared pagination instead of i18n key. 

This reduces the number of reported issues when running `bundle exec i18n-tasks unused`

Apparently, there are lots of pending PR out there that would conflict with this change: #4734, #4733, #4729, #4710
What's the status here? Which one of these alternatives will make it in the end?