### PR TITLE
Select user ids from reports using pluck

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -46,7 +46,7 @@ class IssuesController < ApplicationController
     @issues, @newer_issues_id, @older_issues_id = get_page_items(@issues, :limit => @params[:limit])
 
     @unique_reporters = @issues.each_with_object({}) do |issue, reporters|
-      user_ids = issue.reports.order(:created_at => :desc).map(&:user_id).uniq
+      user_ids = issue.reports.order(:created_at => :desc).pluck(:user_id).uniq
       reporters[issue.id] = {
         :count => user_ids.size,
         :users => User.in_order_of(:id, user_ids.first(3))


### PR DESCRIPTION
#4990 added the *Reporter Users* column. It uses reports to sort the users, but actually all it needs to get from the db are user ids. The existing version with `map` fetches the entire report by doing `SELECT "reports".*`. Here I'm replacing it with `pluck` that does `SELECT "reports"."user_id"`.