### PR TITLE
Update to iD v2.30.4

### DIFF
--- a/vendor/assets/iD/iD.js
+++ b/vendor/assets/iD/iD.js
@@ -20136,7 +20136,7 @@
   // package.json
   var package_default = {
     name: "iD",
-    version: "2.30.3",
+    version: "2.30.4",
     description: "A friendly editor for OpenStreetMap",
     main: "dist/iD.min.js",
     repository: "github:openstreetmap/iD",


### PR DESCRIPTION
updates the editor layer index again, this time addressing https://github.com/openstreetmap/iD/issues/10486