### PR TITLE
Resourceful routes for received/issued blocks

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,6 +28,7 @@ FactoryBot/ExcessiveCreateList:
     - 'test/controllers/traces_controller_test.rb'
     - 'test/controllers/user_blocks_controller_test.rb'
     - 'test/controllers/users/issued_blocks_controller_test.rb'
+    - 'test/controllers/users/received_blocks_controller_test.rb'
     - 'test/system/users_test.rb'
 
 # Offense count: 635

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,6 +27,7 @@ FactoryBot/ExcessiveCreateList:
     - 'test/controllers/notes_controller_test.rb'
     - 'test/controllers/traces_controller_test.rb'
     - 'test/controllers/user_blocks_controller_test.rb'
+    - 'test/controllers/users/issued_blocks_controller_test.rb'
     - 'test/system/users_test.rb'
 
 # Offense count: 635

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -56,7 +56,7 @@ class Ability
           can [:read, :resolve, :ignore, :reopen], Issue
           can :create, IssueComment
           can [:create, :update, :destroy], Redaction
-          can [:create, :revoke_all], UserBlock
+          can [:create, :destroy], UserBlock
           can :update, UserBlock, :creator => user
           can :update, UserBlock, :revoker => user
           can :update, UserBlock, :active? => true

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -24,7 +24,7 @@ class Ability
       can [:create, :destroy], :session
       can [:read, :data, :georss], Trace
       can [:read, :terms, :create, :save, :suspended, :auth_success, :auth_failure], User
-      can [:read, :blocks_on], UserBlock
+      can :read, UserBlock
     end
 
     if user&.active?

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -24,7 +24,7 @@ class Ability
       can [:create, :destroy], :session
       can [:read, :data, :georss], Trace
       can [:read, :terms, :create, :save, :suspended, :auth_success, :auth_failure], User
-      can [:read, :blocks_on, :blocks_by], UserBlock
+      can [:read, :blocks_on], UserBlock
     end
 
     if user&.active?

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -9,11 +9,11 @@ class UserBlocksController < ApplicationController
 
   authorize_resource
 
-  before_action :lookup_user, :only => [:new, :create, :revoke_all]
+  before_action :lookup_user, :only => [:new, :create]
   before_action :lookup_user_block, :only => [:show, :edit, :update]
   before_action :require_valid_params, :only => [:create, :update]
   before_action :check_database_readable
-  before_action :check_database_writable, :only => [:create, :update, :revoke_all]
+  before_action :check_database_writable, :only => [:create, :update]
 
   def index
     @params = params.permit
@@ -102,16 +102,6 @@ class UserBlocksController < ApplicationController
       end
     else
       redirect_to edit_user_block_path(params[:id])
-    end
-  end
-
-  ##
-  # revokes all active blocks
-  def revoke_all
-    if request.post? && params[:confirm]
-      @user.blocks.active.each { |block| block.revoke!(current_user) }
-      flash[:notice] = t ".flash"
-      redirect_to user_received_blocks_path(@user)
     end
   end
 

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -9,7 +9,7 @@ class UserBlocksController < ApplicationController
 
   authorize_resource
 
-  before_action :lookup_user, :only => [:new, :create, :revoke_all, :blocks_on]
+  before_action :lookup_user, :only => [:new, :create, :revoke_all]
   before_action :lookup_user_block, :only => [:show, :edit, :update]
   before_action :require_valid_params, :only => [:create, :update]
   before_action :check_database_readable
@@ -111,23 +111,8 @@ class UserBlocksController < ApplicationController
     if request.post? && params[:confirm]
       @user.blocks.active.each { |block| block.revoke!(current_user) }
       flash[:notice] = t ".flash"
-      redirect_to user_blocks_on_path(@user)
+      redirect_to user_received_blocks_path(@user)
     end
-  end
-
-  ##
-  # shows a list of all the blocks on the given user
-  def blocks_on
-    @params = params.permit(:display_name)
-
-    user_blocks = UserBlock.where(:user => @user)
-
-    @user_blocks, @newer_user_blocks_id, @older_user_blocks_id = get_page_items(user_blocks, :includes => [:user, :creator, :revoker])
-
-    @show_user_name = false
-    @show_creator_name = true
-
-    render :partial => "page" if turbo_frame_request_id == "pagination"
   end
 
   private

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -9,7 +9,7 @@ class UserBlocksController < ApplicationController
 
   authorize_resource
 
-  before_action :lookup_user, :only => [:new, :create, :revoke_all, :blocks_on, :blocks_by]
+  before_action :lookup_user, :only => [:new, :create, :revoke_all, :blocks_on]
   before_action :lookup_user_block, :only => [:show, :edit, :update]
   before_action :require_valid_params, :only => [:create, :update]
   before_action :check_database_readable
@@ -126,21 +126,6 @@ class UserBlocksController < ApplicationController
 
     @show_user_name = false
     @show_creator_name = true
