### PR TITLE
Re-enable JavaScript unit tests using Teaspoon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,8 @@ jobs:
       run: bundle exec rails assets:precompile
     - name: Run tests
       run: bundle exec rails test:all
+    - name: Run javascript tests
+      run: bundle exec teaspoon
     - name: Report completion to Coveralls
       uses: coverallsapp/github-action@v2.3.0
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,8 @@ jobs:
       run: bundle exec bin/yarn install
     - name: Compile assets
       run: bundle exec rails assets:precompile
+    - name: Create tmp/pids directory
+      run: mkdir -p tmp/pids
     - name: Run tests
       run: bundle exec rails test:all
     - name: Run javascript tests

--- a/Gemfile
+++ b/Gemfile
@@ -178,10 +178,3 @@ group :test do
   gem "simplecov-lcov", :require => false
   gem "webmock"
 end
-
-group :development, :test do
-  gem "annotate"
-
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", :require => "debug/prelude"
-end

--- a/Gemfile
+++ b/Gemfile
@@ -144,6 +144,9 @@ gem "unicode-display_width"
 # Keep ruby 3.0 compatibility
 gem "multi_xml", "~> 0.6.0"
 
+gem "teaspoon"
+gem "teaspoon-mocha"
+
 # Gems useful for development
 group :development do
   gem "better_errors"

--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ gem "unicode-display_width"
 gem "multi_xml", "~> 0.6.0"
 
 gem "teaspoon"
-gem "teaspoon-mocha"
+gem "teaspoon-mocha", "~> 2.3.3"
 
 # Gems useful for development
 group :development do
@@ -180,4 +180,11 @@ group :test do
   gem "simplecov", :require => false
   gem "simplecov-lcov", :require => false
   gem "webmock"
+end
+
+group :development, :test do
+  gem "annotate"
+
+  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem "debug", :require => "debug/prelude"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     argon2 (2.3.0)
       ffi (~> 1.15)
       ffi-compiler (~> 1.0)
@@ -169,6 +172,9 @@ GEM
       sprockets-rails
       tilt
     date (3.3.4)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
     delayed_job (4.1.12)
@@ -614,6 +620,7 @@ DEPENDENCIES
   active_record_union
   activerecord-import
   addressable (~> 2.8)
+  annotate
   argon2
   autoprefixer-rails
   aws-sdk-s3
@@ -632,6 +639,7 @@ DEPENDENCIES
   connection_pool
   dalli
   dartsass-sprockets
+  debug
   debug_inspector
   delayed_job_active_record
   doorkeeper
@@ -704,7 +712,7 @@ DEPENDENCIES
   sprockets-exporters_pack
   strong_migrations (< 2.0.0)
   teaspoon
-  teaspoon-mocha
+  teaspoon-mocha (~> 2.3.3)
   terser
   turbo-rails
   unicode-display_width

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,6 +578,10 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     terser (1.2.3)
       execjs (>= 0.3.0, < 3)
+    teaspoon (1.2.2)
+      railties (>= 3.2.5)
+    teaspoon-mocha (2.3.3)
+      teaspoon (>= 1.0.0)
     thor (1.3.2)
     tilt (2.4.0)
     timeout (0.4.1)
@@ -707,6 +711,7 @@ DEPENDENCIES
   simplecov-lcov
   sprockets-exporters_pack
   strong_migrations (< 2.0.0)
+  teaspoon-mocha (~> 2.3)
   terser
   turbo-rails
   unicode-display_width

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,9 +85,6 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    annotate (3.2.0)
-      activerecord (>= 3.2, < 8.0)
-      rake (>= 10.4, < 14.0)
     argon2 (2.3.0)
       ffi (~> 1.15)
       ffi-compiler (~> 1.0)
@@ -172,9 +169,6 @@ GEM
       sprockets-rails
       tilt
     date (3.3.4)
-    debug (1.9.2)
-      irb (~> 1.10)
-      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
     delayed_job (4.1.12)
