### PR TITLE
Use map tiles dark mode with leaflet-osm plugin

### DIFF
--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -231,5 +231,13 @@ OSM = {
         Math.pow(Math.sin(latdiff / 2), 2) +
         Math.cos(lat1) * Math.cos(lat2) * Math.pow(Math.sin(lngdiff / 2), 2)
       ));
+  },
+
+  isDarkMap: function() {
+    var siteTheme = $('html').attr('data-bs-theme');
+    var mapTheme = $('html').attr('data-map-theme');
+    if (mapTheme) return mapTheme === 'dark';
+    if (siteTheme) return siteTheme === 'dark';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
   }
 };

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -9,7 +9,7 @@
 
 body {
   font-size: $typeheight;
-  --dark-mode-map-filter: brightness(.8);
+  --dark-mode-map-filter: none;
 }
 
 time[title] {

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -12,7 +12,7 @@ L.OSM.TileLayer = L.TileLayer.extend({
     options = L.Util.setOptions(this, options);
     url = isDarkMap ? options.darkUrl : options.lightUrl;
     if (url) this.schemeClass = isDarkMap ? 'dark' : 'light';
-    L.TileLayer.prototype.initialize.call(this, options.url);
+    L.TileLayer.prototype.initialize.call(this, url || options.url);
     this.on('add', function () {
       if (this._container && this.schemeClass) this._container.classList.add(this.schemeClass);
       if (this._container && this.options.filter) this._container.style.setProperty('--dark-mode-map-filter', this.options.filter);

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -8,14 +8,17 @@ L.OSM.TileLayer = L.TileLayer.extend({
 
   initialize: function (options) {
     isDarkMap = OSM.isDarkMap();
-    options.filter = (isDarkMap ? options.darkFilter : options.lightFilter) || options.filter;
+    options.filter = (isDarkMap ? options.darkFilter : options.lightFilter) || options.filter || 'none';
     options = L.Util.setOptions(this, options);
     url = isDarkMap ? options.darkUrl : options.lightUrl;
     if (url) this.schemeClass = isDarkMap ? 'dark' : 'light';
     L.TileLayer.prototype.initialize.call(this, url || options.url);
     this.on('add', function () {
-      if (this._container && this.schemeClass) this._container.classList.add(this.schemeClass);
-      if (this._container && this.options.filter) this._container.style.setProperty('--dark-mode-map-filter', this.options.filter);
+      if (this._container) {
+        if (this.schemeClass) this._container.classList.add(this.schemeClass);
+        this._container.style.setProperty('--dark-mode-map-filter', this.options.filter);
+        if (document.getElementById('map').contains(this._container)) document.querySelector('.key-ui').style.setProperty('--dark-mode-map-filter', this.options.filter);
+      }
     });
   }
 });

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -47,6 +47,7 @@ L.OSM.CycleMap = L.OSM.TileLayer.extend({
 L.OSM.TransportMap = L.OSM.TileLayer.extend({
   options: {
     url: 'https://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}{r}.png?apikey={apikey}',
+    darkUrl: 'https://{s}.tile.thunderforest.com/transport-dark/{z}/{x}/{y}{r}.png?apikey={apikey}',
     maxZoom: 21,
     attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors. Tiles courtesy of <a href="http://www.thunderforest.com/" target="_blank">Andy Allan</a>'
   }

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -14,10 +14,11 @@ L.OSM.TileLayer = L.TileLayer.extend({
     if (url) this.schemeClass = isDarkMap ? 'dark' : 'light';
     L.TileLayer.prototype.initialize.call(this, url || options.url);
     this.on('add', function () {
-      if (this._container) {
-        if (this.schemeClass) this._container.classList.add(this.schemeClass);
-        this._container.style.setProperty('--dark-mode-map-filter', this.options.filter);
-        if (document.getElementById('map').contains(this._container)) document.querySelector('.key-ui').style.setProperty('--dark-mode-map-filter', this.options.filter);
+      container = this.getContainer();
+      if (container) {
+        if (this.schemeClass) container.classList.add(this.schemeClass);
+        container.style.setProperty('--dark-mode-map-filter', this.options.filter);
+        if (document.getElementById('map').contains(container)) document.querySelector('.key-ui').style.setProperty('--dark-mode-map-filter', this.options.filter);
       }
     });
   }

--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -7,8 +7,16 @@ L.OSM.TileLayer = L.TileLayer.extend({
   },
 
   initialize: function (options) {
+    isDarkMap = OSM.isDarkMap();
+    options.filter = (isDarkMap ? options.darkFilter : options.lightFilter) || options.filter;
     options = L.Util.setOptions(this, options);
+    url = isDarkMap ? options.darkUrl : options.lightUrl;
+    if (url) this.schemeClass = isDarkMap ? 'dark' : 'light';
     L.TileLayer.prototype.initialize.call(this, options.url);
+    this.on('add', function () {
+      if (this._container && this.schemeClass) this._container.classList.add(this.schemeClass);
+      if (this._container && this.options.filter) this._container.style.setProperty('--dark-mode-map-filter', this.options.filter);
+    });
   }
 });
 


### PR DESCRIPTION
This lean and updated variant of #4777 follows the rules laid out in #5328 that were implemented in #5362.
Since the editing of the user preference happens on a different view/site, there is no need to listen to color scheme changes on the fly and the whole logic can happen in the initialization of `L.OSM.TileLayer`.
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/1cf69912-61df-43e0-98f4-8b618b4b2e0e)|![image](https://github.com/user-attachments/assets/39c96953-2135-49a0-96f3-563da18ae011)|

Additionally, a "dark" CSS class is introduced to allow better style targeting if the user wants to.
for example like this:
![image](https://github.com/user-attachments/assets/d90080f6-5265-41fa-8845-f4aeaa5e4a14)