### PR TITLE
Fix map blink when active Mapnik + some overlay

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -116,6 +116,9 @@ L.OSM.Map = L.Map.extend({
 
   updateLayers: function (layerParam) {
     var layers = layerParam || "M";
+    if (this.getMapBaseLayer() && this.getMapBaseLayer().options.code === "M" && !layers.includes("M")) {
+      layers += "M";
+    }
 
     for (let i = this.baseLayers.length - 1; i >= 0; i--) {
       if (layers.indexOf(this.baseLayers[i].options.code) === -1) {


### PR DESCRIPTION
#5474 added an unpleasant blink when an overlay is enabled and Mapnik is base layer, and you try to close the sidebar:


https://github.com/user-attachments/assets/4d3063b9-dd39-4553-844b-e2bd99c11241

This is because `var layers = layerParam || "M";` does not add `M` when overlay is enabled (`layerParam` is not empty). I added a check that if Mapnik is the current layer, then we add its code, so that`.removeLayer()` was not called for it.

Checking `this.getMapbaslaver() &&` is important because when opening the tab it can return `undefined`.