### PR TITLE
OCI: ignore invalid replacement token

### DIFF
--- a/lib/osm_community_index.rb
+++ b/lib/osm_community_index.rb
@@ -38,7 +38,11 @@ module OsmCommunityIndex
                community_en_yaml.dig("_defaults", community.type, "name")
     community_name = community_locale_yaml.dig("_communities", community.strings["communityID"])
     # Change the `{community}` placeholder to `%{community}` and use Ruby's Kernel.format to fill it in.
-    translated_name = format(template.gsub("{", "%{"), { :community => community_name }) if template && community_name
+    begin
+      translated_name = format(template.gsub("{", "%{"), { :community => community_name }) if template && community_name
+    rescue KeyError => e
+      Rails.logger.warn e.full_message
+    end
     return translated_name if translated_name
 
     # Otherwise fall back to the (English-language) resource name

--- a/test/lib/osm_community_index_test.rb
+++ b/test/lib/osm_community_index_test.rb
@@ -40,4 +40,14 @@ class CountryTest < ActiveSupport::TestCase
     name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml)
     assert_equal("Translated Community Chapter", name)
   end
+
+  def test_i18n_invalid_replacement_token
+    # Ignore invalid replacement tokens in OCI data provided. This might happen if translators were mistakenly translating the predefined token ids.
+    community = Community.new({ "id" => "foo-chapter", "type" => "osm-lc", "strings" => { "community" => "Community Name", "communityID" => "communityname" } })
+    community_locale_yaml = { "_communities" => { "communityname" => "Translated Community" }, "_defaults" => { "osm-lc" => { "name" => "{comminauté} Chapter" } } }
+    community_en_yaml = {}
+
+    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml)
+    assert_equal("Community Name", name)
+  end
 end


### PR DESCRIPTION
In #5210, updating the OSM community index failed due to invalid replacement tokens. This issue needs to be resolved upstream. However, we can add a bit of error handling and still apply the update. EN is used for erroneous translations. 