### PR TITLE
Increase the limit when a warning about a large number of objects is displayed

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -80,10 +80,10 @@ OSM.initializeDataLayer = function (map) {
 
     /*
      * Modern browsers are quite happy showing far more than 100 features in
-     * the data browser, so increase the limit to 2000 by default, but keep
+     * the data browser, so increase the limit to 4000 by default, but keep
      * it restricted to 500 for IE8 and 100 for older IEs.
      */
-    var maxFeatures = 2000;
+    var maxFeatures = 4000;
 
     /*@cc_on
       if (navigator.appVersion < 8) {


### PR DESCRIPTION
After #5474, data rendering is no longer a bottle of performance. Modern browsers do a great job with moving the map, which displays many objects (moreover, it can also be accelerated)

The only exception is mobile browsers. Therefore, I stopped at 4000 objects.