### PR TITLE
Make the "remember me" option work as intended

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    session[:remember_me] ||= params[:remember_me]
+    session[:remember_me] = params[:remember_me] == "yes"
 
     referer = safe_referer(params[:referer]) if params[:referer]
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -40,7 +40,7 @@
   <%= f.password_field :password, :autocomplete => "on", :tabindex => 2, :value => "", :skip_label => true %>
 
   <%= f.form_group do %>
-    <%= f.check_box :remember_me, { :label => t(".remember"), :tabindex => 3, :checked => (params[:remember_me] == "yes") }, "yes" %>
+    <%= f.check_box :remember_me, { :label => t(".remember"), :tabindex => 3, :checked => (params[:remember_me] == "true") }, "yes" %>
   <% end %>
 
   <div class="mb-3">

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -54,6 +54,24 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
+  def test_login_remembered
+    user = create(:user)
+
+    post login_path, :params => { :username => user.display_name, :password => "test", :remember_me => "yes" }
+    assert_redirected_to root_path
+
+    assert_equal 28 * 86400, session[:_remember_for]
+  end
+
+  def test_login_not_remembered
+    user = create(:user)
+
+    post login_path, :params => { :username => user.display_name, :password => "test", :remember_me => "0" }
+    assert_redirected_to root_path
+
+    assert_nil session[:_remember_for]
+  end
+
   def test_logout_without_referer
     post logout_path
     assert_redirected_to root_path


### PR DESCRIPTION
The "remember me" checkbox has not been working properly, or rather it has been treated as checked even when it isn't.

The reason is the "Gotcha" details in the [check_box documentation](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-check_box) which means that the parameter has the value `"0"` when unticked.