### PR TITLE
Convert social share helper library into a real helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,5 @@
 module ApplicationHelper
   require "rexml/document"
-  include SocialShareButtonHelper
 
   def linkify(text)
     if text.html_safe?
@@ -75,33 +74,5 @@ module ApplicationHelper
     end
   rescue StandardError
     flash.inspect if Rails.env.development?
-  end
-
-  # Generates a set of social share buttons based on the specified options.
-  def render_social_share_buttons(opts = {})
-    sites = opts.fetch(:allow_sites, [])
-    valid_sites, invalid_sites = SocialShareButtonHelper.filter_allowed_sites(sites)
-
-    # Log invalid sites
-    invalid_sites.each do |invalid_site|
-      Rails.logger.error("Invalid site or icon not configured: #{invalid_site}")
-    end
-
-    tag.div(
-      :class => "social-share-button d-flex gap-1 align-items-end flex-wrap mb-3"
-    ) do
-      valid_sites.map do |site|
-        link_options = {
-          :rel => ["nofollow", opts[:rel]].compact,
-          :class => "ssb-icon rounded-circle",
-          :title => I18n.t("application.share.#{site}.title"),
-          :target => "_blank"
-        }
-
-        link_to SocialShareButtonHelper.generate_share_url(site, opts), link_options do
-          image_tag(SocialShareButtonHelper.icon_path(site), :alt => I18n.t("application.share.#{site}.alt"), :size => 28)
-        end
-      end.join.html_safe
-    end
   end
 end

--- a/test/helpers/social_share_button_helper_test.rb
+++ b/test/helpers/social_share_button_helper_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class SocialShareButtonHelperTest < ActionView::TestCase
   include SocialShareButtonHelper
-  include ApplicationHelper
 
   def setup
     @options = {
@@ -33,16 +32,5 @@ class SocialShareButtonHelperTest < ActionView::TestCase
     SocialShareButtonHelper::SOCIAL_SHARE_CONFIG.each_key do |site|
       assert_includes result, site.to_s # Convert symbol to string
     end
-  end
-
-  def test_filter_allowed_sites
-    valid_sites, invalid_sites = SocialShareButtonHelper.filter_allowed_sites(%w[x facebook invalid_site])
-    assert_equal %w[x facebook], valid_sites
-    assert_equal %w[invalid_site], invalid_sites
-  end
-
-  def test_icon_path
-    assert_equal "social_icons/x.svg", SocialShareButtonHelper.icon_path("x")
-    assert_equal "", SocialShareButtonHelper.icon_path("invalid_site")
   end
 end


### PR DESCRIPTION
This converts the confusingly named `SocialShareButtonHelper` which is really a library, but tested by a helper test, into a real helper and moves the actual `render_social_share_buttons` helper there from the application helper.

The other methods are then private as they're only used by `render_social_share_buttons` so are no longer tested separately as they're not visible to the test but will be tested implicitly by the calls to `render_social_share_buttons` in the other tests so coverage should be the same.