-
-    render :partial => "page" if turbo_frame_request_id == "pagination"
-  end
-
-  ##
-  # shows a list of all the blocks by the given user.
-  def blocks_by
-    @params = params.permit(:display_name)
-
-    user_blocks = UserBlock.where(:creator => @user)
-
-    @user_blocks, @newer_user_blocks_id, @older_user_blocks_id = get_page_items(user_blocks, :includes => [:user, :creator, :revoker])
-
-    @show_user_name = true
-    @show_creator_name = false
 
     render :partial => "page" if turbo_frame_request_id == "pagination"
   end

--- a/app/controllers/users/issued_blocks_controller.rb
+++ b/app/controllers/users/issued_blocks_controller.rb
@@ -1,0 +1,31 @@
+module Users
+  class IssuedBlocksController < ApplicationController
+    include UserMethods
+    include PaginationMethods
+
+    layout "site"
+
+    before_action :authorize_web
+    before_action :set_locale
+
+    authorize_resource :class => UserBlock
+
+    before_action :lookup_user
+    before_action :check_database_readable
+
+    ##
+    # shows a list of all the blocks by the given user.
+    def show
+      @params = params.permit(:user_display_name)
+
+      user_blocks = UserBlock.where(:creator => @user)
+
+      @user_blocks, @newer_user_blocks_id, @older_user_blocks_id = get_page_items(user_blocks, :includes => [:user, :creator, :revoker])
+
+      @show_user_name = true
+      @show_creator_name = false
+
+      render :partial => "user_blocks/page" if turbo_frame_request_id == "pagination"
+    end
+  end
+end

--- a/app/controllers/users/received_blocks_controller.rb
+++ b/app/controllers/users/received_blocks_controller.rb
@@ -12,6 +12,7 @@ module Users
 
     before_action :lookup_user
     before_action :check_database_readable
+    before_action :check_database_writable, :only => :destroy
 
     ##
     # shows a list of all the blocks on the given user
@@ -26,6 +27,22 @@ module Users
       @show_creator_name = true
 
       render :partial => "user_blocks/page" if turbo_frame_request_id == "pagination"
+    end
+
+    ##
+    # shows revoke all active blocks page
+    def edit; end
+
+    ##
+    # revokes all active blocks
+    def destroy
+      if params[:confirm]
+        @user.blocks.active.each { |block| block.revoke!(current_user) }
+        flash[:notice] = t ".flash"
+        redirect_to user_received_blocks_path(@user)
+      else
+        render :action => :edit
+      end
     end
   end
 end

--- a/app/controllers/users/received_blocks_controller.rb
+++ b/app/controllers/users/received_blocks_controller.rb
@@ -1,0 +1,31 @@
+module Users
+  class ReceivedBlocksController < ApplicationController
+    include UserMethods
+    include PaginationMethods
+
+    layout "site"
+
+    before_action :authorize_web
+    before_action :set_locale
+
+    authorize_resource :class => UserBlock
+
+    before_action :lookup_user
+    before_action :check_database_readable
+
+    ##
+    # shows a list of all the blocks on the given user
+    def show
+      @params = params.permit(:user_display_name)
+
+      user_blocks = UserBlock.where(:user => @user)
+
+      @user_blocks, @newer_user_blocks_id, @older_user_blocks_id = get_page_items(user_blocks, :includes => [:user, :creator, :revoker])
+
+      @show_user_name = false
+      @show_creator_name = true
+
+      render :partial => "user_blocks/page" if turbo_frame_request_id == "pagination"
+    end
+  end
+end

--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -7,16 +7,16 @@
   <% if current_user&.blocks&.exists? %>
     <li class="nav-item">
       <%= link_to t(".blocks_on_me"),
-                  user_blocks_on_path(current_user),
-                  :class => ["nav-link", { :active => action_name == "blocks_on" && current_user == @user }] %>
+                  user_received_blocks_path(current_user),
+                  :class => ["nav-link", { :active => controller_name == "received_blocks" && current_user == @user }] %>
     </li>
   <% end %>
   <% on_user = @user || @user_block&.user %>
   <% if on_user != current_user && on_user&.blocks&.exists? %>
     <li class="nav-item">
       <%= link_to t(".blocks_on_user_html", :user => tag.span(on_user.display_name, :class => "username text-truncate d-inline-block align-bottom", :dir => "auto")),
-                  user_blocks_on_path(on_user),
-                  :class => ["nav-link", { :active => action_name == "blocks_on" }] %>
+                  user_received_blocks_path(on_user),
+                  :class => ["nav-link", { :active => controller_name == "received_blocks" }] %>
     </li>
   <% end %>
   <% if current_user&.blocks_created&.exists? %>

--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -22,16 +22,16 @@
   <% if current_user&.blocks_created&.exists? %>
     <li class="nav-item">
       <%= link_to t(".blocks_by_me"),
