### PR TITLE
Include data: when using allow_thirdparty_images CSP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
 
   def self.allow_thirdparty_images(**options)
     content_security_policy(options) do |policy|
-      policy.img_src("*")
+      policy.img_src("*", :data)
     end
   end
 


### PR DESCRIPTION
We have `allow_thirdparty_images` policy on some pages that sets `img-src` policy to `*`. But `*` does not include data uris. That causes some of the ui elements to disappear.

For example, on `/account/edit` there's no dropdown icon:
![image](https://github.com/user-attachments/assets/faa20e87-2740-46bb-a1c3-c66ca075fc6b)

After this fix:
![image](https://github.com/user-attachments/assets/8a6cb78b-a10e-4847-a329-b473a297fbea)
