### PR TITLE
Enable dark mode attribution font color

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -507,7 +507,7 @@ body.small-nav {
     filter: brightness(.8);
   }
 
-  .leaflet-control-attribution a {
+  .leaflet-container .leaflet-control-attribution a {
     color: var(--bs-link-color);
   }
 


### PR DESCRIPTION
### Description
This PR increases the specificity of the dark mode attribution selector. The style was first added in #4764, but didn't overwrite Leaflet's default link selector. That increased specificity fixes #5329's bug report about this by @Nekzuris


| before | after |
|-|-|
| ![image](https://github.com/user-attachments/assets/ff079ae9-0c21-49cb-b6dd-1ceca1c09b6f) | ![image](https://github.com/user-attachments/assets/934381e1-6e39-4273-a52f-2faae5ea9a08) |