### PR TITLE
Add profile location

### DIFF
--- a/app/assets/javascripts/home_location_name-endpoint.js
+++ b/app/assets/javascripts/home_location_name-endpoint.js
@@ -1,0 +1,65 @@
+OSM.HomeLocationNameGeocoder = function Endpoint(latInput, lonInput, locationNameInput) {
+  const endpoint = {
+    autofill: true,
+    countryName: locationNameInput.val().trim()
+  };
+
+  let requestController = null;
+
+  endpoint.updateHomeLocationName = function (
+    updateInput = true,
+    lat = latInput.val().trim(),
+    lon = lonInput.val().trim(),
+    successFn
+  ) {
+    if (!lat || !lon || !endpoint.autofill) {
+      return;
+    }
+
+    const geocodeUrl = "/search/nominatim_reverse_query",
+          csrf_param = $("meta[name=csrf-param]").attr("content"),
+          csrf_token = $("meta[name=csrf-token]").attr("content"),
+          params = new URLSearchParams({
+            lat,
+            lon,
+            zoom: 3
+          });
+    params.set(csrf_param, csrf_token);
+
+    if (requestController) {
+      requestController.abort();
+    }
+    const currentRequestController = new AbortController();
+    requestController = currentRequestController;
+
+    fetch(geocodeUrl, {
+      method: "POST",
+      body: params,
+      signal: requestController.signal,
+      headers: { accept: "application/json" }
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        const country = data.length ? data[0].name : "";
+
+        if (updateInput) {
+          $("#home_location_name").val(country);
+        } else if (endpoint.countryName !== country) {
+          endpoint.autofill = false;
+        }
+        endpoint.countryName = country;
+        requestController = null;
+
+        if (successFn) {
+          successFn();
+        }
+      })
+      .catch(() => {
+        if (currentRequestController === requestController) {
+          requestController = null;
+        }
+      });
+  };
+
+  return endpoint;
+};

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -31,6 +31,7 @@ class ProfilesController < ApplicationController
 
     current_user.home_lat = params[:user][:home_lat]
     current_user.home_lon = params[:user][:home_lon]
+    current_user.home_location_name = params[:user][:home_location_name]
 
     if current_user.save
       flash[:notice] = t ".success"

--- a/app/controllers/searches/nominatim_reverse_queries_controller.rb
+++ b/app/controllers/searches/nominatim_reverse_queries_controller.rb
@@ -24,6 +24,11 @@ module Searches
                       :zoom => zoom,
                       :name => description,
                       :type => object_type, :id => object_id)
+
+        respond_to do |format|
+          format.html
+          format.json { render :json => @results }
+        end
       end
     rescue StandardError => e
       host = URI(Settings.nominatim_url).host

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@
 #  home_lat             :float
 #  home_lon             :float
 #  home_zoom            :integer          default(3)
+#  home_location_name   :string
 #  pass_salt            :string
 #  email_valid          :boolean          default(FALSE), not null
 #  new_email            :string

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -52,6 +52,7 @@
         <button type="button" id="home_undelete" class="btn btn-outline-primary" hidden><%= t ".undelete" %></button>
       </div>
     </div>
+    <%= f.text_field :home_location_name, :wrapper_class => "my-2 col-sm-4 pe-3", :class => "mt-auto", :id => "home_location_name" %>
     <div class="form-check">
       <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.home_location? %> checked <% end %> id="updatehome" />
       <label class="form-check-label" for="updatehome"><%= t ".update home location on click" %></label>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -143,6 +143,16 @@
       <div class='text-body-secondary'>
         <small>
           <dl class="list-inline">
+            <% if @user.home_location_name&.strip.present? %>
+              <dt class="list-inline-item m-0 align-text-bottom">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-geo-alt-fill" viewBox="0 0 16 16">
+                  <path d="M8 16s6-5.686 6-10A6 6 0 0 0 2 6c0 4.314 6 10 6 10m0-7a3 3 0 1 1 0-6 3 3 0 0 1 0 6">
+                    <title><%= t ".home location" %></title>
+                  </path>
+                </svg>
+              </dt>
+              <dd class="list-inline-item"><%= @user.home_location_name %></dd>
+            <% end %>
             <dt class="list-inline-item m-0"><%= t ".mapper since" %></dt>
             <dd class="list-inline-item"><%= l @user.created_at.to_date, :format => :long %></dd>
             <dt class="list-inline-item m-0"><%= t ".last map edit" %></dt>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2891,6 +2891,7 @@ en:
       follow: Follow
       mapper since: "Mapper since:"
       last map edit: "Last map edit:"
