### PR TITLE
Remove "User's Diary" from diary entry og:title

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -71,6 +71,7 @@ class DiaryEntriesController < ApplicationController
     if @entry
       @title = t ".title", :user => params[:display_name], :title => @entry.title
       @opengraph_properties = {
+        "og:title" => @entry.title,
         "og:image" => @entry.body.image,
         "og:image:alt" => @entry.body.image_alt,
         "og:description" => @entry.body.description,

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -4,7 +4,7 @@ module OpenGraphHelper
   def opengraph_tags(title, properties)
     tags = {
       "og:site_name" => t("layouts.project_name.title"),
-      "og:title" => title || t("layouts.project_name.title"),
+      "og:title" => properties["og:title"] || title || t("layouts.project_name.title"),
       "og:type" => "website",
       "og:url" => url_for(:only_path => false),
       "og:description" => properties["og:description"] || t("layouts.intro_text")

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -648,6 +648,17 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_show_og_title
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :title => "The Important Blog Post")
+
+    get diary_entry_path(user, diary_entry)
+    assert_response :success
+    assert_dom "head meta[property='og:title']" do
+      assert_dom "> @content", "The Important Blog Post"
+    end
+  end
+
   def test_show_og_image_with_no_image
     user = create(:user)
     diary_entry = create(:diary_entry, :user => user, :body => "nothing")


### PR DESCRIPTION
When diary posts are shared they might look like this on small screens:

![image](https://github.com/user-attachments/assets/9b71498b-14bc-4c59-a93d-7c2556fa0c03)

The problem is that the title starts with "User's Diary |". The actual title comes after that and may be cut off significantly. Since that "User's Diary |" is not actually a diary entry title, I'm removing it from Open Graph `og:title` here.

Where am I putting it instead? Currently nowhere because:

- I considered putting it in `og:site_name` so instead of "OpenStreetMap" there's something like "User's Diary on OpenStreetMap", but that might confuse services that expect the site name to correspond to the domain name.
- There's an obvious [article:author](https://ogp.me/#type_article) property, however, looking at Mastodon and Discourse source code, it doesn't seem to be widely supported.
- What's worse, there [isn't even a clear agreement](https://surniaulula.com/2014/standards/og/pinterest-articleauthor-incompatible-with-open-graph/) what this property should contain. Some sources claim that any string is ok there, other say that a url is required, possibly even a Facebook url.

"User's Diary" should still be present for diary entry list pages.