### PR TITLE
Don't show types twice in issue type select

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -18,8 +18,8 @@ class IssuesController < ApplicationController
     @title = t ".title"
 
     @issue_types = []
-    @issue_types.push("Note", "User") if current_user.moderator?
-    @issue_types.push("DiaryEntry", "DiaryComment", "User") if current_user.administrator?
+    @issue_types |= %w[Note User] if current_user.moderator?
+    @issue_types |= %w[DiaryEntry DiaryComment User] if current_user.administrator?
 
     @users = User.joins(:roles).where(:user_roles => { :role => current_user.roles.map(&:role) }).distinct
     @issues = Issue.visible_to(current_user)


### PR DESCRIPTION
If you have both moderator and admin flags, the issue search form is going to have "User" twice.

Before:
![image](https://github.com/user-attachments/assets/57bc307a-57c9-427b-8c7b-21531ffebec3)

After:
![image](https://github.com/user-attachments/assets/f0dd0428-5dce-41cc-861f-c26cf1039697)
