### PR TITLE
Adds optional use of note's author and description v2

### DIFF
--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -1,6 +1,14 @@
 module NoteHelper
   include ActionView::Helpers::TranslationHelper
 
+  def note_description(author, description)
+    if !author.nil? && author.status == "deleted"
+      RichText.new("text", t("notes.show.description_when_author_is_deleted"))
+    else
+      description
+    end
+  end
+
   def note_event(event, at, by)
     if by.nil?
       t("notes.show.event_#{event}_by_anonymous_html",

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -28,6 +28,8 @@
 class Note < ApplicationRecord
   include GeoRecord
 
+  belongs_to :author, :class_name => "User", :foreign_key => "user_id", :optional => true
+
   has_many :comments, -> { left_joins(:author).where(:visible => true, :users => { :status => [nil, "active", "confirmed"] }).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id
   has_many :all_comments, -> { left_joins(:author).order(:created_at) }, :class_name => "NoteComment", :foreign_key => :note_id, :inverse_of => :note
   has_many :subscriptions, :class_name => "NoteSubscription"
@@ -91,12 +93,20 @@ class Note < ApplicationRecord
 
   # Return the note's description, derived from the first comment
   def description
-    comments.first.body
+    if user_ip.nil? && user_id.nil?
+      comments.first.body
+    else
+      RichText.new("text", super)
+    end
   end
 
   # Return the note's author object, derived from the first comment
   def author
-    comments.first.author
+    if user_ip.nil? && user_id.nil?
+      comments.first.author
+    else
+      super
+    end
   end
 
   private

--- a/app/views/api/notes/_note.rss.builder
+++ b/app/views/api/notes/_note.rss.builder
@@ -13,7 +13,7 @@ xml.item do
   xml.guid api_note_url(note)
   xml.description render(:partial => "description", :object => note, :formats => [:html])
 
-  xml.dc :creator, note.author.display_name if note.author
+  xml.dc :creator, note.author.display_name unless note.author.nil? || note.author.status == "deleted"
 
   xml.pubDate note.created_at.to_fs(:rfc822)
   xml.geo :lat, note.lat

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -48,7 +48,7 @@
       </td>
       <td><%= link_to note.id, note %></td>
       <td><%= note_author(note.author) %></td>
-      <td><%= note.description.to_html %></td>
+      <td><%= note_description(note.author, note.description).to_html %></td>
       <td><%= friendly_date_ago(note.created_at) %></td>
       <td><%= friendly_date_ago(note.updated_at) %></td>
     </tr>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -5,7 +5,7 @@
 <div>
   <h4><%= t(".description") %></h4>
   <div class="overflow-hidden ms-2">
-    <%= h(@note.description.to_html) %>
+    <%= h(note_description(@note.author, @note.description).to_html) %>
   </div>
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3069,6 +3069,7 @@ en:
       open_title: "Unresolved note #%{note_name}"
       closed_title: "Resolved note #%{note_name}"
       hidden_title: "Hidden note #%{note_name}"
+      description_when_author_is_deleted: "deleted"
       event_opened_by_html: "Created by %{user} %{time_ago}"
       event_opened_by_anonymous_html: "Created by anonymous %{time_ago}"
       event_commented_by_html: "Comment from %{user} %{time_ago}"


### PR DESCRIPTION
### Description

It seems to me that #5511 didn't go in satisfying direction, so, created new PR based on [original suggestion](https://github.com/openstreetmap/openstreetmap-website/pull/5485#pullrequestreview-2545467592).

PR adds optional use of author and description from notes (in case data-migration is done) and author and description from first visible note comment (in case data-migration is not done). Also, adds author association to Note model.

### How has this been tested?

Automated unit tests and manual testing. Also tested after applying [migration script](https://github.com/openstreetmap/openstreetmap-website/pull/5485/commits/3981e9e02daec8441340bda6572111c795df82cb).