### PR TITLE
Don't check ids of new notes in create note system tests

### DIFF
--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -23,7 +23,7 @@ class CreateNoteTest < ApplicationSystemTestCase
       fill_in "text", :with => "Some newly added note description"
       click_on "Add Note"
 
-      assert_content "Unresolved note ##{Note.last.id}"
+      assert_content "Unresolved note #"
       assert_content "Some newly added note description"
     end
   end
@@ -56,7 +56,7 @@ class CreateNoteTest < ApplicationSystemTestCase
 
       click_on "Add Note"
 
-      assert_content "Unresolved note ##{Note.last.id}"
+      assert_content "Unresolved note #"
       assert_content "Some newly added note description"
     end
   end


### PR DESCRIPTION
If I'm making purely ui tests here I can't possibly know id of new notes, therefore I shouldn't check them.

But the actual reason is that it looks like `assert_content "Unresolved note ##{Note.last.id}"` line is sometimes reached before db writes are complete. `Note.last.id` is not going to have an expected value in these cases.