### PR TITLE
Show only description as a marker tooltip in note layer

### DIFF
--- a/app/assets/javascripts/index/layers/notes.js
+++ b/app/assets/javascripts/index/layers/notes.js
@@ -40,9 +40,16 @@ OSM.initializeNotesLayer = function (map) {
     if (marker) {
       marker.setIcon(noteIcons[feature.properties.status]);
     } else {
+      let title;
+      const description = feature.properties.comments[0];
+
+      if (description?.action === "opened") {
+        title = description.text;
+      }
+
       marker = L.marker(feature.geometry.coordinates.reverse(), {
         icon: noteIcons[feature.properties.status],
-        title: feature.properties.comments[0].text,
+        title,
         opacity: 0.8,
         interactive: true
       });

--- a/test/system/note_layer_test.rb
+++ b/test/system/note_layer_test.rb
@@ -1,0 +1,40 @@
+require "application_system_test_case"
+
+class NoteLayerTest < ApplicationSystemTestCase
+  test "note marker should have description as a title" do
+    position = (1.1 * GeoRecord::SCALE).to_i
+    create(:note, :latitude => position, :longitude => position) do |note|
+      create(:note_comment, :note => note, :body => "Note description")
+    end
+
+    visit root_path(:anchor => "map=18/1.1/1.1&layers=N")
+    all "img.leaflet-marker-icon", :count => 1 do |marker|
+      assert_equal "Note description", marker["title"]
+    end
+  end
+
+  test "note marker should not have a title if the note has no visible description" do
+    position = (1.1 * GeoRecord::SCALE).to_i
+    create(:note, :latitude => position, :longitude => position) do |note|
+      create(:note_comment, :note => note, :body => "Note description is hidden", :visible => false)
+      create(:note_comment, :note => note, :body => "Note comment visible", :event => "commented")
+    end
+
+    visit root_path(:anchor => "map=18/1.1/1.1&layers=N")
+    all "img.leaflet-marker-icon", :count => 1 do |marker|
+      assert_equal "", marker["title"]
+    end
+  end
+
+  test "note marker should not have a title if the note has no visible description and comments" do
+    position = (1.1 * GeoRecord::SCALE).to_i
+    create(:note, :latitude => position, :longitude => position) do |note|
+      create(:note_comment, :note => note, :body => "Note description is hidden", :visible => false)
+    end
+
+    visit root_path(:anchor => "map=18/1.1/1.1&layers=N")
+    all "img.leaflet-marker-icon", :count => 1 do |marker|
+      assert_equal "", marker["title"]
+    end
+  end
+end


### PR DESCRIPTION
Currently note markers in note layers don't necessarily display note descriptions. There's no check if the first "comment" returned by the api is a description or is it a regular comment because the description is hidden:

https://github.com/user-attachments/assets/50af9642-0067-4b9a-941e-64826c0271d0

I wrote this comment https://github.com/openstreetmap/openstreetmap-website/pull/5511#discussion_r1931817739 where I say that it can be fixed by adding attributes to comments that indicate whether they are descriptions or actually comments. But that is not necessary because there's a status attribute, and if its value is `opened`, the "comment" is a description. This PR adds this check to note layer.