### PR TITLE
Removed unused translations in changesets namespace

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,7 +441,6 @@ en:
         sorry: "Sorry, the list of changeset comments you requested took too long to retrieve."
   changesets:
     changeset:
-      anonymous: "Anonymous"
       no_edits: "(no edits)"
       view_changeset_details: "View changeset details"
     index:
@@ -473,7 +472,6 @@ en:
       title: "Changeset %{id}"
       created_by_html: "Created by %{link_user} on %{created}."
     no_such_entry:
-      title: "No such changeset"
       heading: "No entry with the id: %{id}"
       body: "Sorry, there is no changeset with the id %{id}. Please check your spelling, or maybe the link you clicked is wrong."
     show:


### PR DESCRIPTION
PR makes following changes:

1. Updates i18n-tasks.yml to ignore unused translations for keys from changesets.paging_nav.* (because they are used in pagination mechanism using string interpolation),
2. Pulls out ?: operator from t() in changesets/show.html.erb so changesets.show.{comment_by_html, hidden_comment_by_html} translation keys are no longer reported as unused and
3. Removes unused translation keys changesets.{changeset.anonymous, no_such_entry.title} from en.yml because .anonymous was added in fddda4e and was stopped being used in 3e305fb and .title was added in f0764d3 but never used.