### PR TITLE
Install add/remove event listeners directly on note layer

### DIFF
--- a/app/assets/javascripts/index/layers/notes.js
+++ b/app/assets/javascripts/index/layers/notes.js
@@ -20,20 +20,14 @@ OSM.initializeNotesLayer = function (map) {
     })
   };
 
-  map.on("layeradd", function (e) {
-    if (e.layer === noteLayer) {
-      loadNotes();
-      map.on("moveend", loadNotes);
-    }
-  }).on("layerremove", function (e) {
-    if (e.layer === noteLayer) {
-      map.off("moveend", loadNotes);
-      noteLayer.clearLayers();
-      notes = {};
-    }
-  });
-
-  noteLayer.on("click", function (e) {
+  noteLayer.on("add", () => {
+    loadNotes();
+    map.on("moveend", loadNotes);
+  }).on("remove", () => {
+    map.off("moveend", loadNotes);
+    noteLayer.clearLayers();
+    notes = {};
+  }).on("click", function (e) {
     if (e.layer.id) {
       OSM.router.route("/note/" + e.layer.id);
     }


### PR DESCRIPTION
https://github.com/openstreetmap/openstreetmap-website/commit/de78176e04961c52f1fa1283812ec06ce6eb90cf added `layeradd`/`layerremove` listeners on `map` that check the layer and only do something if it's `noteLayer`. Later https://github.com/openstreetmap/openstreetmap-website/commit/85282f5cdd5b37016027feda0a16d8cbdc6a2581 added `click` listener directly on `noteLayer`. But `layeradd`/`layerremove` could also be installed directly on `noteLayer`, then comparing the layers wouldn't be necessary.

Elsewhere the same thing is considered for data layer: https://github.com/openstreetmap/openstreetmap-website/pull/5474#issuecomment-2584926028