### PR TITLE
Adds validating of notes foreign key

### DIFF
--- a/db/migrate/20250105154621_validate_foreign_key_on_notes.rb
+++ b/db/migrate/20250105154621_validate_foreign_key_on_notes.rb
@@ -1,0 +1,5 @@
+class ValidateForeignKeyOnNotes < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :notes, :users
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3218,7 +3218,7 @@ ALTER TABLE ONLY public.note_comments
 --
 
 ALTER TABLE ONLY public.notes
-    ADD CONSTRAINT notes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) NOT VALID;
+    ADD CONSTRAINT notes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -3408,6 +3408,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20250105154621'),
 ('20250104140952'),
 ('20241023004427'),
 ('20241022141247'),


### PR DESCRIPTION
### Description

PR adds migration for validation foreign key in `notes` table referencing `users` table.

This PR is 3rd from set of PRs described [here](https://github.com/openstreetmap/openstreetmap-website/pull/5485#pullrequestreview-2545467592).

### How has this been tested?

Automated unit tests and manual testing.
