### PR TITLE
Added error handling for data layer

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -63,6 +63,17 @@ OSM.initializeDataLayer = function (map) {
           .click(add)));
   }
 
+  function displayLoadError(message) {
+    $("#browse_status").html(
+      $("<div class='p-3'>").append(
+        $("<h2 class='flex-grow-1 text-break'>")
+          .text(I18n.t("browse.start_rjs.load_data")),
+        $("<div>").append(
+          $("<div class='d-flex'>").append(
+            $("<p class='alert alert-warning'>")
+              .text(I18n.t("browse.start_rjs.feature_error", { message: message }))))));
+  }
+
   var dataLoader;
 
   function getData() {
@@ -114,6 +125,18 @@ OSM.initializeDataLayer = function (map) {
         }
 
         dataLoader = null;
+      },
+      error: function (XMLHttpRequest, textStatus) {
+        dataLoader = null;
+        if (textStatus === "abort") { return; }
+
+        if (XMLHttpRequest.status === 400 && XMLHttpRequest.responseText) {
+          displayLoadError(XMLHttpRequest.responseText);
+        } else if (XMLHttpRequest.statusText) {
+          displayLoadError(XMLHttpRequest.statusText);
+        } else {
+          displayLoadError(String(XMLHttpRequest.status));
+        }
       }
     });
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,6 +392,7 @@ en:
         relation: "relation"
     start_rjs:
       feature_warning: "Loading %{num_features} features, which may make your browser slow or unresponsive. Are you sure you want to display this data?"
+      feature_error: "Features could not be loaded: %{message}"
       load_data: "Load Data"
       loading: "Loading..."
     tag_details:


### PR DESCRIPTION
As discussed in https://github.com/openstreetmap/openstreetmap-website/pull/5474#issuecomment-2585349128, this PR adds error handling for failed API calls when displaying the data layer.

Sample screenshot:

![image](https://github.com/user-attachments/assets/4d2d2e77-fcb5-43c4-a5ba-a4c3ffaa8b71)
![image](https://github.com/user-attachments/assets/ecd1e9fc-19af-451b-8cbe-3129700e01de)

Oh well, and this one is a topic for another PR:

![image](https://github.com/user-attachments/assets/7902ee78-f0ea-41a3-a91b-f718a4a70b12)

