### PR TITLE
Use form with normal-sized button on follows show pages

### DIFF
--- a/app/views/follows/show.html.erb
+++ b/app/views/follows/show.html.erb
@@ -2,7 +2,9 @@
   <h1><%= t(@already_follows ? ".unfollow.heading" : ".follow.heading", :user => @friend.display_name) %></h1>
 <% end %>
 
-<%= link_to t(@already_follows ? ".unfollow.button" : ".follow.button"),
-            follow_path(:display_name => @friend.display_name, :referer => params[:referer]),
-            :method => (@already_follows ? :delete : :post),
-            :class => "btn btn-sm btn-primary" %>
+<%= bootstrap_form_tag :method => (@already_follows ? :delete : :post) do |f| %>
+  <% if params[:referer] -%>
+  <%= f.hidden_field :referer, :value => params[:referer] %>
+  <% end -%>
+  <%= f.primary @already_follows ? t(".unfollow.button") : t(".follow.button") %>
+<% end %>


### PR DESCRIPTION
Originally the make/remove friend pages contained a form:
https://github.com/openstreetmap/openstreetmap-website/blob/17323257685bf5134d9286f5baefaddcae65478c/app/views/friendships/make_friend.html.erb#L5-L10

#5261 replaces these two pages with one `/user/:user/follow` page. That have doesn't have a form. Instead it has a link styled as a button. This is probably because there were multiple changes to paths during the development of that PR. But I don't know why it shouldn't be a true button with the paths we eventually settled on. Also the link has a small button css class on it. I don't know why the button that is the only thing on the page should be small. Probably it was a copypasted code from subscribe/unsubscribe buttons or something similar.

Before:
![image](https://github.com/user-attachments/assets/6616b537-8396-4179-a4d6-fb2a02a483b4)

After:
![image](https://github.com/user-attachments/assets/6220a921-7e62-4ff4-8f11-5fea68e872b4)
