### PR TITLE
Remove logger.debug from relation update action

### DIFF
--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -48,8 +48,6 @@ module Api
     end
 
     def update
-      logger.debug request.raw_post
-
       relation = Relation.find(params[:id])
       new_relation = Relation.from_xml(request.raw_post)
 


### PR DESCRIPTION
Was added in https://github.com/openstreetmap/openstreetmap-website/commit/2b7a40069f7af2e72c81f9488411135f286515f9. A similar debug statement also existed for nodes, added in https://github.com/openstreetmap/openstreetmap-website/commit/328d47e506972fededfa1080967224928c36a4cf, later removed.