### PR TITLE
Removes author_{id, ip} methods from Note model

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -99,16 +99,6 @@ class Note < ApplicationRecord
     comments.first.author
   end
 
-  # Return the note's author ID, derived from the first comment
-  def author_id
-    comments.first.author_id
-  end
-
-  # Return the note's author IP address, derived from the first comment
-  def author_ip
-    comments.first.author_ip
-  end
-
   private
 
   # Fill in default values for new notes

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -65,23 +65,6 @@ class NoteTest < ActiveSupport::TestCase
     assert_equal user, comment.note.author
   end
 
-  def test_author_id
-    comment = create(:note_comment)
-    assert_nil comment.note.author_id
-
-    user = create(:user)
-    comment = create(:note_comment, :author => user)
-    assert_equal user.id, comment.note.author_id
-  end
-
-  def test_author_ip
-    comment = create(:note_comment)
-    assert_nil comment.note.author_ip
-
-    comment = create(:note_comment, :author_ip => IPAddr.new("192.168.1.1"))
-    assert_equal IPAddr.new("192.168.1.1"), comment.note.author_ip
-  end
-
   # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05
   def test_lat_lon_format
     note = build(:note, :latitude => 0.00004 * GeoRecord::SCALE, :longitude => 0.00008 * GeoRecord::SCALE)


### PR DESCRIPTION
### Description

PR removes author_id, author_ip methods from Note model because they are not used anymore. Also, removed associated unit tests.

### How has this been tested?

Tested only using automated tests and by searching sources for potential usages.