### PR TITLE
Use class based map tiles dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -9,7 +9,6 @@
 
 body {
   font-size: $typeheight;
-  --dark-mode-map-filter: brightness(.8);
 }
 
 time[title] {
@@ -516,13 +515,13 @@ body.small-nav {
 }
 
 @mixin dark-map-color-scheme {
-  .leaflet-tile-container,
+  .leaflet-layer,
   .mapkey-table-entry td:first-child > * {
-    filter: var(--dark-mode-map-filter);
+    filter: var(--dark-mode-map-filter, none);
   }
 
-  .leaflet-tile-container .leaflet-tile {
-    filter: none;
+  .no-filter, .dark {
+    --dark-mode-map-filter: none;
   }
 }
 

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -31,6 +31,7 @@
   apiKeyId: "THUNDERFOREST_KEY"
   canEmbed: true
   canDownloadImage: true
+  filterClass: "no-filter"
   credit:
     id: "thunderforest_credit"
     children:
@@ -39,6 +40,7 @@
         href: "https://www.thunderforest.com/"
 
 - leafletOsmId: "TransportMap"
+  leafletOsmDarkId: "TransportDarkMap"
   code: "T"
   layerId: "transportmap"
   nameId: "transport_map"


### PR DESCRIPTION
A cleaner, class-based variant of #5426, enabling moving more logic out of `layeradd` into `initialize`.