### PR TITLE
Adds migration for adding description, user_id, user_ip columns to notes

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,20 +2,27 @@
 #
 # Table name: notes
 #
-#  id         :bigint(8)        not null, primary key
-#  latitude   :integer          not null
-#  longitude  :integer          not null
-#  tile       :bigint(8)        not null
-#  updated_at :datetime         not null
-#  created_at :datetime         not null
-#  status     :enum             not null
-#  closed_at  :datetime
+#  id          :bigint(8)        not null, primary key
+#  latitude    :integer          not null
+#  longitude   :integer          not null
+#  tile        :bigint(8)        not null
+#  updated_at  :datetime         not null
+#  created_at  :datetime         not null
+#  status      :enum             not null
+#  closed_at   :datetime
+#  description :text             default(""), not null
+#  user_id     :bigint(8)
+#  user_ip     :inet
 #
 # Indexes
 #
 #  notes_created_at_idx   (created_at)
 #  notes_tile_status_idx  (tile,status)
 #  notes_updated_at_idx   (updated_at)
+#
+# Foreign Keys
+#
+#  notes_user_id_fkey  (user_id => users.id)
 #
 
 class Note < ApplicationRecord

--- a/db/migrate/20250104140952_add_description_to_notes.rb
+++ b/db/migrate/20250104140952_add_description_to_notes.rb
@@ -1,0 +1,9 @@
+class AddDescriptionToNotes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :notes, :description, :text, :null => false, :default => ""
+    add_column :notes, :user_id, :bigint
+    add_column :notes, :user_ip, :inet
+
+    add_foreign_key :notes, :users, :column => :user_id, :name => "notes_user_id_fkey", :validate => false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1073,7 +1073,10 @@ CREATE TABLE public.notes (
     updated_at timestamp without time zone NOT NULL,
     created_at timestamp without time zone NOT NULL,
     status public.note_status_enum NOT NULL,
-    closed_at timestamp without time zone
+    closed_at timestamp without time zone,
+    description text DEFAULT ''::text NOT NULL,
+    user_id bigint,
+    user_ip inet
 );
 
 
@@ -3211,6 +3214,14 @@ ALTER TABLE ONLY public.note_comments
 
 
 --
+-- Name: notes notes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notes
+    ADD CONSTRAINT notes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+
+
+--
 -- Name: redactions redactions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3397,6 +3408,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20250104140952'),
 ('20241023004427'),
 ('20241022141247'),
 ('20240913171951'),


### PR DESCRIPTION
### Description
PR adds migration script for adding new columns (`description`, `user_id`, `user_ip`) to `notes` table. Also, migration adds foreign key (with turned OFF validation) connecting `notes` and `users` tables (using `user_id` column).

This PR is 2nd from set of PRs described [here](https://github.com/openstreetmap/openstreetmap-website/pull/5485#pullrequestreview-2545467592).

### How has this been tested?
Automated unit tests and manual testing