### PR TITLE
Added greeting to friendship notification

### DIFF
--- a/app/views/user_mailer/friendship_notification.html.erb
+++ b/app/views/user_mailer/friendship_notification.html.erb
@@ -1,3 +1,5 @@
+<p><%= t ".hi", :to_user => @friendship.befriendee.display_name %></p>
+
 <p><%= t ".had_added_you", :user => @friendship.befriender.display_name %></p>
 
 <%= message_body do %>

--- a/app/views/user_mailer/friendship_notification.text.erb
+++ b/app/views/user_mailer/friendship_notification.text.erb
@@ -1,3 +1,5 @@
+<%= t ".hi", :to_user => @friendship.befriendee.display_name %>
+
 <%= t '.had_added_you', :user => @friendship.befriender.display_name %>
 
 <%= t '.see_their_profile', :userurl => @viewurl %>


### PR DESCRIPTION
PR adds greeting 'Hi {user display name},' to friendship notification messages (both HTML and TEXT). As a side effect, user_mailer.friendship_notification.hi is not anymore reported as unused.