### PR TITLE
Move trace descriptions out of success/failure sentences in emails

### DIFF
--- a/app/views/user_mailer/_gpx_description.html.erb
+++ b/app/views/user_mailer/_gpx_description.html.erb
@@ -1,9 +1,16 @@
-<% trace_name = tag.strong(@trace_name) %>
-<% trace_name = link_to(trace_name, @trace_url) if @trace_url %>
-<% trace_description = tag.em(@trace_description) %>
-<% if @trace_tags.length > 0 %>
-  <% tags = safe_join @trace_tags.map { |trace_tag| tag.em trace_tag.tag }, ", " %>
-  <%= t ".description_with_tags_html", :trace_name => trace_name, :trace_description => trace_description, :tags => tags %>
-<% else %>
-  <%= t ".description_with_no_tags_html", :trace_name => trace_name, :trace_description => trace_description %>
-<% end %>
+<p><%= t ".details" %></p>
+
+<dl>
+  <dt><%= t ".filename" %>
+  <% if @trace_url %>
+    <dd><%= link_to(@trace_name, @trace_url) %>
+  <% else %>
+    <dd><%= @trace_name %>
+  <% end %>
+  <dt><%= t ".description" %>
+  <dd><%= @trace_description %>
+  <% if @trace_tags.length > 0 %>
+    <dt><%= t ".tags" %>
+    <dd><%= @trace_tags.map(&:tag).join(", ") %>
+  <% end %>
+</dl>

--- a/app/views/user_mailer/_gpx_description.text.erb
+++ b/app/views/user_mailer/_gpx_description.text.erb
@@ -1,8 +1,14 @@
-<% trace_name = @trace_name %>
-<% trace_description = @trace_description %>
+<%= t ".details" %>
+
+<%= t ".filename" %>
+	<%= @trace_name %>
+<% if @trace_url %>
+<%= t ".url" %>
+	<%= @trace_url %>
+<% end %>
+<%= t ".description" %>
+	<%= @trace_description %>
 <% if @trace_tags.length > 0 %>
-  <% tags = @trace_tags.map { |trace_tag| trace_tag.tag }.join(", ") %>
-  <%= t ".description_with_tags", :trace_name => trace_name, :trace_description => trace_description, :tags => tags %>
-<% else %>
-  <%= t ".description_with_no_tags", :trace_name => trace_name, :trace_description => trace_description %>
+<%= t ".tags" %>
+	<%= @trace_tags.map(&:tag).join(", ") %>
 <% end %>

--- a/app/views/user_mailer/gpx_failure.html.erb
+++ b/app/views/user_mailer/gpx_failure.html.erb
@@ -1,9 +1,10 @@
 <p><%= t ".hi", :to_user => @to_user %></p>
 
-<p>
-  <%= render :partial => "gpx_description" %>
-  <%= t ".failed_to_import" %>
-</p>
+<p><%= t ".failed_to_import" %>
+
+<%= render :partial => "gpx_description" %>
+
+<p><%= t ".verify" %></p>
 
 <blockquote>
   <%= @error %>

--- a/app/views/user_mailer/gpx_failure.text.erb
+++ b/app/views/user_mailer/gpx_failure.text.erb
@@ -1,7 +1,10 @@
 <%= t ".hi", :to_user => @to_user %>
 
-<%= render :partial => "gpx_description" %>
 <%= t ".failed_to_import" %>
+
+<%= render :partial => "gpx_description" %>
+
+<%= t ".verify" %>
 
 ==
 <%= @error %>

--- a/app/views/user_mailer/gpx_success.html.erb
+++ b/app/views/user_mailer/gpx_success.html.erb
@@ -1,9 +1,8 @@
 <p><%= t ".hi", :to_user => @to_user %></p>
 
-<p>
-  <%= render :partial => "gpx_description" %>
-  <%= t(".loaded", :trace_points => @trace_points, :count => @possible_points) %>
-</p>
+<p><%= t ".loaded_successfully", :trace_points => @trace_points, :count => @possible_points %>
+
+<%= render :partial => "gpx_description" %>
 
 <p>
   <%= t ".all_your_traces_html", :url => link_to(@my_traces_url, @my_traces_url) %>

--- a/app/views/user_mailer/gpx_success.text.erb
+++ b/app/views/user_mailer/gpx_success.text.erb
@@ -1,8 +1,7 @@
 <%= t ".hi", :to_user => @to_user %>
 
-<%= render :partial => "gpx_description" %>
-<%= t(".loaded", :trace_points => @trace_points, :count => @possible_points) %>
+<%= t ".loaded_successfully", :trace_points => @trace_points, :count => @possible_points %>
 
-<%= t ".trace_location", :trace_url => @trace_url %>
+<%= render :partial => "gpx_description" %>
 
 <%= t ".all_your_traces", :url => @my_traces_url %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1669,23 +1669,24 @@ en:
       befriend_them: "You can also add them as a friend at %{befriendurl}."
       befriend_them_html: "You can also add them as a friend at %{befriendurl}."
     gpx_description:
