### PR TITLE
Use fetch() instead of iframe to make remote control requests

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -255,20 +255,10 @@ $(document).ready(function () {
     });
 
     function sendRemoteEditCommand(url, callback) {
-      var iframe = $("<iframe>");
-      var timeoutId = setTimeout(function () {
-        alert(I18n.t("site.index.remote_failed"));
-        iframe.remove();
-      }, 5000);
-
-      iframe
-        .hide()
-        .appendTo("body")
-        .attr("src", url)
-        .on("load", function () {
-          clearTimeout(timeoutId);
-          iframe.remove();
-          if (callback) callback();
+      fetch(url, { mode: "no-cors", signal: AbortSignal.timeout(5000) })
+        .then(callback)
+        .catch(function () {
+          alert(I18n.t("site.index.remote_failed"));
         });
     }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -253,9 +253,7 @@ class ApplicationController < ActionController::Base
   def map_layout
     policy = request.content_security_policy.clone
 
-    policy.child_src(*policy.child_src, "http://127.0.0.1:8111", "https://127.0.0.1:8112")
-    policy.frame_src(*policy.frame_src, "http://127.0.0.1:8111", "https://127.0.0.1:8112")
-    policy.connect_src(*policy.connect_src, Settings.nominatim_url, Settings.overpass_url, Settings.fossgis_osrm_url, Settings.graphhopper_url, Settings.fossgis_valhalla_url)
+    policy.connect_src(*policy.connect_src, "http://127.0.0.1:8111", Settings.nominatim_url, Settings.overpass_url, Settings.fossgis_osrm_url, Settings.graphhopper_url, Settings.fossgis_valhalla_url)
     policy.form_action(*policy.form_action, "render.openstreetmap.org")
     policy.style_src(*policy.style_src, :unsafe_inline)
 


### PR DESCRIPTION
An alternative to #3760.

Uses no-cors mode https://github.com/openstreetmap/openstreetmap-website/pull/3760#issuecomment-1290363544 which should work with Potlatch. Requires a browser that is not too old (probably 5 years old max).