### PR TITLE
Make browse not found pages consistent

### DIFF
--- a/app/controllers/old_nodes_controller.rb
+++ b/app/controllers/old_nodes_controller.rb
@@ -10,6 +10,6 @@ class OldNodesController < OldElementsController
     @type = "node"
     @feature = OldNode.preload(:old_tags, :changeset => [:changeset_tags, :user]).find([params[:id], params[:version]])
   rescue ActiveRecord::RecordNotFound
-    render :action => "not_found", :status => :not_found
+    render "browse/not_found", :status => :not_found
   end
 end

--- a/app/controllers/old_relations_controller.rb
+++ b/app/controllers/old_relations_controller.rb
@@ -10,6 +10,6 @@ class OldRelationsController < OldElementsController
     @type = "relation"
     @feature = OldRelation.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_members => :member).find([params[:id], params[:version]])
   rescue ActiveRecord::RecordNotFound
-    render :action => "not_found", :status => :not_found
+    render "browse/not_found", :status => :not_found
   end
 end

--- a/app/controllers/old_ways_controller.rb
+++ b/app/controllers/old_ways_controller.rb
@@ -10,6 +10,6 @@ class OldWaysController < OldElementsController
     @type = "way"
     @feature = OldWay.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:node_tags, :ways] }).find([params[:id], params[:version]])
   rescue ActiveRecord::RecordNotFound
-    render :action => "not_found", :status => :not_found
+    render "browse/not_found", :status => :not_found
   end
 end

--- a/app/views/browse/not_found.html.erb
+++ b/app/views/browse/not_found.html.erb
@@ -2,6 +2,4 @@
 
 <%= render "sidebar_header", :title => t(".title") %>
 
-<div>
-  <p><%= t ".sorry", :type => t(".type.#{@type}"), :id => params[:id] %>
-</div>
+<%= render "not_found_message" %>

--- a/app/views/changesets/_not_found_message.html.erb
+++ b/app/views/changesets/_not_found_message.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <p><%= t ".sorry", :id => params[:id] %></p>
+</div>

--- a/app/views/nodes/_not_found_message.html.erb
+++ b/app/views/nodes/_not_found_message.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <p><%= t ".sorry", :id => params[:id] %></p>
+</div>

--- a/app/views/notes/_not_found_message.html.erb
+++ b/app/views/notes/_not_found_message.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <p><%= t ".sorry", :id => params[:id] %></p>
+</div>

--- a/app/views/old_nodes/_not_found_message.html.erb
+++ b/app/views/old_nodes/_not_found_message.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <% if params[:version] %>
+    <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
+  <% else %>
+    <p><%= t "nodes.not_found_message.sorry", :id => params[:id] %></p>
+  <% end %>
+</div>

--- a/app/views/old_nodes/not_found.html.erb
+++ b/app/views/old_nodes/not_found.html.erb
@@ -1,7 +1,0 @@
-<% set_title(t("browse.not_found.title")) %>
-
-<%= render "sidebar_header", :title => t("browse.not_found.title") %>
-
-<div>
-  <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
-</div>

--- a/app/views/old_relations/_not_found_message.html.erb
+++ b/app/views/old_relations/_not_found_message.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <% if params[:version] %>
+    <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
+  <% else %>
+    <p><%= t "relations.not_found_message.sorry", :id => params[:id] %></p>
+  <% end %>
+</div>

--- a/app/views/old_relations/not_found.html.erb
+++ b/app/views/old_relations/not_found.html.erb
@@ -1,7 +1,0 @@
-<% set_title(t("browse.not_found.title")) %>
-
-<%= render "sidebar_header", :title => t("browse.not_found.title") %>
-
-<div>
-  <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
-</div>

--- a/app/views/old_ways/_not_found_message.html.erb
+++ b/app/views/old_ways/_not_found_message.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <% if params[:version] %>
+    <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
+  <% else %>
+    <p><%= t "ways.not_found_message.sorry", :id => params[:id] %></p>
+  <% end %>
+</div>

--- a/app/views/old_ways/not_found.html.erb
+++ b/app/views/old_ways/not_found.html.erb
@@ -1,7 +1,0 @@
-<% set_title(t("browse.not_found.title")) %>
-
-<%= render "sidebar_header", :title => t("browse.not_found.title") %>
-
-<div>
-  <p><%= t ".sorry", :id => params[:id], :version => params[:version] %></p>
-</div>

