### PR TITLE
Add status filter to user's note page

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -18,12 +18,13 @@ class NotesController < ApplicationController
   def index
     param! :page, Integer, :min => 1
 
-    @params = params.permit(:display_name)
+    @params = params.permit(:display_name, :status)
     @title = t ".title", :user => @user.display_name
     @page = (params[:page] || 1).to_i
     @page_size = 10
     @notes = @user.notes
     @notes = @notes.visible unless current_user&.moderator?
+    @notes = @notes.where(:status => params[:status]) unless params[:status] == "all" || params[:status].blank?
     @notes = @notes.order("updated_at DESC, id").distinct.offset((@page - 1) * @page_size).limit(@page_size).preload(:comments => :author)
 
     render :layout => "site"

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -6,6 +6,20 @@
            :commented => tag.span(t(".subheading_commented"), :class => "px-2 py-1 bg-body") %></p>
 <% end %>
 
+<%= form_with :url => user_notes_path(@user), :method => :get, :data => { :turbo => true } do %>
+  <div class="row gx-2 align-items-end">
+    <div class="col-sm-auto mb-3">
+      <%= label_tag :status, t(".status") %>
+      <%= select_tag :status,
+                     options_for_select([[t(".all"), "all"], [t(".open"), "open"], [t(".closed"), "closed"]], params[:status] || "all"),
+                     :class => "form-select" %>
+    </div>
+    <div class="col-sm-auto mb-3">
+      <%= submit_tag t(".apply"), :name => nil, :class => "btn btn-primary" %>
+    </div>
+  </div>
+<% end %>
+
 <% if @notes.empty? %>
   <h4><%= t ".no_notes" %></h4>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2966,6 +2966,11 @@ en:
       description: "Description"
       created_at: "Created at"
       last_changed: "Last changed"
+      apply: "Apply"
+      all: "All"
+      open: "Open"
+      closed: "Closed"
+      status: "Status"
     show:
       title: "Note: %{id}"
       description: "Description"

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -184,4 +184,38 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_template "notes/new"
     assert_select "#sidebar_content a[href='#{login_path(:referer => new_note_path)}']", :count => 0
   end
+
+  def test_index_filter_by_status
+    user = create(:user)
+    other_user = create(:user)
+
+    open_note = create(:note, :status => "open")
+    create(:note_comment, :note => open_note, :author => user)
+
+    closed_note = create(:note, :status => "closed")
+    create(:note_comment, :note => closed_note, :author => user)
+
+    hidden_note = create(:note, :status => "hidden")
+    create(:note_comment, :note => hidden_note, :author => user)
+
+    commented_note = create(:note, :status => "open")
+    create(:note_comment, :note => commented_note, :author => other_user)
+    create(:note_comment, :note => commented_note, :author => user)
+
+    get user_notes_path(user, :status => "all")
+    assert_response :success
+    assert_select "table.note_list tbody tr", :count => 3
+
+    get user_notes_path(user, :status => "open")
+    assert_response :success
+    assert_select "table.note_list tbody tr", :count => 2
+
+    get user_notes_path(user, :status => "closed")
+    assert_response :success
+    assert_select "table.note_list tbody tr", :count => 1
+
+    get user_notes_path(user)
+    assert_response :success
+    assert_select "table.note_list tbody tr", :count => 3
+  end
 end


### PR DESCRIPTION
### Description
This PR partly addresses #832 and serves as a smaller alternative to #5255 as suggested in comments. It aims to enhance user experience on user note pages by providing filtering functionality for notes by status. The `with_status` scope is added to the `Note` model, and the `NotesController` is updated accordingly. Default behavior remains unchanged since the status preselected value is set to `All` by default.

### How has this been tested?
Test for the new scope is added to note model test to ensure functionality is working as expected.

### Screenshots
<img width="1142" alt="Screenshot 2024-10-30 at 22 07 56" src="https://github.com/user-attachments/assets/cf15a288-91c3-40fe-b2f1-690fab42b248">
<img width="1144" alt="Screenshot 2024-10-30 at 22 07 46" src="https://github.com/user-attachments/assets/8145173f-8c3d-417d-a708-94d25f952e6a">
