### PR TITLE
Remove test_logout_removes_session_token

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -95,12 +95,4 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_template "sessions/destroy"
     assert_select "input[name=referer][value=?]", "/test"
   end
-
-  def test_logout_removes_session_token
-    user = build(:user, :pending)
-    post user_new_path, :params => { :user => user.attributes }
-    post user_save_path, :params => { :read_ct => 1, :read_tou => 1 }
-    post logout_path
-    assert_redirected_to root_path
-  end
 end


### PR DESCRIPTION
This test was about tokens that don't exist since #4535. That PR modified the test by removing the assert that checked the number of tokens in https://github.com/openstreetmap/openstreetmap-website/commit/4dff06a6293971c3e17f8508859a1d80717a23f6. Yet the test was kept although it doesn't do what it was supposed to do.

It also has `post user_save_path` that used to happen after `post user_new_path` when the terms page was shown during signups. This is not happening after #4455, and `post user_save_path` was removed from other tests in https://github.com/openstreetmap/openstreetmap-website/commit/1276fb944a8024884f3121d21577ef892353dfd1.