### PR TITLE
Removed unused translations in user_blocks

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2911,12 +2911,9 @@ en:
       created: "Created:"
       duration: "Duration:"
       status: "Status:"
-      show: "Show"
       edit: "Edit"
-      confirm: "Are you sure?"
       reason: "Reason for block:"
       revoker: "Revoker:"
-      needs_view: "The user needs to log in before this block will be cleared."
     block:
       not_revoked: "(not revoked)"
       show: "Show"


### PR DESCRIPTION
PR removes user_blocks.show.{confirm, needs_view, show} translation keys added at daa2496. confirm and show has never been used, while needs_view ended being used at ca06b3c.