### PR TITLE
Don't remove-readd standard layer with visible overlays

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -115,19 +115,18 @@ L.OSM.Map = L.Map.extend({
   },
 
   updateLayers: function (layerParam) {
-    var layers = layerParam || "M";
+    const oldBaseLayer = this.getMapBaseLayer();
+    let newBaseLayer;
 
-    for (let i = this.baseLayers.length - 1; i >= 0; i--) {
-      if (layers.indexOf(this.baseLayers[i].options.code) === -1) {
-        this.removeLayer(this.baseLayers[i]);
+    for (const layer of this.baseLayers) {
+      if (!newBaseLayer || layerParam.includes(layer.options.code)) {
+        newBaseLayer = layer;
       }
     }
 
-    for (let i = this.baseLayers.length - 1; i >= 0; i--) {
-      if (layers.indexOf(this.baseLayers[i].options.code) >= 0 || i === 0) {
-        this.addLayer(this.baseLayers[i]);
-        return;
-      }
+    if (newBaseLayer !== oldBaseLayer) {
+      if (oldBaseLayer) this.removeLayer(oldBaseLayer);
+      if (newBaseLayer) this.addLayer(newBaseLayer);
     }
   },
 


### PR DESCRIPTION
This is a first commit of another fix which I didn't finish yet because of https://github.com/openstreetmap/openstreetmap-website/pull/5570#issuecomment-2621121469 and some other things[^1] but it should fix the same problem #5570 fixes. Unlike #5570 this PR removes references to `"M"` being the default layer. #5570 add a bunch more. I want to remove `"M"`s because the layer config is in `config/layers.yml` and you just read the code from there.

`map.updateLayers` already has an assumption that the first layer is the default one in addition to the assumption that it's  `"M"`. Potentially these assumptions may diverge, so it's better to remove one, and I'd rather remove `"M"` because it's also avoids the situation of what if there's no `"M"` layer. And that's not impossible, M used to stand for "Mapnik", but we don't call this layer "Mapnik" anymore.

[^1]: like `OSM.STATUS` checks