### PR TITLE
Move code that runs after user save from save_new_user to create method

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -41,4 +41,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def within_sidebar(&)
     within("#sidebar_content", &)
   end
+
+  def within_content_body(&)
+    within("#content > .content-body", &)
+  end
 end

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -1,6 +1,43 @@
 require "application_system_test_case"
 
 class UserSignupTest < ApplicationSystemTestCase
+  include ActionMailer::TestHelper
+
+  def setup
+    stub_request(:get, /.*gravatar.com.*d=404/).to_return(:status => 404)
+  end
+
+  test "Sign up with confirmation email" do
+    visit root_path
+
+    click_on "Sign Up"
+
+    within_content_body do
+      fill_in "Email", :with => "new_user_account@example.com"
+      fill_in "Display Name", :with => "new_user_account"
+      fill_in "Password", :with => "new_user_password"
+      fill_in "Confirm Password", :with => "new_user_password"
+
+      assert_emails 1 do
+        click_on "Sign Up"
+
+        assert_content "We sent you a confirmation email"
+      end
+    end
+
+    email = ActionMailer::Base.deliveries.first
+    assert_equal 1, email.to.count
+    assert_equal "new_user_account@example.com", email.to.first
+    email_text = email.parts[0].parts[0].decoded
+    match = %r{/user/new_user_account/confirm\?confirm_string=\S+}.match(email_text)
+    assert_not_nil match
+
+    visit match[0]
+
+    assert_content "new_user_account"
+    assert_content "Welcome!"
+  end
+
   test "Sign up from login page" do
     visit login_path
 

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -6,18 +6,22 @@ class UserSignupTest < ApplicationSystemTestCase
 
     click_on "Sign up"
 
-    assert_content "Confirm Password"
+    within_content_body do
+      assert_content "Confirm Password"
+    end
   end
 
   test "Show OpenID form when OpenID provider button is clicked" do
     visit login_path
 
-    assert_no_field "OpenID URL"
-    assert_no_button "Continue"
+    within_content_body do
+      assert_no_field "OpenID URL"
+      assert_no_button "Continue"
 
-    click_on "Log in with OpenID"
+      click_on "Log in with OpenID"
 
-    assert_field "OpenID URL"
-    assert_button "Continue"
+      assert_field "OpenID URL"
+      assert_button "Continue"
+    end
   end
 end


### PR DESCRIPTION
Currently `save_new_user` does other things like redirects after the actual save. That obscures which pages are reachable from actions that call `save_new_user`, see https://github.com/openstreetmap/openstreetmap-website/issues/5431#issuecomment-2564561794.

Also `save_new_user` accesses referer in two different ways: as a function argument and as `params[:referer]`.

---

Added test for clicking *Sign Up*, filling out email-login-password, clicking *Sign Up*, opening confirmation link from email.