### PR TITLE
Group untagged way nodes with same related ways

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -1,4 +1,22 @@
 module BrowseHelper
+  def group_way_nodes(way)
+    groups = []
+
+    way.way_nodes.each do |way_node|
+      related_ways = related_ways_of_way_node(way_node)
+      if !groups.empty? && way_node.node.tags.empty? && groups.last[:nodes].last.tags.empty? && groups.last[:related_ways] == related_ways
+        groups.last[:nodes] << way_node.node
+      else
+        groups << {
+          :nodes => [way_node.node],
+          :related_ways => related_ways
+        }
+      end
+    end
+
+    groups
+  end
+
   def element_icon(type, object)
     selected_icon_data = { :filename => "#{type}.svg", :priority => 1 }
 
@@ -118,5 +136,9 @@ module BrowseHelper
 
   def name_locales(object)
     object.tags.keys.map { |k| Regexp.last_match(1) if k =~ /^name:(.*)$/ }.flatten
+  end
+
+  def related_ways_of_way_node(way_node)
+    way_node.node.ways.uniq.sort.reject { |related_way| related_way.id == way_node.way_id }
   end
 end

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -25,15 +25,19 @@
       <details <%= "open" if way.way_nodes.count < 10 %>>
         <summary><%= t ".nodes_count", :count => way.way_nodes.count %></summary>
         <ul class="list-unstyled browse-element-list">
-          <% way.way_nodes.each do |wn| %>
-            <%= element_list_item "node", wn.node do %>
-              <%= element_single_current_link "node", wn.node %>
-              <% related_ways = wn.node.ways.reject { |w| w.id == wn.way_id } %>
+          <% group_way_nodes(way).each do |node_group| %>
+            <%= element_list_item "node", node_group[:nodes].first do %>
+              <% node_group[:nodes].each_with_index do |node, i| %>
+                <%= " · " if i.positive? %>
+                <%= element_single_current_link "node", node %>
+              <% end %>
               <% icon_connector = " " %>
-              <% if related_ways.size > 0 then %>
+              <% if node_group[:related_ways].size.positive? %>
                 (<%= t ".also_part_of_html",
-                       :count => related_ways.size,
-                       :related_ways => to_sentence(related_ways.map { |w| element_icon("way", w) + icon_connector + element_single_current_link("way", w) }) %>)
+                       :count => node_group[:related_ways].size,
+                       :related_ways => to_sentence(node_group[:related_ways].map do |w|
+                                                      element_icon("way", w) + icon_connector + element_single_current_link("way", w)
+                                                    end) %>)
               <% end %>
             <% end %>
           <% end %>

--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -4,6 +4,124 @@ class BrowseHelperTest < ActionView::TestCase
   include ERB::Util
   include ApplicationHelper
 
