### PR TITLE
Removed unused translations in user_role namespace

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2833,15 +2833,9 @@ en:
       doesnt_have_role: "The user does not have role %{role}."
       not_revoke_admin_current_user: "Cannot revoke administrator role from current user."
     grant:
-      title: Confirm role granting
-      heading: Confirm role granting
       are_you_sure: "Are you sure you want to grant the role `%{role}' to the user `%{name}'?"
-      confirm: "Confirm"
     revoke:
-      title: Confirm role revoking
-      heading: Confirm role revoking
       are_you_sure: "Are you sure you want to revoke the role `%{role}' from the user `%{name}'?"
-      confirm: "Confirm"
   user_blocks:
     model:
       non_moderator_update: "Must be a moderator to create or update a block."


### PR DESCRIPTION
PR removes user_role.{grant,revoke}.{title, heading, confirm} translation keys from en.yml started / ended using in 30d5e78 and 8a7040e / 5f33656.