### PR TITLE
Convert Auth.providers into array

### DIFF
--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -19,7 +19,11 @@
   <fieldset class="mb-3">
     <label for="user_auth_provider" class="form-label"><%= t(".external auth") %></label>
     <div class="row">
-      <%= f.select(:auth_provider, { t("auth.providers.none") => "" }.merge(Auth.providers), :hide_label => true, :wrapper => { :class => "col-auto mb-0" }) %>
+      <%= f.select :auth_provider,
+                   Auth.providers.map { |provider| [I18n.t("auth.providers.#{provider}"), provider] },
+                   :include_blank => t("auth.providers.none"),
+                   :hide_label => true,
+                   :wrapper => { :class => "col-auto mb-0" } %>
       <%= f.text_field(:auth_uid, :hide_label => true, :wrapper => { :class => "col mb-0" }) %>
     </div>
     <small class="form-text text-body-secondary">(<a href="<%= t ".openid.link" %>" target="_new"><%= t ".openid.link text" %></a>)</small>

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -1,4 +1,4 @@
-<% prefered_auth_button_available = @preferred_auth_provider != "openid" && Auth.providers.value?(@preferred_auth_provider) %>
+<% prefered_auth_button_available = @preferred_auth_provider != "openid" && Auth.providers.include?(@preferred_auth_provider) %>
 
 <div>
   <%= tag.div :id => "login_auth_buttons",
@@ -11,7 +11,7 @@
     <% end %>
 
     <div class="col justify-content-center d-flex align-items-center flex-wrap gap-2">
-      <% Auth.providers.each_value do |provider| %>
+      <% Auth.providers.each do |provider| %>
         <% if provider == "openid" %>
           <%= button_tag image_tag("auth_providers/openid.svg",
                                    :alt => t(".openid.alt"),

--- a/lib/auth.rb
+++ b/lib/auth.rb
@@ -1,15 +1,13 @@
 module Auth
-  @providers = {}
+  @providers = ["openid"]
+  @providers << "google" if Settings.key?(:google_auth_id)
+  @providers << "facebook" if Settings.key?(:facebook_auth_id)
+  @providers << "microsoft" if Settings.key?(:microsoft_auth_id)
+  @providers << "github" if Settings.key?(:github_auth_id)
+  @providers << "wikipedia" if Settings.key?(:wikipedia_auth_id)
+  @providers.freeze
 
   def self.providers
-    @providers[I18n.locale] ||= {
-      I18n.t("auth.providers.openid") => "openid"
-    }.tap do |providers|
-      providers[I18n.t("auth.providers.google")] = "google" if Settings.key?(:google_auth_id)
-      providers[I18n.t("auth.providers.facebook")] = "facebook" if Settings.key?(:facebook_auth_id)
-      providers[I18n.t("auth.providers.microsoft")] = "microsoft" if Settings.key?(:microsoft_auth_id)
-      providers[I18n.t("auth.providers.github")] = "github" if Settings.key?(:github_auth_id)
-      providers[I18n.t("auth.providers.wikipedia")] = "wikipedia" if Settings.key?(:wikipedia_auth_id)
-    end.freeze
+    @providers
   end
 end


### PR DESCRIPTION
There's `Auth` module that lists currently enabled auth providers. It's used in two different places: auth providers template for login/signup pages and account edit page.

What the module actually does is it prepares options for `<select>` on the account edit page. That's why it includes localization strings as keys of a hash. The template on login/signup pages needs different strings and ignores the keys. Why do we need then to include the localization strings in `Auth` at all?