### PR TITLE
Don't interpolate type in issue title

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -48,7 +48,7 @@ class IssuesController < ApplicationController
   end
 
   def show
-    @title = t ".title", :status => @issue.status.humanize, :issue_id => @issue.id
+    @title = t ".title.#{@issue.status}", :issue_id => @issue.id
     @read_reports = @issue.read_reports
     @unread_reports = @issue.unread_reports
     @comments = @issue.comments

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-<h1><%= t ".title", :status => @issue.status.humanize, :issue_id => @issue.id %></h1>
+<h1><%= @title %></h1>
 <p><%= @issue.reportable.model_name.human %> : <%= link_to reportable_title(@issue.reportable), reportable_url(@issue.reportable) %></p>
 <p class="text-body-secondary">
   <small>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1477,7 +1477,10 @@ en:
         open: Open
         resolved: Resolved
     show:
-      title: "%{status} Issue #%{issue_id}"
+      title:
+        open: "Open Issue #%{issue_id}"
+        ignored: "Ignored Issue #%{issue_id}"
+        resolved: "Resolved Issue #%{issue_id}"
       reports:
         one: "%{count} report"
         other: "%{count} reports"


### PR DESCRIPTION
The title of `/issues/:id` pages is constructed by substituting the status into the locale string, making it difficult to translate.

![image](https://github.com/user-attachments/assets/6bd5764d-4e05-405a-8990-054dd101b341)

This PR makes it closer to what we have for note titles:
https://github.com/openstreetmap/openstreetmap-website/blob/fe81ac334cfef04751a959297dca24e472cb025f/config/locales/en.yml#L2977-L2979