-                  user_blocks_by_path(current_user),
-                  :class => ["nav-link", { :active => action_name == "blocks_by" && current_user == @user }] %>
+                  user_issued_blocks_path(current_user),
+                  :class => ["nav-link", { :active => controller_name == "issued_blocks" && current_user == @user }] %>
     </li>
   <% end %>
   <% by_user = @user || @user_block&.creator %>
   <% if by_user != current_user && by_user&.blocks_created&.exists? %>
     <li class="nav-item">
       <%= link_to t(".blocks_by_user_html", :user => tag.span(by_user.display_name, :class => "username text-truncate d-inline-block align-bottom", :dir => "auto")),
-                  user_blocks_by_path(by_user),
-                  :class => ["nav-link", { :active => action_name == "blocks_by" }] %>
+                  user_issued_blocks_path(by_user),
+                  :class => ["nav-link", { :active => controller_name == "issued_blocks" }] %>
     </li>
   <% end %>
   <% if @user_block&.persisted? %>

--- a/app/views/user_blocks/_page.html.erb
+++ b/app/views/user_blocks/_page.html.erb
@@ -16,10 +16,11 @@
         <th></th>
       </tr>
     </thead>
-    <%= render :partial => "block", :collection => @user_blocks %>
+    <%= render :partial => "user_blocks/block", :collection => @user_blocks %>
   </table>
 
   <%= render "shared/pagination",
+             :translation_scope => "shared.pagination.user_blocks",
              :newer_id => @newer_user_blocks_id,
              :older_id => @older_user_blocks_id %>
 </turbo-frame>

--- a/app/views/users/issued_blocks/show.html.erb
+++ b/app/views/users/issued_blocks/show.html.erb
@@ -3,11 +3,11 @@
 <% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html", :name => link_to(@user.display_name, @user)) %></h1>
-  <%= render :partial => "navigation" %>
+  <%= render :partial => "user_blocks/navigation" %>
 <% end %>
 
 <% unless @user_blocks.empty? %>
-<%= render :partial => "page" %>
+<%= render :partial => "user_blocks/page" %>
 <% else %>
 <p><%= t ".empty", :name => @user.display_name %></p>
 <% end %>

--- a/app/views/users/received_blocks/edit.html.erb
+++ b/app/views/users/received_blocks/edit.html.erb
@@ -6,7 +6,7 @@
 
 <% unless @user.blocks.active.empty? %>
 
-  <%= bootstrap_form_for :revoke_all, :url => { :action => "revoke_all" } do |f| %>
+  <%= bootstrap_form_for :revoke_all, :url => { :action => :destroy }, :method => :delete do |f| %>
     <div class="mb-3">
       <div class="form-check">
         <%= check_box_tag "confirm", "yes", false, { :class => "form-check-input" } %>

--- a/app/views/users/received_blocks/show.html.erb
+++ b/app/views/users/received_blocks/show.html.erb
@@ -3,11 +3,11 @@
 <% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= t(".heading_html", :name => link_to(@user.display_name, @user)) %></h1>
-  <%= render :partial => "navigation" %>
+  <%= render :partial => "user_blocks/navigation" %>
 <% end %>
 
 <% unless @user_blocks.empty? %>
-<%= render :partial => "page" %>
+<%= render :partial => "user_blocks/page" %>
 <% else %>
 <p><%= t ".empty", :name => @user.display_name %></p>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,7 +42,7 @@
 
             <% if can?(:create, UserBlock) and current_user.blocks_created.exists? %>
               <li>
-                <%= link_to t(".blocks by me"), user_blocks_by_path(current_user) %>
+                <%= link_to t(".blocks by me"), user_issued_blocks_path(current_user) %>
                 <span class='badge count-number'><%= number_with_delimiter(current_user.blocks_created.active.size) %></span>
               </li>
             <% end %>
@@ -100,7 +100,7 @@
 
             <% if @user.moderator? and @user.blocks_created.exists? %>
               <li>
-                <%= link_to t(".moderator_history"), user_blocks_by_path(@user) %>
+                <%= link_to t(".moderator_history"), user_issued_blocks_path(@user) %>
                 <span class='badge count-number'><%= number_with_delimiter(@user.blocks_created.active.size) %></span>
               </li>
             <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -105,9 +105,9 @@
               </li>
             <% end %>
 
-            <% if can?(:revoke_all, UserBlock) and @user.blocks.active.exists? %>
+            <% if can?(:destroy, UserBlock) and @user.blocks.active.exists? %>
               <li>
-                <%= link_to t(".revoke_all_blocks"), revoke_all_user_blocks_path(@user) %>
+                <%= link_to t(".revoke_all_blocks"), edit_user_received_blocks_path(@user) %>
               </li>
             <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,7 @@
 
             <% if current_user.blocks.exists? %>
               <li>
-                <%= link_to t(".blocks on me"), user_blocks_on_path(current_user) %>
+                <%= link_to t(".blocks on me"), user_received_blocks_path(current_user) %>
                 <span class='badge count-number'><%= number_with_delimiter(current_user.blocks.active.size) %></span>
               </li>
             <% end %>
@@ -93,7 +93,7 @@
 
             <% if @user.blocks.exists? %>
               <li>
