### PR TITLE
Fix left/right sidebar resizing on mobile devices

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -347,15 +347,22 @@ L.OSM.Map = L.Map.extend({
   },
 
   setSidebarOverlaid: function (overlaid) {
-    var sidebarWidth = 350;
+    var mediumDeviceWidth = window.getComputedStyle(document.documentElement).getPropertyValue("--bs-breakpoint-md");
+    var isMediumDevice = window.matchMedia(`(max-width: ${mediumDeviceWidth})`).matches;
+    var sidebarWidth = $("#sidebar").width();
+    var sidebarHeight = $("#sidebar").height();
     if (overlaid && !$("#content").hasClass("overlay-sidebar")) {
       $("#content").addClass("overlay-sidebar");
       this.invalidateSize({ pan: false });
-      if ($("html").attr("dir") !== "rtl") {
+      if (isMediumDevice) {
+        this.panBy([0, -sidebarHeight], { animate: false });
+      } else if ($("html").attr("dir") !== "rtl") {
         this.panBy([-sidebarWidth, 0], { animate: false });
       }
     } else if (!overlaid && $("#content").hasClass("overlay-sidebar")) {
-      if ($("html").attr("dir") !== "rtl") {
+      if (isMediumDevice) {
+        this.panBy([0, $("#map").height() / 2], { animate: false });
+      } else if ($("html").attr("dir") !== "rtl") {
         this.panBy([sidebarWidth, 0], { animate: false });
       }
       $("#content").removeClass("overlay-sidebar");

--- a/app/assets/javascripts/leaflet.sidebar.js
+++ b/app/assets/javascripts/leaflet.sidebar.js
@@ -17,6 +17,8 @@ L.OSM.sidebar = function (selector) {
   };
 
   control.togglePane = function (pane, button) {
+    var mediumDeviceWidth = window.getComputedStyle(document.documentElement).getPropertyValue("--bs-breakpoint-md");
+    var isMediumDevice = window.matchMedia(`(max-width: ${mediumDeviceWidth})`).matches;
     var paneWidth = 250;
 
     current
@@ -27,18 +29,22 @@ L.OSM.sidebar = function (selector) {
       .removeClass("active");
 
     if (current === pane) {
-      if ($("html").attr("dir") === "rtl") {
-        map.panBy([-paneWidth, 0], { animate: false });
-      }
       $(sidebar).hide();
       $("#content").addClass("overlay-right-sidebar");
       current = currentButton = $();
+      if (isMediumDevice) {
+        map.panBy([0, -$("#map").height() / 2], { animate: false });
+      } else if ($("html").attr("dir") === "rtl") {
+        map.panBy([-paneWidth, 0], { animate: false });
+      }
     } else {
       $(sidebar).show();
       $("#content").removeClass("overlay-right-sidebar");
       current = pane;
       currentButton = button || $();
-      if ($("html").attr("dir") === "rtl") {
+      if (isMediumDevice) {
+        map.panBy([0, $("#map").height()], { animate: false });
+      } else if ($("html").attr("dir") === "rtl") {
         map.panBy([paneWidth, 0], { animate: false });
       }
     }


### PR DESCRIPTION
This PR fixes multiple issues about the map resetting its position when opening various menus on mobile devices.

https://github.com/openstreetmap/openstreetmap-website/issues/4755
https://github.com/openstreetmap/openstreetmap-website/issues/991 (partly because the sidebar can still cover the selected object in the Map data layer)
...

1. Get rid of the hardcoded left sidebar width.
2. On mobile devices, use adjust the height, not the width of the map

### How has this been tested?

<table>

<tr> 

<th>

Before

https://github.com/user-attachments/assets/9c283266-b43a-48d2-9f25-ffe73752c837

<tr> 

<th>

After

https://github.com/user-attachments/assets/9cf73154-c043-430a-a143-f8d47ad0f080


<th>

After with RTL

https://github.com/user-attachments/assets/ed973523-98d2-46a8-be2b-ca8619e1085f


</tr> 

</table>
