### PR TITLE
Remove public domain checkbox from signup and terms pages

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -38,6 +38,7 @@ class Ability
         can [:read, :create, :destroy], :oauth2_authorization
         can [:update, :destroy], :account
         can :update, :account_terms
+        can :create, :account_pd_declaration
         can :read, :dashboard
         can [:create, :subscribe, :unsubscribe], DiaryEntry
         can :update, DiaryEntry, :user => user

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -29,7 +29,7 @@ class Ability
 
     if user&.active?
       can :welcome, :site
-      can :read, [:deletion, :account_terms]
+      can :read, [:deletion, :account_terms, :account_pd_declaration]
 
       if Settings.status != "database_offline"
         can [:subscribe, :unsubscribe], Changeset

--- a/app/controllers/accounts/pd_declarations_controller.rb
+++ b/app/controllers/accounts/pd_declarations_controller.rb
@@ -10,6 +10,18 @@ module Accounts
     def show; end
 
     def create
+      if current_user.consider_pd
+        flash[:warning] = t(".already_declared")
+      else
+        current_user.consider_pd = params[:consider_pd]
+
+        if current_user.consider_pd
+          flash[:notice] = t(".successfully_declared") if current_user.save
+        else
+          flash[:warning] = t(".did_not_confirm")
+        end
+      end
+
       redirect_to edit_account_path
     end
   end

--- a/app/controllers/accounts/pd_declarations_controller.rb
+++ b/app/controllers/accounts/pd_declarations_controller.rb
@@ -1,0 +1,12 @@
+module Accounts
+  class PdDeclarationsController < ApplicationController
+    layout "site"
+
+    before_action :authorize_web
+    before_action :set_locale
+
+    authorize_resource :class => :account_pd_declaration
+
+    def show; end
+  end
+end

--- a/app/controllers/accounts/pd_declarations_controller.rb
+++ b/app/controllers/accounts/pd_declarations_controller.rb
@@ -8,5 +8,9 @@ module Accounts
     authorize_resource :class => :account_pd_declaration
 
     def show; end
+
+    def create
+      redirect_to edit_account_path
+    end
   end
 end

--- a/app/controllers/accounts/terms_controller.rb
+++ b/app/controllers/accounts/terms_controller.rb
@@ -34,7 +34,6 @@ module Accounts
         flash[:notice] = { :partial => "accounts/terms/terms_declined_flash" } if current_user.save
       else
         unless current_user.terms_agreed?
-          current_user.consider_pd = params[:user][:consider_pd]
           current_user.tou_agreed = Time.now.utc
           current_user.terms_agreed = Time.now.utc
           current_user.terms_seen = true

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -222,8 +222,7 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:email, :display_name,
                                  :auth_provider, :auth_uid,
-                                 :pass_crypt, :pass_crypt_confirmation,
-                                 :consider_pd)
+                                 :pass_crypt, :pass_crypt_confirmation)
   end
 
   ##

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -29,13 +29,14 @@
     <small class="form-text text-body-secondary">(<a href="<%= t ".openid.link" %>" target="_new"><%= t ".openid.link text" %></a>)</small>
   </fieldset>
 
-  <div class="mb-3">
-    <label class="form-label"><%= t ".contributor terms.heading" %></label>
+  <div class="mb-3 d-flex flex-column flex-sm-row column-gap-1">
+    <label class="form-label text-nowrap mb-0"><%= t ".contributor terms.heading" %></label>
     <span class="form-text text-body-secondary">
       <% if current_user.terms_agreed? %>
         <%= t ".contributor terms.agreed" %>
         (<a href="<%= t ".contributor terms.link" %>" target="_new"><%= t ".contributor terms.link text" %></a>)
         <% if current_user.consider_pd? %>
+          <br>
           <%= t ".contributor terms.agreed_with_pd" %>
         <% end %>
       <% else %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -35,9 +35,12 @@
       <% if current_user.terms_agreed? %>
         <%= t ".contributor terms.agreed" %>
         (<a href="<%= t ".contributor terms.link" %>" target="_new"><%= t ".contributor terms.link text" %></a>)
+        <br>
         <% if current_user.consider_pd? %>
-          <br>
           <%= t ".contributor terms.agreed_with_pd" %>
