### PR TITLE
Remove unused visible_nodes hashes from api element controllers

### DIFF
--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -102,14 +102,11 @@ module Api
         node_ids += way_node_ids.flatten
         nodes = Node.where(:id => node_ids.uniq).includes(:node_tags)
 
-        visible_nodes = {}
-
         @nodes = []
         nodes.each do |node|
           next unless node.visible? # should be unnecessary if data is consistent.
 
           @nodes << node
-          visible_nodes[node.id] = node
         end
 
         @ways = []

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -76,15 +76,10 @@ module Api
       @way = Way.includes(:nodes => :node_tags).find(params[:id])
 
       if @way.visible
-        visible_nodes = {}
-
         @nodes = []
 
         @way.nodes.uniq.each do |node|
-          if node.visible
-            @nodes << node
-            visible_nodes[node.id] = node
-          end
+          @nodes << node if node.visible
         end
 
         # Render the result


### PR DESCRIPTION
There was a method called `to_xml_node` defined on way models. It had a cache parameter, and `visible_nodes` was passed as this parameter in https://github.com/openstreetmap/openstreetmap-website/commit/6300fa2a4fa717ef60f715a5303916b85d951c47. Later in https://github.com/openstreetmap/openstreetmap-website/commit/363155a2a86796d27ee9161f1ee9b74d6fa307e5 xml output was rewritten and `to_xml_node` was no longer used. The method was removed in https://github.com/openstreetmap/openstreetmap-website/commit/2b1bac1279e268c8e5fcca34c950f30d2c06ec1c. Same for relations.

However `visible_nodes` stayed. It's being written to but is never read.