### PR TITLE
Message read_mark and mute resources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -146,7 +146,6 @@ Rails/SpecificActionNames:
     - 'app/controllers/export_controller.rb'
     - 'app/controllers/geocoder_controller.rb'
     - 'app/controllers/issues_controller.rb'
-    - 'app/controllers/messages_controller.rb'
     - 'app/controllers/site_controller.rb'
     - 'app/controllers/traces_controller.rb'
     - 'app/controllers/users_controller.rb'

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -43,7 +43,7 @@ class Ability
         can :update, DiaryEntry, :user => user
         can [:create], DiaryComment
         can [:show, :create, :destroy], Follow
-        can [:read, :create, :mark, :unmute, :destroy], Message
+        can [:read, :create, :unmute, :destroy], Message
         can [:close, :reopen], Note
         can [:read, :update], :preference
         can :update, :profile

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -43,7 +43,7 @@ class Ability
         can :update, DiaryEntry, :user => user
         can [:create], DiaryComment
         can [:show, :create, :destroy], Follow
-        can [:read, :create, :unmute, :destroy], Message
+        can [:read, :create, :destroy], Message
         can [:close, :reopen], Note
         can [:read, :update], :preference
         can :update, :profile

--- a/app/controllers/messages/mutes_controller.rb
+++ b/app/controllers/messages/mutes_controller.rb
@@ -1,0 +1,33 @@
+module Messages
+  class MutesController < ApplicationController
+    layout "site"
+
+    before_action :authorize_web
+    before_action :set_locale
+
+    authorize_resource :message
+
+    before_action :check_database_readable
+    before_action :check_database_writable
+
+    # Moves message into Inbox by unsetting the muted-flag
+    def destroy
+      message = current_user.muted_messages.find(params[:message_id])
+
+      if message.unmute
+        flash[:notice] = t(".notice")
+      else
+        flash[:error] = t(".error")
+      end
+
+      if current_user.muted_messages.none?
+        redirect_to messages_inbox_path
+      else
+        redirect_to messages_muted_inbox_path
+      end
+    rescue ActiveRecord::RecordNotFound
+      @title = t "messages.no_such_message.title"
+      render :template => "messages/no_such_message", :status => :not_found
+    end
+  end
+end

--- a/app/controllers/messages/read_marks_controller.rb
+++ b/app/controllers/messages/read_marks_controller.rb
@@ -1,0 +1,39 @@
+module Messages
+  class ReadMarksController < ApplicationController
+    layout "site"
+
+    before_action :authorize_web
+    before_action :set_locale
+
+    authorize_resource :message
+
+    before_action :check_database_readable
+    before_action :check_database_writable
+
+    def create
+      mark true
+    end
+
+    def destroy
+      mark false
+    end
+
+    private
+
+    def mark(message_read)
+      @message = current_user.messages.unscope(:where => :muted).find(params[:message_id])
+      @message.message_read = message_read
+      if @message.save
+        flash[:notice] = t ".notice"
+        if @message.muted?
+          redirect_to messages_muted_inbox_path, :status => :see_other
+        else
+          redirect_to messages_inbox_path, :status => :see_other
+        end
+      end
+    rescue ActiveRecord::RecordNotFound
+      @title = t "messages.no_such_message.title"
+      render :template => "messages/no_such_message", :status => :not_found
+    end
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -73,23 +73,6 @@ class MessagesController < ApplicationController
     render :action => "no_such_message", :status => :not_found
   end
 
-  # Moves message into Inbox by unsetting the muted-flag
-  def unmute
-    message = current_user.muted_messages.find(params[:message_id])
-
-    if message.unmute
-      flash[:notice] = t(".notice")
-    else
-      flash[:error] = t(".error")
-    end
-
-    if current_user.muted_messages.none?
-      redirect_to messages_inbox_path
-    else
-      redirect_to messages_muted_inbox_path
-    end
-  end
-
   private
 
   ##

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,7 @@ class MessagesController < ApplicationController
 
   before_action :lookup_user, :only => [:new, :create]
   before_action :check_database_readable
-  before_action :check_database_writable, :only => [:new, :create, :mark, :destroy]
+  before_action :check_database_writable, :only => [:new, :create, :destroy]
 
   allow_thirdparty_images :only => [:new, :create, :show]
 
@@ -67,30 +67,6 @@ class MessagesController < ApplicationController
       referer = safe_referer(params[:referer]) if params[:referer]
 
       redirect_to referer || messages_inbox_path, :status => :see_other
