### PR TITLE
Test anonymous notes counter

### DIFF
--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -78,4 +78,27 @@ class CreateNoteTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test "encouragement to contribute appears after 10 created notes" do
+    encouragement_threshold = 10
+
+    encouragement_threshold.times do |n|
+      visit new_note_path(:anchor => "map=16/0/#{0.001 * n}")
+
+      within_sidebar do
+        assert_no_content(/already posted at least \d+ anonymous note/)
+
+        fill_in "text", :with => "new note ##{n + 1}"
+        click_on "Add Note"
+
+        assert_content "new note ##{n + 1}"
+      end
+    end
+
+    visit new_note_path(:anchor => "map=16/0/#{0.001 * encouragement_threshold}")
+
+    within_sidebar do
+      assert_content(/already posted at least #{encouragement_threshold} anonymous note/)
+    end
+  end
 end

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -79,7 +79,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "encouragement to contribute appears after 10 created notes" do
+  test "encouragement to contribute appears after 10 created notes and disappears after login" do
     encouragement_threshold = 10
 
     encouragement_threshold.times do |n|
@@ -99,6 +99,20 @@ class CreateNoteTest < ApplicationSystemTestCase
 
     within_sidebar do
       assert_content(/already posted at least #{encouragement_threshold} anonymous note/)
+    end
+
+    sign_in_as(create(:user))
+    visit new_note_path(:anchor => "map=16/0/#{0.001 * encouragement_threshold}")
+
+    within_sidebar do
+      assert_no_content(/already posted at least \d+ anonymous note/)
+    end
+
+    sign_out
+    visit new_note_path(:anchor => "map=16/0/#{0.001 * encouragement_threshold}")
+
+    within_sidebar do
+      assert_no_content(/already posted at least \d+ anonymous note/)
     end
   end
 end


### PR DESCRIPTION
Tests I used for #5468. They create 10 anonymous notes and check that the encouragement message appears, then log in or sign up and check that the message disappears.