### PR TITLE
Simplify calls to user block path helpers

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -64,7 +64,7 @@ class UserBlocksController < ApplicationController
         render :action => "new"
       end
     else
-      redirect_to new_user_block_path(:display_name => params[:display_name])
+      redirect_to new_user_block_path(params[:display_name])
     end
   end
 
@@ -101,7 +101,7 @@ class UserBlocksController < ApplicationController
         end
       end
     else
-      redirect_to edit_user_block_path(:id => params[:id])
+      redirect_to edit_user_block_path(params[:id])
     end
   end
 

--- a/test/controllers/api/user_blocks_controller_test.rb
+++ b/test/controllers/api/user_blocks_controller_test.rb
@@ -16,11 +16,11 @@ module Api
     def test_show
       block = create(:user_block)
 
-      get api_user_block_path(:id => block)
+      get api_user_block_path(block)
       assert_response :success
       assert_select "user_block[id='#{block.id}']", 1
 
-      get api_user_block_path(:id => block, :format => "json")
+      get api_user_block_path(block, :format => "json")
       assert_response :success
       js = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil js
@@ -28,7 +28,7 @@ module Api
     end
 
     def test_show_not_found
-      get api_user_block_path(:id => 123)
+      get api_user_block_path(123)
       assert_response :not_found
       assert_equal "text/plain", @response.media_type
     end

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -123,26 +123,26 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     revoked_block = create(:user_block, :revoked)
 
     # Viewing a block should fail when a bogus ID is given
-    get user_block_path(:id => 99999)
+    get user_block_path(99999)
     assert_response :not_found
     assert_template "not_found"
     assert_select "p", "Sorry, the user block with ID 99999 could not be found."
 
     # Viewing an expired block should work
-    get user_block_path(:id => expired_block)
+    get user_block_path(expired_block)
     assert_response :success
     assert_select "h1 a[href='#{user_path expired_block.user}']", :text => expired_block.user.display_name
     assert_select "h1 a[href='#{user_path expired_block.creator}']", :text => expired_block.creator.display_name
 
     # Viewing a revoked block should work
-    get user_block_path(:id => revoked_block)
+    get user_block_path(revoked_block)
     assert_response :success
     assert_select "h1 a[href='#{user_path revoked_block.user}']", :text => revoked_block.user.display_name
     assert_select "h1 a[href='#{user_path revoked_block.creator}']", :text => revoked_block.creator.display_name
     assert_select "a[href='#{user_path revoked_block.revoker}']", :text => revoked_block.revoker.display_name
 
     # Viewing an active block should work, but shouldn't mark it as seen
-    get user_block_path(:id => active_block)
+    get user_block_path(active_block)
     assert_response :success
     assert_select "h1 a[href='#{user_path active_block.user}']", :text => active_block.user.display_name
     assert_select "h1 a[href='#{user_path active_block.creator}']", :text => active_block.creator.display_name
@@ -293,7 +293,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     end
 
     # We should get an error if the user doesn't exist
-    get new_user_block_path(:display_name => "non_existent_user")
+    get new_user_block_path("non_existent_user")
     assert_response :not_found
     assert_template "users/no_such_user"
     assert_select "h1", "The user non_existent_user does not exist"
@@ -307,21 +307,21 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     active_block = create(:user_block, :creator => creator_user)
 
     # Check that the block edit page requires us to login
-    get edit_user_block_path(:id => active_block)
+    get edit_user_block_path(active_block)
     assert_redirected_to login_path(:referer => edit_user_block_path(active_block))
 
     # Login as a normal user
     session_for(create(:user))
 
     # Check that normal users can't load the block edit page
-    get edit_user_block_path(:id => active_block)
+    get edit_user_block_path(active_block)
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as a moderator
     session_for(other_moderator_user)
 
     # Check that the block edit page loads for moderators
-    get edit_user_block_path(:id => active_block)
+    get edit_user_block_path(active_block)
     assert_response :success
     assert_select "h1 a[href='#{user_path active_block.user}']", :text => active_block.user.display_name
     assert_select "form#edit_user_block_#{active_block.id}", :count => 1 do
@@ -338,7 +338,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     session_for(creator_user)
 
     # Check that the block edit page loads for the creator
-    get edit_user_block_path(:id => active_block)
+    get edit_user_block_path(active_block)
     assert_response :success
     assert_select "h1 a[href='#{user_path active_block.user}']", :text => active_block.user.display_name
     assert_select "form#edit_user_block_#{active_block.id}", :count => 1 do
@@ -352,7 +352,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     end
 
     # We should get an error if the user doesn't exist
-    get edit_user_block_path(:id => 99999)
+    get edit_user_block_path(99999)
     assert_response :not_found
     assert_template "not_found"
     assert_select "p", "Sorry, the user block with ID 99999 could not be found."
@@ -421,7 +421,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
                             :user_block => { :needs_view => false, :reason => "Vandalism" })
     end
     b = UserBlock.last
-    assert_redirected_to user_block_path(:id => b.id)
+    assert_redirected_to user_block_path(b)
     assert_equal "Created a block on user #{target_user.display_name}.", flash[:notice]
     assert_in_delta Time.now.utc, b.created_at, 1
     assert_in_delta Time.now.utc, b.updated_at, 1
@@ -466,14 +466,14 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     active_block = create(:user_block, :creator => moderator_user)
 
     # Not logged in yet, so updating a block should fail
-    put user_block_path(:id => active_block)
+    put user_block_path(active_block)
     assert_response :forbidden
 
     # Login as a normal user
     session_for(create(:user))
 
     # Check that normal users can't update blocks
-    put user_block_path(:id => active_block)
+    put user_block_path(active_block)
     assert_redirected_to :controller => "errors", :action => "forbidden"
 
     # Login as the moderator
@@ -481,14 +481,14 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
 
     # A bogus block period should result in an error
     assert_no_difference "UserBlock.count" do
-      put user_block_path(:id => active_block, :user_block_period => "99")
+      put user_block_path(active_block, :user_block_period => "99")
     end
     assert_redirected_to edit_user_block_path(active_block)
     assert_equal "The blocking period must be one of the values selectable in the drop-down list.", flash[:error]
 
     # Check that updating a block works
     assert_no_difference "UserBlock.count" do
-      put user_block_path(:id => active_block,
+      put user_block_path(active_block,
                           :user_block_period => "12",
                           :user_block => { :needs_view => true, :reason => "Vandalism" })
     end
@@ -500,7 +500,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Vandalism", b.reason
 
     # We should get an error if the block doesn't exist
-    put user_block_path(:id => 99999)
+    put user_block_path(99999)
     assert_response :not_found
     assert_template "not_found"
     assert_select "p", "Sorry, the user block with ID 99999 could not be found."


### PR DESCRIPTION
Similar to #5424, for `*_user_block_path` helpers.