### PR TITLE
Remove code that added now-unused field_with_errors css class

### DIFF
--- a/config/initializers/field_error.rb
+++ b/config/initializers/field_error.rb
@@ -1,9 +1,0 @@
-ActionView::Base.field_error_proc = proc do |html_tag, _instance|
-  class_attr_index = html_tag.index 'class="'
-
-  if class_attr_index
-    html_tag.insert class_attr_index + 7, "field_with_errors "
-  else
-    html_tag.insert html_tag.index(%r{/?>}), ' class="field_with_errors"'.html_safe
-  end
-end


### PR DESCRIPTION
This `.field_with_errors` writer was added in https://github.com/openstreetmap/openstreetmap-website/commit/933b0913304fdd581c7cb3f1ec30450d6e04c63a, but the class was not used since https://github.com/openstreetmap/openstreetmap-website/commit/df1ec6b6809b533829fc2c171699540bbb92a85b.