### PR TITLE
Translation scope for shared pagination

### DIFF
--- a/app/views/diary_comments/_page.html.erb
+++ b/app/views/diary_comments/_page.html.erb
@@ -19,7 +19,6 @@
   </table>
 
   <%= render "shared/pagination",
-             :translation_scope => "shared.pagination.diary_comments",
              :newer_id => @newer_comments_id,
              :older_id => @older_comments_id %>
 </turbo-frame>

--- a/app/views/diary_comments/_page.html.erb
+++ b/app/views/diary_comments/_page.html.erb
@@ -19,8 +19,7 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "diary_comments.page.newer_comments",
-             :older_key => "diary_comments.page.older_comments",
+             :translation_scope => "shared.pagination.diary_comments",
              :newer_id => @newer_comments_id,
              :older_id => @older_comments_id %>
 </turbo-frame>

--- a/app/views/diary_entries/_page.html.erb
+++ b/app/views/diary_entries/_page.html.erb
@@ -4,8 +4,7 @@
   <%= render @entries %>
 
   <%= render "shared/pagination",
-             :newer_key => "diary_entries.page.newer_entries",
-             :older_key => "diary_entries.page.older_entries",
+             :translation_scope => "shared.pagination.diary_entries",
              :newer_id => @newer_entries_id,
              :older_id => @older_entries_id %>
 </turbo-frame>

--- a/app/views/diary_entries/_page.html.erb
+++ b/app/views/diary_entries/_page.html.erb
@@ -4,7 +4,6 @@
   <%= render @entries %>
 
   <%= render "shared/pagination",
-             :translation_scope => "shared.pagination.diary_entries",
              :newer_id => @newer_entries_id,
              :older_id => @older_entries_id %>
 </turbo-frame>

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -36,8 +36,7 @@
       </tbody>
     </table>
     <%= render "shared/pagination",
-               :newer_key => "issues.page.newer_issues",
-               :older_key => "issues.page.older_issues",
+               :translation_scope => "shared.pagination.issues",
                :newer_id => @newer_issues_id,
                :older_id => @older_issues_id %>
   <% end %>

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -36,7 +36,6 @@
       </tbody>
     </table>
     <%= render "shared/pagination",
-               :translation_scope => "shared.pagination.issues",
                :newer_id => @newer_issues_id,
                :older_id => @older_issues_id %>
   <% end %>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -3,7 +3,7 @@
   <ul class="pagination">
     <% newer_link_content = capture do %>
       <%= previous_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
-      <%= t(newer_key) %>
+      <%= t :newer, :scope => translation_scope %>
     <% end %>
     <% if newer_id -%>
       <li class="page-item d-flex">
@@ -16,7 +16,7 @@
     <% end -%>
 
     <% older_link_content = capture do %>
-      <%= t(older_key) %>
+      <%= t :older, :scope => translation_scope %>
       <%= next_page_svg_tag :class => "flex-shrink-0 d-none d-sm-block" %>
     <% end %>
     <% if older_id -%>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,3 +1,4 @@
+<% translation_scope ||= "shared.pagination.#{controller.controller_name}" %>
 <nav>
   <% link_class = "page-link icon-link text-center" %>
   <ul class="pagination">

--- a/app/views/traces/_page.html.erb
+++ b/app/views/traces/_page.html.erb
@@ -1,7 +1,6 @@
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= render "shared/pagination",
-             :newer_key => "traces.page.newer",
-             :older_key => "traces.page.older",
+             :translation_scope => "shared.pagination.traces",
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 
@@ -12,8 +11,7 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "traces.page.newer",
-             :older_key => "traces.page.older",
+             :translation_scope => "shared.pagination.traces",
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 </turbo-frame>

--- a/app/views/traces/_page.html.erb
+++ b/app/views/traces/_page.html.erb
@@ -1,6 +1,5 @@
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= render "shared/pagination",
-             :translation_scope => "shared.pagination.traces",
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 
@@ -11,7 +10,6 @@
   </table>
 
   <%= render "shared/pagination",
-             :translation_scope => "shared.pagination.traces",
              :newer_id => @newer_traces_id,
              :older_id => @older_traces_id %>
 </turbo-frame>

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -19,7 +19,6 @@
   </table>
 
   <%= render "shared/pagination",
-             :translation_scope => "shared.pagination.user_blocks",
              :newer_id => @newer_user_blocks_id,
              :older_id => @older_user_blocks_id %>
 </turbo-frame>

--- a/app/views/user_blocks/_blocks.html.erb
+++ b/app/views/user_blocks/_blocks.html.erb
@@ -19,8 +19,7 @@
   </table>
 
   <%= render "shared/pagination",
-             :newer_key => "user_blocks.blocks.newer",
-             :older_key => "user_blocks.blocks.older",
+             :translation_scope => "shared.pagination.user_blocks",
              :newer_id => @newer_user_blocks_id,
              :older_id => @older_user_blocks_id %>
 </turbo-frame>

