### PR TITLE
API active blocks list

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -30,6 +30,8 @@ class ApiAbility
         can [:read, :update, :destroy], Message if scopes.include?("consume_messages")
         can :create, Message if scopes.include?("send_messages")
 
+        can :read, :active_user_blocks_list if scopes.include?("read_prefs")
+
         if user.terms_agreed?
           can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset if scopes.include?("write_map")
           can :create, ChangesetComment if scopes.include?("write_changeset_comments")

--- a/app/controllers/api/user_blocks/active_lists_controller.rb
+++ b/app/controllers/api/user_blocks/active_lists_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module UserBlocks
+    class ActiveListsController < ApiController
+      before_action :authorize
+
+      authorize_resource :class => :active_user_blocks_list
+
+      before_action :set_request_formats
+
+      def show; end
+    end
+  end
+end

--- a/app/controllers/api/user_blocks/active_lists_controller.rb
+++ b/app/controllers/api/user_blocks/active_lists_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module UserBlocks
     class ActiveListsController < ApiController
-      before_action :authorize
+      before_action -> { authorize(:skip_blocks => true) }
 
       authorize_resource :class => :active_user_blocks_list
 

--- a/app/controllers/api/user_blocks/active_lists_controller.rb
+++ b/app/controllers/api/user_blocks/active_lists_controller.rb
@@ -7,7 +7,10 @@ module Api
 
       before_action :set_request_formats
 
-      def show; end
+      def show
+        @user_blocks = current_user.blocks.active.order(:id => :desc)
+        @skip_reason = true
+      end
     end
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -49,9 +49,9 @@ class ApiController < ApplicationController
     end
   end
 
-  def authorize(errormessage: "Couldn't authenticate you", skip_terms: false)
+  def authorize(errormessage: "Couldn't authenticate you", skip_blocks: false, skip_terms: false)
     # make the current_user object from any auth sources we have
-    setup_user_auth(:skip_terms => skip_terms)
+    setup_user_auth(:skip_blocks => skip_blocks, :skip_terms => skip_terms)
 
     # handle authenticate pass/fail
     unless current_user
@@ -99,7 +99,7 @@ class ApiController < ApplicationController
   # sets up the current_user for use by other methods. this is mostly called
   # from the authorize method, but can be called elsewhere if authorisation
   # is optional.
-  def setup_user_auth(skip_terms: false)
+  def setup_user_auth(skip_blocks: false, skip_terms: false)
     logger.info " setup_user_auth"
     # try and setup using OAuth
     self.current_user = User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token&.accessible?
@@ -107,13 +107,15 @@ class ApiController < ApplicationController
     # have we identified the user?
     if current_user
       # check if the user has been banned
-      user_block = current_user.blocks.active.take
-      unless user_block.nil?
-        set_locale
-        if user_block.zero_hour?
-          report_error t("application.setup_user_auth.blocked_zero_hour"), :forbidden
-        else
-          report_error t("application.setup_user_auth.blocked"), :forbidden
+      unless skip_blocks
+        user_block = current_user.blocks.active.take
+        unless user_block.nil?
+          set_locale
+          if user_block.zero_hour?
+            report_error t("application.setup_user_auth.blocked_zero_hour"), :forbidden
+          else
+            report_error t("application.setup_user_auth.blocked"), :forbidden
+          end
         end
       end
 

--- a/app/views/api/user_blocks/_user_block.json.jbuilder
+++ b/app/views/api/user_blocks/_user_block.json.jbuilder
@@ -1,13 +1,11 @@
-json.user_block do
-  json.id user_block.id
-  json.created_at user_block.created_at.xmlschema
-  json.updated_at user_block.updated_at.xmlschema
-  json.ends_at user_block.ends_at.xmlschema
-  json.needs_view user_block.needs_view
+json.id user_block.id
+json.created_at user_block.created_at.xmlschema
+json.updated_at user_block.updated_at.xmlschema
+json.ends_at user_block.ends_at.xmlschema
+json.needs_view user_block.needs_view
 
-  json.user :uid => user_block.user_id, :user => user_block.user.display_name
-  json.creator :uid => user_block.creator_id, :user => user_block.creator.display_name
-  json.revoker :uid => user_block.revoker_id, :user => user_block.revoker.display_name if user_block.revoker
+json.user :uid => user_block.user_id, :user => user_block.user.display_name
+json.creator :uid => user_block.creator_id, :user => user_block.creator.display_name
+json.revoker :uid => user_block.revoker_id, :user => user_block.revoker.display_name if user_block.revoker
 
-  json.reason user_block.reason
-end
+json.reason user_block.reason unless @skip_reason

--- a/app/views/api/user_blocks/_user_block.xml.builder
+++ b/app/views/api/user_blocks/_user_block.xml.builder
@@ -10,5 +10,6 @@ xml.user_block(attrs) do
   xml.user :uid => user_block.user_id, :user => user_block.user.display_name
   xml.creator :uid => user_block.creator_id, :user => user_block.creator.display_name
   xml.revoker :uid => user_block.revoker_id, :user => user_block.revoker.display_name if user_block.revoker
-  xml.reason user_block.reason
+
+  xml.reason user_block.reason unless @skip_reason
 end

--- a/app/views/api/user_blocks/active_lists/show.json.jbuilder
+++ b/app/views/api/user_blocks/active_lists/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "api/root_attributes"
+
+json.user_blocks do
+  json.array! @user_blocks, :partial => "api/user_blocks/user_block", :as => :user_block
+end

--- a/app/views/api/user_blocks/active_lists/show.xml.builder
+++ b/app/views/api/user_blocks/active_lists/show.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/user_blocks/user_block", :collection => @user_blocks) || "")
+end

