### PR TITLE
Displays links for friend options on user profile only if user is signed in

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -81,15 +81,15 @@
               <%= link_to t(".comments"), diary_comments_path(@user) %>
               <span class='badge count-number'><%= number_with_delimiter(@user.diary_comments.size) %></span>
             </li>
-            <li>
-              <% if current_user and current_user.friends_with?(@user) %>
-                <%= link_to t(".remove as friend"), remove_friend_path(:display_name => @user.display_name), :method => :post %>
-              <% elsif current_user %>
-                <%= link_to t(".add as friend"), make_friend_path(:display_name => @user.display_name), :method => :post %>
-              <% else %>
-                <%= link_to t(".add as friend"), make_friend_path(:display_name => @user.display_name) %>
-              <% end %>
-            </li>
+            <% if current_user %>
+              <li>
+                <% if current_user.friends_with?(@user) %>
+                  <%= link_to t(".remove as friend"), remove_friend_path(:display_name => @user.display_name), :method => :post %>
+                <% else %>
+                  <%= link_to t(".add as friend"), make_friend_path(:display_name => @user.display_name), :method => :post %>
+                <% end %>
+              </li>
+            <% end %>
 
             <% if @user.blocks.exists? %>
               <li>


### PR DESCRIPTION
PR proposes displaying "Send Message", "Add Friend" and "Unfriend" links (buttons) on user profile page only if user is signed in. Previously, these links (buttons) were always displayed.

Fixes #5199 

Signed In:
![image](https://github.com/user-attachments/assets/9456879b-e3f7-4cc6-8706-43685f8f7cc0)

Signed Out:
![image](https://github.com/user-attachments/assets/8e65cd0c-eb62-4d18-84b5-ae01d6b7f495)
