### PR TITLE
Use baselayerchange/overlayadd/overlayremove instead of layeradd/layerremove

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -173,7 +173,7 @@ $(document).ready(function () {
   var expiry = new Date();
   expiry.setYear(expiry.getFullYear() + 10);
 
-  map.on("moveend layeradd layerremove", function () {
+  map.on("moveend baselayerchange overlayadd overlayremove", function () {
     updateLinks(
       map.getCenter().wrap(),
       map.getZoom(),
@@ -205,7 +205,7 @@ $(document).ready(function () {
   });
 
   if (OSM.MATOMO) {
-    map.on("layeradd", function (e) {
+    map.on("baselayerchange overlayadd", function (e) {
       if (e.layer.options) {
         var goal = OSM.MATOMO.goals[e.layer.options.layerId];
 

--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -25,18 +25,16 @@ OSM.initializeDataLayer = function (map) {
     onSelect(e.layer);
   });
 
-  map.on("layeradd", function (e) {
-    if (e.layer === dataLayer) {
-      map.on("moveend", updateData);
-      updateData();
-    }
+  dataLayer.on("add", function () {
+    map.fire("overlayadd", { layer: this });
+    map.on("moveend", updateData);
+    updateData();
   });
 
-  map.on("layerremove", function (e) {
-    if (e.layer === dataLayer) {
-      map.off("moveend", updateData);
-      $("#browse_status").empty();
-    }
+  dataLayer.on("remove", function () {
+    map.off("moveend", updateData);
+    $("#browse_status").empty();
+    map.fire("overlayremove", { layer: this });
   });
 
   function updateData() {

--- a/app/assets/javascripts/index/layers/notes.js
+++ b/app/assets/javascripts/index/layers/notes.js
@@ -23,10 +23,12 @@ OSM.initializeNotesLayer = function (map) {
   noteLayer.on("add", () => {
     loadNotes();
     map.on("moveend", loadNotes);
+    map.fire("overlayadd", { layer: noteLayer });
   }).on("remove", () => {
     map.off("moveend", loadNotes);
     noteLayer.clearLayers();
     notes = {};
+    map.fire("overlayremove", { layer: noteLayer });
   }).on("click", function (e) {
     if (e.layer.id) {
       OSM.router.route("/note/" + e.layer.id);

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -61,18 +61,16 @@ L.OSM.layers = function (options) {
 
       input.on("click", function () {
         layers.forEach(function (other) {
-          if (other === layer) {
-            map.addLayer(other);
-          } else {
+          if (other !== layer) {
             map.removeLayer(other);
           }
         });
-        map.fire("baselayerchange", { layer: layer });
+        map.addLayer(layer);
       });
 
       item.on("dblclick", toggle);
 
-      map.on("layeradd layerremove", function () {
+      map.on("baselayerchange", function () {
         input.prop("checked", map.hasLayer(layer));
       });
     });
@@ -121,10 +119,9 @@ L.OSM.layers = function (options) {
           } else {
             map.removeLayer(layer);
           }
-          map.fire("overlaylayerchange", { layer: layer });
         });
 
-        map.on("layeradd layerremove", function () {
+        map.on("overlayadd overlayremove", function () {
           input.prop("checked", map.hasLayer(layer));
         });
 

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -269,7 +269,7 @@ L.OSM.share = function (options) {
 
     marker.on("dragend", movedMarker);
     map.on("move", movedMap);
-    map.on("moveend layeradd layerremove", update);
+    map.on("moveend baselayerchange overlayadd overlayremove", update);
 
     $ui
       .on("show", shown)

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -190,7 +190,7 @@ OSM.Router = function (map, rts) {
     currentRoute = routes.recognize(currentPath);
   };
 
-  map.on("moveend baselayerchange overlaylayerchange", router.updateHash);
+  map.on("moveend baselayerchange overlayadd overlayremove", router.updateHash);
   $(window).on("hashchange", router.hashUpdated);
 
   return router;


### PR DESCRIPTION
### Description
This is fix #5466 After merging https://github.com/openstreetmap/leaflet-osm/pull/43 flame graph looks like this:

<img width="1208" src="https://github.com/user-attachments/assets/435540a1-ebe4-40e6-8051-2d881e3ed28e" />

https://share.firefox.dev/4a2Wc9Z

Most of the time is spent on two handlers that update information about the current location and elements in the right sidebar. 

Unfortunately, replacing `layeradd layerremove` with `baselayerchange overlaylayerchange` (https://github.com/openstreetmap/openstreetmap-website/issues/5466#issuecomment-2571570472) is difficult, since in addition to the Map Data layer, other elements may be displayed on the map. For example, the currently selected object on the map. It is not clear how to separate changes to Map Data objects and changes to the selected element. It is necessary to track changes in the active element, otherwise at least the Edit button will break.

~~Therefore, I implemented a little ugly, but safer in terms of breaking business logic. When adding the Map Data layer, I set the pause flag in the slowdown handlers. While the Map Data is rendering, the user cannot interact with the interface, so it seems safe to pause the event handlers.~~

Total 15s vs 0.5s when rendering 5000 elements.

<img width="1207" src="https://github.com/user-attachments/assets/13a099d0-0918-4c32-840d-24faf5a1cb8c" />

https://share.firefox.dev/4h4IK7C

