### PR TITLE
Move user preferences routes to api namespace

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,15 +71,15 @@ OpenStreetMap::Application.routes.draw do
     get "user/details" => "users#details"
     get "user/gpx_files" => "users#gpx_files"
     get "users" => "users#index", :as => :api_users
+  end
 
-    resources :user_preferences, :except => [:new, :create, :edit], :param => :preference_key, :path => "user/preferences", :controller => "user_preferences" do
+  namespace :api, :path => "api/0.6" do
+    resources :user_preferences, :except => [:new, :create, :edit], :param => :preference_key, :path => "user/preferences" do
       collection do
         put "" => "user_preferences#update_all", :as => ""
       end
     end
-  end
 
-  namespace :api, :path => "api/0.6" do
     resources :messages, :path => "user/messages", :constraints => { :id => /\d+/ }, :only => [:create, :show, :update, :destroy] do
       collection do
         get "inbox"

--- a/test/controllers/api/user_preferences_controller_test.rb
+++ b/test/controllers/api/user_preferences_controller_test.rb
@@ -35,14 +35,14 @@ module Api
     # test showing all preferences
     def test_index
       # first try without auth
-      get user_preferences_path
+      get api_user_preferences_path
       assert_response :unauthorized, "should be authenticated"
 
       # authenticate as a user with no preferences
       auth_header = bearer_authorization_header
 
       # try the read again
-      get user_preferences_path, :headers => auth_header
+      get api_user_preferences_path, :headers => auth_header
       assert_select "osm" do
         assert_select "preferences", :count => 1 do
           assert_select "preference", :count => 0
@@ -56,7 +56,7 @@ module Api
       auth_header = bearer_authorization_header(user)
 
       # try the read again
-      get user_preferences_path, :headers => auth_header
+      get api_user_preferences_path, :headers => auth_header
       assert_response :success
       assert_equal "application/xml", @response.media_type
       assert_select "osm" do
@@ -68,7 +68,7 @@ module Api
       end
 
       # Test json
-      get user_preferences_path(:format => "json"), :headers => auth_header
+      get api_user_preferences_path(:format => "json"), :headers => auth_header
       assert_response :success
       assert_equal "application/json", @response.media_type
 
@@ -85,20 +85,20 @@ module Api
       create(:user_preference, :user => user, :k => "key", :v => "value")
 
       # try a read without auth
-      get user_preference_path(:preference_key => "key")
+      get api_user_preference_path(:preference_key => "key")
       assert_response :unauthorized, "should be authenticated"
 
       # authenticate as a user with preferences
       auth_header = bearer_authorization_header(user)
 
       # try the read again
-      get user_preference_path(:preference_key => "key"), :headers => auth_header
+      get api_user_preference_path(:preference_key => "key"), :headers => auth_header
       assert_response :success
       assert_equal "text/plain", @response.media_type
       assert_equal "value", @response.body
 
       # try the read again for a non-existent key
-      get user_preference_path(:preference_key => "unknown_key"), :headers => auth_header
+      get api_user_preference_path(:preference_key => "unknown_key"), :headers => auth_header
       assert_response :not_found
     end
 
@@ -111,7 +111,7 @@ module Api
 
       # try a put without auth
       assert_no_difference "UserPreference.count" do
-        put user_preferences_path, :params => "<osm><preferences><preference k='key' v='new_value'/><preference k='new_key' v='value'/></preferences></osm>"
+        put api_user_preferences_path, :params => "<osm><preferences><preference k='key' v='new_value'/><preference k='new_key' v='value'/></preferences></osm>"
       end
       assert_response :unauthorized, "should be authenticated"
       assert_equal "value", UserPreference.find([user.id, "key"]).v
@@ -125,7 +125,7 @@ module Api
 
       # try the put again
       assert_no_difference "UserPreference.count" do
-        put user_preferences_path, :params => "<osm><preferences><preference k='key' v='new_value'/><preference k='new_key' v='value'/></preferences></osm>", :headers => auth_header
+        put api_user_preferences_path, :params => "<osm><preferences><preference k='key' v='new_value'/><preference k='new_key' v='value'/></preferences></osm>", :headers => auth_header
       end
       assert_response :success
       assert_equal "text/plain", @response.media_type
@@ -138,7 +138,7 @@ module Api
 
       # try a put with duplicate keys
       assert_no_difference "UserPreference.count" do
-        put user_preferences_path, :params => "<osm><preferences><preference k='key' v='value'/><preference k='key' v='newer_value'/></preferences></osm>", :headers => auth_header
+        put api_user_preferences_path, :params => "<osm><preferences><preference k='key' v='value'/><preference k='key' v='newer_value'/></preferences></osm>", :headers => auth_header
       end
       assert_response :bad_request
       assert_equal "text/plain", @response.media_type
@@ -147,13 +147,13 @@ module Api
 
       # try a put with invalid content
       assert_no_difference "UserPreference.count" do
-        put user_preferences_path, :params => "nonsense", :headers => auth_header
+        put api_user_preferences_path, :params => "nonsense", :headers => auth_header
       end
       assert_response :bad_request
 
       # try a put with unicode characters
       assert_no_difference "UserPreference.count" do
-        put user_preferences_path, :params => "<osm><preferences><preference k='kêy' v='néw_vâlué'/><preference k='nêw_kêy' v='vâlué'/></preferences></osm>", :headers => auth_header
+        put api_user_preferences_path, :params => "<osm><preferences><preference k='kêy' v='néw_vâlué'/><preference k='nêw_kêy' v='vâlué'/></preferences></osm>", :headers => auth_header
       end
       assert_response :success
       assert_equal "text/plain", @response.media_type
