### PR TITLE
Update arguments of data overlay interestingNode()

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -312,13 +312,11 @@ L.OSM.Map = L.Map.extend({
             }
           });
 
-          map._objectLayer.interestingNode = function (node, ways, relations) {
+          map._objectLayer.interestingNode = function (node, wayNodes, relationNodes) {
             if (object.type === "node") {
               return true;
             } else if (object.type === "relation") {
-              for (var i = 0; i < relations.length; i++) {
-                if (relations[i].members.indexOf(node) !== -1) return true;
-              }
+              return Boolean(relationNodes[node.id]);
             } else {
               return false;
             }

--- a/test/system/browse_test.rb
+++ b/test/system/browse_test.rb
@@ -1,0 +1,13 @@
+require "application_system_test_case"
+
+class BrowseTest < ApplicationSystemTestCase
+  test "relation member nodes should be visible on the map when viewing relations" do
+    relation = create(:relation)
+    node = create(:node)
+    create(:relation_member, :relation => relation, :member => node)
+
+    visit relation_path(relation)
+
+    assert_selector "#map .leaflet-overlay-pane path"
+  end
+end


### PR DESCRIPTION
Makes relation node members (for example, bus stops in routes) *interesting* again.

Fixes https://github.com/openstreetmap/leaflet-osm/pull/43#issuecomment-2574558124.