### PR TITLE
Let header username expand to screen width in small nav mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -217,6 +217,10 @@ body.small-nav {
     .search_forms {
       display: block;
     }
+
+    .username {
+      max-width: unset;
+    }
   }
 
   #sidebar .search_forms {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -85,7 +85,7 @@
     </ul>
     <% if current_user && current_user.id %>
       <div class='d-inline-flex dropdown user-menu logged-in'>
-        <button class='d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1' type='button' data-bs-toggle='dropdown'>
+        <button class='d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1 mw-100' type='button' data-bs-toggle='dropdown'>
           <%= user_thumbnail_tiny(current_user, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
           <% if current_user.new_messages.size > 0 %>
             <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/515569f3-57d4-4d8d-bea7-312e1c818f0e)

After:
![image](https://github.com/user-attachments/assets/a0aab805-aebc-4322-9859-daea6a484775)
