### PR TITLE
Restore loading spinner in richtext previews

### DIFF
--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -6,8 +6,10 @@
    */
   $(document).on("change", ".richtext_container textarea", function () {
     var container = $(this).closest(".richtext_container");
+    var preview = container.find(".tab-pane[id$='_preview']");
 
-    container.find(".tab-pane[id$='_preview']").empty();
+    preview.children(".richtext_placeholder").attr("hidden", true);
+    preview.children(".richtext").empty();
   });
 
   /*
@@ -31,14 +33,14 @@
     var editor = container.find("textarea");
     var preview = container.find(".tab-pane[id$='_preview']");
 
-    if (preview.contents().length === 0) {
-      preview.oneTime(500, "loading", function () {
-        preview.addClass("loading");
+    if (preview.children(".richtext").contents().length === 0) {
+      preview.oneTime(200, "loading", function () {
+        preview.children(".richtext_placeholder").removeAttr("hidden");
       });
 
-      preview.load(editor.data("previewUrl"), { text: editor.val() }, function () {
+      preview.children(".richtext").load(editor.data("previewUrl"), { text: editor.val() }, function () {
         preview.stopTime("loading");
-        preview.removeClass("loading");
+        preview.children(".richtext_placeholder").attr("hidden", true);
       });
     }
   });

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -15,7 +15,14 @@
       <div id="<%= id %>_edit" class="tab-pane show active">
         <%= builder.text_area(attribute, options.merge(:wrapper => false, "data-preview-url" => preview_url(:type => type))) %>
       </div>
-      <div id="<%= id %>_preview" class="tab-pane richtext text-break"></div>
+      <div id="<%= id %>_preview" class="tab-pane">
+        <div class="richtext_placeholder text-center py-5" hidden>
+          <div class="spinner-border" role="status">
+            <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
+          </div>
+        </div>
+        <div class="richtext text-break"></div>
+      </div>
       <div id="<%= id %>_help" class="tab-pane">
         <div class="card bg-body-tertiary h-100">
           <div class="card-body">


### PR DESCRIPTION
Richtext preview loading animation was added in https://github.com/openstreetmap/openstreetmap-website/commit/eb789dbf757e760e8348e0aa75343eb53996b7e3 but later probably got broken. Its `loading` css class was removed in https://github.com/openstreetmap/openstreetmap-website/commit/df1ec6b6809b533829fc2c171699540bbb92a85b but javascript still adds/removes it to no effect.

This PR adds a Bootstrap spinner to the preview pane.

![image](https://github.com/user-attachments/assets/41f925ce-66b3-4149-abcc-5033e26ecb0b)
