### PR TITLE
Add standard patch/put api message update action

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,17 +77,17 @@ OpenStreetMap::Application.routes.draw do
         put "" => "user_preferences#update_all", :as => ""
       end
     end
+  end
 
-    resources :messages, :path => "user/messages", :constraints => { :id => /\d+/ }, :only => [:create, :show, :update, :destroy], :controller => "messages", :as => :api_messages do
+  namespace :api, :path => "api/0.6" do
+    resources :messages, :path => "user/messages", :constraints => { :id => /\d+/ }, :only => [:create, :show, :update, :destroy] do
       collection do
         get "inbox"
         get "outbox"
       end
     end
     post "/user/messages/:id" => "messages#update"
-  end
 
-  namespace :api, :path => "api/0.6" do
     resources :traces, :path => "gpx", :only => [:create, :show, :update, :destroy], :id => /\d+/ do
       scope :module => :traces do
         resource :data, :only => :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,14 +78,13 @@ OpenStreetMap::Application.routes.draw do
       end
     end
 
-    resources :messages, :path => "user/messages", :constraints => { :id => /\d+/ }, :only => [:create, :show, :destroy], :controller => "messages", :as => :api_messages do
+    resources :messages, :path => "user/messages", :constraints => { :id => /\d+/ }, :only => [:create, :show, :update, :destroy], :controller => "messages", :as => :api_messages do
       collection do
         get "inbox"
         get "outbox"
       end
     end
-
-    post "/user/messages/:id" => "messages#update", :as => :api_message_update
+    post "/user/messages/:id" => "messages#update"
   end
 
   namespace :api, :path => "api/0.6" do

--- a/test/controllers/api/messages_controller_test.rb
+++ b/test/controllers/api/messages_controller_test.rb
@@ -46,8 +46,12 @@ module Api
         { :controller => "api/messages", :action => "create" }
       )
       assert_routing(
-        { :path => "/api/0.6/user/messages/1", :method => :post },
+        { :path => "/api/0.6/user/messages/1", :method => :put },
         { :controller => "api/messages", :action => "update", :id => "1" }
+      )
+      assert_recognizes(
+        { :controller => "api/messages", :action => "update", :id => "1" },
+        { :path => "/api/0.6/user/messages/1", :method => :post }
       )
       assert_routing(
         { :path => "/api/0.6/user/messages/1", :method => :delete },
@@ -253,27 +257,27 @@ module Api
       msg = create(:message, :unread, :sender => sender, :recipient => recipient)
 
       # attempt to mark message as read by recipient, not authenticated
-      post api_message_path(:id => msg.id), :params => { :read_status => true }
+      put api_message_path(:id => msg.id), :params => { :read_status => true }
       assert_response :unauthorized
 
       # attempt to mark message as read by recipient, not allowed
-      post api_message_path(:id => msg.id), :params => { :read_status => true }, :headers => user3_auth
+      put api_message_path(:id => msg.id), :params => { :read_status => true }, :headers => user3_auth
       assert_response :forbidden
 
       # missing parameter
-      post api_message_path(:id => msg.id), :headers => recipient_auth
+      put api_message_path(:id => msg.id), :headers => recipient_auth
       assert_response :bad_request
 
       # wrong type of parameter
-      post api_message_path(:id => msg.id),
-           :params => { :read_status => "not a boolean" },
-           :headers => recipient_auth
+      put api_message_path(:id => msg.id),
+          :params => { :read_status => "not a boolean" },
+          :headers => recipient_auth
       assert_response :bad_request
 
       # mark message as read by recipient
-      post api_message_path(:id => msg.id, :format => "json"),
-           :params => { :read_status => true },
-           :headers => recipient_auth
+      put api_message_path(:id => msg.id, :format => "json"),
+          :params => { :read_status => true },
+          :headers => recipient_auth
       assert_response :success
       assert_equal "application/json", response.media_type
       js = ActiveSupport::JSON.decode(@response.body)
@@ -292,9 +296,9 @@ module Api
       assert_equal msg.body, jsm["body"]
 
       # mark message as unread by recipient
-      post api_message_path(:id => msg.id, :format => "json"),
-           :params => { :read_status => false },
-           :headers => recipient_auth
+      put api_message_path(:id => msg.id, :format => "json"),
+          :params => { :read_status => false },
+          :headers => recipient_auth
       assert_response :success
       assert_equal "application/json", response.media_type
       js = ActiveSupport::JSON.decode(@response.body)


### PR DESCRIPTION
A standard HTTP verb for update action in Rails is PATCH/PUT, but for messages API [it was made POST for some reason](https://wiki.openstreetmap.org/wiki/Messaging_API_proposal#Update_read_status_of_a_message). Here I'm adding PATCH/PUT. I'm keeping POST outside of the resources, but we should deprecate it.

Also I'm moving the resources to the api namespace. This allows to remove `:as`.