### PR TITLE
Preload parent objects for user comments

### DIFF
--- a/app/controllers/users/changeset_comments_controller.rb
+++ b/app/controllers/users/changeset_comments_controller.rb
@@ -8,7 +8,7 @@ module Users
 
       @params = params.permit(:display_name, :before, :after)
 
-      @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, :includes => [:author])
+      @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, :includes => [:author, :changeset])
     end
   end
 end

--- a/app/controllers/users/diary_comments_controller.rb
+++ b/app/controllers/users/diary_comments_controller.rb
@@ -8,7 +8,7 @@ module Users
 
       @params = params.permit(:display_name, :before, :after)
 
-      @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, :includes => [:user])
+      @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, :includes => [:user, :diary_entry])
 
       render :partial => "page" if turbo_frame_request_id == "pagination"
     end


### PR DESCRIPTION
I noticed that the comment views were loading objects one by one and this should make it more efficient.