### PR TITLE
Add New Redaction button to redactions page

### DIFF
--- a/app/views/redactions/index.html.erb
+++ b/app/views/redactions/index.html.erb
@@ -10,3 +10,9 @@
 <% else %>
   <p><%= t ".empty" %></p>
 <% end %>
+
+<% if can?(:create, Redaction) %>
+  <div>
+    <%= link_to t(".new"), new_redaction_path, :class => "btn btn-outline-primary" %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3204,6 +3204,7 @@ en:
       empty: "No redactions to show."
       heading: "List of Redactions"
       title: "List of Redactions"
+      new: "New Redaction"
     new:
       heading: "Enter Information for New Redaction"
       title: "Creating New Redaction"


### PR DESCRIPTION
There's no link to the new redaction page from [redactions list](https://www.openstreetmap.org/redactions) for anyone, even though other buttons like Edit and Delete are present on each redaction page.

![image](https://github.com/user-attachments/assets/0f399429-3bb8-4007-afe2-aa74ba9c0726)
