### PR TITLE
Disable filter inheritance on tiles, apply filter to tile container

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -506,9 +506,13 @@ body.small-nav {
 }
 
 @include color-mode(dark) {
-  .leaflet-tile-container .leaflet-tile,
+  .leaflet-tile-container,
   .mapkey-table-entry td:first-child > * {
     filter: var(--dark-mode-map-filter);
+  }
+
+  .leaflet-tile-container .leaflet-tile {
+    filter: none;
   }
 
   .leaflet-container .leaflet-control-attribution a {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -9,6 +9,7 @@
 
 body {
   font-size: $typeheight;
+  --dark-mode-map-filter: brightness(.8);
 }
 
 time[title] {
@@ -507,7 +508,7 @@ body.small-nav {
 @include color-mode(dark) {
   .leaflet-tile-container .leaflet-tile,
   .mapkey-table-entry td:first-child > * {
-    filter: brightness(.8);
+    filter: var(--dark-mode-map-filter);
   }
 
   .leaflet-container .leaflet-control-attribution a {


### PR DESCRIPTION
If a filter is applied to every tile separately, it's possible that the gaps between tiles become visible when zooming. I've only seen this happening in Chrome, both on desktop and mobile.

It could have been the reason why I applied the filter to `.leaflet-tile-container` in the first place, which I had to undo in #5330. Now I'm applying the filter to the container again, but I disable the unexpected filer inheritance (which is disabled in the current unreleased Leaflet code).

Before:

https://github.com/user-attachments/assets/cfa6b459-b1b1-4a7e-8523-5c656e62d3ca

After:

https://github.com/user-attachments/assets/92d9c6b4-bb08-4f16-ac01-edfdecc0fc76

