### PR TITLE
Consistent usage of layer information in _osm_location cookie

### DIFF
--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -80,7 +80,7 @@ OSM = {
   },
 
   mapParams: function (search) {
-    var params = OSM.params(search), mapParams = {}, loc, match;
+    var params = OSM.params(search), mapParams = {}, match;
 
     if (params.mlon && params.mlat) {
       mapParams.marker = true;
@@ -101,6 +101,8 @@ OSM = {
 
     var hash = OSM.parseHash(location.hash);
 
+    const loc = Cookies.get('_osm_location')?.split("|");
+
     // Decide on a map starting position. Various ways of doing this.
     if (hash.center) {
       mapParams.lon = hash.center.lng;
@@ -119,8 +121,7 @@ OSM = {
       mapParams.lon = parseFloat(params.mlon);
       mapParams.lat = parseFloat(params.mlat);
       mapParams.zoom = parseInt(params.zoom || 12);
-    } else if (loc = Cookies.get('_osm_location')) {
-      loc = loc.split("|");
+    } else if (loc) {
       mapParams.lon = parseFloat(loc[0]);
       mapParams.lat = parseFloat(loc[1]);
       mapParams.zoom = parseInt(loc[2]);


### PR DESCRIPTION
As reported in #3971, some URLs like https://www.openstreetmap.org/?mlat=53.32607&mlon=-1.49033 reset the currently selected layers. In order to restore the previous setting, a user needs to select both map and overlay layers after clicking on the link. 

It seems a bit premature to simply override the current layers with default values, in case the link does not include any layer information.

Instead, this PR unconditionally extracts the current layers from the _osm_location cookie, so it can be applied consistently across different url parsing alternatives.

As before, if the link includes layers in the hash value, that information takes precedence.

This change mainly impacts line 144 below:

```
mapParams.layers = hash.layers || (loc && loc[3]) || '';
```

loc[3] will now always contain  the selected layers, as long as the cookie is available.




