### PR TITLE
Remove check_api_readable from api messages controller

### DIFF
--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -5,7 +5,6 @@ module Api
     before_action :authorize
 
     before_action :check_api_writable, :only => [:create, :update, :destroy]
-    before_action :check_api_readable, :except => [:create, :update, :destroy]
 
     authorize_resource
 


### PR DESCRIPTION
This check was moved to `ApiController` superclass in #4859, but `MessagesController` was written before that and merged after that in #4605.