### PR TITLE
Add a page to view active blocks

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -38,6 +38,7 @@ class Ability
         can [:read, :create, :destroy], :oauth2_authorization
         can [:update, :destroy], :account
         can :update, :account_terms
+        can :read, :account_block
         can :read, :dashboard
         can [:create, :subscribe, :unsubscribe], DiaryEntry
         can :update, DiaryEntry, :user => user

--- a/app/controllers/accounts/blocks_controller.rb
+++ b/app/controllers/accounts/blocks_controller.rb
@@ -1,0 +1,12 @@
+module Accounts
+  class BlocksController < ApplicationController
+    layout "site"
+
+    before_action :authorize_web
+    before_action :set_locale
+
+    authorize_resource :class => :account_block
+
+    def index; end
+  end
+end

--- a/app/controllers/accounts/blocks_controller.rb
+++ b/app/controllers/accounts/blocks_controller.rb
@@ -7,6 +7,9 @@ module Accounts
 
     authorize_resource :class => :account_block
 
-    def index; end
+    def index
+      unseen_block = current_user.blocks.where(:deactivates_at => nil).order(:id).take
+      redirect_to unseen_block if unseen_block
+    end
   end
 end

--- a/app/controllers/accounts/blocks_controller.rb
+++ b/app/controllers/accounts/blocks_controller.rb
@@ -9,7 +9,12 @@ module Accounts
 
     def index
       unseen_block = current_user.blocks.where(:deactivates_at => nil).order(:id).take
-      redirect_to unseen_block if unseen_block
+      if unseen_block
+        redirect_to unseen_block
+      else
+        active_block = current_user.blocks.active.order(:id).take
+        redirect_to active_block if active_block
+      end
     end
   end
 end

--- a/app/views/accounts/blocks/index.html.erb
+++ b/app/views/accounts/blocks/index.html.erb
@@ -1,0 +1,3 @@
+<% content_for :heading do %>
+  <h1><%= t ".title" %></h1>
+<% end %>

--- a/app/views/accounts/blocks/index.html.erb
+++ b/app/views/accounts/blocks/index.html.erb
@@ -1,3 +1,5 @@
 <% content_for :heading do %>
   <h1><%= t ".title" %></h1>
 <% end %>
+
+<p><%= t ".no_active_blocks" %></p>

--- a/app/views/accounts/blocks/index.html.erb
+++ b/app/views/accounts/blocks/index.html.erb
@@ -3,3 +3,9 @@
 <% end %>
 
 <p><%= t ".no_active_blocks" %></p>
+
+<% if current_user.blocks.exists? %>
+  <div class="mb-3">
+    <%= link_to t(".review_button"), user_received_blocks_path(current_user), :class => "btn btn-outline-primary" %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,6 +279,7 @@ en:
     blocks:
       index:
         title: Blocks on Me
+        no_active_blocks: There are no active blocks on your account.
     deletions:
       show:
         title: Delete My Account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,6 +276,9 @@ en:
       success: "User information updated successfully."
     destroy:
       success: "Account Deleted."
+    blocks:
+      index:
+        title: Blocks on Me
     deletions:
       show:
         title: Delete My Account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,6 +280,7 @@ en:
       index:
         title: Blocks on Me
         no_active_blocks: There are no active blocks on your account.
+        review_button: Review past blocks
     deletions:
       show:
         title: Delete My Account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,6 +278,7 @@ OpenStreetMap::Application.routes.draw do
 
   resource :account, :only => [:edit, :update, :destroy] do
     scope :module => :accounts do
+      resources :blocks, :only => :index
       resource :terms, :only => [:show, :update]
       resource :deletion, :only => :show
     end

--- a/test/controllers/accounts/blocks_controller_test.rb
+++ b/test/controllers/accounts/blocks_controller_test.rb
@@ -24,6 +24,7 @@ module Accounts
       assert_response :success
       assert_dom "#content > .content-body" do
         assert_dom "p", :text => /no active blocks/
+        assert_dom "a", :text => "Review past blocks", :count => 0
       end
     end
 
@@ -36,6 +37,9 @@ module Accounts
       assert_response :success
       assert_dom "#content > .content-body" do
         assert_dom "p", :text => /no active blocks/
