### PR TITLE
Extend user block periods

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,7 +54,7 @@ api_timeout: 300
 # Timeout for web pages in seconds
 web_timeout: 30
 # Periods (in hours) which are allowed for user blocks
-user_block_periods: [0, 1, 3, 6, 12, 24, 48, 96, 168, 336, 731, 4383, 8766, 87660]
+user_block_periods: [0, 1, 3, 6, 12, 24, 48, 96, 168, 336, 731, 4383, 8766, 87660, 131490, 175320]
 # Account deletion cooldown period (in hours) since last changeset close; null to disable, 0 to make sure there aren't any open changesets when the deletion happens
 user_account_deletion_delay: null
 # Rate limit for message sending


### PR DESCRIPTION
Extend user block periods to include 15 and 20 years

### Description
There are currently around 10 user blocks that were created with a duration of 9 years and will end on 2026-01-01. Earlier blocks from 2015 and before that were decided as "indefinite" have ended on 2025-01-01.

To prevent 10 year bans from expiring even though the user was supposed to be banned indef. and to renew bans that have expired, this PR adds block periods of 15 and 20 years.
