### PR TITLE
Use map tiles dark mode without leaflet-osm plugin

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -31,6 +31,9 @@ L.OSM.layers = function (options) {
         var miniMap = L.map(mapContainer[0], { attributionControl: false, zoomControl: false, keyboard: false })
           .addLayer(new layer.constructor(layer.options));
 
+        if (layer.options.schemeClass)
+          miniMap.getPane('tilePane').classList.add(layer.options.schemeClass);
+
         miniMap.dragging.disable();
         miniMap.touchZoom.disable();
         miniMap.doubleClickZoom.disable();

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -34,6 +34,7 @@ L.OSM.layers = function (options) {
         if (layer.options.schemeClass) {
           miniMap.getPane("tilePane").classList.add(layer.options.schemeClass);
         }
+        miniMap.getPane("tilePane").style.setProperty("--dark-mode-map-filter", layer.options.filter || "none");
 
         miniMap.dragging.disable();
         miniMap.touchZoom.disable();

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -31,8 +31,9 @@ L.OSM.layers = function (options) {
         var miniMap = L.map(mapContainer[0], { attributionControl: false, zoomControl: false, keyboard: false })
           .addLayer(new layer.constructor(layer.options));
 
-        if (layer.options.schemeClass)
-          miniMap.getPane('tilePane').classList.add(layer.options.schemeClass);
+        if (layer.options.schemeClass) {
+          miniMap.getPane("tilePane").classList.add(layer.options.schemeClass);
+        }
 
         miniMap.dragging.disable();
         miniMap.touchZoom.disable();

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -35,7 +35,7 @@ L.OSM.Map = L.Map.extend({
         } else if (property === "darkUrl") {
           if (OSM.isDarkMap()) {
             layerOptions.url = value;
-            layerOptions.schemeClass = 'dark';
+            layerOptions.schemeClass = "dark";
           }
         } else {
           layerOptions[property] = value;
@@ -57,17 +57,19 @@ L.OSM.Map = L.Map.extend({
       code: "G"
     });
 
-    this.on("layeradd", function ({layer}) {
+    this.on("layeradd", function ({ layer }) {
       if (this.baseLayers.indexOf(layer) >= 0) {
         this.setMaxZoom(layer.options.maxZoom);
         const container = layer.getContainer();
         if (!container) return;
         if (layer.options.schemeClass) container.classList.add(layer.options.schemeClass);
         const filterRecievers = [container];
-        if (document.getElementById('map').contains(container))
-          filterRecievers.push(document.querySelector('.key-ui'));
-        for (let el of filterRecievers)
-          el.style.setProperty('--dark-mode-map-filter', layer.options.filter || 'none');
+        if (document.getElementById("map").contains(container)) {
+          filterRecievers.push(document.querySelector(".key-ui"));
+        }
+        for (let el of filterRecievers) {
+          el.style.setProperty("--dark-mode-map-filter", layer.options.filter || "none");
+        }
       }
     });
 
@@ -389,16 +391,18 @@ L.extend(L.Icon.Default.prototype, {
   }
 });
 
-OSM.isDarkMap = function() {
+OSM.isDarkMap = function () {
   var themeFlags = [
-    $('body').attr('data-map-theme'),
-    $('html').attr('data-bs-theme')
+    $("body").attr("data-map-theme"),
+    $("html").attr("data-bs-theme")
   ];
-  for (var themeFlag of themeFlags)
-    if (themeFlag)
-      return themeFlag === 'dark';
-  return window.matchMedia('(prefers-color-scheme: dark)').matches;
-}
+  for (var themeFlag of themeFlags) {
+    if (themeFlag) {
+      return themeFlag === "dark";
+    }
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+};
 
 OSM.getUserIcon = function (url) {
   return L.icon({

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -38,6 +38,7 @@
   layerId: "transportmap"
   nameId: "transport_map"
   apiKeyId: "THUNDERFOREST_KEY"
+  darkUrl: "https://{s}.tile.thunderforest.com/transport-dark/{z}/{x}/{y}{r}.png?apikey={apikey}"
   credit:
     id: "thunderforest_credit"
     children:


### PR DESCRIPTION
Like #5396 but without involving leaflet-osm.
Again, since embeds carry no color scheme preferences, I skipped the partially redundant implementation there.