### PR TITLE
Replace submitted note table colors with created/resolved

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -64,7 +64,13 @@ time[title] {
   .table-success {
     --bs-table-bg: rgb(var(--bs-success-rgb), .25);
   }
-  .table-primary, .table-secondary, .table-success {
+  .table-warning {
+    --bs-table-bg: rgb(var(--bs-warning-rgb), .25);
+  }
+  .table-danger {
+    --bs-table-bg: rgb(var(--bs-danger-rgb), .25);
+  }
+  .table-primary, .table-secondary, .table-success, .table-warning, .table-danger {
     --bs-table-color: initial;
     border-color: inherit;
   }

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,9 +1,11 @@
 <% content_for :heading do %>
   <h1><%= t ".heading", :user => @user.display_name %></h1>
-  <p><%= t ".subheading_html",
-           :user => link_to(@user.display_name, @user),
-           :submitted => tag.span(t(".subheading_submitted"), :class => "px-2 py-1 bg-primary bg-opacity-25"),
-           :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-body") %></p>
+  <p class="lh-lg"><%= t ".subheading_html",
+                         :user => link_to(@user.display_name, @user),
+                         :submitted => tag.span(t(".subheading_submitted"), :class => "px-2 py-1 bg-danger bg-opacity-25"),
+                         :submitted_and_resolved => tag.span(t(".subheading_submitted_and_resolved"), :class => "px-2 py-1 bg-warning bg-opacity-25"),
+                         :resolved => tag.span(t(".subheading_resolved"), :class => "px-2 py-1 bg-success bg-opacity-25"),
+                         :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-body") %></p>
 <% end %>
 
 <% if @notes.empty? %>
@@ -24,7 +26,15 @@
       </tr>
     </thead>
   <% @notes.each do |note| -%>
-    <tr<% if note.author == @user %> class="table-primary"<% end %>>
+    <% opened_by_user = note.comments.any? { |comment| comment.author == @user && comment.event == "opened" } %>
+    <% closed_by_user = note.comments.any? { |comment| comment.author == @user && comment.event == "closed" } %>
+    <%= tag.tr :class => if opened_by_user && closed_by_user
+                           "table-warning"
+                         elsif opened_by_user
+                           "table-danger"
+                         elsif closed_by_user
+                           "table-success"
+                         end do %>
       <td>
         <% if note.closed? %>
           <%= image_tag("closed_note_marker.svg", :alt => "closed", :width => 25, :height => 40) %>
@@ -37,7 +47,7 @@
       <td><%= note.comments.first.body.to_html %></td>
       <td><%= friendly_date_ago(note.created_at) %></td>
       <td><%= friendly_date_ago(note.updated_at) %></td>
-    </tr>
+    <% end %>
   <% end -%>
   </table>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2957,8 +2957,10 @@ en:
     index:
       title: "Notes submitted or commented on by %{user}"
       heading: "%{user}'s Notes"
-      subheading_html: "Notes %{submitted} or %{commented} by %{user}"
-      subheading_submitted: "submitted"
+      subheading_html: "Notes %{submitted}, %{submitted_and_resolved}, %{resolved} or %{commented} by %{user}"
+      subheading_submitted: "created"
+      subheading_submitted_and_resolved: "created and resolved"
+      subheading_resolved: "resolved"
       subheading_commented: "commented on"
       no_notes: No notes
       id: "Id"


### PR DESCRIPTION
Instead of *submitted* and *commented* note colors switch to *created*, *resolved* and *commented*.

Reasons:
- Close actions were colored as *commented* even if notes were closed without any comments. Now they are going to be colored as *resolved*.
- *Submitted* is not a term we use for notes, we have "add a note" and notes "created by".
- There was a [complaint](https://github.com/openstreetmap/openstreetmap-website/pull/4700#issuecomment-2221682594) about the primary color used for submitted notes that is blue making links harder to see. What other color can we use? For example, the *success* color, like we do for unread messages. But that's the color of the resolved note marker, and then we might as well add the unresolved color.

Caveats:
- I keep "submitted" in locale keys to avoid errors while `subheading_html` is not updated.
- I ignore *reopen* events because if I don't, I'd have to treat them as *open* events but then there wouldn't be an equivalent to the previous *submitted* state. And the equivalent is green *created* + yellow *created and resolved*.
- I had to add this *created and resolved* state because what if the user did both actions? I can't pick one more important color. If I look at note status changes, the latest action is the most important one and I'd have to color notes as *resolved*. But then again I'd lose the equivalent to the previous *submitted* state.

![image](https://github.com/user-attachments/assets/03ac5999-0822-4c03-938d-a8447f3114a4)

Dark mode:
![image](https://github.com/user-attachments/assets/8c88a294-bb1a-42d5-b169-051f68f34916)

Legend while locale strings aren't updated:
![image](https://github.com/user-attachments/assets/754fcbe2-f27d-4103-9359-71932981a56a)
