### PR TITLE
Minor changes to docs

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -76,7 +76,7 @@ For iD, do the following:
 
 An example excerpt from settings.local.yml:
 
-```
+```yaml
 # Default editor
 default_editor: "id"
 # OAuth 2 Client ID for iD
@@ -99,7 +99,7 @@ To allow [Notes](https://wiki.openstreetmap.org/wiki/Notes) and changeset discus
 
 An example excerpt from settings.local.yml:
 
-```
+```yaml
 # OAuth 2 Client ID for the web site
 oauth_application: "SGm8QJ6tmoPXEaUPIZzLUmm1iujltYZVWCp9hvGsqXg"
 # OAuth 2 Client Secret for the web site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 * https://www.ruby-lang.org/ - The homepage of Ruby which has more links and some great tutorials.
 * https://rubyonrails.org/ - The homepage of Rails, also has links and tutorials.
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -24,27 +24,37 @@ Use [Docker Engine](https://docs.docker.com/engine/install/ubuntu/) with the [do
 
 The first step is to fork/clone the repo to your local machine:
 
-    git clone https://github.com/openstreetmap/openstreetmap-website.git
+```
+git clone https://github.com/openstreetmap/openstreetmap-website.git
+```
 
 Now change working directory to the `openstreetmap-website`:
 
-    cd openstreetmap-website
+```
+cd openstreetmap-website
+```
 
 ## Initial Setup
 
 ### Storage
 
-    cp config/example.storage.yml config/storage.yml
+```
+cp config/example.storage.yml config/storage.yml
+```
 
 ### Database
 
-    cp config/docker.database.yml config/database.yml
+```
+cp config/docker.database.yml config/database.yml
+```
 
 ## Prepare local settings file
 
 This is a workaround. [See issues/2185 for details](https://github.com/openstreetmap/openstreetmap-website/issues/2185#issuecomment-508676026).
 
-    touch config/settings.local.yml
+```
+touch config/settings.local.yml
+```
 
 **Windows users:** `touch` is not an availible command in Windows so just create a `settings.local.yml` file in the `config` directory, or if you have WSL you can run `wsl touch config/settings.local.yml`.
 
@@ -52,13 +62,17 @@ This is a workaround. [See issues/2185 for details](https://github.com/openstree
 
 To build local Docker images run from the root directory of the repository:
 
-    docker compose build
+```
+docker compose build
+```
 
 If this is your first time running or you have removed cache this will take some time to complete. Once the Docker images have finished building you can launch the images as containers.
 
 To launch the app run:
 
-    docker compose up -d
+```
+docker compose up -d
+```
 
 This will launch one Docker container for each 'service' specified in `docker-compose.yml` and run them in the background. There are two options for inspecting the logs of these running containers:
 
@@ -69,21 +83,29 @@ This will launch one Docker container for each 'service' specified in `docker-co
 
 Run the Rails database migrations:
 
-    docker compose run --rm web bundle exec rails db:migrate
+```
+docker compose run --rm web bundle exec rails db:migrate
+```
 
 ### Tests
 
 Prepare the test database:
 
-    docker compose run --rm web bundle exec rails db:test:prepare
+```
+docker compose run --rm web bundle exec rails db:test:prepare
+```
 
 Run the test suite:
 
-    docker compose run --rm web bundle exec rails test:all
+```
+docker compose run --rm web bundle exec rails test:all
+```
 
 If you encounter errors about missing assets, precompile the assets:
 
-    docker compose run --rm web bundle exec rake assets:precompile
+```
+docker compose run --rm web bundle exec rake assets:precompile
+```
 
 ### Loading an OSM extract
 
@@ -91,31 +113,37 @@ This installation comes with no geographic data loaded. You can either create ne
 
 For example, let's download the District of Columbia from Geofabrik or [any other region](https://download.geofabrik.de):
 
-    wget https://download.geofabrik.de/north-america/us/district-of-columbia-latest.osm.pbf
+```
+wget https://download.geofabrik.de/north-america/us/district-of-columbia-latest.osm.pbf
+```
 
 You can now use Docker to load this extract into your local Docker-based OSM instance:
 
-    docker compose run --rm web osmosis \
-        -verbose    \
-        --read-pbf district-of-columbia-latest.osm.pbf \
-        --log-progress \
-        --write-apidb \
-            host="db" \
-            database="openstreetmap" \
-            user="openstreetmap" \
-            validateSchemaVersion="no"
+```
+docker compose run --rm web osmosis \
+    -verbose    \
+    --read-pbf district-of-columbia-latest.osm.pbf \
+    --log-progress \
+    --write-apidb \
+        host="db" \
+        database="openstreetmap" \
+        user="openstreetmap" \
+        validateSchemaVersion="no"
+```
 
 **Windows users:** Powershell uses `` ` `` and CMD uses `^` at the end of each line, e.g.:
 
-    docker compose run --rm web osmosis `
-        -verbose    `
-        --read-pbf district-of-columbia-latest.osm.pbf `
-        --log-progress `
-        --write-apidb `
-            host="db" `
-            database="openstreetmap" `
-            user="openstreetmap" `
-            validateSchemaVersion="no"
+```
+docker compose run --rm web osmosis `
+    -verbose    `
+    --read-pbf district-of-columbia-latest.osm.pbf `
+    --log-progress `
+    --write-apidb `
+        host="db" `
+        database="openstreetmap" `
+        user="openstreetmap" `
+        validateSchemaVersion="no"
+```
 
 Once you have data loaded for Washington, DC you should be able to navigate to [`http://localhost:3000/#map=12/38.8938/-77.0146`](http://localhost:3000/#map=12/38.8938/-77.0146) to begin working with your local instance.
 
@@ -127,12 +155,18 @@ See [`CONFIGURE.md`](CONFIGURE.md) for information on how to manage users and en
 
 If you want to get into a web container and run specific commands you can fire up a throwaway container to run bash in via:
 
-    docker compose run --rm web bash
+```
+docker compose run --rm web bash
+```
 
 Alternatively, if you want to use the already-running `web` container then you can `exec` into it via:
 
-    docker compose exec web bash
+```
+docker compose exec web bash
+```
 
 Similarly, if you want to `exec` in the db container use:
 
-    docker compose exec db bash
+```
+docker compose exec db bash
+```

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,3 +1,5 @@
+# Frequently Asked Questions
+
 ## How do I create a banner to promote my OpenStreetMap event?
 
 We occasionally display banner images on the main page of [openstreetmap.org](https://www.openstreetmap.org/) to


### PR DESCRIPTION
This PR combines a few minor changes to the docs that I noticed while working on #5318 

* Add missing top-level headers to two files
* Standardise on fenced code blocks in markdown, for consistency and to allow language declarations
* Use language declarations for yaml code blocks

I also considered adding language information for code intended to be typed at the console, but then that turns out to be more complex with a choice of declarations (e.g. `bash` vs `console`) and whether to add `$ ` as a guide that it should be typed, and what to do with things that start with a console command but is then mainly `irb` from that point on, so I'll leave all that for some other time.