+  def test_group_way_nodes_one_node
+    way = create(:way_with_nodes, :nodes_count => 1)
+
+    assert_equal [
+      { :nodes => [way.nodes[0]], :related_ways => [] }
+    ], group_way_nodes(way)
+  end
+
+  def test_group_way_nodes_two_untagged_nodes
+    way = create(:way_with_nodes, :nodes_count => 2)
+
+    assert_equal [
+      { :nodes => [way.nodes[0], way.nodes[1]], :related_ways => [] }
+    ], group_way_nodes(way)
+  end
+
+  def test_group_way_nodes_two_tagged_nodes
+    way = create(:way_with_nodes, :nodes_count => 2)
+    create(:node_tag, :node => way.nodes[0], :k => "name", :v => "Distinct Node 0")
+    create(:node_tag, :node => way.nodes[1], :k => "name", :v => "Distinct Node 1")
+
+    assert_equal [
+      { :nodes => [way.nodes[0]], :related_ways => [] },
+      { :nodes => [way.nodes[1]], :related_ways => [] }
+    ], group_way_nodes(way)
+  end
+
+  #
+  # (b)--1--(a)--2--(c)
+  #
+  def test_group_way_nodes_shared_with_one_way
+    way1 = create(:way)
+    way2 = create(:way)
+    node_a = create(:node)
+    node_b = create(:node)
+    node_c = create(:node)
+    create(:way_node, :way => way1, :node => node_a, :sequence_id => 1)
+    create(:way_node, :way => way1, :node => node_b, :sequence_id => 2)
+    create(:way_node, :way => way2, :node => node_a, :sequence_id => 1)
+    create(:way_node, :way => way2, :node => node_c, :sequence_id => 2)
+
+    assert_equal [
+      { :nodes => [node_a], :related_ways => [way2] },
+      { :nodes => [node_b], :related_ways => [] }
+    ], group_way_nodes(way1)
+    assert_equal [
+      { :nodes => [node_a], :related_ways => [way1] },
+      { :nodes => [node_c], :related_ways => [] }
+    ], group_way_nodes(way2)
+  end
+
+  #
+  # (b)--1--(a)--2--(c)
+  #           \    /
+  #            \  /
+  #            (d)
+  #
+  def test_group_way_nodes_shared_with_one_looped_way
+    way1 = create(:way)
+    way2 = create(:way)
+    node_a = create(:node)
+    node_b = create(:node)
+    node_c = create(:node)
+    node_d = create(:node)
+    create(:way_node, :way => way1, :node => node_a, :sequence_id => 1)
+    create(:way_node, :way => way1, :node => node_b, :sequence_id => 2)
+    create(:way_node, :way => way2, :node => node_a, :sequence_id => 1)
+    create(:way_node, :way => way2, :node => node_c, :sequence_id => 2)
+    create(:way_node, :way => way2, :node => node_d, :sequence_id => 3)
+    create(:way_node, :way => way2, :node => node_a, :sequence_id => 4)
+
+    assert_equal [
+      { :nodes => [node_a], :related_ways => [way2] },
+      { :nodes => [node_b], :related_ways => [] }
+    ], group_way_nodes(way1)
+    assert_equal [
+      { :nodes => [node_a], :related_ways => [way1] },
+      { :nodes => [node_c, node_d], :related_ways => [] },
+      { :nodes => [node_a], :related_ways => [way1] }
+    ], group_way_nodes(way2)
+  end
+
+  #
+  # (b)--1--(a)--2--(c)
+  #           \
+  #            3
+  #             \
+  #             (d)
+  #
+  def test_group_way_nodes_shared_with_two_ways
+    way1 = create(:way)
+    way2 = create(:way)
+    way3 = create(:way)
+    node_a = create(:node)
+    node_b = create(:node)
+    node_c = create(:node)
+    node_d = create(:node)
+    create(:way_node, :way => way1, :node => node_a, :sequence_id => 1)
+    create(:way_node, :way => way1, :node => node_b, :sequence_id => 2)
+    create(:way_node, :way => way2, :node => node_a, :sequence_id => 1)
+    create(:way_node, :way => way2, :node => node_c, :sequence_id => 2)
+    create(:way_node, :way => way3, :node => node_a, :sequence_id => 1)
+    create(:way_node, :way => way3, :node => node_d, :sequence_id => 2)
+
+    assert_equal [
+      { :nodes => [node_a], :related_ways => [way2, way3] },
+      { :nodes => [node_b], :related_ways => [] }
+    ], group_way_nodes(way1)
+    assert_equal [
+      { :nodes => [node_a], :related_ways => [way1, way3] },
+      { :nodes => [node_c], :related_ways => [] }
+    ], group_way_nodes(way2)
+    assert_equal [
+      { :nodes => [node_a], :related_ways => [way1, way2] },
+      { :nodes => [node_d], :related_ways => [] }
+    ], group_way_nodes(way3)
+  end
+
   def test_printable_element_name
     node = create(:node, :with_history, :version => 2)
     node_v1 = node.old_nodes.find_by(:version => 1)


### PR DESCRIPTION
Extracted from #5355.

In #5317 I proposed to make the following change to browse way pages: for way nodes that are also part of other ways, instead of showing those ways inline as "(part of ways ...)" show them as foldable `<details>`. But that takes more vertical space especially if they are not folded by default and the question was whether we should fold them https://github.com/openstreetmap/openstreetmap-website/pull/5317#pullrequestreview-2434039905. But I think this is not a very efficient way of saving space because:
- if a (part of ways) list is short, we're not saving much by folding it
- long list are rare, therefore we don't save much by folding them either

A more efficient way to save space is to group similar nodes. This PR groups together untagged nodes that have the same related ways. Such nodes are not interesting on their own and don't deserve an entire line spend on them. With the current magnitude of ids and sidebar width we can fit three on one line when there's no scrollbar (and we can tweak letter spacing later to fit three even with a scrollbar). Long sequences of such nodes are expected on natural features, possibly sharing boundaries with other natural features, such as wood-grassland.

Before:
![image](https://github.com/user-attachments/assets/48832c40-47a1-4025-a3d2-021c50e2dd7f)

After:
![image](https://github.com/user-attachments/assets/d2487190-ce78-45fd-a597-c40a7fcbdfb6)

Also fixes https://github.com/openstreetmap/openstreetmap-website/issues/1147.

Before:
![image](https://github.com/user-attachments/assets/f7b78619-9c6b-4c1a-a538-038a17b8dc7e)

After:
![image](https://github.com/user-attachments/assets/513a72e9-3416-41d7-b4dc-f9f7a2e05860)