-    end
-  rescue ActiveRecord::RecordNotFound
-    @title = t "messages.no_such_message.title"
-    render :action => "no_such_message", :status => :not_found
-  end
-
-  # Set the message as being read or unread.
-  def mark
-    @message = current_user.messages.unscope(:where => :muted).find(params[:message_id])
-    if params[:mark] == "unread"
-      message_read = false
-      notice = t ".as_unread"
-    else
-      message_read = true
-      notice = t ".as_read"
-    end
-    @message.message_read = message_read
-    if @message.save
-      flash[:notice] = notice
-      if @message.muted?
-        redirect_to messages_muted_inbox_path, :status => :see_other
-      else
-        redirect_to messages_inbox_path, :status => :see_other
-      end
     end
   rescue ActiveRecord::RecordNotFound
     @title = t "messages.no_such_message.title"

--- a/app/views/messages/mailboxes/_message.html.erb
+++ b/app/views/messages/mailboxes/_message.html.erb
@@ -4,8 +4,8 @@
   <td class="text-nowrap"><%= l message.sent_on, :format => :friendly %></td>
   <td class="text-nowrap">
     <div class="d-flex justify-content-end gap-1">
-      <%= button_to t(".unread_button"), message_read_mark_path(message), :method => :delete, :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :class => "inbox-mark-unread", :hidden => !message.message_read? } %>
-      <%= button_to t(".read_button"), message_read_mark_path(message), :method => :post, :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :class => "inbox-mark-read", :hidden => message.message_read? } %>
+      <%= button_to t(".unread_button"), message_read_mark_path(message), :method => :delete, :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :hidden => !message.message_read? } %>
+      <%= button_to t(".read_button"), message_read_mark_path(message), :method => :post, :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :hidden => message.message_read? } %>
       <%= button_to t(".destroy_button"), message_path(message, :referer => request.fullpath), :method => :delete, :class => "btn btn-sm btn-danger", :form => { :data => { :turbo => true }, :class => "destroy-message" } %>
       <% if message.muted? %>
         <%= button_to t(".unmute_button"), message_unmute_path(message), :method => :patch, :class => "btn btn-sm btn-secondary", :form => { :data => { :turbo => true } } %>

--- a/app/views/messages/mailboxes/_message.html.erb
+++ b/app/views/messages/mailboxes/_message.html.erb
@@ -4,8 +4,8 @@
   <td class="text-nowrap"><%= l message.sent_on, :format => :friendly %></td>
   <td class="text-nowrap">
     <div class="d-flex justify-content-end gap-1">
-      <%= button_to t(".unread_button"), message_mark_path(message, :mark => "unread"), :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :class => "inbox-mark-unread", :hidden => !message.message_read? } %>
-      <%= button_to t(".read_button"), message_mark_path(message, :mark => "read"), :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :class => "inbox-mark-read", :hidden => message.message_read? } %>
+      <%= button_to t(".unread_button"), message_read_mark_path(message), :method => :delete, :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :class => "inbox-mark-unread", :hidden => !message.message_read? } %>
+      <%= button_to t(".read_button"), message_read_mark_path(message), :method => :post, :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :class => "inbox-mark-read", :hidden => message.message_read? } %>
       <%= button_to t(".destroy_button"), message_path(message, :referer => request.fullpath), :method => :delete, :class => "btn btn-sm btn-danger", :form => { :data => { :turbo => true }, :class => "destroy-message" } %>
       <% if message.muted? %>
         <%= button_to t(".unmute_button"), message_unmute_path(message), :method => :patch, :class => "btn btn-sm btn-secondary", :form => { :data => { :turbo => true } } %>

--- a/app/views/messages/mailboxes/_message.html.erb
+++ b/app/views/messages/mailboxes/_message.html.erb
@@ -8,7 +8,7 @@
       <%= button_to t(".read_button"), message_read_mark_path(message), :method => :post, :class => "btn btn-sm btn-primary", :form => { :data => { :turbo => true }, :hidden => message.message_read? } %>
       <%= button_to t(".destroy_button"), message_path(message, :referer => request.fullpath), :method => :delete, :class => "btn btn-sm btn-danger", :form => { :data => { :turbo => true }, :class => "destroy-message" } %>
       <% if message.muted? %>
