### PR TITLE
Initialize I18n and OSM as soon as application.js loads

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,29 @@
 //= require richtext
 //= require qs/dist/qs
 
+{
+  const application_data = $("head").data();
+
+  I18n.default_locale = OSM.DEFAULT_LOCALE;
+  I18n.locale = application_data.locale;
+  I18n.fallbacks = true;
+
+  OSM.preferred_editor = application_data.preferredEditor;
+  OSM.preferred_languages = application_data.preferredLanguages;
+
+  if (application_data.user) {
+    OSM.user = application_data.user;
+
+    if (application_data.userHome) {
+      OSM.home = application_data.userHome;
+    }
+  }
+
+  if (application_data.location) {
+    OSM.location = application_data.location;
+  }
+}
+
 /*
  * Called as the user scrolls/zooms around to manipulate hrefs of the
  * view tab and various other links
@@ -121,27 +144,6 @@ $(document).ready(function () {
   $("nav.primary li a").on("click", function () {
     $("header").toggleClass("closed");
   });
-
-  var application_data = $("head").data();
-
-  I18n.default_locale = OSM.DEFAULT_LOCALE;
-  I18n.locale = application_data.locale;
-  I18n.fallbacks = true;
-
-  OSM.preferred_editor = application_data.preferredEditor;
-  OSM.preferred_languages = application_data.preferredLanguages;
-
-  if (application_data.user) {
-    OSM.user = application_data.user;
-
-    if (application_data.userHome) {
-      OSM.home = application_data.userHome;
-    }
-  }
-
-  if (application_data.location) {
-    OSM.location = application_data.location;
-  }
 
   $("#edit_tab")
     .attr("title", I18n.t("javascripts.site.edit_disabled_tooltip"));


### PR DESCRIPTION
That's what was happening before https://github.com/openstreetmap/openstreetmap-website/commit/d7b4f88d5e342b5c2b4f2435d0394e4286524678, but after that the init code was moved inside `$(document).ready( ... )`. That means it may not run before other code wants to use it, like https://github.com/openstreetmap/openstreetmap-website/pull/5402#discussion_r1923067165. `<head>` already exists by the time application.js runs, it should be possible to read html attributes from there.