### PR TITLE
Removed unused translations in preferences.show

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1867,8 +1867,6 @@ en:
   preferences:
     show:
       title: My Preferences
-      preferred_editor: Preferred Editor
-      preferred_languages: Preferred Languages
       preferred_site_color_scheme: Preferred Website Color Scheme
       site_color_schemes:
         auto: Auto


### PR DESCRIPTION
After merging 967e6d4 preferences.show.{preferred_editor, preferred_languages} are not used anymore. PR removes these translation keys.