### PR TITLE
API element resources - index paths

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,6 @@ OpenStreetMap::Application.routes.draw do
     get "node/:id" => "nodes#show", :as => :api_node, :id => /\d+/
     put "node/:id" => "nodes#update", :id => /\d+/
     delete "node/:id" => "nodes#delete", :id => /\d+/
-    get "nodes" => "nodes#index"
 
     put "way/create" => "ways#create"
     get "way/:id/history" => "old_ways#history", :as => :api_way_history, :id => /\d+/
@@ -50,7 +49,6 @@ OpenStreetMap::Application.routes.draw do
     get "way/:id" => "ways#show", :as => :api_way, :id => /\d+/
     put "way/:id" => "ways#update", :id => /\d+/
     delete "way/:id" => "ways#delete", :id => /\d+/
-    get "ways" => "ways#index"
 
     put "relation/create" => "relations#create"
     get "relation/:id/relations" => "relations#relations_for_relation", :as => :relation_relations, :id => /\d+/
@@ -61,10 +59,13 @@ OpenStreetMap::Application.routes.draw do
     get "relation/:id" => "relations#show", :as => :api_relation, :id => /\d+/
     put "relation/:id" => "relations#update", :id => /\d+/
     delete "relation/:id" => "relations#delete", :id => /\d+/
-    get "relations" => "relations#index"
   end
 
   namespace :api, :path => "api/0.6" do
+    resources :nodes, :only => :index
+    resources :ways, :only => :index
+    resources :relations, :only => :index
+
     resource :map, :only => :show
 
     resources :tracepoints, :path => "trackpoints", :only => :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,6 @@ OpenStreetMap::Application.routes.draw do
     put "way/:id" => "ways#update", :id => /\d+/
     delete "way/:id" => "ways#delete", :id => /\d+/
 
-    put "relation/create" => "relations#create"
     get "relation/:id/relations" => "relations#relations_for_relation", :as => :relation_relations, :id => /\d+/
     get "relation/:id/history" => "old_relations#history", :as => :api_relation_history, :id => /\d+/
     get "relation/:id/full" => "relations#full", :as => :relation_full, :id => /\d+/
@@ -66,7 +65,8 @@ OpenStreetMap::Application.routes.draw do
     resources :ways, :only => [:index, :create]
     put "way/create" => "ways#create", :as => nil
 
-    resources :relations, :only => :index
+    resources :relations, :only => [:index, :create]
+    put "relation/create" => "relations#create", :as => nil
 
     resource :map, :only => :show
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,6 @@ OpenStreetMap::Application.routes.draw do
     put "node/:id" => "nodes#update", :id => /\d+/
     delete "node/:id" => "nodes#delete", :id => /\d+/
 
-    put "way/create" => "ways#create"
     get "way/:id/history" => "old_ways#history", :as => :api_way_history, :id => /\d+/
     get "way/:id/full" => "ways#full", :as => :way_full, :id => /\d+/
     get "way/:id/relations" => "relations#relations_for_way", :as => :way_relations, :id => /\d+/
@@ -64,7 +63,8 @@ OpenStreetMap::Application.routes.draw do
     resources :nodes, :only => [:index, :create]
     put "node/create" => "nodes#create", :as => nil
 
-    resources :ways, :only => :index
+    resources :ways, :only => [:index, :create]
+    put "way/create" => "ways#create", :as => nil
 
     resources :relations, :only => :index
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,6 @@ OpenStreetMap::Application.routes.draw do
     post "changeset/comment/:id/hide" => "changeset_comments#destroy", :as => :changeset_comment_hide, :id => /\d+/
     post "changeset/comment/:id/unhide" => "changeset_comments#restore", :as => :changeset_comment_unhide, :id => /\d+/
 
-    put "node/create" => "nodes#create"
     get "node/:id/ways" => "ways#ways_for_node", :as => :node_ways, :id => /\d+/
     get "node/:id/relations" => "relations#relations_for_node", :as => :node_relations, :id => /\d+/
     get "node/:id/history" => "old_nodes#history", :as => :api_node_history, :id => /\d+/
@@ -62,8 +61,11 @@ OpenStreetMap::Application.routes.draw do
   end
 
   namespace :api, :path => "api/0.6" do
-    resources :nodes, :only => :index
+    resources :nodes, :only => [:index, :create]
+    put "node/create" => "nodes#create", :as => nil
+
     resources :ways, :only => :index
+
     resources :relations, :only => :index
 
     resource :map, :only => :show

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -2115,7 +2115,7 @@ module Api
       # add a single node to it
       with_controller(NodesController.new) do
         xml = "<osm><node lon='0.1' lat='0.2' changeset='#{changeset_id}'/></osm>"
