### PR TITLE
Moves the note's description, author ID, and author IP from the first comment to the note itself

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,20 +2,27 @@
 #
 # Table name: notes
 #
-#  id         :bigint(8)        not null, primary key
-#  latitude   :integer          not null
-#  longitude  :integer          not null
-#  tile       :bigint(8)        not null
-#  updated_at :datetime         not null
-#  created_at :datetime         not null
-#  status     :enum             not null
-#  closed_at  :datetime
+#  id          :bigint(8)        not null, primary key
+#  latitude    :integer          not null
+#  longitude   :integer          not null
+#  tile        :bigint(8)        not null
+#  updated_at  :datetime         not null
+#  created_at  :datetime         not null
+#  status      :enum             not null
+#  closed_at   :datetime
+#  description :text             default(""), not null
+#  user_id     :bigint(8)
+#  user_ip     :inet
 #
 # Indexes
 #
 #  notes_created_at_idx   (created_at)
 #  notes_tile_status_idx  (tile,status)
 #  notes_updated_at_idx   (updated_at)
+#
+# Foreign Keys
+#
+#  notes_user_id_fkey  (user_id => users.id)
 #
 
 class Note < ApplicationRecord

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -28,6 +28,8 @@
 class Note < ApplicationRecord
   include GeoRecord
 
