### PR TITLE
Add copyright/attribution message to downloaded map images

### DIFF
--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -159,6 +159,7 @@ L.OSM.share = function (options) {
           .attr("class", "form-select w-auto")
           .append($("<option>").val("png").text("PNG").prop("selected", true))
           .append($("<option>").val("jpeg").text("JPEG"))
+          .append($("<option>").val("webp").text("WEBP"))
           .append($("<option>").val("svg").text("SVG"))
           .append($("<option>").val("pdf").text("PDF"))));
 
@@ -200,6 +201,25 @@ L.OSM.share = function (options) {
             .attr("type", "checkbox")
             .attr("class", "form-check-input")
             .bind("change", toggleFilter))));
+
+    $("<div>")
+      .attr("class", "row mb-3")
+      .appendTo($form)
+      .append($("<div>")
+        .attr("class", "col-auto")
+        .append($("<div>")
+          .attr("class", "form-check")
+          .append($("<label>")
+            .attr("for", "attribution")
+            .attr("class", "form-check-label")
+            .text(I18n.t("javascripts.share.attribution")))
+          .append($("<input>")
+            .attr("name", "attribution")
+            .attr("id", "attribution")
+            .attr("type", "checkbox")
+            .attr("checked", "checked")
+            .attr("value", "X")
+            .attr("class", "form-check-input"))));
 
     const mapnikNames = ["minlon", "minlat", "maxlon", "maxlat", "lat", "lon"];
 

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -15,6 +15,7 @@ class ExportController < ApplicationController
     bbox = BoundingBox.from_lon_lat_params(params)
     style = params[:format]
     format = params[:mapnik_format]
+    attribution = params[:attribution] ||= ""
 
     case style
     when "osm"
@@ -25,7 +26,7 @@ class ExportController < ApplicationController
       # redirect to a special 'export' cgi script
       scale = params[:mapnik_scale]
 
-      redirect_to "https://render.openstreetmap.org/cgi-bin/export?bbox=#{bbox}&scale=#{scale}&format=#{format}", :allow_other_host => true
+      redirect_to "https://render.openstreetmap.org/cgi-bin/export?bbox=#{bbox}&scale=#{scale}&format=#{format}&attribution=#{attribution}", :allow_other_host => true
     when "cyclemap", "transportmap"
       zoom = params[:zoom]
       lat = params[:lat]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3135,6 +3135,7 @@ en:
       geo_uri: "Geo URI"
       embed: "HTML"
       custom_dimensions: "Set custom dimensions"
+      attribution: "Include attribution"
       format: "Format:"
       scale: "Scale:"
       image_dimensions: "Image will show the %{layer} layer at %{width} x %{height}"

--- a/test/controllers/export_controller_test.rb
+++ b/test/controllers/export_controller_test.rb
@@ -24,8 +24,8 @@ class ExportControllerTest < ActionDispatch::IntegrationTest
   ###
   # test the finish action for mapnik images
   def test_finish_mapnik
-    post export_finish_path(:minlon => 0, :minlat => 50, :maxlon => 1, :maxlat => 51, :format => "mapnik", :mapnik_format => "test", :mapnik_scale => "12")
-    assert_redirected_to "https://render.openstreetmap.org/cgi-bin/export?bbox=0.0,50.0,1.0,51.0&scale=12&format=test"
+    post export_finish_path(:minlon => 0, :minlat => 50, :maxlon => 1, :maxlat => 51, :format => "mapnik", :mapnik_format => "test", :mapnik_scale => "12", :attribution => "X")
+    assert_redirected_to "https://render.openstreetmap.org/cgi-bin/export?bbox=0.0,50.0,1.0,51.0&scale=12&format=test&attribution=X"
   end
 
   ###


### PR DESCRIPTION
This PR covers the UI facing parts for https://github.com/openstreetmap/chef/pull/735 and adds WebP as additional output format, as well as a checkbox to toggle copyright/attribution in the map export.

![image](https://github.com/user-attachments/assets/037f8b7c-a09a-4841-9b8b-8ed9d4667f87)

Fixes #551 
Depends on https://github.com/openstreetmap/chef/pull/735 (=make sure the export script has been deployed and works properly before merging)