### PR TITLE
Adds optional use of notes records

### DIFF
--- a/app/assets/javascripts/index/layers/notes.js
+++ b/app/assets/javascripts/index/layers/notes.js
@@ -44,10 +44,13 @@ OSM.initializeNotesLayer = function (map) {
       marker.setIcon(noteIcons[feature.properties.status]);
     } else {
       let title;
-      const description = feature.properties.comments[0];
 
-      if (description?.action === "opened") {
-        title = description.text;
+      if (feature.properties.comments.length > 0) {
+        const description = feature.properties.comments[0];
+
+        if (description?.action === "opened") {
+          title = description.text;
+        }
       }
 
       marker = L.marker(feature.geometry.coordinates.reverse(), {

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -1,6 +1,14 @@
 module NoteHelper
   include ActionView::Helpers::TranslationHelper
 
+  def note_description(author, description)
+    if !author.nil? && author.status == "deleted"
+      RichText.new("text", t("notes.show.description_when_author_is_deleted"))
+    else
+      description
+    end
+  end
+
   def note_event(event, at, by)
     if by.nil?
       t("notes.show.event_#{event}_by_anonymous_html",

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -28,6 +28,8 @@
 class Note < ApplicationRecord
   include GeoRecord
 
+  belongs_to :author, :class_name => "User", :foreign_key => "user_id", :optional => true
+
   has_many :comments, -> { left_joins(:author).where(:visible => true, :users => { :status => [nil, "active", "confirmed"] }).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id
   has_many :all_comments, -> { left_joins(:author).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id, :inverse_of => :note
   has_many :subscriptions, :class_name => "NoteSubscription"
@@ -89,14 +91,28 @@ class Note < ApplicationRecord
     closed_at + DEFAULT_FRESHLY_CLOSED_LIMIT
   end
 
-  # Return the note's description, derived from the first comment
-  def description
-    comments.first.body
+  def author_deleted?
+    !author.nil? && author.status == "deleted"
   end
 
-  # Return the note's author object, derived from the first comment
+  # Return the note's description, unless record is unavailable and
+  # it will be derived from the first comment
+  def description
+    if user_ip.nil? && user_id.nil?
+      all_comments.first.body
+    else
+      RichText.new("text", super)
+    end
+  end
+
+  # Return the note's author object, unless record is unavailable and
+  # it will be derived from the first comment
   def author
-    comments.first.author
+    if user_ip.nil? && user_id.nil?
+      all_comments.first.author
+    else
+      super
+    end
   end
 
   private

--- a/app/views/api/notes/_note.rss.builder
+++ b/app/views/api/notes/_note.rss.builder
@@ -13,7 +13,7 @@ xml.item do
   xml.guid api_note_url(note)
   xml.description render(:partial => "description", :object => note, :formats => [:html])
 
-  xml.dc :creator, note.author.display_name if note.author
+  xml.dc :creator, note.author.display_name unless note.author.nil? || note.author_deleted?
 
   xml.pubDate note.created_at.to_fs(:rfc822)
   xml.geo :lat, note.lat

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -48,7 +48,7 @@
       </td>
       <td><%= link_to note.id, note %></td>
       <td><%= note_author(note.author) %></td>
-      <td><%= note.description.to_html %></td>
+      <td><%= note_description(note.author, note.description).to_html %></td>
       <td><%= friendly_date_ago(note.created_at) %></td>
       <td><%= friendly_date_ago(note.updated_at) %></td>
     </tr>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -52,10 +52,10 @@
     <% end %>
   </div>
 
-  <% if @note_comments.length > 1 %>
+  <% if @note_comments.length > (@note.author_deleted? ? 0 : 1) %>
     <div class='note-comments'>
       <ul class="list-unstyled">
-        <% @note_comments.drop(1).each do |comment| %>
+        <% @note_comments.drop(@note.author_deleted? ? 0 : 1).each do |comment| %>
           <li id="c<%= comment.id %>">
             <small class='text-body-secondary'><%= note_event(comment.event, comment.created_at, comment.author) %></small>
             <div class="mx-2">

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -5,7 +5,7 @@
 <div>
   <h4><%= t(".description") %></h4>
   <div class="overflow-hidden ms-2">
-    <%= h(@note.description.to_html) %>
+    <%= h(note_description(@note.author, @note.description).to_html) %>
   </div>
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3069,6 +3069,7 @@ en:
       open_title: "Unresolved note #%{note_name}"
       closed_title: "Resolved note #%{note_name}"
       hidden_title: "Hidden note #%{note_name}"
+      description_when_author_is_deleted: "deleted"
       event_opened_by_html: "Created by %{user} %{time_ago}"
       event_opened_by_anonymous_html: "Created by anonymous %{time_ago}"
       event_commented_by_html: "Comment from %{user} %{time_ago}"


### PR DESCRIPTION
### Description

PR adds use of `description`, `user_id`, `user_ip` from `notes` table if data-migration is done, otherwise use `body`, `author_id`, `author_ip` from note's first comment. Decision procedure "data-migration is done" is defined with "is user_ip or user_id not nil?".

This PR is 4th from set of PRs described [here](https://github.com/openstreetmap/openstreetmap-website/pull/5485#pullrequestreview-2545467592).

### How has this been tested?

Automated unit tests and manual testing.