### PR TITLE
Truncate usernames in block navigation tabs

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -938,7 +938,11 @@ div.secondary-actions {
   max-width: 20em;
 }
 
-/* Rules for tabs inside secondary background sections */
+/* Rules for navigation tabs */
+
+.nav-tabs .username {
+  max-width: 20em;
+}
 
 .bg-body-secondary .nav-tabs {
   --bs-border-color: var(--bs-secondary-border-subtle);

--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -14,7 +14,7 @@
   <% on_user = @user || @user_block&.user %>
   <% if on_user != current_user && on_user&.blocks&.exists? %>
     <li class="nav-item">
-      <%= link_to t(".blocks_on_user", :user => on_user.display_name),
+      <%= link_to t(".blocks_on_user_html", :user => tag.span(on_user.display_name, :class => "username text-truncate d-inline-block align-bottom", :dir => "auto")),
                   user_blocks_on_path(on_user),
                   :class => ["nav-link", { :active => action_name == "blocks_on" }] %>
     </li>
@@ -29,7 +29,7 @@
   <% by_user = @user || @user_block&.creator %>
   <% if by_user != current_user && by_user&.blocks_created&.exists? %>
     <li class="nav-item">
-      <%= link_to t(".blocks_by_user", :user => by_user.display_name),
+      <%= link_to t(".blocks_by_user_html", :user => tag.span(by_user.display_name, :class => "username text-truncate d-inline-block align-bottom", :dir => "auto")),
                   user_blocks_by_path(by_user),
                   :class => ["nav-link", { :active => action_name == "blocks_by" }] %>
     </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2925,9 +2925,9 @@ en:
     navigation:
       all_blocks: "All Blocks"
       blocks_on_me: "Blocks on Me"
-      blocks_on_user: "Blocks on %{user}"
+      blocks_on_user_html: "Blocks on %{user}"
       blocks_by_me: "Blocks by Me"
-      blocks_by_user: "Blocks by %{user}"
+      blocks_by_user_html: "Blocks by %{user}"
       block: "Block #%{id}"
       new_block: "New Block"
   user_mutes:


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/9c7d4782-8031-4114-adc3-2ab38fc59b7f)

After:
![image](https://github.com/user-attachments/assets/be8ed423-c1c2-4ffc-bcef-bc12500517d7)

Usernames have `dir=auto` to support truncation on the correct side:
![image](https://github.com/user-attachments/assets/855295b9-cbfa-4f42-bca3-163a2e2c10bd)