-        <%= button_to t(".unmute_button"), message_unmute_path(message), :method => :patch, :class => "btn btn-sm btn-secondary", :form => { :data => { :turbo => true } } %>
+        <%= button_to t(".unmute_button"), message_mute_path(message), :method => :delete, :class => "btn btn-sm btn-secondary", :form => { :data => { :turbo => true } } %>
       <% end %>
     </div>
   </td>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -20,7 +20,7 @@
 <div>
   <%= link_to t(".reply_button"), new_message_reply_path(@message), :class => "btn btn-primary" %>
   <% if current_user == @message.recipient %>
-    <%= link_to t(".unread_button"), message_mark_path(@message, :mark => "unread"), :method => "post", :class => "btn btn-primary" %>
+    <%= link_to t(".unread_button"), message_read_mark_path(@message), :method => "delete", :class => "btn btn-primary" %>
     <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>
   <% else %>
     <%= link_to t(".destroy_button"), message_path(@message), :method => "delete", :class => "btn btn-danger" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1782,14 +1782,16 @@ en:
       destroy_button: "Delete"
       back: "Back"
       wrong_user: "You are logged in as '%{user}' but the message you have asked to read was not sent by or to that user. Please log in as the correct user in order to read it."
-    mark:
-      as_read: "Message marked as read"
-      as_unread: "Message marked as unread"
     unmute:
       notice: "Message has been moved to Inbox"
       error: "The message could not be moved to the Inbox."
     destroy:
       destroyed: "Message deleted"
+    read_marks:
+      create:
+        notice: "Message marked as read"
+      destroy:
+        notice: "Message marked as unread"
     mailboxes:
       heading:
         my_inbox: "My Inbox"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1782,9 +1782,6 @@ en:
       destroy_button: "Delete"
       back: "Back"
       wrong_user: "You are logged in as '%{user}' but the message you have asked to read was not sent by or to that user. Please log in as the correct user in order to read it."
-    unmute:
-      notice: "Message has been moved to Inbox"
-      error: "The message could not be moved to the Inbox."
     destroy:
       destroyed: "Message deleted"
     read_marks:
@@ -1792,6 +1789,10 @@ en:
         notice: "Message marked as read"
       destroy:
         notice: "Message marked as unread"
+    mutes:
+      destroy:
+        notice: "Message has been moved to Inbox"
+        error: "The message could not be moved to the Inbox."
     mailboxes:
       heading:
         my_inbox: "My Inbox"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -322,10 +322,12 @@ OpenStreetMap::Application.routes.draw do
 
   # messages
   resources :messages, :path_names => { :new => "new/:display_name" }, :id => /\d+/, :only => [:new, :create, :show, :destroy] do
-    post :mark
     patch :unmute
 
-    resource :reply, :module => :messages, :path_names => { :new => "new" }, :only => :new
+    scope :module => :messages do
+      resource :reply, :path_names => { :new => "new" }, :only => :new
+      resource :read_mark, :only => [:create, :destroy]
+    end
   end
   namespace :messages, :path => "/messages" do
     resource :inbox, :only => :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -322,11 +322,10 @@ OpenStreetMap::Application.routes.draw do
 
   # messages
   resources :messages, :path_names => { :new => "new/:display_name" }, :id => /\d+/, :only => [:new, :create, :show, :destroy] do
-    patch :unmute
-
     scope :module => :messages do
       resource :reply, :path_names => { :new => "new" }, :only => :new
       resource :read_mark, :only => [:create, :destroy]
+      resource :mute, :only => :destroy
     end
   end
   namespace :messages, :path => "/messages" do

--- a/test/controllers/messages/mutes_controller_test.rb
+++ b/test/controllers/messages/mutes_controller_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+module Messages
+  class MutesControllerTest < ActionDispatch::IntegrationTest
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/messages/1/mute", :method => :delete },
+        { :controller => "messages/mutes", :action => "destroy", :message_id => "1" }
+      )
+    end
+
+    def test_destroy_when_not_logged_in
+      sender_user = create(:user)
+      recipient_user = create(:user)
+      create(:user_mute, :owner => recipient_user, :subject => sender_user)
+      message = create(:message, :unread, :sender => sender_user, :recipient => recipient_user)
+
+      delete message_mute_path(message)
+      assert_response :forbidden
+    end
+
+    def test_destroy_as_other_user
+      sender_user = create(:user)
+      recipient_user = create(:user)
+      create(:user_mute, :owner => recipient_user, :subject => sender_user)
+      message = create(:message, :unread, :sender => sender_user, :recipient => recipient_user)
+      session_for(create(:user))
+
+      delete message_mute_path(message)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+
+    def test_destroy_as_sender
+      sender_user = create(:user)
+      recipient_user = create(:user)
+      create(:user_mute, :owner => recipient_user, :subject => sender_user)
+      message = create(:message, :unread, :sender => sender_user, :recipient => recipient_user)
+      session_for(sender_user)
+
+      delete message_mute_path(message)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+
+    def test_destroy_as_recipient
+      sender_user = create(:user)
+      recipient_user = create(:user)
+      create(:user_mute, :owner => recipient_user, :subject => sender_user)
+      message = create(:message, :unread, :sender => sender_user, :recipient => recipient_user)
+      session_for(recipient_user)
+
+      delete message_mute_path(message)
+      assert_redirected_to messages_inbox_path
+      assert_not message.reload.muted
+    end
+
+    def test_destroy_on_missing_message
+      session_for(create(:user))
+
+      delete message_mute_path(99999)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+  end
+end

