### PR TITLE
Remove doorkeeper_token branch from web deny_access

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -304,10 +304,7 @@ class ApplicationController < ActionController::Base
   end
 
   def deny_access(_exception)
-    if doorkeeper_token
-      set_locale
-      report_error t("oauth.permissions.missing"), :forbidden
-    elsif current_user
+    if current_user
       set_locale
       respond_to do |format|
         format.html { redirect_to :controller => "/errors", :action => "forbidden" }


### PR DESCRIPTION
`deny_access` was split into `web_deny_access` and `api_deny_access` in https://github.com/openstreetmap/openstreetmap-website/commit/8f70fb21146b1e8b90125e02d54e70bceea1d5fd. Later `api_deny_access` was moved to `ApiController` in https://github.com/openstreetmap/openstreetmap-website/commit/742291a840ea9dd741ef439e8678c50d1537973b. However the token-checking branch was left in `ApplicationController`. You're not going to have `doorkeeper_token` outside of the api, right?