### PR TITLE
Add date and url settings for offline message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -259,12 +259,7 @@ class ApplicationController < ActionController::Base
 
     request.content_security_policy = policy
 
-    case Settings.status
-    when "database_offline", "api_offline"
-      flash.now[:warning] = t("layouts.osm_offline")
-    when "database_readonly", "api_readonly"
-      flash.now[:warning] = t("layouts.osm_read_only")
-    end
+    flash.now[:warning] = { :partial => "layouts/offline_flash" } unless api_status == "online"
 
     request.xhr? ? "xhr" : "map"
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -107,6 +107,14 @@ class SiteController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       # don't try and derive a location from a missing/deleted object
     end
+
+    if api_status != "online"
+      flash.now[:warning] = { :partial => "layouts/offline_flash" }
+    elsif current_user && !current_user.data_public?
+      flash.now[:warning] = { :partial => "not_public_flash" }
+    else
+      @enable_editor = true
+    end
   end
 
   def copyright

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -137,11 +137,7 @@ class SiteController < ApplicationController
   def export; end
 
   def offline
-    flash.now[:warning] = if Settings.status == "database_offline"
-                            t("layouts.osm_offline")
-                          else
-                            t("layouts.osm_read_only")
-                          end
+    flash.now[:warning] = { :partial => "layouts/offline_flash" }
     render :html => nil, :layout => true
   end
 

--- a/app/views/layouts/_offline_flash.erb
+++ b/app/views/layouts/_offline_flash.erb
@@ -1,0 +1,5 @@
+<% if %w[database_offline api_offline].include? Settings.status %>
+  <%= t("layouts.osm_offline") %>
+<% elsif %w[database_readonly api_readonly].include? Settings.status %>
+  <%= t("layouts.osm_read_only") %>
+<% end %>

--- a/app/views/layouts/_offline_flash.erb
+++ b/app/views/layouts/_offline_flash.erb
@@ -1,5 +1,17 @@
-<% if %w[database_offline api_offline].include? Settings.status %>
-  <%= t(".osm_offline") %>
-<% elsif %w[database_readonly api_readonly].include? Settings.status %>
-  <%= t(".osm_read_only") %>
-<% end %>
+<div class="d-flex flex-column gap-2">
+  <% if %w[database_offline api_offline].include? Settings.status %>
+    <p class="mb-0">
+      <%= t(".osm_offline") %>
+    </p>
+  <% elsif %w[database_readonly api_readonly].include? Settings.status %>
+    <p class="mb-0">
+      <%= t(".osm_read_only") %>
+    </p>
+  <% end %>
+
+  <% if Settings.status_announcement_url %>
+    <p class="mb-0">
+      <%= link_to t(".announcement"), Settings.status_announcement_url %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/layouts/_offline_flash.erb
+++ b/app/views/layouts/_offline_flash.erb
@@ -9,6 +9,15 @@
     </p>
   <% end %>
 
+  <% if Settings.status_expected_restore_date %>
+    <% expected_restore_time = Time.parse(Settings.status_expected_restore_date).utc %>
+    <% if expected_restore_time > Time.now.utc %>
+      <p class="mb-0">
+        <%= t ".expected_restore_html", :time => friendly_date(expected_restore_time) %>
+      </p>
+    <% end %>
+  <% end %>
+
   <% if Settings.status_announcement_url %>
     <p class="mb-0">
       <%= link_to t(".announcement"), Settings.status_announcement_url %>

--- a/app/views/layouts/_offline_flash.erb
+++ b/app/views/layouts/_offline_flash.erb
@@ -1,5 +1,5 @@
 <% if %w[database_offline api_offline].include? Settings.status %>
-  <%= t("layouts.osm_offline") %>
+  <%= t(".osm_offline") %>
 <% elsif %w[database_readonly api_readonly].include? Settings.status %>
-  <%= t("layouts.osm_read_only") %>
+  <%= t(".osm_read_only") %>
 <% end %>

--- a/app/views/site/_not_public_flash.erb
+++ b/app/views/site/_not_public_flash.erb
@@ -1,0 +1,3 @@
+<p><%= t ".not_public" %></p>
+<p><%= t ".not_public_description_html", :user_page => (link_to t(".user_page_link"), edit_account_path(:anchor => "public")) %></p>
+<p><%= t ".anon_edits_html", :link => link_to(t(".anon_edits_link_text"), t(".anon_edits_link")) %></p>

--- a/app/views/site/edit.html.erb
+++ b/app/views/site/edit.html.erb
@@ -1,17 +1,5 @@
 <% content_for :content do %>
