### PR TITLE
Rename 'keyid' layer option to 'layerId'

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -207,7 +207,7 @@ $(document).ready(function () {
   if (OSM.MATOMO) {
     map.on("layeradd", function (e) {
       if (e.layer.options) {
-        var goal = OSM.MATOMO.goals[e.layer.options.keyid];
+        var goal = OSM.MATOMO.goals[e.layer.options.layerId];
 
         if (goal) {
           $("body").trigger("matomogoal", goal);

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -26,8 +26,6 @@ L.OSM.Map = L.Map.extend({
       for (const [property, value] of Object.entries(layerDefinition)) {
         if (property === "credit") {
           layerOptions.attribution = makeAttribution(value);
-        } else if (property === "keyId") {
-          layerOptions.keyid = value;
         } else if (property === "nameId") {
           layerOptions.name = I18n.t(`javascripts.map.base.${value}`);
         } else if (property === "apiKeyId") {
@@ -134,7 +132,7 @@ L.OSM.Map = L.Map.extend({
   getMapBaseLayerId: function () {
     var baseLayerId;
     this.eachLayer(function (layer) {
-      if (layer.options && layer.options.keyid) baseLayerId = layer.options.keyid;
+      if (layer.options && layer.options.layerId) baseLayerId = layer.options.layerId;
     });
     return baseLayerId;
   },

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -1,6 +1,6 @@
 - leafletOsmId: "Mapnik"
   code: "M"
-  keyId: "mapnik"
+  layerId: "mapnik"
   nameId: "standard"
   credit:
     id: "make_a_donation"
@@ -9,7 +9,7 @@
 
 - leafletOsmId: "CyclOSM"
   code: "Y"
-  keyId: "cyclosm"
+  layerId: "cyclosm"
   nameId: "cyclosm"
   credit:
     id: "cyclosm_credit"
@@ -23,7 +23,7 @@
 
 - leafletOsmId: "CycleMap"
   code: "C"
-  keyId: "cyclemap"
+  layerId: "cyclemap"
   nameId: "cycle_map"
   apiKeyId: "THUNDERFOREST_KEY"
   credit:
@@ -35,7 +35,7 @@
 
 - leafletOsmId: "TransportMap"
   code: "T"
-  keyId: "transportmap"
+  layerId: "transportmap"
   nameId: "transport_map"
   apiKeyId: "THUNDERFOREST_KEY"
   credit:
@@ -47,7 +47,7 @@
 
 - leafletOsmId: "TracestrackTopo"
   code: "P"
-  keyId: "tracestracktopo"
+  layerId: "tracestracktopo"
   nameId: "tracestracktop_topo"
   apiKeyId: "TRACESTRACK_KEY"
   credit:
@@ -59,7 +59,7 @@
 
 - leafletOsmId: "HOT"
   code: "H"
-  keyId: "hot"
+  layerId: "hot"
   nameId: "hot"
   credit:
     id: "hotosm_credit"


### PR DESCRIPTION
Each base map layer has a `keyid`. It was introduced in https://github.com/openstreetmap/openstreetmap-website/commit/79df86023c5db1f1c47c80808565733c1200656a to hide/show map key entries for different layers. But since then it was also used for various other things and the function to get it is `getMapBaseLayerId`. So it's a `layerId` actually.