### PR TITLE
Test share textarea not to leak into note text on hiding resolved notes

### DIFF
--- a/test/system/resolve_note_test.rb
+++ b/test/system/resolve_note_test.rb
@@ -58,6 +58,37 @@ class ResolveNoteTest < ApplicationSystemTestCase
     end
   end
 
+  test "can hide an open note as moderator" do
+    note = create(:note_with_comments)
+    user = create(:moderator_user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_button "Hide"
+
+      click_on "Hide"
+
+      assert_content "Hidden note ##{note.id}"
+    end
+  end
+
+  test "can hide a closed note as moderator" do
+    note = create(:note_with_comments, :closed)
+    user = create(:moderator_user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_button "Hide"
+
+      click_on "Hide"
+
+      assert_content "Hidden note ##{note.id}"
+      assert_no_content "<iframe" # leak from share textarea
+    end
+  end
+
   test "can't resolve a note when blocked" do
     note = create(:note_with_comments)
     user = create(:user)


### PR DESCRIPTION
Follows #5419.

I figured out why bug on *Hide* was happening. It was happening when hiding resolved notes because there's no textarea for resolved notes. #5419 fixed that bug. Here I'm adding a test that would have failed.