### PR TITLE
Write the new role in reassign checkbox label

### DIFF
--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -21,7 +21,8 @@
   <%= bootstrap_form_for @new_comment, :url => issue_comments_path(@issue) do |f| %>
     <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
     <%= f.form_group do %>
-      <%= f.check_box :reassign, { :label => t(".reassign_param"), :id => "reassign", :name => "reassign", :checked => false }, true, false %>
+      <%= f.check_box :reassign, { :label => @issue.assigned_role == "administrator" ? t(".reassign_to_moderators") : t(".reassign_to_administrators"),
+                                   :id => "reassign", :name => "reassign", :checked => false }, true, false %>
     <% end %>
     <%= f.primary %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1551,7 +1551,8 @@ en:
       reopened: Issue status has been set to 'Open'
     comments:
       comment_from_html: "Comment from %{user_link} on %{comment_created_at}"
-      reassign_param: Reassign Issue?
+      reassign_to_moderators: Reassign Issue to Moderators
+      reassign_to_administrators: Reassign Issue to Administrators
     reports:
       reported_by_html: "Reported as %{category} by %{user} on %{updated_at}"
     helper:

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -114,15 +114,15 @@ class IssuesTest < ApplicationSystemTestCase
     assert_equal("test comment", issue.comments.first.body)
   end
 
-  def test_reassign_issue
-    issue = create(:issue)
-    assert_equal "administrator", issue.assigned_role
+  def test_reassign_issue_to_moderators
+    issue = create(:issue, :assigned_role => "administrator")
     sign_in_as(create(:administrator_user))
 
     visit issue_path(issue)
 
+    assert_unchecked_field "Reassign Issue to Moderators"
     fill_in :issue_comment_body, :with => "reassigning to moderators"
-    check :reassign
+    check "Reassign Issue to Moderators"
     click_on "Add Comment"
 
     assert_content "and the issue was reassigned"
@@ -132,6 +132,24 @@ class IssuesTest < ApplicationSystemTestCase
     assert_equal "moderator", issue.assigned_role
   end
 
+  def test_reassign_issue_to_administrators
+    issue = create(:issue, :assigned_role => "moderator")
+    sign_in_as(create(:moderator_user))
+
+    visit issue_path(issue)
+
+    assert_unchecked_field "Reassign Issue to Administrators"
+    fill_in :issue_comment_body, :with => "reassigning to administrators"
+    check "Reassign Issue to Administrators"
+    click_on "Add Comment"
+
+    assert_content "and the issue was reassigned"
+    assert_current_path issues_path(:status => "open")
+
+    issue.reload
+    assert_equal "administrator", issue.assigned_role
+  end
+
   def test_reassign_issue_as_super_user
     issue = create(:issue)
     sign_in_as(create(:super_user))
@@ -139,7 +157,7 @@ class IssuesTest < ApplicationSystemTestCase
     visit issue_path(issue)
 
     fill_in :issue_comment_body, :with => "reassigning to moderators"
-    check :reassign
+    check "Reassign Issue to Moderators"
     click_on "Add Comment"
 
     assert_content "and the issue was reassigned"


### PR DESCRIPTION
Says who the issue is going to be reassigned to. You can have both admin and mod roles, in this case it's not obvious what the new role is. Also it's not obvious if you don't know that issues are assigned to roles and not to users.

![image](https://github.com/user-attachments/assets/bf30c8ae-f262-4af2-a0d9-679ba874a589)
