### PR TITLE
Add 'canDownloadImage' layer option

### DIFF
--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -338,7 +338,7 @@ L.OSM.share = function (options) {
 
     function update() {
       const layer = map.getMapBaseLayer();
-      var canEmbed = layer && layer.options.canEmbed;
+      var canEmbed = Boolean(layer && layer.options.canEmbed);
       var bounds = map.getBounds();
 
       $("#link_marker")
@@ -411,15 +411,10 @@ L.OSM.share = function (options) {
       $("#mapnik_image_width").text(mapWidth);
       $("#mapnik_image_height").text(mapHeight);
 
-      const layerId = map.getMapBaseLayerId();
-      const layerKeys = new Map([
-        ["mapnik", "standard"],
-        ["cyclemap", "cycle_map"],
-        ["transportmap", "transport_map"]
-      ]);
+      const canDownloadImage = Boolean(layer && layer.options.canDownloadImage);
 
-      $("#mapnik_image_layer").text(layerKeys.has(layerId) ? I18n.t(`javascripts.map.base.${layerKeys.get(layerId)}`) : "");
-      $("#map_format").val(layerId);
+      $("#mapnik_image_layer").text(canDownloadImage ? layer.options.name : "");
+      $("#map_format").val(canDownloadImage ? layer.options.layerId : "");
 
       $("#map_zoom").val(map.getZoom());
       $("#mapnik_lon").val(map.getCenter().lng);
@@ -427,18 +422,9 @@ L.OSM.share = function (options) {
       $("#map_width").val(mapWidth);
       $("#map_height").val(mapHeight);
 
-      if (["cyclemap", "transportmap"].includes(map.getMapBaseLayerId())) {
-        $("#export-image").show();
-        $("#mapnik_scale_row").hide();
-        $("#export-warning").hide();
-      } else if (map.getMapBaseLayerId() === "mapnik") {
-        $("#export-image").show();
-        $("#mapnik_scale_row").show();
-        $("#export-warning").hide();
-      } else {
-        $("#export-image").hide();
-        $("#export-warning").show();
-      }
+      $("#export-image").toggle(canDownloadImage);
+      $("#export-warning").toggle(!canDownloadImage);
+      $("#mapnik_scale_row").toggle(canDownloadImage && layer.options.layerId === "mapnik");
     }
 
     function select() {

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -130,7 +130,12 @@ L.OSM.share = function (options) {
     $("<div>")
       .attr("id", "export-warning")
       .attr("class", "text-body-secondary")
-      .text(I18n.t("javascripts.share.only_standard_layer"))
+      .text(I18n.t("javascripts.share.only_layers_exported_as_image"))
+      .append(
+        $("<ul>").append(
+          map.baseLayers
+            .filter(layer => layer.options.canDownloadImage)
+            .map(layer => $("<li>").text(layer.options.name))))
       .appendTo($imageSection);
 
     $form = $("<form>")

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -3,6 +3,7 @@
   layerId: "mapnik"
   nameId: "standard"
   canEmbed: true
+  canDownloadImage: true
   credit:
     id: "make_a_donation"
     href: "https://supporting.openstreetmap.org"
@@ -29,6 +30,7 @@
   nameId: "cycle_map"
   apiKeyId: "THUNDERFOREST_KEY"
   canEmbed: true
+  canDownloadImage: true
   credit:
     id: "thunderforest_credit"
     children:
@@ -42,6 +44,7 @@
   nameId: "transport_map"
   apiKeyId: "THUNDERFOREST_KEY"
   canEmbed: true
+  canDownloadImage: true
   credit:
     id: "thunderforest_credit"
     children:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3105,7 +3105,7 @@ en:
       center_marker: "Center map on marker"
       paste_html: "Paste HTML to embed in website"
       view_larger_map: "View Larger Map"
-      only_standard_layer: "Only the Standard, Cycle Map and Transport layers can be exported as an image"
+      only_layers_exported_as_image: "Only the following layers can be exported as an image:"
     embed:
       report_problem: "Report a problem"
     key:


### PR DESCRIPTION
Follows #5388. Removes hardcoded layer id checks in *Share > Image*, except for one special mapnik check.

If a layer that can't be downloaded is selected, the message shows a list of available layers:

Before:
![image](https://github.com/user-attachments/assets/ce67b154-f8e2-4d85-a62a-b0ff72a9e2b9)

After:
![image](https://github.com/user-attachments/assets/551fdfaf-9c3e-4324-ab5c-b386f7c7a3cf)