-                <%= link_to t(".block_history"), user_blocks_on_path(@user) %>
+                <%= link_to t(".block_history"), user_received_blocks_path(@user) %>
                 <span class='badge count-number'><%= number_with_delimiter(@user.blocks.active.size) %></span>
               </li>
             <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2851,6 +2851,11 @@ en:
         title: "Blocks by %{name}"
         heading_html: "List of Blocks by %{name}"
         empty: "%{name} has not made any blocks yet."
+    received_blocks:
+      show:
+        title: "Blocks on %{name}"
+        heading_html: "List of Blocks on %{name}"
+        empty: "%{name} has not been blocked yet."
     lists:
       show:
         title: Users
@@ -2967,10 +2972,6 @@ en:
         read_html: "read at %{time}"
         time_in_future_title: "%{time_absolute}; in %{time_relative}"
         time_in_past_title: "%{time_absolute}; %{time_relative}"
-    blocks_on:
-      title: "Blocks on %{name}"
-      heading_html: "List of Blocks on %{name}"
-      empty: "%{name} has not been blocked yet."
     show:
       title: "%{block_on} blocked by %{block_by}"
       heading_html: "%{block_on} blocked by %{block_by}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2846,6 +2846,11 @@ en:
       report: Report this User
     go_public:
       flash success: "All your edits are now public, and you are now allowed to edit."
+    issued_blocks:
+      show:
+        title: "Blocks by %{name}"
+        heading_html: "List of Blocks by %{name}"
+        empty: "%{name} has not made any blocks yet."
     lists:
       show:
         title: Users
@@ -2966,10 +2971,6 @@ en:
       title: "Blocks on %{name}"
       heading_html: "List of Blocks on %{name}"
       empty: "%{name} has not been blocked yet."
-    blocks_by:
-      title: "Blocks by %{name}"
-      heading_html: "List of Blocks by %{name}"
-      empty: "%{name} has not made any blocks yet."
     show:
       title: "%{block_on} blocked by %{block_by}"
       heading_html: "%{block_on} blocked by %{block_by}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2856,6 +2856,17 @@ en:
         title: "Blocks on %{name}"
         heading_html: "List of Blocks on %{name}"
         empty: "%{name} has not been blocked yet."
+      edit:
+        title: "Revoking all blocks on %{block_on}"
+        heading_html: "Revoking all blocks on %{block_on}"
+        empty: "%{name} has no active blocks."
+        confirm: "Are you sure you wish to revoke %{active_blocks}?"
+        active_blocks:
+          one: "%{count} active block"
+          other: "%{count} active blocks"
+        revoke: "Revoke!"
+      destroy:
+        flash: "All active blocks have been revoked."
     lists:
       show:
         title: Users
@@ -2932,16 +2943,6 @@ en:
       title: "User blocks"
       heading: "List of user blocks"
       empty: "No blocks have been made yet."
-    revoke_all:
-      title: "Revoking all blocks on %{block_on}"
-      heading_html: "Revoking all blocks on %{block_on}"
-      empty: "%{name} has no active blocks."
-      confirm: "Are you sure you wish to revoke %{active_blocks}?"
-      active_blocks:
-        one: "%{count} active block"
-        other: "%{count} active blocks"
-      revoke: "Revoke!"
-      flash: "All active blocks have been revoked."
     helper:
       time_future_html: "Ends in %{time}."
       until_login: "Active until the user logs in."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,6 +271,9 @@ OpenStreetMap::Application.routes.draw do
   # user pages
   resources :users, :path => "user", :param => :display_name, :only => [:show, :destroy] do
     resource :role, :controller => "user_roles", :path => "roles/:role", :only => [:create, :destroy]
+    scope :module => :users do
+      resource :issued_blocks, :path => "blocks_by", :only => :show
+    end
   end
   get "/user/:display_name/account", :to => redirect(:path => "/account/edit")
   post "/user/:display_name/set_status" => "users#set_status", :as => :set_status_user
@@ -331,7 +334,6 @@ OpenStreetMap::Application.routes.draw do
 
   # banning pages
   get "/user/:display_name/blocks" => "user_blocks#blocks_on", :as => "user_blocks_on"
-  get "/user/:display_name/blocks_by" => "user_blocks#blocks_by", :as => "user_blocks_by"
   resources :user_blocks, :path_names => { :new => "new/:display_name" }
   match "/user/:display_name/blocks/revoke_all" => "user_blocks#revoke_all", :via => [:get, :post], :as => "revoke_all_user_blocks"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,7 +273,7 @@ OpenStreetMap::Application.routes.draw do
     resource :role, :controller => "user_roles", :path => "roles/:role", :only => [:create, :destroy]
     scope :module => :users do
       resource :issued_blocks, :path => "blocks_by", :only => :show
-      resource :received_blocks, :path => "blocks", :only => :show
+      resource :received_blocks, :path => "blocks", :only => [:show, :edit, :destroy]
     end
   end
   get "/user/:display_name/account", :to => redirect(:path => "/account/edit")
@@ -335,7 +335,6 @@ OpenStreetMap::Application.routes.draw do
 
   # banning pages
   resources :user_blocks, :path_names => { :new => "new/:display_name" }
