### PR TITLE
Add default browse icons for nodes, ways, relations

### DIFF
--- a/app/assets/images/browse/node.svg
+++ b/app/assets/images/browse/node.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 256 256">
+<rect width="240" height="240" stroke="#8888" fill="#fffc" stroke-width="16" ry="32" x="8" y="8"/>
+<circle cx="128" cy="128" r="024" fill="#bee6be" stroke="black" stroke-width="10"/>
+</svg>

--- a/app/assets/images/browse/relation.svg
+++ b/app/assets/images/browse/relation.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 256 256">
+<rect width="240" height="240" stroke="#8888" fill="#fffc" stroke-width="16" ry="32" x="8" y="8"/>
+<path d="M 068 068 L 196 062" stroke-width="16" stroke="#888"/>
+<path d="M 068 068 L 196 142" stroke-width="16" stroke="#888"/>
+<path d="M 068 068 L 062 196" stroke-width="16" stroke="#888"/>
+<path d="M 068 068 L 142 196" stroke-width="16" stroke="#888"/>
+<circle cx="196" cy="062" r="024" fill="black"/>
+<circle cx="196" cy="142" r="024" fill="black"/>
+<circle cx="062" cy="196" r="024" fill="black"/>
+<circle cx="142" cy="196" r="024" fill="black"/>
+<circle cx="072" cy="072" r="032" fill="#bee6be" stroke="black" stroke-width="8"/>
+</svg>

--- a/app/assets/images/browse/way.svg
+++ b/app/assets/images/browse/way.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 256 256">
+<rect width="240" height="240" stroke="#8888" fill="#fffc" stroke-width="16" ry="32" x="8" y="8"/>
+<path stroke="#888" fill="none" stroke-width="16" d="M 169 058 L 057 145 L 195 199"/>
+<circle cx="169" cy="058" r="024" fill="black"/>
+<circle cx="057" cy="145" r="024" fill="black"/>
+<circle cx="195" cy="199" r="024" fill="black"/>
+</svg>

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -973,6 +973,10 @@ img.trace_image {
   .node, .way, .relation {
     margin-left: 25px;
   }
+
+  .node::before     { content: image-url('browse/node.svg'); }
+  .way::before      { content: image-url('browse/way.svg'); }
+  .relation::before { content: image-url('browse/relation.svg'); }
 }
 
 @each $class, $item in $map-sidebar-icons {


### PR DESCRIPTION
Add icons for elements that don't have any icon defined by their tags.

![image](https://github.com/user-attachments/assets/fcee8f42-668b-4f15-a7cf-ca44ecf6f6b5) ![image](https://github.com/user-attachments/assets/19ca136d-5842-4b77-9405-d615d743c4f5)

Those are the standard node/way/relation icons as used in the wiki, taginfo etc with small modifications. The most visible modification is that I made the borders lighter. I did this to make them stand out less when displayed along with tag icons:

![image](https://github.com/user-attachments/assets/652415e2-1b8d-4d8a-99b6-426b972fb3a2)

Actually I'm doing this to try out some vertical space saving changes to #5317 that are going to look better if every list element item has something to act as a bullet point. That would be an icon, so it's better to always have one.