### PR TITLE
Bump allowed ECMAScript version to 2021 (ES12)

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -5,7 +5,7 @@ module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
-      ecmaVersion: 2015,
+      ecmaVersion: 2021,
       sourceType: "script",
       globals: {
         ...globals.browser,


### PR DESCRIPTION
We've been on 2015 for a long time as we no longer care about IE there's probably no good reason not to bump it.

I've had a look at the support matrices and up to 2022 just about everything seems to be supported in all current browsers. Detailed results can be found:

* [ECMAScript 2016](https://caniuse.com/?feats=array-includes,mdn-javascript_operators_exponentiation)
* [ECMAScript 2017](https://caniuse.com/?feats=async-functions,object-values,object-entries,mdn-javascript_builtins_object_getownpropertydescriptors,pad-start-end,mdn-javascript_grammar_trailing_commas_trailing_commas_in_functions)
* [ECMAScript 2018](https://caniuse.com/?feats=mdn-javascript_builtins_regexp_dotall,js-regexp-lookbehind,mdn-javascript_builtins_symbol_asynciterator,mdn-javascript_functions_method_definitions_async_generator_methods,mdn-javascript_grammar_template_literals_template_literal_revision,mdn-javascript_operators_destructuring_rest_in_objects,mdn-javascript_operators_destructuring_rest_in_arrays,promise-finally)
* [ECMAScript 2019](https://caniuse.com/?feats=array-flat,mdn-javascript_builtins_object_fromentries,mdn-javascript_builtins_string_trimstart,mdn-javascript_builtins_symbol_description,mdn-javascript_statements_try_catch_optional_catch_binding,mdn-javascript_builtins_json_stringify_well_formed_stringify,mdn-javascript_builtins_array_sort_stable_sorting,mdn-javascript_builtins_function_tostring_tostring_revision)
* [ECMAScript 2020](https://caniuse.com/?feats=mdn-javascript_operators_optional_chaining,mdn-javascript_operators_nullish_coalescing,mdn-javascript_builtins_globalthis,es6-module-dynamic-import,bigint,mdn-javascript_builtins_promise_allsettled,mdn-javascript_builtins_string_matchall,mdn-javascript_statements_export_namespace,mdn-javascript_operators_import_meta)
* [ECMAScript 2021](https://caniuse.com/?feats=mdn-javascript_builtins_string_replaceall,mdn-javascript_builtins_promise_any,mdn-javascript_builtins_weakref,mdn-javascript_operators_logical_or_assignment,mdn-javascript_operators_logical_and_assignment,mdn-javascript_operators_nullish_coalescing_assignment,mdn-javascript_grammar_numeric_separators,mdn-javascript_builtins_finalizationregistry)
* [ECMAScript 2022](https://caniuse.com/?feats=mdn-javascript_builtins_array_at,mdn-javascript_builtins_regexp_hasindices,mdn-javascript_builtins_object_hasown,mdn-javascript_builtins_error_cause,mdn-javascript_operators_await_top_level,mdn-javascript_classes_private_class_fields,mdn-javascript_classes_private_class_methods,mdn-javascript_classes_static_class_fields,mdn-javascript_classes_static_initialization_blocks)

There is at least one 2023 feature that isn't fully supported yet:

* [ECMAScript 2023](https://caniuse.com/?feats=mdn-javascript_builtins_array_findlast,mdn-javascript_builtins_array_findlastindex,mdn-javascript_grammar_hashbang_comments,mdn-javascript_builtins_weakmap_symbol_as_keys,mdn-javascript_builtins_array_toreversed,mdn-javascript_builtins_array_tosorted,mdn-javascript_builtins_array_tospliced,mdn-javascript_builtins_array_with)