### PR TITLE
Replace 'remove this redaction' confirmation and request with Turbo

### DIFF
--- a/app/views/redactions/show.html.erb
+++ b/app/views/redactions/show.html.erb
@@ -18,7 +18,7 @@
     <%= link_to t(".edit"), edit_redaction_path(@redaction), :class => "btn btn-outline-primary" %>
   <% end %>
   <% if can?(:destroy, Redaction) %>
-    <%= link_to t(".destroy"), @redaction, :method => "delete", :class => "btn btn-outline-danger", :remote => true, :data => { :confirm => t(".confirm") } %>
+    <%= link_to t(".destroy"), @redaction, :class => "btn btn-outline-danger", :data => { :turbo => true, :turbo_method => "DELETE", :turbo_confirm => t(".confirm") } %>
   <% end %>
 </div>
 <% end %>

--- a/test/system/redaction_destroy_test.rb
+++ b/test/system/redaction_destroy_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+class RedactionDestroyTest < ApplicationSystemTestCase
+  test "fails to delete nonempty redaction" do
+    redaction = create(:redaction, :title => "Some-unwanted-data-redaction")
+    create(:old_node, :redaction => redaction)
+
+    sign_in_as create(:moderator_user)
+    visit redaction_path(redaction)
+    assert_text "Some-unwanted-data-redaction"
+
+    accept_alert do
+      click_on "Remove this redaction"
+    end
+    assert_text "Redaction is not empty"
+    assert_text "Some-unwanted-data-redaction"
+  end
+
+  test "deletes empty redaction" do
+    redaction = create(:redaction, :title => "No-unwanted-data-redaction")
+
+    sign_in_as create(:moderator_user)
+    visit redaction_path(redaction)
+    assert_text "No-unwanted-data-redaction"
+
+    accept_alert do
+      click_on "Remove this redaction"
+    end
+    assert_text "Redaction destroyed"
+    assert_text "List of Redactions"
+    assert_no_text "No-unwanted-data-redaction"
+  end
+end


### PR DESCRIPTION
The existing `:method => "delete" ...` don't entirely work for some reason. The browser gets stuck on redirects after the request is done.

![image](https://github.com/user-attachments/assets/aa455e8b-6599-40a6-92d7-8f1181aa1b83)
