### PR TITLE
Don't show older/newer buttons if all items fit on one page

### DIFF
--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,3 +1,5 @@
+<% if older_id || newer_id %>
+
 <% translation_scope ||= "shared.pagination.#{controller.controller_name}" %>
 <nav>
   <% link_class = "page-link icon-link text-center" %>
@@ -31,3 +33,5 @@
     <% end -%>
   </ul>
 </nav>
+
+<% end %>


### PR DESCRIPTION
Do the suggestion https://github.com/openstreetmap/openstreetmap-website/pull/5262#pullrequestreview-2369829924. It's somewhat related to that pull request because pagination buttons will take more space. Maybe we don't want that if the page contents is small.

With this PR pagination buttons are shown as usual if there's more than one page:
![image](https://github.com/user-attachments/assets/60a8734a-a54a-4399-a237-48687d54b60f)

But if there's only one page, they are removed:
![image](https://github.com/user-attachments/assets/6a15a7aa-50b2-44fe-b6c4-7499d4e978bb)
