### PR TITLE
Simplify write_notes scope check in api notes controller

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -384,11 +384,7 @@ module Api
     def add_comment(note, text, event, notify: true)
       attributes = { :visible => true, :event => event, :body => text }
 
-      if doorkeeper_token
-        author = current_user if scope_enabled?(:write_notes)
-      else
-        author = current_user
-      end
+      author = current_user if scope_enabled?(:write_notes)
 
       if author
         attributes[:author_id] = author.id

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -230,6 +230,17 @@ module Api
       assert_equal note, subscription.note
     end
 
+    def test_create_no_scope_fail
+      user = create(:user)
+      auth_header = bearer_authorization_header user, :scopes => %w[read_prefs]
+
+      assert_no_difference "Note.count" do
+        post api_notes_path(:lat => -1.0, :lon => -1.0, :text => "This is a description", :format => "json"), :headers => auth_header
+
+        assert_response :forbidden
+      end
+    end
+
     def test_comment_success
       open_note_with_comment = create(:note_with_comments)
       user = create(:user)


### PR DESCRIPTION
`scope_enabled?` returns nil if there's no `doorkeeper_token`, then `author` stays undefined. The else branch removed in this PR would have done the same because there's no `current_user` in this case too.