### PR TITLE
Pass correct URL to Facebook sharing

### DIFF
--- a/lib/social_share_button_helper.rb
+++ b/lib/social_share_button_helper.rb
@@ -39,7 +39,7 @@ module SocialShareButtonHelper
     when :linkedin
       "https://www.linkedin.com/sharing/share-offsite/?url=#{URI.encode_www_form_component(params[:url])}"
     when :facebook
-      "https://www.facebook.com/sharer/sharer.php?u=#{URI.encode_www_form_component('params[:url]')}&t=#{URI.encode_www_form_component(params[:title])}"
+      "https://www.facebook.com/sharer/sharer.php?u=#{URI.encode_www_form_component(params[:url])}&t=#{URI.encode_www_form_component(params[:title])}"
     when :mastodon
       "https://mastodonshare.com/?text=#{URI.encode_www_form_component(params[:title])}&url=#{URI.encode_www_form_component(params[:url])}"
     when :telegram


### PR DESCRIPTION
It was trying to pass the literal text `params[:url]` as the URL due to incorrect quoting.