### PR TITLE
DataLayer to consume JSON format responses

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -102,10 +102,11 @@ OSM.initializeDataLayer = function (map) {
 
     dataLoader = $.ajax({
       url: url,
-      success: function (xml) {
+      dataType: "json",
+      success: function (data) {
         dataLayer.clearLayers();
 
-        var features = dataLayer.buildFeatures(xml);
+        var features = dataLayer.buildFeatures(data);
 
         function addFeatures() {
           $("#browse_status").empty();

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -315,8 +315,8 @@ L.OSM.Map = L.Map.extend({
       var map = this;
       this._objectLoader = $.ajax({
         url: OSM.apiUrl(object),
-        dataType: "xml",
-        success: function (xml) {
+        dataType: "json",
+        success: function (data) {
           map._object = object;
 
           map._objectLayer = new L.OSM.DataLayer(null, {
@@ -338,7 +338,7 @@ L.OSM.Map = L.Map.extend({
             }
           };
 
-          map._objectLayer.addData(xml);
+          map._objectLayer.addData(data);
           map._objectLayer.addTo(map);
 
           if (callback) callback(map._objectLayer.getBounds());


### PR DESCRIPTION
https://github.com/openstreetmap/leaflet-osm/pull/44 introduced OSM JSON support in the underlying leaflet osm package. This PR enables the new feature by requesting application/json format (via Accept header).