### PR TITLE
Close button for loading error alert

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -61,11 +61,16 @@ OSM.initializeDataLayer = function (map) {
           .click(add)));
   }
 
-  function displayLoadError(message) {
+  function displayLoadError(message, close) {
     $("#browse_status").html(
       $("<div class='p-3'>").append(
-        $("<h2 class='flex-grow-1 text-break'>")
-          .text(I18n.t("browse.start_rjs.load_data")),
+        $("<div class='d-flex'>").append(
+          $("<h2 class='flex-grow-1 text-break'>")
+            .text(I18n.t("browse.start_rjs.load_data")),
+          $("<div>").append(
+            $("<button type='button' class='btn-close'>")
+              .attr("aria-label", I18n.t("javascripts.close"))
+              .click(close))),
         $("<div>").append(
           $("<div class='d-flex'>").append(
             $("<p class='alert alert-warning'>")
@@ -128,12 +133,16 @@ OSM.initializeDataLayer = function (map) {
         dataLoader = null;
         if (textStatus === "abort") { return; }
 
+        function closeError() {
+          $("#browse_status").empty();
+        }
+
         if (XMLHttpRequest.status === 400 && XMLHttpRequest.responseText) {
-          displayLoadError(XMLHttpRequest.responseText);
+          displayLoadError(XMLHttpRequest.responseText, closeError);
         } else if (XMLHttpRequest.statusText) {
-          displayLoadError(XMLHttpRequest.statusText);
+          displayLoadError(XMLHttpRequest.statusText, closeError);
         } else {
-          displayLoadError(String(XMLHttpRequest.status));
+          displayLoadError(String(XMLHttpRequest.status), closeError);
         }
       }
     });


### PR DESCRIPTION
#5551 added a window with an error if the user is trying to download too much data. But this window cannot be closed, only turn off the Map Data layer. But what if you have already turned it off?

https://github.com/user-attachments/assets/0b40a9ed-c3b7-47ee-90fb-67b264880ff9

Now it looks like this (similar to the warning about loading a large amount of data):

<img width="810" src="https://github.com/user-attachments/assets/5ef802c5-fbca-4ce6-a12c-c5d9c26d2b37" />
