### PR TITLE
Don't update deactivates_at if block was already viewed

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -29,7 +29,7 @@ class UserBlocksController < ApplicationController
   end
 
   def show
-    if current_user && current_user == @user_block.user
+    if current_user && current_user == @user_block.user && !@user_block.deactivates_at
       @user_block.needs_view = false
       @user_block.deactivates_at = [@user_block.ends_at, Time.now.utc].max
       @user_block.save!


### PR DESCRIPTION
When a blocked user visits their block page, its deactivation time is recorded. Problem is this only needs to happen if there's no deactivation time set. If it's already set, it should be kept at what it is.

The possible bug is that if the user visits their block page after the block is lifted, that visit time gets into `deactivates_at` and is reported as the block end time despite the block ending earlier.