### PR TITLE
Add coordinate precision function

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -4,13 +4,10 @@ OSM.initializeContextMenu = function (map) {
   map.contextmenu.addItem({
     text: I18n.t("javascripts.context.directions_from"),
     callback: function directionsFromHere(e) {
-      var precision = OSM.zoomPrecision(map.getZoom()),
-          latlng = e.latlng.wrap(),
-          lat = latlng.lat.toFixed(precision),
-          lng = latlng.lng.toFixed(precision);
+      const latlng = OSM.cropLocation(e.latlng, map.getZoom());
 
       OSM.router.route("/directions?" + Qs.stringify({
-        from: lat + "," + lng,
+        from: latlng.join(","),
         to: getDirectionsEndpointCoordinatesFromInput($("#route_to"))
       }));
     }
@@ -19,14 +16,11 @@ OSM.initializeContextMenu = function (map) {
   map.contextmenu.addItem({
     text: I18n.t("javascripts.context.directions_to"),
     callback: function directionsToHere(e) {
-      var precision = OSM.zoomPrecision(map.getZoom()),
-          latlng = e.latlng.wrap(),
-          lat = latlng.lat.toFixed(precision),
-          lng = latlng.lng.toFixed(precision);
+      const latlng = OSM.cropLocation(e.latlng, map.getZoom());
 
       OSM.router.route("/directions?" + Qs.stringify({
         from: getDirectionsEndpointCoordinatesFromInput($("#route_from")),
-        to: lat + "," + lng
+        to: latlng.join(",")
       }));
     }
   });
@@ -34,36 +28,27 @@ OSM.initializeContextMenu = function (map) {
   map.contextmenu.addItem({
     text: I18n.t("javascripts.context.add_note"),
     callback: function addNoteHere(e) {
-      var precision = OSM.zoomPrecision(map.getZoom()),
-          latlng = e.latlng.wrap(),
-          lat = latlng.lat.toFixed(precision),
-          lng = latlng.lng.toFixed(precision);
+      const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom());
 
-      OSM.router.route("/note/new?lat=" + lat + "&lon=" + lng);
+      OSM.router.route("/note/new?" + Qs.stringify({ lat, lon }));
     }
   });
 
   map.contextmenu.addItem({
     text: I18n.t("javascripts.context.show_address"),
     callback: function describeLocation(e) {
-      var precision = OSM.zoomPrecision(map.getZoom()),
-          latlng = e.latlng.wrap(),
-          lat = latlng.lat.toFixed(precision),
-          lng = latlng.lng.toFixed(precision);
+      const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom()).map(encodeURIComponent);
 
-      OSM.router.route("/search?lat=" + encodeURIComponent(lat) + "&lon=" + encodeURIComponent(lng));
+      OSM.router.route("/search?" + Qs.stringify({ lat, lon }));
     }
   });
 
   map.contextmenu.addItem({
     text: I18n.t("javascripts.context.query_features"),
     callback: function queryFeatures(e) {
-      var precision = OSM.zoomPrecision(map.getZoom()),
-          latlng = e.latlng.wrap(),
-          lat = latlng.lat.toFixed(precision),
-          lng = latlng.lng.toFixed(precision);
+      const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom());
 
-      OSM.router.route("/query?lat=" + lat + "&lon=" + lng);
+      OSM.router.route("/query?" + Qs.stringify({ lat, lon }));
     }
   });
 

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -34,7 +34,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
   };
 
   function markerDragListener(e) {
-    var latlng = convertLatLngToZoomPrecision(e.target.getLatLng());
+    const latlng = L.latLng(OSM.cropLocation(e.target.getLatLng(), map.getZoom()));
 
     setLatLng(latlng);
     setInputValueFromLatLng(latlng);
@@ -107,12 +107,6 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
 
   function setInputValueFromLatLng(latlng) {
     input.val(latlng.lat + ", " + latlng.lng);
-  }
-
-  function convertLatLngToZoomPrecision(latlng) {
-    var precision = OSM.zoomPrecision(map.getZoom());
-
-    return L.latLng(latlng.lat.toFixed(precision), latlng.lng.toFixed(precision));
   }
 
   return endpoint;

--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -36,16 +36,16 @@ OSM.Export = function (map) {
   }
 
   function setBounds(bounds) {
-    var precision = OSM.zoomPrecision(map.getZoom());
-    $("#minlon").val(bounds.getWest().toFixed(precision));
-    $("#minlat").val(bounds.getSouth().toFixed(precision));
-    $("#maxlon").val(bounds.getEast().toFixed(precision));
-    $("#maxlat").val(bounds.getNorth().toFixed(precision));
+    const truncated = [bounds.getSouthWest(), bounds.getNorthEast()]
+      .map(c => OSM.cropLocation(c, map.getZoom()));
+    $("#minlon").val(truncated[0][1]);
+    $("#minlat").val(truncated[0][0]);
+    $("#maxlon").val(truncated[1][1]);
+    $("#maxlat").val(truncated[1][0]);
 
     $("#export_overpass").attr("href",
                                "https://overpass-api.de/api/map?bbox=" +
-                               $("#minlon").val() + "," + $("#minlat").val() + "," +
-                               $("#maxlon").val() + "," + $("#maxlat").val());
+                               truncated.map(p => p.reverse()).join());
   }
 
   function validateControls() {

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -33,12 +33,9 @@ OSM.Search = function (map) {
   $(".describe_location").on("click", function (e) {
     e.preventDefault();
     $("header").addClass("closed");
-    var center = map.getCenter().wrap(),
-        precision = OSM.zoomPrecision(map.getZoom()),
-        lat = center.lat.toFixed(precision),
-        lng = center.lng.toFixed(precision);
+    const [lat, lon] = OSM.cropLocation(map.getCenter(), map.getZoom()).map(encodeURIComponent);
 
-    OSM.router.route("/search?lat=" + encodeURIComponent(lat) + "&lon=" + encodeURIComponent(lng));
+    OSM.router.route("/search?" + Qs.stringify({ lat, lon }));
   });
 
   $("#sidebar_content")

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -153,13 +153,10 @@ L.OSM.Map = L.Map.extend({
   },
 
   getUrl: function (marker) {
-    var precision = OSM.zoomPrecision(this.getZoom()),
-        params = {};
+    const params = {};
 
     if (marker && this.hasLayer(marker)) {
-      var latLng = marker.getLatLng().wrap();
-      params.mlat = latLng.lat.toFixed(precision);
-      params.mlon = latLng.lng.toFixed(precision);
+      [params.mlat, params.mlon] = OSM.cropLocation(marker.getLatLng(), this.getZoom());
     }
 
     var url = window.location.protocol + "//" + OSM.SERVER_URL + "/",
@@ -237,21 +234,14 @@ L.OSM.Map = L.Map.extend({
   },
 
   getGeoUri: function (marker) {
-    var precision = OSM.zoomPrecision(this.getZoom()),
-        latLng,
-        params = {};
+    let latLng = this.getCenter();
+    const zoom = this.getZoom();
 
     if (marker && this.hasLayer(marker)) {
-      latLng = marker.getLatLng().wrap();
-    } else {
-      latLng = this.getCenter();
+      latLng = marker.getLatLng();
     }
 
-    params.lat = latLng.lat.toFixed(precision);
-    params.lon = latLng.lng.toFixed(precision);
-    params.zoom = this.getZoom();
-
-    return "geo:" + params.lat + "," + params.lon + "?z=" + params.zoom;
+    return `geo:${OSM.cropLocation(latLng, zoom).join(",")}?z=${zoom}`;
   },
 
   addObject: function (object, callback) {

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -190,13 +190,9 @@ OSM = {
       layers = args.layers || "";
     }
 
-    center = center.wrap();
     layers = layers.replace("M", "");
 
-    var precision = OSM.zoomPrecision(zoom),
-        hash = "#map=" + zoom +
-          "/" + center.lat.toFixed(precision) +
-          "/" + center.lng.toFixed(precision);
+    let hash = "#map=" + [zoom, ...OSM.cropLocation(center, zoom)].join("/");
 
     if (layers) {
       hash += "&layers=" + layers;
@@ -211,11 +207,16 @@ OSM = {
     return Math.ceil(Math.log10(pixels / degrees));
   },
 
+  cropLocation: function (latLng, zoom) {
+    const precision = OSM.zoomPrecision(zoom),
+          wrapped = latLng.wrap();
+    return [wrapped.lat, wrapped.lng].map(c => c.toFixed(precision));
+  },
+
   locationCookie: function (map) {
-    var center = map.getCenter().wrap(),
-        zoom = map.getZoom(),
-        precision = OSM.zoomPrecision(zoom);
-    return [center.lng.toFixed(precision), center.lat.toFixed(precision), zoom, map.getLayersCode()].join("|");
+    const zoom = map.getZoom(),
+          center = OSM.cropLocation(map.getCenter(), zoom).reverse();
+    return [...center, zoom, map.getLayersCode()].join("|");
   },
 
   distance: function (latlng1, latlng2) {

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -64,12 +64,10 @@ $(document).ready(function () {
       map.on("click", function (e) {
         if (!$("#updatehome").is(":checked")) return;
 
-        var zoom = map.getZoom(),
-            precision = OSM.zoomPrecision(zoom),
-            location = e.latlng.wrap();
+        const [lat, lon] = OSM.cropLocation(e.latlng);
 
-        $("#home_lat").val(location.lat.toFixed(precision));
-        $("#home_lon").val(location.lng.toFixed(precision));
+        $("#home_lat").val(lat);
+        $("#home_lon").val(lon);
 
         deleted_lat = null;
         deleted_lon = null;


### PR DESCRIPTION
The amount of `latlng.lat/lng.toFixed(precision)` calls has been bugging me.
I've put a function next to OSM.zoomPrecision that outputs a latlng array that can be destructured, spread and `join`ed.