### PR TITLE
Remove unused timer from new note js controller

### DIFF
--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -139,8 +139,6 @@ OSM.NewNote = function (map) {
 
     newNote.on("remove", function () {
       addNoteButton.removeClass("active");
-    }).on("dragstart", function () {
-      $(newNote).stopTime("removenote");
     }).on("dragend", function () {
       content.find("textarea").focus();
     });


### PR DESCRIPTION
https://github.com/openstreetmap/openstreetmap-website/commit/51dcf86f40200bf4728097868f45aa2fe12968f3 added the "removenote" timer. Its use was removed in https://github.com/openstreetmap/openstreetmap-website/commit/d380ce79aabcd98ade3eabe8f982e516311f6aee but the `stopTime` cleanup stuck.