### PR TITLE
Removed unused translations from activerecord.errors and updated i18n-tasks.yml

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -130,6 +130,7 @@ ignore_unused:
   - 'datetime.distance_in_words_ago.*'
   - 'reports.new.categories.*' # double interpolation in reports_helper
   - 'shared.pagination.*'
+  - 'auth.providers.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,8 +38,6 @@ en:
   activerecord:
     errors:
       messages:
-        invalid_email_address: does not appear to be a valid e-mail address
-        email_address_not_routable: is not routable
         display_name_is_user_n: can't be user_n unless n is your user id
       models:
         user_mute:


### PR DESCRIPTION
PR removes unused translations activerecord.errors.messages.{invalid_email_address, email_address_not_routable} started / ended using in 63862d0 / 90a7efc and updated i18n-tasks.yml to ignore reporting auth.providers.* as unused although they are used in app/views/application/_auth_providers.html.erb, ..