### PR TITLE
Use resourceful routes for api tracepoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,11 +64,11 @@ OpenStreetMap::Application.routes.draw do
     get "relations" => "relations#index"
 
     get "map" => "map#index"
-
-    get "trackpoints" => "tracepoints#index"
   end
 
   namespace :api, :path => "api/0.6" do
+    resources :tracepoints, :path => "trackpoints", :only => :index
+
     resources :users, :only => :index
     resources :users, :path => "user", :id => /\d+/, :only => :show
     resources :user_traces, :path => "user/gpx_files", :module => :users, :controller => :traces, :only => :index

--- a/test/controllers/api/tracepoints_controller_test.rb
+++ b/test/controllers/api/tracepoints_controller_test.rb
@@ -34,7 +34,7 @@ module Api
       maxlon = point.longitude + 0.001
       maxlat = point.latitude + 0.001
       bbox = "#{minlon},#{minlat},#{maxlon},#{maxlat}"
-      get trackpoints_path(:bbox => bbox)
+      get api_tracepoints_path(:bbox => bbox)
       assert_response :success
       assert_select "gpx[version='1.0'][creator='OpenStreetMap.org']", :count => 1 do
         assert_select "trk" do
@@ -56,7 +56,7 @@ module Api
       maxlon = point.longitude + 0.002
       maxlat = point.latitude + 0.002
       bbox = "#{minlon},#{minlat},#{maxlon},#{maxlat}"
-      get trackpoints_path(:bbox => bbox)
+      get api_tracepoints_path(:bbox => bbox)
       assert_response :success
       assert_select "gpx[version='1.0'][creator='OpenStreetMap.org']", :count => 1 do
         assert_select "trk", :count => 1 do
@@ -83,7 +83,7 @@ module Api
       maxlon = point.longitude + 0.002
       maxlat = point.latitude + 0.002
       bbox = "#{minlon},#{minlat},#{maxlon},#{maxlat}"
-      get trackpoints_path(:bbox => bbox)
+      get api_tracepoints_path(:bbox => bbox)
       assert_response :success
       assert_select "gpx[version='1.0'][creator='OpenStreetMap.org']", :count => 1 do
         assert_select "trk", :count => 1 do
@@ -100,26 +100,26 @@ module Api
     end
 
     def test_index_without_bbox
-      get trackpoints_path
+      get api_tracepoints_path
       assert_response :bad_request
       assert_equal "The parameter bbox is required", @response.body, "A bbox param was expected"
     end
 
     def test_traces_page_less_than_zero
       -10.upto(-1) do |i|
-        get trackpoints_path(:page => i, :bbox => "-0.1,-0.1,0.1,0.1")
+        get api_tracepoints_path(:page => i, :bbox => "-0.1,-0.1,0.1,0.1")
         assert_response :bad_request
         assert_equal "Page number must be greater than or equal to 0", @response.body, "The page number was #{i}"
       end
       0.upto(10) do |i|
-        get trackpoints_path(:page => i, :bbox => "-0.1,-0.1,0.1,0.1")
+        get api_tracepoints_path(:page => i, :bbox => "-0.1,-0.1,0.1,0.1")
         assert_response :success, "The page number was #{i} and should have been accepted"
       end
     end
 
     def test_bbox_too_big
       @badbigbbox.each do |bbox|
-        get trackpoints_path(:bbox => bbox)
+        get api_tracepoints_path(:bbox => bbox)
         assert_response :bad_request, "The bbox:#{bbox} was expected to be too big"
         assert_equal "The maximum bbox size is #{Settings.max_request_area}, and your request was too large. Either request a smaller area, or use planet.osm", @response.body, "bbox: #{bbox}"
       end
@@ -127,7 +127,7 @@ module Api
 
     def test_bbox_malformed
       @badmalformedbbox.each do |bbox|
-        get trackpoints_path(:bbox => bbox)
+        get api_tracepoints_path(:bbox => bbox)
         assert_response :bad_request, "The bbox:#{bbox} was expected to be malformed"
         assert_equal "The parameter bbox must be of the form min_lon,min_lat,max_lon,max_lat", @response.body, "bbox: #{bbox}"
       end
@@ -135,7 +135,7 @@ module Api
 
     def test_bbox_lon_mixedup
       @badlonmixedbbox.each do |bbox|
-        get trackpoints_path(:bbox => bbox)
+        get api_tracepoints_path(:bbox => bbox)
         assert_response :bad_request, "The bbox:#{bbox} was expected to have the longitude mixed up"
         assert_equal "The minimum longitude must be less than the maximum longitude, but it wasn't", @response.body, "bbox: #{bbox}"
       end
@@ -143,7 +143,7 @@ module Api
 
     def test_bbox_lat_mixedup
       @badlatmixedbbox.each do |bbox|
-        get trackpoints_path(:bbox => bbox)
+        get api_tracepoints_path(:bbox => bbox)
         assert_response :bad_request, "The bbox:#{bbox} was expected to have the latitude mixed up"
         assert_equal "The minimum latitude must be less than the maximum latitude, but it wasn't", @response.body, "bbox: #{bbox}"
       end
@@ -153,7 +153,7 @@ module Api
     def test_lat_lon_xml_format
       create(:tracepoint, :latitude => (0.00004 * GeoRecord::SCALE).to_i, :longitude => (0.00008 * GeoRecord::SCALE).to_i)
 
-      get trackpoints_path(:bbox => "0,0,0.1,0.1")
+      get api_tracepoints_path(:bbox => "0,0,0.1,0.1")
       assert_match(/lat="0.0000400"/, response.body)
       assert_match(/lon="0.0000800"/, response.body)
     end


### PR DESCRIPTION
Doesn't do much, mostly changes `trackpoints_path` to `api_tracepoints_path`, with `api_` prefix like other api paths.