### PR TITLE
Note subscriptions

### DIFF
--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -9,6 +9,7 @@ class ApiCapability
 
       if user&.active?
         can [:create, :comment, :close, :reopen], Note if scope?(token, :write_notes)
+        can :create, NoteSubscription if scope?(token, :write_notes)
         can [:show, :data], Trace if scope?(token, :read_gpx)
         can [:create, :update, :destroy], Trace if scope?(token, :write_gpx)
         can [:details], User if scope?(token, :read_prefs)

--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -9,7 +9,7 @@ class ApiCapability
 
       if user&.active?
         can [:create, :comment, :close, :reopen], Note if scope?(token, :write_notes)
-        can :create, NoteSubscription if scope?(token, :write_notes)
+        can [:create, :destroy], NoteSubscription if scope?(token, :write_notes)
         can [:show, :data], Trace if scope?(token, :read_gpx)
         can [:create, :update, :destroy], Trace if scope?(token, :write_gpx)
         can [:details], User if scope?(token, :read_prefs)

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -37,31 +37,35 @@ OSM.Note = function (map) {
   };
 
   function initialize(path, id) {
-    content.find("button[type=submit]").on("click", function (e) {
+    content.find("button[name]").on("click", function (e) {
       e.preventDefault();
       var data = $(e.target).data();
-      var form = e.target.form;
-
-      $(form).find("button[type=submit]").prop("disabled", true);
-
-      $.ajax({
+      var name = $(e.target).attr("name");
+      var ajaxSettings = {
         url: data.url,
         type: data.method,
         oauth: true,
-        data: { text: $(form.text).val() },
-        success: function () {
-          OSM.loadSidebarContent(path, function () {
+        success: () => {
+          OSM.loadSidebarContent(path, () => {
             initialize(path, id);
             moveToNote();
           });
         },
-        error: function (xhr) {
-          $(form).find("#comment-error")
+        error: updateButtons
+      };
+
+      if (name !== "subscribe" && name !== "unsubscribe") {
+        ajaxSettings.data = { text: $("textarea").val() };
+        ajaxSettings.error = (xhr) => {
+          content.find("#comment-error")
             .text(xhr.responseText)
             .prop("hidden", false);
-          updateButtons(form);
-        }
-      });
+          updateButtons();
+        };
+      }
+
+      content.find("button[name]").prop("disabled", true);
+      $.ajax(ajaxSettings);
     });
 
     content.find("textarea").on("input", function (e) {
@@ -82,14 +86,16 @@ OSM.Note = function (map) {
     }
   }
 
-  function updateButtons(form) {
-    $(form).find("button[type=submit]").prop("disabled", false);
-    if ($(form.text).val() === "") {
-      $(form.close).text($(form.close).data("defaultActionText"));
-      $(form.comment).prop("disabled", true);
+  function updateButtons() {
+    var resolveButton = content.find("button[name='close']");
+    var commentButton = content.find("button[name='comment']");
+
+    content.find("button[name]").prop("disabled", false);
+    if (content.find("textarea").val() === "") {
+      resolveButton.text(resolveButton.data("defaultActionText"));
+      commentButton.prop("disabled", true);
     } else {
-      $(form.close).text($(form.close).data("commentActionText"));
-      $(form.comment).prop("disabled", false);
+      resolveButton.text(resolveButton.data("commentActionText"));
     }
   }
 

--- a/app/controllers/api/note_subscriptions_controller.rb
+++ b/app/controllers/api/note_subscriptions_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  class NoteSubscriptionsController < ApiController
+    before_action :check_api_writable
+    before_action :authorize
+
+    authorize_resource
+
+    def create
+      note_id = params[:note_id].to_i
+      note = Note.find(note_id)
+      note.subscribers << current_user
+    rescue ActiveRecord::RecordNotUnique
+      head :conflict
+    end
+  end
+end

--- a/app/controllers/api/note_subscriptions_controller.rb
+++ b/app/controllers/api/note_subscriptions_controller.rb
@@ -12,5 +12,11 @@ module Api
     rescue ActiveRecord::RecordNotUnique
       head :conflict
     end
+
+    def destroy
+      note_id = params[:note_id].to_i
+      count = NoteSubscription.where(:user => current_user, :note => note_id).delete_all
+      head :not_found if count.zero?
+    end
   end
 end

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -28,6 +28,32 @@
     <p class='alert alert-warning'><%= t ".anonymous_warning" %></p>
   <% end -%>
 
+  <div class="row">
+    <div class="col">
+      <h4><%= t(".discussion") %></h4>
+    </div>
+
+    <% if current_user %>
+      <div class="col-auto">
+        <% if @note.subscribers.exists?(current_user.id) %>
+          <%= tag.button t(".unsubscribe"),
+                         :type => "button",
+                         :class => "btn btn-sm btn-primary",
+                         :name => "unsubscribe",
+                         :data => { :method => "DELETE",
+                                    :url => api_note_subscription_path(@note) } %>
+        <% else %>
+          <%= tag.button t(".subscribe"),
+                         :type => "button",
+                         :class => "btn btn-sm btn-primary",
+                         :name => "subscribe",
+                         :data => { :method => "POST",
+                                    :url => api_note_subscription_path(@note) } %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
   <% if @note_comments.length > 1 %>
     <div class='note-comments'>
       <ul class="list-unstyled">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2984,6 +2984,9 @@ en:
       report: report this note
       coordinates_html: "%{latitude}, %{longitude}"
       anonymous_warning: This note includes comments from anonymous users which should be independently verified.
+      discussion: Discussion
+      subscribe: Subscribe
+      unsubscribe: Unsubscribe
       hide: Hide
       resolve: Resolve
       reactivate: Reactivate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,8 @@ OpenStreetMap::Application.routes.draw do
         post "close"
         post "reopen"
       end
+
+      resource :subscription, :only => :create, :controller => "note_subscriptions"
     end
 
     resources :user_blocks, :only => :show, :id => /\d+/, :controller => "user_blocks"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,7 @@ OpenStreetMap::Application.routes.draw do
         post "reopen"
       end
 
-      resource :subscription, :only => :create, :controller => "note_subscriptions"
+      resource :subscription, :only => [:create, :destroy], :controller => "note_subscriptions"
     end
 
     resources :user_blocks, :only => :show, :id => /\d+/, :controller => "user_blocks"

--- a/test/controllers/api/note_subscriptions_controller_test.rb
+++ b/test/controllers/api/note_subscriptions_controller_test.rb
@@ -7,6 +7,10 @@ module Api
         { :path => "/api/0.6/notes/1/subscription", :method => :post },
         { :controller => "api/note_subscriptions", :action => "create", :note_id => "1" }
       )
+      assert_routing(
+        { :path => "/api/0.6/notes/1/subscription", :method => :delete },
+        { :controller => "api/note_subscriptions", :action => "destroy", :note_id => "1" }
+      )
     end
 
     def test_create
@@ -21,7 +25,6 @@ module Api
           assert_response :success
         end
       end
-      assert_response :success
       assert_equal user, note.subscribers.last
     end
 
@@ -71,6 +74,59 @@ module Api
           assert_response :conflict
         end
       end
+    end
+
+    def test_destroy
+      user = create(:user)
+      auth_header = bearer_authorization_header user
+      note = create(:note_with_comments)
+      create(:note_subscription, :user => user, :note => note)
+      assert_equal [user], note.subscribers
+
+      assert_difference "NoteSubscription.count", -1 do
+        assert_difference "note.subscribers.count", -1 do
+          delete api_note_subscription_path(note), :headers => auth_header
+          assert_response :success
+        end
+      end
+    end
+
+    def test_destroy_fail_anonymous
+      note = create(:note_with_comments)
+
+      delete api_note_subscription_path(note)
+      assert_response :unauthorized
+    end
+
+    def test_destroy_fail_no_scope
+      user = create(:user)
+      auth_header = bearer_authorization_header user, :scopes => %w[read_prefs]
+      note = create(:note_with_comments)
+      create(:note_subscription, :user => user, :note => note)
+
+      assert_no_difference "NoteSubscription.count" do
+        assert_no_difference "note.subscribers.count" do
+          delete api_note_subscription_path(note), :headers => auth_header
+          assert_response :forbidden
+        end
+      end
+    end
+
+    def test_destroy_fail_note_not_found
+      user = create(:user)
+      auth_header = bearer_authorization_header user
+
+      delete api_note_subscription_path(999111), :headers => auth_header
+      assert_response :not_found
+    end
+
+    def test_destroy_fail_not_subscribed
+      user = create(:user)
+      auth_header = bearer_authorization_header user
+      note = create(:note_with_comments)
+
+      delete api_note_subscription_path(note), :headers => auth_header
+      assert_response :not_found
     end
   end
 end

--- a/test/controllers/api/note_subscriptions_controller_test.rb
+++ b/test/controllers/api/note_subscriptions_controller_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+module Api
+  class NoteSubscriptionsControllerTest < ActionDispatch::IntegrationTest
+    def test_routes
+      assert_routing(
+        { :path => "/api/0.6/notes/1/subscription", :method => :post },
+        { :controller => "api/note_subscriptions", :action => "create", :note_id => "1" }
+      )
+    end
+
+    def test_create
+      user = create(:user)
+      auth_header = bearer_authorization_header user
+      note = create(:note_with_comments)
+      assert_empty note.subscribers
+
+      assert_difference "NoteSubscription.count", 1 do
+        assert_difference "note.subscribers.count", 1 do
+          post api_note_subscription_path(note), :headers => auth_header
+          assert_response :success
+        end
+      end
+      assert_response :success
+      assert_equal user, note.subscribers.last
+    end
+
+    def test_create_fail_anonymous
+      note = create(:note_with_comments)
+
+      assert_no_difference "NoteSubscription.count" do
+        assert_no_difference "note.subscribers.count" do
+          post api_note_subscription_path(note)
+          assert_response :unauthorized
+        end
+      end
+    end
+
+    def test_create_fail_no_scope
+      user = create(:user)
+      auth_header = bearer_authorization_header user, :scopes => %w[read_prefs]
+      note = create(:note_with_comments)
+
+      assert_no_difference "NoteSubscription.count" do
+        assert_no_difference "note.subscribers.count" do
+          post api_note_subscription_path(note), :headers => auth_header
+          assert_response :forbidden
+        end
+      end
+    end
+
+    def test_create_fail_note_not_found
+      user = create(:user)
+      auth_header = bearer_authorization_header user
+
+      assert_no_difference "NoteSubscription.count" do
+        post api_note_subscription_path(999111), :headers => auth_header
+        assert_response :not_found
+      end
+    end
+
+    def test_create_fail_already_subscribed
+      user = create(:user)
+      auth_header = bearer_authorization_header user
+      note = create(:note_with_comments)
+      create(:note_subscription, :user => user, :note => note)
+
+      assert_no_difference "NoteSubscription.count" do
+        assert_no_difference "note.subscribers.count" do
+          post api_note_subscription_path(note), :headers => auth_header
+          assert_response :conflict
+        end
+      end
+    end
+  end
+end

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -22,7 +22,7 @@ class NoteCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  def test_add_comment
+  test "can add comment" do
     note = create(:note_with_comments)
     user = create(:user)
     sign_in_as(user)
@@ -123,6 +123,51 @@ class NoteCommentsTest < ApplicationSystemTestCase
       assert_text "Resolved note"
       assert_text "Your access to the API has been blocked"
       assert_button "Reactivate", :disabled => false
+    end
+  end
+
+  test "no subscribe button when not logged in" do
+    note = create(:note_with_comments)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_no_button "Subscribe"
+      assert_no_button "Unsubscribe"
+    end
+  end
+
+  test "can subscribe" do
+    note = create(:note_with_comments)
+    user = create(:user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_button "Subscribe"
+      assert_no_button "Unsubscribe"
+
+      click_on "Subscribe"
+
+      assert_no_button "Subscribe"
+      assert_button "Unsubscribe"
+    end
+  end
+
+  test "can unsubscribe" do
+    note = create(:note_with_comments)
+    user = create(:user)
+    create(:note_subscription, :note => note, :user => user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_no_button "Subscribe"
+      assert_button "Unsubscribe"
+
+      click_on "Unsubscribe"
+
+      assert_button "Subscribe"
+      assert_no_button "Unsubscribe"
     end
   end
 end


### PR DESCRIPTION
Adds a subscription functionality to notes, similar to changesets and diary entry subscriptions.

Without this it's impossible to unsubscribe from notes you may not care about. If you did any mass note manipulation in some area, chances are someone else will start altering these notes later. In this case you'll receive waves of emails and there's no way to stop them.

See also https://osmfoundation.org/wiki/Operations/Minutes/2024-05-02#Discussion_on_spam_reports_via_ISP. "Encourage Microsoft to work on maintaining separate subscriptions for notes, as there was some work already done by them on refactoring the way notes are presented and they are interested in improving the notes." - I'm not sure what work on notes was done by Microsoft at that time.

---

Needs to be merged in at least two parts because backfilling. Backfilling is done in a migration here which may not be the best idea. We already did data migrations like that but they were simpler.

![image](https://github.com/user-attachments/assets/b7d1a726-82b3-43c2-b447-250a7a64c459)