+        <% else %>
+          <%= t ".contributor terms.not_agreed_with_pd" %>
+          (<%= link_to t(".contributor terms.pd_link_text"), account_pd_declaration_path %>)
         <% end %>
       <% else %>
         <%= t ".contributor terms.not yet agreed" %>

--- a/app/views/accounts/pd_declarations/show.html.erb
+++ b/app/views/accounts/pd_declarations/show.html.erb
@@ -1,0 +1,3 @@
+<% content_for :heading do %>
+  <h1><%= t ".title" %></h1>
+<% end %>

--- a/app/views/accounts/pd_declarations/show.html.erb
+++ b/app/views/accounts/pd_declarations/show.html.erb
@@ -10,4 +10,5 @@
                     :checked => current_user.consider_pd,
                     :disabled => current_user.consider_pd %>
   <% end %>
+  <%= f.primary t(".confirm"), :disabled => current_user.consider_pd %>
 <% end %>

--- a/app/views/accounts/pd_declarations/show.html.erb
+++ b/app/views/accounts/pd_declarations/show.html.erb
@@ -3,9 +3,11 @@
 <% end %>
 
 <%= bootstrap_form_tag do |f| %>
-  <%= f.check_box :consider_pd,
-                  :label => t(".consider_pd"),
-                  :autocomplete => :off,
-                  :checked => current_user.consider_pd,
-                  :disabled => current_user.consider_pd %>
+  <%= f.form_group :help => link_to(t(".consider_pd_why"), t(".consider_pd_why_url"), :target => :new) do %>
+    <%= f.check_box :consider_pd,
+                    :label => t(".consider_pd"),
+                    :autocomplete => :off,
+                    :checked => current_user.consider_pd,
+                    :disabled => current_user.consider_pd %>
+  <% end %>
 <% end %>

--- a/app/views/accounts/pd_declarations/show.html.erb
+++ b/app/views/accounts/pd_declarations/show.html.erb
@@ -1,3 +1,11 @@
 <% content_for :heading do %>
   <h1><%= t ".title" %></h1>
 <% end %>
+
+<%= bootstrap_form_tag do |f| %>
+  <%= f.check_box :consider_pd,
+                  :label => t(".consider_pd"),
+                  :autocomplete => :off,
+                  :checked => current_user.consider_pd,
+                  :disabled => current_user.consider_pd %>
+<% end %>

--- a/app/views/accounts/terms/show.html.erb
+++ b/app/views/accounts/terms/show.html.erb
@@ -72,13 +72,4 @@
     <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :disabled => true, :class => "btn btn-primary") %>
     <%= submit_tag(t(".cancel"), :name => "decline", :id => "decline", :class => "btn btn-outline-secondary") %>
   </div>
-
-  <div class="mb-3">
-    <div class="form-check">
-      <%= check_box("user", "consider_pd", :class => "form-check-input") %>
-    <label for="user_consider_pd" class="form-check-label">
-      <%= t ".consider_pd" %>
-    </label>
-    <span class="minorNote">(<%= link_to(t(".consider_pd_why"), t(".consider_pd_why_url"), :target => :new) %>)</span>
-  </div>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -78,17 +78,9 @@
                                                  :contributor_terms_link => link_to(t(".by_signing_up.contributor_terms"),
                                                                                     t(".by_signing_up.contributor_terms_url"),
                                                                                     :target => :new)) %></p>
-  <%= f.form_group do %>
-    <%= f.check_box :consider_pd,
-                    :tabindex => 5,
-                    :label => t(".consider_pd_html",
-                                :consider_pd_link => link_to(t(".consider_pd"),
-                                                             t(".consider_pd_url"),
-                                                             :target => :new)) %>
-  <% end %>
 
   <div class="mb-3">
-    <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary", :tabindex => 6) %>
+    <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary", :tabindex => 5) %>
   </div>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,6 +328,8 @@ en:
       show:
         title: Consider my contributions to be in the Public Domain
         consider_pd: "I consider my contributions to be in the Public Domain"
