### PR TITLE
Move scope_enabled? to ApiController

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -170,4 +170,10 @@ class ApiController < ApplicationController
 
     raise OSM::APIRateLimitExceeded if new_changes > max_changes
   end
+
+  def scope_enabled?(scope)
+    doorkeeper_token&.includes_scope?(scope)
+  end
+
+  helper_method :scope_enabled?
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -354,10 +354,4 @@ class ApplicationController < ActionController::Base
 
     referer&.to_s
   end
-
-  def scope_enabled?(scope)
-    doorkeeper_token&.includes_scope?(scope)
-  end
-
-  helper_method :scope_enabled?
 end


### PR DESCRIPTION
`scope_enabled?` is only called from api controllers/views and it references `doorkeeper_token` available only during api calls.