### PR TITLE
Replace var in javascript with let/const

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -76,7 +76,7 @@ window.updateLinks = function (loc, zoom, layers, object) {
 
   // Disable the button group and also the buttons to avoid
   // inconsistent behaviour when zooming
-  var editDisabled = zoom < 13;
+  const editDisabled = zoom < 13;
   $("#edit_tab")
     .tooltip({ placement: "bottom" })
     .tooltip(editDisabled ? "enable" : "disable")
@@ -97,7 +97,7 @@ $(document).ready(function () {
   let moreItemWidth = 0;
 
   function updateHeader() {
-    var windowWidth = $(window).width();
+    const windowWidth = $(window).width();
 
     if (windowWidth < breakpointWidth) {
       $("body").addClass("small-nav");

--- a/app/assets/javascripts/diary_entry.js
+++ b/app/assets/javascripts/diary_entry.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-  var marker, map;
+  let marker, map;
 
   function setLocation(e) {
     const latlng = e.latlng.wrap();
@@ -21,9 +21,9 @@ $(document).ready(function () {
     $("#map").show();
     $("#usemap").hide();
 
-    var params = $("#map").data();
-    var centre = [params.lat, params.lon];
-    var position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
+    const params = $("#map").data();
+    const centre = [params.lat, params.lon];
+    const position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
 
     map = L.map("map", {
       attributionControl: false,

--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -32,7 +32,7 @@ window.onload = function () {
 <% end %>
   };
 
-  var map = L.map("map");
+  const map = L.map("map");
   map.attributionControl.setPrefix("");
   map.removeControl(map.attributionControl);
 
@@ -80,7 +80,7 @@ L.Control.OSMReportAProblem = L.Control.Attribution.extend({
   },
 
   onAdd: function (map) {
-    var container = L.Control.Attribution.prototype.onAdd.call(this, map);
+    const container = L.Control.Attribution.prototype.onAdd.call(this, map);
 
     map.on("moveend", this._update, this);
 

--- a/app/assets/javascripts/fixthemap.js
+++ b/app/assets/javascripts/fixthemap.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
-  var params = OSM.params();
+  const params = OSM.params();
 
-  var url = "/note/new";
+  let url = "/note/new";
   if (!params.zoom) params.zoom = 17;
   if (params.lat && params.lon) url += OSM.formatHash(params);
   $(".icon.note").attr("href", url);

--- a/app/assets/javascripts/id.js
+++ b/app/assets/javascripts/id.js
@@ -3,7 +3,7 @@
 /* globals iD */
 
 document.addEventListener("DOMContentLoaded", function () {
-  var container = document.getElementById("id-container");
+  const container = document.getElementById("id-container");
 
   if (typeof iD === "undefined" || !iD.utilDetect().support) {
     container.innerHTML = "This editor is supported " +
@@ -11,16 +11,16 @@ document.addEventListener("DOMContentLoaded", function () {
       "Please upgrade your browser or use JOSM to edit the map.";
     container.className = "unsupported";
   } else {
-    var idContext = iD.coreContext();
+    const idContext = iD.coreContext();
     idContext.connection().apiConnections([]);
-    var url = location.protocol + "//" + location.host;
+    const url = location.protocol + "//" + location.host;
     idContext.preauth({
       url: url,
       apiUrl: url === "https://www.openstreetmap.org" ? "https://api.openstreetmap.org" : url,
       access_token: container.dataset.token
     });
 
-    var id = idContext
+    const id = idContext
       .embed(true)
       .assetPath("iD/")
       .assetMap(JSON.parse(container.dataset.assetMap))
@@ -33,18 +33,18 @@ document.addEventListener("DOMContentLoaded", function () {
       return;
     }
 
-    var hashChangedAutomatically = false;
+    let hashChangedAutomatically = false;
     id.map().on("move.embed", parent.$.throttle(250, function () {
       if (id.inIntro()) return;
-      var zoom = ~~id.map().zoom(),
-          center = id.map().center(),
-          llz = { lon: center[0], lat: center[1], zoom: zoom };
+      const zoom = ~~id.map().zoom(),
+            center = id.map().center(),
+            llz = { lon: center[0], lat: center[1], zoom: zoom };
 
       parent.updateLinks(llz, zoom);
 
       // Manually resolve URL to avoid iframe JS context weirdness.
       // https://gist.github.com/jfirebaugh/5439412
-      var hash = parent.OSM.formatHash(llz);
+      const hash = parent.OSM.formatHash(llz);
       if (hash !== parent.location.hash) {
         hashChangedAutomatically = true;
         parent.location.replace(parent.location.href.replace(/(#.*|$)/, hash));
@@ -63,7 +63,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     parent.$("body").on("click", "a.set_position", function (e) {
       e.preventDefault();
-      var data = parent.$(this).data();
+      const data = parent.$(this).data();
       goToLocation(data);
     });
 
@@ -73,7 +73,7 @@ document.addEventListener("DOMContentLoaded", function () {
         return;
       }
       e.preventDefault();
-      var data = parent.OSM.mapParams();
+      const data = parent.OSM.mapParams();
       goToLocation(data);
     });
   }

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -25,7 +25,7 @@
 //= require router
 
 $(document).ready(function () {
-  var map = new L.OSM.Map("map", {
+  const map = new L.OSM.Map("map", {
     zoomControl: false,
     layerControl: false,
     contextmenu: true,
@@ -33,7 +33,7 @@ $(document).ready(function () {
   });
 
   OSM.loadSidebarContent = function (path, callback) {
-    var content_path = path;
+    let content_path = path;
 
     map.setSidebarOverlaid(false);
 
@@ -78,7 +78,7 @@ $(document).ready(function () {
       });
   };
 
-  var params = OSM.mapParams();
+  const params = OSM.mapParams();
 
   map.attributionControl.setPrefix("");
 
@@ -90,19 +90,19 @@ $(document).ready(function () {
     }
   });
 
-  var sidebar = L.OSM.sidebar("#map-ui")
+  const sidebar = L.OSM.sidebar("#map-ui")
     .addTo(map);
 
-  var position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
+  const position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
 
   function addControlGroup(controls) {
     for (const control of controls) control.addTo(map);
 
-    var firstContainer = controls[0].getContainer();
+    const firstContainer = controls[0].getContainer();
     $(firstContainer).find(".control-button").first()
       .addClass("control-button-first");
 
-    var lastContainer = controls[controls.length - 1].getContainer();
+    const lastContainer = controls[controls.length - 1].getContainer();
     $(lastContainer).find(".control-button").last()
       .addClass("control-button-last");
   }
@@ -166,7 +166,7 @@ $(document).ready(function () {
 
   $(".leaflet-control .control-button").tooltip({ placement: "left", container: "body" });
 
-  var expiry = new Date();
+  const expiry = new Date();
   expiry.setYear(expiry.getFullYear() + 10);
 
   map.on("moveend baselayerchange overlayadd overlayremove", function () {
@@ -188,11 +188,11 @@ $(document).ready(function () {
     Cookies.set("_osm_welcome", "hide", { secure: true, expires: expiry, path: "/", samesite: "lax" });
   });
 
-  var bannerExpiry = new Date();
+  const bannerExpiry = new Date();
   bannerExpiry.setYear(bannerExpiry.getFullYear() + 1);
 
   $("#banner .btn-close").on("click", function (e) {
-    var cookieId = e.target.id;
+    const cookieId = e.target.id;
     $("#banner").hide();
     e.preventDefault();
     if (cookieId) {
@@ -203,7 +203,7 @@ $(document).ready(function () {
   if (OSM.MATOMO) {
     map.on("baselayerchange overlayadd", function (e) {
       if (e.layer.options) {
-        var goal = OSM.MATOMO.goals[e.layer.options.layerId];
+        const goal = OSM.MATOMO.goals[e.layer.options.layerId];
 
         if (goal) {
           $("body").trigger("matomogoal", goal);
@@ -223,14 +223,14 @@ $(document).ready(function () {
   }
 
   function remoteEditHandler(bbox, object) {
-    var remoteEditHost = "http://127.0.0.1:8111",
-        osmHost = location.protocol + "//" + location.host,
-        query = new URLSearchParams({
-          left: bbox.getWest() - 0.0001,
-          top: bbox.getNorth() + 0.0001,
-          right: bbox.getEast() + 0.0001,
-          bottom: bbox.getSouth() - 0.0001
-        });
+    const remoteEditHost = "http://127.0.0.1:8111",
+          osmHost = location.protocol + "//" + location.host,
+          query = new URLSearchParams({
+            left: bbox.getWest() - 0.0001,
+            top: bbox.getNorth() + 0.0001,
+            right: bbox.getEast() + 0.0001,
+            bottom: bbox.getSouth() - 0.0001
+          });
 
     if (object && object.type !== "note") query.set("select", object.type + object.id); // can't select notes
     sendRemoteEditCommand(remoteEditHost + "/load_and_zoom?" + query, function () {
@@ -253,7 +253,7 @@ $(document).ready(function () {
   }
 
   $("a[data-editor=remote]").click(function (e) {
-    var params = OSM.mapParams(this.search);
+    const params = OSM.mapParams(this.search);
     remoteEditHandler(map.getBounds(), params.object);
     e.preventDefault();
   });
@@ -273,7 +273,7 @@ $(document).ready(function () {
   }
 
   OSM.Index = function (map) {
-    var page = {};
+    const page = {};
 
     page.pushstate = page.popstate = function () {
       map.setSidebarOverlaid(true);
@@ -295,7 +295,7 @@ $(document).ready(function () {
   };
 
   OSM.Browse = function (map, type) {
-    var page = {};
+    const page = {};
 
     page.pushstate = page.popstate = function (path, id) {
       OSM.loadSidebarContent(path, function () {
@@ -308,7 +308,7 @@ $(document).ready(function () {
     };
 
     function addObject(type, id, center) {
-      var hashParams = OSM.parseHash(window.location.hash);
+      const hashParams = OSM.parseHash(window.location.hash);
       map.addObject({ type: type, id: parseInt(id, 10) }, function (bounds) {
         if (!hashParams.center && bounds.isValid() &&
             (center || !map.getBounds().contains(bounds))) {
@@ -327,7 +327,7 @@ $(document).ready(function () {
   };
 
   OSM.OldBrowse = function () {
-    var page = {};
+    const page = {};
 
     page.pushstate = page.popstate = function (path) {
       OSM.loadSidebarContent(path);
@@ -336,7 +336,7 @@ $(document).ready(function () {
     return page;
   };
 
-  var history = OSM.History(map);
+  const history = OSM.History(map);
 
   OSM.router = OSM.Router(map, {
     "/": OSM.Index(map),

--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -1,6 +1,6 @@
 OSM.Changeset = function (map) {
-  var page = {},
-      content = $("#sidebar_content");
+  const page = {},
+        content = $("#sidebar_content");
 
   page.pushstate = page.popstate = function (path) {
     OSM.loadSidebarContent(path, function () {
@@ -12,7 +12,7 @@ OSM.Changeset = function (map) {
     const changesetData = content.find("[data-changeset]").data("changeset");
     changesetData.type = "changeset";
 
-    var hashParams = OSM.parseHash(window.location.hash);
+    const hashParams = OSM.parseHash(window.location.hash);
     initialize();
     map.addObject(changesetData, function (bounds) {
       if (!hashParams.center && bounds.isValid()) {
@@ -24,7 +24,7 @@ OSM.Changeset = function (map) {
   };
 
   function updateChangeset(method, url, include_data) {
-    var data;
+    let data;
 
     content.find("#comment-error").prop("hidden", true);
     content.find("button[data-method][data-url]").prop("disabled", true);
@@ -56,8 +56,8 @@ OSM.Changeset = function (map) {
   function initialize() {
     content.find("button[data-method][data-url]").on("click", function (e) {
       e.preventDefault();
-      var data = $(e.target).data();
-      var include_data = e.target.name === "comment";
+      const data = $(e.target).data();
+      const include_data = e.target.name === "comment";
       updateChangeset(data.method, data.url, include_data);
     });
 

--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -69,7 +69,7 @@ OSM.initializeContextMenu = function (map) {
     return $(input).val();
   }
 
-  var updateMenu = function updateMenu() {
+  const updateMenu = function updateMenu() {
     map.contextmenu.setDisabled(2, map.getZoom() < 12);
     map.contextmenu.setDisabled(4, map.getZoom() < 14);
   };

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -1,5 +1,5 @@
 OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, changeCallback) {
-  var endpoint = {};
+  const endpoint = {};
 
   endpoint.marker = L.marker([0, 0], {
     icon: L.icon({
@@ -52,7 +52,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
 
   function inputChangeListener(e) {
     // make text the same in both text boxes
-    var value = e.target.value;
+    const value = e.target.value;
     endpoint.setValue(value);
   }
 
@@ -61,8 +61,8 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     delete endpoint.geocodeRequest;
     input.removeClass("is-invalid");
 
-    var coordinatesMatch = value.match(/^\s*([+-]?\d+(?:\.\d*)?)(?:\s+|\s*[/,]\s*)([+-]?\d+(?:\.\d*)?)\s*$/);
-    var latlng = coordinatesMatch && L.latLng(coordinatesMatch[1], coordinatesMatch[2]);
+    const coordinatesMatch = value.match(/^\s*([+-]?\d+(?:\.\d*)?)(?:\s+|\s*[/,]\s*)([+-]?\d+(?:\.\d*)?)\s*$/);
+    const latlng = coordinatesMatch && L.latLng(coordinatesMatch[1], coordinatesMatch[2]);
 
     if (latlng && endpoint.cachedReverseGeocode && endpoint.cachedReverseGeocode.latlng.equals(latlng)) {
       setLatLng(latlng);
@@ -92,8 +92,8 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
   };
 
   endpoint.swapCachedReverseGeocodes = function (otherEndpoint) {
-    var g0 = endpoint.cachedReverseGeocode;
-    var g1 = otherEndpoint.cachedReverseGeocode;
+    const g0 = endpoint.cachedReverseGeocode;
+    const g1 = otherEndpoint.cachedReverseGeocode;
     delete endpoint.cachedReverseGeocode;
     delete otherEndpoint.cachedReverseGeocode;
     if (g0) otherEndpoint.cachedReverseGeocode = g0;

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -4,59 +4,59 @@
 
 OSM.Directions = function (map) {
   let controller = null; // the AbortController for the current route request if a route request is in progress
-  var chosenEngine;
+  let chosenEngine;
 
-  var popup = L.popup({ autoPanPadding: [100, 100] });
+  const popup = L.popup({ autoPanPadding: [100, 100] });
 
-  var polyline = L.polyline([], {
+  const polyline = L.polyline([], {
     color: "#03f",
     opacity: 0.3,
     weight: 10
   });
 
-  var highlight = L.polyline([], {
+  const highlight = L.polyline([], {
     color: "#ff0",
     opacity: 0.5,
     weight: 12
   });
 
-  var endpointDragCallback = function (dragging) {
+  const endpointDragCallback = function (dragging) {
     if (!map.hasLayer(polyline)) return;
     if (dragging && !chosenEngine.draggable) return;
     if (dragging && controller) return;
 
     getRoute(false, !dragging);
   };
-  var endpointChangeCallback = function () {
+  const endpointChangeCallback = function () {
     getRoute(true, true);
   };
 
-  var endpoints = [
+  const endpoints = [
     OSM.DirectionsEndpoint(map, $("input[name='route_from']"), OSM.MARKER_GREEN, endpointDragCallback, endpointChangeCallback),
     OSM.DirectionsEndpoint(map, $("input[name='route_to']"), OSM.MARKER_RED, endpointDragCallback, endpointChangeCallback)
   ];
 
-  var expiry = new Date();
+  const expiry = new Date();
   expiry.setYear(expiry.getFullYear() + 10);
 
-  var engines = OSM.Directions.engines;
+  const engines = OSM.Directions.engines;
 
   engines.sort(function (a, b) {
-    var localised_a = I18n.t("javascripts.directions.engines." + a.id),
-        localised_b = I18n.t("javascripts.directions.engines." + b.id);
+    const localised_a = I18n.t("javascripts.directions.engines." + a.id),
+          localised_b = I18n.t("javascripts.directions.engines." + b.id);
     return localised_a.localeCompare(localised_b);
   });
 
-  var select = $("select.routing_engines");
+  const select = $("select.routing_engines");
 
   engines.forEach(function (engine, i) {
     select.append("<option value='" + i + "'>" + I18n.t("javascripts.directions.engines." + engine.id) + "</option>");
   });
 
   $(".directions_form .reverse_directions").on("click", function () {
-    var coordFrom = endpoints[0].latlng,
-        coordTo = endpoints[1].latlng,
-        routeFrom = "",
+    const coordFrom = endpoints[0].latlng,
+          coordTo = endpoints[1].latlng;
+    let routeFrom = "",
         routeTo = "";
     if (coordFrom) {
       routeFrom = coordFrom.lat + "," + coordFrom.lng;
@@ -90,8 +90,8 @@ OSM.Directions = function (map) {
   }
 
   function formatTime(s) {
-    var m = Math.round(s / 60);
-    var h = Math.floor(m / 60);
+    let m = Math.round(s / 60);
+    const h = Math.floor(m / 60);
     m -= h * 60;
     return h + ":" + (m < 10 ? "0" : "") + m;
   }
@@ -136,7 +136,7 @@ OSM.Directions = function (map) {
         map.fitBounds(polyline.getBounds().pad(0.05));
       }
 
-      var distanceText = $("<p>").append(
+      const distanceText = $("<p>").append(
         I18n.t("javascripts.directions.distance") + ": " + formatDistance(route.distance) + ". " +
         I18n.t("javascripts.directions.time") + ": " + formatTime(route.time) + ".");
       if (typeof route.ascend !== "undefined" && typeof route.descend !== "undefined") {
@@ -146,9 +146,9 @@ OSM.Directions = function (map) {
           I18n.t("javascripts.directions.descend") + ": " + formatHeight(route.descend) + ".");
       }
 
-      var turnByTurnTable = $("<table class='table table-hover table-sm mb-3'>")
+      const turnByTurnTable = $("<table class='table table-hover table-sm mb-3'>")
         .append($("<tbody>"));
-      var directionsCloseButton = $("<button type='button' class='btn-close'>")
+      const directionsCloseButton = $("<button type='button' class='btn-close'>")
         .attr("aria-label", I18n.t("javascripts.close"));
 
       $("#sidebar_content")
@@ -166,7 +166,7 @@ OSM.Directions = function (map) {
       route.steps.forEach(function (step) {
         const [ll, direction, instruction, dist, lineseg] = step;
 
-        var row = $("<tr class='turn'/>");
+        const row = $("<tr class='turn'/>");
         row.append("<td class='border-0'><div class='direction i" + direction + "'/></td> ");
         row.append("<td>" + instruction);
         row.append("<td class='distance text-body-secondary text-end'>" + getDistText(dist));
@@ -218,7 +218,7 @@ OSM.Directions = function (map) {
     }
   }
 
-  var chosenEngineIndex = findEngine("fossgis_osrm_car");
+  let chosenEngineIndex = findEngine("fossgis_osrm_car");
   if (Cookies.get("_osm_directions_engine")) {
     chosenEngineIndex = findEngine(Cookies.get("_osm_directions_engine"));
   }
@@ -236,17 +236,17 @@ OSM.Directions = function (map) {
   });
 
   $(".routing_marker_column img").on("dragstart", function (e) {
-    var dt = e.originalEvent.dataTransfer;
+    const dt = e.originalEvent.dataTransfer;
     dt.effectAllowed = "move";
-    var dragData = { type: $(this).data("type") };
+    const dragData = { type: $(this).data("type") };
     dt.setData("text", JSON.stringify(dragData));
     if (dt.setDragImage) {
-      var img = $("<img>").attr("src", $(e.originalEvent.target).attr("src"));
+      const img = $("<img>").attr("src", $(e.originalEvent.target).attr("src"));
       dt.setDragImage(img.get(0), 12, 21);
     }
   });
 
-  var page = {};
+  const page = {};
 
   page.pushstate = page.popstate = function () {
     $(".search_form").hide();
@@ -258,12 +258,12 @@ OSM.Directions = function (map) {
 
     $("#map").on("drop", function (e) {
       e.preventDefault();
-      var oe = e.originalEvent;
-      var dragData = JSON.parse(oe.dataTransfer.getData("text"));
-      var type = dragData.type;
-      var pt = L.DomEvent.getMousePosition(oe, map.getContainer()); // co-ordinates of the mouse pointer at present
+      const oe = e.originalEvent;
+      const dragData = JSON.parse(oe.dataTransfer.getData("text"));
+      const type = dragData.type;
+      const pt = L.DomEvent.getMousePosition(oe, map.getContainer()); // co-ordinates of the mouse pointer at present
       pt.y += 20;
-      var ll = map.containerPointToLatLng(pt);
+      const ll = map.containerPointToLatLng(pt);
       const llWithPrecision = OSM.cropLocation(ll, map.getZoom());
       endpoints[type === "from" ? 0 : 1].setValue(llWithPrecision.join(", "));
     });
@@ -275,7 +275,7 @@ OSM.Directions = function (map) {
           route = (params.get("route") || "").split(";");
 
     if (params.has("engine")) {
-      var engineIndex = findEngine(params.get("engine"));
+      const engineIndex = findEngine(params.get("engine"));
 
       if (engineIndex >= 0) {
         setEngine(engineIndex);

--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -1,7 +1,7 @@
 OSM.Export = function (map) {
-  var page = {};
+  const page = {};
 
-  var locationFilter = new L.LocationFilter({
+  const locationFilter = new L.LocationFilter({
     enableButton: false,
     adjustButton: false
   }).on("change", update);
@@ -13,7 +13,7 @@ OSM.Export = function (map) {
   }
 
   function boundsChanged() {
-    var bounds = getBounds();
+    const bounds = getBounds();
     map.fitBounds(bounds);
     locationFilter.setBounds(bounds);
     locationFilter.enable();

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -1,7 +1,7 @@
 //= require jquery-simulate/jquery.simulate
 
 OSM.History = function (map) {
-  var page = {};
+  const page = {};
 
   $("#sidebar_content")
     .on("click", ".changeset_more a", loadMore)
@@ -12,7 +12,7 @@ OSM.History = function (map) {
       unHighlightChangeset($(this).data("changeset").id);
     });
 
-  var group = L.featureGroup()
+  const group = L.featureGroup()
     .on("mouseover", function (e) {
       highlightChangeset(e.layer.id);
     })
@@ -28,13 +28,13 @@ OSM.History = function (map) {
   };
 
   function highlightChangeset(id) {
-    var layer = group.getLayer(id);
+    const layer = group.getLayer(id);
     if (layer) layer.setStyle({ fillOpacity: 0.3, color: "#FF6600", weight: 3 });
     $("#changeset_" + id).addClass("selected");
   }
 
   function unHighlightChangeset(id) {
-    var layer = group.getLayer(id);
+    const layer = group.getLayer(id);
     if (layer) layer.setStyle({ fillOpacity: 0, color: "#FF9500", weight: 2 });
     $("#changeset_" + id).removeClass("selected");
   }
@@ -49,8 +49,8 @@ OSM.History = function (map) {
 
   function displayMoreChangesets(html) {
     $("#sidebar_content .changeset_more").replaceWith(html);
-    var oldList = $("#sidebar_content .changesets ol").first();
-    var newList = oldList.next("ol");
+    const oldList = $("#sidebar_content .changesets ol").first();
+    const newList = oldList.next("ol");
     newList.children().appendTo(oldList);
     newList.remove();
   }
@@ -60,8 +60,8 @@ OSM.History = function (map) {
 
     if (window.location.pathname === "/history") {
       data.set("bbox", map.getBounds().wrap().toBBoxString());
-      var feedLink = $("link[type=\"application/atom+xml\"]"),
-          feedHref = feedLink.attr("href").split("?")[0];
+      const feedLink = $("link[type=\"application/atom+xml\"]"),
+            feedHref = feedLink.attr("href").split("?")[0];
       feedLink.attr("href", feedHref + "?" + data);
     }
 
@@ -79,7 +79,7 @@ OSM.History = function (map) {
     e.preventDefault();
     e.stopPropagation();
 
-    var div = $(this).parents(".changeset_more");
+    const div = $(this).parents(".changeset_more");
 
     $(this).hide();
     div.find(".loader").show();
@@ -90,17 +90,17 @@ OSM.History = function (map) {
     });
   }
 
-  var changesets = [];
+  let changesets = [];
 
   function updateBounds() {
     group.clearLayers();
 
     for (const changeset of changesets) {
-      var bottomLeft = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.minlon)),
-          topRight = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.maxlon)),
-          width = topRight.x - bottomLeft.x,
-          height = bottomLeft.y - topRight.y,
-          minSize = 20; // Min width/height of changeset in pixels
+      const bottomLeft = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.minlon)),
+            topRight = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.maxlon)),
+            width = topRight.x - bottomLeft.x,
+            height = bottomLeft.y - topRight.y,
+            minSize = 20; // Min width/height of changeset in pixels
 
       if (width < minSize) {
         bottomLeft.x -= ((minSize - width) / 2);
@@ -138,7 +138,7 @@ OSM.History = function (map) {
     updateBounds();
 
     if (window.location.pathname !== "/history") {
-      var bounds = group.getBounds();
+      const bounds = group.getBounds();
       if (bounds.isValid()) map.fitBounds(bounds);
     }
   }

--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -40,7 +40,7 @@ OSM.initializeDataLayer = function (map) {
   });
 
   function updateData() {
-    var bounds = map.getBounds();
+    const bounds = map.getBounds();
     if (!loadedBounds || !loadedBounds.contains(bounds)) {
       getData();
     }
@@ -78,8 +78,8 @@ OSM.initializeDataLayer = function (map) {
   }
 
   function getData() {
-    var bounds = map.getBounds();
-    var url = "/api/" + OSM.API_VERSION + "/map.json?bbox=" + bounds.toBBoxString();
+    const bounds = map.getBounds();
+    const url = "/api/" + OSM.API_VERSION + "/map.json?bbox=" + bounds.toBBoxString();
 
     /*
      * Modern browsers are quite happy showing far more than 100 features in
@@ -102,7 +102,7 @@ OSM.initializeDataLayer = function (map) {
       .then(function (data) {
         dataLayer.clearLayers();
 
-        var features = dataLayer.buildFeatures(data);
+        const features = dataLayer.buildFeatures(data);
 
         function addFeatures() {
           $("#browse_status").empty();

--- a/app/assets/javascripts/index/layers/notes.js
+++ b/app/assets/javascripts/index/layers/notes.js
@@ -3,7 +3,7 @@ OSM.initializeNotesLayer = function (map) {
   const noteLayer = map.noteLayer;
   let notes = {};
 
-  var noteIcons = {
+  const noteIcons = {
     "new": L.icon({
       iconUrl: OSM.NEW_NOTE_MARKER,
       iconSize: [25, 40],
@@ -39,7 +39,7 @@ OSM.initializeNotesLayer = function (map) {
   });
 
   function updateMarker(old_marker, feature) {
-    var marker = old_marker;
+    let marker = old_marker;
     if (marker) {
       marker.setIcon(noteIcons[feature.properties.status]);
     } else {
@@ -67,11 +67,11 @@ OSM.initializeNotesLayer = function (map) {
   };
 
   function loadNotes() {
-    var bounds = map.getBounds();
-    var size = bounds.getSize();
+    const bounds = map.getBounds();
+    const size = bounds.getSize();
 
     if (size <= OSM.MAX_NOTE_REQUEST_AREA) {
-      var url = "/api/" + OSM.API_VERSION + "/notes.json?bbox=" + bounds.toBBoxString();
+      const url = "/api/" + OSM.API_VERSION + "/notes.json?bbox=" + bounds.toBBoxString();
 
       if (noteLoader) noteLoader.abort();
 
@@ -84,15 +84,15 @@ OSM.initializeNotesLayer = function (map) {
     }
 
     function success(json) {
-      var oldNotes = notes;
+      const oldNotes = notes;
       notes = {};
       for (const feature of json.features) {
-        var marker = oldNotes[feature.properties.id];
+        const marker = oldNotes[feature.properties.id];
         delete oldNotes[feature.properties.id];
         notes[feature.properties.id] = updateMarker(marker, feature);
       }
 
-      for (var id in oldNotes) {
+      for (const id in oldNotes) {
         noteLayer.removeLayer(oldNotes[id]);
       }
     }

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -1,12 +1,12 @@
 OSM.NewNote = function (map) {
-  var noteLayer = map.noteLayer,
-      content = $("#sidebar_content"),
-      page = {},
-      addNoteButton = $(".control-note .control-button"),
-      newNoteMarker,
+  const noteLayer = map.noteLayer,
+        content = $("#sidebar_content"),
+        page = {},
+        addNoteButton = $(".control-note .control-button");
+  let newNoteMarker,
       halo;
 
-  var noteIcons = {
+  const noteIcons = {
     "new": L.icon({
       iconUrl: OSM.NEW_NOTE_MARKER,
       iconSize: [25, 40],
@@ -48,7 +48,7 @@ OSM.NewNote = function (map) {
   }
 
   function addCreatedNoteMarker(feature) {
-    var marker = L.marker(feature.geometry.coordinates.reverse(), {
+    const marker = L.marker(feature.geometry.coordinates.reverse(), {
       icon: noteIcons[feature.properties.status],
       opacity: 0.9,
       interactive: true
@@ -132,7 +132,7 @@ OSM.NewNote = function (map) {
     map.addLayer(noteLayer);
 
     const params = new URLSearchParams(path.substring(path.indexOf("?")));
-    var markerLatlng;
+    let markerLatlng;
 
     if (params.has("lat") && params.has("lon")) {
       markerLatlng = L.latLng(params.get("lat"), params.get("lon"));
@@ -161,7 +161,7 @@ OSM.NewNote = function (map) {
 
       createNote(location, text, (feature) => {
         if (typeof OSM.user === "undefined") {
-          var anonymousNotesCount = Number(Cookies.get("_osm_anonymous_notes_count")) || 0;
+          const anonymousNotesCount = Number(Cookies.get("_osm_anonymous_notes_count")) || 0;
           Cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { secure: true, expires: 30, path: "/", samesite: "lax" });
         }
         content.find("textarea").val("");

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -1,8 +1,8 @@
 OSM.Note = function (map) {
-  var content = $("#sidebar_content"),
-      page = {};
+  const content = $("#sidebar_content"),
+        page = {};
 
-  var noteIcons = {
+  const noteIcons = {
     "new": L.icon({
       iconUrl: OSM.NEW_NOTE_MARKER,
       iconSize: [25, 40],
@@ -22,9 +22,9 @@ OSM.Note = function (map) {
 
   page.pushstate = page.popstate = function (path, id) {
     OSM.loadSidebarContent(path, function () {
-      var data = $(".details").data();
+      const data = $(".details").data();
       if (!data) return;
-      var latLng = L.latLng(data.coordinates.split(","));
+      const latLng = L.latLng(data.coordinates.split(","));
       initialize(path, id, map.getBounds().contains(latLng));
     });
   };
@@ -36,9 +36,9 @@ OSM.Note = function (map) {
   function initialize(path, id, skipMoveToNote) {
     content.find("button[name]").on("click", function (e) {
       e.preventDefault();
-      var data = $(e.target).data();
-      var name = $(e.target).attr("name");
-      var ajaxSettings = {
+      const data = $(e.target).data();
+      const name = $(e.target).attr("name");
+      const ajaxSettings = {
         url: data.url,
         type: data.method,
         oauth: true,
@@ -70,10 +70,10 @@ OSM.Note = function (map) {
 
     content.find("textarea").val("").trigger("input");
 
-    var data = $(".details").data();
+    const data = $(".details").data();
 
     if (data) {
-      var hashParams = OSM.parseHash(window.location.hash);
+      const hashParams = OSM.parseHash(window.location.hash);
       map.addObject({
         type: "note",
         id: parseInt(id, 10),
@@ -81,7 +81,7 @@ OSM.Note = function (map) {
         icon: noteIcons[data.status]
       }, function () {
         if (!hashParams.center && !skipMoveToNote) {
-          var latLng = L.latLng(data.coordinates.split(","));
+          const latLng = L.latLng(data.coordinates.split(","));
           OSM.router.withoutMoveListener(function () {
             map.setView(latLng, 15, { reset: true });
           });
@@ -91,8 +91,8 @@ OSM.Note = function (map) {
   }
 
   function updateButtons() {
-    var resolveButton = content.find("button[name='close']");
-    var commentButton = content.find("button[name='comment']");
+    const resolveButton = content.find("button[name='close']");
+    const commentButton = content.find("button[name='comment']");
 
     content.find("button[name]").prop("disabled", false);
     if (content.find("textarea").val() === "") {

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -1,11 +1,11 @@
 OSM.Query = function (map) {
-  var url = OSM.OVERPASS_URL,
-      credentials = OSM.OVERPASS_CREDENTIALS,
-      queryButton = $(".control-query .control-button"),
-      uninterestingTags = ["source", "source_ref", "source:ref", "history", "attribution", "created_by", "tiger:county", "tiger:tlid", "tiger:upload_uuid", "KSJ2:curve_id", "KSJ2:lat", "KSJ2:lon", "KSJ2:coordinate", "KSJ2:filename", "note:ja"],
-      marker;
+  const url = OSM.OVERPASS_URL,
+        credentials = OSM.OVERPASS_CREDENTIALS,
+        queryButton = $(".control-query .control-button"),
+        uninterestingTags = ["source", "source_ref", "source:ref", "history", "attribution", "created_by", "tiger:county", "tiger:tlid", "tiger:upload_uuid", "KSJ2:curve_id", "KSJ2:lat", "KSJ2:lon", "KSJ2:coordinate", "KSJ2:filename", "note:ja"];
+  let marker;
 
-  var featureStyle = {
+  const featureStyle = {
     color: "#FF6200",
     weight: 4,
     opacity: 1,
@@ -37,13 +37,13 @@ OSM.Query = function (map) {
   });
 
   function showResultGeometry() {
-    var geometry = $(this).data("geometry");
+    const geometry = $(this).data("geometry");
     if (geometry) map.addLayer(geometry);
     $(this).addClass("selected");
   }
 
   function hideResultGeometry() {
-    var geometry = $(this).data("geometry");
+    const geometry = $(this).data("geometry");
     if (geometry) map.removeLayer(geometry);
     $(this).removeClass("selected");
   }
@@ -54,7 +54,7 @@ OSM.Query = function (map) {
 
   function interestingFeature(feature) {
     if (feature.tags) {
-      for (var key in feature.tags) {
+      for (const key in feature.tags) {
         if (uninterestingTags.indexOf(key) < 0) {
           return true;
         }
@@ -65,19 +65,18 @@ OSM.Query = function (map) {
   }
 
   function featurePrefix(feature) {
-    var tags = feature.tags;
-    var prefix = "";
+    const tags = feature.tags;
+    let prefix = "";
 
     if (tags.boundary === "administrative" && tags.admin_level) {
       prefix = I18n.t("geocoder.search_osm_nominatim.admin_levels.level" + tags.admin_level, {
         defaultValue: I18n.t("geocoder.search_osm_nominatim.prefix.boundary.administrative")
       });
     } else {
-      var prefixes = I18n.t("geocoder.search_osm_nominatim.prefix");
-      var key, value;
+      const prefixes = I18n.t("geocoder.search_osm_nominatim.prefix");
 
-      for (key in tags) {
-        value = tags[key];
+      for (const key in tags) {
+        const value = tags[key];
 
         if (prefixes[key]) {
           if (prefixes[key][value]) {
@@ -86,12 +85,12 @@ OSM.Query = function (map) {
         }
       }
 
-      for (key in tags) {
-        value = tags[key];
+      for (const key in tags) {
+        const value = tags[key];
 
         if (prefixes[key]) {
-          var first = value.slice(0, 1).toUpperCase(),
-              rest = value.slice(1).replace(/_/g, " ");
+          const first = value.slice(0, 1).toUpperCase(),
+                rest = value.slice(1).replace(/_/g, " ");
 
           return first + rest;
         }
@@ -106,8 +105,8 @@ OSM.Query = function (map) {
   }
 
   function featureName(feature) {
-    var tags = feature.tags,
-        locales = OSM.preferred_languages;
+    const tags = feature.tags,
+          locales = OSM.preferred_languages;
 
     for (const locale of locales) {
       if (tags["name:" + locale]) {
@@ -128,7 +127,7 @@ OSM.Query = function (map) {
   }
 
   function featureGeometry(feature) {
-    var geometry;
+    let geometry;
 
     if (feature.type === "node" && feature.lat && feature.lon) {
       geometry = L.circleMarker([feature.lat, feature.lon], featureStyle);
@@ -148,7 +147,7 @@ OSM.Query = function (map) {
   }
 
   function runQuery(latlng, radius, query, $section, merge, compare) {
-    var $ul = $section.find("ul");
+    const $ul = $section.find("ul");
 
     $ul.empty();
     $section.show();
@@ -168,13 +167,13 @@ OSM.Query = function (map) {
     })
       .then(response => response.json())
       .then(function (results) {
-        var elements;
+        let elements;
 
         $section.find(".loader").hide();
 
         if (merge) {
           elements = results.elements.reduce(function (hash, element) {
-            var key = element.type + element.id;
+            const key = element.type + element.id;
             if ("geometry" in element) {
               delete element.bounds;
             }
@@ -196,7 +195,7 @@ OSM.Query = function (map) {
         for (const element of elements) {
           if (!interestingFeature(element)) continue;
 
-          var $li = $("<li>")
+          const $li = $("<li>")
             .addClass("list-group-item list-group-item-action")
             .text(featurePrefix(element) + " ")
             .appendTo($ul);
@@ -236,12 +235,12 @@ OSM.Query = function (map) {
   }
 
   function compareSize(feature1, feature2) {
-    var width1 = feature1.bounds.maxlon - feature1.bounds.minlon,
-        height1 = feature1.bounds.maxlat - feature1.bounds.minlat,
-        area1 = width1 * height1,
-        width2 = feature2.bounds.maxlat - feature2.bounds.minlat,
-        height2 = feature2.bounds.maxlat - feature2.bounds.minlat,
-        area2 = width2 * height2;
+    const width1 = feature1.bounds.maxlon - feature1.bounds.minlon,
+          height1 = feature1.bounds.maxlat - feature1.bounds.minlat,
+          area1 = width1 * height1,
+          width2 = feature2.bounds.maxlat - feature2.bounds.minlat,
+          height2 = feature2.bounds.maxlat - feature2.bounds.minlat,
+          area2 = width2 * height2;
 
     return area1 - area2;
   }
@@ -267,20 +266,20 @@ OSM.Query = function (map) {
    * for each object.
    */
   function queryOverpass(lat, lng) {
-    var latlng = L.latLng(lat, lng).wrap(),
-        bounds = map.getBounds().wrap(),
-        zoom = map.getZoom(),
-        bbox = [bounds.getSouthWest(), bounds.getNorthEast()]
-          .map(c => OSM.cropLocation(c, zoom))
-          .join(),
-        geombbox = "geom(" + bbox + ");",
-        radius = 10 * Math.pow(1.5, 19 - zoom),
-        around = "(around:" + radius + "," + lat + "," + lng + ")",
-        nodes = "node" + around,
-        ways = "way" + around,
-        relations = "relation" + around,
-        nearby = "(" + nodes + ";" + ways + ";);out tags " + geombbox + relations + ";out " + geombbox,
-        isin = "is_in(" + lat + "," + lng + ")->.a;way(pivot.a);out tags bb;out ids " + geombbox + "relation(pivot.a);out tags bb;";
+    const latlng = L.latLng(lat, lng).wrap(),
+          bounds = map.getBounds().wrap(),
+          zoom = map.getZoom(),
+          bbox = [bounds.getSouthWest(), bounds.getNorthEast()]
+            .map(c => OSM.cropLocation(c, zoom))
+            .join(),
+          geombbox = "geom(" + bbox + ");",
+          radius = 10 * Math.pow(1.5, 19 - zoom),
+          around = "(around:" + radius + "," + lat + "," + lng + ")",
+          nodes = "node" + around,
+          ways = "way" + around,
+          relations = "relation" + around,
+          nearby = "(" + nodes + ";" + ways + ";);out tags " + geombbox + relations + ";out " + geombbox,
+          isin = "is_in(" + lat + "," + lng + ")->.a;way(pivot.a);out tags bb;out ids " + geombbox + "relation(pivot.a);out tags bb;";
 
     $("#sidebar_content .query-intro")
       .hide();
@@ -315,7 +314,7 @@ OSM.Query = function (map) {
     queryButton.removeClass("active");
   }
 
-  var page = {};
+  const page = {};
 
   page.pushstate = page.popstate = function (path) {
     OSM.loadSidebarContent(path, function () {

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -9,7 +9,7 @@ OSM.Search = function (map) {
 
   $(".search_form a.btn.switch_link").on("click", function (e) {
     e.preventDefault();
-    var query = $(this).closest("form").find("input[name=query]").val();
+    const query = $(this).closest("form").find("input[name=query]").val();
     let search = "";
     if (query) search = "?" + new URLSearchParams({ from: query });
     OSM.router.route("/directions" + search + OSM.formatHash(map));
@@ -18,7 +18,7 @@ OSM.Search = function (map) {
   $(".search_form").on("submit", function (e) {
     e.preventDefault();
     $("header").addClass("closed");
-    var query = $(this).find("input[name=query]").val();
+    const query = $(this).find("input[name=query]").val();
     let search = "/";
     if (query) search = "/search?" + new URLSearchParams({ query });
     OSM.router.route(search + OSM.formatHash(map));
@@ -38,16 +38,16 @@ OSM.Search = function (map) {
     .on("mouseover", "li.search_results_entry:has(a.set_position)", showSearchResult)
     .on("mouseout", "li.search_results_entry:has(a.set_position)", hideSearchResult);
 
-  var markers = L.layerGroup().addTo(map);
+  const markers = L.layerGroup().addTo(map);
 
   function clickSearchMore(e) {
     e.preventDefault();
     e.stopPropagation();
 
-    var div = $(this).parents(".search_more"),
-        csrf_param = $("meta[name=csrf-param]").attr("content"),
-        csrf_token = $("meta[name=csrf-token]").attr("content"),
-        params = new URLSearchParams();
+    const div = $(this).parents(".search_more"),
+          csrf_param = $("meta[name=csrf-param]").attr("content"),
+          csrf_token = $("meta[name=csrf-token]").attr("content"),
+          params = new URLSearchParams();
 
     $(this).hide();
     div.find(".loader").show();
@@ -63,10 +63,10 @@ OSM.Search = function (map) {
   }
 
   function showSearchResult() {
-    var marker = $(this).data("marker");
+    let marker = $(this).data("marker");
 
     if (!marker) {
-      var data = $(this).find("a.set_position").data();
+      const data = $(this).find("a.set_position").data();
 
       marker = L.marker([data.lat, data.lon], { icon: OSM.getUserIcon() });
 
@@ -77,7 +77,7 @@ OSM.Search = function (map) {
   }
 
   function hideSearchResult() {
-    var marker = $(this).data("marker");
+    const marker = $(this).data("marker");
 
     if (marker) {
       markers.removeLayer(marker);
@@ -93,7 +93,7 @@ OSM.Search = function (map) {
   }
 
   function clickSearchResult(e) {
-    var data = $(this).data();
+    const data = $(this).data();
 
     panToSearchResult(data);
 
@@ -104,7 +104,7 @@ OSM.Search = function (map) {
     e.stopPropagation();
   }
 
-  var page = {};
+  const page = {};
 
   page.pushstate = page.popstate = function (path) {
     const params = new URLSearchParams(path.substring(path.indexOf("?")));
@@ -120,16 +120,16 @@ OSM.Search = function (map) {
 
   page.load = function () {
     $(".search_results_entry").each(function (index) {
-      var entry = $(this),
-          csrf_param = $("meta[name=csrf-param]").attr("content"),
-          csrf_token = $("meta[name=csrf-token]").attr("content"),
-          params = new URLSearchParams({
-            zoom: map.getZoom(),
-            minlon: map.getBounds().getWest(),
-            minlat: map.getBounds().getSouth(),
-            maxlon: map.getBounds().getEast(),
-            maxlat: map.getBounds().getNorth()
-          });
+      const entry = $(this),
+            csrf_param = $("meta[name=csrf-param]").attr("content"),
+            csrf_token = $("meta[name=csrf-token]").attr("content"),
+            params = new URLSearchParams({
+              zoom: map.getZoom(),
+              minlon: map.getBounds().getWest(),
+              minlat: map.getBounds().getSouth(),
+              maxlon: map.getBounds().getEast(),
+              maxlat: map.getBounds().getNorth()
+            });
       params.set(csrf_param, csrf_token);
       fetch(entry.data("href"), {
         method: "POST",
@@ -140,7 +140,7 @@ OSM.Search = function (map) {
           entry.html(html);
           // go to first result of first geocoder
           if (index === 0) {
-            var firstResult = entry.find("*[data-lat][data-lon]:first").first();
+            const firstResult = entry.find("*[data-lat][data-lon]:first").first();
             if (firstResult.length) {
               panToSearchResult(firstResult.data());
             }

--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -1,8 +1,8 @@
 L.OSM.key = function (options) {
-  var control = L.OSM.sidebarPane(options, "key", null, "javascripts.key.title");
+  const control = L.OSM.sidebarPane(options, "key", null, "javascripts.key.title");
 
   control.onAddPane = function (map, button, $ui) {
-    var $section = $("<div>")
+    const $section = $("<div>")
       .attr("class", "p-3")
       .appendTo($ui);
 
@@ -24,7 +24,7 @@ L.OSM.key = function (options) {
     }
 
     function updateButton() {
-      var disabled = OSM.LAYERS_WITH_MAP_KEY.indexOf(map.getMapBaseLayerId()) === -1;
+      const disabled = OSM.LAYERS_WITH_MAP_KEY.indexOf(map.getMapBaseLayerId()) === -1;
       button
         .toggleClass("disabled", disabled)
         .attr("data-bs-original-title",
@@ -34,11 +34,11 @@ L.OSM.key = function (options) {
     }
 
     function update() {
-      var layerId = map.getMapBaseLayerId(),
-          zoom = map.getZoom();
+      const layerId = map.getMapBaseLayerId(),
+            zoom = map.getZoom();
 
       $(".mapkey-table-entry").each(function () {
-        var data = $(this).data();
+        const data = $(this).data();
         $(this).toggle(
           layerId === data.layer &&
           (!data.zoomMin || zoom >= data.zoomMin) &&

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -1,34 +1,34 @@
 L.OSM.layers = function (options) {
-  var control = L.OSM.sidebarPane(options, "layers", "javascripts.map.layers.title", "javascripts.map.layers.header");
+  const control = L.OSM.sidebarPane(options, "layers", "javascripts.map.layers.title", "javascripts.map.layers.header");
 
   control.onAddPane = function (map, button, $ui, toggle) {
-    var layers = options.layers;
+    const layers = options.layers;
 
-    var baseSection = $("<div>")
+    const baseSection = $("<div>")
       .attr("class", "base-layers d-grid gap-3 p-3 border-bottom border-secondary-subtle")
       .appendTo($ui);
 
     layers.forEach(function (layer, i) {
-      var id = "map-ui-layer-" + i;
+      const id = "map-ui-layer-" + i;
 
-      var buttonContainer = $("<div class='position-relative'>")
+      const buttonContainer = $("<div class='position-relative'>")
         .appendTo(baseSection);
 
-      var mapContainer = $("<div class='position-absolute top-0 start-0 bottom-0 end-0 z-0 bg-body-secondary'>")
+      const mapContainer = $("<div class='position-absolute top-0 start-0 bottom-0 end-0 z-0 bg-body-secondary'>")
         .appendTo(buttonContainer);
 
-      var input = $("<input type='radio' class='btn-check' name='layer'>")
+      const input = $("<input type='radio' class='btn-check' name='layer'>")
         .prop("id", id)
         .prop("checked", map.hasLayer(layer))
         .appendTo(buttonContainer);
 
-      var item = $("<label class='btn btn-outline-primary border-4 rounded-3 bg-transparent position-absolute p-0 h-100 w-100 overflow-hidden'>")
+      const item = $("<label class='btn btn-outline-primary border-4 rounded-3 bg-transparent position-absolute p-0 h-100 w-100 overflow-hidden'>")
         .prop("for", id)
         .append($("<span class='badge position-absolute top-0 start-0 rounded-top-0 rounded-start-0 py-1 px-2 bg-body bg-opacity-75 text-body text-wrap text-start fs-6 lh-base'>").append(layer.options.name))
         .appendTo(buttonContainer);
 
       map.whenReady(function () {
-        var miniMap = L.map(mapContainer[0], { attributionControl: false, zoomControl: false, keyboard: false })
+        const miniMap = L.map(mapContainer[0], { attributionControl: false, zoomControl: false, keyboard: false })
           .addLayer(new layer.constructor(layer.options));
 
         miniMap.dragging.disable();
@@ -76,7 +76,7 @@ L.OSM.layers = function (options) {
     });
 
     if (OSM.STATUS !== "api_offline" && OSM.STATUS !== "database_offline") {
-      var overlaySection = $("<div>")
+      const overlaySection = $("<div>")
         .attr("class", "overlay-layers p-3")
         .appendTo($ui);
 
@@ -85,11 +85,11 @@ L.OSM.layers = function (options) {
         .attr("class", "text-body-secondary small mb-2")
         .appendTo(overlaySection);
 
-      var overlays = $("<ul class='list-unstyled form-check'>")
+      const overlays = $("<ul class='list-unstyled form-check'>")
         .appendTo(overlaySection);
 
-      var addOverlay = function (layer, name, maxArea) {
-        var item = $("<li>")
+      const addOverlay = function (layer, name, maxArea) {
+        const item = $("<li>")
           .appendTo(overlays);
 
         if (name === "notes" || name === "data") {
@@ -98,13 +98,13 @@ L.OSM.layers = function (options) {
             .tooltip("disable");
         }
 
-        var label = $("<label>")
+        const label = $("<label>")
           .attr("class", "form-check-label")
           .appendTo(item);
 
-        var checked = map.hasLayer(layer);
+        let checked = map.hasLayer(layer);
 
-        var input = $("<input>")
+        const input = $("<input>")
           .attr("type", "checkbox")
           .attr("class", "form-check-input")
           .prop("checked", checked)
@@ -126,7 +126,7 @@ L.OSM.layers = function (options) {
         });
 
         map.on("zoomend", function () {
-          var disabled = map.getBounds().getSize() >= maxArea;
+          const disabled = map.getBounds().getSize() >= maxArea;
           $(input).prop("disabled", disabled);
 
           if (disabled && $(input).is(":checked")) {

--- a/app/assets/javascripts/leaflet.locate.js
+++ b/app/assets/javascripts/leaflet.locate.js
@@ -1,5 +1,5 @@
 L.OSM.locate = function (options) {
-  var control = L.control.locate({
+  const control = L.control.locate({
     icon: "icon geolocate",
     iconLoading: "icon geolocate",
     strings: {
@@ -12,7 +12,7 @@ L.OSM.locate = function (options) {
   });
 
   control.onAdd = function (map) {
-    var container = Object.getPrototypeOf(this).onAdd.apply(this, [map]);
+    const container = Object.getPrototypeOf(this).onAdd.apply(this, [map]);
     $(container)
       .removeClass("leaflet-control-locate leaflet-bar")
       .addClass("control-locate")

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -128,7 +128,7 @@ L.OSM.Map = L.Map.extend({
   },
 
   getLayersCode: function () {
-    var layerConfig = "";
+    let layerConfig = "";
     this.eachLayer(function (layer) {
       if (layer.options && layer.options.code) {
         layerConfig += layer.options.code;
@@ -155,9 +155,9 @@ L.OSM.Map = L.Map.extend({
       [params.mlat, params.mlon] = OSM.cropLocation(marker.getLatLng(), this.getZoom());
     }
 
-    var url = window.location.protocol + "//" + OSM.SERVER_URL + "/",
-        query = new URLSearchParams(params),
-        hash = OSM.formatHash(this);
+    let url = window.location.protocol + "//" + OSM.SERVER_URL + "/";
+    const query = new URLSearchParams(params),
+          hash = OSM.formatHash(this);
 
     if (query) url += "?" + query;
     if (hash) url += hash;
@@ -166,33 +166,31 @@ L.OSM.Map = L.Map.extend({
   },
 
   getShortUrl: function (marker) {
-    var zoom = this.getZoom(),
-        latLng = marker && this.hasLayer(marker) ? marker.getLatLng().wrap() : this.getCenter().wrap(),
-        str = window.location.protocol + "//" + window.location.hostname.replace(/^www\.openstreetmap\.org/i, "osm.org") + "/go/",
-        char_array = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_~",
-        x = Math.round((latLng.lng + 180.0) * ((1 << 30) / 90.0)),
-        y = Math.round((latLng.lat + 90.0) * ((1 << 30) / 45.0)),
-        // JavaScript only has to keep 32 bits of bitwise operators, so this has to be
-        // done in two parts. each of the parts c1/c2 has 30 bits of the total in it
-        // and drops the last 4 bits of the full 64 bit Morton code.
-        c1 = interlace(x >>> 17, y >>> 17),
-        c2 = interlace((x >>> 2) & 0x7fff, (y >>> 2) & 0x7fff),
-        digit,
-        i;
+    const zoom = this.getZoom(),
+          latLng = marker && this.hasLayer(marker) ? marker.getLatLng().wrap() : this.getCenter().wrap(),
+          char_array = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_~",
+          x = Math.round((latLng.lng + 180.0) * ((1 << 30) / 90.0)),
+          y = Math.round((latLng.lat + 90.0) * ((1 << 30) / 45.0)),
+          // JavaScript only has to keep 32 bits of bitwise operators, so this has to be
+          // done in two parts. each of the parts c1/c2 has 30 bits of the total in it
+          // and drops the last 4 bits of the full 64 bit Morton code.
+          c1 = interlace(x >>> 17, y >>> 17),
+          c2 = interlace((x >>> 2) & 0x7fff, (y >>> 2) & 0x7fff);
+    let str = window.location.protocol + "//" + window.location.hostname.replace(/^www\.openstreetmap\.org/i, "osm.org") + "/go/";
 
-    for (i = 0; i < Math.ceil((zoom + 8) / 3.0) && i < 5; ++i) {
-      digit = (c1 >> (24 - (6 * i))) & 0x3f;
+    for (let i = 0; i < Math.ceil((zoom + 8) / 3.0) && i < 5; ++i) {
+      const digit = (c1 >> (24 - (6 * i))) & 0x3f;
       str += char_array.charAt(digit);
     }
-    for (i = 5; i < Math.ceil((zoom + 8) / 3.0); ++i) {
-      digit = (c2 >> (24 - (6 * (i - 5)))) & 0x3f;
+    for (let i = 5; i < Math.ceil((zoom + 8) / 3.0); ++i) {
+      const digit = (c2 >> (24 - (6 * (i - 5)))) & 0x3f;
       str += char_array.charAt(digit);
     }
-    for (i = 0; i < ((zoom + 8) % 3); ++i) str += "-";
+    for (let i = 0; i < ((zoom + 8) % 3); ++i) str += "-";
 
     // Called to interlace the bits in x and y, making a Morton code.
     function interlace(x, y) {
-      var interlaced_x = x,
+      let interlaced_x = x,
           interlaced_y = y;
       interlaced_x = (interlaced_x | (interlaced_x << 8)) & 0x00ff00ff;
       interlaced_x = (interlaced_x | (interlaced_x << 4)) & 0x0f0f0f0f;
@@ -206,7 +204,7 @@ L.OSM.Map = L.Map.extend({
     }
 
     const params = new URLSearchParams();
-    var layers = this.getLayersCode().replace("M", "");
+    const layers = this.getLayersCode().replace("M", "");
 
     if (layers) {
       params.set("layers", layers);
@@ -240,14 +238,14 @@ L.OSM.Map = L.Map.extend({
   },
 
   addObject: function (object, callback) {
-    var objectStyle = {
+    const objectStyle = {
       color: "#FF6200",
       weight: 4,
       opacity: 1,
       fillOpacity: 0.5
     };
 
-    var changesetStyle = {
+    const changesetStyle = {
       weight: 4,
       color: "#FF9500",
       opacity: 1,
@@ -255,7 +253,7 @@ L.OSM.Map = L.Map.extend({
       interactive: false
     };
 
-    var haloStyle = {
+    const haloStyle = {
       weight: 2.5,
       radius: 20,
       fillOpacity: 0.5,
@@ -292,7 +290,7 @@ L.OSM.Map = L.Map.extend({
       if (callback) callback(this._objectLayer.getBounds());
       this.fire("overlayadd", { layer: this._objectLayer });
     } else { // element handled by L.OSM.DataLayer
-      var map = this;
+      const map = this;
       this._objectLoader = new AbortController();
       fetch(OSM.apiUrl(object), {
         headers: { accept: "application/json" },
@@ -347,10 +345,10 @@ L.OSM.Map = L.Map.extend({
   },
 
   setSidebarOverlaid: function (overlaid) {
-    var mediumDeviceWidth = window.getComputedStyle(document.documentElement).getPropertyValue("--bs-breakpoint-md");
-    var isMediumDevice = window.matchMedia(`(max-width: ${mediumDeviceWidth})`).matches;
-    var sidebarWidth = $("#sidebar").width();
-    var sidebarHeight = $("#sidebar").height();
+    const mediumDeviceWidth = window.getComputedStyle(document.documentElement).getPropertyValue("--bs-breakpoint-md");
+    const isMediumDevice = window.matchMedia(`(max-width: ${mediumDeviceWidth})`).matches;
+    const sidebarWidth = $("#sidebar").width();
+    const sidebarHeight = $("#sidebar").height();
     if (overlaid && !$("#content").hasClass("overlay-sidebar")) {
       $("#content").addClass("overlay-sidebar");
       this.invalidateSize({ pan: false });
@@ -384,15 +382,15 @@ L.extend(L.Icon.Default.prototype, {
   _oldGetIconUrl: L.Icon.Default.prototype._getIconUrl,
 
   _getIconUrl: function (name) {
-    var url = this._oldGetIconUrl(name);
+    const url = this._oldGetIconUrl(name);
     return L.Icon.Default.imageUrls[url];
   }
 });
 
 OSM.isDarkMap = function () {
-  var mapTheme = $("body").attr("data-map-theme");
+  const mapTheme = $("body").attr("data-map-theme");
   if (mapTheme) return mapTheme === "dark";
-  var siteTheme = $("html").attr("data-bs-theme");
+  const siteTheme = $("html").attr("data-bs-theme");
   if (siteTheme) return siteTheme === "dark";
   return window.matchMedia("(prefers-color-scheme: dark)").matches;
 };

--- a/app/assets/javascripts/leaflet.note.js
+++ b/app/assets/javascripts/leaflet.note.js
@@ -1,11 +1,11 @@
 L.OSM.note = function (options) {
-  var control = L.control(options);
+  const control = L.control(options);
 
   control.onAdd = function (map) {
-    var $container = $("<div>")
+    const $container = $("<div>")
       .attr("class", "control-note");
 
-    var link = $("<a>")
+    const link = $("<a>")
       .attr("class", "control-button")
       .attr("href", "#")
       .html("<span class=\"icon note\"></span>")
@@ -14,8 +14,8 @@ L.OSM.note = function (options) {
     map.on("zoomend", update);
 
     function update() {
-      var wasDisabled = link.hasClass("disabled"),
-          isDisabled = OSM.STATUS === "database_offline" || map.getZoom() < 12;
+      const wasDisabled = link.hasClass("disabled"),
+            isDisabled = OSM.STATUS === "database_offline" || map.getZoom() < 12;
       link
         .toggleClass("disabled", isDisabled)
         .attr("data-bs-original-title", I18n.t(isDisabled ?

--- a/app/assets/javascripts/leaflet.query.js
+++ b/app/assets/javascripts/leaflet.query.js
@@ -1,11 +1,11 @@
 L.OSM.query = function (options) {
-  var control = L.control(options);
+  const control = L.control(options);
 
   control.onAdd = function (map) {
-    var $container = $("<div>")
+    const $container = $("<div>")
       .attr("class", "control-query");
 
-    var link = $("<a>")
+    const link = $("<a>")
       .attr("class", "control-button")
       .attr("href", "#")
       .html("<span class=\"icon query\"></span>")
@@ -14,8 +14,8 @@ L.OSM.query = function (options) {
     map.on("zoomend", update);
 
     function update() {
-      var wasDisabled = link.hasClass("disabled"),
-          isDisabled = map.getZoom() < 14;
+      const wasDisabled = link.hasClass("disabled"),
+            isDisabled = map.getZoom() < 14;
       link
         .toggleClass("disabled", isDisabled)
         .attr("data-bs-original-title", I18n.t(isDisabled ?

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -1,16 +1,16 @@
 L.OSM.share = function (options) {
-  var control = L.OSM.sidebarPane(options, "share", "javascripts.share.title", "javascripts.share.title"),
-      marker = L.marker([0, 0], { draggable: true }),
-      locationFilter = new L.LocationFilter({
-        enableButton: false,
-        adjustButton: false
-      });
+  const control = L.OSM.sidebarPane(options, "share", "javascripts.share.title", "javascripts.share.title"),
+        marker = L.marker([0, 0], { draggable: true }),
+        locationFilter = new L.LocationFilter({
+          enableButton: false,
+          adjustButton: false
+        });
 
   control.onAddPane = function (map, button, $ui) {
     // Link / Embed
     $("#content").addClass("overlay-right-sidebar");
 
-    var $linkSection = $("<div>")
+    const $linkSection = $("<div>")
       .attr("class", "share-link p-3 border-bottom border-secondary-subtle")
       .appendTo($ui);
 
@@ -18,7 +18,7 @@ L.OSM.share = function (options) {
       .text(I18n.t("javascripts.share.link"))
       .appendTo($linkSection);
 
-    var $form = $("<form>")
+    let $form = $("<form>")
       .appendTo($linkSection);
 
     $("<div>")
@@ -54,7 +54,7 @@ L.OSM.share = function (options) {
       .on("click", "a", function (e) {
         e.preventDefault();
         if (!$(this).hasClass("btn-primary")) return;
-        var id = "#" + $(this).attr("for");
+        const id = "#" + $(this).attr("for");
         $(this).siblings("a")
           .removeClass("active");
         $(this).addClass("active");
@@ -104,7 +104,7 @@ L.OSM.share = function (options) {
 
     // Geo URI
 
-    var $geoUriSection = $("<div>")
+    const $geoUriSection = $("<div>")
       .attr("class", "share-geo-uri p-3 border-bottom border-secondary-subtle")
       .appendTo($ui);
 
@@ -119,7 +119,7 @@ L.OSM.share = function (options) {
 
     // Image
 
-    var $imageSection = $("<div>")
+    const $imageSection = $("<div>")
       .attr("class", "share-image p-3")
       .appendTo($ui);
 
@@ -227,8 +227,8 @@ L.OSM.share = function (options) {
         .appendTo($form);
     }
 
-    var csrf_param = $("meta[name=csrf-param]").attr("content"),
-        csrf_token = $("meta[name=csrf-token]").attr("content");
+    const csrf_param = $("meta[name=csrf-param]").attr("content"),
+          csrf_token = $("meta[name=csrf-token]").attr("content");
 
     $("<input>")
       .attr("name", csrf_param)
@@ -236,7 +236,7 @@ L.OSM.share = function (options) {
       .attr("type", "hidden")
       .appendTo($form);
 
-    var args = {
+    const args = {
       layer: "<span id=\"mapnik_image_layer\"></span>",
       width: "<span id=\"mapnik_image_width\"></span>",
       height: "<span id=\"mapnik_image_height\"></span>"
@@ -319,7 +319,7 @@ L.OSM.share = function (options) {
     }
 
     function escapeHTML(string) {
-      var htmlEscapes = {
+      const htmlEscapes = {
         "&": "&amp;",
         "<": "&lt;",
         ">": "&gt;",
@@ -333,8 +333,8 @@ L.OSM.share = function (options) {
 
     function update() {
       const layer = map.getMapBaseLayer();
-      var canEmbed = Boolean(layer && layer.options.canEmbed);
-      var bounds = map.getBounds();
+      const canEmbed = Boolean(layer && layer.options.canEmbed);
+      let bounds = map.getBounds();
 
       $("#link_marker")
         .prop("checked", map.hasLayer(marker));
@@ -355,7 +355,7 @@ L.OSM.share = function (options) {
       });
 
       if (map.hasLayer(marker)) {
-        var latLng = marker.getLatLng().wrap();
+        const latLng = marker.getLatLng().wrap();
         params.set("marker", latLng.lat + "," + latLng.lng);
       }
 
@@ -386,10 +386,10 @@ L.OSM.share = function (options) {
         bounds = locationFilter.getBounds();
       }
 
-      var scale = $("#mapnik_scale").val(),
-          size = L.bounds(L.CRS.EPSG3857.project(bounds.getSouthWest()),
-                          L.CRS.EPSG3857.project(bounds.getNorthEast())).getSize(),
-          maxScale = Math.floor(Math.sqrt(size.x * size.y / 0.3136));
+      let scale = $("#mapnik_scale").val();
+      const size = L.bounds(L.CRS.EPSG3857.project(bounds.getSouthWest()),
+                            L.CRS.EPSG3857.project(bounds.getNorthEast())).getSize(),
+            maxScale = Math.floor(Math.sqrt(size.x * size.y / 0.3136));
 
       $("#mapnik_minlon").val(bounds.getWest());
       $("#mapnik_minlat").val(bounds.getSouth());
@@ -427,17 +427,17 @@ L.OSM.share = function (options) {
     }
 
     function getScale() {
-      var bounds = map.getBounds(),
-          centerLat = bounds.getCenter().lat,
-          halfWorldMeters = 6378137 * Math.PI * Math.cos(centerLat * Math.PI / 180),
-          meters = halfWorldMeters * (bounds.getEast() - bounds.getWest()) / 180,
-          pixelsPerMeter = map.getSize().x / meters,
-          metersPerPixel = 1 / (92 * 39.3701);
+      const bounds = map.getBounds(),
+            centerLat = bounds.getCenter().lat,
+            halfWorldMeters = 6378137 * Math.PI * Math.cos(centerLat * Math.PI / 180),
+            meters = halfWorldMeters * (bounds.getEast() - bounds.getWest()) / 180,
+            pixelsPerMeter = map.getSize().x / meters,
+            metersPerPixel = 1 / (92 * 39.3701);
       return Math.round(1 / (pixelsPerMeter * metersPerPixel));
     }
 
     function roundScale(scale) {
-      var precision = 5 * Math.pow(10, Math.floor(Math.LOG10E * Math.log(scale)) - 2);
+      const precision = 5 * Math.pow(10, Math.floor(Math.LOG10E * Math.log(scale)) - 2);
       return precision * Math.ceil(scale / precision);
     }
   };

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -1,11 +1,11 @@
 L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
-  var control = L.control(options);
+  const control = L.control(options);
 
   control.onAdd = function (map) {
-    var $container = $("<div>")
+    const $container = $("<div>")
       .attr("class", "control-" + uiClass);
 
-    var button = $("<a>")
+    const button = $("<a>")
       .attr("class", "control-button")
       .attr("href", "#")
       .html("<span class=\"icon " + uiClass + "\"></span>")
@@ -17,7 +17,7 @@ L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
 
     button.appendTo($container);
 
-    var $ui = $("<div>")
+    const $ui = $("<div>")
       .attr("class", uiClass + "-ui");
 
     $("<div class='d-flex p-3 pb-0'>")

--- a/app/assets/javascripts/leaflet.sidebar.js
+++ b/app/assets/javascripts/leaflet.sidebar.js
@@ -1,7 +1,7 @@
 L.OSM.sidebar = function (selector) {
-  var control = {},
-      sidebar = $(selector),
-      current = $(),
+  const control = {},
+        sidebar = $(selector);
+  let current = $(),
       currentButton = $(),
       map;
 
@@ -17,9 +17,9 @@ L.OSM.sidebar = function (selector) {
   };
 
   control.togglePane = function (pane, button) {
-    var mediumDeviceWidth = window.getComputedStyle(document.documentElement).getPropertyValue("--bs-breakpoint-md");
-    var isMediumDevice = window.matchMedia(`(max-width: ${mediumDeviceWidth})`).matches;
-    var paneWidth = 250;
+    const mediumDeviceWidth = window.getComputedStyle(document.documentElement).getPropertyValue("--bs-breakpoint-md");
+    const isMediumDevice = window.matchMedia(`(max-width: ${mediumDeviceWidth})`).matches;
+    const paneWidth = 250;
 
     current
       .hide()

--- a/app/assets/javascripts/leaflet.zoom.js
+++ b/app/assets/javascripts/leaflet.zoom.js
@@ -4,8 +4,8 @@ L.OSM.Zoom = L.Control.extend({
   },
 
   onAdd: function (map) {
-    var zoomName = "zoom",
-        container = L.DomUtil.create("div", zoomName);
+    const zoomName = "zoom",
+          container = L.DomUtil.create("div", zoomName);
 
     this._map = map;
 
@@ -32,14 +32,14 @@ L.OSM.Zoom = L.Control.extend({
   },
 
   _createButton: function (html, title, className, container, fn, context) {
-    var link = L.DomUtil.create("a", "control-button " + className, container);
+    const link = L.DomUtil.create("a", "control-button " + className, container);
     link.innerHTML = html;
     link.href = "#";
     link.title = title;
 
     L.DomUtil.create("span", "icon " + className, link);
 
-    var stop = L.DomEvent.stopPropagation;
+    const stop = L.DomEvent.stopPropagation;
 
     L.DomEvent
       .on(link, "click", stop)
@@ -52,8 +52,8 @@ L.OSM.Zoom = L.Control.extend({
   },
 
   _updateDisabled: function () {
-    var map = this._map,
-        className = "disabled";
+    const map = this._map,
+          className = "disabled";
 
     L.DomUtil.removeClass(this._zoomInButton, className);
     L.DomUtil.removeClass(this._zoomOutButton, className);

--- a/app/assets/javascripts/matomo.js
+++ b/app/assets/javascripts/matomo.js
@@ -1,9 +1,9 @@
 if (OSM.MATOMO) {
   $(document).ready(function () {
-    var base = document.location.protocol + "//" + OSM.MATOMO.location + "/";
-    var matomoTracker;
+    const base = document.location.protocol + "//" + OSM.MATOMO.location + "/";
+    let matomoTracker;
 
-    var matomoLoader = $.ajax({
+    const matomoLoader = $.ajax({
       url: base + "matomo.js",
       dataType: "script",
       cache: true,

--- a/app/assets/javascripts/oauth.js
+++ b/app/assets/javascripts/oauth.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-  var application_data = $("head").data();
+  const application_data = $("head").data();
 
   if (application_data.oauthToken) {
     $.ajaxPrefilter(function (options) {

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -44,8 +44,8 @@ OSM = {
   CLOSED_NOTE_MARKER: <%= image_path("closed_note_marker.svg").to_json %>,
 
   apiUrl: function (object) {
-    var apiType = object.type === "note" ? "notes" : object.type;
-    var url = "/api/" + OSM.API_VERSION + "/" + apiType + "/" + object.id;
+    const apiType = object.type === "note" ? "notes" : object.type;
+    let url = "/api/" + OSM.API_VERSION + "/" + apiType + "/" + object.id;
 
     if (object.type === "way" || object.type === "relation") {
       url += "/full";
@@ -57,13 +57,13 @@ OSM = {
   },
 
   params: function (search) {
-    var query = search || window.location.search;
+    const query = search || window.location.search;
     return Object.fromEntries(new URLSearchParams(query));
   },
 
   mapParams: function (search) {
-    var params = OSM.params(search),
-        mapParams = {};
+    const params = OSM.params(search),
+          mapParams = {};
 
     if (params.mlon && params.mlat) {
       mapParams.marker = true;
@@ -78,7 +78,7 @@ OSM = {
       }
     }
 
-    var hash = OSM.parseHash(location.hash);
+    const hash = OSM.parseHash(location.hash);
 
     const loc = Cookies.get("_osm_location")?.split("|");
 
@@ -120,7 +120,7 @@ OSM = {
 
     mapParams.layers = hash.layers || (loc && loc[3]) || "";
 
-    var scale = parseFloat(params.scale);
+    const scale = parseFloat(params.scale);
     if (scale > 0) {
       mapParams.zoom = Math.log(360.0 / (scale * 512.0)) / Math.log(2.0);
     }
@@ -129,19 +129,19 @@ OSM = {
   },
 
   parseHash: function (hash) {
-    var args = {};
+    const args = {};
 
-    var i = hash.indexOf("#");
+    const i = hash.indexOf("#");
     if (i < 0) {
       return args;
     }
 
     const hashParams = new URLSearchParams(hash.slice(i + 1));
 
-    var map = (hashParams.get("map") || "").split("/"),
-        zoom = parseInt(map[0], 10),
-        lat = parseFloat(map[1]),
-        lon = parseFloat(map[2]);
+    const map = (hashParams.get("map") || "").split("/"),
+          zoom = parseInt(map[0], 10),
+          lat = parseFloat(map[1]),
+          lon = parseFloat(map[2]);
 
     if (!isNaN(zoom) && !isNaN(lat) && !isNaN(lon)) {
       args.center = new L.LatLng(lat, lon);
@@ -156,7 +156,7 @@ OSM = {
   },
 
   formatHash: function (args) {
-    var center, zoom, layers;
+    let center, zoom, layers;
 
     if (args instanceof L.Map) {
       center = args.getCenter();
@@ -180,8 +180,8 @@ OSM = {
   },
 
   zoomPrecision: function (zoom) {
-    var pixels = Math.pow(2, 8 + zoom);
-    var degrees = 180;
+    const pixels = Math.pow(2, 8 + zoom);
+    const degrees = 180;
     return Math.ceil(Math.log10(pixels / degrees));
   },
 
@@ -198,12 +198,12 @@ OSM = {
   },
 
   distance: function (latlng1, latlng2) {
-    var lat1 = latlng1.lat * Math.PI / 180,
-        lng1 = latlng1.lng * Math.PI / 180,
-        lat2 = latlng2.lat * Math.PI / 180,
-        lng2 = latlng2.lng * Math.PI / 180,
-        latdiff = lat2 - lat1,
-        lngdiff = lng2 - lng1;
+    const lat1 = latlng1.lat * Math.PI / 180,
+          lng1 = latlng1.lng * Math.PI / 180,
+          lat2 = latlng2.lat * Math.PI / 180,
+          lng2 = latlng2.lng * Math.PI / 180,
+          latdiff = lat2 - lat1,
+          lngdiff = lng2 - lng1;
 
     return 6372795 * 2 * Math.asin(
       Math.sqrt(

--- a/app/assets/javascripts/richtext.js
+++ b/app/assets/javascripts/richtext.js
@@ -5,8 +5,8 @@
    * the user next switches to it.
    */
   $(document).on("change", ".richtext_container textarea", function () {
-    var container = $(this).closest(".richtext_container");
-    var preview = container.find(".tab-pane[id$='_preview']");
+    const container = $(this).closest(".richtext_container");
+    const preview = container.find(".tab-pane[id$='_preview']");
 
     preview.children(".richtext_placeholder").attr("hidden", true).removeClass("delayed-fade-in");
     preview.children(".richtext").empty();
@@ -17,10 +17,10 @@
    * when switching away from an edit pane
    */
   $(document).on("hide.bs.tab", ".richtext_container button[data-bs-target$='_edit']", function () {
-    var container = $(this).closest(".richtext_container");
-    var editor = container.find("textarea");
-    var preview = container.find(".tab-pane[id$='_preview']");
-    var minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
+    const container = $(this).closest(".richtext_container");
+    const editor = container.find("textarea");
+    const preview = container.find(".tab-pane[id$='_preview']");
+    const minHeight = editor.outerHeight() - preview.outerHeight() + preview.height();
 
     preview.css("min-height", minHeight + "px");
   });
@@ -29,9 +29,9 @@
    * Install a handler to switch to preview mode
    */
   $(document).on("show.bs.tab", ".richtext_container button[data-bs-target$='_preview']", function () {
-    var container = $(this).closest(".richtext_container");
-    var editor = container.find("textarea");
-    var preview = container.find(".tab-pane[id$='_preview']");
+    const container = $(this).closest(".richtext_container");
+    const editor = container.find("textarea");
+    const preview = container.find(".tab-pane[id$='_preview']");
 
     if (preview.children(".richtext").contents().length === 0) {
       preview.children(".richtext_placeholder").removeAttr("hidden").addClass("delayed-fade-in");
@@ -50,18 +50,18 @@
   });
 
   function invalidTextareaListener() {
-    var container = $(this).closest(".richtext_container");
+    const container = $(this).closest(".richtext_container");
 
     container.find("button[data-bs-target$='_edit']").tab("show");
   }
 
   function updateHelp() {
     $(".richtext_container .richtext_help_sidebar:not(:visible):not(:empty)").each(function () {
-      var container = $(this).closest(".richtext_container");
+      const container = $(this).closest(".richtext_container");
       $(this).children().appendTo(container.find(".tab-pane[id$='_help']"));
     });
     $(".richtext_container .richtext_help_sidebar:visible:empty").each(function () {
-      var container = $(this).closest(".richtext_container");
+      const container = $(this).closest(".richtext_container");
       container.find(".tab-pane[id$='_help']").children().appendTo($(this));
       if (container.find("button[data-bs-target$='_help'].active").length) {
         container.find("button[data-bs-target$='_edit']").tab("show");

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -47,13 +47,13 @@
    move the map without the hash changing.
  */
 OSM.Router = function (map, rts) {
-  var escapeRegExp = /[-{}[\]+?.,\\^$|#\s]/g;
-  var optionalParam = /\((.*?)\)/g;
-  var namedParam = /(\(\?)?:\w+/g;
-  var splatParam = /\*\w+/g;
+  const escapeRegExp = /[-{}[\]+?.,\\^$|#\s]/g;
+  const optionalParam = /\((.*?)\)/g;
+  const namedParam = /(\(\?)?:\w+/g;
+  const splatParam = /\*\w+/g;
 
   function Route(path, controller) {
-    var regexp = new RegExp("^" +
+    const regexp = new RegExp("^" +
       path.replace(escapeRegExp, "\\$&")
         .replace(optionalParam, "(?:$1)?")
         .replace(namedParam, function (match, optional) {
@@ -61,14 +61,14 @@ OSM.Router = function (map, rts) {
         })
         .replace(splatParam, "(.*?)") + "(?:\\?.*)?$");
 
-    var route = {};
+    const route = {};
 
     route.match = function (path) {
       return regexp.test(path);
     };
 
     route.run = function (action, path) {
-      var params = [];
+      let params = [];
 
       if (path) {
         params = regexp.exec(path).map(function (param, i) {
@@ -93,15 +93,15 @@ OSM.Router = function (map, rts) {
     }
   };
 
-  var currentPath = window.location.pathname.replace(/(.)\/$/, "$1") + window.location.search,
+  let currentPath = window.location.pathname.replace(/(.)\/$/, "$1") + window.location.search,
       currentRoute = routes.recognize(currentPath),
       currentHash = location.hash || OSM.formatHash(map);
 
-  var router = {};
+  const router = {};
 
   function updateSecondaryNav() {
     $("header nav.secondary > ul > li > a").each(function () {
-      var active = $(this).attr("href") === window.location.pathname;
+      const active = $(this).attr("href") === window.location.pathname;
 
       $(this)
         .toggleClass("text-secondary", !active)
@@ -111,8 +111,8 @@ OSM.Router = function (map, rts) {
 
   $(window).on("popstate", function (e) {
     if (!e.originalEvent.state) return; // Is it a real popstate event or just a hash change?
-    var path = window.location.pathname + window.location.search,
-        route = routes.recognize(path);
+    const path = window.location.pathname + window.location.search,
+          route = routes.recognize(path);
     if (path === currentPath) return;
     currentRoute.run("unload", null, route === currentRoute);
     currentPath = path;
@@ -123,11 +123,11 @@ OSM.Router = function (map, rts) {
   });
 
   router.route = function (url) {
-    var path = url.replace(/#.*/, ""),
-        route = routes.recognize(path);
+    const path = url.replace(/#.*/, ""),
+          route = routes.recognize(path);
     if (!route) return false;
     currentRoute.run("unload", null, route === currentRoute);
-    var state = OSM.parseHash(url);
+    const state = OSM.parseHash(url);
     map.setState(state);
     window.history.pushState(state, document.title, url);
     currentPath = path;
@@ -147,17 +147,17 @@ OSM.Router = function (map, rts) {
   };
 
   router.updateHash = function () {
-    var hash = OSM.formatHash(map);
+    const hash = OSM.formatHash(map);
     if (hash === currentHash) return;
     currentHash = hash;
     router.stateChange(OSM.parseHash(hash));
   };
 
   router.hashUpdated = function () {
-    var hash = location.hash;
+    const hash = location.hash;
     if (hash === currentHash) return;
     currentHash = hash;
-    var state = OSM.parseHash(hash);
+    const state = OSM.parseHash(hash);
     map.setState(state);
     router.stateChange(state, hash);
   };
@@ -176,7 +176,7 @@ OSM.Router = function (map, rts) {
   };
 
   router.load = function () {
-    var loadState = currentRoute.run("load", currentPath);
+    const loadState = currentRoute.run("load", currentPath);
     router.stateChange(loadState || {});
   };
 

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -7,8 +7,8 @@
 }());
 
 $(document).ready(function () {
-  var defaultHomeZoom = 12;
-  var map, marker, deleted_lat, deleted_lon;
+  const defaultHomeZoom = 12;
+  let map, marker, deleted_lat, deleted_lon;
 
   if ($("#map").length) {
     map = L.map("map", {
@@ -16,12 +16,12 @@ $(document).ready(function () {
       zoomControl: false
     }).addLayer(new L.OSM.Mapnik());
 
-    var position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
+    const position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
 
     L.OSM.zoom({ position: position })
       .addTo(map);
 
-    var locate = L.control.locate({
+    const locate = L.control.locate({
       position: position,
       icon: "icon geolocate",
       iconLoading: "icon geolocate",
@@ -33,7 +33,7 @@ $(document).ready(function () {
       }
     }).addTo(map);
 
-    var locateContainer = locate.getContainer();
+    const locateContainer = locate.getContainer();
 
     $(locateContainer)
       .removeClass("leaflet-control-locate leaflet-bar")
@@ -73,9 +73,9 @@ $(document).ready(function () {
         deleted_lon = null;
         respondToHomeUpdate();
       }).on("moveend", function () {
-        var lat = $("#home_lat").val().trim(),
-            lon = $("#home_lon").val().trim(),
-            location;
+        const lat = $("#home_lat").val().trim(),
+              lon = $("#home_lon").val().trim();
+        let location;
 
         try {
           if (lat && lon) {
@@ -95,15 +95,15 @@ $(document).ready(function () {
       });
 
       $("#home_show").click(function () {
-        var lat = $("#home_lat").val(),
-            lon = $("#home_lon").val();
+        const lat = $("#home_lat").val(),
+              lon = $("#home_lon").val();
 
         map.setView([lat, lon], defaultHomeZoom);
       });
 
       $("#home_delete").click(function () {
-        var lat = $("#home_lat").val(),
-            lon = $("#home_lon").val();
+        const lat = $("#home_lat").val(),
+              lon = $("#home_lon").val();
 
         $("#home_lat, #home_lon").val("");
         deleted_lat = lat;
@@ -122,7 +122,7 @@ $(document).ready(function () {
       });
     } else {
       $("[data-user]").each(function () {
-        var user = $(this).data("user");
+        const user = $(this).data("user");
         if (user.lon && user.lat) {
           L.marker([user.lat, user.lon], { icon: OSM.getUserIcon(user.icon) }).addTo(map)
             .bindPopup(user.description, { minWidth: 200 });
@@ -132,9 +132,9 @@ $(document).ready(function () {
   }
 
   function respondToHomeUpdate() {
-    var lat = $("#home_lat").val().trim(),
-        lon = $("#home_lon").val().trim(),
-        location;
+    const lat = $("#home_lat").val().trim(),
+          lon = $("#home_lon").val().trim();
+    let location;
 
     try {
       if (lat && lon) {
@@ -160,14 +160,14 @@ $(document).ready(function () {
   }
 
   function isCloseEnoughToMapCenter(location) {
-    var inputPt = map.latLngToContainerPoint(location),
-        centerPt = map.latLngToContainerPoint(map.getCenter());
+    const inputPt = map.latLngToContainerPoint(location),
+          centerPt = map.latLngToContainerPoint(map.getCenter());
 
     return centerPt.distanceTo(inputPt) < 10;
   }
 
   function updateAuthUID() {
-    var provider = $("select#user_auth_provider").val();
+    const provider = $("select#user_auth_provider").val();
 
     if (provider === "openid") {
       $("input#user_auth_uid").show().prop("disabled", false);
@@ -210,7 +210,7 @@ $(document).ready(function () {
   });
 
   $("input[name=legale]").change(function () {
-    var url = $(this).data("url");
+    const url = $(this).data("url");
 
     $("#contributorTerms").html("<div class='spinner-border' role='status'><span class='visually-hidden'>" + I18n.t("browse.start_rjs.loading") + "</span></div>");
     $("#contributorTerms").load(url);

--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -1,8 +1,8 @@
 $(document).ready(function () {
-  var params = OSM.params();
+  const params = OSM.params();
 
   if (params.lat && params.lon) {
-    var url = "/edit";
+    let url = "/edit";
 
     if (params.editor) url += "?editor=" + params.editor;
     if (!params.zoom) params.zoom = 17;

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -141,9 +141,11 @@ module.exports = [
       "no-useless-call": "error",
       "no-useless-concat": "error",
       "no-useless-return": "error",
+      "no-var": "error",
       "no-void": "error",
       "no-warning-comments": "warn",
       "operator-assignment": "error",
+      "prefer-const": "error",
       "prefer-object-spread": "error",
       "radix": ["error", "always"],
       "yoda": "error"

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -23,7 +23,7 @@ describe("OSM", function () {
 
   describe(".params", function () {
     it("parses params", function () {
-      var params = OSM.params("?foo=a&bar=b");
+      const params = OSM.params("?foo=a&bar=b");
       expect(params).to.have.property("foo", "a");
       expect(params).to.have.property("bar", "b");
     });
@@ -41,14 +41,14 @@ describe("OSM", function () {
     });
 
     it("parses marker params", function () {
-      var params = OSM.mapParams("?mlat=57.6247&mlon=-3.6845");
+      const params = OSM.mapParams("?mlat=57.6247&mlon=-3.6845");
       expect(params).to.have.property("mlat", 57.6247);
       expect(params).to.have.property("mlon", -3.6845);
       expect(params).to.have.property("marker", true);
     });
 
     it("parses object params", function () {
-      var params = OSM.mapParams("?node=1");
+      let params = OSM.mapParams("?node=1");
       expect(params).to.have.property("object");
       expect(params.object).to.eql({ type: "node", id: 1 });
 
@@ -62,8 +62,8 @@ describe("OSM", function () {
     });
 
     it("parses bbox params", function () {
-      var expected = L.latLngBounds([57.6247, -3.6845], [57.7247, -3.7845]);
-      var params = OSM.mapParams("?bbox=-3.6845,57.6247,-3.7845,57.7247");
+      const expected = L.latLngBounds([57.6247, -3.6845], [57.7247, -3.7845]);
+      let params = OSM.mapParams("?bbox=-3.6845,57.6247,-3.7845,57.7247");
       expect(params).to.have.property("bounds").deep.equal(expected);
 
       params = OSM.mapParams("?minlon=-3.6845&minlat=57.6247&maxlon=-3.7845&maxlat=57.7247");
@@ -71,7 +71,7 @@ describe("OSM", function () {
     });
 
     it("parses mlat/mlon/zoom params", function () {
-      var params = OSM.mapParams("?mlat=57.6247&mlon=-3.6845");
+      let params = OSM.mapParams("?mlat=57.6247&mlon=-3.6845");
       expect(params).to.have.property("lat", 57.6247);
       expect(params).to.have.property("lon", -3.6845);
       expect(params).to.have.property("zoom", 12);
@@ -92,21 +92,21 @@ describe("OSM", function () {
 
     it("sets lat/lon from OSM.home", function () {
       OSM.home = { lat: 57.6247, lon: -3.6845 };
-      var params = OSM.mapParams("?");
+      const params = OSM.mapParams("?");
       expect(params).to.have.property("lat", 57.6247);
       expect(params).to.have.property("lon", -3.6845);
     });
 
     it("sets bbox from OSM.location", function () {
       OSM.location = { minlon: -3.6845, minlat: 57.6247, maxlon: -3.7845, maxlat: 57.7247 };
-      var expected = L.latLngBounds([57.6247, -3.6845], [57.7247, -3.7845]);
-      var params = OSM.mapParams("?");
+      const expected = L.latLngBounds([57.6247, -3.6845], [57.7247, -3.7845]);
+      const params = OSM.mapParams("?");
       expect(params).to.have.property("bounds").deep.equal(expected);
     });
 
     it("parses params from the _osm_location cookie", function () {
       document.cookie = "_osm_location=-3.6845|57.6247|5|M";
-      var params = OSM.mapParams("?");
+      const params = OSM.mapParams("?");
       expect(params).to.have.property("lat", 57.6247);
       expect(params).to.have.property("lon", -3.6845);
       expect(params).to.have.property("zoom", 5);
@@ -114,7 +114,7 @@ describe("OSM", function () {
     });
 
     it("defaults lat/lon to London", function () {
-      var params = OSM.mapParams("?");
+      let params = OSM.mapParams("?");
       expect(params).to.have.property("lat", 51.5);
       expect(params).to.have.property("lon", -0.1);
       expect(params).to.have.property("zoom", 5);
@@ -126,7 +126,7 @@ describe("OSM", function () {
     });
 
     it("parses layers param", function () {
-      var params = OSM.mapParams("?");
+      let params = OSM.mapParams("?");
       expect(params).to.have.property("layers", "");
 
       document.cookie = "_osm_location=-3.6845|57.6247|5|C";
@@ -141,25 +141,25 @@ describe("OSM", function () {
 
   describe(".parseHash", function () {
     it("parses lat/lon/zoom params", function () {
-      var args = OSM.parseHash("#map=5/57.6247/-3.6845&layers=M");
+      const args = OSM.parseHash("#map=5/57.6247/-3.6845&layers=M");
       expect(args).to.have.property("center").deep.equal(L.latLng(57.6247, -3.6845));
       expect(args).to.have.property("zoom", 5);
     });
 
     it("parses layers params", function () {
-      var args = OSM.parseHash("#map=5/57.6247/-3.6845&layers=M");
+      const args = OSM.parseHash("#map=5/57.6247/-3.6845&layers=M");
       expect(args).to.have.property("layers", "M");
     });
   });
 
   describe(".formatHash", function () {
     it("formats lat/lon/zoom params", function () {
-      var args = { center: L.latLng(57.6247, -3.6845), zoom: 9 };
+      const args = { center: L.latLng(57.6247, -3.6845), zoom: 9 };
       expect(OSM.formatHash(args)).to.eq("#map=9/57.625/-3.685");
     });
 
     it("respects zoomPrecision", function () {
-      var args = { center: L.latLng(57.6247, -3.6845), zoom: 5 };
+      let args = { center: L.latLng(57.6247, -3.6845), zoom: 5 };
       expect(OSM.formatHash(args)).to.eq("#map=5/57.62/-3.68");
 
 
@@ -172,12 +172,12 @@ describe("OSM", function () {
     });
 
     it("formats layers params", function () {
-      var args = { center: L.latLng(57.6247, -3.6845), zoom: 9, layers: "C" };
+      const args = { center: L.latLng(57.6247, -3.6845), zoom: 9, layers: "C" };
       expect(OSM.formatHash(args)).to.eq("#map=9/57.625/-3.685&layers=C");
     });
 
     it("ignores default layers", function () {
-      var args = { center: L.latLng(57.6247, -3.6845), zoom: 9, layers: "M" };
+      const args = { center: L.latLng(57.6247, -3.6845), zoom: 9, layers: "M" };
       expect(OSM.formatHash(args)).to.eq("#map=9/57.625/-3.685");
     });
   });
@@ -230,14 +230,14 @@ describe("OSM", function () {
   describe(".locationCookie", function () {
     it("creates a location cookie value", function () {
       $("body").html($("<div id='map'>"));
-      var map = new L.OSM.Map("map", { center: [57.6247, -3.6845], zoom: 9 });
+      const map = new L.OSM.Map("map", { center: [57.6247, -3.6845], zoom: 9 });
       map.updateLayers("");
       expect(OSM.locationCookie(map)).to.eq("-3.685|57.625|9|M");
     });
 
     it("respects zoomPrecision", function () {
       $("body").html($("<div id='map'>"));
-      var map = new L.OSM.Map("map", { center: [57.6247, -3.6845], zoom: 9 });
+      const map = new L.OSM.Map("map", { center: [57.6247, -3.6845], zoom: 9 });
       map.updateLayers("");
       expect(OSM.locationCookie(map)).to.eq("-3.685|57.625|9|M");
       // map.setZoom() doesn't update the zoom level for some reason
@@ -249,8 +249,8 @@ describe("OSM", function () {
 
   describe(".distance", function () {
     it("computes distance between points", function () {
-      var latlng1 = L.latLng(51.76712, -0.00484),
-          latlng2 = L.latLng(51.7675159, -0.0078329);
+      const latlng1 = L.latLng(51.76712, -0.00484),
+            latlng2 = L.latLng(51.7675159, -0.0078329);
 
       expect(OSM.distance(latlng1, latlng2)).to.be.closeTo(210.664, 0.005);
       expect(OSM.distance(latlng2, latlng1)).to.be.closeTo(210.664, 0.005);


### PR DESCRIPTION
This updates the eslint config to prohibit use of  `var` and to prefer `const` over `let` and then fixes all uses of `var` to respect that.