### PR TITLE
Improve scaling and vertical alignment of browse icons

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -965,8 +965,14 @@ img.trace_image {
   .node::before,
   .way::before,
   .relation::before {
+    content: "";
     display: inline-block;
+    background-size: calc(1em * 1.25) auto;
+    background-position: left center;
+    background-repeat: no-repeat;
+    vertical-align: text-bottom;
     width: 25px;
+    height: calc(1em * 1.25);
     margin-left: -25px;
   }
 
@@ -974,14 +980,14 @@ img.trace_image {
     margin-left: 25px;
   }
 
-  .node::before     { content: image-url('browse/node.svg'); }
-  .way::before      { content: image-url('browse/way.svg'); }
-  .relation::before { content: image-url('browse/relation.svg'); }
+  .node::before     { background-image: image-url('browse/node.svg'); }
+  .way::before      { background-image: image-url('browse/way.svg'); }
+  .relation::before { background-image: image-url('browse/relation.svg'); }
 }
 
 @each $class, $item in $map-sidebar-icons {
   .browse-section #{$class}::before {
-    content: image-url('browse/#{map.get($item, "filename")}');
+    background-image: image-url('browse/#{map.get($item, "filename")}');
   }
 
   @if map.get($item, "invert") {


### PR DESCRIPTION
Although we're using SVG icons because they are being added using pseudo elements it's currently impossible to directly set a size for them to scale to as https://stackoverflow.com/a/8993934 explains.

So instead we use a solution based on the alternate approach there of setting the image as a background image, which can be scaled to our preferred size and then aligned.

The only tricky part is working out the vertical size to scale to - just using `1em` doesn't really look right as it doesn't allow for the descenders so I've scaled it up a bit which seems to look about right in firefox and chrome.

Here's a before and after example:

![image](https://github.com/user-attachments/assets/077e6313-da4a-4da7-88cb-cf5f3b9baedc)
