### PR TITLE
Restrict version of dry-schema for ruby 3.1.2 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "bootstrap_form", "~> 5.0"
 gem "cancancan"
 gem "config"
 gem "delayed_job_active_record"
+gem "dry-schema", "< 1.14.0" # see https://github.com/openstreetmap/openstreetmap-website/issues/5482
 gem "dry-validation"
 gem "frozen_record"
 gem "http_accept_language", "~> 2.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,13 +230,13 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-schema (1.14.0)
+    dry-schema (1.13.4)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 1.0, >= 1.0.1)
-      dry-core (~> 1.1)
-      dry-initializer (~> 3.2)
-      dry-logic (~> 1.5)
-      dry-types (~> 1.8)
+      dry-core (~> 1.0, < 2)
+      dry-initializer (~> 3.0)
+      dry-logic (>= 1.4, < 2)
+      dry-types (>= 1.7, < 2)
       zeitwerk (~> 2.6)
     dry-types (1.8.0)
       bigdecimal (~> 3.0)
@@ -245,11 +245,11 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
-    dry-validation (1.11.0)
+    dry-validation (1.10.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 1.1)
-      dry-initializer (~> 3.2)
-      dry-schema (~> 1.14)
+      dry-core (~> 1.0, < 2)
+      dry-initializer (~> 3.0)
+      dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
     erb_lint (0.8.0)
       activesupport
@@ -696,6 +696,7 @@ DEPENDENCIES
   doorkeeper
   doorkeeper-i18n
   doorkeeper-openid_connect
+  dry-schema (< 1.14.0)
   dry-validation
   erb_lint
   factory_bot_rails


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18673 affects some methods using anonymous blocks, and was fixed in ruby 3.1.3. However, debian/bookworm ruby 3.1 package is based on 3.1.2 and does not yet contain this fix.

Since bookworm is used in our Docker build, and also used in production by OSMF, then we can restrict dry-schema to a version that does not use anonymous blocks.

Fixes #5482