--- a/test/controllers/messages/read_marks_controller_test.rb
+++ b/test/controllers/messages/read_marks_controller_test.rb
@@ -1,0 +1,126 @@
+require "test_helper"
+
+module Messages
+  class ReadMarksControllerTest < ActionDispatch::IntegrationTest
+    ##
+    # test all routes which lead to this controller
+    def test_routes
+      assert_routing(
+        { :path => "/messages/1/read_mark", :method => :post },
+        { :controller => "messages/read_marks", :action => "create", :message_id => "1" }
+      )
+      assert_routing(
+        { :path => "/messages/1/read_mark", :method => :delete },
+        { :controller => "messages/read_marks", :action => "destroy", :message_id => "1" }
+      )
+    end
+
+    def test_create_when_not_logged_in
+      message = create(:message, :unread)
+
+      post message_read_mark_path(message)
+      assert_response :forbidden
+    end
+
+    def test_create_as_other_user
+      message = create(:message, :unread)
+      session_for(create(:user))
+
+      post message_read_mark_path(message)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+
+    def test_create_as_sender
+      message = create(:message, :unread)
+      session_for(message.sender)
+
+      post message_read_mark_path(message)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+
+    def test_create_as_recipient
+      message = create(:message, :unread)
+      session_for(message.recipient)
+
+      post message_read_mark_path(message)
+      assert_redirected_to messages_inbox_path
+      assert message.reload.message_read
+    end
+
+    def test_create_on_missing_message
+      session_for(create(:user))
+
+      post message_read_mark_path(99999)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+
+    def test_create_on_message_from_muted_user
+      sender_user = create(:user)
+      recipient_user = create(:user)
+      create(:user_mute, :owner => recipient_user, :subject => sender_user)
+      message = create(:message, :unread, :sender => sender_user, :recipient => recipient_user)
+      session_for(recipient_user)
+
+      post message_read_mark_path(message)
+      assert_redirected_to messages_muted_inbox_path
+      assert message.reload.message_read
+    end
+
+    def test_destroy_when_not_logged_in
+      message = create(:message, :read)
+
+      delete message_read_mark_path(message)
+      assert_response :forbidden
+    end
+
+    def test_destroy_as_other_user
+      message = create(:message, :read)
+      session_for(create(:user))
+
+      delete message_read_mark_path(message)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+
+    def test_destroy_as_sender
+      message = create(:message, :read)
+      session_for(message.sender)
+
+      delete message_read_mark_path(message)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+
+    def test_destroy_as_recipient
+      message = create(:message, :read)
+      session_for(message.recipient)
+
+      delete message_read_mark_path(message)
+      assert_redirected_to messages_inbox_path
+      assert_not message.reload.message_read
+    end
+
+    def test_destroy_on_missing_message
+      session_for(create(:user))
+
+      delete message_read_mark_path(99999)
+      assert_response :not_found
+      assert_template "no_such_message"
+    end
+
+    def test_destroy_on_message_from_muted_user
+      sender_user = create(:user)
+      recipient_user = create(:user)
+      create(:user_mute, :owner => recipient_user, :subject => sender_user)
+      message = create(:message, :read, :sender => sender_user, :recipient => recipient_user)
+      session_for(recipient_user)
+
+      delete message_read_mark_path(message, :mark => "unread")
+      assert_redirected_to messages_muted_inbox_path
+      assert_not message.reload.message_read
+    end
+  end
+end


### PR DESCRIPTION
Converts remaining actions of messages controller that RuboCop doesn't like into resources:
- `read_mark` which can be created and destroyed instead of `mark` action
- `mute` which can be destroyed instead of `unmute` action