### PR TITLE
Adding map note tags - part 1 - added migration script and model files

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -26,6 +26,8 @@ class Note < ApplicationRecord
   has_many :subscriptions, :class_name => "NoteSubscription"
   has_many :subscribers, :through => :subscriptions, :source => :user
 
+  has_many :note_tags
+
   validates :id, :uniqueness => true, :presence => { :on => :update },
                  :numericality => { :on => :update, :only_integer => true }
   validates :latitude, :longitude, :numericality => { :only_integer => true }

--- a/app/models/note_tag.rb
+++ b/app/models/note_tag.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: note_tags
+#
+#  note_id :bigint(8)        not null, primary key
+#  k       :string           default(""), not null, primary key
+#  v       :string           default(""), not null
+#
+# Foreign Keys
+#
+#  note_tags_id_fkey  (note_id => notes.id)
+#
+
+class NoteTag < ApplicationRecord
+  belongs_to :note
+
+  validates :note, :associated => true
+  validates :k, :v, :allow_blank => true, :length => { :maximum => 255 }, :characters => true
+  validates :k, :uniqueness => { :scope => :note_id }
+end

--- a/db/migrate/20241030122707_create_note_tags.rb
+++ b/db/migrate/20241030122707_create_note_tags.rb
@@ -1,0 +1,12 @@
+class CreateNoteTags < ActiveRecord::Migration[7.2]
+  def change
+    # Create a table, primary and foreign keys
+    create_table :note_tags, :primary_key => [:note_id, :k] do |t|
+      t.column "note_id", :bigint, :null => false
+      t.column "k",  :string, :default => "", :null => false
+      t.column "v",  :string, :default => "", :null => false
+
+      t.foreign_key :notes, :column => :note_id, :name => "note_tags_id_fkey"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1062,6 +1062,17 @@ CREATE TABLE public.note_subscriptions (
 
 
 --
+-- Name: note_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.note_tags (
+    note_id bigint NOT NULL,
+    k character varying DEFAULT ''::character varying NOT NULL,
+    v character varying DEFAULT ''::character varying NOT NULL
+);
+
+
+--
 -- Name: notes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2026,6 +2037,14 @@ ALTER TABLE ONLY public.note_comments
 
 ALTER TABLE ONLY public.note_subscriptions
     ADD CONSTRAINT note_subscriptions_pkey PRIMARY KEY (user_id, note_id);
+
+
+--
+-- Name: note_tags note_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.note_tags
+    ADD CONSTRAINT note_tags_pkey PRIMARY KEY (note_id, k);
 
 
 --
@@ -3211,6 +3230,14 @@ ALTER TABLE ONLY public.note_comments
 
 
 --
+-- Name: note_tags note_tags_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.note_tags
+    ADD CONSTRAINT note_tags_id_fkey FOREIGN KEY (note_id) REFERENCES public.notes(id);
+
+
+--
 -- Name: redactions redactions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3397,6 +3424,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20241030122707'),
 ('20241023004427'),
 ('20241022141247'),
 ('20240913171951'),

--- a/test/factories/note_tags.rb
+++ b/test/factories/note_tags.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :note_tag do
+    sequence(:k) { |n| "Key #{n}" }
+    sequence(:v) { |n| "Value #{n}" }
+
+    note
+  end
+end

--- a/test/models/note_tag_test.rb
+++ b/test/models/note_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NoteTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/note_tag_test.rb
+++ b/test/models/note_tag_test.rb
@@ -1,7 +1,49 @@
 require "test_helper"
 
 class NoteTagTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def test_length_key_valid
+    tag = create(:note_tag)
+    [0, 255].each do |i|
+      tag.k = "k" * i
+      assert_predicate tag, :valid?
+    end
+  end
+
+  def test_length_value_valid
+    tag = create(:note_tag)
+    [0, 255].each do |i|
+      tag.v = "v" * i
+      assert_predicate tag, :valid?
+    end
+  end
+
+  def test_length_key_invalid
+    tag = create(:note_tag)
+    tag.k = "k" * 256
+    assert_not_predicate tag, :valid?, "Key should be too long"
+    assert_predicate tag.errors[:k], :any?
+  end
+
+  def test_length_value_invalid
+    tag = create(:note_tag)
+    tag.v = "v" * 256
+    assert_not_predicate tag, :valid?, "Value should be too long"
+    assert_predicate tag.errors[:v], :any?
+  end
+
+  def test_orphaned_tag_invalid
+    tag = create(:note_tag)
+    tag.note = nil
+    assert_not_predicate tag, :valid?, "Orphaned tag should be invalid"
+    assert_predicate tag.errors[:note], :any?
+  end
+
+  def test_uniqueness
+    existing = create(:note_tag)
+    tag = build(:note_tag, :note => existing.note, :k => existing.k, :v => existing.v)
+    assert_predicate tag, :new_record?
+    assert_not_predicate tag, :valid?
+    assert_raise(ActiveRecord::RecordInvalid) { tag.save! }
+    assert_predicate tag, :new_record?
+  end
 end


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->

Added migration for creating `note_tags` DB table, created model file `NoteTag.rb`, updated associations with `Note` class and added `note_tag` factory and unit tests `NoteTagTests` for testing basic functionalities (key/value lengths validity, key/value lengths invalidity, orphaned tags invalidity and note-tags uniqueness).

This PR is first step of adding support for map note tags described in #5294 and which fully implementation can be found [here](https://github.com/nenad-vujicic/openstreetmap-website/tree/issue_5294_poc) (decomposed to smaller because of simpler review).

### How has this been tested?
<!--Explain the steps you took to test your code.-->

Tested by running linters from `lint.yml` workflow, unit tests and by manually inserting note-tags manipulations and as part of [complete implementation](https://github.com/nenad-vujicic/openstreetmap-website/tree/issue_5294_poc) locally.