### PR TITLE
Fix allow_thirdparty_images options

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
   helper_method :oauth_token
 
   def self.allow_thirdparty_images(**options)
-    content_security_policy(options) do |policy|
+    content_security_policy(**options) do |policy|
       policy.img_src("*", :data)
     end
   end

--- a/app/controllers/diary_comments_controller.rb
+++ b/app/controllers/diary_comments_controller.rb
@@ -13,7 +13,7 @@ class DiaryCommentsController < ApplicationController
   before_action :lookup_user, :only => :index
   before_action :check_database_writable, :only => [:create, :hide, :unhide]
 
-  allow_thirdparty_images :only => :index
+  allow_thirdparty_images :only => [:index, :create]
 
   def index
     @title = t ".title", :user => @user.display_name

--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -104,6 +104,7 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
     assert_template :new
+    assert_match(/img-src \* data:;/, @response.headers["Content-Security-Policy-Report-Only"])
 
     # Now try again with the right id
     assert_difference "ActionMailer::Base.deliveries.size", entry.subscribers.count do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -57,6 +57,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get user_new_path, :params => { :cookie_test => "true" }
     assert_response :success
 
+    assert_no_match(/img-src \* data:;/, @response.headers["Content-Security-Policy-Report-Only"])
+
     assert_select "html", :count => 1 do
       assert_select "head", :count => 1 do
         assert_select "title", :text => /Sign Up/, :count => 1
@@ -297,6 +299,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     get user_path(user)
     assert_response :success
+    assert_match(/img-src \* data:;/, @response.headers["Content-Security-Policy-Report-Only"])
     assert_select "div.content-heading" do
       assert_select "a[href^='/user/#{ERB::Util.u(user.display_name)}/history']", 1
       assert_select "a[href='/user/#{ERB::Util.u(user.display_name)}/traces']", 1


### PR DESCRIPTION
When you write something like `allow_thirdparty_images :only => :index` you'd expect the CSP to be altered only on `index` action. But actually `:only => ...` was ignored and `allow_thirdparty_images` ran on all actions because `content_security_policy` didn't receive `options` correctly.

Other `allow_` methods from `app/controllers/application_controller.rb` should be similarly fixed, except I haven't figured out whether they are required at all. For example `allow_all_form_action` in `app/controllers/oauth2_authorizations_controller.rb` came from https://github.com/openstreetmap/openstreetmap-website/commit/b96f3867e61dad3d7f14a0d8da01ea0cab1c83ec, but are redirects done using form actions? Forms in `app/views/oauth2_authorizations/new.html.erb` have actions pointing to the osm website.