### PR TITLE
Note subscriptions db table

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -401,6 +401,8 @@ module Api
       note.comments.map(&:author).uniq.each do |user|
         UserMailer.note_comment_notification(comment, user).deliver_later if notify && user && user != current_user && user.visible?
       end
+
+      NoteSubscription.find_or_create_by(:note => note, :user => current_user) if current_user
     end
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -23,6 +23,8 @@ class Note < ApplicationRecord
 
   has_many :comments, -> { left_joins(:author).where(:visible => true, :users => { :status => [nil, "active", "confirmed"] }).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id
   has_many :all_comments, -> { left_joins(:author).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id, :inverse_of => :note
+  has_many :subscriptions, :class_name => "NoteSubscription"
+  has_many :subscribers, :through => :subscriptions, :source => :user
 
   validates :id, :uniqueness => true, :presence => { :on => :update },
                  :numericality => { :on => :update, :only_integer => true }

--- a/app/models/note_subscription.rb
+++ b/app/models/note_subscription.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: note_subscriptions
+#
+#  user_id :bigint(8)        not null, primary key
+#  note_id :bigint(8)        not null, primary key
+#
+# Indexes
+#
+#  index_note_subscriptions_on_note_id  (note_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class NoteSubscription < ApplicationRecord
+  belongs_to :user
+  belongs_to :note
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,8 @@ class User < ApplicationRecord
   has_and_belongs_to_many :changeset_subscriptions, :class_name => "Changeset", :join_table => "changesets_subscribers", :foreign_key => "subscriber_id"
   has_many :note_comments, :foreign_key => :author_id, :inverse_of => :author
   has_many :notes, :through => :note_comments
+  has_many :note_subscriptions, :class_name => "NoteSubscription"
+  has_many :subscribed_notes, :through => :note_subscriptions, :source => :note
 
   has_many :oauth2_applications, :class_name => Doorkeeper.config.application_model.name, :as => :owner
   has_many :access_grants, :class_name => Doorkeeper.config.access_grant_model.name, :foreign_key => :resource_owner_id

--- a/db/migrate/20241022141247_create_note_subscriptions.rb
+++ b/db/migrate/20241022141247_create_note_subscriptions.rb
@@ -1,0 +1,8 @@
+class CreateNoteSubscriptions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :note_subscriptions, :primary_key => [:user_id, :note_id] do |t|
+      t.references :user, :foreign_key => true, :index => false
+      t.references :note, :foreign_key => true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1052,6 +1052,16 @@ ALTER SEQUENCE public.note_comments_id_seq OWNED BY public.note_comments.id;
 
 
 --
+-- Name: note_subscriptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.note_subscriptions (
+    user_id bigint NOT NULL,
+    note_id bigint NOT NULL
+);
+
+
+--
 -- Name: notes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2011,6 +2021,14 @@ ALTER TABLE ONLY public.note_comments
 
 
 --
+-- Name: note_subscriptions note_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.note_subscriptions
+    ADD CONSTRAINT note_subscriptions_pkey PRIMARY KEY (user_id, note_id);
+
+
+--
 -- Name: notes notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2499,6 +2517,13 @@ CREATE INDEX index_note_comments_on_created_at ON public.note_comments USING btr
 
 
 --
+-- Name: index_note_subscriptions_on_note_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_note_subscriptions_on_note_id ON public.note_subscriptions USING btree (note_id);
+
+
+--
 -- Name: index_oauth_access_grants_on_application_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2954,6 +2979,14 @@ ALTER TABLE ONLY public.diary_entry_subscriptions
 
 
 --
+-- Name: note_subscriptions fk_rails_2c1913f293; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.note_subscriptions
+    ADD CONSTRAINT fk_rails_2c1913f293 FOREIGN KEY (note_id) REFERENCES public.notes(id);
+
+
+--
 -- Name: oauth_access_grants fk_rails_330c32d8d9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2991,6 +3024,14 @@ ALTER TABLE ONLY public.oauth_openid_requests
 
 ALTER TABLE ONLY public.active_storage_variant_records
     ADD CONSTRAINT fk_rails_993965df05 FOREIGN KEY (blob_id) REFERENCES public.active_storage_blobs(id);
+
+
+--
+-- Name: note_subscriptions fk_rails_a352f4eced; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.note_subscriptions
+    ADD CONSTRAINT fk_rails_a352f4eced FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -3356,6 +3397,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20241022141247'),
 ('20240913171951'),
 ('20240912181413'),
 ('20240910175616'),


### PR DESCRIPTION
Part one of #5283. Creates the note subscription table and starts adding subscriptions for anyone who comments a note. These subscriptions are not yet used for anything, email notifications still go to all note commenters.