-        put node_create_path, :params => xml, :headers => auth_header
+        post api_nodes_path, :params => xml, :headers => auth_header
         assert_response :success, "Couldn't create node."
       end
 
@@ -2130,7 +2130,7 @@ module Api
       # add another node to it
       with_controller(NodesController.new) do
         xml = "<osm><node lon='0.2' lat='0.1' changeset='#{changeset_id}'/></osm>"
-        put node_create_path, :params => xml, :headers => auth_header
+        post api_nodes_path, :params => xml, :headers => auth_header
         assert_response :success, "Couldn't create second node."
       end
 
@@ -2500,7 +2500,7 @@ module Api
       with_controller(NodesController.new) do
         # create a new node
         xml = "<osm><node changeset='#{cs_id}' lat='0.0' lon='0.0'/></osm>"
-        put node_create_path, :params => xml, :headers => auth_header
+        post api_nodes_path, :params => xml, :headers => auth_header
         assert_response :success, "can't create a new node"
         node_id = @response.body.to_i
 

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -434,15 +434,15 @@ module Api
       node5 = create(:node, :deleted, :with_history, :version => 2)
 
       # check error when no parameter provided
-      get nodes_path
+      get api_nodes_path
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get nodes_path(:nodes => "")
+      get api_nodes_path(:nodes => "")
       assert_response :bad_request
 
       # test a working call
-      get nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}")
+      get api_nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}")
       assert_response :success
       assert_select "osm" do
         assert_select "node", :count => 5
@@ -454,7 +454,7 @@ module Api
       end
 
       # test a working call with json format
-      get nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}", :format => "json")
+      get api_nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id}", :format => "json")
 
       js = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil js
@@ -467,7 +467,7 @@ module Api
       assert_equal 1, (js["elements"].count { |a| a["id"] == node5.id && a["visible"] == false })
 
       # check error when a non-existent node is included
-      get nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id},0")
+      get api_nodes_path(:nodes => "#{node1.id},#{node2.id},#{node3.id},#{node4.id},#{node5.id},0")
       assert_response :not_found
     end
 

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -174,15 +174,15 @@ module Api
       relation4.old_relations.find_by(:version => 1).redact!(create(:redaction))
 
       # check error when no parameter provided
-      get relations_path
+      get api_relations_path
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get relations_path(:relations => "")
+      get api_relations_path(:relations => "")
       assert_response :bad_request
 
       # test a working call
-      get relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}")
+      get api_relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}")
       assert_response :success
       assert_select "osm" do
         assert_select "relation", :count => 4
@@ -193,7 +193,7 @@ module Api
       end
 
       # test a working call with json format
-      get relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}", :format => "json")
+      get api_relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id}", :format => "json")
 
       js = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil js
@@ -205,7 +205,7 @@ module Api
       assert_equal 1, (js["elements"].count { |a| a["id"] == relation4.id && a["visible"].nil? })
 
       # check error when a non-existent relation is included
