### PR TITLE
Don't html-escape note description

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -5,7 +5,7 @@
 <div>
   <h4><%= t(".description") %></h4>
   <div class="overflow-hidden ms-2">
-    <%= h(note_description(@note.author, @note.description).to_html) %>
+    <%= note_description(@note.author, @note.description).to_html %>
   </div>
 
   <div class="details" data-coordinates="<%= @note.lat %>,<%= @note.lon %>" data-status="<%= @note.status %>">


### PR DESCRIPTION
The description is already html-safe after to_html.

This is a leftover from https://github.com/openstreetmap/openstreetmap-website/commit/01aa27031526280d8b1d219902a7b4c97617d19f, we don't explicitly escape other text->richtext->html like note comments.