### PR TITLE
Add indexes on user+id to changeset and diary comments

### DIFF
--- a/app/models/changeset_comment.rb
+++ b/app/models/changeset_comment.rb
@@ -12,6 +12,7 @@
 # Indexes
 #
 #  index_changeset_comments_on_author_id_and_created_at     (author_id,created_at)
+#  index_changeset_comments_on_author_id_and_id             (author_id,id)
 #  index_changeset_comments_on_changeset_id_and_created_at  (changeset_id,created_at)
 #  index_changeset_comments_on_created_at                   (created_at)
 #

--- a/app/models/diary_comment.rb
+++ b/app/models/diary_comment.rb
@@ -15,6 +15,7 @@
 #
 #  diary_comment_user_id_created_at_index  (user_id,created_at)
 #  diary_comments_entry_id_idx             (diary_entry_id,id) UNIQUE
+#  index_diary_comments_on_user_id_and_id  (user_id,id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20250121191749_add_user_comment_indexes.rb
+++ b/db/migrate/20250121191749_add_user_comment_indexes.rb
@@ -1,0 +1,8 @@
+class AddUserCommentIndexes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :changeset_comments, [:author_id, :id], :algorithm => :concurrently
+    add_index :diary_comments, [:user_id, :id], :algorithm => :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2401,6 +2401,13 @@ CREATE INDEX index_changeset_comments_on_author_id_and_created_at ON public.chan
 
 
 --
+-- Name: index_changeset_comments_on_author_id_and_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_changeset_comments_on_author_id_and_id ON public.changeset_comments USING btree (author_id, id);
+
+
+--
 -- Name: index_changeset_comments_on_changeset_id_and_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2433,6 +2440,13 @@ CREATE INDEX index_changesets_subscribers_on_changeset_id ON public.changesets_s
 --
 
 CREATE UNIQUE INDEX index_changesets_subscribers_on_subscriber_id_and_changeset_id ON public.changesets_subscribers USING btree (subscriber_id, changeset_id);
+
+
+--
+-- Name: index_diary_comments_on_user_id_and_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_diary_comments_on_user_id_and_id ON public.diary_comments USING btree (user_id, id);
 
 
 --
@@ -3408,6 +3422,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20250121191749'),
 ('20250105154621'),
 ('20250104140952'),
 ('20241023004427'),


### PR DESCRIPTION
This adds indexes on `user+id` to diary and changeset comments to make comment views more efficient.

Once this is merged we can switch the `diary_comments` association on users to sort by id instead of creation date and then drop the creation date indexes.