-  match "/user/:display_name/blocks/revoke_all" => "user_blocks#revoke_all", :via => [:get, :post], :as => "revoke_all_user_blocks"
 
   # issues and reports
   resources :issues do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,7 @@ OpenStreetMap::Application.routes.draw do
     resource :role, :controller => "user_roles", :path => "roles/:role", :only => [:create, :destroy]
     scope :module => :users do
       resource :issued_blocks, :path => "blocks_by", :only => :show
+      resource :received_blocks, :path => "blocks", :only => :show
     end
   end
   get "/user/:display_name/account", :to => redirect(:path => "/account/edit")
@@ -333,7 +334,6 @@ OpenStreetMap::Application.routes.draw do
   resources :user_mutes, :only => [:index]
 
   # banning pages
-  get "/user/:display_name/blocks" => "user_blocks#blocks_on", :as => "user_blocks_on"
   resources :user_blocks, :path_names => { :new => "new/:display_name" }
   match "/user/:display_name/blocks/revoke_all" => "user_blocks#revoke_all", :via => [:get, :post], :as => "revoke_all_user_blocks"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -332,8 +332,7 @@ OpenStreetMap::Application.routes.draw do
   # banning pages
   get "/user/:display_name/blocks" => "user_blocks#blocks_on", :as => "user_blocks_on"
   get "/user/:display_name/blocks_by" => "user_blocks#blocks_by", :as => "user_blocks_by"
-  get "/blocks/new/:display_name" => "user_blocks#new", :as => "new_user_block"
-  resources :user_blocks, :except => :new
+  resources :user_blocks, :path_names => { :new => "new/:display_name" }
   match "/user/:display_name/blocks/revoke_all" => "user_blocks#revoke_all", :via => [:get, :post], :as => "revoke_all_user_blocks"
 
   # issues and reports

--- a/test/controllers/user_blocks/table_test_helper.rb
+++ b/test/controllers/user_blocks/table_test_helper.rb
@@ -1,0 +1,24 @@
+module UserBlocks
+  module TableTestHelper
+    private
+
+    def check_user_blocks_table(user_blocks)
+      assert_dom "table#block_list tbody tr" do |rows|
+        assert_equal user_blocks.count, rows.count, "unexpected number of rows in user blocks table"
+        rows.zip(user_blocks).map do |row, user_block|
+          assert_dom row, "a[href='#{user_block_path user_block}']", 1
+        end
+      end
+    end
+
+    def check_no_page_link(name)
+      assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/, :count => 0 }, "unexpected #{name} page link"
+    end
+
+    def check_page_link(name)
+      assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/ }, "missing #{name} page link" do |buttons|
+        return buttons.first.attributes["href"].value
+      end
+    end
+  end
+end

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -36,15 +36,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
       { :path => "/user_blocks/1", :method => :delete },
       { :controller => "user_blocks", :action => "destroy", :id => "1" }
     )
-
-    assert_routing(
-      { :path => "/user/username/blocks/revoke_all", :method => :get },
-      { :controller => "user_blocks", :action => "revoke_all", :display_name => "username" }
-    )
-    assert_routing(
-      { :path => "/user/username/blocks/revoke_all", :method => :post },
-      { :controller => "user_blocks", :action => "revoke_all", :display_name => "username" }
-    )
   end
 
   ##
@@ -596,83 +587,6 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     block.reload
     assert_not_predicate block, :active?
     assert_equal other_moderator_user, block.revoker
-  end
-
-  ##
-  # test the revoke all page
-  def test_revoke_all_page
-    blocked_user = create(:user)
-    create(:user_block, :user => blocked_user)
-
-    # Asking for the revoke all blocks page with a bogus user name should fail
-    get user_received_blocks_path("non_existent_user")
-    assert_response :not_found
-
-    # Check that the revoke all blocks page requires us to login
-    get revoke_all_user_blocks_path(blocked_user)
-    assert_redirected_to login_path(:referer => revoke_all_user_blocks_path(blocked_user))
-
-    # Login as a normal user
-    session_for(create(:user))
-
-    # Check that normal users can't load the revoke all blocks page
-    get revoke_all_user_blocks_path(blocked_user)
-    assert_redirected_to :controller => "errors", :action => "forbidden"
-
-    # Login as a moderator
-    session_for(create(:moderator_user))
-
-    # Check that the revoke all blocks page loads for moderators
-    get revoke_all_user_blocks_path(blocked_user)
-    assert_response :success
-    assert_select "h1 a[href='#{user_path blocked_user}']", :text => blocked_user.display_name
-  end
-
-  ##
-  # test the revoke all action
-  def test_revoke_all_action
-    blocked_user = create(:user)
-    active_block1 = create(:user_block, :user => blocked_user)
-    active_block2 = create(:user_block, :user => blocked_user)
-    expired_block1 = create(:user_block, :expired, :user => blocked_user)
-    blocks = [active_block1, active_block2, expired_block1]
-    moderator_user = create(:moderator_user)
-
-    assert_predicate active_block1, :active?
-    assert_predicate active_block2, :active?
-    assert_not_predicate expired_block1, :active?
-
-    # Login as a normal user
-    session_for(create(:user))
-
-    # Check that normal users can't load the block revoke page
-    get revoke_all_user_blocks_path(:blocked_user)
-    assert_redirected_to :controller => "errors", :action => "forbidden"
-
-    # Login as a moderator
-    session_for(moderator_user)
-
-    # Check that revoking blocks using GET should fail
-    get revoke_all_user_blocks_path(blocked_user, :confirm => true)
-    assert_response :success
-    assert_template "revoke_all"
-
-    blocks.each(&:reload)
-    assert_predicate active_block1, :active?
-    assert_predicate active_block2, :active?
-    assert_not_predicate expired_block1, :active?
-
-    # Check that revoking blocks works using POST
-    post revoke_all_user_blocks_path(blocked_user, :confirm => true)
-    assert_redirected_to user_received_blocks_path(blocked_user)
-
-    blocks.each(&:reload)
-    assert_not_predicate active_block1, :active?
-    assert_not_predicate active_block2, :active?
-    assert_not_predicate expired_block1, :active?
-    assert_equal moderator_user, active_block1.revoker
-    assert_equal moderator_user, active_block2.revoker
-    assert_not_equal moderator_user, expired_block1.revoker
   end
 
   ##

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require_relative "user_blocks/table_test_helper"
 
 class UserBlocksControllerTest < ActionDispatch::IntegrationTest
