### PR TITLE
Remove layersAdded variable from map.updateLayers()

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -115,8 +115,7 @@ L.OSM.Map = L.Map.extend({
   },
 
   updateLayers: function (layerParam) {
-    var layers = layerParam || "M",
-        layersAdded = "";
+    var layers = layerParam || "M";
 
     for (let i = this.baseLayers.length - 1; i >= 0; i--) {
       if (layers.indexOf(this.baseLayers[i].options.code) === -1) {
@@ -125,11 +124,9 @@ L.OSM.Map = L.Map.extend({
     }
 
     for (let i = this.baseLayers.length - 1; i >= 0; i--) {
-      if (layers.indexOf(this.baseLayers[i].options.code) >= 0) {
+      if (layers.indexOf(this.baseLayers[i].options.code) >= 0 || i === 0) {
         this.addLayer(this.baseLayers[i]);
-        layersAdded = layersAdded + this.baseLayers[i].options.code;
-      } else if (i === 0 && layersAdded === "") {
-        this.addLayer(this.baseLayers[i]);
+        return;
       }
     }
   },


### PR DESCRIPTION
`layersAdded` is a leftover from `updateLayers` logic before #5474, when there was a single loop that both added and removed layers. Now there are two loops, the first one is removing layers, while the second one is adding, but it can only add one layer.

Before this PR:
- the second loop checks the layer code
- if it matches, the layer is added and its code is recorded into `layersAdded`
- on the final iteration if there's no match, `layersAdded` is checked
- if it's empty, layer[0] is added

After:
- the second loop checks the layer code match OR if it's the final iteration *
- if the condition is true, the layer is added and the function returns because there's nothing else to do

Looks like I also fixed a bug: you could construct an url with several base layers like this https://www.openstreetmap.org/#layers=CYT and they all will be added. That's not supposed to happen. After this PR only one base layer is added.

\* I'm checking `i == 0` inside the loop instead of adding layer[0] after the loop to allow the function to work with empty base layer set. Maybe that's going to be useful for someone.