### PR TITLE
Don't apply extra encodeURIComponent to lat/lon search params

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -35,7 +35,7 @@ OSM.initializeContextMenu = function (map) {
   map.contextmenu.addItem({
     text: I18n.t("javascripts.context.show_address"),
     callback: function describeLocation(e) {
-      const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom()).map(encodeURIComponent);
+      const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom());
 
       OSM.router.route("/search?" + new URLSearchParams({ lat, lon }));
     }

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -31,7 +31,7 @@ OSM.Search = function (map) {
   $(".describe_location").on("click", function (e) {
     e.preventDefault();
     $("header").addClass("closed");
-    const [lat, lon] = OSM.cropLocation(map.getCenter(), map.getZoom()).map(encodeURIComponent);
+    const [lat, lon] = OSM.cropLocation(map.getCenter(), map.getZoom());
 
     OSM.router.route("/search?" + new URLSearchParams({ lat, lon }));
   });


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/pull/5592#discussion_r1938530806

In practice this should make no difference because lat/lon don't contain any characters that need escaping. But there's still no reason for attempting to escape them twice.