+  belongs_to :author, :class_name => "User", :foreign_key => "user_id", :optional => true
+
   has_many :comments, -> { left_joins(:author).where(:visible => true, :users => { :status => [nil, "active", "confirmed"] }).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id
   has_many :all_comments, -> { left_joins(:author).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id, :inverse_of => :note
   has_many :subscriptions, :class_name => "NoteSubscription"
@@ -89,14 +91,14 @@ class Note < ApplicationRecord
     closed_at + DEFAULT_FRESHLY_CLOSED_LIMIT
   end
 
-  # Return the author object, derived from the first comment
-  def author
-    comments.first.author
-  end
-
   # Return the author IP address, derived from the first comment
   def author_ip
-    comments.first.author_ip
+    user_ip
+  end
+
+  # Return the note's description
+  def description
+    RichText.new("text", self[:description])
   end
 
   private

--- a/app/views/api/notes/_comment.html.erb
+++ b/app/views/api/notes/_comment.html.erb
@@ -1,8 +1,12 @@
 <div class="note-comment" style="margin-top: 5px">
   <% if comment.author.nil? -%>
-  <div class="note-comment-description" style="font-size: smaller; color: #999999"><%= t ".#{comment.event}_at_html", :when => friendly_date_ago(comment.created_at) %></div>
+    <div class="note-comment-description" style="font-size: smaller; color: #999999"><%= t ".#{comment.event}_at_html", :when => friendly_date_ago(comment.created_at) %></div>
   <% else -%>
-  <div class="note-comment-description" style="font-size: smaller; color: #999999"><%= t ".#{comment.event}_at_by_html", :when => friendly_date_ago(comment.created_at), :user => note_author(comment.author, :only_path => false) %></div>
+    <div class="note-comment-description" style="font-size: smaller; color: #999999"><%= t ".#{comment.event}_at_by_html", :when => friendly_date_ago(comment.created_at), :user => note_author(comment.author, :only_path => false) %></div>
   <% end -%>
-  <div class="note-comment-text"><%= comment.body %></div>
+  <% if comment.event == "opened" -%>
+    <div class="note-comment-text"><%= comment.note.description %></div>
+  <% else -%>
+    <div class="note-comment-text"><%= comment.body %></div>
+  <% end -%>
 </div>

--- a/app/views/api/notes/_note.json.jbuilder
+++ b/app/views/api/notes/_note.json.jbuilder
@@ -32,8 +32,13 @@ json.properties do
     json.action comment.event
 
     if comment.body
-      json.text comment.body.to_text
-      json.html comment.body.to_html
+      if comment.event == "opened"
+        json.text note.description.to_text
+        json.html note.description.to_html
+      else
+        json.text comment.body.to_text
+        json.html comment.body.to_html
+      end
     end
   end
 end

--- a/app/views/api/notes/_note.xml.builder
+++ b/app/views/api/notes/_note.xml.builder
@@ -28,8 +28,13 @@ xml.note("lon" => note.lon, "lat" => note.lat) do
         xml.action comment.event
 
         if comment.body
-          xml.text comment.body.to_text
-          xml.html comment.body.to_html
+          if comment.event == "opened"
+            xml.text note.description.to_text
+            xml.html note.description.to_html
+          else
+            xml.text comment.body.to_text
+            xml.html comment.body.to_html
+          end
         end
       end
     end

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -5,7 +5,7 @@
 <div>
   <h4><%= t(".description") %></h4>
   <div class="overflow-hidden ms-2">
-    <%= h(@note_comments.first.body.to_html) %>
+    <%= h(@note.description.to_html) %>
   </div>
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">

--- a/db/migrate/20250104140952_add_description_to_notes.rb
+++ b/db/migrate/20250104140952_add_description_to_notes.rb
@@ -1,0 +1,9 @@
+class AddDescriptionToNotes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :notes, :description, :text, :null => false, :default => ""
+    add_column :notes, :user_id, :bigint
+    add_column :notes, :user_ip, :inet
+
+    add_foreign_key :notes, :users, :column => :user_id, :name => "notes_user_id_fkey", :validate => false
+  end
+end

--- a/db/migrate/20250105154621_validate_foreign_key_on_notes.rb
+++ b/db/migrate/20250105154621_validate_foreign_key_on_notes.rb
@@ -1,0 +1,5 @@
+class ValidateForeignKeyOnNotes < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :notes, :users
+  end
+end

--- a/db/migrate/20250106160355_backfill_note_descriptions.rb
+++ b/db/migrate/20250106160355_backfill_note_descriptions.rb
@@ -5,27 +5,165 @@ class BackfillNoteDescriptions < ActiveRecord::Migration[7.2]
   disable_ddl_transaction!
 
   def up
-    Note.in_batches(:of => 1000) do |notes|
-      note_ids = notes.pluck(:id)
-      comments = NoteComment.where(:note_id => note_ids, :event => "opened").group_by(&:note_id)
+    @processed_count = 0
+    @failed_notes = []
+    @start_time = Time.current
 
-      values = notes.map do |note|
-        first_comment = comments[note.id].first
-        user_ip_value = first_comment.author_ip.nil? ? "NULL::inet" : "'#{first_comment.author_ip}'::inet"
-        user_id_value = first_comment.author_id.nil? ? "NULL::bigint" : "'#{first_comment.author_id}'::bigint"
-        "(#{note.id}, '#{first_comment.body}', #{user_ip_value}, #{user_id_value})"
-      end.join(", ")
+    # Log the start of the migration with timing details
+    say_with_time "Starting note description backfill..." do
+      Note.in_batches(:of => 1000) do |batch|
+        process_batch(batch)
+        log_progress
+      end
 
-      sql_query = <<-SQL.squish
-        UPDATE notes
-        SET description = data.description,
-            user_ip = COALESCE(data.user_ip::inet, notes.user_ip),
-            user_id = COALESCE(data.user_id::bigint, notes.user_id)
-        FROM (VALUES #{values}) AS data(id, description, user_ip, user_id)
-        WHERE notes.id = data.id;
-      SQL
-
-      ActiveRecord::Base.connection.execute(sql_query)
+      log_final_summary
+      handle_failed_notes if @failed_notes.any?
     end
+  end
+
+  private
+
+  def process_batch(notes)
+    note_ids = notes.pluck(:id)
+    comments = fetch_comments(note_ids)
+
+    begin
+      process_notes_batch(notes, comments)
+    rescue StandardError => e
+      # Capture and log any errors that occur while processing a batch
+      handle_batch_error(note_ids, e)
+    end
+  end
+
+  def fetch_comments(note_ids)
+    # Fetch all relevant comments grouped by note_id for efficient access
+    NoteComment
+      .where(:note_id => note_ids, :event => "opened")
+      .select(:note_id, :body, :author_ip, :author_id)
+      .order(:created_at)
+      .group_by(&:note_id)
+  end
+
+  def process_notes_batch(notes, comments)
+    values = notes.filter_map do |note|
+      next unless comments[note.id]&.first
+
+      first_comment = comments[note.id].first
+      generate_value_entry(note, first_comment)
+    rescue StandardError => e
+      # Add the note to the failed list if an error occurs
+      @failed_notes << { :note_id => note.id, :error => e.message }
+      nil
+    end
+
+    return if values.empty?
+
+    execute_batch_update(values)
+    @processed_count += values.size
+  end
+
+  def generate_value_entry(note, comment)
+    # Convert all values to strings and properly handle NULL values
+    description = ActiveRecord::Base.connection.quote(comment.body.to_s)
+    user_ip = ActiveRecord::Base.connection.quote(comment.author_ip.to_s)
+    user_id = comment.author_id.nil? ? "NULL" : comment.author_id
+
+    "(#{note.id}, #{description}, #{user_ip}, #{user_id})"
+  rescue StandardError => e
+    # Raise a specific error for easier debugging during the migration
+    raise StandardError, "Failed to generate value entry for note #{note.id}: #{e.message}"
+  end
+
+  def execute_batch_update(values)
+    sql = <<-SQL.squish
+      UPDATE notes
+      SET description = CASE WHEN data.description = '' THEN notes.description ELSE data.description END,
+          user_ip = CASE WHEN data.user_ip = '' THEN notes.user_ip ELSE data.user_ip::inet END,
+          user_id = CASE WHEN data.user_id IS NULL THEN notes.user_id ELSE data.user_id::bigint END
+      FROM (VALUES #{values.join(', ')}) AS data(id, description, user_ip, user_id)
+      WHERE notes.id = data.id;
+    SQL
+
+    # Execute the batch SQL update
+    ActiveRecord::Base.connection.execute(sql)
+  rescue StandardError => e
+    raise StandardError, "Failed to execute batch update: #{e.message}"
+  end
+
+  def handle_batch_error(note_ids, error)
+    say "Error processing batch with IDs #{note_ids.first}-#{note_ids.last}: #{error.message}"
+    @failed_notes.concat(note_ids.map { |id| { :note_id => id, :error => error.message } })
+  end
+
+  def log_progress
+    return unless (@processed_count % 5000).zero?
+
+    # Log periodic progress updates to monitor the migration
+    elapsed = Time.current - @start_time
+    rate = @processed_count / elapsed
+
+    say "Processed #{@processed_count} notes in #{elapsed.round(2)}s (#{rate.round(2)} notes/s)"
+    say "Failed notes so far: #{@failed_notes.size}"
+  end
+
+  def log_final_summary
+    # Log the final summary of the migration, including totals and timing
+    elapsed = Time.current - @start_time
+    say "Migration completed in #{elapsed.round(2)}s"
+    say "Total processed: #{@processed_count}"
+    say "Total failed: #{@failed_notes.size}"
+  end
+
+  def handle_failed_notes
+    return if @failed_notes.empty?
+
+    timestamp = Time.current.strftime("%Y%m%d_%H%M%S")
+    filename = Rails.root.join("log", "failed_note_migrations_#{timestamp}.log")
+
+    # Write failed notes and their errors to a log file for debugging
+    File.open(filename, "w") do |file|
+      file.puts "Failed notes from migration run at #{timestamp}"
+      file.puts "Total failed notes: #{@failed_notes.size}"
+      file.puts "\nDetailed errors:"
+
+      @failed_notes.each do |failed_note|
+        file.puts "Note ID: #{failed_note[:note_id]} - Error: #{failed_note[:error]}"
+      end
+    end
+
+    say "Failed notes have been logged to: #{filename}"
+
+    # Retry failed notes individually if the total is small
+    retry_failed_notes if @failed_notes.size <= 1000
+  end
+
+  def retry_failed_notes
+    say "Attempting to retry failed notes individually..."
+
+    @failed_notes.each do |failed_note|
+      note = Note.find(failed_note[:note_id])
+      comment = NoteComment.find_by(:note_id => note.id, :event => "opened")
+
+      next unless comment
+
+      # Convert IPAddr to string for the update
+      ip_address = comment.author_ip.respond_to?(:to_s) ? comment.author_ip.to_s : comment.author_ip
+
+      note.update!(
+        :description => comment.body,
+        :user_ip => ip_address,
+        :user_id => comment.author_id
+      )
+
+      say "Successfully retried note #{failed_note[:note_id]}"
+    rescue StandardError => e
+      # Log retry failures for debugging
+      say "Retry failed for note #{failed_note[:note_id]}: #{e.message}"
+    end
+  end
+
+  def down
+    # Raise an error for irreversible migrations to prevent accidental rollback
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20250106160355_backfill_note_descriptions.rb
+++ b/db/migrate/20250106160355_backfill_note_descriptions.rb
@@ -1,0 +1,31 @@
+class BackfillNoteDescriptions < ActiveRecord::Migration[7.2]
+  class Note < ApplicationRecord; end
+  class NoteComment < ApplicationRecord; end
+
+  disable_ddl_transaction!
+
+  def up
+    Note.in_batches(:of => 1000) do |notes|
+      note_ids = notes.pluck(:id)
+      comments = NoteComment.where(:note_id => note_ids, :event => "opened").group_by(&:note_id)
+
+      values = notes.map do |note|
+        first_comment = comments[note.id].first
+        user_ip_value = first_comment.author_ip.nil? ? "NULL::inet" : "'#{first_comment.author_ip}'::inet"
+        user_id_value = first_comment.author_id.nil? ? "NULL::bigint" : "'#{first_comment.author_id}'::bigint"
+        "(#{note.id}, '#{first_comment.body}', #{user_ip_value}, #{user_id_value})"
+      end.join(", ")
+
+      sql_query = <<-SQL.squish
+        UPDATE notes
+        SET description = data.description,
+            user_ip = COALESCE(data.user_ip::inet, notes.user_ip),
+            user_id = COALESCE(data.user_id::bigint, notes.user_id)
+        FROM (VALUES #{values}) AS data(id, description, user_ip, user_id)
+        WHERE notes.id = data.id;
+      SQL
+
+      ActiveRecord::Base.connection.execute(sql_query)
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1073,7 +1073,10 @@ CREATE TABLE public.notes (
     updated_at timestamp without time zone NOT NULL,
     created_at timestamp without time zone NOT NULL,
     status public.note_status_enum NOT NULL,
-    closed_at timestamp without time zone
+    closed_at timestamp without time zone,
+    description text DEFAULT ''::text NOT NULL,
+    user_id bigint,
+    user_ip inet
 );
 
 
@@ -3211,6 +3214,14 @@ ALTER TABLE ONLY public.note_comments
 
 
 --
+-- Name: notes notes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notes
+    ADD CONSTRAINT notes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: redactions redactions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3397,6 +3408,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20250106160355'),
+('20250105154621'),
+('20250104140952'),
 ('20241023004427'),
 ('20241022141247'),
 ('20240913171951'),

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -329,7 +329,7 @@ module Api
       second_user = create(:user)
       third_user = create(:user)
 
-      note_with_comments_by_users = create(:note) do |note|
+      note_with_comments_by_users = create(:note, :author => first_user) do |note|
         create(:note_comment, :note => note, :author => first_user)
         create(:note_comment, :note => note, :author => second_user)
       end
@@ -664,10 +664,10 @@ module Api
     end
 
     def test_show_hidden_comment
-      note_with_hidden_comment = create(:note) do |note|
-        create(:note_comment, :note => note, :body => "Valid comment for hidden note")
-        create(:note_comment, :note => note, :visible => false)
-        create(:note_comment, :note => note, :body => "Another valid comment for hidden note")
+      note_with_hidden_comment = create(:note, :description => "Test Note description") do |note|
+        create(:note_comment, :note => note, :event => "opened", :body => "")
+        create(:note_comment, :note => note, :event => "commented", :visible => false, :body => "Valid comment for hidden note")
+        create(:note_comment, :note => note, :event => "commented", :body => "Another valid comment for hidden note")
       end
 
       get api_note_path(note_with_hidden_comment, :format => "json")
@@ -677,7 +677,7 @@ module Api
       assert_equal "Feature", js["type"]
       assert_equal note_with_hidden_comment.id, js["properties"]["id"]
       assert_equal 2, js["properties"]["comments"].count
-      assert_equal "Valid comment for hidden note", js["properties"]["comments"][0]["text"]
+      assert_equal "Test Note description", js["properties"]["comments"][0]["text"]
       assert_equal "Another valid comment for hidden note", js["properties"]["comments"][1]["text"]
     end
 

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :note do
     latitude { 1 * GeoRecord::SCALE }
     longitude { 1 * GeoRecord::SCALE }
+    description { "This is note's description!" }
     # tile { QuadTile.tile_for_point(1,1) }
 
     trait :closed do

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -48,20 +48,20 @@ class NoteTest < ActiveSupport::TestCase
   end
 
   def test_author
-    comment = create(:note_comment)
-    assert_nil comment.note.author
+    note = create(:note)
+    assert_nil note.author
 
     user = create(:user)
-    comment = create(:note_comment, :author => user)
-    assert_equal user, comment.note.author
+    note = create(:note, :author => user)
+    assert_equal user, note.author
   end
 
   def test_author_ip
-    comment = create(:note_comment)
-    assert_nil comment.note.author_ip
+    note = create(:note)
+    assert_nil note.author_ip
 
-    comment = create(:note_comment, :author_ip => IPAddr.new("192.168.1.1"))
-    assert_equal IPAddr.new("192.168.1.1"), comment.note.author_ip
+    note = create(:note, :user_ip => IPAddr.new("192.168.1.1"))
+    assert_equal IPAddr.new("192.168.1.1"), note.author_ip
   end
 
   # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -56,11 +56,11 @@ class IndexTest < ApplicationSystemTestCase
 
   test "can navigate from hidden note to visible note" do
     sign_in_as(create(:moderator_user))
-    hidden_note = create(:note, :status => "hidden")
-    create(:note_comment, :note => hidden_note, :body => "this-is-a-hidden-note")
+    hidden_note = create(:note, :status => "hidden", :description => "this-is-a-hidden-note")
+    create(:note_comment, :note => hidden_note, :event => "opened", :body => "")
     position = (1.003 * GeoRecord::SCALE).to_i
-    visible_note = create(:note, :latitude => position, :longitude => position)
-    create(:note_comment, :note => visible_note, :body => "this-is-a-visible-note")
+    visible_note = create(:note, :latitude => position, :longitude => position, :description => "this-is-a-visible-note")
+    create(:note_comment, :note => visible_note, :event => "opened", :body => "")
 
     visit root_path(:anchor => "map=15/1/1") # view place of hidden note in case it is not rendered during note_path(hidden_note)
     visit note_path(hidden_note)

--- a/test/system/report_note_test.rb
+++ b/test/system/report_note_test.rb
@@ -2,9 +2,9 @@ require "application_system_test_case"
 
 class ReportNoteTest < ApplicationSystemTestCase
   def test_no_link_when_not_logged_in
-    note = create(:note_with_comments)
+    note = create(:note_with_comments, :description => "TD 1")
     visit note_path(note)
-    assert_content note.comments.first.body
+    assert_content "TD 1"
 
     assert_no_content I18n.t("notes.show.report")
   end

--- a/test/system/report_user_test.rb
+++ b/test/system/report_user_test.rb
@@ -2,9 +2,9 @@ require "application_system_test_case"
 
 class ReportUserTest < ApplicationSystemTestCase
   def test_no_link_when_not_logged_in
-    note = create(:note_with_comments)
+    note = create(:note_with_comments, :description => "TD 1")
     visit note_path(note)
-    assert_content note.comments.first.body
+    assert_content "TD 1"
 
     assert_no_content I18n.t("users.show.report")
   end


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
PR improves using of note's description / author_id / author_ip by:

1. Adding new fields to notes table for storing these 3 values
2. Copying values from first note's comment to notes table
3. Replacing using note's description / author / author_id from first note's comment with from note's table directly

A few comments:
- We left adding description to body when creating new note - it looked dirty to add blank string ("") or similar, also, left comments body intact during data-migration for improving performances,
- We kept backward compatibility of generated XML / JSON / .. by inserting note's description as a first comment's text,
- We added more robust version of data-migration script for retrying migration of failed notes.

### How has this been tested?
By running automated tests and by semi-manual testing (semi-manual generating notes, doing migration and applying changes, manually checking rendered notes and new memory variables content).