### PR TITLE
Add OAuth Refresh token when `openid` scope is used

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -210,7 +210,9 @@ Doorkeeper.configure do
   # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
   # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
   #
-  # use_refresh_token
+  use_refresh_token do |context|
+    context.scopes.include?("openid")
+  end
 
   # Provide support for an owner to be assigned to each registered application (disabled by default)
   # Optional parameter confirmation: true (default: false) if you want to enforce ownership of

--- a/test/integration/oauth2_test.rb
+++ b/test/integration/oauth2_test.rb
@@ -15,6 +15,9 @@ class OAuth2Test < ActionDispatch::IntegrationTest
 
     assert_equal "read_prefs", token["scope"]
     test_token(token["access_token"], user, client)
+
+    refresh_token = token["refresh_token"]
+    assert_nil refresh_token
   end
 
   def test_oauth2_oob
@@ -87,6 +90,9 @@ class OAuth2Test < ActionDispatch::IntegrationTest
 
     access_token = token["access_token"]
     assert_not_nil access_token
+
+    refresh_token = token["refresh_token"]
+    assert_not_nil refresh_token
 
     id_token = token["id_token"]
     assert_not_nil id_token


### PR DESCRIPTION
### Description
OSM `access_token` don't have expiry but `id_token` which is generated when `openid` scope is enabled has expiry of 2 minutes. Making `id_token` to also never expiry seems to me more problematic than no expiry for `access_token` because `id_token` can not be revoked, hence it is important to have short expiry. But with short expiry it makes `id_token` not very useful and it would complicate authentication against 3rd party services. Instead I think it is better to enable refresh token on OSM when `openid` scope is enabled for app which allows apps to refresh `id_token` by calling `/oauth/token` using refresh token. This way app can refresh `id_token` at any time and send it to 3rd party service which can authenticate user.

### How has this been tested?
Added unit tests, and manually on my machine, also verified that calling `/oauth/token` with refresh token works and produces fresh `id_token`.

### More details
My main goal on how to use this is following. Mobile app such as EveryDoor, StreetComplete... Can add `openid` to their OAuth Application scopes. That will result in getting `id_token` property in JSON of osm.org/oauth/token that can be passed to Panoramax as `Authorization Bearer jwt_token_that_osm.org/oauth/token_returned_in_id_token_field` when uploading photos. This will allow Panoramax API to use [https://www.openstreetmap.org/oauth2/discovery/keys](https://www.openstreetmap.org/oauth2/discovery/keys) which has public key stored that can be used to verify the `id_token` and authenticate user. So from user perspective no additional logins or anything else needs to be done against Panoramax service. Another nice thing about sending OpenConnect ID token is that even if Panoramax service is compromised, this token is only useful to confirm this user did action, it does not give Panoramax any authorization to do anything against osm.org API.
With this PR, mobile app will be able to fetch fresh `id_token` at any time and send it to Panoramax service which can authenticate user as long as whole operation takes less than 2 minutes which should be plenty.
