### PR TITLE
Support unwrapped bbox values in changeset history queries

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -220,7 +220,7 @@ OSM.History = function (map) {
     const neClamped = crs.unproject(crs.project(ne));
 
     if (sw.lat >= swClamped.lat || ne.lat <= neClamped.lat || ne.lng - sw.lng < 360) {
-      data.set("bbox", map.getBounds().wrap().toBBoxString());
+      data.set("bbox", map.getBounds().toBBoxString());
     }
   }
 

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -53,8 +53,8 @@ module Api
       user = create(:user)
       changeset = create(:changeset, :user => user)
       closed_changeset = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 1, 1, 0, 0, 0), :closed_at => Time.utc(2008, 1, 2, 0, 0, 0))
-      changeset2 = create(:changeset, :min_lat => (5 * GeoRecord::SCALE).round, :min_lon => (5 * GeoRecord::SCALE).round, :max_lat => (15 * GeoRecord::SCALE).round, :max_lon => (15 * GeoRecord::SCALE).round)
-      changeset3 = create(:changeset, :min_lat => (4.5 * GeoRecord::SCALE).round, :min_lon => (4.5 * GeoRecord::SCALE).round, :max_lat => (5 * GeoRecord::SCALE).round, :max_lon => (5 * GeoRecord::SCALE).round)
+      changeset2 = create(:changeset, :bbox => [5, 5, 15, 15])
+      changeset3 = create(:changeset, :bbox => [4.5, 4.5, 5, 5])
 
       get api_changesets_path(:bbox => "-10,-10, 10, 10")
       assert_response :success, "can't get changesets in bbox"
@@ -627,9 +627,7 @@ module Api
     end
 
     def test_show_bbox_json
-      # test bbox attribute
-      changeset = create(:changeset, :min_lat => (-5 * GeoRecord::SCALE).round, :min_lon => (5 * GeoRecord::SCALE).round,
-                                     :max_lat => (15 * GeoRecord::SCALE).round, :max_lon => (12 * GeoRecord::SCALE).round)
+      changeset = create(:changeset, :bbox => [5, -5, 12, 15])
 
       get api_changeset_path(changeset, :format => "json")
       assert_response :success, "cannot get first changeset"
@@ -2092,9 +2090,7 @@ module Api
       create(:changeset, :user => user, :created_at => Time.now.utc - 7.days)
 
       # create a changeset that puts us near the initial size limit
-      changeset = create(:changeset, :user => user,
-                                     :min_lat => (-0.5 * GeoRecord::SCALE).round, :min_lon => (0.5 * GeoRecord::SCALE).round,
-                                     :max_lat => (0.5 * GeoRecord::SCALE).round, :max_lon => (2.5 * GeoRecord::SCALE).round)
+      changeset = create(:changeset, :user => user, :bbox => [0.5, -0.5, 2.5, 0.5])
 
       # create authentication header
       auth_header = bearer_authorization_header user

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -394,7 +394,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     create(:changeset_tag, :changeset => changeset, :k => "website", :v => "http://example.com/")
     closed_changeset = create(:changeset, :closed, :num_changes => 1, :min_lat => 5 * GeoRecord::SCALE, :min_lon => 5 * GeoRecord::SCALE, :max_lat => 5 * GeoRecord::SCALE, :max_lon => 5 * GeoRecord::SCALE)
     _elsewhere_changeset = create(:changeset, :num_changes => 1, :min_lat => -5 * GeoRecord::SCALE, :min_lon => -5 * GeoRecord::SCALE, :max_lat => -5 * GeoRecord::SCALE, :max_lon => -5 * GeoRecord::SCALE)
-    _empty_changeset = create(:changeset, :num_changes => 0, :min_lat => -5 * GeoRecord::SCALE, :min_lon => -5 * GeoRecord::SCALE, :max_lat => -5 * GeoRecord::SCALE, :max_lon => -5 * GeoRecord::SCALE)
+    _empty_changeset = create(:changeset, :num_changes => 0, :min_lat => 5 * GeoRecord::SCALE, :min_lon => 5 * GeoRecord::SCALE, :max_lat => 5 * GeoRecord::SCALE, :max_lon => 5 * GeoRecord::SCALE)
 
     get history_feed_path(:format => :atom, :bbox => "4.5,4.5,5.5,5.5")
     assert_response :success

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -91,8 +91,8 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
   ##
   # This should display the last 20 changesets closed in a specific area
   def test_index_bbox
