### PR TITLE
Set needs_view by default for new blocks

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -37,7 +37,7 @@ class UserBlocksController < ApplicationController
   end
 
   def new
-    @user_block = UserBlock.new
+    @user_block = UserBlock.new(:needs_view => true)
   end
 
   def edit


### PR DESCRIPTION
If a block is created without `needs_view`, it's less likely to get noticed by the receiving user. Nobody could come up with any reason why blocks shouldn't be `needs_view` by default.