### PR TITLE
Always show changeset element page links below headings

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -92,7 +92,7 @@ module BrowseHelper
     end
     link_classes = ["page-link", { "px-1" => width > max_width_for_default_padding }]
 
-    tag.ul :class => "pagination pagination-sm mb-1 ms-auto" do
+    tag.ul :class => "pagination pagination-sm mb-2" do
       pagination_items(pages, {}).each do |body, page_or_class|
         linked = !(page_or_class.is_a? String)
         link = if linked

--- a/app/views/changesets/_paging_nav.html.erb
+++ b/app/views/changesets/_paging_nav.html.erb
@@ -1,11 +1,9 @@
-<div class="d-flex flex-wrap gap-2">
-  <h4 class="fs-5 mb-0"><%= type_and_paginated_count(type, pages) %></h4>
-  <% if pages.page_count > 1 %>
-    <%= sidebar_classic_pagination(pages, "#{type}_page") do |page|
-          {
-            :title => type_and_paginated_count(type, pages, page),
-            :data => { :turbo => "true" }
-          }
-        end %>
-  <% end %>
-</div>
+<h4 class="fs-5"><%= type_and_paginated_count(type, pages) %></h4>
+<% if pages.page_count > 1 %>
+  <%= sidebar_classic_pagination(pages, "#{type}_page") do |page|
+        {
+          :title => type_and_paginated_count(type, pages, page),
+          :data => { :turbo => "true" }
+        }
+      end %>
+<% end %>


### PR DESCRIPTION
What I tried to achieve previously was to save space. If the page links fit to the right of the heading, let them be there.

But this works fine only with full sidebar reloads. With turbo frame reloads it's more noticeable when the links become wider, don't fit and move below the heading. Here I'm making them always be below.

Before:

![image](https://github.com/user-attachments/assets/5441ace5-4e72-483b-90ab-d690aa78c441)
![image](https://github.com/user-attachments/assets/b61fa7ad-cb6a-44d5-9d7b-e05b83df09a5)

After:

![image](https://github.com/user-attachments/assets/327a2af0-4e5b-4085-b181-2126c5a75ea5)
![image](https://github.com/user-attachments/assets/c24caa28-e1ec-4142-b875-0287d18e03c9)
