### PR TITLE
Replace query marker fade animation with css

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -289,18 +289,10 @@ OSM.Query = function (map) {
       .hide();
 
     if (marker) map.removeLayer(marker);
-    marker = L.circle(latlng, radius, featureStyle).addTo(map);
-
-    $(document).everyTime(75, "fadeQueryMarker", function (i) {
-      if (i === 10) {
-        map.removeLayer(marker);
-      } else {
-        marker.setStyle({
-          opacity: 1 - (i * 0.1),
-          fillOpacity: 0.5 - (i * 0.05)
-        });
-      }
-    }, 10);
+    marker = L.circle(latlng, Object.assign({
+      radius: radius,
+      className: "query-marker"
+    }, featureStyle)).addTo(map);
 
     runQuery(latlng, radius, nearby, $("#query-nearby"), false);
     runQuery(latlng, radius, isin, $("#query-isin"), true, compareSize);

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -368,6 +368,14 @@ body.small-nav {
     .leaflet-marker-draggable {
       cursor: move;
     }
+
+    .query-marker {
+      animation: 1500ms forwards query-marker-fade;
+
+      @keyframes query-marker-fade {
+        to { opacity: 0 }
+      }
+    }
   }
 
   #map-ui {


### PR DESCRIPTION
Fixes #5305.

Currently query markers are animated using javascript which requires managing timed events. We don't do it correctly, we don't cancel them when markers are removed. That's why #5305 happens.

This PR replaces the javascript animation with the css which doesn't require any event handlers. I could have added animation end events to remove the marker layer but once faded out it doesn't affect anything and it's cleaned up in `page.unload`.