### PR TITLE
Style small auth buttons similarly to preferred auth buttons

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -60,7 +60,7 @@ module UserHelper
                 :size => "36"),
       auth_path(options.merge(:provider => provider)),
       :method => :post,
-      :class => "auth_button btn btn-light p-2",
+      :class => "auth_button btn btn-outline-secondary border p-2",
       :title => t("application.auth_providers.#{provider}.title")
     )
   end

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -20,7 +20,7 @@
                          :data => { "bs-toggle" => "collapse",
                                     "bs-target" => "#login_auth_buttons, #openid_login_form" },
                          :title => t(".openid.title"),
-                         :class => "btn btn-light p-2" %>
+                         :class => "btn btn-outline-secondary border p-2" %>
         <% elsif provider != @preferred_auth_provider %>
           <%= auth_button provider %>
         <% end -%>

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -112,7 +112,7 @@ class UserHelperTest < ActionView::TestCase
   def test_auth_button
     button = auth_button("google")
     img_tag = "<img alt=\"Google logo\" class=\"rounded-1\" src=\"/images/auth_providers/google.svg\" width=\"36\" height=\"36\" />"
-    assert_equal("<a class=\"auth_button btn btn-light p-2\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
+    assert_equal("<a class=\"auth_button btn btn-outline-secondary border p-2\" title=\"Log in with Google\" rel=\"nofollow\" data-method=\"post\" href=\"/auth/google\">#{img_tag}</a>", button)
   end
 
   private


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/issues/5329#issue-2661831842

Before:
![image](https://github.com/user-attachments/assets/cb4c621d-8950-4ded-a019-a8c836c34818)
![image](https://github.com/user-attachments/assets/344c5ec7-f2ba-43c4-8b02-fc31d5cade14)

After:
![image](https://github.com/user-attachments/assets/f6f5396d-f153-4895-80d3-af7a40128b4f)
![image](https://github.com/user-attachments/assets/d4ef424f-9e7d-4074-b87a-d9fa22c191c1)
