### PR TITLE
Use URI.encode_uri_component when generating share urls

### DIFF
--- a/app/helpers/social_share_button_helper.rb
+++ b/app/helpers/social_share_button_helper.rb
@@ -35,8 +35,8 @@ module SocialShareButtonHelper
 
   def generate_share_url(site, title, url)
     site = site.to_sym
-    title = URI.encode_www_form_component(title)
-    url = URI.encode_www_form_component(url)
+    title = URI.encode_uri_component(title)
+    url = URI.encode_uri_component(url)
 
     case site
     when :email

--- a/test/helpers/social_share_button_helper_test.rb
+++ b/test/helpers/social_share_button_helper_test.rb
@@ -9,9 +9,14 @@ class SocialShareButtonHelperTest < ActionView::TestCase
 
     SOCIAL_SHARE_CONFIG.each_value do |icon|
       assert_dom buttons_dom, "div:has(a img[src='/images/#{icon}'])", :count => 1 do
-        assert_dom "a[href*='Test+Title']"
+        assert_dom "a[href*='Test%20Title']"
         assert_dom "a[href*='https%3A%2F%2Fexample.com']"
       end
     end
+  end
+
+  def test_generate_share_url_email
+    url = generate_share_url(:email, "Diary Entry Title", "https://osm.example.com/some/diary/entry")
+    assert_equal "mailto:?subject=Diary%20Entry%20Title&body=https%3A%2F%2Fosm.example.com%2Fsome%2Fdiary%2Fentry", url
   end
 end


### PR DESCRIPTION
Fixes #5587.

I think it's safer to always use `URI.encode_uri_component` instead of `URI.encode_www_form_component`. Space is going to be encoded as `%20`. Space as `+` sometimes doesn't work.