+        consider_pd_why: "Why would I want my contributions to be Public Domain?"
+        consider_pd_why_url: https://osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
   browse:
     deleted_ago_by_html: "Deleted %{time_ago} by %{user}"
     edited_ago_by_html: "Edited %{time_ago} by %{user}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2787,9 +2787,6 @@ en:
         privacy_policy_url: https://osmfoundation.org/wiki/Privacy_Policy
         privacy_policy_title: OSMF privacy policy including section on email addresses
         html: 'Your address is not displayed publicly, see our %{privacy_policy_link} for more information.'
-      consider_pd_html: "I consider my contributions to be in the %{consider_pd_link}."
-      consider_pd: "public domain"
-      consider_pd_url: https://osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
       or: "or"
       use external auth: "or sign up with a third party"
     no_such_user:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,6 +327,7 @@ en:
     pd_declarations:
       show:
         title: Consider my contributions to be in the Public Domain
+        consider_pd: "I consider my contributions to be in the Public Domain"
   browse:
     deleted_ago_by_html: "Deleted %{time_ago} by %{user}"
     edited_ago_by_html: "Edited %{time_ago} by %{user}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,6 +324,9 @@ en:
         terms_declined_html: We are sorry that you have decided to not accept the new Contributor Terms. For more information, please see %{terms_declined_link}.
         terms_declined_link: this wiki page
         terms_declined_url: https://wiki.openstreetmap.org/wiki/Contributor_Terms_Declined
+    pd_declarations:
+      show:
+        title: Consider my contributions to be in the Public Domain
   browse:
     deleted_ago_by_html: "Deleted %{time_ago} by %{user}"
     edited_ago_by_html: "Edited %{time_ago} by %{user}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,7 @@ en:
         consider_pd: "I consider my contributions to be in the Public Domain"
         consider_pd_why: "Why would I want my contributions to be Public Domain?"
         consider_pd_why_url: https://osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
+        confirm: Confirm
   browse:
     deleted_ago_by_html: "Deleted %{time_ago} by %{user}"
     edited_ago_by_html: "Edited %{time_ago} by %{user}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -331,6 +331,10 @@ en:
         consider_pd_why: "Why would I want my contributions to be Public Domain?"
         consider_pd_why_url: https://osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
         confirm: Confirm
+      create:
+        successfully_declared: "You have successfully declared that you consider your edits to be in the Public Domain."
+        already_declared: "You have already declared that you consider your edits to be in the Public Domain."
+        did_not_confirm: "You didn't confirm that you consider your edits to be in the Public Domain."
   browse:
     deleted_ago_by_html: "Deleted %{time_ago} by %{user}"
     edited_ago_by_html: "Edited %{time_ago} by %{user}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,6 +259,8 @@ en:
         agreed_with_pd: "You have also declared that you consider your edits to be in the Public Domain."
         link: "https://osmfoundation.org/wiki/Licence/Contributor_Terms"
         link text: "what is this?"
+        not_agreed_with_pd: "You haven't declared that you consider your edits to be in the Public Domain."
+        pd_link_text: "declare"
       save changes button: Save Changes
       delete_account: Delete Account...
     go_public:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,9 +306,6 @@ en:
         read_ct: "I have read and agree to the above contributor terms"
         tou_explain_html: "These %{tou_link} govern the use of the website and other infrastructure provided by the OSMF. Please click on the link, read and agree to the text."
         read_tou: "I have read and agree to the Terms of Use"
-        consider_pd: "In addition to the above, I consider my contributions to be in the Public Domain"
-        consider_pd_why: "what's this?"
-        consider_pd_why_url: https://osmfoundation.org/wiki/Licence_and_Legal_FAQ/Why_would_I_want_my_contributions_to_be_public_domain
         guidance_info_html: "Information to help understand these terms: a %{readable_summary_link} and some %{informal_translations_link}"
         readable_summary: human readable summary
         informal_translations: informal translations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -279,6 +279,7 @@ OpenStreetMap::Application.routes.draw do
   resource :account, :only => [:edit, :update, :destroy] do
     scope :module => :accounts do
       resource :terms, :only => [:show, :update]
+      resource :pd_declaration, :only => :show
       resource :deletion, :only => :show
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -279,7 +279,7 @@ OpenStreetMap::Application.routes.draw do
   resource :account, :only => [:edit, :update, :destroy] do
     scope :module => :accounts do
       resource :terms, :only => [:show, :update]
-      resource :pd_declaration, :only => :show
+      resource :pd_declaration, :only => [:show, :create]
       resource :deletion, :only => :show
     end
   end

