### PR TITLE
Use resourceful routes for user new/create actions

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -111,7 +111,7 @@
     <% else %>
       <div class="d-inline-flex btn-group login-menu" role="">
         <%= link_to t("layouts.log_in"), login_path(:referer => request.fullpath), :class => "geolink btn btn-outline-secondary" %>
-        <%= link_to t("layouts.sign_up"), user_new_path, :class => "btn btn-outline-secondary" %>
+        <%= link_to t("layouts.sign_up"), new_user_path, :class => "btn btn-outline-secondary" %>
       </div>
     <% end %>
   </nav>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -51,7 +51,7 @@
         </p>
         <div class="d-flex gap-2">
           <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>
-          <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+          <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= new_user_path %>"><%= t("layouts.start_mapping") %></a>
         </div>
       </div>
     <% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -7,7 +7,7 @@
   <% if !current_user %>
     <p class="alert alert-warning"><%= t ".anonymous_warning_html",
                                          :log_in => link_to(t(".anonymous_warning_log_in"), login_path(:referer => new_note_path)),
-                                         :sign_up => link_to(t(".anonymous_warning_sign_up"), user_new_path) %></p>
+                                         :sign_up => link_to(t(".anonymous_warning_sign_up"), new_user_path) %></p>
   <% end %>
   <p class="alert alert-warning" id="new-note-zoom-warning" hidden><%= t "javascripts.site.createnote_disabled_tooltip" %></p>
   <form action="#">

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -16,7 +16,7 @@
     <h3 class='fs-5'><%= t ".how_to_help.join_the_community.title" %></h3>
     <p><%= t ".how_to_help.join_the_community.explanation_html" %></p>
     <p class='text-center'>
-      <a class="btn btn-primary" href="<%= user_new_path %>"><%= t("layouts.start_mapping") %></a>
+      <a class="btn btn-primary" href="<%= new_user_path %>"><%= t("layouts.start_mapping") %></a>
     </p>
   </div>
   <div class='col-sm'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,8 +182,6 @@ OpenStreetMap::Application.routes.draw do
   get "/key" => "site#key"
   get "/id" => "site#id"
   get "/query" => "browse#query"
-  get "/user/new" => "users#new"
-  post "/user/new" => "users#create"
   get "/user/terms" => "users#terms"
   post "/user/save" => "users#save"
   post "/user/:display_name/confirm/resend" => "confirmations#confirm_resend", :as => :user_confirm_resend
@@ -269,7 +267,7 @@ OpenStreetMap::Application.routes.draw do
   post "/diary_comments/:comment/unhide" => "diary_comments#unhide", :comment => /\d+/, :as => :unhide_diary_comment
 
   # user pages
-  resources :users, :path => "user", :param => :display_name, :only => [:show, :destroy] do
+  resources :users, :path => "user", :param => :display_name, :only => [:new, :create, :show, :destroy] do
     resource :role, :controller => "user_roles", :path => "roles/:role", :only => [:create, :destroy]
     scope :module => :users do
       resource :issued_blocks, :path => "blocks_by", :only => :show

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -37,7 +37,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_confirm_get
     user = build(:user, :pending)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     get user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
@@ -48,7 +48,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_get_already_confirmed
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     # Get the confirmation page
@@ -68,7 +68,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_success_no_token_no_referer
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post logout_path
@@ -81,7 +81,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_success_good_token_no_referer
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string }
@@ -91,7 +91,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_success_bad_token_no_referer
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post logout_path
@@ -105,7 +105,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_success_no_token_with_referer
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post logout_path
@@ -118,7 +118,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_success_good_token_with_referer
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string, :referer => new_diary_entry_path }
@@ -128,7 +128,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_success_bad_token_with_referer
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post logout_path
@@ -142,7 +142,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_expired_token
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     travel 2.weeks do
@@ -155,7 +155,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_already_confirmed
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     post user_confirm_path, :params => { :display_name => user.display_name, :confirm_string => confirm_string, :referer => new_diary_entry_path }
@@ -172,7 +172,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_confirm_deleted
     user = build(:user, :pending)
     stub_gravatar_request(user.email)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
     confirm_string = User.find_by(:email => user.email).generate_token_for(:new_user)
 
     User.find_by(:display_name => user.display_name).hide!
