### PR TITLE
Adds description and author_id methods to Note

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -82,12 +82,22 @@ class Note < ApplicationRecord
     closed_at + DEFAULT_FRESHLY_CLOSED_LIMIT
   end
 
-  # Return the author object, derived from the first comment
+  # Return the note's description, derived from the first comment
+  def description
+    comments.first.body
+  end
+
+  # Return the note's author object, derived from the first comment
   def author
     comments.first.author
   end
 
-  # Return the author IP address, derived from the first comment
+  # Return the note's author ID, derived from the first comment
+  def author_id
+    comments.first.author_id
+  end
+
+  # Return the note's author IP address, derived from the first comment
   def author_ip
     comments.first.author_ip
   end

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -48,7 +48,7 @@
       </td>
       <td><%= link_to note.id, note %></td>
       <td><%= note_author(note.author) %></td>
-      <td><%= note.comments.first.body.to_html %></td>
+      <td><%= note.description.to_html %></td>
       <td><%= friendly_date_ago(note.created_at) %></td>
       <td><%= friendly_date_ago(note.updated_at) %></td>
     </tr>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -5,7 +5,7 @@
 <div>
   <h4><%= t(".description") %></h4>
   <div class="overflow-hidden ms-2">
-    <%= h(@note_comments.first.body.to_html) %>
+    <%= h(@note.description.to_html) %>
   </div>
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -47,6 +47,15 @@ class NoteTest < ActiveSupport::TestCase
     assert_not_predicate create(:note, :status => "open", :closed_at => nil), :closed?
   end
 
+  def test_description
+    comment = create(:note_comment)
+    assert_equal comment.body, comment.note.description
+
+    user = create(:user)
+    comment = create(:note_comment, :author => user)
+    assert_equal comment.body, comment.note.description
+  end
+
   def test_author
     comment = create(:note_comment)
     assert_nil comment.note.author
@@ -54,6 +63,15 @@ class NoteTest < ActiveSupport::TestCase
     user = create(:user)
     comment = create(:note_comment, :author => user)
     assert_equal user, comment.note.author
+  end
+
+  def test_author_id
+    comment = create(:note_comment)
+    assert_nil comment.note.author_id
+
+    user = create(:user)
+    comment = create(:note_comment, :author => user)
+    assert_equal user.id, comment.note.author_id
   end
 
   def test_author_ip

--- a/test/system/report_note_test.rb
+++ b/test/system/report_note_test.rb
@@ -4,7 +4,7 @@ class ReportNoteTest < ApplicationSystemTestCase
   def test_no_link_when_not_logged_in
     note = create(:note_with_comments)
     visit note_path(note)
-    assert_content note.comments.first.body
+    assert_content note.description
 
     assert_no_content I18n.t("notes.show.report")
   end

--- a/test/system/report_user_test.rb
+++ b/test/system/report_user_test.rb
@@ -4,7 +4,7 @@ class ReportUserTest < ApplicationSystemTestCase
   def test_no_link_when_not_logged_in
     note = create(:note_with_comments)
     visit note_path(note)
-    assert_content note.comments.first.body
+    assert_content note.description
 
     assert_no_content I18n.t("users.show.report")
   end


### PR DESCRIPTION
### Description
PR adds `description` and `author_id` (`author_ip` is already there) methods to Note model file. Methods use first comment for retrieving requested information. Also, adds unit tests for testing functionality of added methods.

This PR is 1st from set of PRs described [here](https://github.com/openstreetmap/openstreetmap-website/pull/5485#pullrequestreview-2545467592).

### How has this been tested?
Automated unit tests and manual testing