### PR TITLE
Removed unused translation keys from diary_entries

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -580,8 +580,6 @@ en:
       report: Report this comment
     location:
       location: "Location:"
-      view: "View"
-      edit: "Edit"
       coordinates: "%{latitude}; %{longitude}"
     feed:
       user:


### PR DESCRIPTION
PR removes diary_entries.location.{edit,view} unused translation keys. They were added at 0b913ef and stopped being used at 53fc3e8 / aa121fa.