+        assert_dom "a", :text => "Review past blocks" do
+          assert_dom "> @href", user_received_blocks_path(user)
+        end
       end
     end
 

--- a/test/controllers/accounts/blocks_controller_test.rb
+++ b/test/controllers/accounts/blocks_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+module Accounts
+  class BlocksControllerTest < ActionDispatch::IntegrationTest
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/account/blocks", :method => :get },
+        { :controller => "accounts/blocks", :action => "index" }
+      )
+    end
+
+    def test_index_not_logged_in
+      get account_blocks_path
+      assert_redirected_to login_path(:referer => account_blocks_path)
+    end
+
+    def test_index_not_blocked
+      user = create(:user)
+      session_for(user)
+
+      get account_blocks_path
+      assert_response :success
+    end
+  end
+end

--- a/test/controllers/accounts/blocks_controller_test.rb
+++ b/test/controllers/accounts/blocks_controller_test.rb
@@ -23,5 +23,28 @@ module Accounts
       get account_blocks_path
       assert_response :success
     end
+
+    def test_index_with_unseen_block
+      user = create(:user)
+      session_for(user)
+      unseen_block = create(:user_block, :needs_view, :user => user)
+
+      get account_blocks_path
+      assert_redirected_to user_block_path(unseen_block)
+    end
+
+    def test_index_with_two_unseen_blocks
+      user = create(:user)
+      session_for(user)
+      unseen_block1 = create(:user_block, :needs_view, :user => user)
+      unseen_block2 = create(:user_block, :needs_view, :user => user)
+
+      get account_blocks_path
+      assert_redirected_to user_block_path(unseen_block1)
+      follow_redirect!
+
+      get account_blocks_path
+      assert_redirected_to user_block_path(unseen_block2)
+    end
   end
 end

--- a/test/controllers/accounts/blocks_controller_test.rb
+++ b/test/controllers/accounts/blocks_controller_test.rb
@@ -22,6 +22,9 @@ module Accounts
 
       get account_blocks_path
       assert_response :success
+      assert_dom "#content > .content-body" do
+        assert_dom "p", :text => /no active blocks/
+      end
     end
 
     def test_index_with_inactive_block
@@ -31,6 +34,9 @@ module Accounts
 
       get account_blocks_path
       assert_response :success
+      assert_dom "#content > .content-body" do
+        assert_dom "p", :text => /no active blocks/
+      end
     end
 
     def test_index_with_unseen_block

--- a/test/controllers/accounts/blocks_controller_test.rb
+++ b/test/controllers/accounts/blocks_controller_test.rb
@@ -24,6 +24,15 @@ module Accounts
       assert_response :success
     end
 
+    def test_index_with_inactive_block
+      user = create(:user)
+      session_for(user)
+      create(:user_block, :expired, :user => user)
+
+      get account_blocks_path
+      assert_response :success
+    end
+
     def test_index_with_unseen_block
       user = create(:user)
       session_for(user)
@@ -45,6 +54,29 @@ module Accounts
 
       get account_blocks_path
       assert_redirected_to user_block_path(unseen_block2)
+    end
+
+    def test_index_with_seen_block
+      user = create(:user)
+      session_for(user)
+      seen_block = create(:user_block, :user => user)
+
+      get account_blocks_path
+      assert_redirected_to user_block_path(seen_block)
+    end
+
+    def test_index_with_seen_and_unseen_blocks
+      user = create(:user)
+      session_for(user)
+      seen_block = create(:user_block, :user => user)
+      unseen_block = create(:user_block, :needs_view, :user => user)
+
+      get account_blocks_path
+      assert_redirected_to user_block_path(unseen_block)
+      follow_redirect!
+
+      get account_blocks_path
+      assert_redirected_to user_block_path(seen_block)
     end
   end
 end


### PR DESCRIPTION
This PR adds `/account/blocks` page that does the following:
- if there are needs_view blocks, redirects to the earliest one of them
- if there are any active blocks, redirects to the earliest one of them
- if there are no active blocks, displays a message that there aren't any blocks, possibly with a link to `/user/:username/blocks` for reviewing past blocks

![image](https://github.com/user-attachments/assets/a7b0ab84-b1fe-4351-85d9-ea4b106f331c)
