### PR TITLE
Add user transient attribute to oauth factories

### DIFF
--- a/test/abilities/api_abilities_test.rb
+++ b/test/abilities/api_abilities_test.rb
@@ -36,7 +36,7 @@ end
 
 class ModeratorApiAbilityTest < ApiAbilityTest
   test "Note permissions" do
-    token = create(:oauth_access_token, :scopes => %w[write_notes], :resource_owner_id => create(:moderator_user).id)
+    token = create(:oauth_access_token, :scopes => %w[write_notes], :user => create(:moderator_user))
     ability = ApiAbility.new token
 
     [:index, :create, :comment, :feed, :show, :search, :close, :reopen, :destroy].each do |action|

--- a/test/abilities/api_capability_test.rb
+++ b/test/abilities/api_capability_test.rb
@@ -26,7 +26,7 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with permissionless token" do
-    token = create(:oauth_access_token, :resource_owner_id => create(:moderator_user).id)
+    token = create(:oauth_access_token, :user => create(:moderator_user))
     ability = ApiAbility.new token
 
     [:create, :destroy, :restore].each do |action|
@@ -35,7 +35,7 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with write_api token" do
-    token = create(:oauth_access_token, :resource_owner_id => create(:moderator_user).id, :scopes => %w[write_api])
+    token = create(:oauth_access_token, :user => create(:moderator_user), :scopes => %w[write_api])
     ability = ApiAbility.new token
 
     [:create, :destroy, :restore].each do |action|
@@ -68,7 +68,7 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with permissionless token" do
-    token = create(:oauth_access_token, :resource_owner_id => create(:moderator_user).id)
+    token = create(:oauth_access_token, :user => create(:moderator_user))
     ability = ApiAbility.new token
 
     [:destroy].each do |action|
@@ -77,7 +77,7 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with write_notes token" do
-    token = create(:oauth_access_token, :resource_owner_id => create(:moderator_user).id, :scopes => %w[write_notes])
+    token = create(:oauth_access_token, :user => create(:moderator_user), :scopes => %w[write_notes])
     ability = ApiAbility.new token
 
     [:destroy].each do |action|

--- a/test/controllers/oauth2_authorized_applications_controller_test.rb
+++ b/test/controllers/oauth2_authorized_applications_controller_test.rb
@@ -17,10 +17,10 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
   def test_index
     user = create(:user)
     application1 = create(:oauth_application)
-    create(:oauth_access_grant, :resource_owner_id => user.id, :application => application1)
+    create(:oauth_access_grant, :user => user, :application => application1)
     create(:oauth_access_token, :user => user, :application => application1)
     application2 = create(:oauth_application)
-    create(:oauth_access_grant, :resource_owner_id => user.id, :application => application2)
+    create(:oauth_access_grant, :user => user, :application => application2)
     create(:oauth_access_token, :user => user, :application => application2)
     create(:oauth_application)
 
@@ -38,9 +38,9 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
   def test_index_scopes
     user = create(:user)
     application1 = create(:oauth_application, :scopes => %w[read_prefs write_prefs write_diary read_gpx write_gpx])
-    create(:oauth_access_grant, :resource_owner_id => user.id, :application => application1, :scopes => %w[read_prefs write_prefs])
+    create(:oauth_access_grant, :user => user, :application => application1, :scopes => %w[read_prefs write_prefs])
     create(:oauth_access_token, :user => user, :application => application1, :scopes => %w[read_prefs write_prefs])
-    create(:oauth_access_grant, :resource_owner_id => user.id, :application => application1, :scopes => %w[read_prefs write_diary])
+    create(:oauth_access_grant, :user => user, :application => application1, :scopes => %w[read_prefs write_diary])
     create(:oauth_access_token, :user => user, :application => application1, :scopes => %w[read_prefs write_diary])
 
     get oauth_authorized_applications_path
@@ -63,10 +63,10 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
   def test_destroy
     user = create(:user)
     application1 = create(:oauth_application)
-    create(:oauth_access_grant, :resource_owner_id => user.id, :application => application1)
+    create(:oauth_access_grant, :user => user, :application => application1)
     create(:oauth_access_token, :user => user, :application => application1)
     application2 = create(:oauth_application)
-    create(:oauth_access_grant, :resource_owner_id => user.id, :application => application2)
+    create(:oauth_access_grant, :user => user, :application => application2)
     create(:oauth_access_token, :user => user, :application => application2)
     create(:oauth_application)
 

--- a/test/controllers/oauth2_authorized_applications_controller_test.rb
+++ b/test/controllers/oauth2_authorized_applications_controller_test.rb
@@ -18,10 +18,10 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
     user = create(:user)
     application1 = create(:oauth_application)
     create(:oauth_access_grant, :resource_owner_id => user.id, :application => application1)
