### PR TITLE
Put api keys directly in js layer definitions

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -18,8 +18,6 @@ L.OSM.Map = L.Map.extend({
     this.baseLayers = [];
 
     for (const layerDefinition of OSM.LAYER_DEFINITIONS) {
-      if (layerDefinition.apiKeyId && !OSM[layerDefinition.apiKeyId]) continue;
-
       let layerConstructor = L.OSM.TileLayer;
       const layerOptions = {};
 
@@ -28,8 +26,6 @@ L.OSM.Map = L.Map.extend({
           layerOptions.attribution = makeAttribution(value);
         } else if (property === "nameId") {
           layerOptions.name = I18n.t(`javascripts.map.base.${value}`);
-        } else if (property === "apiKeyId") {
-          layerOptions.apikey = OSM[value];
         } else if (property === "leafletOsmId") {
           layerConstructor = L.OSM[value];
         } else {

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -23,15 +23,7 @@ OSM = {
   FOSSGIS_VALHALLA_URL:    <%= Settings.fossgis_valhalla_url.to_json %>,
   DEFAULT_LOCALE:          <%= I18n.default_locale.to_json %>,
 
-<% if Settings.key?(:thunderforest_key) %>
-  THUNDERFOREST_KEY:       <%= Settings.thunderforest_key.to_json %>,
-<% end %>
-
-<% if Settings.key?(:tracestrack_key) %>
-  TRACESTRACK_KEY:         <%= Settings.tracestrack_key.to_json %>,
-<% end %>
-
-  LAYER_DEFINITIONS:       <%= YAML.load_file(Rails.root.join("config/layers.yml")).to_json %>,
+  LAYER_DEFINITIONS:       <%= MapLayers::definitions("config/layers.yml").to_json %>,
   LAYERS_WITH_MAP_KEY:     <%= YAML.load_file(Rails.root.join("config/key.yml")).keys.to_json %>,
 
   MARKER_GREEN:            <%= image_path("marker-green.png").to_json %>,

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -28,7 +28,7 @@
   code: "C"
   layerId: "cyclemap"
   nameId: "cycle_map"
-  apiKeyId: "THUNDERFOREST_KEY"
+  apiKeyId: "thunderforest_key"
   canEmbed: true
   canDownloadImage: true
   credit:
@@ -42,7 +42,7 @@
   code: "T"
   layerId: "transportmap"
   nameId: "transport_map"
-  apiKeyId: "THUNDERFOREST_KEY"
+  apiKeyId: "thunderforest_key"
   canEmbed: true
   canDownloadImage: true
   credit:
@@ -56,7 +56,7 @@
   code: "P"
   layerId: "tracestracktopo"
   nameId: "tracestracktop_topo"
-  apiKeyId: "TRACESTRACK_KEY"
+  apiKeyId: "tracestrack_key"
   credit:
     id: "tracestrack_credit"
     children:

--- a/lib/map_layers.rb
+++ b/lib/map_layers.rb
@@ -1,0 +1,13 @@
+module MapLayers
+  def self.definitions(layers_filename)
+    YAML.load_file(Rails.root.join(layers_filename)).filter_map do |layer|
+      if layer["apiKeyId"]
+        next unless Settings[layer["apiKeyId"]]
+
+        layer["apikey"] = Settings[layer["apiKeyId"]]
+        layer.delete "apiKeyId"
+      end
+      layer
+    end
+  end
+end


### PR DESCRIPTION
Currently map layer API keys have one extra level of indirection:
- keys are defined in the settings
- `osm.js.erb` reads them from the settings and writes them to `OSM.THUNDERFOREST_KEY` and `OSM.TRACESTRACK_KEY`
- `layers.yml` contain names of `OSM` properties to check for keys

Instead of this `osm.js.erb` could write keys directly to layer definitions, skipping `OSM.THUNDERFOREST_KEY` and `OSM.TRACESTRACK_KEY`. `layers.yml` could contain the corresponding settings names. The advantage is that Thunderforest and Tracestrack keys are no longer special. A new key can be added just by editing `settings.yml` and `layers.yml`. Also it's possible to skip layer definitions if they require a key and that key is missing.