### PR TITLE
Add articles before "exit" and "roundabout"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3147,16 +3147,16 @@ en:
         slight_left_without_exit: Slight left onto %{name}
         via_point_without_exit: (via point)
         follow_without_exit: Follow %{name}
-        roundabout_without_exit: At roundabout take exit onto %{name}
-        leave_roundabout_without_exit: Leave roundabout - %{name}
-        stay_roundabout_without_exit: Stay on roundabout - %{name}
+        roundabout_without_exit: At the roundabout take the exit onto %{name}
+        leave_roundabout_without_exit: Leave the roundabout - %{name}
+        stay_roundabout_without_exit: Stay on the roundabout - %{name}
         start_without_exit: Start on %{name}
         destination_without_exit: Reach destination
         against_oneway_without_exit: Go against one-way on %{name}
         end_oneway_without_exit: End of one-way on %{name}
-        roundabout_with_exit: At roundabout take exit %{exit} onto %{name}
-        roundabout_with_exit_ordinal: At roundabout take %{exit} exit onto %{name}
-        exit_roundabout: Exit roundabout onto %{name}
+        roundabout_with_exit: At the roundabout take the exit %{exit} onto %{name}
+        roundabout_with_exit_ordinal: At the roundabout take the %{exit} exit onto %{name}
+        exit_roundabout: Exit the roundabout onto %{name}
         unnamed: "unnamed road"
         courtesy: "Directions courtesy of %{link}"
         exit_counts:


### PR DESCRIPTION
There are articles before "ramp" everywhere,
and it sounds more correct with articles
before "exit" and "roundabout", too.