-    create(:oauth_access_token, :resource_owner_id => user.id, :application => application1)
+    create(:oauth_access_token, :user => user, :application => application1)
     application2 = create(:oauth_application)
     create(:oauth_access_grant, :resource_owner_id => user.id, :application => application2)
-    create(:oauth_access_token, :resource_owner_id => user.id, :application => application2)
+    create(:oauth_access_token, :user => user, :application => application2)
     create(:oauth_application)
 
     get oauth_authorized_applications_path
@@ -39,9 +39,9 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
     user = create(:user)
     application1 = create(:oauth_application, :scopes => %w[read_prefs write_prefs write_diary read_gpx write_gpx])
     create(:oauth_access_grant, :resource_owner_id => user.id, :application => application1, :scopes => %w[read_prefs write_prefs])
-    create(:oauth_access_token, :resource_owner_id => user.id, :application => application1, :scopes => %w[read_prefs write_prefs])
+    create(:oauth_access_token, :user => user, :application => application1, :scopes => %w[read_prefs write_prefs])
     create(:oauth_access_grant, :resource_owner_id => user.id, :application => application1, :scopes => %w[read_prefs write_diary])
-    create(:oauth_access_token, :resource_owner_id => user.id, :application => application1, :scopes => %w[read_prefs write_diary])
+    create(:oauth_access_token, :user => user, :application => application1, :scopes => %w[read_prefs write_diary])
 
     get oauth_authorized_applications_path
     assert_redirected_to login_path(:referer => oauth_authorized_applications_path)
@@ -64,10 +64,10 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
     user = create(:user)
     application1 = create(:oauth_application)
     create(:oauth_access_grant, :resource_owner_id => user.id, :application => application1)
-    create(:oauth_access_token, :resource_owner_id => user.id, :application => application1)
+    create(:oauth_access_token, :user => user, :application => application1)
     application2 = create(:oauth_application)
     create(:oauth_access_grant, :resource_owner_id => user.id, :application => application2)
-    create(:oauth_access_token, :resource_owner_id => user.id, :application => application2)
+    create(:oauth_access_token, :user => user, :application => application2)
     create(:oauth_application)
 
     delete oauth_authorized_application_path(:id => application1.id)

--- a/test/factories/oauth_access_grant.rb
+++ b/test/factories/oauth_access_grant.rb
@@ -1,9 +1,14 @@
 FactoryBot.define do
   factory :oauth_access_grant, :class => "Doorkeeper::AccessGrant" do
-    resource_owner_id :factory => :user
     application :factory => :oauth_application
+
+    resource_owner_id { user.id }
 
     expires_in { 86400 }
     redirect_uri { application.redirect_uri }
+
+    transient do
+      user { create(:user) } # rubocop:disable FactoryBot/FactoryAssociationWithStrategy
+    end
   end
 end

--- a/test/factories/oauth_access_token.rb
+++ b/test/factories/oauth_access_token.rb
@@ -2,6 +2,10 @@ FactoryBot.define do
   factory :oauth_access_token, :class => "Doorkeeper::AccessToken" do
     application :factory => :oauth_application
 
-    resource_owner_id { create(:user).id }
+    resource_owner_id { user.id }
+
+    transient do
+      user { create(:user) } # rubocop:disable FactoryBot/FactoryAssociationWithStrategy
+    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -306,7 +306,7 @@ class UserTest < ActiveSupport::TestCase
 
   def test_soft_destroy_revokes_oauth2_tokens
     user = create(:user)
-    oauth_access_token = create(:oauth_access_token, :resource_owner_id => user.id)
+    oauth_access_token = create(:oauth_access_token, :user => user)
     assert_equal 1, user.access_tokens.not_expired.count
 
     user.soft_destroy

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -138,7 +138,7 @@ module ActiveSupport
     def bearer_authorization_header(token_or_user = nil, scopes: Oauth::SCOPES)
       token = case token_or_user
               when nil then create(:oauth_access_token, :scopes => scopes).token
-              when User then create(:oauth_access_token, :resource_owner_id => token_or_user.id, :scopes => scopes).token
+              when User then create(:oauth_access_token, :user => token_or_user, :scopes => scopes).token
               when Doorkeeper::AccessToken then token_or_user.token
               when String then token_or_user
               end


### PR DESCRIPTION
It's annoying to type
```
create(:oauth_access_token, :resource_owner_id => user.id, ...
```

This PR shortens it to
```
create(:oauth_access_grant, :user => user, ...
```

Doorkeper classes don't have actual associations with our models and looks like this line in `oauth_access_grant` factory never worked
```
resource_owner_id :factory => :user
```
And I also have to tell RuboCop not to enforce these associations.