### PR TITLE
Use flash.now for messages to be shown during this request

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -106,19 +106,6 @@ Minitest/EmptyLineBeforeAssertionMethods:
 Minitest/MultipleAssertions:
   Max: 60
 
-# Offense count: 10
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/ActionControllerFlashBeforeRender:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/confirmations_controller.rb'
-    - 'app/controllers/issue_comments_controller.rb'
-    - 'app/controllers/messages_controller.rb'
-    - 'app/controllers/passwords_controller.rb'
-    - 'app/controllers/traces_controller.rb'
-    - 'app/controllers/user_blocks_controller.rb'
-    - 'app/controllers/users_controller.rb'
-
 # Offense count: 2
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -116,7 +116,7 @@ class TracesController < ApplicationController
         @trace.schedule_import
         redirect_to :action => :index, :display_name => current_user.display_name
       else
-        flash[:error] = t(".upload_failed") if @trace.valid?
+        flash.now[:error] = t(".upload_failed") if @trace.valid?
 
         render :action => "new"
       end


### PR DESCRIPTION
I'm not sure why the other files were in rubocop_todo, perhaps they had been refactored since the file was last generated.