--- a/app/views/api/user_blocks/show.json.jbuilder
+++ b/app/views/api/user_blocks/show.json.jbuilder
@@ -1,3 +1,5 @@
 json.partial! "api/root_attributes"
 
-json.partial! @user_block
+json.user_block do
+  json.partial! @user_block
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,9 @@ OpenStreetMap::Application.routes.draw do
     end
 
     resources :user_blocks, :only => :show, :id => /\d+/, :controller => "user_blocks"
+    namespace :user_blocks, :path => "user/blocks" do
+      resource :active_list, :path => "active", :only => :show
+    end
   end
 
   # Data browsing

--- a/test/controllers/api/user_blocks/active_lists_controller_test.rb
+++ b/test/controllers/api/user_blocks/active_lists_controller_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+module Api
+  module UserBlocks
+    class ActiveListsControllerTest < ActionDispatch::IntegrationTest
+      ##
+      # test all routes which lead to this controller
+      def test_routes
+        assert_routing(
+          { :path => "/api/0.6/user/blocks/active", :method => :get },
+          { :controller => "api/user_blocks/active_lists", :action => "show" }
+        )
+        assert_routing(
+          { :path => "/api/0.6/user/blocks/active.json", :method => :get },
+          { :controller => "api/user_blocks/active_lists", :action => "show", :format => "json" }
+        )
+      end
+
+      def test_show_no_auth_header
+        get api_user_blocks_active_list_path
+        assert_response :unauthorized
+      end
+
+      def test_show_no_permission
+        user = create(:user)
+        user_auth_header = bearer_authorization_header(user, :scopes => %w[])
+
+        get api_user_blocks_active_list_path, :headers => user_auth_header
+        assert_response :forbidden
+      end
+
+      def test_show_empty
+        user = create(:user)
+        user_auth_header = bearer_authorization_header(user, :scopes => %w[read_prefs])
+        create(:user_block, :expired, :user => user)
+
+        get api_user_blocks_active_list_path, :headers => user_auth_header
+        assert_response :success
+        assert_dom "user_block", :count => 0
+      end
+    end
+  end
+end

--- a/test/controllers/api/user_blocks/active_lists_controller_test.rb
+++ b/test/controllers/api/user_blocks/active_lists_controller_test.rb
@@ -50,6 +50,10 @@ module Api
 
         get api_user_blocks_active_list_path, :headers => user_auth_header
         assert_response :success
+        assert_dom "user_block", :count => 2 do |dom_blocks|
+          assert_dom dom_blocks[0], "> @id", block1.id.to_s
+          assert_dom dom_blocks[1], "> @id", block0.id.to_s
+        end
       end
 
       def test_show_json
@@ -63,6 +67,11 @@ module Api
 
         get api_user_blocks_active_list_path(:format => "json"), :headers => user_auth_header
         assert_response :success
+        js = ActiveSupport::JSON.decode(@response.body)
+        assert_not_nil js
+        assert_equal 2, js["user_blocks"].count
+        assert_equal block1.id, js["user_blocks"][0]["id"]
+        assert_equal block0.id, js["user_blocks"][1]["id"]
       end
     end
   end

--- a/test/controllers/api/user_blocks/active_lists_controller_test.rb
+++ b/test/controllers/api/user_blocks/active_lists_controller_test.rb
@@ -38,6 +38,32 @@ module Api
         assert_response :success
         assert_dom "user_block", :count => 0
       end
+
+      def test_show
+        user = create(:moderator_user)
+        user_auth_header = bearer_authorization_header(user, :scopes => %w[read_prefs])
+        create(:user_block, :expired, :user => user)
+        block0 = create(:user_block, :user => user)
+        block1 = create(:user_block, :user => user)
+        create(:user_block)
+        create(:user_block, :creator => user)
+
+        get api_user_blocks_active_list_path, :headers => user_auth_header
+        assert_response :success
+      end
+
+      def test_show_json
+        user = create(:moderator_user)
+        user_auth_header = bearer_authorization_header(user, :scopes => %w[read_prefs])
+        create(:user_block, :expired, :user => user)
+        block0 = create(:user_block, :user => user)
+        block1 = create(:user_block, :user => user)
+        create(:user_block)
+        create(:user_block, :creator => user)
+
+        get api_user_blocks_active_list_path(:format => "json"), :headers => user_auth_header
+        assert_response :success
+      end
     end
   end
 end


### PR DESCRIPTION
See https://community.openstreetmap.org/t/is-this-the-same-person/123461/30

Problem: how an app accessing OSM API can determine that the current user is blocked, and tell them that they're blocked? Here's a method I came up with: https://github.com/streetcomplete/StreetComplete/issues/6062#issuecomment-2565450817. It has two hacky steps:
1. accessing `/api/0.6/user/#id` without auth header, because `/api/0.6/user/details` is inaccessible while blocked
2. generating a login link with referrer pointing to the block list

Some people access an endpoint that is known to generate 403 errors only when blocked instead of **1**, but there's no guarantee that things will stay that way. `/api/0.6/user/#id` may also become inaccessible without authorization in the future. This PR does **1** in an unambiguous way by providing an endpoint that lists active blocks for the current user. It it accessible even if the user is blocked.

`GET user/blocks/active` outputs a list of `<user_block>` elements like #4240. Currently I'm skipping block reason texts because I'm making this similar to *Messages API* which also skips message texts in lists. While this list is short and adding reasons wouldn't make the results very long, we may add a similar list of all blocks / by all users and it will get long.

I probably should add a limit but I can't imagine anyone collecting a lot of *active* blocks. More than one is already unusual.

`user/blocks/active` requires `read_prefs` scope, which may look strange, but that's because this scope is also responsible for user identity. Similarly `user/details` requires `read_prefs` despite not reading preferences.