-    changesets = create_list(:changeset, 10, :num_changes => 1, :min_lat => 50000000, :max_lat => 50000001, :min_lon => 50000000, :max_lon => 50000001)
-    other_changesets = create_list(:changeset, 10, :num_changes => 1, :min_lat => 0, :max_lat => 1, :min_lon => 0, :max_lon => 1)
+    changesets = create_list(:changeset, 10, :num_changes => 1, :bbox => [5, 5, 5, 5])
+    other_changesets = create_list(:changeset, 10, :num_changes => 1, :bbox => [0, 0, 1, 1])
 
     # First check they all show up without a bbox parameter
     get history_path(:format => "html", :list => "1"), :xhr => true
@@ -389,12 +389,12 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
   ##
   # This should display the last 20 changesets closed in a specific area
   def test_feed_bbox
-    changeset = create(:changeset, :num_changes => 1, :min_lat => 5 * GeoRecord::SCALE, :min_lon => 5 * GeoRecord::SCALE, :max_lat => 5 * GeoRecord::SCALE, :max_lon => 5 * GeoRecord::SCALE)
+    changeset = create(:changeset, :num_changes => 1, :bbox => [5, 5, 5, 5])
     create(:changeset_tag, :changeset => changeset)
     create(:changeset_tag, :changeset => changeset, :k => "website", :v => "http://example.com/")
-    closed_changeset = create(:changeset, :closed, :num_changes => 1, :min_lat => 5 * GeoRecord::SCALE, :min_lon => 5 * GeoRecord::SCALE, :max_lat => 5 * GeoRecord::SCALE, :max_lon => 5 * GeoRecord::SCALE)
-    _elsewhere_changeset = create(:changeset, :num_changes => 1, :min_lat => -5 * GeoRecord::SCALE, :min_lon => -5 * GeoRecord::SCALE, :max_lat => -5 * GeoRecord::SCALE, :max_lon => -5 * GeoRecord::SCALE)
-    _empty_changeset = create(:changeset, :num_changes => 0, :min_lat => 5 * GeoRecord::SCALE, :min_lon => 5 * GeoRecord::SCALE, :max_lat => 5 * GeoRecord::SCALE, :max_lon => 5 * GeoRecord::SCALE)
+    closed_changeset = create(:changeset, :closed, :num_changes => 1, :bbox => [5, 5, 5, 5])
+    _elsewhere_changeset = create(:changeset, :num_changes => 1, :bbox => [-5, -5, -5, -5])
+    _empty_changeset = create(:changeset, :num_changes => 0, :bbox => [5, 5, 5, 5])
 
     get history_feed_path(:format => :atom, :bbox => "4.5,4.5,5.5,5.5")
     assert_response :success

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -117,6 +117,127 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     check_index_result(changesets)
   end
 
