### PR TITLE
Removed various unused translation keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -432,8 +432,6 @@ en:
       comment:
         comment: "New comment on changeset #%{changeset_id} by %{author}"
         commented_at_by_html: "Updated %{when} by %{user}"
-      comments:
-        comment: "New comment on changeset #%{changeset_id} by %{author}"
       show:
         title_all: OpenStreetMap changeset discussion
         title_particular: "OpenStreetMap changeset #%{changeset_id} discussion"
@@ -1458,7 +1456,6 @@ en:
       not_updated: Not Updated
       search: Search
       search_guidance: "Search Issues:"
-      link_to_reports: View Reports
       states:
         ignored: Ignored
         open: Open
@@ -1855,7 +1852,6 @@ en:
       remember: "Remember me"
       lost password link: "Lost your password?"
       login_button: "Log in"
-      register now: Register now
       with external: "or log in with a third party"
       or: "or"
       auth failure: "Sorry, could not log in with those details."


### PR DESCRIPTION
PR removes changeset_comments.feeds.comments.comment (added / removed 5cd417f / 2cf3861), issues.index.link_to_reports (added / removed 79bd177 / 05ae075) and sessions.new.register now (added / removed 5197124 / 9649b19) unused translation keys.