### PR TITLE
Color mode preference

### DIFF
--- a/app/assets/stylesheets/parameters.scss
+++ b/app/assets/stylesheets/parameters.scss
@@ -20,4 +20,3 @@ $table-border-factor: .1;
 $list-group-hover-bg: rgba(var(--bs-emphasis-color-rgb), .075);
 
 $enable-negative-margins: true;
-$color-mode-type: media-query;

--- a/app/assets/stylesheets/screen-auto-ltr.scss
+++ b/app/assets/stylesheets/screen-auto-ltr.scss
@@ -1,0 +1,3 @@
+@use "common" with (
+  $color-mode-type: media-query
+);

--- a/app/assets/stylesheets/screen-auto-rtl.rtlcss.scss
+++ b/app/assets/stylesheets/screen-auto-rtl.rtlcss.scss
@@ -1,0 +1,3 @@
+@use "common" with (
+  $color-mode-type: media-query
+);

--- a/app/assets/stylesheets/screen-light-ltr.scss
+++ b/app/assets/stylesheets/screen-light-ltr.scss
@@ -1,0 +1,3 @@
+@use "common" with (
+  $color-mode-type: data
+);

--- a/app/assets/stylesheets/screen-light-rtl.rtlcss.scss
+++ b/app/assets/stylesheets/screen-light-rtl.rtlcss.scss
@@ -1,0 +1,3 @@
+@use "common" with (
+  $color-mode-type: data
+);

--- a/app/assets/stylesheets/screen-ltr.scss
+++ b/app/assets/stylesheets/screen-ltr.scss
@@ -1,1 +1,0 @@
-@import "common";

--- a/app/assets/stylesheets/screen-rtl.rtlcss.scss
+++ b/app/assets/stylesheets/screen-rtl.rtlcss.scss
@@ -1,1 +1,0 @@
-@import "common";

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -21,6 +21,12 @@ class PreferencesController < ApplicationController
                                     else
                                       params[:user][:preferred_editor]
                                     end
+
+    cookies["_osm_color_scheme"] = {
+      :value => params[:color_scheme],
+      :expires => 10.years.from_now
+    }
+
     if current_user.save
       # Use a partial so that it is rendered during the next page load in the correct language.
       flash[:notice] = { :partial => "preferences/update_success_flash" }

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -5,7 +5,11 @@
   <%= javascript_include_tag "turbo", :type => "module" %>
   <%= javascript_include_tag "application" %>
   <%= javascript_include_tag "i18n/#{I18n.locale}" %>
-  <%= stylesheet_link_tag "screen-#{dir}", :media => "screen" %>
+  <% if request.cookies["_osm_color_scheme"] == "light" %>
+    <%= stylesheet_link_tag "screen-light-#{dir}", :media => "screen" %>
+  <% else %>
+    <%= stylesheet_link_tag "screen-auto-#{dir}", :media => "screen" %>
+  <% end %>
   <%= stylesheet_link_tag "print-#{dir}", :media => "print" %>
   <%= stylesheet_link_tag "leaflet-all", :media => "screen, print" %>
   <%= render :partial => "layouts/meta" %>

--- a/app/views/preferences/edit.html.erb
+++ b/app/views/preferences/edit.html.erb
@@ -7,6 +7,14 @@
 
   <%= f.text_field :languages %>
 
+  <div class="mb-3">
+    <%= label_tag "color_scheme", t("preferences.show.preferred_color_scheme"), :class => "form-label" %>
+    <%= select_tag "color_scheme",
+                   options_for_select([[t("preferences.show.color_schemes.auto"), "auto"],
+                                       [t("preferences.show.color_schemes.light"), "light"]], request.cookies["_osm_color_scheme"]),
+                   :class => "form-select" %>
+  </div>
+
   <%= f.primary t(".save") %>
   <%= link_to t(".cancel"), preferences_path, :class => "btn btn-link" %>
 <% end %>

--- a/app/views/preferences/show.html.erb
+++ b/app/views/preferences/show.html.erb
@@ -19,7 +19,15 @@
         <li><%= locale %></li>
       <% end %>
     </ul>
+  </dd>
 
+  <dt class="col-sm-4"><%= t ".preferred_color_scheme" %></dt>
+  <dd class="col-sm-8">
+    <% if request.cookies["_osm_color_scheme"] == "light" %>
+      <%= t ".color_schemes.light" %>
+    <% else %>
+      <%= t ".color_schemes.auto" %>
+    <% end %>
   </dd>
 </dl>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1807,6 +1807,10 @@ en:
       title: My Preferences
       preferred_editor: Preferred Editor
       preferred_languages: Preferred Languages
+      preferred_color_scheme: Preferred Color Scheme
+      color_schemes:
+        auto: Auto
+        light: Light
       edit_preferences: Edit Preferences
     edit:
       title: Edit Preferences


### PR DESCRIPTION
A quick implementation of auto/light scheme switch for those who want to stay on the light scheme even when their browser says they want the dark one.

![image](https://github.com/user-attachments/assets/66ae2ce8-d30e-4361-af39-31c9d2a20aa8)
![image](https://github.com/user-attachments/assets/0256b9c5-f07e-4014-858e-c5a21d5c05d9)
![image](https://github.com/user-attachments/assets/45f4743a-d339-4183-aea7-3e840a8b67bc)

Its on the `/preferences` page but it's not actually a preference stored in the `User` model. It's stored in a cookie. The question is do we want to store it in a cookie? Maybe we do because what browser reports as a preferred scheme is per browser, not per user, then perhaps its override should also be per browser. And it will be easier to extend the availability of this option to anonymous users. It is kind of available already, if they know how to edit cookies.