### PR TITLE
Fix browse elements timeouts

### DIFF
--- a/app/views/nodes/timeout.html.erb
+++ b/app/views/nodes/timeout.html.erb
@@ -1,0 +1,5 @@
+<% set_title(t("browse.timeout.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.timeout.title") %>
+
+<p><%= t ".sorry", :id => params[:id] %></p>

--- a/app/views/old_nodes/timeout.html.erb
+++ b/app/views/old_nodes/timeout.html.erb
@@ -1,0 +1,5 @@
+<% set_title(t("browse.timeout.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.timeout.title") %>
+
+<p><%= t ".sorry", :id => params[:id] %></p>

--- a/app/views/old_relations/timeout.html.erb
+++ b/app/views/old_relations/timeout.html.erb
@@ -1,0 +1,5 @@
+<% set_title(t("browse.timeout.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.timeout.title") %>
+
+<p><%= t ".sorry", :id => params[:id] %></p>

--- a/app/views/old_ways/timeout.html.erb
+++ b/app/views/old_ways/timeout.html.erb
@@ -1,0 +1,5 @@
+<% set_title(t("browse.timeout.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.timeout.title") %>
+
+<p><%= t ".sorry", :id => params[:id] %></p>

--- a/app/views/relations/timeout.html.erb
+++ b/app/views/relations/timeout.html.erb
@@ -1,0 +1,5 @@
+<% set_title(t("browse.timeout.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.timeout.title") %>
+
+<p><%= t ".sorry", :id => params[:id] %></p>

--- a/app/views/ways/timeout.html.erb
+++ b/app/views/ways/timeout.html.erb
@@ -1,0 +1,5 @@
+<% set_title(t("browse.timeout.title")) %>
+
+<%= render "sidebar_header", :title => t("browse.timeout.title") %>
+
+<p><%= t ".sorry", :id => params[:id] %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,15 +403,30 @@ en:
       introduction: "Click on the map to find nearby features."
       nearby: "Nearby features"
       enclosing: "Enclosing features"
+  nodes:
+    timeout:
+      sorry: "Sorry, the data for the node with the id %{id}, took too long to retrieve."
   old_nodes:
     not_found:
       sorry: "Sorry, node #%{id} version %{version} could not be found."
+    timeout:
+      sorry: "Sorry, the history of the node with the id %{id}, took too long to retrieve."
+  ways:
+    timeout:
+      sorry: "Sorry, the data for the way with the id %{id}, took too long to retrieve."
   old_ways:
     not_found:
       sorry: "Sorry, way #%{id} version %{version} could not be found."
+    timeout:
+      sorry: "Sorry, the history of the way with the id %{id}, took too long to retrieve."
+  relations:
+    timeout:
+      sorry: "Sorry, the data for the relation with the id %{id}, took too long to retrieve."
   old_relations:
     not_found:
       sorry: "Sorry, relation #%{id} version %{version} could not be found."
+    timeout:
+      sorry: "Sorry, the history of the relation with the id %{id}, took too long to retrieve."
   changeset_comments:
     feeds:
       comment:

--- a/test/controllers/nodes_controller_test.rb
+++ b/test/controllers/nodes_controller_test.rb
@@ -90,4 +90,15 @@ class NodesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a", :text => "View History", :count => 1
     assert_select ".secondary-actions a", :text => "View Unredacted History", :count => 1
   end
+
+  def test_show_timeout
+    node = create(:node)
+    with_settings(:web_timeout => -1) do
+      get node_path(node)
+    end
+    assert_response :error
+    assert_template :layout => "map"
+    assert_dom "h2", "Timeout Error"
+    assert_dom "p", /#{Regexp.quote("the node with the id #{node.id}")}/
+  end
 end

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -218,6 +218,17 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select "#sidebar_content", /node #0 version 0 could not be found/
   end
 
+  def test_show_timeout
+    node = create(:node, :with_history)
+    with_settings(:web_timeout => -1) do
+      get old_node_path(node, 1)
+    end
+    assert_response :error
+    assert_template :layout => "map"
+    assert_dom "h2", "Timeout Error"
+    assert_dom "p", /#{Regexp.quote("the node with the id #{node.id}")}/
+  end
+
   private
 
   def create_redacted_node

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -177,6 +177,17 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "#sidebar_content", /relation #0 version 0 could not be found/
   end
 
+  def test_show_timeout
+    relation = create(:relation, :with_history)
+    with_settings(:web_timeout => -1) do
+      get old_relation_path(relation, 1)
+    end
+    assert_response :error
+    assert_template :layout => "map"
+    assert_dom "h2", "Timeout Error"
+    assert_dom "p", /#{Regexp.quote("the relation with the id #{relation.id}")}/
+  end
+
   private
 
   def create_redacted_relation

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -182,6 +182,17 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select "#sidebar_content", /way #0 version 0 could not be found/
   end
 
+  def test_show_timeout
+    way = create(:way, :with_history)
+    with_settings(:web_timeout => -1) do
+      get old_way_path(way, 1)
+    end
+    assert_response :error
+    assert_template :layout => "map"
+    assert_dom "h2", "Timeout Error"
+    assert_dom "p", /#{Regexp.quote("the way with the id #{way.id}")}/
+  end
+
   private
 
   def create_redacted_way

--- a/test/controllers/relations_controller_test.rb
+++ b/test/controllers/relations_controller_test.rb
@@ -36,4 +36,15 @@ class RelationsControllerTest < ActionDispatch::IntegrationTest
     sidebar_browse_check :relation_path, member.id, "browse/feature"
     assert_select "a[href='#{relation_path relation}']", :count => 1
   end
+
+  def test_show_timeout
+    relation = create(:relation)
+    with_settings(:web_timeout => -1) do
+      get relation_path(relation)
+    end
+    assert_response :error
+    assert_template :layout => "map"
+    assert_dom "h2", "Timeout Error"
+    assert_dom "p", /#{Regexp.quote("the relation with the id #{relation.id}")}/
+  end
 end

--- a/test/controllers/ways_controller_test.rb
+++ b/test/controllers/ways_controller_test.rb
@@ -36,4 +36,15 @@ class WaysControllerTest < ActionDispatch::IntegrationTest
     sidebar_browse_check :way_path, member.id, "browse/feature"
     assert_select "a[href='#{relation_path relation}']", :count => 1
   end
+
+  def test_show_timeout
+    way = create(:way)
+    with_settings(:web_timeout => -1) do
+      get way_path(way)
+    end
+    assert_response :error
+    assert_template :layout => "map"
+    assert_dom "h2", "Timeout Error"
+    assert_dom "p", /#{Regexp.quote("the way with the id #{way.id}")}/
+  end
 end


### PR DESCRIPTION
Like #5178, was part of https://github.com/openstreetmap/openstreetmap-website/pull/4617.

Shows messages like this on element, element version and element history page timeouts:
![image](https://github.com/user-attachments/assets/ec4e4d57-0f5b-4d16-b2f1-97afd8c85940)

Currently those are failing with "Missing template .../timeout".