### PR TITLE
Report deactivates_at as block read date

### DIFF
--- a/app/helpers/user_blocks_helper.rb
+++ b/app/helpers/user_blocks_helper.rb
@@ -35,7 +35,7 @@ module UserBlocksHelper
     else
       if block.revoker_id.nil?
         if block.deactivates_at > block.ends_at
-          t("user_blocks.helper.short.read_html", :time => block_short_time_in_past(block.updated_at))
+          t("user_blocks.helper.short.read_html", :time => block_short_time_in_past(block.deactivates_at))
         else
           t("user_blocks.helper.short.ended")
         end

--- a/test/helpers/user_blocks_helper_test.rb
+++ b/test/helpers/user_blocks_helper_test.rb
@@ -58,7 +58,16 @@ class UserBlocksHelperTest < ActionView::TestCase
 
       block.update(:needs_view => false, :deactivates_at => Time.now.utc)
 
-      assert_match "read at", block_short_status(block)
+      read_date = Time.now.utc.to_date.strftime
+      short_status_dom = Rails::Dom::Testing.html_document.parse(block_short_status(block))
+      assert_dom short_status_dom, ":root", :text => "read at #{read_date}"
+
+      travel 24.hours
+
+      block.update(:reason => "updated reason")
+
+      short_status_dom = Rails::Dom::Testing.html_document.parse(block_short_status(block))
+      assert_dom short_status_dom, ":root", :text => "read at #{read_date}"
     end
   end
 


### PR DESCRIPTION
I changed `updated_at` to `deactivates_at` in #5476 and forgot to make the same change on the next line. This can cause block update dates to be reported as block read dates. Those dates are different for blocks that were edited by moderators after they were read. The reason text can still be updated for such blocks.