--- a/test/controllers/accounts/pd_declarations_controller_test.rb
+++ b/test/controllers/accounts/pd_declarations_controller_test.rb
@@ -9,6 +9,10 @@ module Accounts
         { :path => "/account/pd_declaration", :method => :get },
         { :controller => "accounts/pd_declarations", :action => "show" }
       )
+      assert_routing(
+        { :path => "/account/pd_declaration", :method => :post },
+        { :controller => "accounts/pd_declarations", :action => "create" }
+      )
     end
 
     def test_show_not_logged_in
@@ -24,6 +28,21 @@ module Accounts
       get account_pd_declaration_path
 
       assert_response :success
+    end
+
+    def test_create_not_logged_in
+      post account_pd_declaration_path
+
+      assert_response :forbidden
+    end
+
+    def test_create
+      user = create(:user)
+      session_for(user)
+
+      post account_pd_declaration_path
+
+      assert_redirected_to edit_account_path
     end
   end
 end

--- a/test/controllers/accounts/pd_declarations_controller_test.rb
+++ b/test/controllers/accounts/pd_declarations_controller_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+module Accounts
+  class PdDeclarationsControllerTest < ActionDispatch::IntegrationTest
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/account/pd_declaration", :method => :get },
+        { :controller => "accounts/pd_declarations", :action => "show" }
+      )
+    end
+
+    def test_show_not_logged_in
+      get account_pd_declaration_path
+
+      assert_redirected_to login_path(:referer => account_pd_declaration_path)
+    end
+
+    def test_show_agreed
+      user = create(:user)
+      session_for(user)
+
+      get account_pd_declaration_path
+
+      assert_response :success
+    end
+  end
+end

--- a/test/controllers/accounts/pd_declarations_controller_test.rb
+++ b/test/controllers/accounts/pd_declarations_controller_test.rb
@@ -36,13 +36,57 @@ module Accounts
       assert_response :forbidden
     end
 
-    def test_create
+    def test_create_unconfirmed
       user = create(:user)
       session_for(user)
 
       post account_pd_declaration_path
 
       assert_redirected_to edit_account_path
+      assert_nil flash[:notice]
+      assert_equal "You didn't confirm that you consider your edits to be in the Public Domain.", flash[:warning]
+
+      user.reload
+      assert_not_predicate user, :consider_pd
+    end
+
+    def test_create_confirmed
+      user = create(:user)
+      session_for(user)
+
+      post account_pd_declaration_path, :params => { :consider_pd => true }
+
+      assert_equal "You have successfully declared that you consider your edits to be in the Public Domain.", flash[:notice]
+      assert_nil flash[:warning]
+
+      user.reload
+      assert_predicate user, :consider_pd
+    end
+
+    def test_create_already_declared_unconfirmed
+      user = create(:user, :consider_pd => true)
+      session_for(user)
+
+      post account_pd_declaration_path
+
+      assert_nil flash[:notice]
+      assert_equal "You have already declared that you consider your edits to be in the Public Domain.", flash[:warning]
+
+      user.reload
+      assert_predicate user, :consider_pd
+    end
+
+    def test_create_already_declared_confirmed
+      user = create(:user, :consider_pd => true)
+      session_for(user)
+
+      post account_pd_declaration_path, :params => { :consider_pd => true }
+
+      assert_nil flash[:notice]
+      assert_equal "You have already declared that you consider your edits to be in the Public Domain.", flash[:warning]
+
+      user.reload
+      assert_predicate user, :consider_pd
     end
   end
 end

--- a/test/controllers/accounts/terms_controller_test.rb
+++ b/test/controllers/accounts/terms_controller_test.rb
@@ -52,13 +52,12 @@ module Accounts
       user = create(:user, :terms_seen => false, :terms_agreed => nil)
       session_for(user)
 
-      put account_terms_path, :params => { :user => { :consider_pd => true }, :read_ct => 1, :read_tou => 1 }
+      put account_terms_path, :params => { :read_ct => 1, :read_tou => 1 }
       assert_redirected_to edit_account_path
       assert_equal "Thanks for accepting the new contributor terms!", flash[:notice]
 
       user.reload
 
