### PR TITLE
Set colors for trace visibility badges using .text-bg-*

### DIFF
--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -27,7 +27,7 @@
                          when "public", "identifiable" then "success"
                          else "danger"
                          end %>
-        <span class="badge bg-<%= badge_class %> text-white"><%= t(".#{trace.visibility}") %></span>
+        <span class="badge text-bg-<%= badge_class %>"><%= t(".#{trace.visibility}") %></span>
       </li>
     </ul>
     <p class="text-body-secondary mb-0">


### PR DESCRIPTION
As recommended in https://getbootstrap.com/docs/5.3/components/badge/#background-colors, this sets both background and text colors in one declaration, with text depending on background.

See https://github.com/openstreetmap/openstreetmap-website/issues/5329#issuecomment-2478795244

![image](https://github.com/user-attachments/assets/efc6f37b-5c15-4af5-81b3-ae4c6d87f62a)

![image](https://github.com/user-attachments/assets/7e7cd925-a93c-4d58-a07b-6c947cbf67c6)