+  def test_index_bbox_across_antimeridian_with_changesets_close_to_antimeridian
+    west_of_antimeridian_changeset = create(:changeset, :num_changes => 1, :bbox => [176, 0, 178, 1])
+    east_of_antimeridian_changeset = create(:changeset, :num_changes => 1, :bbox => [-178, 0, -176, 1])
+
+    get history_path(:format => "html", :list => "1")
+    assert_response :success
+    check_index_result([east_of_antimeridian_changeset, west_of_antimeridian_changeset])
+
+    # negative longitudes
+    get history_path(:format => "html", :list => "1", :bbox => "-190,-10,-170,10")
+    assert_response :success
+    check_index_result([east_of_antimeridian_changeset, west_of_antimeridian_changeset])
+
+    get history_path(:format => "html", :list => "1", :bbox => "-183,-10,-177,10")
+    assert_response :success
+    check_index_result([east_of_antimeridian_changeset, west_of_antimeridian_changeset])
+
+    get history_path(:format => "html", :list => "1", :bbox => "-181,-10,-177,10")
+    assert_response :success
+    check_index_result([east_of_antimeridian_changeset])
+
+    get history_path(:format => "html", :list => "1", :bbox => "-183,-10,-179,10")
+    assert_response :success
+    check_index_result([west_of_antimeridian_changeset])
+
+    get history_path(:format => "html", :list => "1", :bbox => "-181,-10,-179,10")
+    assert_response :success
+    check_index_result([])
+
+    # positive longitudes
+    get history_path(:format => "html", :list => "1", :bbox => "170,-10,190,10")
+    assert_response :success
+    check_index_result([east_of_antimeridian_changeset, west_of_antimeridian_changeset])
+
+    get history_path(:format => "html", :list => "1", :bbox => "177,-10,183,10")
+    assert_response :success
+    check_index_result([east_of_antimeridian_changeset, west_of_antimeridian_changeset])
+
+    get history_path(:format => "html", :list => "1", :bbox => "177,-10,181,10")
+    assert_response :success
+    check_index_result([west_of_antimeridian_changeset])
+
+    get history_path(:format => "html", :list => "1", :bbox => "179,-10,183,10")
+    assert_response :success
+    check_index_result([east_of_antimeridian_changeset])
+
+    get history_path(:format => "html", :list => "1", :bbox => "179,-10,181,10")
+    assert_response :success
+    check_index_result([])
+  end
+
+  def test_index_bbox_across_antimeridian_with_changesets_around_globe
+    changeset1 = create(:changeset, :num_changes => 1, :bbox => [-150, 40, -140, 50])
+    changeset2 = create(:changeset, :num_changes => 1, :bbox => [-30, -30, -20, -20])
+    changeset3 = create(:changeset, :num_changes => 1, :bbox => [10, 60, 20, 70])
+    changeset4 = create(:changeset, :num_changes => 1, :bbox => [150, -60, 160, -50])
+
+    # no bbox, get all changesets
+    get history_path(:format => "html", :list => "1")
+    assert_response :success
+    check_index_result([changeset4, changeset3, changeset2, changeset1])
+
+    # large enough bbox within normal range
+    get history_path(:format => "html", :list => "1", :bbox => "-170,-80,170,80")
+    assert_response :success
+    check_index_result([changeset4, changeset3, changeset2, changeset1])
+
+    # bbox for [1,2] within normal range
+    get history_path(:format => "html", :list => "1", :bbox => "-160,-80,0,80")
+    assert_response :success
+    check_index_result([changeset2, changeset1])
+
+    # bbox for [1,4] containing antimeridian with negative lon
+    get history_path(:format => "html", :list => "1", :bbox => "-220,-80,-100,80")
+    assert_response :success
+    check_index_result([changeset4, changeset1])
+
+    # bbox for [1,4] containing antimeridian with positive lon
+    get history_path(:format => "html", :list => "1", :bbox => "100,-80,220,80")
+    assert_response :success
+    check_index_result([changeset4, changeset1])
+
+    # large enough bbox outside normal range
+    get history_path(:format => "html", :list => "1", :bbox => "-220,-80,220,80")
+    assert_response :success
+    check_index_result([changeset4, changeset3, changeset2, changeset1])
+  end
+
+  ##
+  # Test that -180..180 longitudes don't result in empty bbox
+  def test_index_bbox_entire_world
+    changeset = create(:changeset, :num_changes => 1, :bbox => [30, 60, 31, 61])
+
+    get history_path(:format => "html", :list => "1", :bbox => "-180,-80,-180,80")
+    assert_response :success
+    check_index_result([])
+
+    get history_path(:format => "html", :list => "1", :bbox => "180,-80,180,80")
+    assert_response :success
+    check_index_result([])
+
+    get history_path(:format => "html", :list => "1", :bbox => "-180,-80,180,80")
+    assert_response :success
+    check_index_result([changeset])
+  end
+
+  ##
+  # Test that -270..270 longitudes don't result in 90..-90 bbox
+  def test_index_bbox_larger_than_entire_world
+    changeset1 = create(:changeset, :num_changes => 1, :bbox => [30, 60, 31, 61])
+    changeset2 = create(:changeset, :num_changes => 1, :bbox => [130, 60, 131, 61])
+
+    get history_path(:format => "html", :list => "1", :bbox => "-90,-80,90,80")
+    assert_response :success
+    check_index_result([changeset1])
+
+    get history_path(:format => "html", :list => "1", :bbox => "-270,-80,270,80")
+    assert_response :success
+    check_index_result([changeset2, changeset1])
+  end
+
   ##
   # Checks the display of the user changesets listing
   def test_index_user

--- a/test/factories/changesets.rb
+++ b/test/factories/changesets.rb
@@ -1,7 +1,15 @@
 FactoryBot.define do
   factory :changeset do
+    transient do
+      bbox { nil }
+    end
+
     created_at { Time.now.utc }
     closed_at { Time.now.utc + 1.day }
+    min_lon { (bbox[0] * GeoRecord::SCALE).round if bbox }
+    min_lat { (bbox[1] * GeoRecord::SCALE).round if bbox }
+    max_lon { (bbox[2] * GeoRecord::SCALE).round if bbox }
+    max_lat { (bbox[3] * GeoRecord::SCALE).round if bbox }
 
     user
 

--- a/test/system/browse_comment_links_test.rb
+++ b/test/system/browse_comment_links_test.rb
@@ -2,8 +2,7 @@ require "application_system_test_case"
 
 class BrowseCommentLinksTest < ApplicationSystemTestCase
   test "visiting changeset comment link should pan to changeset" do
-    changeset = create(:changeset, :min_lat => 60 * GeoRecord::SCALE, :min_lon => 30 * GeoRecord::SCALE,
-                                   :max_lat => 60 * GeoRecord::SCALE, :max_lon => 30 * GeoRecord::SCALE)
+    changeset = create(:changeset, :bbox => [30, 60, 30, 60])
     comment = create(:changeset_comment, :changeset => changeset, :body => "Linked changeset comment")
 
     visit changeset_path(changeset, :anchor => "c#{comment.id}")

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -110,9 +110,9 @@ class HistoryTest < ApplicationSystemTestCase
   end
 
   test "update sidebar when before param is included and map is moved" do