+  include UserBlocks::TableTestHelper
+
   ##
   # test all routes which lead to this controller
   def test_routes
@@ -1028,24 +1031,5 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     assert_not_predicate block, :active?
     assert_equal "Updated Reason Again", block.reason
     assert_equal original_ends_at, block.ends_at
-  end
-
-  def check_user_blocks_table(user_blocks)
-    assert_dom "table#block_list tbody tr" do |rows|
-      assert_equal user_blocks.count, rows.count, "unexpected number of rows in user blocks table"
-      rows.zip(user_blocks).map do |row, user_block|
-        assert_dom row, "a[href='#{user_block_path user_block}']", 1
-      end
-    end
-  end
-
-  def check_no_page_link(name)
-    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/, :count => 0 }, "unexpected #{name} page link"
-  end
-
-  def check_page_link(name)
-    assert_select "a.page-link", { :text => /#{Regexp.quote(name)}/ }, "missing #{name} page link" do |buttons|
-      return buttons.first.attributes["href"].value
-    end
   end
 end

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -834,6 +834,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     get user_blocks_on_path(blocked_user)
     assert_response :success
     assert_select "h1 a[href='#{user_path blocked_user}']", :text => blocked_user.display_name
+    assert_select "a.active[href='#{user_blocks_on_path blocked_user}']"
     assert_select "table#block_list tbody", :count => 1 do
       assert_select "tr", 2
       assert_select "a[href='#{user_block_path(active_block)}']", 1
@@ -844,6 +845,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     get user_blocks_on_path(unblocked_user)
     assert_response :success
     assert_select "h1 a[href='#{user_path unblocked_user}']", :text => unblocked_user.display_name
+    assert_select "a.active[href='#{user_blocks_on_path unblocked_user}']"
     assert_select "table#block_list tbody", :count => 1 do
       assert_select "tr", 1
       assert_select "a[href='#{user_block_path(expired_block)}']", 1
@@ -910,6 +912,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     get user_blocks_by_path(moderator_user)
     assert_response :success
     assert_select "h1 a[href='#{user_path moderator_user}']", :text => moderator_user.display_name
+    assert_select "a.active[href='#{user_blocks_by_path moderator_user}']"
     assert_select "table#block_list tbody", :count => 1 do
       assert_select "tr", 1
       assert_select "a[href='#{user_block_path(active_block)}']", 1
@@ -919,6 +922,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
     get user_blocks_by_path(second_moderator_user)
     assert_response :success
     assert_select "h1 a[href='#{user_path second_moderator_user}']", :text => second_moderator_user.display_name
+    assert_select "a.active[href='#{user_blocks_by_path second_moderator_user}']"
     assert_select "table#block_list tbody", :count => 1 do
       assert_select "tr", 2
       assert_select "a[href='#{user_block_path(expired_block)}']", 1

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -5,7 +5,7 @@ class UserBlocksControllerTest < ActionDispatch::IntegrationTest
   # test all routes which lead to this controller
   def test_routes
     assert_routing(
-      { :path => "/blocks/new/username", :method => :get },
+      { :path => "/user_blocks/new/username", :method => :get },
       { :controller => "user_blocks", :action => "new", :display_name => "username" }
     )
 

--- a/test/controllers/users/issued_blocks_controller_test.rb
+++ b/test/controllers/users/issued_blocks_controller_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+require_relative "../user_blocks/table_test_helper"
+
+module Users
+  class IssuedBlocksControllerTest < ActionDispatch::IntegrationTest
+    include UserBlocks::TableTestHelper
+
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/user/username/blocks_by", :method => :get },
+        { :controller => "users/issued_blocks", :action => "show", :user_display_name => "username" }
+      )
+    end
+
+    def test_show
+      moderator_user = create(:moderator_user)
+      second_moderator_user = create(:moderator_user)
+      normal_user = create(:user)
+      active_block = create(:user_block, :creator => moderator_user)
+      expired_block = create(:user_block, :expired, :creator => second_moderator_user)
+      revoked_block = create(:user_block, :revoked, :creator => second_moderator_user)
+
+      # Asking for a list of blocks with a bogus user name should fail
+      get user_issued_blocks_path("non_existent_user")
+      assert_response :not_found
+      assert_template "users/no_such_user"
+      assert_select "h1", "The user non_existent_user does not exist"
+
+      # Check the list of blocks given by one moderator
+      get user_issued_blocks_path(moderator_user)
+      assert_response :success
+      assert_select "h1 a[href='#{user_path moderator_user}']", :text => moderator_user.display_name
+      assert_select "a.active[href='#{user_issued_blocks_path moderator_user}']"
+      assert_select "table#block_list tbody", :count => 1 do
+        assert_select "tr", 1
+        assert_select "a[href='#{user_block_path(active_block)}']", 1
+      end
+
+      # Check the list of blocks given by a different moderator
+      get user_issued_blocks_path(second_moderator_user)
+      assert_response :success
+      assert_select "h1 a[href='#{user_path second_moderator_user}']", :text => second_moderator_user.display_name
+      assert_select "a.active[href='#{user_issued_blocks_path second_moderator_user}']"
+      assert_select "table#block_list tbody", :count => 1 do
+        assert_select "tr", 2
+        assert_select "a[href='#{user_block_path(expired_block)}']", 1
+        assert_select "a[href='#{user_block_path(revoked_block)}']", 1
+      end
+
+      # Check the list of blocks (not) given by a normal user
+      get user_issued_blocks_path(normal_user)
+      assert_response :success
+      assert_select "table#block_list", false
+      assert_select "p", "#{normal_user.display_name} has not made any blocks yet."
+    end
+
+    def test_show_paged
+      user = create(:moderator_user)
+      user_blocks = create_list(:user_block, 50, :creator => user).reverse
+      next_path = user_issued_blocks_path(user)
+
+      get next_path
+      assert_response :success
+      check_user_blocks_table user_blocks[0...20]
+      check_no_page_link "Newer Blocks"
+      next_path = check_page_link "Older Blocks"
+
+      get next_path
+      assert_response :success
+      check_user_blocks_table user_blocks[20...40]
+      check_page_link "Newer Blocks"
+      next_path = check_page_link "Older Blocks"
+
+      get next_path
+      assert_response :success
+      check_user_blocks_table user_blocks[40...50]
+      check_page_link "Newer Blocks"
+      check_no_page_link "Older Blocks"
+    end
+
+    def test_show_invalid_paged
+      user = create(:moderator_user)
+
+      %w[-1 0 fred].each do |id|
+        get user_issued_blocks_path(user, :before => id)
+        assert_redirected_to :controller => "/errors", :action => :bad_request
+
+        get user_issued_blocks_path(user, :after => id)
+        assert_redirected_to :controller => "/errors", :action => :bad_request
+      end
+    end
+  end
+end

