### PR TITLE
Replace lookup_friend with lookup_user in FollowsController

### DIFF
--- a/app/views/follows/show.html.erb
+++ b/app/views/follows/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :heading do %>
-  <h1><%= t(@already_follows ? ".unfollow.heading" : ".follow.heading", :user => @friend.display_name) %></h1>
+  <h1><%= t(@already_follows ? ".unfollow.heading" : ".follow.heading", :user => @user.display_name) %></h1>
 <% end %>
 
 <%= bootstrap_form_tag :method => (@already_follows ? :delete : :post) do |f| %>


### PR DESCRIPTION
More *friend* cleanups. Removes `lookup_friend` method that sets `@friend` variable, replacing it with `lookup_user` that sets `@user`. `@user` will allow to treat `follow` as a nested resource of a user.