### PR TITLE
Apply dimming filter to tiles directly

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -502,7 +502,7 @@ body.small-nav {
 }
 
 @include color-mode(dark) {
-  .leaflet-tile-container,
+  .leaflet-tile-container .leaflet-tile,
   .mapkey-table-entry td:first-child > * {
     filter: brightness(.8);
   }


### PR DESCRIPTION
In dark mode tiles are actually darker than I intended them to be:
![image](https://github.com/user-attachments/assets/2e846a31-1811-4e09-8023-d3ea4cc6542f) vs ![image](https://github.com/user-attachments/assets/27b1c81a-ed69-4c61-bfa6-9216cd79ca15)

See https://github.com/openstreetmap/openstreetmap-website/pull/5325#issuecomment-2478943023 and https://github.com/openstreetmap/openstreetmap-website/pull/5325#issuecomment-2479026722 for explanations.