-      description_with_tags: "It looks like your file %{trace_name} with the description %{trace_description} and the following tags: %{tags}"
-      description_with_tags_html: "It looks like your file %{trace_name} with the description %{trace_description} and the following tags: %{tags}"
-      description_with_no_tags: "It looks like your file %{trace_name} with the description %{trace_description} and no tags"
-      description_with_no_tags_html: "It looks like your file %{trace_name} with the description %{trace_description} and no tags"
+      details: "Your file details:"
+      filename: Filename
+      url: URL
+      description: Description
+      tags: Tags
     gpx_failure:
       hi: "Hi %{to_user},"
-      failed_to_import: "failed to be imported as a GPS trace file. Please verify that your file is a valid GPX file or an archive containing GPX file(s) in the supported format (.tar.gz, .tar.bz2, .tar, .zip, .gpx.gz, .gpx.bz2). Could there be a format or syntax issue with your file? Here is the importing error:"
-      more_info: "More information about GPX import failures and how to avoid them can be found at %{url}."
+      failed_to_import: "It looks like your file failed to be imported as a GPS trace."
+      verify: "Please verify that your file is a valid GPX file or an archive containing GPX file(s) in the supported format (.tar.gz, .tar.bz2, .tar, .zip, .gpx.gz, .gpx.bz2). Could there be a format or syntax issue with your file? Here is the importing error:"
+      more_info: "More information about GPX import failures and how to avoid them can be found at %{url}"
       more_info_html: "More information about GPX import failures and how to avoid them can be found at %{url}."
       import_failures_url: "https://wiki.openstreetmap.org/wiki/GPX_Import_Failures"
       subject: "[OpenStreetMap] GPX Import failure"
     gpx_success:
       hi: "Hi %{to_user},"
-      loaded:
-        one: "loaded successfully with %{trace_points} out of a possible %{count} point."
-        other: "loaded successfully with %{trace_points} out of a possible %{count} points."
-      trace_location: "Your trace is available at %{trace_url}"
+      loaded_successfully:
+        one: "It looks like your file loaded successfully with %{trace_points} out of a possible %{count} point."
+        other: "It looks like your file loaded successfully with %{trace_points} out of a possible %{count} points."
       all_your_traces: "All your successfully uploaded GPX traces can be found at %{url}"
       all_your_traces_html: "All your successfully uploaded GPX traces can be found at %{url}."
       subject: "[OpenStreetMap] GPX Import success"

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -15,7 +15,7 @@ class UserMailerTest < ActionMailer::TestCase
     end
     email = UserMailer.gpx_success(trace, 100)
 
-    assert_match("<em>one</em>, <em>two&amp;three</em>, <em>four&lt;five</em>", email.html_part.body.to_s)
+    assert_match("one, two&amp;three, four&lt;five", email.html_part.body.to_s)
     assert_match("one, two&three, four<five", email.text_part.body.to_s)
   end
 


### PR DESCRIPTION
Fixes #4012. As I say in https://github.com/openstreetmap/openstreetmap-website/issues/4012#issuecomment-2529365698 the current success/failure sentences are too long because we try to put in trace name/description/tags into them. I don't think anyone wants to read sentences that long. Shorter sentences won't have to be combined from parts, which will improve translatability.

## Before

HTML success email:
![image](https://github.com/user-attachments/assets/8de7acfc-9b57-45f9-8ba9-8cd0ef3fcc5b)

## After

HTML success email:
![image](https://github.com/user-attachments/assets/7edf7e19-df10-4415-8f93-bdaa45acbec2)

HTML failure email:
![image](https://github.com/user-attachments/assets/bff7f426-d0a4-48d3-9333-9621c79eaff7)

Plaintext success email:
```
Hi fakeuser1,

It looks like your file loaded successfully with 295 out of a possible 295 points.

Your file details:

Filename
	11716462.gpx
URL
	http://openstreetmap.example.com/user/fakeuser1/traces/100
Description
	new trace description here
Tags
	new, trace, tags, here


All your successfully uploaded GPX traces can be found at http://openstreetmap.example.com/traces/mine
```

Plaintext failure email:
```
Hi fakeuser1,

It looks like your file failed to be imported as a GPS trace.

Your file details:

Filename
	Screenshot_from_2025_01_06_12_50_06.png
Description
	new trace description here
Tags
	new, trace, tags, here


Please verify that your file is a valid GPX file or an archive containing GPX file(s) in the supported format (.tar.gz, .tar.bz2, .tar, .zip, .gpx.gz, .gpx.bz2). Could there be a format or syntax issue with your file? Here is the importing error:

==
Fatal error: Start tag expected, '<' not found at :1.
==

More information about GPX import failures and how to avoid them can be found at https://wiki.openstreetmap.org/wiki/GPX_Import_Failures
```