### PR TITLE
Send <head> along with pagination frames

### DIFF
--- a/app/controllers/diary_comments_controller.rb
+++ b/app/controllers/diary_comments_controller.rb
@@ -25,7 +25,7 @@ class DiaryCommentsController < ApplicationController
 
     @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, :includes => [:user])
 
-    render :partial => "page" if turbo_frame_request_id == "pagination"
+    render "_page", :layout => "turbo_frame_visit" if turbo_frame_request_id == "pagination"
   end
 
   def create

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -61,7 +61,7 @@ class DiaryEntriesController < ApplicationController
 
     @entries, @newer_entries_id, @older_entries_id = get_page_items(entries, :includes => [:user, :language])
 
-    render :partial => "page" if turbo_frame_request_id == "pagination"
+    render "_page", :layout => "turbo_frame_visit" if turbo_frame_request_id == "pagination"
   end
 
   def show

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -44,7 +44,7 @@ class IssuesController < ApplicationController
     end
 
     @issues, @newer_issues_id, @older_issues_id = get_page_items(@issues, :limit => @params[:limit])
-    render :partial => "page" if turbo_frame_request_id == "pagination"
+    render "_page", :layout => "turbo_frame_visit" if turbo_frame_request_id == "pagination"
   end
 
   def show

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -66,7 +66,7 @@ class TracesController < ApplicationController
     # final helper vars for view
     @target_user = target_user
 
-    render :partial => "page" if turbo_frame_request_id == "pagination"
+    render "_page", :layout => "turbo_frame_visit" if turbo_frame_request_id == "pagination"
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,7 +41,7 @@ class UsersController < ApplicationController
       @users_count = users.count
       @users, @newer_users_id, @older_users_id = get_page_items(users, :limit => 50)
 
-      render :partial => "page" if turbo_frame_request_id == "pagination"
+      render "_page", :layout => "turbo_frame_visit" if turbo_frame_request_id == "pagination"
     end
   end
 

--- a/app/views/layouts/turbo_frame_visit.html.erb
+++ b/app/views/layouts/turbo_frame_visit.html.erb
@@ -1,0 +1,2 @@
+<%= render :partial => "layouts/head" %>
+<%= yield %>

--- a/test/system/user_logout_test.rb
+++ b/test/system/user_logout_test.rb
@@ -45,4 +45,27 @@ class UserLogoutTest < ApplicationSystemTestCase
     assert_content "Log In"
     assert_content "Public GPS Traces"
   end
+
+  test "Sign out after navigating with Turbo pagination" do
+    saved_allow_forgery_protection = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+
+    create(:language, :code => "en")
+    create(:diary_entry, :title => "First Diary Entry")
+    create_list(:diary_entry, 20) # rubocop:disable FactoryBot/ExcessiveCreateList
+    user = create(:user)
+    sign_in_as user
+
+    visit diary_entries_path
+    assert_no_link "Log In"
+
+    click_on "Older Entries"
+    assert_link "First Diary Entry"
+
+    click_on user.display_name
+    click_on "Log Out"
+    assert_link "Log In"
+  ensure
+    ActionController::Base.allow_forgery_protection = saved_allow_forgery_protection
+  end
 end


### PR DESCRIPTION
Things broken by Turbo pagination part 2, the previous part is #5111.

Previous/next page visits are promoted to full page visits with Turbo rewriting most of `<head>` tags. If new tags aren't sent together with the updated frame, old ones will be simply deleted. That includes deleting a page title and csrf token tags, which is going to break some functionality, particularly logouts.

Open any page with Turbo pagination, click *Older/Newer* link, notice that the page title is gone. Then click *Logout* and it's not going to work. https://github.com/openstreetmap/openstreetmap-website/pull/4646#issuecomment-2284931759 worked correctly for changeset elements pagination because it's not promoted to page visits.
