### PR TITLE
Pass bbox to changeset page via data attribute

### DIFF
--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -1,29 +1,26 @@
 OSM.Changeset = function (map) {
   var page = {},
-      content = $("#sidebar_content"),
-      currentChangesetId;
+      content = $("#sidebar_content");
 
-  page.pushstate = page.popstate = function (path, id) {
+  page.pushstate = page.popstate = function (path) {
     OSM.loadSidebarContent(path, function () {
-      page.load(path, id);
+      page.load();
     });
   };
 
-  page.load = function (path, id) {
-    if (id) currentChangesetId = id;
-    initialize();
-    addChangeset(currentChangesetId);
-  };
+  page.load = function () {
+    const changesetData = content.find("[data-changeset]").data("changeset");
+    changesetData.type = "changeset";
 
-  function addChangeset(id) {
-    map.addObject({ type: "changeset", id: parseInt(id, 10) }, function (bounds) {
+    initialize();
+    map.addObject(changesetData, function (bounds) {
       if (!window.location.hash && bounds.isValid()) {
         OSM.router.withoutMoveListener(function () {
           map.fitBounds(bounds);
         });
       }
     });
-  }
+  };
 
   function updateChangeset(method, url, include_data) {
     var data;

--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -12,13 +12,12 @@ OSM.Changeset = function (map) {
   page.load = function (path, id) {
     if (id) currentChangesetId = id;
     initialize();
-    addChangeset(currentChangesetId, true);
+    addChangeset(currentChangesetId);
   };
 
-  function addChangeset(id, center) {
+  function addChangeset(id) {
     map.addObject({ type: "changeset", id: parseInt(id, 10) }, function (bounds) {
-      if (!window.location.hash && bounds.isValid() &&
-          (center || !map.getBounds().contains(bounds))) {
+      if (!window.location.hash && bounds.isValid()) {
         OSM.router.withoutMoveListener(function () {
           map.fitBounds(bounds);
         });

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -267,7 +267,7 @@ L.OSM.Map = L.Map.extend({
 
     this.removeObject();
 
-    if (object.type === "note") {
+    if (object.type === "note" || object.type === "changeset") {
       this._objectLoader = {
         abort: function () {}
       };
@@ -275,18 +275,27 @@ L.OSM.Map = L.Map.extend({
       this._object = object;
       this._objectLayer = L.featureGroup().addTo(this);
 
-      L.circleMarker(object.latLng, haloStyle).addTo(this._objectLayer);
+      if (object.type === "note") {
+        L.circleMarker(object.latLng, haloStyle).addTo(this._objectLayer);
 
-      if (object.icon) {
-        L.marker(object.latLng, {
-          icon: object.icon,
-          opacity: 1,
-          interactive: true
-        }).addTo(this._objectLayer);
+        if (object.icon) {
+          L.marker(object.latLng, {
+            icon: object.icon,
+            opacity: 1,
+            interactive: true
+          }).addTo(this._objectLayer);
+        }
+      } else if (object.type === "changeset") {
+        if (object.bbox) {
+          L.rectangle([
+            [object.bbox.minlat, object.bbox.minlon],
+            [object.bbox.maxlat, object.bbox.maxlon]
+          ], changesetStyle).addTo(this._objectLayer);
+        }
       }
 
       if (callback) callback(this._objectLayer.getBounds());
-    } else { // element or changeset handled by L.OSM.DataLayer
+    } else { // element handled by L.OSM.DataLayer
       var map = this;
       this._objectLoader = $.ajax({
         url: OSM.apiUrl(object),

--- a/app/helpers/changesets_helper.rb
+++ b/app/helpers/changesets_helper.rb
@@ -41,4 +41,20 @@ module ChangesetsHelper
       t "changesets.index.title"
     end
   end
+
+  def changeset_data(changeset)
+    changeset_data = { :id => changeset.id }
+
+    if changeset.bbox_valid?
+      bbox = changeset.bbox.to_unscaled
+      changeset_data[:bbox] = {
+        :minlon => bbox.min_lon,
+        :minlat => bbox.min_lat,
+        :maxlon => bbox.max_lon,
+        :maxlat => bbox.max_lat
+      }
+    end
+
+    changeset_data
+  end
 end

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -1,16 +1,4 @@
-<% changeset_data = { :id => changeset.id }
-
-   if changeset.bbox_valid?
-     bbox = changeset.bbox.to_unscaled
-     changeset_data[:bbox] = {
-       :minlon => bbox.min_lon,
-       :minlat => bbox.min_lat,
-       :maxlon => bbox.max_lon,
-       :maxlat => bbox.max_lat
-     }
-   end %>
-
-<%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data }, :class => "list-group-item list-group-item-action" do %>
+<%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data(changeset) }, :class => "list-group-item list-group-item-action" do %>
   <p class="fs-6 text-truncate text-wrap">
     <a class="changeset_id link-body-emphasis stretched-link" href="<%= changeset_path(changeset) %>">
       <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -6,7 +6,9 @@
   <p class="fs-6 overflow-x-auto">
     <%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %>
   </p>
-  <p class="details"><%= changeset_details(@changeset) %></p>
+  <%= tag.p :class => "details", :data => { :changeset => changeset_data(@changeset) } do %>
+    <%= changeset_details(@changeset) %>
+  <% end %>
 
   <%= render :partial => "browse/tag_details", :object => @changeset.tags.except("comment") %>
 


### PR DESCRIPTION
Fixes #4081 on `/changeset/:id` pages.

Previously changeset bbox was loaded using `L.OSM.DataLayer`. That requied additional http request. Also `L.OSM.DataLayer` assumed that all changesets have bounding boxes which is not true.