--- a/test/controllers/users/received_blocks_controller_test.rb
+++ b/test/controllers/users/received_blocks_controller_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+require_relative "../user_blocks/table_test_helper"
+
+module Users
+  class ReceivedBlocksControllerTest < ActionDispatch::IntegrationTest
+    include UserBlocks::TableTestHelper
+
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/user/username/blocks", :method => :get },
+        { :controller => "users/received_blocks", :action => "show", :user_display_name => "username" }
+      )
+    end
+
+    def test_show
+      blocked_user = create(:user)
+      unblocked_user = create(:user)
+      normal_user = create(:user)
+      active_block = create(:user_block, :user => blocked_user)
+      revoked_block = create(:user_block, :revoked, :user => blocked_user)
+      expired_block = create(:user_block, :expired, :user => unblocked_user)
+
+      # Asking for a list of blocks with a bogus user name should fail
+      get user_received_blocks_path("non_existent_user")
+      assert_response :not_found
+      assert_template "users/no_such_user"
+      assert_select "h1", "The user non_existent_user does not exist"
+
+      # Check the list of blocks for a user that has never been blocked
+      get user_received_blocks_path(normal_user)
+      assert_response :success
+      assert_select "table#block_list", false
+      assert_select "p", "#{normal_user.display_name} has not been blocked yet."
+
+      # Check the list of blocks for a user that is currently blocked
+      get user_received_blocks_path(blocked_user)
+      assert_response :success
+      assert_select "h1 a[href='#{user_path blocked_user}']", :text => blocked_user.display_name
+      assert_select "a.active[href='#{user_received_blocks_path blocked_user}']"
+      assert_select "table#block_list tbody", :count => 1 do
+        assert_select "tr", 2
+        assert_select "a[href='#{user_block_path(active_block)}']", 1
+        assert_select "a[href='#{user_block_path(revoked_block)}']", 1
+      end
+
+      # Check the list of blocks for a user that has previously been blocked
+      get user_received_blocks_path(unblocked_user)
+      assert_response :success
+      assert_select "h1 a[href='#{user_path unblocked_user}']", :text => unblocked_user.display_name
+      assert_select "a.active[href='#{user_received_blocks_path unblocked_user}']"
+      assert_select "table#block_list tbody", :count => 1 do
+        assert_select "tr", 1
+        assert_select "a[href='#{user_block_path(expired_block)}']", 1
+      end
+    end
+
+    def test_show_paged
+      user = create(:user)
+      user_blocks = create_list(:user_block, 50, :user => user).reverse
+      next_path = user_received_blocks_path(user)
+
+      get next_path
+      assert_response :success
+      check_user_blocks_table user_blocks[0...20]
+      check_no_page_link "Newer Blocks"
+      next_path = check_page_link "Older Blocks"
+
+      get next_path
+      assert_response :success
+      check_user_blocks_table user_blocks[20...40]
+      check_page_link "Newer Blocks"
+      next_path = check_page_link "Older Blocks"
+
+      get next_path
+      assert_response :success
+      check_user_blocks_table user_blocks[40...50]
+      check_page_link "Newer Blocks"
+      check_no_page_link "Older Blocks"
+    end
+
+    def test_show_invalid_paged
+      user = create(:user)
+
+      %w[-1 0 fred].each do |id|
+        get user_received_blocks_path(user, :before => id)
+        assert_redirected_to :controller => "/errors", :action => :bad_request
+
+        get user_received_blocks_path(user, :after => id)
+        assert_redirected_to :controller => "/errors", :action => :bad_request
+      end
+    end
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -305,7 +305,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/account']", 0
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks']", 0
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks_by']", 0
-      assert_select "a[href='/blocks/new/#{ERB::Util.u(user.display_name)}']", 0
+      assert_select "a[href='/user_blocks/new/#{ERB::Util.u(user.display_name)}']", 0
     end
 
     # Test a user who has been blocked
