### PR TITLE
Add eslint-plugin-erb to provide linting of our .js.erb files

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -10,15 +10,15 @@ $(document).ready(function () {
     var params = {};
 
     if (mapParams.object) {
-      params.id = mapParams.object.type + '/' + mapParams.object.id;
+      params.id = mapParams.object.type + "/" + mapParams.object.id;
       mapParams = OSM.parseHash(location.hash);
       if (mapParams.center) {
-        params.map = mapParams.zoom + '/' + mapParams.center.lat + '/' + mapParams.center.lng;
+        params.map = mapParams.zoom + "/" + mapParams.center.lat + "/" + mapParams.center.lng;
       }
     } else if (id.data("lat") && id.data("lon")) {
       params.map = "16/" + id.data("lat") + "/" + id.data("lon");
     } else {
-      params.map = (mapParams.zoom || 17) + '/' + mapParams.lat + '/' + mapParams.lon;
+      params.map = (mapParams.zoom || 17) + "/" + mapParams.lat + "/" + mapParams.lon;
     }
 
     if (hashParams.background) params.background = hashParams.background;

--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -15,13 +15,13 @@ I18n.default_locale = <%= I18n.default_locale.to_json %>;
 I18n.fallbacks = true;
 
 window.onload = function () {
-  var query = (window.location.search || '?').slice(1),
-      args  = {};
+  var query = (window.location.search || "?").slice(1),
+      args = {};
 
-  var pairs = query.split('&');
+  var pairs = query.split("&");
   for (var i = 0; i < pairs.length; i++) {
-    var parts = pairs[i].split('=');
-    args[parts[0]] = decodeURIComponent(parts[1] || '');
+    var parts = pairs[i].split("=");
+    args[parts[0]] = decodeURIComponent(parts[1] || "");
   }
 
   var mapnikOptions = {
@@ -37,7 +37,7 @@ window.onload = function () {
   };
 
   var map = L.map("map");
-  map.attributionControl.setPrefix('');
+  map.attributionControl.setPrefix("");
   map.removeControl(map.attributionControl);
 
   if (args.layer === "cyclosm") {
@@ -53,19 +53,21 @@ window.onload = function () {
   }
 
   if (args.marker) {
-    L.marker(args.marker.split(','), {icon: L.icon({
+    L.marker(args.marker.split(","), { icon: L.icon({
       iconUrl: <%= asset_path('leaflet/dist/images/marker-icon.png').to_json %>,
       iconSize: new L.Point(25, 41),
       iconAnchor: new L.Point(12, 41),
       shadowUrl: <%= asset_path('leaflet/dist/images/marker-shadow.png').to_json %>,
       shadowSize: new L.Point(41, 41)
-    })}).addTo(map);
+    }) }).addTo(map);
   }
 
   if (args.bbox) {
-    var bbox = args.bbox.split(',');
-    map.fitBounds([L.latLng(bbox[1], bbox[0]),
-                   L.latLng(bbox[3], bbox[2])]);
+    var bbox = args.bbox.split(",");
+    map.fitBounds([
+      L.latLng(bbox[1], bbox[0]),
+      L.latLng(bbox[3], bbox[2])
+    ]);
   } else {
     map.fitWorld();
   }
@@ -75,14 +77,14 @@ window.onload = function () {
 
 L.Control.OSMReportAProblem = L.Control.Attribution.extend({
   options: {
-    position: 'bottomright',
-    prefix: '<a href="https://www.openstreetmap.org/fixthemap?lat={x}&lon={y}&zoom={z}" target="_blank">'+I18n.t('javascripts.embed.report_problem')+'</a>'
+    position: "bottomright",
+    prefix: "<a href=\"https://www.openstreetmap.org/fixthemap?lat={x}&lon={y}&zoom={z}\" target=\"_blank\">" + I18n.t("javascripts.embed.report_problem") + "</a>"
   },
 
   onAdd: function (map) {
     var container = L.Control.Attribution.prototype.onAdd.call(this, map);
 
-    map.on('moveend', this._update, this);
+    map.on("moveend", this._update, this);
 
     return container;
   },
@@ -92,8 +94,8 @@ L.Control.OSMReportAProblem = L.Control.Attribution.extend({
 
     this._container.innerHTML =
       this._container.innerHTML
-        .replace('{x}', this._map.getCenter().lat)
-        .replace('{y}', this._map.getCenter().lng)
-        .replace('{z}', this._map.getZoom());
+        .replace("{x}", this._map.getCenter().lat)
+        .replace("{y}", this._map.getCenter().lng)
+        .replace("{z}", this._map.getZoom());
   }
 });

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -58,16 +58,16 @@ OSM = {
     return url;
   },
 
-  params: function(search) {
+  params: function (search) {
     var params = {};
 
-    search = (search || window.location.search).replace('?', '').split(/&|;/);
+    search = (search || window.location.search).replace("?", "").split(/&|;/);
 
     for (var i = 0; i < search.length; ++i) {
       var pair = search[i],
-        j = pair.indexOf('='),
-        key = pair.slice(0, j),
-        val = pair.slice(++j);
+          j = pair.indexOf("="),
+          key = pair.slice(0, j),
+          val = pair.slice(++j);
 
       try {
         params[key] = decodeURIComponent(val);
@@ -90,18 +90,18 @@ OSM = {
 
     // Old-style object parameters; still in use for edit links e.g. /edit?way=1234
     if (params.node) {
-      mapParams.object = {type: 'node', id: parseInt(params.node)};
+      mapParams.object = { type: "node", id: parseInt(params.node, 10) };
     } else if (params.way) {
-      mapParams.object = {type: 'way', id: parseInt(params.way)};
+      mapParams.object = { type: "way", id: parseInt(params.way, 10) };
     } else if (params.relation) {
-      mapParams.object = {type: 'relation', id: parseInt(params.relation)};
+      mapParams.object = { type: "relation", id: parseInt(params.relation, 10) };
     } else if (params.note) {
-      mapParams.object = {type: 'note', id: parseInt(params.note)};
+      mapParams.object = { type: "note", id: parseInt(params.note, 10) };
     }
 
     var hash = OSM.parseHash(location.hash);
 
-    const loc = Cookies.get('_osm_location')?.split("|");
+    const loc = Cookies.get("_osm_location")?.split("|");
 
     // Decide on a map starting position. Various ways of doing this.
     if (hash.center) {
@@ -109,7 +109,7 @@ OSM = {
       mapParams.lat = hash.center.lat;
       mapParams.zoom = hash.zoom;
     } else if (params.bbox) {
-      var bbox = params.bbox.split(',');
+      var bbox = params.bbox.split(",");
       mapParams.bounds = L.latLngBounds(
         [parseFloat(bbox[1]), parseFloat(bbox[0])],
         [parseFloat(bbox[3]), parseFloat(bbox[2])]);
@@ -120,28 +120,27 @@ OSM = {
     } else if (params.mlon && params.mlat) {
       mapParams.lon = parseFloat(params.mlon);
       mapParams.lat = parseFloat(params.mlat);
-      mapParams.zoom = parseInt(params.zoom || 12);
+      mapParams.zoom = parseInt(params.zoom || 12, 10);
     } else if (loc) {
       mapParams.lon = parseFloat(loc[0]);
       mapParams.lat = parseFloat(loc[1]);
-      mapParams.zoom = parseInt(loc[2]);
+      mapParams.zoom = parseInt(loc[2], 10);
     } else if (OSM.home) {
       mapParams.lon = OSM.home.lon;
       mapParams.lat = OSM.home.lat;
       mapParams.zoom = 10;
     } else if (OSM.location) {
       mapParams.bounds = L.latLngBounds(
-        [OSM.location.minlat,
-         OSM.location.minlon],
-        [OSM.location.maxlat,
-         OSM.location.maxlon]);
+        [OSM.location.minlat, OSM.location.minlon],
+        [OSM.location.maxlat, OSM.location.maxlon]
+      );
     } else {
       mapParams.lon = -0.1;
       mapParams.lat = 51.5;
-      mapParams.zoom = parseInt(params.zoom || 5);
+      mapParams.zoom = parseInt(params.zoom || 5, 10);
     }
 
-    mapParams.layers = hash.layers || (loc && loc[3]) || '';
+    mapParams.layers = hash.layers || (loc && loc[3]) || "";
 
     var scale = parseFloat(params.scale);
     if (scale > 0) {
@@ -151,20 +150,20 @@ OSM = {
     return mapParams;
   },
 
-  parseHash: function(hash) {
+  parseHash: function (hash) {
     var args = {};
 
-    var i = hash.indexOf('#');
+    var i = hash.indexOf("#");
     if (i < 0) {
       return args;
     }
 
     hash = Qs.parse(hash.slice(i + 1));
 
-    var map = (hash.map || '').split('/'),
-      zoom = parseInt(map[0], 10),
-      lat = parseFloat(map[1]),
-      lon = parseFloat(map[2]);
+    var map = (hash.map || "").split("/"),
+        zoom = parseInt(map[0], 10),
+        lat = parseFloat(map[1]),
+        lon = parseFloat(map[2]);
 
     if (!isNaN(zoom) && !isNaN(lat) && !isNaN(lon)) {
       args.center = new L.LatLng(lat, lon);
@@ -178,7 +177,7 @@ OSM = {
     return args;
   },
 
-  formatHash: function(args) {
+  formatHash: function (args) {
     var center, zoom, layers;
 
     if (args instanceof L.Map) {
@@ -188,44 +187,44 @@ OSM = {
     } else {
       center = args.center || L.latLng(args.lat, args.lon);
       zoom = args.zoom;
-      layers = args.layers || '';
+      layers = args.layers || "";
     }
 
     center = center.wrap();
-    layers = layers.replace('M', '');
+    layers = layers.replace("M", "");
 
     var precision = OSM.zoomPrecision(zoom),
-      hash = '#map=' + zoom +
-        '/' + center.lat.toFixed(precision) +
-        '/' + center.lng.toFixed(precision);
+        hash = "#map=" + zoom +
+          "/" + center.lat.toFixed(precision) +
+          "/" + center.lng.toFixed(precision);
 
     if (layers) {
-      hash += '&layers=' + layers;
+      hash += "&layers=" + layers;
     }
 
     return hash;
   },
 
-  zoomPrecision: function(zoom) {
+  zoomPrecision: function (zoom) {
     var pixels = Math.pow(2, 8 + zoom);
     var degrees = 180;
     return Math.ceil(Math.log10(pixels / degrees));
   },
 
-  locationCookie: function(map) {
+  locationCookie: function (map) {
     var center = map.getCenter().wrap(),
-      zoom = map.getZoom(),
-      precision = OSM.zoomPrecision(zoom);
-    return [center.lng.toFixed(precision), center.lat.toFixed(precision), zoom, map.getLayersCode()].join('|');
+        zoom = map.getZoom(),
+        precision = OSM.zoomPrecision(zoom);
+    return [center.lng.toFixed(precision), center.lat.toFixed(precision), zoom, map.getLayersCode()].join("|");
   },
 
-  distance: function(latlng1, latlng2) {
+  distance: function (latlng1, latlng2) {
     var lat1 = latlng1.lat * Math.PI / 180,
-      lng1 = latlng1.lng * Math.PI / 180,
-      lat2 = latlng2.lat * Math.PI / 180,
-      lng2 = latlng2.lng * Math.PI / 180,
-      latdiff = lat2 - lat1,
-      lngdiff = lng2 - lng1;
+        lng1 = latlng1.lng * Math.PI / 180,
+        lat2 = latlng2.lat * Math.PI / 180,
+        lng2 = latlng2.lng * Math.PI / 180,
+        latdiff = lat2 - lat1,
+        lngdiff = lng2 - lng1;
 
     return 6372795 * 2 * Math.asin(
       Math.sqrt(

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -1,8 +1,10 @@
 const globals = require("globals");
 const js = require("@eslint/js");
+const erb = require("eslint-plugin-erb");
 
 module.exports = [
   js.configs.recommended,
+  erb.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
@@ -19,6 +21,15 @@ module.exports = [
         Turbo: "readonly",
         updateLinks: "readonly"
       }
+    },
+    linterOptions: {
+      // The "unused disable directive" is set to "warn" by default.
+      // For the ERB plugin to work correctly, you must disable
+      // this directive to avoid issues described here
+      // https://github.com/eslint/eslint/discussions/18114
+      // If you're using the CLI, you might also use the following flag:
+      // --report-unused-disable-directives-severity=off
+      reportUnusedDisableDirectives: "off"
     },
     rules: {
       "accessor-pairs": "error",

--- a/lib/tasks/eslint.rake
+++ b/lib/tasks/eslint.rake
@@ -10,7 +10,7 @@ end
 
 def js_files
   Rails.application.assets.each_file.select do |file|
-    file.ends_with?(".js") && !file.match?(%r{/(gems|vendor|i18n|node_modules)/})
+    (file.ends_with?(".js") || file.ends_with?(".js.erb")) && !file.match?(%r{/(gems|vendor|i18n|node_modules)/})
   end
 end
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "openstreetmap",
   "private": true,
   "dependencies": {
+    "eslint-plugin-erb": "^2.1.0",
     "jquery-simulate": "^1.0.2",
     "js-cookie": "^3.0.0",
     "leaflet": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,6 +259,11 @@ eslint-formatter-compact@^8.40.0:
   resolved "https://registry.yarnpkg.com/eslint-formatter-compact/-/eslint-formatter-compact-8.40.0.tgz#d7455b2d75fd70e8c0e7a98a5e189f168e9dfe2d"
   integrity sha512-cwGUs113TgmTQXecx5kfRjB7m0y2wkDLSadPTE2pK6M/wO4N8PjmUaoWOFNCP9MHgsiZwgqd5bZFnDCnszC56Q==
 
+eslint-plugin-erb@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-erb/-/eslint-plugin-erb-2.1.1.tgz#8a0a6c2bcaf3a8573c381b595969145aff93cfc6"
+  integrity sha512-AhznaVwRpQqR8NADjN4SZnKNbaIdAbGxTjCg6cj3UhwGyQOUJ6kXwhYrl1LYrGDNx7Ouyd8xuEG7wepFZyPgFw==
+
 eslint-scope@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.2.0.tgz#377aa6f1cb5dc7592cfd0b7f892fd0cf352ce442"


### PR DESCRIPTION
Fixes #5523 

This is a draft, since our .js.erb files don't currently pass the linting. I've fixed the straightforward ones in #5548 but there are a few more to complete before this can be merged.

I've opened this pull request to make it easier for other developers (who have more JS skills) to help. My recommendation is to checkout this pull request locally, fix the errors, and submit those fixes separately as PRs (e.g. cherry-pick your fixes onto our master branch).