--- a/app/views/users/_page.html.erb
+++ b/app/views/users/_page.html.erb
@@ -3,7 +3,6 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :translation_scope => "shared.pagination.users",
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>
@@ -31,7 +30,6 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :translation_scope => "shared.pagination.users",
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>

--- a/app/views/users/_page.html.erb
+++ b/app/views/users/_page.html.erb
@@ -3,8 +3,7 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :newer_key => "users.page.newer",
-                   :older_key => "users.page.older",
+                   :translation_scope => "shared.pagination.users",
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>
@@ -32,8 +31,7 @@
     <div class="row">
       <div class="col">
         <%= render "shared/pagination",
-                   :newer_key => "users.page.newer",
-                   :older_key => "users.page.older",
+                   :translation_scope => "shared.pagination.users",
                    :newer_id => @newer_users_id,
                    :older_id => @older_users_id %>
       </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -129,6 +129,7 @@ ignore_unused:
   - 'helpers.submit.*'
   - 'datetime.distance_in_words_ago.*'
   - 'reports.new.categories.*' # double interpolation in reports_helper
+  - 'shared.pagination.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -535,8 +535,6 @@ en:
       no_entries: No diary entries
     page:
       recent_entries: "Recent diary entries"
-      older_entries: Older Entries
-      newer_entries: Newer Entries
     edit:
       title: Edit Diary Entry
       marker_text: Diary entry location
@@ -604,8 +602,6 @@ en:
       post: Post
       when: When
       comment: Comment
-      newer_comments: "Newer Comments"
-      older_comments: "Older Comments"
     new:
       heading: Add a comment to the following diary entry discussion?
   doorkeeper:
@@ -1482,8 +1478,6 @@ en:
         ignored: Ignored
         open: Open
         resolved: Resolved
-      older_issues: Older Issues
-      newer_issues: Newer Issues
     show:
       title: "%{status} Issue #%{issue_id}"
       reports:
@@ -1895,6 +1889,25 @@ en:
       edit: Edit
       preview: Preview
       help: Help
+    pagination:
+      diary_comments:
+        older: Older Comments
+        newer: Newer Comments
+      diary_entries:
+        older: Older Entries
+        newer: Newer Entries
+      issues:
+        older: Older Issues
+        newer: Newer Issues
+      traces:
+        older: Older Traces
+        newer: Newer Traces
+      user_blocks:
+        older: Older Blocks
+        newer: Newer Blocks
+      users:
+        older: Older Users
+        newer: Newer Users
   site:
     about:
       heading_html: "%{copyright}OpenStreetMap %{br} contributors"
@@ -2537,9 +2550,6 @@ en:
       my_traces: "My Traces"
       traces_from: "Public Traces from %{user}"
       remove_tag_filter: "Remove Tag Filter"
-    page:
-      older: "Older Traces"
-      newer: "Newer Traces"
     destroy:
       scheduled_for_deletion: "Trace scheduled for deletion"
     offline_warning:
@@ -2793,8 +2803,6 @@ en:
       summary_no_ip_html: "%{name} created on %{date}"
       empty: No matching users found
     page:
-      older: "Older Users"
-      newer: "Newer Users"
       found_users:
         one: "%{count} user found"
         other: "%{count} users found"
@@ -2929,8 +2937,6 @@ en:
       reason: "Reason for block"
       status: "Status"
       revoker_name: "Revoked by"
-      older: "Older Blocks"
-      newer: "Newer Blocks"
     navigation:
       all_blocks: "All Blocks"
       blocks_on_me: "Blocks on Me"

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -183,7 +183,7 @@ class IssuesTest < ApplicationSystemTestCase
     end
 
     # Second Page
-    click_on I18n.t("issues.page.older_issues")
+    click_on "Older Issues"
     assert_no_content I18n.t("issues.page.user_not_found")
     assert_no_content I18n.t("issues.page.issues_not_found")
     4.upto(8).each do |n|
@@ -194,7 +194,7 @@ class IssuesTest < ApplicationSystemTestCase
     end
 
     # Back to First Page
-    click_on I18n.t("issues.page.newer_issues")
+    click_on "Newer Issues"
     assert_no_content I18n.t("issues.page.user_not_found")
     assert_no_content I18n.t("issues.page.issues_not_found")
     4.upto(8).each do |n|


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/pull/5174#issuecomment-2338001493

- "Older/Newer" strings are moved to the `shared.pagination` scope. 
- `shared.pagination` is ignored by `i18n-tasks`.
- Instead of receiving (multiple, currently two but possibly more in the future) translation keys, the `shared/pagination` template receives one translation scope.
- Actually it's not necessary to pass this scope in most of the cases because it can be guessed from the controller name.