### PR TITLE
Masked off reporting as unused various keys

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -132,6 +132,8 @@ ignore_unused:
   - 'reports.new.categories.*' # double interpolation in reports_helper
   - 'shared.pagination.*'
   - 'auth.providers.*'
+  - 'time.formats.blog' # used for formatting blog dates
+  - 'time.formats.friendly' # used for formatting dates / times in a friendly way
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1844,7 +1844,6 @@ en:
       failure: Couldn't update profile.
   sessions:
     new:
-      title: "Log in"
       tab_title: "Log in"
       login_to_authorize_html: "Log in to OpenStreetMap to access %{client_app_name}."
       email or username: "Email Address or Username"
@@ -2292,7 +2291,6 @@ en:
       welcome_mat_url: https://welcome.openstreetmap.org/
     sidebar:
       search_results: Search Results
-      close: Close
     search:
       search: Search
       get_directions_title: "Find directions between two points"

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -5,7 +5,7 @@ class IssuesTest < ApplicationSystemTestCase
 
   def test_view_issues_not_logged_in
     visit issues_path
-    assert_content I18n.t("sessions.new.title")
+    assert_content "Log in"
   end
 
   def test_view_issues_normal_user


### PR DESCRIPTION
This PR:

- adds time.formats.{blog, friendly} translation keys under ignore_unused in i18n-tasks.yml since used on numerous places for formatting dates / times,
- removes site.sidebar.close because started being used at 3a51160 and ended being used at 6adcce4 and
- removes sessions.new.title because started being used at f18baae and has been used only in test/system/issues_test.rb (from which we removed it because tests are always in EN).

Mentioned translation keys are no longer reported as unused.