### PR TITLE
Improved unused translation keys in users

### DIFF
--- a/app/views/users/terms.html.erb
+++ b/app/views/users/terms.html.erb
@@ -69,8 +69,8 @@
   <%= hidden_field_tag("referer", h(params[:referer])) unless params[:referer].nil? %>
 
   <div class="mb-3">
-    <%= submit_tag("Continue", :name => "continue", :id => "continue", :disabled => true, :class => "btn btn-primary") %>
-    <%= submit_tag("Cancel", :name => "decline", :id => "decline", :class => "btn btn-outline-secondary") %>
+    <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :disabled => true, :class => "btn btn-primary") %>
+    <%= submit_tag(t(".cancel"), :name => "decline", :id => "decline", :class => "btn btn-outline-secondary") %>
   </div>
 
   <div class="mb-3">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2691,7 +2691,6 @@ en:
         privacy_policy_title: OSMF privacy policy including section on email addresses
         contributor_terms_url: "https://wiki.osmfoundation.org/wiki/Licence/Contributor_Terms"
         contributor_terms: "contributor terms"
-      tou: "terms of use"
       continue: Sign Up
       terms accepted: "Thanks for accepting the new contributor terms!"
       email_help:
@@ -2719,9 +2718,9 @@ en:
       guidance_info_html: "Information to help understand these terms: a %{readable_summary_link} and some %{informal_translations_link}"
       readable_summary: human readable summary
       informal_translations: informal translations
-      continue: Continue
+      continue: "Continue"
       declined: "https://wiki.openstreetmap.org/wiki/Contributor_Terms_Declined"
-      decline: "Decline"
+      cancel: "Cancel"
       you need to accept or decline: "Please read and then either accept or decline the new Contributor Terms to continue."
       legale_select: "Country of residence:"
       legale_names:


### PR DESCRIPTION
PR removes users.new.tou (added 9649b19 and has never been used, used layouts.tou instead), replaces users.terms.decline with users.terms.cancel and together with users.terms.continue starts being used at /users/terms.html.erb (where both were added at 9a9e13a and removed at 1be8d59, probably forgotten to be re-added under t()).