-      assert user.consider_pd
       assert_not_nil user.terms_agreed
       assert user.terms_seen
     end
@@ -67,13 +66,12 @@ module Accounts
       user = create(:user, :terms_seen => false, :terms_agreed => nil)
       session_for(user)
 
-      put account_terms_path, :params => { :user => { :consider_pd => true }, :referer => "/test", :read_ct => 1, :read_tou => 1 }
+      put account_terms_path, :params => { :referer => "/test", :read_ct => 1, :read_tou => 1 }
       assert_redirected_to "/test"
       assert_equal "Thanks for accepting the new contributor terms!", flash[:notice]
 
       user.reload
 
-      assert user.consider_pd
       assert_not_nil user.terms_agreed
       assert user.terms_seen
     end

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -34,8 +34,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => dup_email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
-                                       :pass_crypt_confirmation => "testtest",
-                                       :consider_pd => "1" } }
+                                       :pass_crypt_confirmation => "testtest" } }
         end
       end
     end
@@ -57,8 +56,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :pass_crypt => "testtest",
                                        :pass_crypt_confirmation => "testtest",
                                        :auth_provider => "google",
-                                       :auth_uid => "123454321",
-                                       :consider_pd => "1" } }
+                                       :auth_uid => "123454321" } }
         end
       end
     end
@@ -97,8 +95,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
-                                       :pass_crypt_confirmation => "blahblah",
-                                       :consider_pd => "1" } }
+                                       :pass_crypt_confirmation => "blahblah" } }
         end
       end
     end
@@ -117,8 +114,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => email,
                                        :display_name => dup_display_name,
                                        :auth_provider => "google",
-                                       :auth_uid => "123454321",
-                                       :consider_pd => "1" } }
+                                       :auth_uid => "123454321" } }
         end
       end
     end
@@ -138,8 +134,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :pass_crypt => "testtest",
-                                       :pass_crypt_confirmation => "testtest",
-                                       :consider_pd => "1" } }
+                                       :pass_crypt_confirmation => "testtest" } }
           assert_redirected_to :controller => :confirmations, :action => :confirm, :display_name => display_name
           follow_redirect!
         end
@@ -192,8 +187,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :pass_crypt => password,
-                                       :pass_crypt_confirmation => password,
-                                       :consider_pd => "1" },
+                                       :pass_crypt_confirmation => password },
                             :referer => referer }
           assert_response(:redirect)
           assert_redirected_to :controller => :confirmations, :action => :confirm, :display_name => display_name
@@ -254,8 +248,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "openid",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" } }
+                                       :auth_uid => auth_uid } }
         end
       end
     end
@@ -330,8 +323,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "openid",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" } }
+                                       :auth_uid => auth_uid } }
           follow_redirect!
         end
       end
@@ -392,8 +384,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "google",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" },
+                                       :auth_uid => auth_uid },
                             :email_hmac => email_hmac }
           assert_redirected_to welcome_path
           follow_redirect!
@@ -479,8 +470,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "google",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" } }
+                                       :auth_uid => auth_uid } }
           assert_response :redirect
           follow_redirect!
         end
@@ -541,8 +531,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "facebook",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" },
+                                       :auth_uid => auth_uid },
                             :email_hmac => email_hmac }
           assert_redirected_to welcome_path
           follow_redirect!
@@ -628,8 +617,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "facebook",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" } }
+                                       :auth_uid => auth_uid } }
           assert_response :redirect
           follow_redirect!
         end
@@ -689,8 +677,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                :params => { :user => { :email => new_email,
                                        :display_name => display_name,
                                        :auth_provider => "microsoft",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" },
+                                       :auth_uid => auth_uid },
                             :email_hmac => email_hmac }
           assert_redirected_to welcome_path
           follow_redirect!
@@ -775,8 +762,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "microsoft",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" } }
+                                       :auth_uid => auth_uid } }
           assert_response :redirect
           follow_redirect!
         end
@@ -926,8 +912,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "github",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" } }
+                                       :auth_uid => auth_uid } }
           assert_response :redirect
           follow_redirect!
         end
@@ -1076,8 +1061,7 @@ class UserCreationTest < ActionDispatch::IntegrationTest
                                        :email_hmac => email_hmac,
                                        :display_name => display_name,
                                        :auth_provider => "wikipedia",
