### PR TITLE
Masks off unused translation keys in activerecord

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -134,6 +134,8 @@ ignore_unused:
   - 'auth.providers.*'
   - 'time.formats.blog' # used for formatting blog dates
   - 'time.formats.friendly' # used for formatting dates / times in a friendly way
+  - 'activerecord.errors.models.user_mute.attributes.subject.format' # used for formatting error message during validation in user_mute.rb
+  - 'activerecord.errors.models.user_mute.is_already_muted' # used as part of error message during validation in user_mute.rb
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'


### PR DESCRIPTION
PR replaces .is_already_muted with I18n.t("activerecord.errors.models.user_mute.is_already_muted") in user_mute.rb and adds activerecord.errors.models.user_mute.attributes.subject.format under ignore_unused (in i18n-tasks.yml) since used for formatting above validation error message, so they are not reported as unused anymore.