### PR TITLE
Set dir=auto on username in header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -90,7 +90,7 @@
           <% if current_user.new_messages.size > 0 %>
             <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
           <% end %>
-          <span class='username align-middle text-truncate'>
+          <span class='username align-middle text-truncate' dir='auto'>
             <%= current_user.display_name %>
           </span>
         </button>


### PR DESCRIPTION
There's a problem with truncated usernames if their directionality doesn't match the ui. This PR fixes the current username in the header.

Before:
![image](https://github.com/user-attachments/assets/e19aa034-b6b1-48a2-8086-20b61a05b181)

After:
![image](https://github.com/user-attachments/assets/9d2dbceb-901f-4d59-a0e9-267f23d56cc9)

There's also a bigger issue #3428 and some stale pull requests trying to fix it.