### PR TITLE
Check deactivates_at to report if block was read after its end date

### DIFF
--- a/app/helpers/user_blocks_helper.rb
+++ b/app/helpers/user_blocks_helper.rb
@@ -34,7 +34,7 @@ module UserBlocksHelper
       end
     else
       if block.revoker_id.nil?
-        if block.updated_at > block.ends_at
+        if block.deactivates_at > block.ends_at
           t("user_blocks.helper.short.read_html", :time => block_short_time_in_past(block.updated_at))
         else
           t("user_blocks.helper.short.ended")

--- a/test/helpers/user_blocks_helper_test.rb
+++ b/test/helpers/user_blocks_helper_test.rb
@@ -30,6 +30,38 @@ class UserBlocksHelperTest < ActionView::TestCase
     end
   end
 
+  def test_block_short_status_with_immediate_update
+    freeze_time do
+      block = UserBlock.new :user => create(:user),
+                            :creator => create(:moderator_user),
+                            :reason => "because",
+                            :created_at => Time.now.utc,
+                            :ends_at => Time.now.utc,
+                            :deactivates_at => Time.now.utc,
+                            :needs_view => false
+
+      travel 1.second
+
+      block.save
+
+      assert_equal "ended", block_short_status(block)
+    end
+  end
+
+  def test_block_short_status_read
+    freeze_time do
+      block = create(:user_block, :needs_view, :ends_at => Time.now.utc)
+
+      travel 24.hours
+
+      assert_equal "active until read", block_short_status(block)
+
+      block.update(:needs_view => false, :deactivates_at => Time.now.utc)
+
+      assert_match "read at", block_short_status(block)
+    end
+  end
+
   def test_block_duration_in_words
     words = block_duration_in_words(364.days)
     assert_equal "11 months", words


### PR DESCRIPTION
Blocks table update in #4200 was done before `deactivates_at` was introduced. Because of that there's still code that checks `updated_at` instead of `deactivates_at`.

This PR fixes a bug which should be difficult to notice because it happens only with zero-duration blocks that don't need to be viewed. Usually it doesn't make sense to create such blocks. These blocks are incorrectly reported as "read" in the table even if they weren't read because `updated_at` is slightly greater than `ends_at`.