@@ -574,14 +568,14 @@ GEM
     stringio (3.1.1)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
-    terser (1.2.3)
-      execjs (>= 0.3.0, < 3)
     teaspoon (1.2.2)
       railties (>= 3.2.5)
     teaspoon-mocha (2.3.3)
       teaspoon (>= 1.0.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    terser (1.2.3)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     tilt (2.4.0)
     timeout (0.4.1)
@@ -620,7 +614,6 @@ DEPENDENCIES
   active_record_union
   activerecord-import
   addressable (~> 2.8)
-  annotate
   argon2
   autoprefixer-rails
   aws-sdk-s3
@@ -639,7 +632,6 @@ DEPENDENCIES
   connection_pool
   dalli
   dartsass-sprockets
-  debug
   debug_inspector
   delayed_job_active_record
   doorkeeper
@@ -711,7 +703,8 @@ DEPENDENCIES
   simplecov-lcov
   sprockets-exporters_pack
   strong_migrations (< 2.0.0)
-  teaspoon-mocha (~> 2.3)
+  teaspoon
+  teaspoon-mocha
   terser
   turbo-rails
   unicode-display_width

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -123,6 +123,18 @@ module.exports = [
     }
   },
   {
+    // Additional configuration for test files
+    files: ["test/**/*.js"],
+    languageOptions: {
+      globals: {
+        ...globals.mocha,
+        expect: "readonly",
+        assert: "readonly",
+        should: "readonly"
+      }
+    }
+  },
+  {
     files: ["config/eslint.js"],
     languageOptions: {
       ecmaVersion: 2019,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,13 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
 -- Name: btree_gist; Type: EXTENSION; Schema: -; Owner: -
 --
 

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 //= require jquery
 //= require js-cookie/dist/js.cookie
 //= require osm

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -1,5 +1,5 @@
 //= require jquery
-//= require jquery.cookie/jquery.cookie
+//= require js-cookie/dist/js.cookie
 //= require osm
 //= require leaflet/dist/leaflet-src
 //= require leaflet.osm

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 //= require jquery
 //= require js-cookie/dist/js.cookie
 //= require osm
@@ -11,15 +10,15 @@
 describe("OSM", function () {
   describe(".apiUrl", function () {
     it("returns a URL for a way", function () {
-      expect(OSM.apiUrl({type: "way", id: 10})).to.eq("/api/0.6/way/10/full");
+      expect(OSM.apiUrl({ type: "way", id: 10 })).to.eq("/api/0.6/way/10/full");
     });
 
     it("returns a URL for a node", function () {
-      expect(OSM.apiUrl({type: "node", id: 10})).to.eq("/api/0.6/node/10");
+      expect(OSM.apiUrl({ type: "node", id: 10 })).to.eq("/api/0.6/node/10");
     });
 
     it("returns a URL for a specific version", function () {
-      expect(OSM.apiUrl({type: "node", id: 10, version: 2})).to.eq("/api/0.6/node/10/2");
+      expect(OSM.apiUrl({ type: "node", id: 10, version: 2 })).to.eq("/api/0.6/node/10/2");
     });
   });
 
@@ -52,15 +51,15 @@ describe("OSM", function () {
     it("parses object params", function () {
       var params = OSM.mapParams("?node=1");
       expect(params).to.have.property("object");
-      expect(params.object).to.eql({type: "node", id: 1});
+      expect(params.object).to.eql({ type: "node", id: 1 });
 
       params = OSM.mapParams("?way=1");
       expect(params).to.have.property("object");
-      expect(params.object).to.eql({type: "way", id: 1});
+      expect(params.object).to.eql({ type: "way", id: 1 });
 
       params = OSM.mapParams("?relation=1");
       expect(params).to.have.property("object");
-      expect(params.object).to.eql({type: "relation", id: 1});
+      expect(params.object).to.eql({ type: "relation", id: 1 });
     });
 
     it("parses bbox params", function () {
@@ -86,21 +85,21 @@ describe("OSM", function () {
 
     it("parses lat/lon/zoom from the hash", function () {
       document.location.hash = "#map=16/57.6247/-3.6845";
-      params = OSM.mapParams("?");
+      const params = OSM.mapParams("?");
       expect(params).to.have.property("lat", 57.6247);
       expect(params).to.have.property("lon", -3.6845);
       expect(params).to.have.property("zoom", 16);
     });
 
     it("sets lat/lon from OSM.home", function () {
-      OSM.home = {lat: 57.6247, lon: -3.6845};
+      OSM.home = { lat: 57.6247, lon: -3.6845 };
       var params = OSM.mapParams("?");
       expect(params).to.have.property("lat", 57.6247);
       expect(params).to.have.property("lon", -3.6845);
     });
 
     it("sets bbox from OSM.location", function () {
-      OSM.location = {minlon: -3.6845, minlat: 57.6247, maxlon: -3.7845, maxlat: 57.7247};
+      OSM.location = { minlon: -3.6845, minlat: 57.6247, maxlon: -3.7845, maxlat: 57.7247 };
       var expected = L.latLngBounds([57.6247, -3.6845], [57.7247, -3.7845]);
       var params = OSM.mapParams("?");
       expect(params).to.have.property("bounds").deep.equal(expected);
@@ -135,7 +134,7 @@ describe("OSM", function () {
       params = OSM.mapParams("?");
       expect(params).to.have.property("layers", "C");
 
-      document.location.hash = "#map=5/57.6247/-3.6845&layers=M"
+      document.location.hash = "#map=5/57.6247/-3.6845&layers=M";
       params = OSM.mapParams("?");
       expect(params).to.have.property("layers", "M");
     });
@@ -241,8 +240,8 @@ describe("OSM", function () {
 
   describe(".distance", function () {
     it("computes distance between points", function () {
-      var latlng1 = L.latLng(51.76712,-0.00484),
-        latlng2 = L.latLng(51.7675159, -0.0078329);
+      var latlng1 = L.latLng(51.76712, -0.00484),
+          latlng2 = L.latLng(51.7675159, -0.0078329);
 
       expect(OSM.distance(latlng1, latlng2)).to.be.closeTo(210.664, 0.005);
       expect(OSM.distance(latlng2, latlng1)).to.be.closeTo(210.664, 0.005);

--- a/test/javascripts/test_helper.js
+++ b/test/javascripts/test_helper.js
@@ -1,0 +1,40 @@
+// Teaspoon includes some support files, but you can use anything from your own support path too.
+// require support/expect
+// require support/sinon
+//= require support/chai
+// require support/chai-jq-0.0.7
+// require support/your-support-file
+//
+// PhantomJS (Teaspoons default driver) doesn't have support for Function.prototype.bind, which has caused confusion.
+// Use this polyfill to avoid the confusion.
+//= require support/phantomjs-shims
+//
+// You can require your own javascript files here. By default this will include everything in application, however you
+// may get better load performance if you require the specific files that are being used in the spec that tests them.
+//= require application
+//
+// Deferring execution
+// If you're using CommonJS, RequireJS or some other asynchronous library you can defer execution. Call
+// Teaspoon.execute() after everything has been loaded. Simple example of a timeout:
+//
+// Teaspoon.defer = true
+// setTimeout(Teaspoon.execute, 1000)
+//
+// Matching files
+// By default Teaspoon will look for files that match _spec.{js,js.coffee,.coffee}. Add a filename_spec.js file in your
+// spec path and it'll be included in the default suite automatically. If you want to customize suites, check out the
+// configuration in teaspoon_env.rb
+//
+// Manifest
+// If you'd rather require your spec files manually (to control order for instance) you can disable the suite matcher in
+// the configuration and use this file as a manifest.
+//
+// For more information: http://github.com/modeset/teaspoon
+//
+// Chai
+// If you're using Chai, you'll probably want to initialize your preferred assertion style. You can read more about Chai
+// at: http://chaijs.com/guide/styles
+//
+// window.assert = chai.assert;
+window.expect = chai.expect;
+// window.should = chai.should();

--- a/test/javascripts/test_helper.js
+++ b/test/javascripts/test_helper.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Teaspoon includes some support files, but you can use anything from your own support path too.
 // require support/expect
 // require support/sinon

--- a/test/javascripts/test_helper.js
+++ b/test/javascripts/test_helper.js
@@ -2,7 +2,7 @@
 // require support/expect
 // require support/sinon
 //= require support/chai
-// require support/chai-jq-0.0.7
+//= require support/chai-jq-0.0.7
 // require support/your-support-file
 //
 // PhantomJS (Teaspoons default driver) doesn't have support for Function.prototype.bind, which has caused confusion.
@@ -35,6 +35,6 @@
 // If you're using Chai, you'll probably want to initialize your preferred assertion style. You can read more about Chai
 // at: http://chaijs.com/guide/styles
 //
-// window.assert = chai.assert;
+window.assert = chai.assert;
 window.expect = chai.expect;
-// window.should = chai.should();
+window.should = chai.should();

--- a/test/teaspoon_env.rb
+++ b/test/teaspoon_env.rb
@@ -41,11 +41,11 @@ Teaspoon.configure do |config|
     suite.matcher = "{test/javascripts,app/assets}/**/*_test.{js,js.coffee,coffee,es6,js.es6}"
 
     # Load additional JS files, but requiring them in your spec helper is the preferred way to do this.
-    #suite.javascripts = []
+    # suite.javascripts = []
 
     # You can include your own stylesheets if you want to change how Teaspoon looks.
     # Note: Spec related CSS can and should be loaded using fixtures.
-    #suite.stylesheets = ["teaspoon"]
+    # suite.stylesheets = ["teaspoon"]
 
     # This suites spec helper, which can require additional support files. This file is loaded before any of your test
     # files are loaded.
@@ -62,22 +62,22 @@ Teaspoon.configure do |config|
 
     # Hooks allow you to use `Teaspoon.hook("fixtures")` before, after, or during your spec run. This will make a
     # synchronous Ajax request to the server that will call all of the blocks you've defined for that hook name.
-    #suite.hook :fixtures, &proc{}
+    # suite.hook :fixtures, &proc{}
 
     # Determine whether specs loaded into the test harness should be embedded as individual script tags or concatenated
     # into a single file. Similar to Rails' asset `debug: true` and `config.assets.debug = true` options. By default,
     # Teaspoon expands all assets to provide more valuable stack traces that reference individual source files.
-    #suite.expand_assets = true
+    # suite.expand_assets = true
 
     # Non-.js file extensions Teaspoon should consider JavaScript files
-    #suite.js_extensions = [/(\.js)?.coffee/, /(\.js)?.es6/, ".es6.js"]
+    # suite.js_extensions = [/(\.js)?.coffee/, /(\.js)?.es6/, ".es6.js"]
   end
 
   # Example suite. Since we're just filtering to files already within the root test/javascripts, these files will also
   # be run in the default suite -- but can be focused into a more specific suite.
-  #config.suite :targeted do |suite|
+  # config.suite :targeted do |suite|
   #  suite.matcher = "spec/javascripts/targeted/*_spec.{js,js.coffee,coffee}"
-  #end
+  # end
 
   # CONSOLE RUNNER SPECIFIC
   #
@@ -98,7 +98,14 @@ Teaspoon.configure do |config|
   # Selenium Webdriver: https://github.com/jejacks0n/teaspoon/wiki/Using-Selenium-WebDriver
   # BrowserStack Webdriver: https://github.com/jejacks0n/teaspoon/wiki/Using-BrowserStack-WebDriver
   # Capybara Webkit: https://github.com/jejacks0n/teaspoon/wiki/Using-Capybara-Webkit
-  #config.driver = :phantomjs
+  require "selenium-webdriver"
+  config.driver = :selenium
+  config.driver_options = {
+    :client_driver => :firefox,
+    :selenium_options => {
+      :options => Selenium::WebDriver::Firefox::Options.new(:args => ["-headless"])
+    }
+  }
 
   # Specify additional options for the driver.
   #
@@ -106,41 +113,41 @@ Teaspoon.configure do |config|
   # Selenium Webdriver: https://github.com/jejacks0n/teaspoon/wiki/Using-Selenium-WebDriver
   # BrowserStack Webdriver: https://github.com/jejacks0n/teaspoon/wiki/Using-BrowserStack-WebDriver
   # Capybara Webkit: https://github.com/jejacks0n/teaspoon/wiki/Using-Capybara-Webkit
-  #config.driver_options = nil
+  # config.driver_options = nil
 
   # Specify the timeout for the driver. Specs are expected to complete within this time frame or the run will be
   # considered a failure. This is to avoid issues that can arise where tests stall.
-  #config.driver_timeout = 180
+  # config.driver_timeout = 180
 
   # Specify a server to use with Rack (e.g. thin, mongrel). If nil is provided Rack::Server is used.
-  #config.server = nil
+  # config.server = nil
 
   # Specify a host to run on a specific host, otherwise Teaspoon will use 127.0.0.1.
-  #config.server_host = nil
+  # config.server_host = nil
 
   # Specify a port to run on a specific port, otherwise Teaspoon will use a random available port.
-  #config.server_port = nil
+  # config.server_port = nil
 
   # Timeout for starting the server in seconds. If your server is slow to start you may have to bump this, or you may
   # want to lower this if you know it shouldn't take long to start.
-  #config.server_timeout = 20
+  # config.server_timeout = 20
 
   # Force Teaspoon to fail immediately after a failing suite. Can be useful to make Teaspoon fail early if you have
   # several suites, but in environments like CI this may not be desirable.
-  #config.fail_fast = true
+  # config.fail_fast = true
 
   # Specify the formatters to use when outputting the results.
   # Note: Output files can be specified by using `"junit>/path/to/output.xml"`.
   #
   # Available: :dot, :clean, :documentation, :json, :junit, :pride, :rspec_html, :snowday, :swayze_or_oprah, :tap, :tap_y, :teamcity
-  #config.formatters = [:dot]
+  # config.formatters = [:dot]
 
   # Specify if you want color output from the formatters.
-  #config.color = true
+  # config.color = true
 
   # Teaspoon pipes all console[log/debug/error] to $stdout. This is useful to catch places where you've forgotten to
   # remove them, but in verbose applications this may not be desirable.
-  #config.suppress_log = false
+  # config.suppress_log = false
 
   # COVERAGE REPORTS / THRESHOLD ASSERTIONS
   #
@@ -157,7 +164,7 @@ Teaspoon.configure do |config|
   # Specify that you always want a coverage configuration to be used. Otherwise, specify that you want coverage
   # on the CLI.
   # Set this to "true" or the name of your coverage config.
-  #config.use_coverage = nil
+  # config.use_coverage = nil
 
   # You can have multiple coverage configs by passing a name to config.coverage.
   # e.g. config.coverage :ci do |coverage|
@@ -166,21 +173,21 @@ Teaspoon.configure do |config|
     # Which coverage reports Istanbul should generate. Correlates directly to what Istanbul supports.
     #
     # Available: text-summary, text, html, lcov, lcovonly, cobertura, teamcity
-    #coverage.reports = ["text-summary", "html"]
+    # coverage.reports = ["text-summary", "html"]
 
     # The path that the coverage should be written to - when there's an artifact to write to disk.
     # Note: Relative to `config.root`.
-    #coverage.output_path = "coverage"
+    # coverage.output_path = "coverage"
 
     # Assets to be ignored when generating coverage reports. Accepts an array of filenames or regular expressions. The
     # default excludes assets from vendor, gems and support libraries.
-    #coverage.ignore = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
+    # coverage.ignore = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
 
     # Various thresholds requirements can be defined, and those thresholds will be checked at the end of a run. If any
     # aren't met the run will fail with a message. Thresholds can be defined as a percentage (0-100), or nil.
-    #coverage.statements = nil
-    #coverage.functions = nil
-    #coverage.branches = nil
-    #coverage.lines = nil
+    # coverage.statements = nil
+    # coverage.functions = nil
+    # coverage.branches = nil
+    # coverage.lines = nil
   end
 end

--- a/test/teaspoon_env.rb
+++ b/test/teaspoon_env.rb
@@ -1,0 +1,186 @@
+Teaspoon.configure do |config|
+  # Determines where the Teaspoon routes will be mounted. Changing this to "/jasmine" would allow you to browse to
+  # `http://localhost:3000/jasmine` to run your tests.
+  config.mount_at = "/teaspoon"
+
+  # Specifies the root where Teaspoon will look for files. If you're testing an engine using a dummy application it can
+  # be useful to set this to your engines root (e.g. `Teaspoon::Engine.root`).
+  # Note: Defaults to `Rails.root` if nil.
+  config.root = nil
+
+  # Paths that will be appended to the Rails assets paths
+  # Note: Relative to `config.root`.
+  config.asset_paths = ["test/javascripts", "test/javascripts/stylesheets"]
+
+  # Fixtures are rendered through a controller, which allows using HAML, RABL/JBuilder, etc. Files in these paths will
+  # be rendered as fixtures.
+  config.fixture_paths = ["test/javascripts/fixtures"]
+
+  # SUITES
+  #
+  # You can modify the default suite configuration and create new suites here. Suites are isolated from one another.
+  #
+  # When defining a suite you can provide a name and a block. If the name is left blank, :default is assumed. You can
+  # omit various directives and the ones defined in the default suite will be used.
+  #
+  # To run a specific suite
+  # - in the browser: http://localhost/teaspoon/[suite_name]
+  # - with the rake task: rake teaspoon suite=[suite_name]
+  # - with the cli: teaspoon --suite=[suite_name]
+  config.suite do |suite|
+    # Specify the framework you would like to use. This allows you to select versions, and will do some basic setup for
+    # you -- which you can override with the directives below. This should be specified first, as it can override other
+    # directives.
+    # Note: If no version is specified, the latest is assumed.
+    #
+    # Versions: 1.10.0, 1.17.1, 1.18.2, 1.19.0, 2.0.1, 2.1.0, 2.2.4, 2.2.5, 2.3.3
+    suite.use_framework :mocha, "2.3.3"
+
+    # Specify a file matcher as a regular expression and all matching files will be loaded when the suite is run. These
+    # files need to be within an asset path. You can add asset paths using the `config.asset_paths`.
+    suite.matcher = "{test/javascripts,app/assets}/**/*_test.{js,js.coffee,coffee,es6,js.es6}"
+
+    # Load additional JS files, but requiring them in your spec helper is the preferred way to do this.
+    #suite.javascripts = []
+
+    # You can include your own stylesheets if you want to change how Teaspoon looks.
+    # Note: Spec related CSS can and should be loaded using fixtures.
+    #suite.stylesheets = ["teaspoon"]
+
+    # This suites spec helper, which can require additional support files. This file is loaded before any of your test
+    # files are loaded.
+    suite.helper = "test_helper"
+
+    # Partial to be rendered in the head tag of the runner. You can use the provided ones or define your own by creating
+    # a `_boot.html.erb` in your fixtures path, and adjust the config to `"/boot"` for instance.
+    #
+    # Available: boot, boot_require_js
+    suite.boot_partial = "boot"
+
+    # Partial to be rendered in the body tag of the runner. You can define your own to create a custom body structure.
+    suite.body_partial = "body"
+
+    # Hooks allow you to use `Teaspoon.hook("fixtures")` before, after, or during your spec run. This will make a
+    # synchronous Ajax request to the server that will call all of the blocks you've defined for that hook name.
+    #suite.hook :fixtures, &proc{}
+
+    # Determine whether specs loaded into the test harness should be embedded as individual script tags or concatenated
+    # into a single file. Similar to Rails' asset `debug: true` and `config.assets.debug = true` options. By default,
+    # Teaspoon expands all assets to provide more valuable stack traces that reference individual source files.
+    #suite.expand_assets = true
+
+    # Non-.js file extensions Teaspoon should consider JavaScript files
+    #suite.js_extensions = [/(\.js)?.coffee/, /(\.js)?.es6/, ".es6.js"]
+  end
+
+  # Example suite. Since we're just filtering to files already within the root test/javascripts, these files will also
+  # be run in the default suite -- but can be focused into a more specific suite.
+  #config.suite :targeted do |suite|
+  #  suite.matcher = "spec/javascripts/targeted/*_spec.{js,js.coffee,coffee}"
+  #end
+
+  # CONSOLE RUNNER SPECIFIC
+  #
+  # These configuration directives are applicable only when running via the rake task or command line interface. These
+  # directives can be overridden using the command line interface arguments or with ENV variables when using the rake
+  # task.
+  #
+  # Command Line Interface:
+  # teaspoon --driver=phantomjs --server-port=31337 --fail-fast=true --format=junit --suite=my_suite /spec/file_spec.js
+  #
+  # Rake:
+  # teaspoon DRIVER=phantomjs SERVER_PORT=31337 FAIL_FAST=true FORMATTERS=junit suite=my_suite
+
+  # Specify which headless driver to use. Supports PhantomJS, Selenium Webdriver and BrowserStack Webdriver.
+  #
+  # Available: :phantomjs, :selenium, :browserstack
+  # PhantomJS: https://github.com/jejacks0n/teaspoon/wiki/Using-PhantomJS
+  # Selenium Webdriver: https://github.com/jejacks0n/teaspoon/wiki/Using-Selenium-WebDriver
+  # BrowserStack Webdriver: https://github.com/jejacks0n/teaspoon/wiki/Using-BrowserStack-WebDriver
+  # Capybara Webkit: https://github.com/jejacks0n/teaspoon/wiki/Using-Capybara-Webkit
+  #config.driver = :phantomjs
+
+  # Specify additional options for the driver.
+  #
+  # PhantomJS: https://github.com/jejacks0n/teaspoon/wiki/Using-PhantomJS
+  # Selenium Webdriver: https://github.com/jejacks0n/teaspoon/wiki/Using-Selenium-WebDriver
+  # BrowserStack Webdriver: https://github.com/jejacks0n/teaspoon/wiki/Using-BrowserStack-WebDriver
+  # Capybara Webkit: https://github.com/jejacks0n/teaspoon/wiki/Using-Capybara-Webkit
+  #config.driver_options = nil
+
+  # Specify the timeout for the driver. Specs are expected to complete within this time frame or the run will be
+  # considered a failure. This is to avoid issues that can arise where tests stall.
+  #config.driver_timeout = 180
+
+  # Specify a server to use with Rack (e.g. thin, mongrel). If nil is provided Rack::Server is used.
+  #config.server = nil
+
+  # Specify a host to run on a specific host, otherwise Teaspoon will use 127.0.0.1.
+  #config.server_host = nil
+
+  # Specify a port to run on a specific port, otherwise Teaspoon will use a random available port.
+  #config.server_port = nil
+
+  # Timeout for starting the server in seconds. If your server is slow to start you may have to bump this, or you may
+  # want to lower this if you know it shouldn't take long to start.
+  #config.server_timeout = 20
+
+  # Force Teaspoon to fail immediately after a failing suite. Can be useful to make Teaspoon fail early if you have
+  # several suites, but in environments like CI this may not be desirable.
+  #config.fail_fast = true
+
+  # Specify the formatters to use when outputting the results.
+  # Note: Output files can be specified by using `"junit>/path/to/output.xml"`.
+  #
+  # Available: :dot, :clean, :documentation, :json, :junit, :pride, :rspec_html, :snowday, :swayze_or_oprah, :tap, :tap_y, :teamcity
+  #config.formatters = [:dot]
+
+  # Specify if you want color output from the formatters.
+  #config.color = true
+
+  # Teaspoon pipes all console[log/debug/error] to $stdout. This is useful to catch places where you've forgotten to
+  # remove them, but in verbose applications this may not be desirable.
+  #config.suppress_log = false
+
+  # COVERAGE REPORTS / THRESHOLD ASSERTIONS
+  #
+  # Coverage reports requires Istanbul (https://github.com/gotwarlost/istanbul) to add instrumentation to your code and
+  # display coverage statistics.
+  #
+  # Coverage configurations are similar to suites. You can define several, and use different ones under different
+  # conditions.
+  #
+  # To run with a specific coverage configuration
+  # - with the rake task: rake teaspoon USE_COVERAGE=[coverage_name]
+  # - with the cli: teaspoon --coverage=[coverage_name]
+
+  # Specify that you always want a coverage configuration to be used. Otherwise, specify that you want coverage
+  # on the CLI.
+  # Set this to "true" or the name of your coverage config.
+  #config.use_coverage = nil
+
+  # You can have multiple coverage configs by passing a name to config.coverage.
+  # e.g. config.coverage :ci do |coverage|
+  # The default coverage config name is :default.
+  config.coverage do |coverage|
+    # Which coverage reports Istanbul should generate. Correlates directly to what Istanbul supports.
+    #
+    # Available: text-summary, text, html, lcov, lcovonly, cobertura, teamcity
+    #coverage.reports = ["text-summary", "html"]
+
+    # The path that the coverage should be written to - when there's an artifact to write to disk.
+    # Note: Relative to `config.root`.
+    #coverage.output_path = "coverage"
+
+    # Assets to be ignored when generating coverage reports. Accepts an array of filenames or regular expressions. The
+    # default excludes assets from vendor, gems and support libraries.
+    #coverage.ignore = [%r{/lib/ruby/gems/}, %r{/vendor/assets/}, %r{/support/}, %r{/(.+)_helper.}]
+
+    # Various thresholds requirements can be defined, and those thresholds will be checked at the end of a run. If any
+    # aren't met the run will fail with a message. Thresholds can be defined as a percentage (0-100), or nil.
+    #coverage.statements = nil
+    #coverage.functions = nil
+    #coverage.branches = nil
+    #coverage.lines = nil
+  end
+end


### PR DESCRIPTION
This pull request addresses #2595 , which involves re-enabling JavaScript unit tests. The goal is to restore JavaScript testing after the removal of Konacha. This work continues Andy's effort by cherry-picking commits from [his branch](https://github.com/gravitystorm/openstreetmap-website/tree/teaspoon), where the initial [Teaspoon](https://github.com/jejacks0n/teaspoon) integration began. 

#### Key Updates:
- **Teaspoon Integration**: Teaspoon has been configured to use Selenium WebDriver with Firefox (replacing PhantomJS, which is discontinued).
- **GitHub CI**: The GitHub test CI script has been updated to run JavaScript tests alongside the Rails tests.
- **ESLint Adjustments**: Added ESLint rules for the JavaScript test files in the `test` folder, fixing a few ESLint errors during the process.
  
At the moment, some tests are failing, you can look at the [logs](https://github.com/openstreetmap/openstreetmap-website/actions/runs/10863788529/job/30148346837) for more details. This could be due to changes in implementation or other issues that I am investigating. Any advice on how to approach this would be highly appreciated. I also faced some caching problems inside Docker, but those should be resolved now.

Note: This is still work in progress. I just wanted to get some feedback and to confirm this is going into right direction.


