### PR TITLE
Use system font on error pages

### DIFF
--- a/app/assets/stylesheets/errors.scss
+++ b/app/assets/stylesheets/errors.scss
@@ -1,3 +1,7 @@
+body {
+  font-family: system-ui;
+}
+
 .logo {
   float: left;
   margin: 10px;


### PR DESCRIPTION
I opened #5131 and put a number of changes to error pages to see which of them are acceptable. The discussion there however has been about making more changes. I guess that means nobody objects to the ones I made and we can have them merged.

This PR changes the font of error pages to a default system ui font. Bootstrap does the same thing except also adds fallback fonts for older browsers that don't understand `font-family: system-ui`. We don't need a serif font for a text this short because we don't use serif fonts even for longer texts on the website.

Addresses this from #3532:
> It also looks incredibly ugly, with loads of whitespace and the default browser font.

![image](https://github.com/user-attachments/assets/3e20f2f8-d3d9-404f-b403-c9f1eb338360)
