### PR TITLE
Make select all checkbox on users list work with turbo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,6 +26,7 @@ FactoryBot/ExcessiveCreateList:
     - 'test/controllers/notes_controller_test.rb'
     - 'test/controllers/traces_controller_test.rb'
     - 'test/controllers/user_blocks_controller_test.rb'
+    - 'test/system/users_test.rb'
 
 # Offense count: 635
 # This cop supports safe autocorrection (--autocorrect).

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,5 +1,11 @@
 //= require leaflet.locatecontrol/src/L.Control.Locate
 
+(function () {
+  $(document).on("change", "#user_all", function () {
+    $("#user_list input[type=checkbox]").prop("checked", $("#user_all").prop("checked"));
+  });
+}());
+
 $(document).ready(function () {
   var defaultHomeZoom = 12;
   var map, marker, deleted_lat, deleted_lon;
@@ -199,10 +205,6 @@ $(document).ready(function () {
   } else {
     enableAuth();
   }
-
-  $("#user_all").change(function () {
-    $("#user_list input[type=checkbox]").prop("checked", $("#user_all").prop("checked"));
-  });
 
   $("#content.user_confirm").each(function () {
     $(this).hide();

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -1,0 +1,28 @@
+require "application_system_test_case"
+
+class UsersTest < ApplicationSystemTestCase
+  def setup
+    admin = create(:administrator_user)
+    sign_in_as(admin)
+  end
+
+  test "all users can be selected" do
+    create_list(:user, 100)
+
+    visit users_path
+
+    assert_css "tbody input[type=checkbox]:checked", :count => 0
+    assert_css "tbody input[type=checkbox]:not(:checked)", :count => 50
+    check "user_all"
+    assert_css "tbody input[type=checkbox]:checked", :count => 50
+    assert_css "tbody input[type=checkbox]:not(:checked)", :count => 0
+
+    click_on "Older Users", :match => :first
+
+    assert_css "tbody input[type=checkbox]:checked", :count => 0
+    assert_css "tbody input[type=checkbox]:not(:checked)", :count => 50
+    check "user_all"
+    assert_css "tbody input[type=checkbox]:checked", :count => 50
+    assert_css "tbody input[type=checkbox]:not(:checked)", :count => 0
+  end
+end


### PR DESCRIPTION
This reworks the event handling to allow the "select all" checkbox to work after changing page in the user list.