-    changeset1 = create(:changeset, :num_changes => 1, :min_lat => 50000000, :max_lat => 50000001, :min_lon => 50000000, :max_lon => 50000001)
+    changeset1 = create(:changeset, :num_changes => 1, :bbox => [5, 5, 5, 5])
     create(:changeset_tag, :changeset => changeset1, :k => "comment", :v => "changeset-at-fives")
-    changeset2 = create(:changeset, :num_changes => 1, :min_lat => 50100000, :max_lat => 50100001, :min_lon => 50100000, :max_lon => 50100001)
+    changeset2 = create(:changeset, :num_changes => 1, :bbox => [5.01, 5.01, 5.01, 5.01])
     create(:changeset_tag, :changeset => changeset2, :k => "comment", :v => "changeset-close-to-fives")
     changeset3 = create(:changeset)
 
@@ -136,9 +136,7 @@ class HistoryTest < ApplicationSystemTestCase
   test "all changesets are listed when fully zoomed out" do
     user = create(:user)
     [-177, -90, 0, 90, 177].each do |lon|
-      create(:changeset, :user => user, :num_changes => 1,
-                         :min_lat => 0 * GeoRecord::SCALE, :min_lon => (lon - 1) * GeoRecord::SCALE,
-                         :max_lat => 1 * GeoRecord::SCALE, :max_lon => (lon + 1) * GeoRecord::SCALE) do |changeset|
+      create(:changeset, :user => user, :num_changes => 1, :bbox => [lon - 1, 0, lon + 1, 1]) do |changeset|
         create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "changeset-at-lon(#{lon})")
       end
     end

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -152,6 +152,30 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
+  test "changesets at both sides of antimeridian are listed" do
+    user = create(:user)
+    PAGE_SIZE.times do
+      create(:changeset, :user => user, :num_changes => 1, :bbox => [176, 0, 178, 1]) do |changeset|
+        create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "West-of-antimeridian-changeset")
+      end
+      create(:changeset, :user => user, :num_changes => 1, :bbox => [-178, 0, -176, 1]) do |changeset|
+        create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "East-of-antimeridian-changeset")
+      end
+    end
+
+    visit history_path(:anchor => "map=6/0/179")
+
+    within_sidebar do
+      assert_link "West-of-antimeridian-changeset", :count => PAGE_SIZE / 2
+      assert_link "East-of-antimeridian-changeset", :count => PAGE_SIZE / 2
+
+      click_on "Older Changesets"
+
+      assert_link "West-of-antimeridian-changeset", :count => PAGE_SIZE
+      assert_link "East-of-antimeridian-changeset", :count => PAGE_SIZE
+    end
+  end
+
   private
 
   def create_visible_changeset(user, comment)


### PR DESCRIPTION
Fixes #3423.

> Issue: Only changesets from that very narrow gap are shown.

How narrow this area is depends on zoom and map view width. It's an area between wrapped left and (independently) wrapped right longitude bounds because:

> The bug is caused by Leaflet's method .wrap()

It's not Leaflet's method. Maybe it existed previously in Leaflet and was removed, but we added it again in https://github.com/openstreetmap/openstreetmap-website/commit/f612f573f92c524bbcf4b913e71c9f288383a845. Implementing wrap on `L.LatLngBounds` by wrapping its corners independently is not going to give correct results in a general case.

> Bit more sophisticated fix is to add client-side bbox validation where too large bboxes would be clipped from -180/180 meridian.

It's not difficult to write the logic without clipping. Unfortunately `BoundingBox.from_bbox_params` insists on clipping, that's why I'm not using `BoundingBox`.

> is this a bug or an intentional feature to reduce server load?

I don't think that the current behavior reduces server load. The more changesets you filter out, the longer you have to scan the table. If the current implementation filters out changesets that shouldn't have been filtered out, it slows down the server.

---

This PR fixes only how changesets are selected by the `/history` page based on the current view area, which gets translated into the `bbox` parameter. It doesn't change how bboxes are displayed, which needs further fixing. When you zoom out, you can see the same place on the map several times. If there's a changeset, it also needs to be rendered several times. That usually doesn't matter much because you can see one of its renderings. But that doesn't work if you zoom in close to the date line. Only one side is going to be visible on the map. On the other hand the list in the sidebar should be correct.

![image](https://github.com/user-attachments/assets/2f99ee16-3922-4d93-80d3-b8506f4faa8d)
![image](https://github.com/user-attachments/assets/c858ef6c-47cc-43cc-a2de-5405112a9564)
