### PR TITLE
Use map tiles dark mode from leaflet-osm plugin

### DIFF
--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -31,6 +31,9 @@ L.OSM.layers = function (options) {
         var miniMap = L.map(mapContainer[0], { attributionControl: false, zoomControl: false, keyboard: false })
           .addLayer(new layer.constructor(layer.options));
 
+        if (layer.options.schemeClass) miniMap.getPane("tilePane").classList.add(layer.options.schemeClass);
+        miniMap.getPane("tilePane").style.setProperty("--dark-mode-map-filter", layer.options.filter || "none");
+
         miniMap.dragging.disable();
         miniMap.touchZoom.disable();
         miniMap.doubleClickZoom.disable();

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -61,7 +61,7 @@ L.OSM.Map = L.Map.extend({
       const container = layer.getContainer();
       if (layer.options.schemeClass) container.classList.add(layer.options.schemeClass);
       for (let filterReceiver of [container, document.querySelector(".key-ui")]) {
-        if (!filterReceiver?.style?.setProperty) continue;
+        if (!filterReceiver) continue;
         filterReceiver.style.setProperty("--dark-mode-map-filter", layer.options.filter || "none");
       }
     });

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -39,6 +39,7 @@
         href: "https://www.thunderforest.com/"
 
 - leafletOsmId: "TransportMap"
+  leafletOsmDarkId: "TransportDarkMap"
   code: "T"
   layerId: "transportmap"
   nameId: "transport_map"


### PR DESCRIPTION
A version between #5396 and #5397 using the updated version of leaflet-osm without requiring it.
Also removing some ifs that always evaluate true and removed the dependency on the `.key-ui`.