-  <% if Settings.status == "database_offline" or Settings.status == "api_offline" %>
-    <div class="alert alert-warning text-center">
-        <p class="my-2"><%= t "layouts.osm_offline" %></p>
-    </div>
-  <% elsif Settings.status == "database_readonly" or Settings.status == "api_readonly" %>
-    <div class="alert alert-warning text-center">
-        <p class="my-2"><%= t "layouts.osm_read_only" %></p>
-    </div>
-  <% elsif !current_user.data_public? %>
-    <p><%= t ".not_public" %></p>
-    <p><%= t ".not_public_description_html", :user_page => (link_to t(".user_page_link"), edit_account_path(:anchor => "public")) %></p>
-    <p><%= t ".anon_edits_html", :link => link_to(t(".anon_edits_link_text"), t(".anon_edits_link")) %></p>
-  <% else %>
+  <% if @enable_editor %>
     <%= render :partial => preferred_editor %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1608,6 +1608,7 @@ en:
     offline_flash:
       osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."
       osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential database maintenance work is carried out."
+      expected_restore_html: "Services are expected to be restored in %{time}."
       announcement: "You can read the announcement here."
   user_mailer:
     diary_comment_notification:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1608,6 +1608,7 @@ en:
     offline_flash:
       osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."
       osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential database maintenance work is carried out."
+      announcement: "You can read the announcement here."
   user_mailer:
     diary_comment_notification:
       description: "OpenStreetMap Diary Entry #%{id}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1606,8 +1606,8 @@ en:
     learn_more: "Learn More"
     more: More
     offline_flash:
-      osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."
-      osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential database maintenance work is carried out."
+      osm_offline: "The OpenStreetMap database is currently offline while essential maintenance work is carried out."
+      osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential maintenance work is carried out."
       expected_restore_html: "Services are expected to be restored in %{time}."
       announcement: "You can read the announcement here."
   user_mailer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1598,8 +1598,6 @@ en:
     partners_corpmembers: "OSMF corporate members"
     partners_partners: "partners"
     tou: "Terms of Use"
-    osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."
-    osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential database maintenance work is carried out."
     nothing_to_preview: "Nothing to preview."
     help: Help
     about: About
@@ -1607,6 +1605,9 @@ en:
     communities: Communities
     learn_more: "Learn More"
     more: More
+    offline_flash:
+      osm_offline: "The OpenStreetMap database is currently offline while essential database maintenance work is carried out."
+      osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential database maintenance work is carried out."
   user_mailer:
     diary_comment_notification:
       description: "OpenStreetMap Diary Entry #%{id}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2217,13 +2217,14 @@ en:
         license_url: "https://openstreetmap.org/copyright"
         project_url: "https://openstreetmap.org"
       remote_failed: "Editing failed - make sure JOSM or Merkaartor is loaded and the remote control option is enabled"
-    edit:
+    not_public_flash:
       not_public: "You have not set your edits to be public."
       not_public_description_html: "You can no longer edit the map unless you do so. You can set your edits as public from your %{user_page}."
       user_page_link: user page
       anon_edits_html: "(%{link})"
       anon_edits_link: "https://wiki.openstreetmap.org/wiki/Disabling_anonymous_edits"
       anon_edits_link_text: "Find out why this is the case."
+    edit:
       id_not_configured: "iD has not been configured"
     export:
       title: "Export"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,8 @@ api_version: "0.6"
 #   database_offline - database offline with site in emergency mode
 #   gpx_offline - gpx storage offline
 status: "online"
+# Expected services restoration date added to offline flash messages
+#status_expected_restore_date: "2024-12-18 12:00:00Z"
 # Application status announcement url added to offline flash messages
 #status_announcement_url: "https://en.osm.town/@osm_tech"
 # The maximum area you're allowed to request, in square degrees

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,8 @@ api_version: "0.6"
 #   database_offline - database offline with site in emergency mode
 #   gpx_offline - gpx storage offline
 status: "online"
+# Application status announcement url added to offline flash messages
+#status_announcement_url: "https://en.osm.town/@osm_tech"
 # The maximum area you're allowed to request, in square degrees
 max_request_area: 0.25
 # Number of GPS trace/trackpoints returned per-page


### PR DESCRIPTION
The current message doesn't say much about how long the api/db is expected to stay down.

on map layout:
![image](https://github.com/user-attachments/assets/47f12f55-f483-4d8e-9cf7-3cee3a77663b)

on site layout:
![image](https://github.com/user-attachments/assets/3180b074-4ff5-4189-bd99-79d9e13647b9)
