### PR TITLE
Fix element pagination width calculation

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -86,7 +86,7 @@ module BrowseHelper
     max_width_for_default_padding = 35
 
     width = 0
-    pagination_items(pages, {}).each do |body|
+    pagination_items(pages, {}).each do |(body)|
       width += 2 # padding width
       width += body.length
     end


### PR DESCRIPTION
Fixes #5105, see https://github.com/openstreetmap/openstreetmap-website/issues/5105#issuecomment-2349260230.

`body` in `|body|` gets assigned the entire array, while `body` in `|(body)|` gets the first element, which is the intended effect.