### PR TITLE
Remove ids collected in parallel to model instances in map api

### DIFF
--- a/app/controllers/api/maps_controller.rb
+++ b/app/controllers/api/maps_controller.rb
@@ -57,26 +57,18 @@ module Api
 
       nodes += Node.includes(:node_tags).find(nodes_to_fetch) unless nodes_to_fetch.empty?
 
-      visible_nodes = {}
       @nodes = []
       nodes.each do |node|
-        if node.visible?
-          visible_nodes[node.id] = node
-          @nodes << node
-        end
+        @nodes << node if node.visible?
       end
 
       @ways = []
-      way_ids = []
       ways.each do |way|
-        if way.visible?
-          way_ids << way.id
-          @ways << way
-        end
+        @ways << way if way.visible?
       end
 
-      @relations = Relation.nodes(visible_nodes.keys).visible +
-                   Relation.ways(way_ids).visible
+      @relations = Relation.nodes(@nodes).visible +
+                   Relation.ways(@ways).visible
 
       # we do not normally return the "other" partners referenced by an relation,
       # e.g. if we return a way A that is referenced by relation X, and there's

--- a/app/controllers/api/maps_controller.rb
+++ b/app/controllers/api/maps_controller.rb
@@ -57,15 +57,9 @@ module Api
 
       nodes += Node.includes(:node_tags).find(nodes_to_fetch) unless nodes_to_fetch.empty?
 
-      @nodes = []
-      nodes.each do |node|
-        @nodes << node if node.visible?
-      end
+      @nodes = nodes.filter(&:visible?)
 
-      @ways = []
-      ways.each do |way|
-        @ways << way if way.visible?
-      end
+      @ways = ways.filter(&:visible?)
 
       @relations = Relation.nodes(@nodes).visible +
                    Relation.ways(@ways).visible


### PR DESCRIPTION
Another instance of `visible_nodes` like in #5584, but this time it's being read. However it's largely useless because nodes are already collected into `@nodes`. Same for `way_ids`.