### PR TITLE
Fix friendships limit flash message

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -20,7 +20,7 @@ class FriendshipsController < ApplicationController
       if current_user.friends_with?(@friend)
         flash[:warning] = t ".already_a_friend", :name => @friend.display_name
       elsif current_user.friendships.where(:created_at => Time.now.utc - 1.hour..).count >= current_user.max_friends_per_hour
-        flash.now[:error] = t ".limit_exceeded"
+        flash[:error] = t ".limit_exceeded"
       elsif friendship.save
         flash[:notice] = t ".success", :name => @friend.display_name
         UserMailer.friendship_notification(friendship).deliver_later

--- a/test/system/friendships_test.rb
+++ b/test/system/friendships_test.rb
@@ -1,0 +1,18 @@
+require "application_system_test_case"
+
+class FriendshipsTest < ApplicationSystemTestCase
+  test "show message when max frienships limit is exceeded" do
+    befriendee = create(:user)
+
+    sign_in_as create(:user)
+
+    with_settings(:max_friends_per_hour => 0) do
+      visit user_path(befriendee)
+      assert_link "Add Friend"
+
+      click_on "Add Friend"
+      assert_text "You have friended a lot of users recently"
+      assert_link "Add Friend"
+    end
+  end
+end


### PR DESCRIPTION
If you try to add too many friends, you're supposed to see this message:
![image](https://github.com/user-attachments/assets/5b1e0b91-a372-4611-8a36-7f6d2b8b2e77)

But you won't see it because of `flash.now` followed by a redirect.