@@ -173,7 +173,7 @@ module Api
 
       # try a put without auth
       assert_no_difference "UserPreference.count" do
-        put user_preference_path(:preference_key => "new_key"), :params => "new_value"
+        put api_user_preference_path(:preference_key => "new_key"), :params => "new_value"
       end
       assert_response :unauthorized, "should be authenticated"
       assert_raises ActiveRecord::RecordNotFound do
@@ -185,7 +185,7 @@ module Api
 
       # try adding a new preference
       assert_difference "UserPreference.count", 1 do
-        put user_preference_path(:preference_key => "new_key"), :params => "new_value", :headers => auth_header
+        put api_user_preference_path(:preference_key => "new_key"), :params => "new_value", :headers => auth_header
       end
       assert_response :success
       assert_equal "text/plain", @response.media_type
@@ -194,7 +194,7 @@ module Api
 
       # try changing the value of a preference
       assert_no_difference "UserPreference.count" do
-        put user_preference_path(:preference_key => "new_key"), :params => "newer_value", :headers => auth_header
+        put api_user_preference_path(:preference_key => "new_key"), :params => "newer_value", :headers => auth_header
       end
       assert_response :success
       assert_equal "text/plain", @response.media_type
@@ -203,7 +203,7 @@ module Api
 
       # try changing the value of a preference to include unicode characters
       assert_difference "UserPreference.count", 1 do
-        put user_preference_path(:preference_key => "nêw_kêy"), :params => "néwèr_vâlué", :headers => auth_header
+        put api_user_preference_path(:preference_key => "nêw_kêy"), :params => "néwèr_vâlué", :headers => auth_header
       end
       assert_response :success
       assert_equal "text/plain", @response.media_type
@@ -219,7 +219,7 @@ module Api
 
       # try a delete without auth
       assert_no_difference "UserPreference.count" do
-        delete user_preference_path(:preference_key => "key")
+        delete api_user_preference_path(:preference_key => "key")
       end
       assert_response :unauthorized, "should be authenticated"
       assert_equal "value", UserPreference.find([user.id, "key"]).v
@@ -229,7 +229,7 @@ module Api
 
       # try the delete again
       assert_difference "UserPreference.count", -1 do
-        delete user_preference_path(:preference_key => "key"), :headers => auth_header
+        delete api_user_preference_path(:preference_key => "key"), :headers => auth_header
       end
       assert_response :success
       assert_equal "text/plain", @response.media_type
@@ -240,7 +240,7 @@ module Api
 
       # try the delete again for the same key
       assert_no_difference "UserPreference.count" do
-        delete user_preference_path(:preference_key => "key"), :headers => auth_header
+        delete api_user_preference_path(:preference_key => "key"), :headers => auth_header
       end
       assert_response :not_found
       assert_raises ActiveRecord::RecordNotFound do
@@ -255,7 +255,7 @@ module Api
       auth_header = bearer_authorization_header(user, :scopes => %w[read_prefs])
       create(:user_preference, :user => user, :k => "key", :v => "value")
 
-      get user_preference_path(:preference_key => "key"), :headers => auth_header
+      get api_user_preference_path(:preference_key => "key"), :headers => auth_header
       assert_response :success
     end
 
@@ -267,7 +267,7 @@ module Api
       auth_header = bearer_authorization_header(user, :scopes => %w[])
       create(:user_preference, :user => user, :k => "key", :v => "value")
 
-      get user_preference_path(:preference_key => "key"), :headers => auth_header
+      get api_user_preference_path(:preference_key => "key"), :headers => auth_header
       assert_response :forbidden
     end
   end

--- a/test/integration/oauth2_test.rb
+++ b/test/integration/oauth2_test.rb
@@ -222,18 +222,18 @@ class OAuth2Test < ActionDispatch::IntegrationTest
   end
 
   def test_token(token, user, client)
-    get user_preferences_path
+    get api_user_preferences_path
     assert_response :unauthorized
 
     auth_header = bearer_authorization_header(token)
 
-    get user_preferences_path, :headers => auth_header
+    get api_user_preferences_path, :headers => auth_header
     assert_response :success
 
-    get user_preferences_path(:access_token => token)
+    get api_user_preferences_path(:access_token => token)
     assert_response :unauthorized
 
-    get user_preferences_path(:bearer_token => token)
+    get api_user_preferences_path(:bearer_token => token)
     assert_response :unauthorized
 
     get api_trace_path(:id => 2), :headers => auth_header
@@ -241,17 +241,17 @@ class OAuth2Test < ActionDispatch::IntegrationTest
 
     user.suspend!
 
-    get user_preferences_path, :headers => auth_header
+    get api_user_preferences_path, :headers => auth_header
     assert_response :forbidden
 
     user.hide!
 
-    get user_preferences_path, :headers => auth_header
+    get api_user_preferences_path, :headers => auth_header
     assert_response :forbidden
 
     user.unhide!
 
-    get user_preferences_path, :headers => auth_header
+    get api_user_preferences_path, :headers => auth_header
     assert_response :success
 
     post oauth_revoke_path(:token => token)
@@ -262,7 +262,7 @@ class OAuth2Test < ActionDispatch::IntegrationTest
                            :client_secret => client.plaintext_secret)
     assert_response :success
 
-    get user_preferences_path, :headers => auth_header
+    get api_user_preferences_path, :headers => auth_header
     assert_response :unauthorized
   end
 end


### PR DESCRIPTION
Done to eventually move all api routes to api namespace.

Gives `api_` prefix to path helpers.