-      get relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id},0")
+      get api_relations_path(:relations => "#{relation1.id},#{relation2.id},#{relation3.id},#{relation4.id},0")
       assert_response :not_found
     end
 

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -14,7 +14,7 @@ module Api
         { :controller => "api/ways", :action => "index", :format => "json" }
       )
       assert_routing(
-        { :path => "/api/0.6/way/create", :method => :put },
+        { :path => "/api/0.6/ways", :method => :post },
         { :controller => "api/ways", :action => "create" }
       )
       assert_routing(
@@ -40,6 +40,11 @@ module Api
       assert_routing(
         { :path => "/api/0.6/way/1", :method => :delete },
         { :controller => "api/ways", :action => "delete", :id => "1" }
+      )
+
+      assert_recognizes(
+        { :controller => "api/ways", :action => "create" },
+        { :path => "/api/0.6/way/create", :method => :put }
       )
     end
 
@@ -155,7 +160,7 @@ module Api
       xml = "<osm><way changeset='#{changeset_id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
             "<tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # hope for failure
       assert_response :forbidden,
                       "way upload did not return forbidden status"
@@ -170,7 +175,7 @@ module Api
       xml = "<osm><way changeset='#{changeset_id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
             "<tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # hope for success
       assert_response :success,
                       "way upload did not return success status"
@@ -213,7 +218,7 @@ module Api
       # create a way with non-existing node
       xml = "<osm><way changeset='#{private_open_changeset.id}'>" \
             "<nd ref='0'/><tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :forbidden,
                       "way upload with invalid node using a private user did not return 'forbidden'"
@@ -221,7 +226,7 @@ module Api
       # create a way with no nodes
       xml = "<osm><way changeset='#{private_open_changeset.id}'>" \
             "<tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :forbidden,
                       "way upload with no node using a private userdid not return 'forbidden'"
@@ -229,7 +234,7 @@ module Api
       # create a way inside a closed changeset
       xml = "<osm><way changeset='#{private_closed_changeset.id}'>" \
             "<nd ref='#{node.id}'/></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :forbidden,
                       "way upload to closed changeset with a private user did not return 'forbidden'"
@@ -241,7 +246,7 @@ module Api
       # create a way with non-existing node
       xml = "<osm><way changeset='#{open_changeset.id}'>" \
             "<nd ref='0'/><tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :precondition_failed,
                       "way upload with invalid node did not return 'precondition failed'"
@@ -250,7 +255,7 @@ module Api
       # create a way with no nodes
       xml = "<osm><way changeset='#{open_changeset.id}'>" \
             "<tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :precondition_failed,
                       "way upload with no node did not return 'precondition failed'"
@@ -259,7 +264,7 @@ module Api
       # create a way inside a closed changeset
       xml = "<osm><way changeset='#{closed_changeset.id}'>" \
             "<nd ref='#{node.id}'/></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :conflict,
                       "way upload to closed changeset did not return 'conflict'"
@@ -269,7 +274,7 @@ module Api
             "<nd ref='#{node.id}'/>" \
             "<tag k='foo' v='#{'x' * 256}'/>" \
             "</way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :bad_request,
                       "way upload to with too long tag did not return 'bad_request'"
@@ -696,7 +701,7 @@ module Api
       way_str << "</way></osm>"
 
       # try and upload it
-      put way_create_path, :params => way_str, :headers => auth_header
+      post api_ways_path, :params => way_str, :headers => auth_header
       assert_response :forbidden,
                       "adding new duplicate tags to a way with a non-public user should fail with 'forbidden'"
 
@@ -711,7 +716,7 @@ module Api
       way_str << "</way></osm>"
 
       # try and upload it
-      put way_create_path, :params => way_str, :headers => auth_header
+      post api_ways_path, :params => way_str, :headers => auth_header
       assert_response :bad_request,
                       "adding new duplicate tags to a way should fail with 'bad request'"
       assert_equal "Element way/ has duplicate tags with key addr:housenumber", @response.body
@@ -775,7 +780,7 @@ module Api
       xml = "<osm><way changeset='#{changeset.id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
             "<tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       assert_response :success, "way create did not return success status"
 
       # get the id of the way we created
@@ -797,7 +802,7 @@ module Api
       xml = "<osm><way changeset='#{changeset.id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
             "<tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way create did not hit rate limit"
     end
 
@@ -832,7 +837,7 @@ module Api
       xml = "<osm><way changeset='#{changeset.id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
             "<tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       assert_response :success, "way create did not return success status"
 
       # get the id of the way we created
@@ -854,7 +859,7 @@ module Api
       xml = "<osm><way changeset='#{changeset.id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
             "<tag k='test' v='yes' /></way></osm>"
-      put way_create_path, :params => xml, :headers => auth_header
+      post api_ways_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way create did not hit rate limit"
     end
 

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -98,15 +98,15 @@ module Api
       way4 = create(:way)
 
       # check error when no parameter provided
-      get ways_path
+      get api_ways_path
       assert_response :bad_request
 
       # check error when no parameter value provided
-      get ways_path(:ways => "")
+      get api_ways_path(:ways => "")
       assert_response :bad_request
 
       # test a working call
-      get ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}")
+      get api_ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}")
       assert_response :success
       assert_select "osm" do
         assert_select "way", :count => 4
@@ -117,7 +117,7 @@ module Api
       end
 
       # test a working call with json format
-      get ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}", :format => "json")
+      get api_ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id}", :format => "json")
 
       js = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil js
@@ -129,7 +129,7 @@ module Api
       assert_equal 1, (js["elements"].count { |a| a["id"] == way4.id && a["visible"].nil? })
 
       # check error when a non-existent way is included
-      get ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id},0")
+      get api_ways_path(:ways => "#{way1.id},#{way2.id},#{way3.id},#{way4.id},0")
       assert_response :not_found
     end
 


### PR DESCRIPTION
Part of #5590.

Makes element index paths resourceful:
- `/api/0.6/nodes`
- `/api/0.6/ways`
- `/api/0.6/relations`

Aside from the `index` action, enables `create` by posting at these paths.

However, `create` already exists in the api at `PUT /api/0.6/node/create` etc. This is not a standard way to define `create` actions. `PUT` is supposed to be [idempotent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT), but obviously `create` create is not. You do `PUT /api/0.6/node/create`, you get one new node. You do it twice, you get two.[^1] I'm keeping the existing put-creates by mapping them to the same actions as proper post-creates.

[^1]: That also means that `update` actions which are implemented with `PUT`s are wrong because they create as many new versions as there are `PUT`s. We should be creating new versions by `POST`s instead. I'm not fixing this yet here.