@@ -189,7 +189,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_confirm_resend_success
     user = build(:user, :pending)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
 
     assert_difference "ActionMailer::Base.deliveries.size", 1 do
       perform_enqueued_jobs do
@@ -210,7 +210,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_confirm_resend_deleted
     user = build(:user, :pending)
-    post user_new_path, :params => { :user => user.attributes }
+    post users_path, :params => { :user => user.attributes }
 
     User.find_by(:display_name => user.display_name).hide!
 

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -30,7 +30,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => dup_email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
@@ -51,7 +51,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_difference("User.count", 0) do
       assert_no_difference("ActionMailer::Base.deliveries.size") do
         perform_enqueued_jobs do
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => dup_email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
@@ -74,7 +74,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => email,
                                        :display_name => dup_display_name,
                                        :pass_crypt => "testtest",
@@ -93,7 +93,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_difference("User.count", 0) do
       assert_difference("ActionMailer::Base.deliveries.size", 0) do
         perform_enqueued_jobs do
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
@@ -113,7 +113,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_difference("User.count", 0) do
       assert_no_difference("ActionMailer::Base.deliveries.size") do
         perform_enqueued_jobs do
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => email,
                                        :display_name => dup_display_name,
                                        :auth_provider => "google",
@@ -134,7 +134,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_difference("User.count", 1) do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
@@ -188,7 +188,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_difference("User.count") do
       assert_difference("ActionMailer::Base.deliveries.size", 1) do
         perform_enqueued_jobs do
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :pass_crypt => password,
@@ -250,7 +250,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name, :email => new_email,
                                :auth_provider => "openid", :auth_uid => auth_uid
           follow_redirect!
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "openid",
@@ -326,7 +326,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
           assert_redirected_to :controller => :users, :action => "new", :nickname => display_name, :email => new_email,
                                :auth_provider => "openid", :auth_uid => auth_uid
           follow_redirect!
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "openid",
@@ -388,7 +388,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :auth_provider => "google", :auth_uid => auth_uid
           follow_redirect!
 
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "google",
@@ -474,7 +474,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :email => orig_email, :email_hmac => email_hmac,
                                :auth_provider => "google", :auth_uid => auth_uid
           follow_redirect!
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
@@ -537,7 +537,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :auth_provider => "facebook", :auth_uid => auth_uid
           follow_redirect!
 
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "facebook",
@@ -623,7 +623,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :auth_provider => "facebook", :auth_uid => auth_uid
           follow_redirect!
 
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
@@ -685,7 +685,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :email => new_email, :email_hmac => email_hmac,
                                :auth_provider => "microsoft", :auth_uid => auth_uid
           follow_redirect!
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "microsoft",
@@ -770,7 +770,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :auth_provider => "microsoft", :auth_uid => auth_uid
           follow_redirect!
 
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
@@ -834,7 +834,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :auth_provider => "github", :auth_uid => auth_uid
           follow_redirect!
 
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "github",
@@ -921,7 +921,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :email => orig_email, :email_hmac => email_hmac,
                                :auth_provider => "github", :auth_uid => auth_uid
           follow_redirect!
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
@@ -984,7 +984,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :email => new_email, :email_hmac => email_hmac,
                                :auth_provider => "wikipedia", :auth_uid => auth_uid
           follow_redirect!
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "wikipedia",
@@ -1071,7 +1071,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                :auth_provider => "wikipedia", :auth_uid => auth_uid
           follow_redirect!
 
-          post "/user/new",
+          post "/user",
                :params => { :user => { :email => new_email,
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,


### PR DESCRIPTION
- `user_new_path` helper renamed to `new_user_path`
- user create action moved from `POST /user/new` to `POST /user`, which corresponds to `users_path` helper
