### PR TITLE
Show 'api offline' message on new note page

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -44,5 +44,7 @@ class NotesController < ApplicationController
     render :template => "browse/not_found", :status => :not_found
   end
 
-  def new; end
+  def new
+    render :action => :new_readonly if api_status != "online"
+  end
 end

--- a/app/views/notes/new_readonly.html.erb
+++ b/app/views/notes/new_readonly.html.erb
@@ -1,0 +1,7 @@
+<% set_title(t(".title")) %>
+
+<%= render "sidebar_header", :title => t(".title") %>
+
+<div class="note">
+  <p class="alert alert-warning"><%= t(".warning") %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3032,6 +3032,9 @@ en:
       anonymous_warning_sign_up: "sign up"
       advice: "Your note is public and may be used to update the map, so don't enter personal information, or information from copyrighted maps or directory listings."
       add: Add Note
+    new_readonly:
+      title: "New Note"
+      warning: "New notes cannot be created because the OpenStreetMap API is currently in read-only mode."
     notes_paging_nav:
       showing_page: "Page %{page}"
       next: "Next"

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -1,0 +1,23 @@
+require "application_system_test_case"
+
+class CreateNoteTest < ApplicationSystemTestCase
+  test "can create note" do
+    visit new_note_path(:anchor => "map=18/0/0")
+
+    assert_button "Add Note", :disabled => true
+
+    fill_in "text", :with => "Some newly added note description"
+    click_on "Add Note"
+
+    assert_content "Unresolved note ##{Note.last.id}"
+    assert_content "Some newly added note description"
+  end
+
+  test "cannot create note when api is readonly" do
+    with_settings(:status => "api_readonly") do
+      visit new_note_path(:anchor => "map=18/0/0")
+
+      assert_no_button "Add Note", :disabled => true
+    end
+  end
+end


### PR DESCRIPTION
Show this on `/note/new` if the api is not online:
![image](https://github.com/user-attachments/assets/1c1bb942-28ed-423a-a0cd-2944cbd40410)

This is shown in read-only mode, offline mode already has a different message "Database offline for maintenance".

Fixes #5404.