### PR TITLE
Improvements to danger workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,7 +1,5 @@
 name: Danger
 
-run-name: Updating labels for current PR
-
 on:
   pull_request_target:
     types: [opened, synchronize]

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           DANGER_GITHUB_BEARER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bundle exec danger --verbose --base=${{ github.event.pull_request.base.sha }} --head=${{ github.event.pull_request.head.sha }}
+          bundle exec danger --verbose

--- a/Dangerfile
+++ b/Dangerfile
@@ -4,9 +4,9 @@ pr_number = github.pr_json["number"]
 # Report if number of changed lines is > 500
 if git.lines_of_code > 500
   warn("Number of updated lines of code is too large to be in one PR. Perhaps it should be separated into two or more?")
-  auto_label.set(pr_number, "Big PR", "FBCA04")
+  auto_label.set(pr_number, "big-pr", "FBCA04")
 else
-  auto_label.remove("Big PR")
+  auto_label.remove("big-pr")
 end
 
 # Get list of translation files (except en.yml) which are modified
@@ -16,17 +16,17 @@ end
 
 # Report if some translation file (except en.yml) is modified
 if modified_yml_files.empty?
-  auto_label.remove("Inappropriate Translations")
+  auto_label.remove("inappropriate-translations")
 else
   modified_files_str = modified_yml_files.map { |file| "`#{file}`" }.join(", ")
   warn("The following YAML files other than `en.yml` have been modified: #{modified_files_str}. Only `en.yml` is allowed to be changed. Translations are updated via Translatewiki, see CONTRIBUTING.md.")
-  auto_label.set(pr_number, "Inappropriate Translations", "B60205")
+  auto_label.set(pr_number, "inappropriate-translations", "B60205")
 end
 
 # Report if there are merge-commits in PR
 if git.commits.any? { |c| c.parents.count > 1 }
   warn("Merge commits are found in PR. Please rebase to get rid of the merge commits in this PR, see CONTRIBUTING.md.")
-  auto_label.set(pr_number, "Merge Commits", "D93F0B")
+  auto_label.set(pr_number, "merge-commits", "D93F0B")
 else
-  auto_label.remove("Merge Commits")
+  auto_label.remove("merge-commits")
 end

--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ gem "zeitwerk", "< 2.7"
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
-  gem "danger"
+  gem "danger", :github => "tomhughes/danger", :ref => "pull-request-target"
   gem "danger-auto_label"
   gem "debug_inspector"
   gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,23 @@
+GIT
+  remote: https://github.com/tomhughes/danger.git
+  revision: a265cf74d2f464a25796b48d95697f5eed553454
+  ref: pull-request-target
+  specs:
+    danger (9.5.1)
+      base64 (~> 0.2)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (>= 0.9.0, < 3.0)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.13)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      octokit (>= 4.0)
+      pstore (~> 0.1)
+      terminal-table (>= 1, < 4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -168,20 +188,6 @@ GEM
       rexml
     crass (1.0.6)
     dalli (3.2.8)
-    danger (9.5.1)
-      base64 (~> 0.2)
-      claide (~> 1.0)
-      claide-plugins (>= 0.9.2)
-      colored2 (~> 3.1)
-      cork (~> 0.1)
-      faraday (>= 0.9.0, < 3.0)
-      faraday-http-cache (~> 2.0)
-      git (~> 1.13)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.0)
-      octokit (>= 4.0)
-      pstore (~> 0.1)
-      terminal-table (>= 1, < 4)
     danger-auto_label (1.3.1)
       danger-plugin-api (~> 1.0)
     danger-plugin-api (1.0.0)
@@ -681,7 +687,7 @@ DEPENDENCIES
   config
   connection_pool
   dalli
-  danger
+  danger!
   danger-auto_label
   dartsass-sprockets
   debug


### PR DESCRIPTION
This gets the danger workflow working by switching to my fixed version (current open upstream as https://github.com/danger/danger/pull/1501) and also tweaks a few other things:

* Renames the workflow to reflect that this is not just about labelling
* Drops the `run-name` so that he runs will be names after the PR instead of all having the same name
* Adjusts the label names to be consistent with our other labels.