### PR TITLE
Use CSS filter instead of dimming tiles

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -504,7 +504,13 @@ body.small-nav {
 @include color-mode(dark) {
   .leaflet-tile-container,
   .mapkey-table-entry td:first-child > * {
-    filter: brightness(.8);
+    filter: invert(100%) hue-rotate(180deg) brightness(95%) contrast(90%);
+  }
+
+  /* Reset filter for everything inside of the tile container, so that it
+   * doesn't get applied multiple times via inheritance. */
+  .leaflet-tile-container * {
+    filter: none;
   }
 
   .leaflet-control-attribution a {


### PR DESCRIPTION
### Description
This is basically a hotfix to address the dark mode rollout from today. I'm new to contributing here and kind of in a hurry, sorry in advance if anything in this PR isn't perfect.

The current implementation of dark mode is already pretty good, but the tile display (i.e. the actual map) suffers greatly, since the tiles are simply dimmed using a CSS filter, losing a lot of contrast in the process.

I have borrowed the filter designed by @krjan02 from https://github.com/openstreetmap/openstreetmap-website/issues/2332#issuecomment-867821340 and basically inserted it into the changes made in #4712.

Additionally, I have made sure that the tiles are not being filtered twice due to inheriting the filter from their parent element. Maybe selecting `.leaflet-tile` instead of `.leaflet-tile-container` would solve that problem, too, but I'm assuming that @AntonKhorev had a reason for targeting the container instead.

This is how it would look:

![image](https://github.com/user-attachments/assets/a34b8bed-2b67-49bd-bd61-717dde6fb6d1)

Note that the discussion in #2332 is apparently not over yet, and I don't want to preempt this. However, since dark mode rolled out today and I've already seen several people kind of unhappy with the way it looks now (which is made worse by the fact that there's no way to turn it off if your browser is set to prefer dark mode), I wanted to suggest a quick fix.

### How has this been tested?

That's the thing: I have tested this by editing the CSS in the browser developer tools, because I don't want to set up the whole environment for building/running the website locally. As I said, I'm new to this project. I'd appreciate if someone with a working setup could test the changes.

However, as you can see in the screenshot, the map key is correctly affected by the filter, as are the previews in the "Map Layers" pane.

Also, I'm an experienced developer, but not a front-end dev.