### PR TITLE
Order changeset elements for consistent pagination

### DIFF
--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -79,13 +79,13 @@ class ChangesetsController < ApplicationController
     @changeset = Changeset.find(params[:id])
     case turbo_frame_request_id
     when "changeset_nodes"
-      @node_pages, @nodes = paginate(:old_nodes, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "node_page")
+      @node_pages, @nodes = paginate(:old_nodes, :conditions => { :changeset_id => @changeset.id }, :order => [:node_id, :version], :per_page => 20, :parameter => "node_page")
       render :partial => "elements", :locals => { :type => "node", :elements => @nodes, :pages => @node_pages }
     when "changeset_ways"
-      @way_pages, @ways = paginate(:old_ways, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "way_page")
+      @way_pages, @ways = paginate(:old_ways, :conditions => { :changeset_id => @changeset.id }, :order => [:way_id, :version], :per_page => 20, :parameter => "way_page")
       render :partial => "elements", :locals => { :type => "way", :elements => @ways, :pages => @way_pages }
     when "changeset_relations"
-      @relation_pages, @relations = paginate(:old_relations, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "relation_page")
+      @relation_pages, @relations = paginate(:old_relations, :conditions => { :changeset_id => @changeset.id }, :order => [:relation_id, :version], :per_page => 20, :parameter => "relation_page")
       render :partial => "elements", :locals => { :type => "relation", :elements => @relations, :pages => @relation_pages }
     else
       @comments = if current_user&.moderator?
@@ -93,9 +93,9 @@ class ChangesetsController < ApplicationController
                   else
                     @changeset.comments.includes(:author)
                   end
-      @node_pages, @nodes = paginate(:old_nodes, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "node_page")
-      @way_pages, @ways = paginate(:old_ways, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "way_page")
-      @relation_pages, @relations = paginate(:old_relations, :conditions => { :changeset_id => @changeset.id }, :per_page => 20, :parameter => "relation_page")
+      @node_pages, @nodes = paginate(:old_nodes, :conditions => { :changeset_id => @changeset.id }, :order => [:node_id, :version], :per_page => 20, :parameter => "node_page")
+      @way_pages, @ways = paginate(:old_ways, :conditions => { :changeset_id => @changeset.id }, :order => [:way_id, :version], :per_page => 20, :parameter => "way_page")
+      @relation_pages, @relations = paginate(:old_relations, :conditions => { :changeset_id => @changeset.id }, :order => [:relation_id, :version], :per_page => 20, :parameter => "relation_page")
       if @changeset.user.active? && @changeset.user.data_public?
         changesets = conditions_nonempty(@changeset.user.changesets)
         @next_by_user = changesets.where("id > ?", @changeset.id).reorder(:id => :asc).first


### PR DESCRIPTION
Changeset elements in the history view are being paginated but no order is being specified so stepping through the pages may not give consistent results and may skip elements or show them twice - this is currently visible in the form of occasional test failures in `test_show_paginated_element_links` when it doesn't show elements in the order `create_list` created them.