### PR TITLE
Replace qs with URLSearchParams

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,6 @@
 //= require oauth
 //= require matomo
 //= require richtext
-//= require qs/dist/qs
 
 {
   const application_data = $("head").data();
@@ -45,34 +44,34 @@
  */
 window.updateLinks = function (loc, zoom, layers, object) {
   $(".geolink").each(function (index, link) {
-    var href = link.href.split(/[?#]/)[0],
-        args = Qs.parse(link.search.substring(1)),
-        editlink = $(link).hasClass("editlink");
+    let href = link.href.split(/[?#]/)[0];
+    const queryArgs = new URLSearchParams(link.search),
+          editlink = $(link).hasClass("editlink");
 
-    delete args.node;
-    delete args.way;
-    delete args.relation;
-    delete args.changeset;
-    delete args.note;
+    queryArgs.delete("node");
+    queryArgs.delete("way");
+    queryArgs.delete("relation");
+    queryArgs.delete("changeset");
+    queryArgs.delete("note");
 
     if (object && editlink) {
-      args[object.type] = object.id;
+      queryArgs.set(object.type, object.id);
     }
 
-    var query = Qs.stringify(args);
+    const query = queryArgs.toString();
     if (query) href += "?" + query;
 
-    args = {
+    const hashArgs = {
       lat: loc.lat,
       lon: "lon" in loc ? loc.lon : loc.lng,
       zoom: zoom
     };
 
     if (layers && !editlink) {
-      args.layers = layers;
+      hashArgs.layers = layers;
     }
 
-    href += OSM.formatHash(args);
+    href += OSM.formatHash(hashArgs);
 
     link.href = href;
   });

--- a/app/assets/javascripts/auth_providers.js
+++ b/app/assets/javascripts/auth_providers.js
@@ -1,10 +1,8 @@
-//= require qs/dist/qs
-
 $(document).ready(function () {
   // Attach referer to authentication buttons
   $(".auth_button").each(function () {
-    var params = Qs.parse(this.search.substring(1));
-    params.referer = $("#referer").val();
-    this.search = Qs.stringify(params);
+    const params = new URLSearchParams(this.search);
+    params.set("referer", $("#referer").val());
+    this.search = params.toString();
   });
 });

--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -1,5 +1,3 @@
-//= require qs/dist/qs
-
 $(document).ready(function () {
   var id = $("#id-embed");
 
@@ -7,45 +5,45 @@ $(document).ready(function () {
     var hash = location.hash.substring(1);
     var hashParams = hash ? OSM.params(hash) : {};
     var mapParams = OSM.mapParams();
-    var params = {};
+    var params = new URLSearchParams();
 
     if (mapParams.object) {
-      params.id = mapParams.object.type + "/" + mapParams.object.id;
+      params.set("id", mapParams.object.type + "/" + mapParams.object.id);
       mapParams = OSM.parseHash(location.hash);
       if (mapParams.center) {
-        params.map = mapParams.zoom + "/" + mapParams.center.lat + "/" + mapParams.center.lng;
+        params.set("map", mapParams.zoom + "/" + mapParams.center.lat + "/" + mapParams.center.lng);
       }
     } else if (id.data("lat") && id.data("lon")) {
-      params.map = "16/" + id.data("lat") + "/" + id.data("lon");
+      params.set("map", "16/" + id.data("lat") + "/" + id.data("lon"));
     } else {
-      params.map = (mapParams.zoom || 17) + "/" + mapParams.lat + "/" + mapParams.lon;
+      params.set("map", (mapParams.zoom || 17) + "/" + mapParams.lat + "/" + mapParams.lon);
     }
 
-    if (hashParams.background) params.background = hashParams.background;
-    if (hashParams.comment) params.comment = hashParams.comment;
-    if (hashParams.disable_features) params.disable_features = hashParams.disable_features;
-    if (hashParams.hashtags) params.hashtags = hashParams.hashtags;
-    if (hashParams.locale) params.locale = hashParams.locale;
-    if (hashParams.maprules) params.maprules = hashParams.maprules;
-    if (hashParams.offset) params.offset = hashParams.offset;
-    if (hashParams.photo) params.photo = hashParams.photo;
-    if (hashParams.photo_dates) params.photo_dates = hashParams.photo_dates;
-    if (hashParams.photo_overlay) params.photo_overlay = hashParams.photo_overlay;
-    if (hashParams.photo_username) params.photo_username = hashParams.photo_username;
-    if (hashParams.presets) params.presets = hashParams.presets;
-    if (hashParams.source) params.source = hashParams.source;
-    if (hashParams.validationDisable) params.validationDisable = hashParams.validationDisable;
-    if (hashParams.validationWarning) params.validationWarning = hashParams.validationWarning;
-    if (hashParams.validationError) params.validationError = hashParams.validationError;
-    if (hashParams.walkthrough) params.walkthrough = hashParams.walkthrough;
+    if (hashParams.background) params.set("background", hashParams.background);
+    if (hashParams.comment) params.set("comment", hashParams.comment);
+    if (hashParams.disable_features) params.set("disable_features", hashParams.disable_features);
+    if (hashParams.hashtags) params.set("hashtags", hashParams.hashtags);
+    if (hashParams.locale) params.set("locale", hashParams.locale);
+    if (hashParams.maprules) params.set("maprules", hashParams.maprules);
+    if (hashParams.offset) params.set("offset", hashParams.offset);
+    if (hashParams.photo) params.set("photo", hashParams.photo);
+    if (hashParams.photo_dates) params.set("photo_dates", hashParams.photo_dates);
+    if (hashParams.photo_overlay) params.set("photo_overlay", hashParams.photo_overlay);
+    if (hashParams.photo_username) params.set("photo_username", hashParams.photo_username);
+    if (hashParams.presets) params.set("presets", hashParams.presets);
+    if (hashParams.source) params.set("source", hashParams.source);
+    if (hashParams.validationDisable) params.set("validationDisable", hashParams.validationDisable);
+    if (hashParams.validationWarning) params.set("validationWarning", hashParams.validationWarning);
+    if (hashParams.validationError) params.set("validationError", hashParams.validationError);
+    if (hashParams.walkthrough) params.set("walkthrough", hashParams.walkthrough);
 
     if (id.data("gpx")) {
-      params.gpx = id.data("gpx");
+      params.set("gpx", id.data("gpx"));
     } else if (hashParams.gpx) {
-      params.gpx = hashParams.gpx;
+      params.set("gpx", hashParams.gpx);
     }
 
-    id.attr("src", id.data("url") + "#" + Qs.stringify(params));
+    id.attr("src", id.data("url") + "#" + params);
   } else {
     alert(I18n.t("site.edit.id_not_configured"));
   }

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -22,7 +22,6 @@
 //= require index/changeset
 //= require index/query
 //= require router
-//= require qs/dist/qs
 
 $(document).ready(function () {
   var map = new L.OSM.Map("map", {
@@ -239,18 +238,18 @@ $(document).ready(function () {
   function remoteEditHandler(bbox, object) {
     var remoteEditHost = "http://127.0.0.1:8111",
         osmHost = location.protocol + "//" + location.host,
-        query = {
+        query = new URLSearchParams({
           left: bbox.getWest() - 0.0001,
           top: bbox.getNorth() + 0.0001,
           right: bbox.getEast() + 0.0001,
           bottom: bbox.getSouth() - 0.0001
-        };
+        });
 
-    if (object && object.type !== "note") query.select = object.type + object.id; // can't select notes
-    sendRemoteEditCommand(remoteEditHost + "/load_and_zoom?" + Qs.stringify(query), function () {
+    if (object && object.type !== "note") query.set("select", object.type + object.id); // can't select notes
+    sendRemoteEditCommand(remoteEditHost + "/load_and_zoom?" + query, function () {
       if (object && object.type === "note") {
-        var noteQuery = { url: osmHost + OSM.apiUrl(object) };
-        sendRemoteEditCommand(remoteEditHost + "/import?" + Qs.stringify(noteQuery));
+        const noteQuery = new URLSearchParams({ url: osmHost + OSM.apiUrl(object) });
+        sendRemoteEditCommand(remoteEditHost + "/import?" + noteQuery);
       }
     });
 
@@ -294,9 +293,9 @@ $(document).ready(function () {
     };
 
     page.load = function () {
-      var params = Qs.parse(location.search.substring(1));
-      if (params.query) {
-        $("#sidebar .search_form input[name=query]").value(params.query);
+      const params = new URLSearchParams(location.search);
+      if (params.has("query")) {
+        $("#sidebar .search_form input[name=query]").value(params.get("query"));
       }
       if (!("autofocus" in document.createElement("input"))) {
         $("#sidebar .search_form input[name=query]").focus();

--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -1,12 +1,10 @@
-//= require qs/dist/qs
-
 OSM.initializeContextMenu = function (map) {
   map.contextmenu.addItem({
     text: I18n.t("javascripts.context.directions_from"),
     callback: function directionsFromHere(e) {
       const latlng = OSM.cropLocation(e.latlng, map.getZoom());
 
-      OSM.router.route("/directions?" + Qs.stringify({
+      OSM.router.route("/directions?" + new URLSearchParams({
         from: latlng.join(","),
         to: getDirectionsEndpointCoordinatesFromInput($("#route_to"))
       }));
@@ -18,7 +16,7 @@ OSM.initializeContextMenu = function (map) {
     callback: function directionsToHere(e) {
       const latlng = OSM.cropLocation(e.latlng, map.getZoom());
 
-      OSM.router.route("/directions?" + Qs.stringify({
+      OSM.router.route("/directions?" + new URLSearchParams({
         from: getDirectionsEndpointCoordinatesFromInput($("#route_from")),
         to: latlng.join(",")
       }));
@@ -30,7 +28,7 @@ OSM.initializeContextMenu = function (map) {
     callback: function addNoteHere(e) {
       const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom());
 
-      OSM.router.route("/note/new?" + Qs.stringify({ lat, lon }));
+      OSM.router.route("/note/new?" + new URLSearchParams({ lat, lon }));
     }
   });
 
@@ -39,7 +37,7 @@ OSM.initializeContextMenu = function (map) {
     callback: function describeLocation(e) {
       const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom()).map(encodeURIComponent);
 
-      OSM.router.route("/search?" + Qs.stringify({ lat, lon }));
+      OSM.router.route("/search?" + new URLSearchParams({ lat, lon }));
     }
   });
 
@@ -48,7 +46,7 @@ OSM.initializeContextMenu = function (map) {
     callback: function queryFeatures(e) {
       const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom());
 
-      OSM.router.route("/query?" + Qs.stringify({ lat, lon }));
+      OSM.router.route("/query?" + new URLSearchParams({ lat, lon }));
     }
   });
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -1,7 +1,6 @@
 //= require ./directions-endpoint
 //= require_self
 //= require_tree ./directions
-//= require qs/dist/qs
 
 OSM.Directions = function (map) {
   var routeRequest = null; // jqXHR object of an ongoing route request or null
@@ -67,7 +66,7 @@ OSM.Directions = function (map) {
     }
     endpoints[0].swapCachedReverseGeocodes(endpoints[1]);
 
-    OSM.router.route("/directions?" + Qs.stringify({
+    OSM.router.route("/directions?" + new URLSearchParams({
       route: routeTo + ";" + routeFrom
     }));
   });
@@ -120,7 +119,7 @@ OSM.Directions = function (map) {
     if (!points[0] || !points[1]) return;
     $("header").addClass("closed");
 
-    OSM.router.replace("/directions?" + Qs.stringify({
+    OSM.router.replace("/directions?" + new URLSearchParams({
       engine: chosenEngine.id,
       route: points.map(p => OSM.cropLocation(p, map.getZoom()).join()).join(";")
     }));
@@ -287,19 +286,19 @@ OSM.Directions = function (map) {
     endpoints[0].enable();
     endpoints[1].enable();
 
-    var params = Qs.parse(location.search.substring(1)),
-        route = (params.route || "").split(";");
+    const params = new URLSearchParams(location.search),
+          route = (params.get("route") || "").split(";");
 
-    if (params.engine) {
-      var engineIndex = findEngine(params.engine);
+    if (params.has("engine")) {
+      var engineIndex = findEngine(params.get("engine"));
 
       if (engineIndex >= 0) {
         setEngine(engineIndex);
       }
     }
 
-    endpoints[0].setValue(params.from || route[0] || "");
-    endpoints[1].setValue(params.to || route[1] || "");
+    endpoints[0].setValue(params.get("from") || route[0] || "");
+    endpoints[1].setValue(params.get("to") || route[1] || "");
 
     map.setSidebarOverlaid(!endpoints[0].latlng || !endpoints[1].latlng);
   };

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -1,5 +1,3 @@
-//= require qs/dist/qs
-
 OSM.NewNote = function (map) {
   var noteLayer = map.noteLayer,
       content = $("#sidebar_content"),
@@ -133,11 +131,11 @@ OSM.NewNote = function (map) {
 
     map.addLayer(noteLayer);
 
-    var params = Qs.parse(path.substring(path.indexOf("?") + 1));
+    const params = new URLSearchParams(path.substring(path.indexOf("?")));
     var markerLatlng;
 
-    if (params.lat && params.lon) {
-      markerLatlng = L.latLng(params.lat, params.lon);
+    if (params.has("lat") && params.has("lon")) {
+      markerLatlng = L.latLng(params.get("lat"), params.get("lon"));
     } else {
       markerLatlng = map.getCenter();
     }

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -1,5 +1,3 @@
-//= require qs/dist/qs
-
 OSM.Query = function (map) {
   var url = OSM.OVERPASS_URL,
       credentials = OSM.OVERPASS_CREDENTIALS,
@@ -301,7 +299,7 @@ OSM.Query = function (map) {
   function clickHandler(e) {
     const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom());
 
-    OSM.router.route("/query?" + Qs.stringify({ lat, lon }));
+    OSM.router.route("/query?" + new URLSearchParams({ lat, lon }));
   }
 
   function enableQueryMode() {
@@ -326,8 +324,8 @@ OSM.Query = function (map) {
   };
 
   page.load = function (path, noCentre) {
-    var params = Qs.parse(path.substring(path.indexOf("?") + 1)),
-        latlng = L.latLng(params.lat, params.lon);
+    const params = new URLSearchParams(path.substring(path.indexOf("?"))),
+          latlng = L.latLng(params.get("lat"), params.get("lon"));
 
     if (!window.location.hash && !noCentre && !map.getBounds().contains(latlng)) {
       OSM.router.withoutMoveListener(function () {
@@ -335,7 +333,7 @@ OSM.Query = function (map) {
       });
     }
 
-    queryOverpass(params.lat, params.lon);
+    queryOverpass(params.get("lat"), params.get("lon"));
   };
 
   page.unload = function (sameController) {

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -1,5 +1,3 @@
-//= require qs/dist/qs
-
 OSM.Search = function (map) {
   $(".search_form input[name=query]").on("input", function (e) {
     if ($(e.target).val() === "") {
@@ -35,7 +33,7 @@ OSM.Search = function (map) {
     $("header").addClass("closed");
     const [lat, lon] = OSM.cropLocation(map.getCenter(), map.getZoom()).map(encodeURIComponent);
 
-    OSM.router.route("/search?" + Qs.stringify({ lat, lon }));
+    OSM.router.route("/search?" + new URLSearchParams({ lat, lon }));
   });
 
   $("#sidebar_content")
@@ -115,12 +113,12 @@ OSM.Search = function (map) {
   var page = {};
 
   page.pushstate = page.popstate = function (path) {
-    var params = Qs.parse(path.substring(path.indexOf("?") + 1));
-    if (params.query) {
-      $(".search_form input[name=query]").val(params.query);
+    const params = new URLSearchParams(path.substring(path.indexOf("?")));
+    if (params.has("query")) {
+      $(".search_form input[name=query]").val(params.get("query"));
       $(".describe_location").hide();
-    } else if (params.lat && params.lon) {
-      $(".search_form input[name=query]").val(params.lat + ", " + params.lon);
+    } else if (params.has("lat") && params.has("lon")) {
+      $(".search_form input[name=query]").val(params.get("lat") + ", " + params.get("lon"));
       $(".describe_location").hide();
     }
     OSM.loadSidebarContent(path, page.load);

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -1,5 +1,3 @@
-//= require qs/dist/qs
-
 L.extend(L.LatLngBounds.prototype, {
   getSize: function () {
     return (this._northEast.lat - this._southWest.lat) *
@@ -159,7 +157,7 @@ L.OSM.Map = L.Map.extend({
     }
 
     var url = window.location.protocol + "//" + OSM.SERVER_URL + "/",
-        query = Qs.stringify(params),
+        query = new URLSearchParams(params),
         hash = OSM.formatHash(this);
 
     if (query) url += "?" + query;
@@ -209,22 +207,22 @@ L.OSM.Map = L.Map.extend({
       return (interlaced_x << 1) | interlaced_y;
     }
 
-    var params = {};
+    const params = new URLSearchParams();
     var layers = this.getLayersCode().replace("M", "");
 
     if (layers) {
-      params.layers = layers;
+      params.set("layers", layers);
     }
 
     if (marker && this.hasLayer(marker)) {
-      params.m = "";
+      params.set("m", "");
     }
 
     if (this._object) {
-      params[this._object.type] = this._object.id;
+      params.set(this._object.type, this._object.id);
     }
 
-    var query = Qs.stringify(params);
+    const query = params.toString();
     if (query) {
       str += "?" + query;
     }

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -2,7 +2,6 @@
 //= depend_on settings.local.yml
 //= depend_on layers.yml
 //= depend_on key.yml
-//= require qs/dist/qs
 
 OSM = {
 <% if defined?(Settings.matomo) %>
@@ -158,9 +157,9 @@ OSM = {
       return args;
     }
 
-    hash = Qs.parse(hash.slice(i + 1));
+    const hashParams = new URLSearchParams(hash.slice(i + 1));
 
-    var map = (hash.map || "").split("/"),
+    var map = (hashParams.get("map") || "").split("/"),
         zoom = parseInt(map[0], 10),
         lat = parseFloat(map[1]),
         lon = parseFloat(map[2]);
@@ -170,8 +169,8 @@ OSM = {
       args.zoom = zoom;
     }
 
-    if (hash.layers) {
-      args.layers = hash.layers;
+    if (hashParams.has("layers")) {
+      args.layers = hashParams.get("layers");
     }
 
     return args;

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "js-cookie": "^3.0.0",
     "leaflet": "^1.8.0",
     "leaflet.locatecontrol": "^0.83.0",
-    "osm-community-index": "^5.2.0",
-    "qs": "^6.9.4"
+    "osm-community-index": "^5.2.0"
   },
   "devDependencies": {
     "eslint": "^9.0.0",

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -5,7 +5,6 @@
 //= require leaflet.osm
 //= require leaflet.map
 //= require i18n/translations
-//= require qs/dist/qs
 
 describe("OSM", function () {
   describe(".apiUrl", function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,22 +151,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-call-bind-apply-helpers@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz#32e5892e6361b29b0b545ba6f7763378daca2840"
-  integrity sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==
-  dependencies:
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
-
-call-bound@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.3.tgz#41cfd032b593e39176a71533ab4f384aa04fd681"
-  integrity sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==
-  dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    get-intrinsic "^1.2.6"
-
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -222,32 +206,6 @@ diacritics@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/diacritics/-/diacritics-1.3.0.tgz#3efa87323ebb863e6696cebb0082d48ff3d6f7a1"
   integrity sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==
-
-dunder-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
-  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
-  dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    es-errors "^1.3.0"
-    gopd "^1.2.0"
-
-es-define-property@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
-  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
-
-es-errors@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
-  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
-
-es-object-atoms@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.0.tgz#095de9ecceeb2ca79668212b60ead450ffd323bf"
-  integrity sha512-Ujz8Al/KfOVR7fkaghAB1WvnLsdYxHDWmfoi2vlA2jZWRg31XhIC1a4B+/I24muD8iSbHxJ1JkrfqmWb65P/Mw==
-  dependencies:
-    es-errors "^1.3.0"
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -393,35 +351,6 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-function-bind@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
-  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
-
-get-intrinsic@^1.2.5, get-intrinsic@^1.2.6:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.7.tgz#dcfcb33d3272e15f445d15124bc0a216189b9044"
-  integrity sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==
-  dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    es-define-property "^1.0.1"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.0.0"
-    function-bind "^1.1.2"
-    get-proto "^1.0.0"
-    gopd "^1.2.0"
-    has-symbols "^1.1.0"
-    hasown "^2.0.2"
-    math-intrinsics "^1.1.0"
-
-get-proto@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
-  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
-  dependencies:
-    dunder-proto "^1.0.1"
-    es-object-atoms "^1.0.0"
-
 glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
@@ -434,27 +363,10 @@ globals@^14.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-14.0.0.tgz#898d7413c29babcf6bafe56fcadded858ada724e"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
-gopd@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
-  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
-
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-has-symbols@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
-  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
-
-hasown@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
-  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
-  dependencies:
-    function-bind "^1.1.2"
 
 ignore@^5.2.0:
   version "5.2.0"
@@ -560,11 +472,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-math-intrinsics@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
-  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
-
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -581,11 +488,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
-
-object-inspect@^1.13.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.3.tgz#f14c183de51130243d6d18ae149375ff50ea488a"
-  integrity sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==
 
 optionator@^0.9.3:
   version "0.9.3"
@@ -647,13 +549,6 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.9.4:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
-  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
-  dependencies:
-    side-channel "^1.1.0"
-
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -670,46 +565,6 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
-side-channel-list@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"
-  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
-  dependencies:
-    es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-
-side-channel-map@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
-  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
-  dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.5"
-    object-inspect "^1.13.3"
-
-side-channel-weakmap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz#11dda19d5368e40ce9ec2bdc1fb0ecbc0790ecea"
-  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
-  dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.5"
-    object-inspect "^1.13.3"
-    side-channel-map "^1.0.1"
-
-side-channel@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
-  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
-  dependencies:
-    es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-    side-channel-list "^1.0.0"
-    side-channel-map "^1.0.1"
-    side-channel-weakmap "^1.0.2"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
As javascript now has a builtin way to parse URL search parameters we don't really need the qs module any more, so replace it with the builtin support.