### PR TITLE
Truncate usernames in trace navigation tabs

### DIFF
--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -56,7 +56,8 @@
             </li>
           <% end %>
           <li class="nav-item">
-            <%= link_to t(".traces_from", :user => @target_user&.display_name), { :controller => "traces", :action => "index", :display_name => @target_user&.display_name }, { :class => "nav-link active" } %>
+            <%= link_to t(".traces_from_html", :user => tag.span(@target_user.display_name, :class => "username text-truncate d-inline-block align-bottom", :dir => "auto")),
+                        { :controller => "traces", :action => "index", :display_name => @target_user.display_name }, { :class => "nav-link active" } %>
           </li>
         <% end %>
       </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2544,7 +2544,7 @@ en:
       upload_trace: "Upload a trace"
       all_traces: "All Traces"
       my_traces: "My Traces"
-      traces_from: "Public Traces from %{user}"
+      traces_from_html: "Public Traces from %{user}"
       remove_tag_filter: "Remove Tag Filter"
     destroy:
       scheduled_for_deletion: "Trace scheduled for deletion"


### PR DESCRIPTION
Similar to #5366.

Before:
![image](https://github.com/user-attachments/assets/ceaa71c7-cf85-4170-ae79-f113a998400e)

After:
![image](https://github.com/user-attachments/assets/23222bf5-454d-4f33-805b-4685dccecba4)
