### PR TITLE
Remove "Public editing" line from settings page

### DIFF
--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -30,19 +30,6 @@
   </fieldset>
 
   <div class="mb-3">
-    <label class="form-label"><%= t ".public editing.heading" %></label>
-    <span class="form-text text-body-secondary">
-      <% if current_user.data_public? %>
-        <%= t ".public editing.enabled" %>
-        (<a href="<%= t ".public editing.enabled link" %>" target="_new"><%= t ".public editing.enabled link text" %></a>)
-      <% else %>
-        <%= t ".public editing.disabled" %>
-        (<a href="#public"><%= t ".public editing.disabled link text" %></a>)
-      <% end %>
-    </span>
-  </div>
-
-  <div class="mb-3">
     <label class="form-label"><%= t ".contributor terms.heading" %></label>
     <span class="form-text text-body-secondary">
       <% if current_user.terms_agreed? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,13 +251,6 @@ en:
       openid:
         link: "https://wiki.openstreetmap.org/wiki/OpenID"
         link text: "what is this?"
-      public editing:
-        heading: "Public editing"
-        enabled: "Enabled. Not anonymous and can edit data."
-        enabled link: "https://wiki.openstreetmap.org/wiki/Anonymous_edits"
-        enabled link text: "what is this?"
-        disabled: "Disabled and cannot edit data, all previous edits are anonymous."
-        disabled link text: "why can't I edit?"
       contributor terms:
         heading: "Contributor Terms"
         agreed: "You have agreed to the new Contributor Terms."


### PR DESCRIPTION
There's the *Public editing* line on the `/account/edit` page between *External Authentication* and *Contributor Terms*. I don't think it's useful anymore. All of the accounts created in the last 15 years have public editing enabled. All new users are invited to start editing on the welcome page, so they know they can edit. All users who have been around for a while know they can edit. They don't need to be told that they can edit on the *Settings* page. This PR removes the *Public editing* line.

Before:
![image](https://github.com/user-attachments/assets/487884f7-274c-4519-9319-ca2e69bafe02)

After:
![image](https://github.com/user-attachments/assets/6357a140-b971-47a2-aa57-1186c39daa7b)

---

For a few users that still have an account without public editing enabled, this line is useless anyway because there's an entire section at the bottom of the page about public editing.

Before when not gone public:
![image](https://github.com/user-attachments/assets/9aef396b-3835-4ef3-a465-90b3a31c764e)

After when not gone public:
![image](https://github.com/user-attachments/assets/989f9f46-5884-4570-9b72-f2061b379d7f)
