### PR TITLE
Remove brightness filter for map tiles in dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -502,11 +502,6 @@ body.small-nav {
 }
 
 @include color-mode(dark) {
-  .leaflet-tile-container .leaflet-tile,
-  .mapkey-table-entry td:first-child > * {
-    filter: brightness(.8);
-  }
-
   .leaflet-container .leaflet-control-attribution a {
     color: var(--bs-link-color);
   }


### PR DESCRIPTION
Closes #5327 
See #5328 and https://github.com/openstreetmap/openstreetmap-website/issues/5329#issuecomment-2482070226