### PR TITLE
Decrease padding between close button and inputs in directions form

### DIFF
--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -37,7 +37,7 @@
   </form>
 
   <form method="GET" action="<%= directions_path %>" class="directions_form bg-body-secondary pb-2">
-    <div class="d-flex flex-row-reverse px-3 py-3"><button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button></div>
+    <div class="d-flex flex-row-reverse px-3 pt-3 pb-1"><button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button></div>
 
     <div class="d-flex flex-column mx-2 gap-1">
       <div class="d-flex gap-1 align-items-center">


### PR DESCRIPTION
That space on the top of direction forms is too wasteful.

Before/after:
![image](https://github.com/user-attachments/assets/fc1d86e6-4cb4-441a-a305-0d0a792053ef) ![image](https://github.com/user-attachments/assets/d1cbe84f-346d-4046-bace-81a430e1a35d)
