### PR TITLE
Allow specifying extra layer options in layers.yml

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -29,7 +29,7 @@ L.OSM.layers = function (options) {
 
       map.whenReady(function () {
         var miniMap = L.map(mapContainer[0], { attributionControl: false, zoomControl: false, keyboard: false })
-          .addLayer(new layer.constructor({ apikey: layer.options.apikey }));
+          .addLayer(new layer.constructor(layer.options));
 
         miniMap.dragging.disable();
         miniMap.touchZoom.disable();

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -20,17 +20,26 @@ L.OSM.Map = L.Map.extend({
     for (const layerDefinition of OSM.LAYER_DEFINITIONS) {
       if (layerDefinition.apiKeyId && !OSM[layerDefinition.apiKeyId]) continue;
 
-      const layerOptions = {
-        attribution: makeAttribution(layerDefinition.credit),
-        code: layerDefinition.code,
-        keyid: layerDefinition.keyId,
-        name: I18n.t(`javascripts.map.base.${layerDefinition.nameId}`)
-      };
-      if (layerDefinition.apiKeyId) {
-        layerOptions.apikey = OSM[layerDefinition.apiKeyId];
+      let layerConstructor = L.OSM.TileLayer;
+      const layerOptions = {};
+
+      for (const [property, value] of Object.entries(layerDefinition)) {
+        if (property === "credit") {
+          layerOptions.attribution = makeAttribution(value);
+        } else if (property === "keyId") {
+          layerOptions.keyid = value;
+        } else if (property === "nameId") {
+          layerOptions.name = I18n.t(`javascripts.map.base.${value}`);
+        } else if (property === "apiKeyId") {
+          layerOptions.apikey = OSM[value];
+        } else if (property === "leafletOsmId") {
+          layerConstructor = L.OSM[value];
+        } else {
+          layerOptions[property] = value;
+        }
       }
 
-      const layer = new L.OSM[layerDefinition.leafletOsmId](layerOptions);
+      const layer = new layerConstructor(layerOptions);
       this.baseLayers.push(layer);
     }
 


### PR DESCRIPTION
Now you can (re)define other options accepted by Leaflet tile layers, for example `url` or `maxZoom`. Also you define new tile layers that are not present in `leaflet.osm.js` because `leafletOsmId` is no longer mandatory.

This lets you add, for example, dark version of  Transport Map by adding to `config/layers.yml`:

```yml
- url: 'https://{s}.tile.thunderforest.com/transport-dark/{z}/{x}/{y}{r}.png?apikey={apikey}'
  maxZoom: 21
  code: "U"
  keyId: "transportmapdark"
  nameId: "transport_map"
  apiKeyId: "THUNDERFOREST_KEY"
  credit:
    id: "thunderforest_credit"
    children:
      thunderforest_link:
        id: "andy_allan"
        href: "https://www.thunderforest.com/"
```