### PR TITLE
Update en-GB.yml: don't say "import" when you mean "upload"

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1145,9 +1145,9 @@ en-GB:
       see_their_profile: You can see their profile at %{userurl}.
       befriend_them: You can also add them as a friend at %{befriendurl}.
     gpx_failure:
-      subject: '[OpenStreetMap] GPX Import failure'
+      subject: '[OpenStreetMap] GPX upload failure'
     gpx_success:
-      subject: '[OpenStreetMap] GPX Import success'
+      subject: '[OpenStreetMap] GPX upload success'
     signup_confirm:
       subject: '[OpenStreetMap] Welcome to OpenStreetMap'
       greeting: Hi there!


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Import says                                              
> Unlike editing the map or **uploading GPX traces**, importing combines                     
> an existing dataset with the OSM dataset and thus typically includes a                     
> complex merging process.                                                                   
                                                                                             
Therefore the mail one gets, 
> Subject: [OpenStreetMap] GPX Import success                                                   

shouldn't say "Import", it should just say "Upload".                                         
                                                                                             
I'll just fix these two. I appears elsewhere too.