+      home location: "Home location"
       no activity yet: "No activity yet"
       uid: "User id:"
       ct status: "Contributor terms:"

--- a/db/migrate/20241030090336_add_user_location_name.rb
+++ b/db/migrate/20241030090336_add_user_location_name.rb
@@ -1,0 +1,5 @@
+class AddUserLocationName < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :home_location_name, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1519,7 +1519,8 @@ CREATE TABLE public.users (
     tou_agreed timestamp without time zone,
     diary_comments_count integer DEFAULT 0,
     note_comments_count integer DEFAULT 0,
-    creation_address inet
+    creation_address inet,
+    home_location_name character varying
 );
 
 
@@ -3457,6 +3458,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250121191749'),
 ('20250105154621'),
 ('20250104140952'),
+('20241030090336'),
 ('20241023004427'),
 ('20241022141247'),
 ('20240913171951'),

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -311,6 +311,21 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     search_check "foo bar baz", %w[nominatim]
   end
 
+  ##
+  # Test the nominatim reverse JSON search
+  def test_search_osm_nominatim_reverse_json
+    with_http_stubs "nominatim" do
+      post search_nominatim_reverse_query_path(:lat => 51.7632, :lon => -0.0076, :zoom => 15, :format => "json"), :xhr => true
+      result_name_check_json("Broxbourne, Hertfordshire, East of England, England, United Kingdom")
+
+      post search_nominatim_reverse_query_path(:lat => 51.7632, :lon => -0.0076, :zoom => 17, :format => "json"), :xhr => true
+      result_name_check_json("Dinant Link Road, Broxbourne, Hertfordshire, East of England, England, EN11 8HX, United Kingdom")
+
+      post search_nominatim_reverse_query_path(:lat => 13.7709, :lon => 100.50507, :zoom => 19, :format => "json"), :xhr => true
+      result_name_check_json("MM Steak&Grill, ถนนศรีอยุธยา, บางขุนพรหม, กรุงเทพมหานคร, เขตดุสิต, กรุงเทพมหานคร, 10300, ประเทศไทย")
+    end
+  end
+
   private
 
   def latlon_check(query, lat, lon)
@@ -349,5 +364,12 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_template :show
     assert_template :layout => "xhr"
     assert_equal sources, assigns(:sources).pluck(:name)
+  end
+
+  def result_name_check_json(name)
+    assert_response :success
+    js = ActiveSupport::JSON.decode(@response.body)
+    assert_not_nil js
+    assert_equal name, js[0]["name"]
   end
 end

--- a/test/system/user_location_change_test.rb
+++ b/test/system/user_location_change_test.rb
@@ -1,0 +1,22 @@
+require "application_system_test_case"
+
+class UserLocationChangeTest < ApplicationSystemTestCase
+  def setup
+    stub_request(:get, /.*gravatar.com.*d=404/).to_return(:status => 404)
+  end
+
+  test "User can change their location" do
+    user = create(:user)
+    sign_in_as(user)
+
+    visit user_path(user)
+    assert_no_selector ".bi.bi-geo-alt-fill"
+
+    visit edit_profile_path
+    fill_in "Home location name", :with => "Test Location"
+    click_on "Update Profile"
+
+    visit user_path(user)
+    assert_text "Test Location"
+  end
+end


### PR DESCRIPTION
PR adds location name info on the user profile page. Location name can be changed from "Edit Profile" page either by manual typing or auto-filling according to the home location.

One column was added to the user table to save user's location.
JS logics are responsible for handling:
1) Delete-Undelete buttons interactions
2) Nominatim calls to locate home locations country name
3) Warning logic of the location name

![image](https://github.com/user-attachments/assets/85450fbb-6072-4515-b37f-8d58380c61e9)
![image](https://github.com/user-attachments/assets/807a597e-613e-4ef3-b6c7-b0c65def1497)
![image](https://github.com/user-attachments/assets/f01f4c87-6680-4b1b-96c4-cbef4d2262c0)