### PR TITLE
Remove account terms code unreachable for unregistered users

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -24,13 +24,12 @@ class Ability
       can [:create, :destroy], :session
       can [:read, :data, :georss], Trace
       can [:read, :create, :suspended, :auth_success, :auth_failure], User
-      can [:read, :update], :account_terms
       can :read, UserBlock
     end
 
     if user&.active?
       can :welcome, :site
-      can :read, :deletion
+      can :read, [:deletion, :account_terms]
 
       if Settings.status != "database_offline"
         can [:subscribe, :unsubscribe], Changeset
@@ -38,6 +37,7 @@ class Ability
         can [:read, :destroy], :oauth2_authorized_application
         can [:read, :create, :destroy], :oauth2_authorization
         can [:update, :destroy], :account
+        can :update, :account_terms
         can :read, :dashboard
         can [:create, :subscribe, :unsubscribe], DiaryEntry
         can :update, DiaryEntry, :user => user

--- a/app/controllers/accounts/terms_controller.rb
+++ b/app/controllers/accounts/terms_controller.rb
@@ -20,46 +20,32 @@ module Accounts
       else
         @title = t ".title"
 
-        if current_user&.terms_agreed?
+        if current_user.terms_agreed?
           # Already agreed to terms, so just show settings
           redirect_to edit_account_path
-        elsif current_user.nil?
-          redirect_to login_path(:referer => request.fullpath)
         end
       end
     end
 
     def update
-      @title = t "users.new.title"
-
       if params[:decline] || !(params[:read_tou] && params[:read_ct])
-        if current_user
-          current_user.terms_seen = true
+        current_user.terms_seen = true
 
-          flash[:notice] = { :partial => "accounts/terms/terms_declined_flash" } if current_user.save
-
-          referer = safe_referer(params[:referer]) if params[:referer]
-
-          redirect_to referer || edit_account_path
-        elsif params[:decline]
-          redirect_to t("users.terms.declined"), :allow_other_host => true
-        else
-          redirect_to account_terms_path
-        end
-      elsif current_user
+        flash[:notice] = { :partial => "accounts/terms/terms_declined_flash" } if current_user.save
+      else
         unless current_user.terms_agreed?
           current_user.consider_pd = params[:user][:consider_pd]
           current_user.tou_agreed = Time.now.utc
           current_user.terms_agreed = Time.now.utc
           current_user.terms_seen = true
 
-          flash[:notice] = t "users.new.terms accepted" if current_user.save
+          flash[:notice] = t ".terms accepted" if current_user.save
         end
-
-        referer = safe_referer(params[:referer]) if params[:referer]
-
-        redirect_to referer || edit_account_path
       end
+
+      referer = safe_referer(params[:referer]) if params[:referer]
+
+      redirect_to referer || edit_account_path
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,7 +318,6 @@ en:
         readable_summary: human readable summary
         informal_translations: informal translations
         continue: "Continue"
-        declined: "https://wiki.openstreetmap.org/wiki/Contributor_Terms_Declined"
         cancel: "Cancel"
         you need to accept or decline: "Please read and then either accept or decline the new Contributor Terms to continue."
         legale_select: "Country of residence:"
@@ -326,6 +325,8 @@ en:
           france: "France"
           italy: "Italy"
           rest_of_world: "Rest of the world"
+      update:
+        terms accepted: "Thanks for accepting the new contributor terms!"
       terms_declined_flash:
         terms_declined_html: We are sorry that you have decided to not accept the new Contributor Terms. For more information, please see %{terms_declined_link}.
         terms_declined_link: this wiki page
@@ -2772,7 +2773,6 @@ en:
         contributor_terms_url: "https://osmfoundation.org/wiki/Licence/Contributor_Terms"
         contributor_terms: "contributor terms"
       continue: Sign Up
-      terms accepted: "Thanks for accepting the new contributor terms!"
       email_help:
         privacy_policy: privacy policy
         privacy_policy_url: https://osmfoundation.org/wiki/Privacy_Policy


### PR DESCRIPTION
After the terms page was taken out of the signup process, its controller still had the code for this kind of use by unregistered users. Later I moved the page to `/account/terms` which implies that its only for active users, but I still haven't removed the code.

Here I'm actually removing the unused code. Things like `redirect_to login_path(:referer => request.fullpath) if current_user.nil?` are handled by abilities, only active users are able to access the terms.