--- a/app/views/relations/_not_found_message.html.erb
+++ b/app/views/relations/_not_found_message.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <p><%= t ".sorry", :id => params[:id] %></p>
+</div>

--- a/app/views/ways/_not_found_message.html.erb
+++ b/app/views/ways/_not_found_message.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <p><%= t ".sorry", :id => params[:id] %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -354,13 +354,6 @@ en:
       entry_role_html: "%{relation_name} (as %{relation_role})"
     not_found:
       title: Not Found
-      sorry: "Sorry, %{type} #%{id} could not be found."
-      type:
-        node: node
-        way: way
-        relation: relation
-        changeset: changeset
-        note: note
     timeout:
       title: Timeout Error
       sorry: "Sorry, the data for the %{type} with the id %{id} took too long to retrieve."
@@ -409,26 +402,32 @@ en:
       view_redacted_data: "View Redacted Data"
       view_redaction_message: "View Redaction Message"
   nodes:
+    not_found_message:
+      sorry: "Sorry, node #%{id} could not be found."
     timeout:
       sorry: "Sorry, the data for the node with the id %{id} took too long to retrieve."
   old_nodes:
-    not_found:
+    not_found_message:
       sorry: "Sorry, node #%{id} version %{version} could not be found."
     timeout:
       sorry: "Sorry, the history of the node with the id %{id} took too long to retrieve."
   ways:
+    not_found_message:
+      sorry: "Sorry, way #%{id} could not be found."
     timeout:
       sorry: "Sorry, the data for the way with the id %{id} took too long to retrieve."
   old_ways:
-    not_found:
+    not_found_message:
       sorry: "Sorry, way #%{id} version %{version} could not be found."
     timeout:
       sorry: "Sorry, the history of the way with the id %{id} took too long to retrieve."
   relations:
+    not_found_message:
+      sorry: "Sorry, relation #%{id} could not be found."
     timeout:
       sorry: "Sorry, the data for the relation with the id %{id} took too long to retrieve."
   old_relations:
-    not_found:
+    not_found_message:
       sorry: "Sorry, relation #%{id} version %{version} could not be found."
     timeout:
       sorry: "Sorry, the history of the relation with the id %{id} took too long to retrieve."
@@ -504,6 +503,8 @@ en:
       ways_paginated: "Ways (%{x}-%{y} of %{count})"
       relations: "Relations (%{count})"
       relations_paginated: "Relations (%{x}-%{y} of %{count})"
+    not_found_message:
+      sorry: "Sorry, changeset #%{id} could not be found."
     timeout:
       sorry: "Sorry, the list of changesets you requested took too long to retrieve."
   dashboards:
@@ -3096,6 +3097,8 @@ en:
       showing_page: "Page %{page}"
       next: "Next"
       previous: "Previous"
+    not_found_message:
+      sorry: "Sorry, note #%{id} could not be found."
   javascripts:
     close: Close
     share:

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -213,7 +213,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
   def test_not_found
     get old_node_path(0, 0)
     assert_response :not_found
-    assert_template "old_nodes/not_found"
+    assert_template "browse/not_found"
     assert_template :layout => "map"
     assert_select "#sidebar_content", /node #0 version 0 could not be found/
   end

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -172,7 +172,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
   def test_not_found
     get old_relation_path(0, 0)
     assert_response :not_found
-    assert_template "old_relations/not_found"
+    assert_template "browse/not_found"
     assert_template :layout => "map"
     assert_select "#sidebar_content", /relation #0 version 0 could not be found/
   end

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -177,7 +177,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
   def test_not_found
     get old_way_path(0, 0)
     assert_response :not_found
-    assert_template "old_ways/not_found"
+    assert_template "browse/not_found"
     assert_template :layout => "map"
     assert_select "#sidebar_content", /way #0 version 0 could not be found/
   end


### PR DESCRIPTION
*Not found* pages for various types became slightly different. This PR makes them similar to each other.

The types are (Old)(Node/Way/Relation), Note and Changeset.

- The main template is kept at `browse/not_found`. 
- The type-specific part is the message displayed on that page, it's kept in `not_found_message` templates.
- The string with word substitution "Sorry, %{type} #%{id} could not be found." is replaced by type-specific strings like "Sorry, changeset #%{id} could not be found." where only id (and version numbers in some cases) are substituted. Those should be easier to translate.