### PR TITLE
Use relation icon instead of word in containing relations

### DIFF
--- a/app/views/browse/_containing_relation.html.erb
+++ b/app/views/browse/_containing_relation.html.erb
@@ -1,6 +1,6 @@
-<li><%= linked_name = link_to printable_element_name(containing_relation.relation), containing_relation.relation
+<li><%= linked_name = link_to printable_element_name(containing_relation.relation), containing_relation.relation, :class => "relation"
         if containing_relation.member_role.blank?
-          t ".entry_html", :relation_name => linked_name
+          linked_name
         else
           t ".entry_role_html", :relation_name => linked_name, :relation_role => containing_relation.member_role
         end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -356,8 +356,7 @@ en:
         way: "Way"
         relation: "Relation"
     containing_relation:
-      entry_html: "Relation %{relation_name}"
-      entry_role_html: "Relation %{relation_name} (as %{relation_role})"
+      entry_role_html: "%{relation_name} (as %{relation_role})"
     not_found:
       title: Not Found
       sorry: "Sorry, %{type} #%{id} could not be found."


### PR DESCRIPTION
Fixes #5368.

Before:
![image](https://github.com/user-attachments/assets/62087146-aa60-4816-a407-906caad41b68)

After:
![image](https://github.com/user-attachments/assets/e0fd8a9f-c58d-4616-85b0-b4a76882861d)
