### PR TITLE
Send notifications to note subscribers instead of commenters

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -398,8 +398,10 @@ module Api
 
       comment = note.comments.create!(attributes)
 
-      note.comments.map(&:author).uniq.each do |user|
-        UserMailer.note_comment_notification(comment, user).deliver_later if notify && user && user != current_user && user.visible?
+      if notify
+        note.subscribers.visible.each do |user|
+          UserMailer.note_comment_notification(comment, user).deliver_later if current_user != user
+        end
       end
 
       NoteSubscription.find_or_create_by(:note => note, :user => current_user) if current_user

--- a/test/factories/note_subscriptions.rb
+++ b/test/factories/note_subscriptions.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :note_subscription
+end


### PR DESCRIPTION
Part 3 of #5283. Start using the subscriptions table to send notifications.