### PR TITLE
Show outbox after sending new message

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -49,7 +49,7 @@ class MessagesController < ApplicationController
     elsif @message.save
       flash[:notice] = t ".message_sent"
       UserMailer.message_notification(@message).deliver_later if @message.notify_recipient?
-      redirect_to messages_inbox_path
+      redirect_to messages_outbox_path
     else
       @title = t "messages.new.title"
       render :action => "new"

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -163,7 +163,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
         end
       end
     end
-    assert_redirected_to messages_inbox_path
+    assert_redirected_to messages_outbox_path
     assert_equal "Message sent", flash[:notice]
     e = ActionMailer::Base.deliveries.first
     assert_equal [recipient_user.email], e.to


### PR DESCRIPTION
Currently if you send a new message, you are redirected to your inbox. But you probably want to see the result of the message being sent, and that is in the outbox.

Redirect to inbox existed long ago https://github.com/openstreetmap/openstreetmap-website/commit/e6af088dda8e85f53b11ffbaddb11edf08e4a046, before there was outbox, which was added in https://github.com/openstreetmap/openstreetmap-website/commit/d736a158bee0ff17bdba30496b87e1bfe20e2910.