### PR TITLE
Remove zoomend listener on history unload

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -164,6 +164,7 @@ OSM.History = function (map) {
   page.unload = function () {
     map.removeLayer(group);
     map.off("moveend", update);
+    map.off("zoomend", updateBounds);
   };
 
   return page;


### PR DESCRIPTION
https://github.com/openstreetmap/openstreetmap-website/commit/6b194ed6278d4b05a04a20d6907203ed329bef77 added a map zoom listener to history pages because rendered changeset rectangles depend on the map scale. But the listener is never removed on unload.