### PR TITLE
Add subscribe/unsubscribe buttons to note pages

### DIFF
--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -37,31 +37,35 @@ OSM.Note = function (map) {
   };
 
   function initialize(path, id) {
-    content.find("button[type=submit]").on("click", function (e) {
+    content.find("button[name]").on("click", function (e) {
       e.preventDefault();
       var data = $(e.target).data();
-      var form = e.target.form;
-
-      $(form).find("button[type=submit]").prop("disabled", true);
-
-      $.ajax({
+      var name = $(e.target).attr("name");
+      var ajaxSettings = {
         url: data.url,
         type: data.method,
         oauth: true,
-        data: { text: $(form.text).val() },
-        success: function () {
-          OSM.loadSidebarContent(path, function () {
+        success: () => {
+          OSM.loadSidebarContent(path, () => {
             initialize(path, id);
             moveToNote();
           });
         },
-        error: function (xhr) {
-          $(form).find("#comment-error")
+        error: (xhr) => {
+          content.find("#comment-error")
             .text(xhr.responseText)
-            .prop("hidden", false);
-          updateButtons(form);
+            .prop("hidden", false)
+            .get(0).scrollIntoView({ block: "nearest" });
+          updateButtons();
         }
-      });
+      };
+
+      if (name !== "subscribe" && name !== "unsubscribe") {
+        ajaxSettings.data = { text: $("textarea").val() };
+      }
+
+      content.find("button[name]").prop("disabled", true);
+      $.ajax(ajaxSettings);
     });
 
     content.find("textarea").on("input", function (e) {
@@ -82,14 +86,16 @@ OSM.Note = function (map) {
     }
   }
 
-  function updateButtons(form) {
-    $(form).find("button[type=submit]").prop("disabled", false);
-    if ($(form.text).val() === "") {
-      $(form.close).text($(form.close).data("defaultActionText"));
-      $(form.comment).prop("disabled", true);
+  function updateButtons() {
+    var resolveButton = content.find("button[name='close']");
+    var commentButton = content.find("button[name='comment']");
+
+    content.find("button[name]").prop("disabled", false);
+    if (content.find("textarea").val() === "") {
+      resolveButton.text(resolveButton.data("defaultActionText"));
+      commentButton.prop("disabled", true);
     } else {
-      $(form.close).text($(form.close).data("commentActionText"));
-      $(form.comment).prop("disabled", false);
+      resolveButton.text(resolveButton.data("commentActionText"));
     }
   }
 

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -28,6 +28,32 @@
     <p class='alert alert-warning'><%= t ".anonymous_warning" %></p>
   <% end -%>
 
+  <div class="row">
+    <div class="col">
+      <h4><%= t(".discussion") %></h4>
+    </div>
+
+    <% if current_user %>
+      <div class="col-auto">
+        <% if @note.subscribers.exists?(current_user.id) %>
+          <%= tag.button t(".unsubscribe"),
+                         :type => "button",
+                         :class => "btn btn-sm btn-primary",
+                         :name => "unsubscribe",
+                         :data => { :method => "DELETE",
+                                    :url => api_note_subscription_path(@note) } %>
+        <% else %>
+          <%= tag.button t(".subscribe"),
+                         :type => "button",
+                         :class => "btn btn-sm btn-primary",
+                         :name => "subscribe",
+                         :data => { :method => "POST",
+                                    :url => api_note_subscription_path(@note) } %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
   <% if @note_comments.length > 1 %>
     <div class='note-comments'>
       <ul class="list-unstyled">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2989,6 +2989,9 @@ en:
       report: report this note
       coordinates_html: "%{latitude}, %{longitude}"
       anonymous_warning: This note includes comments from anonymous users which should be independently verified.
+      discussion: Discussion
+      subscribe: Subscribe
+      unsubscribe: Unsubscribe
       hide: Hide
       resolve: Resolve
       reactivate: Reactivate

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -22,7 +22,7 @@ class NoteCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  def test_add_comment
+  test "can add comment" do
     note = create(:note_with_comments)
     user = create(:user)
     sign_in_as(user)
@@ -123,6 +123,51 @@ class NoteCommentsTest < ApplicationSystemTestCase
       assert_text "Resolved note"
       assert_text "Your access to the API has been blocked"
       assert_button "Reactivate", :disabled => false
+    end
+  end
+
+  test "no subscribe button when not logged in" do
+    note = create(:note_with_comments)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_no_button "Subscribe"
+      assert_no_button "Unsubscribe"
+    end
+  end
+
+  test "can subscribe" do
+    note = create(:note_with_comments)
+    user = create(:user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_button "Subscribe"
+      assert_no_button "Unsubscribe"
+
+      click_on "Subscribe"
+
+      assert_no_button "Subscribe"
+      assert_button "Unsubscribe"
+    end
+  end
+
+  test "can unsubscribe" do
+    note = create(:note_with_comments)
+    user = create(:user)
+    create(:note_subscription, :note => note, :user => user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_no_button "Subscribe"
+      assert_button "Unsubscribe"
+
+      click_on "Unsubscribe"
+
+      assert_button "Subscribe"
+      assert_no_button "Unsubscribe"
     end
   end
 end


### PR DESCRIPTION
Part 5 of https://github.com/openstreetmap/openstreetmap-website/pull/5283 that adds the button to subscribe/unsubscribe from a note.

![image](https://github.com/user-attachments/assets/0e88927f-dd80-4b65-8f8e-62912eaab750)
