### PR TITLE
Display old node versions on map view

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -327,18 +327,18 @@ $(document).ready(function () {
   OSM.Browse = function (map, type) {
     var page = {};
 
-    page.pushstate = page.popstate = function (path, id) {
+    page.pushstate = page.popstate = function (path, id, version) {
       OSM.loadSidebarContent(path, function () {
-        addObject(type, id);
+        addObject(type, id, version);
       });
     };
 
-    page.load = function (path, id) {
-      addObject(type, id, true);
+    page.load = function (path, id, version) {
+      addObject(type, id, version, true);
     };
 
-    function addObject(type, id, center) {
-      map.addObject({ type: type, id: parseInt(id, 10) }, function (bounds) {
+    function addObject(type, id, version, center) {
+      map.addObject({ type: type, id: parseInt(id, 10), version: version && parseInt(version, 10) }, function (bounds) {
         if (!window.location.hash && bounds.isValid() &&
             (center || !map.getBounds().contains(bounds))) {
           OSM.router.withoutMoveListener(function () {
@@ -379,7 +379,7 @@ $(document).ready(function () {
     "/user/:display_name/history": history,
     "/note/:id": OSM.Note(map),
     "/node/:id(/history)": OSM.Browse(map, "node"),
-    "/node/:id/history/:version": OSM.OldBrowse(),
+    "/node/:id/history/:version": OSM.Browse(map, "node"),
     "/way/:id(/history)": OSM.Browse(map, "way"),
     "/way/:id/history/:version": OSM.OldBrowse(),
     "/relation/:id(/history)": OSM.Browse(map, "relation"),


### PR DESCRIPTION
Shows node versions like in #4930 but without complications https://github.com/openstreetmap/openstreetmap-website/pull/4930#issuecomment-2198493197 and without saving api calls.

![image](https://github.com/user-attachments/assets/b11c6255-d5ab-440d-ad7a-f1f446233d97)
