### PR TITLE
Remove unnecessary wrapper divs from data layer error message

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -71,10 +71,8 @@ OSM.initializeDataLayer = function (map) {
             $("<button type='button' class='btn-close'>")
               .attr("aria-label", I18n.t("javascripts.close"))
               .click(close))),
-        $("<div>").append(
-          $("<div class='d-flex'>").append(
-            $("<p class='alert alert-warning'>")
-              .text(I18n.t("browse.start_rjs.feature_error", { message: message }))))));
+        $("<p class='alert alert-warning'>")
+          .text(I18n.t("browse.start_rjs.feature_error", { message: message }))));
   }
 
   var dataLoader;


### PR DESCRIPTION
The message was added in #5551.

There is a slight difference, the flex wrapper shrinks the alert paragraph. We don't do that in `displayFeatureWarning`.

Before:
![image](https://github.com/user-attachments/assets/626e3d96-cfe0-4606-a986-59c6d2121951)

After:
![image](https://github.com/user-attachments/assets/f1ea6386-10f3-4d06-957d-7b77dde8ff9f)
