### PR TITLE
Removed 2 unused translations from Traces namespace

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2485,8 +2485,6 @@ en:
       visibility_help_url: "https://wiki.openstreetmap.org/wiki/Visibility_of_GPS_traces"
     update:
       updated: Trace updated
-    trace_optionals:
-      tags: "Tags"
     show:
       title: "Viewing Trace %{name}"
       heading: "Viewing Trace %{name}"
@@ -2544,8 +2542,6 @@ en:
       newer: "Newer Traces"
     destroy:
       scheduled_for_deletion: "Trace scheduled for deletion"
-    make_public:
-      made_public: "Trace made public"
     offline_warning:
       message: "The GPX file upload system is currently unavailable"
     offline:


### PR DESCRIPTION
PR removed 2 unused translations pairs from en.yml:  traces.make_public.made_public (started / ended using in 95595ee / 5651714) and traces.trace_optionals.tags (started / ended using in c30f141 / 7410b59).

There are 2 more unused translations (traces.page.newer and traces.page.older) probably forgotten to be put under t("") (or waiting for more pagination functionality) - didn't touch them.