### PR TITLE
Create base and head branches before running danger

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -22,6 +22,12 @@ jobs:
           ruby-version: 3.1
           rubygems: 3.4.10
           bundler-cache: true
+      - name: Create base branch
+        run: |
+          git fetch ${{ github.event.pull_request.base.repo.clone_url }} ${{ github.event.pull_request.base.ref }}:danger_base
+      - name: Create head branch
+        run: |
+          git fetch ${{ github.event.pull_request.head.repo.clone_url }} ${{ github.event.pull_request.head.ref }}:danger_head
       - name: Danger
         env:
           DANGER_GITHUB_BEARER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ gem "zeitwerk", "< 2.7"
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
-  gem "danger", :github => "tomhughes/danger", :ref => "pull-request-target"
+  gem "danger"
   gem "danger-auto_label"
   gem "debug_inspector"
   gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,3 @@
-GIT
-  remote: https://github.com/tomhughes/danger.git
-  revision: a265cf74d2f464a25796b48d95697f5eed553454
-  ref: pull-request-target
-  specs:
-    danger (9.5.1)
-      base64 (~> 0.2)
-      claide (~> 1.0)
-      claide-plugins (>= 0.9.2)
-      colored2 (~> 3.1)
-      cork (~> 0.1)
-      faraday (>= 0.9.0, < 3.0)
-      faraday-http-cache (~> 2.0)
-      git (~> 1.13)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.0)
-      octokit (>= 4.0)
-      pstore (~> 0.1)
-      terminal-table (>= 1, < 4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -188,6 +168,20 @@ GEM
       rexml
     crass (1.0.6)
     dalli (3.2.8)
+    danger (9.5.1)
+      base64 (~> 0.2)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (>= 0.9.0, < 3.0)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.13)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      octokit (>= 4.0)
+      pstore (~> 0.1)
+      terminal-table (>= 1, < 4)
     danger-auto_label (1.3.1)
       danger-plugin-api (~> 1.0)
     danger-plugin-api (1.0.0)
@@ -688,7 +682,7 @@ DEPENDENCIES
   config
   connection_pool
   dalli
-  danger!
+  danger
   danger-auto_label
   dartsass-sprockets
   debug


### PR DESCRIPTION
Let's have another go at getting danger working shall we...

This avoids the need to path danger, and resolves the problems with not fetching enough history for PRs with many commits, by prefetching the data and creating local `danger_base` and `danger_head` branches which are the default names that danger looks for.