### PR TITLE
Remove unused max_features parameter from feature warning

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -44,7 +44,7 @@ OSM.initializeDataLayer = function (map) {
     }
   }
 
-  function displayFeatureWarning(count, limit, add, cancel) {
+  function displayFeatureWarning(num_features, add, cancel) {
     $("#browse_status").html(
       $("<div class='p-3'>").append(
         $("<div class='d-flex'>").append(
@@ -55,7 +55,7 @@ OSM.initializeDataLayer = function (map) {
               .attr("aria-label", I18n.t("javascripts.close"))
               .click(cancel))),
         $("<p class='alert alert-warning'>")
-          .text(I18n.t("browse.start_rjs.feature_warning", { num_features: count, max_features: limit })),
+          .text(I18n.t("browse.start_rjs.feature_warning", { num_features })),
         $("<input type='submit' class='btn btn-primary d-block mx-auto'>")
           .val(I18n.t("browse.start_rjs.load_data"))
           .click(add)));
@@ -120,7 +120,7 @@ OSM.initializeDataLayer = function (map) {
         if (features.length < maxFeatures) {
           addFeatures();
         } else {
-          displayFeatureWarning(features.length, maxFeatures, addFeatures, cancelAddFeatures);
+          displayFeatureWarning(features.length, addFeatures, cancelAddFeatures);
         }
 
         if (map._objectLayer) {


### PR DESCRIPTION
The message doesn't have max number of features in it, only the current number is present:
![image](https://github.com/user-attachments/assets/923241a7-9f51-49bb-9f40-cc82bcab1c95)

The max number use was added in https://github.com/openstreetmap/openstreetmap-website/commit/8027dc85b13af383ce03044d46ef6d7a471859ec and removed in https://github.com/openstreetmap/openstreetmap-website/commit/b903d8b7462519d6ef8f9175fdbde1df6620ccbb.