### PR TITLE
Abort loading when data layer is removed

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -1,6 +1,6 @@
 OSM.initializeDataLayer = function (map) {
-  var loadedBounds;
-  var dataLayer = map.dataLayer;
+  let dataLoader, loadedBounds;
+  const dataLayer = map.dataLayer;
 
   dataLayer.setStyle({
     way: {
@@ -32,6 +32,8 @@ OSM.initializeDataLayer = function (map) {
   });
 
   dataLayer.on("remove", function () {
+    if (dataLoader) dataLoader.abort();
+    dataLoader = null;
     map.off("moveend", updateData);
     $("#browse_status").empty();
     map.fire("overlayremove", { layer: this });
@@ -76,8 +78,6 @@ OSM.initializeDataLayer = function (map) {
             $("<p class='alert alert-warning'>")
               .text(I18n.t("browse.start_rjs.feature_error", { message: message }))))));
   }
-
-  var dataLoader;
 
   function getData() {
     var bounds = map.getBounds();


### PR DESCRIPTION
Currently data layer loading is only aborted when a new request starts. It's possible to enable data layer, start a long load, disable data layer, and then after a while receive a warning about too much data despite the layer is already disabled.