### PR TITLE
Use turbo for the settings page to stop the URL changing

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -31,7 +31,7 @@ class AccountsController < ApplicationController
        (params[:user][:auth_provider] == current_user.auth_provider &&
         params[:user][:auth_uid] == current_user.auth_uid)
       update_user(current_user, user_params)
-      if current_user.errors.count.zero?
+      if current_user.errors.empty?
         redirect_to edit_account_path
       else
         render :edit, :status => :unprocessable_entity

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -34,7 +34,7 @@ class AccountsController < ApplicationController
       if current_user.errors.count.zero?
         redirect_to edit_account_path
       else
-        render :edit
+        render :edit, :status => :unprocessable_entity
       end
     else
       session[:new_user_settings] = user_params.to_h

--- a/app/controllers/concerns/user_methods.rb
+++ b/app/controllers/concerns/user_methods.rb
@@ -59,8 +59,9 @@ module UserMethods
             # Ignore errors sending email
           end
         else
-          current_user.errors.add(:new_email, current_user.errors[:email])
-          current_user.errors.add(:email, [])
+          current_user.errors.delete(:email).each do |error|
+            current_user.errors.add(:new_email, error)
+          end
         end
 
         user.restore_email!

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -8,7 +8,7 @@
 
 <%= render :partial => "settings_menu" %>
 
-<%= bootstrap_form_for current_user, :url => { :action => :update }, :html => { :multipart => true, :id => "accountForm", :autocomplete => :off } do |f| %>
+<%= bootstrap_form_for current_user, :url => { :action => :update }, :data => { :turbo => true }, :html => { :multipart => true, :id => "accountForm", :autocomplete => :off } do |f| %>
 
   <%= f.text_field :display_name %>
   <%= f.email_field :email, :disabled => true, :label => t(".current email address") %>

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -55,7 +55,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # Changing name to one that exists should fail
     new_attributes = user.attributes.dup.merge(:display_name => create(:user).display_name)
     patch account_path, :params => { :user => new_attributes }
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_template :edit
     assert_select ".alert-success", false
     assert_select "form#accountForm > div > input.is-invalid#user_display_name"
@@ -63,7 +63,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # Changing name to one that exists should fail, regardless of case
     new_attributes = user.attributes.dup.merge(:display_name => create(:user).display_name.upcase)
     patch account_path, :params => { :user => new_attributes }
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_template :edit
     assert_select ".alert-success", false
     assert_select "form#accountForm > div > input.is-invalid#user_display_name"
@@ -88,7 +88,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
         patch account_path, :params => { :user => user.attributes }
       end
     end
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_template :edit
     assert_select ".alert-success", false
     assert_select "form#accountForm > div > input.is-invalid#user_new_email"
@@ -100,7 +100,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
         patch account_path, :params => { :user => user.attributes }
       end
     end
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_template :edit
     assert_select ".alert-success", false
     assert_select "form#accountForm > div > input.is-invalid#user_new_email"


### PR DESCRIPTION
This changes the user settings page to use turbo to fix the problem identified in https://github.com/openstreetmap/openstreetmap-website/pull/5449#issuecomment-2565252266 where the URL changes when submitting a settings page with errors.

It also fixes an issue where errors weren't moved from the `email` to the `new_email` attribute properly, and simplifies checking if errors are present.