@@ -321,7 +321,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='/user/#{ERB::Util.u(blocked_user.display_name)}/account']", 0
       assert_select "a[href='/user/#{ERB::Util.u(blocked_user.display_name)}/blocks']", 1
       assert_select "a[href='/user/#{ERB::Util.u(blocked_user.display_name)}/blocks_by']", 0
-      assert_select "a[href='/blocks/new/#{ERB::Util.u(blocked_user.display_name)}']", 0
+      assert_select "a[href='/user_blocks/new/#{ERB::Util.u(blocked_user.display_name)}']", 0
     end
 
     # Test a moderator who has applied blocks
@@ -337,7 +337,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='/user/#{ERB::Util.u(moderator_user.display_name)}/account']", 0
       assert_select "a[href='/user/#{ERB::Util.u(moderator_user.display_name)}/blocks']", 0
       assert_select "a[href='/user/#{ERB::Util.u(moderator_user.display_name)}/blocks_by']", 1
-      assert_select "a[href='/blocks/new/#{ERB::Util.u(moderator_user.display_name)}']", 0
+      assert_select "a[href='/user_blocks/new/#{ERB::Util.u(moderator_user.display_name)}']", 0
     end
 
     # Login as a normal user
@@ -354,7 +354,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='/account/edit']", 1
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks']", 0
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks_by']", 0
-      assert_select "a[href='/blocks/new/#{ERB::Util.u(user.display_name)}']", 0
+      assert_select "a[href='/user_blocks/new/#{ERB::Util.u(user.display_name)}']", 0
       assert_select "a[href='/api/0.6/user/#{ERB::Util.u(user.id)}']", 0
     end
 
@@ -372,7 +372,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[href='/account/edit']", 0
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks']", 0
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/blocks_by']", 0
-      assert_select "a[href='/blocks/new/#{ERB::Util.u(user.display_name)}']", 1
+      assert_select "a[href='/user_blocks/new/#{ERB::Util.u(user.display_name)}']", 1
       assert_select "a[href='/api/0.6/user/#{ERB::Util.u(user.id)}']", 1
     end
   end

--- a/test/system/user_blocks_test.rb
+++ b/test/system/user_blocks_test.rb
@@ -31,7 +31,7 @@ class UserBlocksSystemTest < ApplicationSystemTestCase
     blocked_user = create(:user)
     sign_in_as(create(:moderator_user))
 
-    visit revoke_all_user_blocks_path(blocked_user)
+    visit edit_user_received_blocks_path(blocked_user)
     assert_title "Revoking all blocks on #{blocked_user.display_name}"
     assert_text "Revoking all blocks on #{blocked_user.display_name}"
     assert_no_button "Revoke!"


### PR DESCRIPTION
This creates `:issued_blocks` and `:received_blocks` resources for users. `:revoke_all` action is changed to deleting received blocks.