### PR TITLE
Move html_safe declaration for user_mailer from layout to helper

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -20,8 +20,6 @@ linters:
         Enabled: false
       Naming/FileName:
         Enabled: false
-      Rails/OutputSafety:
-        Enabled: false
       Style/FrozenStringLiteralComment:
         Enabled: false
   SelfClosingTag:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -169,6 +169,7 @@ Rails/NotNullColumn:
 Rails/OutputSafety:
   Exclude:
     - 'app/helpers/application_helper.rb'
+    - 'app/helpers/user_mailer_helper.rb'
     - 'lib/rich_text.rb'
     - 'test/helpers/application_helper_test.rb'
 

--- a/app/helpers/user_mailer_helper.rb
+++ b/app/helpers/user_mailer_helper.rb
@@ -29,7 +29,7 @@ module UserMailerHelper
     # Because we can't use stylesheets in HTML emails, we need to inline the
     # styles. Rather than copy-paste the same string of CSS into every message,
     # we apply it once here, after the message has been composed.
-    html.gsub("<p>", '<p style="color: black; margin: 0.75em 0; font-family: \'Helvetica Neue\', Arial, Sans-Serif">')
+    html.gsub("<p>", '<p style="color: black; margin: 0.75em 0; font-family: \'Helvetica Neue\', Arial, Sans-Serif">').html_safe
   end
 
   def style_left

--- a/app/views/layouts/user_mailer.html.erb
+++ b/app/views/layouts/user_mailer.html.erb
@@ -28,7 +28,7 @@
                 <table style="background-color: #fff; color: #222; border: solid 1px #ccc; border-collapse: separate">
                   <tr>
                     <td style="text-align: <%= style_left %>; padding: 0px 15px 5px 15px">
-                      <%= raw style_message(yield) %>
+                      <%= style_message(yield) %>
                     </td>
                   </tr>
                 </table>


### PR DESCRIPTION
This allows us to enable output safety checks for all code within erb files.

`rubocop --auto-gen-config` ignores code within the erb files, so it is easier to maintain an exclusion on the helper than inside the layout.
