### PR TITLE
API element resources - full paths

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -16,7 +16,7 @@ class ApiAbility
       can :read, Tracepoint
       can :read, User
       can :read, Node
-      can [:read, :full, :ways_for_node], Way
+      can [:read, :ways_for_node], Way
       can [:read, :full, :relations_for_node, :relations_for_way, :relations_for_relation], Relation
       can [:history, :read], [OldNode, OldWay, OldRelation]
       can :read, UserBlock

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -17,7 +17,7 @@ class ApiAbility
       can :read, User
       can :read, Node
       can [:read, :ways_for_node], Way
-      can [:read, :full, :relations_for_node, :relations_for_way, :relations_for_relation], Relation
+      can [:read, :relations_for_node, :relations_for_way, :relations_for_relation], Relation
       can [:history, :read], [OldNode, OldWay, OldRelation]
       can :read, UserBlock
 

--- a/app/views/api/relations/full.json.jbuilder
+++ b/app/views/api/relations/full.json.jbuilder
@@ -1,7 +1,0 @@
-json.partial! "api/root_attributes"
-
-json.elements do
-  json.array! @nodes, :partial => "/api/nodes/node", :as => :node
-  json.array! @ways, :partial => "/api/ways/way", :as => :way
-  json.array! @relations, :partial => "/api/relations/relation", :as => :relation
-end

--- a/app/views/api/relations/full.xml.builder
+++ b/app/views/api/relations/full.xml.builder
@@ -1,7 +1,0 @@
-xml.instruct!
-
-xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@nodes) || "")
-  osm << (render(@ways) || "")
-  osm << (render(@relations) || "")
-end

--- a/app/views/api/relations/show.json.jbuilder
+++ b/app/views/api/relations/show.json.jbuilder
@@ -1,5 +1,7 @@
 json.partial! "api/root_attributes"
 
 json.elements do
-  json.array! [@relation], :partial => "relation", :as => :relation
+  json.array! @nodes, :partial => "/api/nodes/node", :as => :node
+  json.array! @ways, :partial => "/api/ways/way", :as => :way
+  json.array! @relations, :partial => "/api/relations/relation", :as => :relation
 end

--- a/app/views/api/relations/show.xml.builder
+++ b/app/views/api/relations/show.xml.builder
@@ -1,5 +1,7 @@
 xml.instruct!
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@relation) || "")
+  osm << (render(@nodes) || "")
+  osm << (render(@ways) || "")
+  osm << (render(@relations) || "")
 end

--- a/app/views/api/ways/full.json.jbuilder
+++ b/app/views/api/ways/full.json.jbuilder
@@ -1,6 +1,0 @@
-json.partial! "api/root_attributes"
-
-json.elements do
-  json.array! @nodes, :partial => "/api/nodes/node", :as => :node
-  json.array! [@way], :partial => "/api/ways/way", :as => :way
-end

--- a/app/views/api/ways/full.xml.builder
+++ b/app/views/api/ways/full.xml.builder
@@ -1,6 +1,0 @@
-xml.instruct!
-
-xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@nodes) || "")
-  osm << (render(@way) || "")
-end

--- a/app/views/api/ways/show.json.jbuilder
+++ b/app/views/api/ways/show.json.jbuilder
@@ -1,5 +1,6 @@
 json.partial! "api/root_attributes"
 
 json.elements do
+  json.array! @nodes, :partial => "/api/nodes/node", :as => :node if @nodes
   json.array! [@way], :partial => "way", :as => :way
 end

--- a/app/views/api/ways/show.xml.builder
+++ b/app/views/api/ways/show.xml.builder
@@ -1,5 +1,6 @@
 xml.instruct!
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(@nodes) || "") if @nodes
   osm << (render(@way) || "")
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,6 @@ OpenStreetMap::Application.routes.draw do
     get "node/:id/:version" => "old_nodes#show", :as => :api_old_node, :id => /\d+/, :version => /\d+/
 
     get "way/:id/history" => "old_ways#history", :as => :api_way_history, :id => /\d+/
-    get "way/:id/full" => "ways#full", :as => :way_full, :id => /\d+/
     get "way/:id/relations" => "relations#relations_for_way", :as => :way_relations, :id => /\d+/
     post "way/:id/:version/redact" => "old_ways#redact", :as => :way_version_redact, :version => /\d+/, :id => /\d+/
     get "way/:id/:version" => "old_ways#show", :as => :api_old_way, :id => /\d+/, :version => /\d+/
@@ -55,7 +54,11 @@ OpenStreetMap::Application.routes.draw do
     put "node/create" => "nodes#create", :as => nil
 
     resources :ways, :only => [:index, :create]
-    resources :ways, :path => "way", :id => /\d+/, :only => [:show, :update, :destroy]
+    resources :ways, :path => "way", :id => /\d+/, :only => [:show, :update, :destroy] do
+      member do
+        get :full, :action => :show, :full => true, :as => nil
+      end
+    end
     put "way/create" => "ways#create", :as => nil
 
     resources :relations, :only => [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,6 @@ OpenStreetMap::Application.routes.draw do
 
     get "relation/:id/relations" => "relations#relations_for_relation", :as => :relation_relations, :id => /\d+/
     get "relation/:id/history" => "old_relations#history", :as => :api_relation_history, :id => /\d+/
-    get "relation/:id/full" => "relations#full", :as => :relation_full, :id => /\d+/
     post "relation/:id/:version/redact" => "old_relations#redact", :as => :relation_version_redact, :version => /\d+/, :id => /\d+/
     get "relation/:id/:version" => "old_relations#show", :as => :api_old_relation, :id => /\d+/, :version => /\d+/
   end
@@ -62,7 +61,11 @@ OpenStreetMap::Application.routes.draw do
     put "way/create" => "ways#create", :as => nil
 
     resources :relations, :only => [:index, :create]
-    resources :relations, :path => "relation", :id => /\d+/, :only => [:show, :update, :destroy]
+    resources :relations, :path => "relation", :id => /\d+/, :only => [:show, :update, :destroy] do
+      member do
+        get :full, :action => :show, :full => true, :as => nil
+      end
+    end
     put "relation/create" => "relations#create", :as => nil
 
     resource :map, :only => :show


### PR DESCRIPTION
`full` is not a standard action name, but it's also not really a nested resource. Here I'm mapping them to `show` action with a parameter. A similar thing is done with changeset discussions where the discussion/comment elements are extra things added to the usual `show` output if a parameter is set.

Also there were `user/details` in #5433 which we didn't turn into a nested resource.