### PR TITLE
Improve note testing and text handling

### DIFF
--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -61,7 +61,7 @@ OSM.Note = function (map) {
       };
 
       if (name !== "subscribe" && name !== "unsubscribe" && name !== "reopen") {
-        ajaxSettings.data = { text: $("textarea").val() };
+        ajaxSettings.data = { text: content.find("textarea").val() };
       }
 
       content.find("button[name]").prop("disabled", true);

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -4,20 +4,24 @@ class CreateNoteTest < ApplicationSystemTestCase
   test "can create note" do
     visit new_note_path(:anchor => "map=18/0/0")
 
-    assert_button "Add Note", :disabled => true
+    within_sidebar do
+      assert_button "Add Note", :disabled => true
 
-    fill_in "text", :with => "Some newly added note description"
-    click_on "Add Note"
+      fill_in "text", :with => "Some newly added note description"
+      click_on "Add Note"
 
-    assert_content "Unresolved note ##{Note.last.id}"
-    assert_content "Some newly added note description"
+      assert_content "Unresolved note ##{Note.last.id}"
+      assert_content "Some newly added note description"
+    end
   end
 
   test "cannot create note when api is readonly" do
     with_settings(:status => "api_readonly") do
       visit new_note_path(:anchor => "map=18/0/0")
 
-      assert_no_button "Add Note", :disabled => true
+      within_sidebar do
+        assert_no_button "Add Note", :disabled => true
+      end
     end
   end
 end

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -80,52 +80,6 @@ class NoteCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "can't resolve a note when blocked" do
-    note = create(:note_with_comments)
-    user = create(:user)
-    sign_in_as(user)
-    visit note_path(note)
-    create(:user_block, :user => user)
-
-    within_sidebar do
-      assert_text "Unresolved note"
-      assert_no_text "Resolved note"
-      assert_no_text "Your access to the API has been blocked"
-      assert_button "Resolve", :disabled => false
-      assert_button "Comment", :disabled => true
-
-      click_on "Resolve"
-
-      assert_text "Unresolved note"
-      assert_no_text "Resolved note"
-      assert_text "Your access to the API has been blocked"
-      assert_button "Resolve", :disabled => false
-      assert_button "Comment", :disabled => true
-    end
-  end
-
-  test "can't reactivate a note when blocked" do
-    note = create(:note_with_comments, :closed)
-    user = create(:user)
-    sign_in_as(user)
-    visit note_path(note)
-    create(:user_block, :user => user)
-
-    within_sidebar do
-      assert_no_text "Unresolved note"
-      assert_text "Resolved note"
-      assert_no_text "Your access to the API has been blocked"
-      assert_button "Reactivate", :disabled => false
-
-      click_on "Reactivate"
-
-      assert_no_text "Unresolved note"
-      assert_text "Resolved note"
-      assert_text "Your access to the API has been blocked"
-      assert_button "Reactivate", :disabled => false
-    end
-  end
-
   test "no subscribe button when not logged in" do
     note = create(:note_with_comments)
     visit note_path(note)

--- a/test/system/resolve_note_test.rb
+++ b/test/system/resolve_note_test.rb
@@ -9,11 +9,34 @@ class ResolveNoteTest < ApplicationSystemTestCase
 
     within_sidebar do
       assert_button "Resolve"
+      assert_no_button "Comment & Resolve"
       assert_no_button "Reactivate"
 
       click_on "Resolve"
 
       assert_content "Resolved note ##{note.id}"
+    end
+  end
+
+  test "can resolve an open note with a comment" do
+    note = create(:note_with_comments)
+    user = create(:user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_button "Resolve"
+      assert_no_button "Comment & Resolve"
+      assert_no_button "Reactivate"
+
+      fill_in "text", :with => "Note resolve text"
+
+      assert_button "Comment & Resolve"
+
+      click_on "Comment & Resolve"
+
+      assert_content "Resolved note ##{note.id}"
+      assert_content "Note resolve text"
     end
   end
 
@@ -25,6 +48,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
 
     within_sidebar do
       assert_no_button "Resolve"
+      assert_no_button "Comment & Resolve"
       assert_button "Reactivate"
 
       click_on "Reactivate"

--- a/test/system/resolve_note_test.rb
+++ b/test/system/resolve_note_test.rb
@@ -1,0 +1,36 @@
+require "application_system_test_case"
+
+class ResolveNoteTest < ApplicationSystemTestCase
+  test "can resolve an open note" do
+    note = create(:note_with_comments)
+    user = create(:user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_button "Resolve"
+      assert_no_button "Reactivate"
+
+      click_on "Resolve"
+
+      assert_content "Resolved note ##{note.id}"
+    end
+  end
+
+  test "can reactivate a closed note" do
+    note = create(:note_with_comments, :closed)
+    user = create(:user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_no_button "Resolve"
+      assert_button "Reactivate"
+
+      click_on "Reactivate"
+
+      assert_content "Unresolved note ##{note.id}"
+      assert_no_content "<iframe" # leak from share textarea
+    end
+  end
+end

--- a/test/system/resolve_note_test.rb
+++ b/test/system/resolve_note_test.rb
@@ -57,4 +57,50 @@ class ResolveNoteTest < ApplicationSystemTestCase
       assert_no_content "<iframe" # leak from share textarea
     end
   end
+
+  test "can't resolve a note when blocked" do
+    note = create(:note_with_comments)
+    user = create(:user)
+    sign_in_as(user)
+    visit note_path(note)
+    create(:user_block, :user => user)
+
+    within_sidebar do
+      assert_text "Unresolved note"
+      assert_no_text "Resolved note"
+      assert_no_text "Your access to the API has been blocked"
+      assert_button "Resolve", :disabled => false
+      assert_button "Comment", :disabled => true
+
+      click_on "Resolve"
+
+      assert_text "Unresolved note"
+      assert_no_text "Resolved note"
+      assert_text "Your access to the API has been blocked"
+      assert_button "Resolve", :disabled => false
+      assert_button "Comment", :disabled => true
+    end
+  end
+
+  test "can't reactivate a note when blocked" do
+    note = create(:note_with_comments, :closed)
+    user = create(:user)
+    sign_in_as(user)
+    visit note_path(note)
+    create(:user_block, :user => user)
+
+    within_sidebar do
+      assert_no_text "Unresolved note"
+      assert_text "Resolved note"
+      assert_no_text "Your access to the API has been blocked"
+      assert_button "Reactivate", :disabled => false
+
+      click_on "Reactivate"
+
+      assert_no_text "Unresolved note"
+      assert_text "Resolved note"
+      assert_text "Your access to the API has been blocked"
+      assert_button "Reactivate", :disabled => false
+    end
+  end
 end


### PR DESCRIPTION
- Add test that would have failed in #5359.
- Change the code that selects the text input from `$("textarea")` to `content.find("textarea")`. This should stop the html share code from getting posted to notes, although I couldn't reproduce that happening like @SomeoneElseOSM reported it yesterday. When you press *Hide* the textarea inside the left sidebar exists and is the first one on the page, I don't know how that other textarea got selected instead.