### PR TITLE
New note page on low zooms

### DIFF
--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -96,9 +96,7 @@ OSM.NewNote = function (map) {
     newNoteMarker.addTo(map);
     addHalo(newNoteMarker.getLatLng());
 
-    newNoteMarker.on("remove", function () {
-      addNoteButton.removeClass("active");
-    }).on("dragend", function () {
+    newNoteMarker.on("dragend", function () {
       content.find("textarea").focus();
     });
   }
@@ -158,7 +156,6 @@ OSM.NewNote = function (map) {
       createNote(location, text, (feature) => {
         content.find("textarea").val("");
         addCreatedNoteMarker(feature);
-        addNoteButton.removeClass("active");
         OSM.router.route("/note/" + feature.properties.id);
       });
     });

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -107,6 +107,14 @@ OSM.NewNote = function (map) {
     newNoteMarker = null;
   }
 
+  function updateControls() {
+    const zoomedOut = addNoteButton.hasClass("disabled");
+    const withoutText = content.find("textarea").val() === "";
+
+    content.find("#new-note-zoom-warning").prop("hidden", !zoomedOut);
+    content.find("input[type=submit]").prop("disabled", zoomedOut || withoutText);
+  }
+
   page.pushstate = page.popstate = function (path) {
     OSM.loadSidebarContent(path, function () {
       page.load(path);
@@ -114,9 +122,6 @@ OSM.NewNote = function (map) {
   };
 
   page.load = function (path) {
-    if (addNoteButton.hasClass("disabled")) return;
-    if (addNoteButton.hasClass("active")) return;
-
     addNoteButton.addClass("active");
 
     map.addLayer(noteLayer);
@@ -137,12 +142,8 @@ OSM.NewNote = function (map) {
     addNewNoteMarker(markerLatlng);
 
     content.find("textarea")
-      .on("input", disableWhenBlank)
+      .on("input", updateControls)
       .focus();
-
-    function disableWhenBlank(e) {
-      $(e.target.form.add).prop("disabled", $(e.target).val() === "");
-    }
 
     content.find("input[type=submit]").on("click", function (e) {
       const location = newNoteMarker.getLatLng().wrap();
@@ -160,10 +161,14 @@ OSM.NewNote = function (map) {
       });
     });
 
+    addNoteButton.on("disabled enabled", updateControls);
+    updateControls();
+
     return map.getState();
   };
 
   page.unload = function () {
+    addNoteButton.off("disabled enabled", updateControls);
     removeNewNoteMarker();
     addNoteButton.removeClass("active");
   };

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -35,7 +35,7 @@ OSM.NewNote = function (map) {
     OSM.router.route("/note/new");
   });
 
-  function createNote(marker, text) {
+  function createNote(marker, text, callback) {
     var location = marker.getLatLng().wrap();
 
     marker.options.draggable = false;
@@ -50,19 +50,8 @@ OSM.NewNote = function (map) {
         lon: location.lng,
         text
       },
-      success: function (feature) {
-        noteCreated(feature, marker);
-      }
+      success: callback
     });
-
-    function noteCreated(feature, marker) {
-      content.find("textarea").val("");
-      updateMarker(feature);
-      newNoteMarker = null;
-      noteLayer.removeLayer(marker);
-      addNoteButton.removeClass("active");
-      OSM.router.route("/note/" + feature.properties.id);
-    }
   }
 
   function updateMarker(feature) {
@@ -154,7 +143,14 @@ OSM.NewNote = function (map) {
 
       e.preventDefault();
       $(this).prop("disabled", true);
-      createNote(newNoteMarker, text);
+      createNote(newNoteMarker, text, (feature) => {
+        content.find("textarea").val("");
+        updateMarker(feature);
+        noteLayer.removeLayer(newNoteMarker);
+        newNoteMarker = null;
+        addNoteButton.removeClass("active");
+        OSM.router.route("/note/" + feature.properties.id);
+      });
     });
 
     return map.getState();

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -158,7 +158,6 @@ OSM.NewNote = function (map) {
       createNote(location, text, (feature) => {
         content.find("textarea").val("");
         addCreatedNoteMarker(feature);
-        removeNewNoteMarker();
         addNoteButton.removeClass("active");
         OSM.router.route("/note/" + feature.properties.id);
       });

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -35,14 +35,14 @@ OSM.NewNote = function (map) {
     OSM.router.route("/note/new");
   });
 
-  function createNote(marker, text, url) {
+  function createNote(marker, text) {
     var location = marker.getLatLng().wrap();
 
     marker.options.draggable = false;
     marker.dragging.disable();
 
     $.ajax({
-      url: url,
+      url: "/api/0.6/notes.json",
       type: "POST",
       oauth: true,
       data: {
@@ -154,7 +154,7 @@ OSM.NewNote = function (map) {
 
       e.preventDefault();
       $(this).prop("disabled", true);
-      createNote(newNoteMarker, text, "/api/0.6/notes.json");
+      createNote(newNoteMarker, text);
     });
 
     return map.getState();

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -59,12 +59,6 @@ OSM.NewNote = function (map) {
     marker.addTo(noteLayer);
   }
 
-  page.pushstate = page.popstate = function (path) {
-    OSM.loadSidebarContent(path, function () {
-      page.load(path);
-    });
-  };
-
   function newHalo(loc, a) {
     var hasHalo = halo && map.hasLayer(halo);
 
@@ -83,6 +77,12 @@ OSM.NewNote = function (map) {
       map.addLayer(halo);
     }
   }
+
+  page.pushstate = page.popstate = function (path) {
+    OSM.loadSidebarContent(path, function () {
+      page.load(path);
+    });
+  };
 
   page.load = function (path) {
     if (addNoteButton.hasClass("disabled")) return;

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -35,7 +35,7 @@ OSM.NewNote = function (map) {
     OSM.router.route("/note/new");
   });
 
-  function createNote(marker, form, url) {
+  function createNote(marker, text, url) {
     var location = marker.getLatLng().wrap();
 
     marker.options.draggable = false;
@@ -48,7 +48,7 @@ OSM.NewNote = function (map) {
       data: {
         lat: location.lat,
         lon: location.lng,
-        text: $(form.text).val()
+        text
       },
       success: function (feature) {
         noteCreated(feature, marker);
@@ -150,9 +150,11 @@ OSM.NewNote = function (map) {
     }
 
     content.find("input[type=submit]").on("click", function (e) {
+      const text = content.find("textarea").val();
+
       e.preventDefault();
       $(this).prop("disabled", true);
-      createNote(newNoteMarker, e.target.form, "/api/0.6/notes.json");
+      createNote(newNoteMarker, text, "/api/0.6/notes.json");
     });
 
     return map.getState();

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -57,7 +57,6 @@ OSM.NewNote = function (map) {
     });
     marker.id = feature.properties.id;
     marker.addTo(noteLayer);
-    return marker;
   }
 
   page.pushstate = page.popstate = function (path) {

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -107,6 +107,12 @@ OSM.NewNote = function (map) {
     newNoteMarker = null;
   }
 
+  function moveNewNotMarkerToClick(e) {
+    if (newNoteMarker) newNoteMarker.setLatLng(e.latlng);
+    if (halo) halo.setLatLng(e.latlng);
+    content.find("textarea").focus();
+  }
+
   function updateControls() {
     const zoomedOut = addNoteButton.hasClass("disabled");
     const withoutText = content.find("textarea").val() === "";
@@ -162,6 +168,7 @@ OSM.NewNote = function (map) {
       });
     });
 
+    map.on("click", moveNewNotMarkerToClick);
     addNoteButton.on("disabled enabled", updateControls);
     updateControls();
 
@@ -169,6 +176,7 @@ OSM.NewNote = function (map) {
   };
 
   page.unload = function () {
+    map.off("click", moveNewNotMarkerToClick);
     addNoteButton.off("disabled enabled", updateControls);
     removeNewNoteMarker();
     addNoteButton.removeClass("active");

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -5,7 +5,7 @@ OSM.NewNote = function (map) {
       content = $("#sidebar_content"),
       page = {},
       addNoteButton = $(".control-note .control-button"),
-      newNote,
+      newNoteMarker,
       halo;
 
   var noteIcons = {
@@ -60,7 +60,7 @@ OSM.NewNote = function (map) {
     function noteCreated(feature, marker) {
       content.find("textarea").val("");
       updateMarker(feature);
-      newNote = null;
+      newNoteMarker = null;
       noteLayer.removeLayer(marker);
       addNoteButton.removeClass("active");
       OSM.router.route("/note/" + feature.properties.id);
@@ -124,20 +124,20 @@ OSM.NewNote = function (map) {
       padding: [50, 50]
     });
 
-    newNote = L.marker(markerLatlng, {
+    newNoteMarker = L.marker(markerLatlng, {
       icon: noteIcons.new,
       opacity: 0.9,
       draggable: true
     });
 
-    newNote.on("dragstart dragend", function (a) {
-      newHalo(newNote.getLatLng(), a.type);
+    newNoteMarker.on("dragstart dragend", function (a) {
+      newHalo(newNoteMarker.getLatLng(), a.type);
     });
 
-    newNote.addTo(noteLayer);
-    newHalo(newNote.getLatLng());
+    newNoteMarker.addTo(noteLayer);
+    newHalo(newNoteMarker.getLatLng());
 
-    newNote.on("remove", function () {
+    newNoteMarker.on("remove", function () {
       addNoteButton.removeClass("active");
     }).on("dragend", function () {
       content.find("textarea").focus();
@@ -153,14 +153,14 @@ OSM.NewNote = function (map) {
 
     content.find("input[type=submit]").on("click", function (e) {
       e.preventDefault();
-      createNote(newNote, e.target.form, "/api/0.6/notes.json");
+      createNote(newNoteMarker, e.target.form, "/api/0.6/notes.json");
     });
 
     return map.getState();
   };
 
   page.unload = function () {
-    if (newNote) noteLayer.removeLayer(newNote);
+    if (newNoteMarker) noteLayer.removeLayer(newNoteMarker);
     if (halo) map.removeLayer(halo);
     addNoteButton.removeClass("active");
   };

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -49,7 +49,7 @@ OSM.NewNote = function (map) {
     });
   }
 
-  function updateMarker(feature) {
+  function addCreatedNoteMarker(feature) {
     var marker = L.marker(feature.geometry.coordinates.reverse(), {
       icon: noteIcons[feature.properties.status],
       opacity: 0.9,
@@ -144,7 +144,7 @@ OSM.NewNote = function (map) {
 
       createNote(location, text, (feature) => {
         content.find("textarea").val("");
-        updateMarker(feature);
+        addCreatedNoteMarker(feature);
         noteLayer.removeLayer(newNoteMarker);
         newNoteMarker = null;
         addNoteButton.removeClass("active");

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -35,12 +35,7 @@ OSM.NewNote = function (map) {
     OSM.router.route("/note/new");
   });
 
-  function createNote(marker, text, callback) {
-    var location = marker.getLatLng().wrap();
-
-    marker.options.draggable = false;
-    marker.dragging.disable();
-
+  function createNote(location, text, callback) {
     $.ajax({
       url: "/api/0.6/notes.json",
       type: "POST",
@@ -139,11 +134,15 @@ OSM.NewNote = function (map) {
     }
 
     content.find("input[type=submit]").on("click", function (e) {
+      const location = newNoteMarker.getLatLng().wrap();
       const text = content.find("textarea").val();
 
       e.preventDefault();
       $(this).prop("disabled", true);
-      createNote(newNoteMarker, text, (feature) => {
+      newNoteMarker.options.draggable = false;
+      newNoteMarker.dragging.disable();
+
+      createNote(location, text, (feature) => {
         content.find("textarea").val("");
         updateMarker(feature);
         noteLayer.removeLayer(newNoteMarker);

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -41,8 +41,6 @@ OSM.NewNote = function (map) {
     marker.options.draggable = false;
     marker.dragging.disable();
 
-    $(form).find("input[type=submit]").prop("disabled", true);
-
     $.ajax({
       url: url,
       type: "POST",
@@ -153,6 +151,7 @@ OSM.NewNote = function (map) {
 
     content.find("input[type=submit]").on("click", function (e) {
       e.preventDefault();
+      $(this).prop("disabled", true);
       createNote(newNoteMarker, e.target.form, "/api/0.6/notes.json");
     });
 

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -59,23 +59,22 @@ OSM.NewNote = function (map) {
     marker.addTo(noteLayer);
   }
 
-  function newHalo(loc, a) {
-    var hasHalo = halo && map.hasLayer(halo);
+  function addHalo(latlng) {
+    if (halo) map.removeLayer(halo);
 
-    if (a === "dragstart" && hasHalo) {
-      map.removeLayer(halo);
-    } else {
-      if (hasHalo) map.removeLayer(halo);
+    halo = L.circleMarker(latlng, {
+      weight: 2.5,
+      radius: 20,
+      fillOpacity: 0.5,
+      color: "#FF6200"
+    });
 
-      halo = L.circleMarker(loc, {
-        weight: 2.5,
-        radius: 20,
-        fillOpacity: 0.5,
-        color: "#FF6200"
-      });
+    map.addLayer(halo);
+  }
 
-      map.addLayer(halo);
-    }
+  function removeHalo() {
+    if (halo) map.removeLayer(halo);
+    halo = null;
   }
 
   page.pushstate = page.popstate = function (path) {
@@ -112,11 +111,14 @@ OSM.NewNote = function (map) {
     });
 
     newNoteMarker.on("dragstart dragend", function (a) {
-      newHalo(newNoteMarker.getLatLng(), a.type);
+      removeHalo();
+      if (a.type !== "dragstart") {
+        addHalo(newNoteMarker.getLatLng());
+      }
     });
 
     newNoteMarker.addTo(map);
-    newHalo(newNoteMarker.getLatLng());
+    addHalo(newNoteMarker.getLatLng());
 
     newNoteMarker.on("remove", function () {
       addNoteButton.removeClass("active");
@@ -156,7 +158,7 @@ OSM.NewNote = function (map) {
 
   page.unload = function () {
     if (newNoteMarker) map.removeLayer(newNoteMarker);
-    if (halo) map.removeLayer(halo);
+    removeHalo();
     addNoteButton.removeClass("active");
   };
 

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -113,6 +113,7 @@ OSM.NewNote = function (map) {
 
     content.find("#new-note-zoom-warning").prop("hidden", !zoomedOut);
     content.find("input[type=submit]").prop("disabled", zoomedOut || withoutText);
+    if (newNoteMarker) newNoteMarker.setOpacity(zoomedOut ? 0.5 : 0.9);
   }
 
   page.pushstate = page.popstate = function (path) {

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -115,7 +115,7 @@ OSM.NewNote = function (map) {
       newHalo(newNoteMarker.getLatLng(), a.type);
     });
 
-    newNoteMarker.addTo(noteLayer);
+    newNoteMarker.addTo(map);
     newHalo(newNoteMarker.getLatLng());
 
     newNoteMarker.on("remove", function () {
@@ -144,7 +144,7 @@ OSM.NewNote = function (map) {
       createNote(location, text, (feature) => {
         content.find("textarea").val("");
         addCreatedNoteMarker(feature);
-        noteLayer.removeLayer(newNoteMarker);
+        map.removeLayer(newNoteMarker);
         newNoteMarker = null;
         addNoteButton.removeClass("active");
         OSM.router.route("/note/" + feature.properties.id);
@@ -155,7 +155,7 @@ OSM.NewNote = function (map) {
   };
 
   page.unload = function () {
-    if (newNoteMarker) noteLayer.removeLayer(newNoteMarker);
+    if (newNoteMarker) map.removeLayer(newNoteMarker);
     if (halo) map.removeLayer(halo);
     addNoteButton.removeClass("active");
   };

--- a/app/assets/javascripts/leaflet.note.js
+++ b/app/assets/javascripts/leaflet.note.js
@@ -14,12 +14,19 @@ L.OSM.note = function (options) {
     map.on("zoomend", update);
 
     function update() {
-      var disabled = OSM.STATUS === "database_offline" || map.getZoom() < 12;
+      var wasDisabled = link.hasClass("disabled"),
+          isDisabled = OSM.STATUS === "database_offline" || map.getZoom() < 12;
       link
-        .toggleClass("disabled", disabled)
-        .attr("data-bs-original-title", I18n.t(disabled ?
+        .toggleClass("disabled", isDisabled)
+        .attr("data-bs-original-title", I18n.t(isDisabled ?
           "javascripts.site.createnote_disabled_tooltip" :
           "javascripts.site.createnote_tooltip"));
+
+      if (isDisabled && !wasDisabled) {
+        link.trigger("disabled");
+      } else if (wasDisabled && !isDisabled) {
+        link.trigger("enabled");
+      }
     }
 
     update();

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -9,6 +9,7 @@
                                          :log_in => link_to(t(".anonymous_warning_log_in"), login_path(:referer => new_note_path)),
                                          :sign_up => link_to(t(".anonymous_warning_sign_up"), user_new_path) %></p>
   <% end %>
+  <p class="alert alert-warning" id="new-note-zoom-warning" hidden><%= t "javascripts.site.createnote_disabled_tooltip" %></p>
   <form action="#">
     <input type="hidden" name="lon" autocomplete="off">
     <input type="hidden" name="lat" autocomplete="off">

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -15,6 +15,60 @@ class CreateNoteTest < ApplicationSystemTestCase
     end
   end
 
+  test "cannot create new note when zoomed out" do
+    visit new_note_path(:anchor => "map=12/0/0")
+
+    within_sidebar do
+      assert_no_content "Zoom in to add a note"
+      assert_button "Add Note", :disabled => true
+
+      fill_in "text", :with => "Some newly added note description"
+
+      assert_no_content "Zoom in to add a note"
+      assert_button "Add Note", :disabled => false
+    end
+
+    find(".control-button.zoomout").click
+
+    within_sidebar do
+      assert_content "Zoom in to add a note"
+      assert_button "Add Note", :disabled => true
+    end
+
+    find(".control-button.zoomin").click
+
+    within_sidebar do
+      assert_no_content "Zoom in to add a note"
+      assert_button "Add Note", :disabled => false
+
+      click_on "Add Note"
+
+      assert_content "Unresolved note ##{Note.last.id}"
+      assert_content "Some newly added note description"
+    end
+  end
+
+  test "can open new note page when zoomed out" do
+    visit new_note_path(:anchor => "map=11/0/0")
+
+    within_sidebar do
+      assert_content "Zoom in to add a note"
+      assert_button "Add Note", :disabled => true
+
+      fill_in "text", :with => "Some newly added note description"
+
+      assert_content "Zoom in to add a note"
+      assert_button "Add Note", :disabled => true
+    end
+
+    find(".control-button.zoomin").click
+
+    within_sidebar do
+      assert_no_content "Zoom in to add a note"
+      assert_button "Add Note", :disabled => false
+    end
+  end
+
   test "cannot create note when api is readonly" do
     with_settings(:status => "api_readonly") do
       visit new_note_path(:anchor => "map=18/0/0")


### PR DESCRIPTION
If
- you open `/note/new` while your zoom is too low as described in #1291 
- you zoom out far enough while on `/note/new`,

show a warning message and disable the submit button.

![image](https://github.com/user-attachments/assets/abb8e7d1-316b-411c-94fb-614b87355330)

Fixes #1291 and another bug: note marker was disappearing together with notes layer when visible area became too large.