### PR TITLE
Remove IE conditional compilation that limited max features

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -85,18 +85,9 @@ OSM.initializeDataLayer = function (map) {
 
     /*
      * Modern browsers are quite happy showing far more than 100 features in
-     * the data browser, so increase the limit to 4000 by default, but keep
-     * it restricted to 500 for IE8 and 100 for older IEs.
+     * the data browser, so increase the limit to 4000 by default.
      */
-    var maxFeatures = 4000;
-
-    /*@cc_on
-      if (navigator.appVersion < 8) {
-        maxFeatures = 100;
-      } else if (navigator.appVersion < 9) {
-        maxFeatures = 500;
-      }
-    @*/
+    const maxFeatures = 4000;
 
     if (dataLoader) dataLoader.abort();
 


### PR DESCRIPTION
This targets Internet Explorer 8, a browser that wouldn't work for many other reasons.