### PR TITLE
Move notification code out of note update transactions

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -82,7 +82,7 @@ module Api
       # Extract the arguments
       lon = OSM.parse_float(params[:lon], OSM::APIBadUserInput, "lon was not a number")
       lat = OSM.parse_float(params[:lat], OSM::APIBadUserInput, "lat was not a number")
-      comment = params[:text]
+      text = params[:text]
 
       # Include in a transaction to ensure that there is always a note_comment for every note
       Note.transaction do
@@ -94,7 +94,7 @@ module Api
         @note.save!
 
         # Add a comment to the note
-        add_comment(@note, comment, "opened")
+        add_comment(@note, text, "opened")
       end
 
       # Return a copy of the new note
@@ -112,7 +112,7 @@ module Api
 
       # Extract the arguments
       id = params[:id].to_i
-      comment = params[:text]
+      text = params[:text]
 
       # Find the note and check it is valid
       Note.transaction do
@@ -124,7 +124,7 @@ module Api
         @note.status = "hidden"
         @note.save
 
-        add_comment(@note, comment, "hidden", :notify => false)
+        add_comment(@note, text, "hidden", :notify => false)
       end
 
       # Return a copy of the updated note
@@ -143,7 +143,7 @@ module Api
 
       # Extract the arguments
       id = params[:id].to_i
-      comment = params[:text]
+      text = params[:text]
 
       # Find the note and check it is valid
       Note.transaction do
@@ -153,7 +153,7 @@ module Api
         raise OSM::APINoteAlreadyClosedError, @note if @note.closed?
 
         # Add a comment to the note
-        add_comment(@note, comment, "commented")
+        add_comment(@note, text, "commented")
       end
 
       # Return a copy of the updated note
@@ -171,7 +171,7 @@ module Api
 
       # Extract the arguments
       id = params[:id].to_i
-      comment = params[:text]
+      text = params[:text]
 
       # Find the note and check it is valid
       Note.transaction do
@@ -183,7 +183,7 @@ module Api
         # Close the note and add a comment
         @note.close
 
-        add_comment(@note, comment, "closed")
+        add_comment(@note, text, "closed")
       end
 
       # Return a copy of the updated note
@@ -201,7 +201,7 @@ module Api
 
       # Extract the arguments
       id = params[:id].to_i
-      comment = params[:text]
+      text = params[:text]
 
       # Find the note and check it is valid
       Note.transaction do
@@ -213,7 +213,7 @@ module Api
         # Reopen the note and add a comment
         @note.reopen
 
-        add_comment(@note, comment, "reopened")
+        add_comment(@note, text, "reopened")
       end
 
       # Return a copy of the updated note

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -204,6 +204,7 @@ module Api
       open_note_with_comment = create(:note_with_comments)
       user = create(:user)
       auth_header = bearer_authorization_header user
+
       assert_difference "NoteComment.count", 1 do
         assert_no_difference "ActionMailer::Base.deliveries.size" do
           perform_enqueued_jobs do
@@ -340,10 +341,6 @@ module Api
     def test_close_success
       open_note_with_comment = create(:note_with_comments)
       user = create(:user)
-
-      post close_api_note_path(open_note_with_comment, :text => "This is a close comment", :format => "json")
-      assert_response :unauthorized
-
       auth_header = bearer_authorization_header user
 
       post close_api_note_path(open_note_with_comment, :text => "This is a close comment", :format => "json"), :headers => auth_header
@@ -372,7 +369,9 @@ module Api
     end
 
     def test_close_fail
-      post close_api_note_path(12345)
+      open_note_with_comment = create(:note_with_comments)
+
+      post close_api_note_path(open_note_with_comment, :text => "This is a close comment", :format => "json")
       assert_response :unauthorized
 
       auth_header = bearer_authorization_header
@@ -394,10 +393,6 @@ module Api
     def test_reopen_success
       closed_note_with_comment = create(:note_with_comments, :closed)
       user = create(:user)
-
-      post reopen_api_note_path(closed_note_with_comment, :text => "This is a reopen comment", :format => "json")
-      assert_response :unauthorized
-
       auth_header = bearer_authorization_header user
 
       post reopen_api_note_path(closed_note_with_comment, :text => "This is a reopen comment", :format => "json"), :headers => auth_header
@@ -426,6 +421,11 @@ module Api
     end
 
     def test_reopen_fail
+      closed_note_with_comment = create(:note_with_comments, :closed)
+
+      post reopen_api_note_path(closed_note_with_comment, :text => "This is a reopen comment", :format => "json")
+      assert_response :unauthorized
+
       hidden_note_with_comment = create(:note_with_comments, :status => "hidden")
 
       post reopen_api_note_path(hidden_note_with_comment)


### PR DESCRIPTION
We don't need to notify anyone until the transaction is completed. The notification code was inside the transaction since the very beginning in https://github.com/openstreetmap/openstreetmap-website/commit/b3d62bb85a03a0b68068d3d2e7801ec2cd2e3e7b and I don't know why.