### PR TITLE
Use CSS animations to show delayed loading spinner

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -25,8 +25,6 @@
 //= require qs/dist/qs
 
 $(document).ready(function () {
-  var loaderTimeout;
-
   var map = new L.OSM.Map("map", {
     zoomControl: false,
     layerControl: false,
@@ -39,11 +37,7 @@ $(document).ready(function () {
 
     map.setSidebarOverlaid(false);
 
-    clearTimeout(loaderTimeout);
-
-    loaderTimeout = setTimeout(function () {
-      $("#sidebar_loader").show();
-    }, 200);
+    $("#sidebar_loader").show().addClass("delayed-fade-in");
 
     // IE<10 doesn't respect Vary: X-Requested-With header, so
     // prevent caching the XHR response as a full-page URL.
@@ -60,9 +54,8 @@ $(document).ready(function () {
       url: content_path,
       dataType: "html",
       complete: function (xhr) {
-        clearTimeout(loaderTimeout);
         $("#flash").empty();
-        $("#sidebar_loader").hide();
+        $("#sidebar_loader").removeClass("delayed-fade-in").hide();
 
         var content = $(xhr.responseText);
 

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -8,7 +8,7 @@
     var container = $(this).closest(".richtext_container");
     var preview = container.find(".tab-pane[id$='_preview']");
 
-    preview.children(".richtext_placeholder").attr("hidden", true);
+    preview.children(".richtext_placeholder").attr("hidden", true).removeClass("delayed-fade-in");
     preview.children(".richtext").empty();
   });
 
@@ -34,13 +34,10 @@
     var preview = container.find(".tab-pane[id$='_preview']");
 
     if (preview.children(".richtext").contents().length === 0) {
-      preview.oneTime(200, "loading", function () {
-        preview.children(".richtext_placeholder").removeAttr("hidden");
-      });
+      preview.children(".richtext_placeholder").removeAttr("hidden").addClass("delayed-fade-in");
 
       preview.children(".richtext").load(editor.data("previewUrl"), { text: editor.val() }, function () {
-        preview.stopTime("loading");
-        preview.children(".richtext_placeholder").attr("hidden", true);
+        preview.children(".richtext_placeholder").attr("hidden", true).removeClass("delayed-fade-in");
       });
     }
   });

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -70,6 +70,18 @@ time[title] {
   }
 }
 
+/* Utility for delayed loading spinner */
+
+.delayed-fade-in {
+  animation: 300ms linear forwards delayed-fade-in;
+}
+
+@keyframes delayed-fade-in {
+  0%   { opacity: 0 }
+  66%  { opacity: 0 }
+  100% { opacity: 1 }
+}
+
 /* Rules for the header */
 
 #menu-icon {


### PR DESCRIPTION
Similarly to #5307, we can avoid scheduling/unscheduling js events to show spinners in the richtext preview #5311 and the sidebar loader:

![image](https://github.com/user-attachments/assets/238f7ea7-f2e1-45c7-8ac4-e6f42ac3c2f0)

There's a delay to avoid blinking on fast loads, that delay can be implemented using a css animation.

And we also can stop using `vendor/assets/jquery/jquery.timers.js` which does some ill-advised things like [listening to `unload`](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event).