### PR TITLE
Check if db is writable on oauth authorization pages

### DIFF
--- a/app/controllers/oauth2_authorizations_controller.rb
+++ b/app/controllers/oauth2_authorizations_controller.rb
@@ -7,4 +7,6 @@ class Oauth2AuthorizationsController < Doorkeeper::AuthorizationsController
   allow_all_form_action :only => :new
 
   authorize_resource :class => false
+
+  before_action :check_database_writable
 end

--- a/test/controllers/oauth2_authorizations_controller_test.rb
+++ b/test/controllers/oauth2_authorizations_controller_test.rb
@@ -102,6 +102,20 @@ class Oauth2AuthorizationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", "The requested scope is invalid, unknown, or malformed."
   end
 
+  def test_new_db_readonly
+    application = create(:oauth_application, :scopes => "write_api")
+
+    session_for(create(:user))
+
+    with_settings(:status => "database_readonly") do
+      get oauth_authorization_path(:client_id => application.uid,
+                                   :redirect_uri => application.redirect_uri,
+                                   :response_type => "code",
+                                   :scope => "write_api")
+      assert_redirected_to offline_path
+    end
+  end
+
   def test_create
     application = create(:oauth_application, :scopes => "write_api")
 


### PR DESCRIPTION
Redirect to `/offline` from `/oauth2/authorize` if the database is offline.

Instead of this:
![image](https://github.com/user-attachments/assets/7b9511c5-459b-4b6b-aadf-c45fdb038e87)

users will see this:
![image](https://github.com/user-attachments/assets/b1464660-eb53-4575-83ac-63b54720480f)

Fixes #5400