### PR TITLE
Replace show and index abilities with read ability

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -5,8 +5,7 @@ class Ability
 
   def initialize(user)
     can :query, :browse
-    can :show, [Node, Way, Relation]
-    can [:index, :show], [OldNode, OldWay, OldRelation]
+    can :read, [Node, Way, Relation, OldNode, OldWay, OldRelation]
     can [:show, :create], Note
     can :search, :direction
     can [:index, :permalink, :edit, :help, :fixthemap, :offline, :export, :about, :communities, :preview, :copyright, :key, :id], :site
@@ -14,47 +13,47 @@ class Ability
     can [:search, :search_latlon, :search_osm_nominatim, :search_osm_nominatim_reverse], :geocoder
 
     if Settings.status != "database_offline"
-      can [:index, :feed, :show], Changeset
-      can :show, ChangesetComment
+      can [:read, :feed], Changeset
+      can :read, ChangesetComment
       can [:confirm, :confirm_resend, :confirm_email], :confirmation
-      can [:index, :rss, :show], DiaryEntry
-      can :index, DiaryComment
+      can [:read, :rss], DiaryEntry
+      can :read, DiaryComment
       can [:index], Note
       can [:create, :update], :password
-      can [:index, :show], Redaction
+      can :read, Redaction
       can [:create, :destroy], :session
-      can [:index, :show, :data, :georss], Trace
-      can [:terms, :create, :save, :suspended, :show, :auth_success, :auth_failure], User
-      can [:index, :show, :blocks_on, :blocks_by], UserBlock
+      can [:read, :data, :georss], Trace
+      can [:read, :terms, :create, :save, :suspended, :auth_success, :auth_failure], User
+      can [:read, :blocks_on, :blocks_by], UserBlock
     end
 
     if user&.active?
       can :welcome, :site
-      can [:show], :deletion
+      can :read, :deletion
 
       if Settings.status != "database_offline"
         can [:subscribe, :unsubscribe], Changeset
-        can [:index, :create, :show, :update, :destroy], :oauth2_application
-        can [:index, :destroy], :oauth2_authorized_application
-        can [:show, :create, :destroy], :oauth2_authorization
+        can [:read, :create, :update, :destroy], :oauth2_application
+        can [:read, :destroy], :oauth2_authorized_application
+        can [:read, :create, :destroy], :oauth2_authorization
         can [:update, :destroy], :account
-        can [:show], :dashboard
+        can :read, :dashboard
         can [:create, :subscribe, :unsubscribe], DiaryEntry
         can :update, DiaryEntry, :user => user
         can [:create], DiaryComment
         can [:make_friend, :remove_friend], Friendship
-        can [:create, :reply, :show, :inbox, :outbox, :muted, :mark, :unmute, :destroy], Message
+        can [:read, :create, :reply, :inbox, :outbox, :muted, :mark, :unmute, :destroy], Message
         can [:close, :reopen], Note
-        can [:show, :update], :preference
+        can [:read, :update], :preference
         can :update, :profile
         can :create, Report
         can [:mine, :create, :update, :destroy], Trace
         can [:account, :go_public], User
-        can [:index, :create, :destroy], UserMute
+        can [:read, :create, :destroy], UserMute
 
         if user.moderator?
           can [:hide, :unhide], [DiaryEntry, DiaryComment]
-          can [:index, :show, :resolve, :ignore, :reopen], Issue
+          can [:read, :resolve, :ignore, :reopen], Issue
           can :create, IssueComment
           can [:create, :update, :destroy], Redaction
           can [:create, :revoke_all], UserBlock
@@ -65,10 +64,10 @@ class Ability
 
         if user.administrator?
           can [:hide, :unhide], [DiaryEntry, DiaryComment]
-          can [:index, :show, :resolve, :ignore, :reopen], Issue
+          can [:read, :resolve, :ignore, :reopen], Issue
           can :create, IssueComment
           can [:set_status, :destroy], User
-          can [:show, :update], :users_list
+          can [:read, :update], :users_list
           can [:create, :destroy], UserRole
         end
       end

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -4,27 +4,24 @@ class ApiAbility
   include CanCan::Ability
 
   def initialize(user)
-    can :show, :capability
-    can :index, :map
-    can :show, :permission
-    can :show, :version
+    can :read, [:version, :capability, :permission, :map]
 
     if Settings.status != "database_offline"
-      can [:index, :show, :download], Changeset
-      can [:index, :create, :feed, :show, :search], Note
-      can :index, Tracepoint
-      can [:index, :show], User
-      can [:index, :show], Node
-      can [:index, :show, :full, :ways_for_node], Way
-      can [:index, :show, :full, :relations_for_node, :relations_for_way, :relations_for_relation], Relation
-      can [:history, :show], [OldNode, OldWay, OldRelation]
-      can [:show], UserBlock
+      can [:read, :download], Changeset
+      can [:read, :create, :feed, :search], Note
+      can :read, Tracepoint
+      can :read, User
+      can :read, Node
+      can [:read, :full, :ways_for_node], Way
+      can [:read, :full, :relations_for_node, :relations_for_way, :relations_for_relation], Relation
+      can [:history, :read], [OldNode, OldWay, OldRelation]
+      can :read, UserBlock
 
       if user&.active?
         can [:comment, :close, :reopen], Note
-        can [:create, :show, :update, :destroy], Trace
+        can [:read, :create, :update, :destroy], Trace
         can [:details, :gpx_files], User
-        can [:index, :show, :update, :update_all, :destroy], UserPreference
+        can [:read, :update, :update_all, :destroy], UserPreference
 
         if user.terms_agreed?
           can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset

--- a/app/abilities/api_capability.rb
+++ b/app/abilities/api_capability.rb
@@ -10,13 +10,13 @@ class ApiCapability
       if user&.active?
         can [:create, :comment, :close, :reopen], Note if scope?(token, :write_notes)
         can [:create, :destroy], NoteSubscription if scope?(token, :write_notes)
-        can [:show, :data], Trace if scope?(token, :read_gpx)
+        can [:read, :data], Trace if scope?(token, :read_gpx)
         can [:create, :update, :destroy], Trace if scope?(token, :write_gpx)
         can [:details], User if scope?(token, :read_prefs)
         can [:gpx_files], User if scope?(token, :read_gpx)
-        can [:index, :show], UserPreference if scope?(token, :read_prefs)
+        can :read, UserPreference if scope?(token, :read_prefs)
         can [:update, :update_all, :destroy], UserPreference if scope?(token, :write_prefs)
-        can [:inbox, :outbox, :show, :update, :destroy], Message if scope?(token, :consume_messages)
+        can [:inbox, :outbox, :read, :update, :destroy], Message if scope?(token, :consume_messages)
         can [:create], Message if scope?(token, :send_messages)
 
         if user.terms_agreed?


### PR DESCRIPTION
Use [CanCanCan's `:read` alias](https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md#can-actions) instead of `:index` and `:show` abilities. Similar to https://github.com/openstreetmap/openstreetmap-website/pull/5164 and https://github.com/openstreetmap/openstreetmap-website/pull/5185.

I made a couple of exceptions:
- `Note` has `:show` and `:index` abilities in different branches. I kept them. It's probably because one is on map layout, another one is on site layout and we try to avoid redirecting to the 403 page from map layout.
- I kept `:index` for `:site`. `:index` here means an entirely different thing.