### PR TITLE
Added new Danger rule for catching outdated Gemfile.lock

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -30,3 +30,13 @@ if git.commits.any? { |c| c.parents.count > 1 }
 else
   auto_label.remove("merge-commits")
 end
+
+# Check if Gemfile is modified but Gemfile.lock is not
+gemfile_modified = git.modified_files.include?("Gemfile")
+gemfile_lock_modified = git.modified_files.include?("Gemfile.lock")
+if gemfile_modified && !gemfile_lock_modified
+  warn("Gemfile was updated, but Gemfile.lock wasn't updated. Usually, when Gemfile is updated, you should run `bundle install` to update Gemfile.lock.")
+  auto_label.set(pr_number, "gemfile-lock-outdated", "F9D0C4")
+else
+  auto_label.remove("gemfile-lock-outdated")
+end


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->

Updated the Dangerfile by adding a new rule that checks if the Gemfile is updated while the Gemfile.lock is not, and if so, generates the "gemfile-lock-outdated" PR label.

![image](https://github.com/user-attachments/assets/5a54fb88-ddf5-4570-8272-de40baa1d1a0)

Created upon the [suggestion](https://github.com/openstreetmap/openstreetmap-website/pull/5295#issuecomment-2447849335).

### How has this been tested?
<!--Explain the steps you took to test your code.-->

Tested by running RuboCop locally and by committing changes to my personal fork before creating a problematic PR.