### PR TITLE
Remove references to OAuth 1 client_application model

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,7 +52,6 @@ Lint/AssignmentInCondition:
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/browse_tags_helper.rb'
     - 'app/mailers/user_mailer.rb'
-    - 'app/models/client_application.rb'
     - 'lib/nominatim.rb'
     - 'lib/osm.rb'
     - 'script/deliver-message'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,9 +20,6 @@ en:
         create: Add Comment
       message:
         create: Send
-      client_application:
-        create: Register
-        update: Update
       oauth2_application:
         create: Register
         update: Update


### PR DESCRIPTION
A couple of unused translation strings and a rubocop ignore.