### PR TITLE
Center share popup inside the browser window

### DIFF
--- a/app/assets/javascripts/social_share_button.js
+++ b/app/assets/javascripts/social_share_button.js
@@ -2,8 +2,8 @@ function openShareUrl(url, initialWidth = 640, initialHeight = 480) {
   const width = Math.max(100, Math.min(screen.width, initialWidth));
   const height = Math.max(100, Math.min(screen.height, initialHeight));
 
-  const left = (screen.width / 2) - (width / 2);
-  const top = (screen.height * 0.3) - (height / 2);
+  const left = screenLeft + ((outerWidth - width) / 2);
+  const top = screenTop + ((outerHeight - height) / 2);
   const opts = `width=${width},height=${height},left=${left},top=${top},menubar=no,status=no,location=no`;
 
   window.open(url, "popup", opts);


### PR DESCRIPTION
What the existing share popup window placement does is it places the popup horizontally in the center of the screen. I don't know if the popup can get placed literally in the corner (https://github.com/openstreetmap/openstreetmap-website/issues/5414#issuecomment-2551615977), maybe with a multi-monitor setup? But it still could be a surprising location if the monitor is large enough. Here the logic is changed to place the popup in the center of the browser window. Is it less surprising?

The only alternative to a popup window is a new tab, which is already available with middle click or context menu on share links.