-                                       :auth_uid => auth_uid,
-                                       :consider_pd => "1" } }
+                                       :auth_uid => auth_uid } }
           assert_response :redirect
           follow_redirect!
         end

--- a/test/system/account_pd_declaration_test.rb
+++ b/test/system/account_pd_declaration_test.rb
@@ -11,6 +11,7 @@ class AccountPdDeclarationTest < ApplicationSystemTestCase
 
     within_content_body do
       assert_unchecked_field "I consider my contributions to be in the Public Domain"
+      assert_button "Confirm"
     end
   end
 
@@ -21,6 +22,7 @@ class AccountPdDeclarationTest < ApplicationSystemTestCase
 
     within_content_body do
       assert_checked_field "I consider my contributions to be in the Public Domain", :disabled => true
+      assert_button "Confirm", :disabled => true
     end
   end
 end

--- a/test/system/account_pd_declaration_test.rb
+++ b/test/system/account_pd_declaration_test.rb
@@ -6,12 +6,30 @@ class AccountPdDeclarationTest < ApplicationSystemTestCase
     sign_in_as(@user)
   end
 
-  test "show checkbox if no declaration was made" do
+  test "can decline declaration if no declaration was made" do
     visit account_pd_declaration_path
 
     within_content_body do
       assert_unchecked_field "I consider my contributions to be in the Public Domain"
       assert_button "Confirm"
+
+      click_on "Confirm"
+
+      assert_no_text "You have also declared that you consider your edits to be in the Public Domain."
+    end
+  end
+
+  test "can confirm declaration if no declaration was made" do
+    visit account_pd_declaration_path
+
+    within_content_body do
+      assert_unchecked_field "I consider my contributions to be in the Public Domain"
+      assert_button "Confirm"
+
+      check "I consider my contributions to be in the Public Domain"
+      click_on "Confirm"
+
+      assert_text "You have also declared that you consider your edits to be in the Public Domain."
     end
   end
 

--- a/test/system/account_pd_declaration_test.rb
+++ b/test/system/account_pd_declaration_test.rb
@@ -1,0 +1,26 @@
+require "application_system_test_case"
+
+class AccountPdDeclarationTest < ApplicationSystemTestCase
+  def setup
+    @user = create(:user, :display_name => "test user")
+    sign_in_as(@user)
+  end
+
+  test "show checkbox if no declaration was made" do
+    visit account_pd_declaration_path
+
+    within_content_body do
+      assert_unchecked_field "I consider my contributions to be in the Public Domain"
+    end
+  end
+
+  test "show disabled checkbox if declaration was made" do
+    @user.update(:consider_pd => true)
+
+    visit account_pd_declaration_path
+
+    within_content_body do
+      assert_checked_field "I consider my contributions to be in the Public Domain", :disabled => true
+    end
+  end
+end


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/pull/4455#issuecomment-1899125291, https://github.com/openstreetmap/openstreetmap-website/pull/4455#discussion_r1509952021, https://github.com/openstreetmap/openstreetmap-website/pull/4455#issuecomment-2069941509 for reasons to remove the checkbox from the signup page.

The checkbox is confusingly placed right above the *Sign Up* button:
![image](https://github.com/user-attachments/assets/131dd279-ad12-4543-84c3-328481e4cb4f)
Users might think they have to check it in order to proceed, but they actually don't have to do it. If they check it accidentally and register an account, there's no way to undo it.

I also removed a similar checkbox from the terms page. That page is currently not accessible for new accounts because terms are accepted by signing up. But that's probably going to change because the terms page could be reused for accepting updated terms. Supposedly terms of use were updated and many users need to accept the new terms if GDPR changes happen. If there's a  public domain checkbox on that page, users also might also accidentally check it.

If anyone actually want to declare their contributions in public domain, I added a special page for that. There's a link to it from *Contributor Terms* on the *My Settings* page. I didn't make the link very noticeable because I don't expect many people to visit that page:
![image](https://github.com/user-attachments/assets/fbbe1bac-2548-4c5d-963b-04b0fbe326df)

The page is at `/account/pd_declaration` and is just a checkbox and a confirm button:
![image](https://github.com/user-attachments/assets/ba7cffd7-97d1-435b-a8f2-ac0be0cc0170)
