### PR TITLE
Refactor direction engines and unify structure

### DIFF
--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -1,6 +1,6 @@
 (function () {
   function GraphHopperEngine(id, vehicleType) {
-    var GH_INSTR_MAP = {
+    const GH_INSTR_MAP = {
       "-3": 7, // sharp left
       "-2": 6, // left
       "-1": 5, // slight left
@@ -18,65 +18,61 @@
       "8": 4 // right u-turn
     };
 
+    function _processDirections(path) {
+      const line = L.PolylineUtil.decode(path.points);
+
+      const steps = path.instructions.map(function (instr, i) {
+        const num = `<b>${i + 1}.</b> `;
+        const lineseg = line
+          .slice(instr.interval[0], instr.interval[1] + 1)
+          .map(([lat, lng]) => ({ lat, lng }));
+        return [
+          lineseg[0],
+          GH_INSTR_MAP[instr.sign],
+          num + instr.text,
+          instr.distance,
+          lineseg
+        ]; // TODO does graphhopper map instructions onto line indices?
+      });
+      steps.at(-1)[1] = 14;
+
+      return {
+        line: line,
+        steps: steps,
+        distance: path.distance,
+        time: path.time / 1000,
+        ascend: path.ascend,
+        descend: path.descend
+      };
+    }
+
     return {
       id: id,
       creditline: "<a href=\"https://www.graphhopper.com/\" target=\"_blank\">GraphHopper</a>",
       draggable: false,
 
       getRoute: function (points, callback) {
-      // GraphHopper Directions API documentation
-      // https://graphhopper.com/api/1/docs/routing/
+        // GraphHopper Directions API documentation
+        // https://graphhopper.com/api/1/docs/routing/
+        const data = {
+          vehicle: vehicleType,
+          locale: I18n.currentLocale(),
+          key: "LijBPDQGfu7Iiq80w3HzwB4RUDJbMbhs6BU0dEnn",
+          elevation: false,
+          instructions: true,
+          turn_costs: vehicleType === "car",
+          point: points.map(p => p.lat + "," + p.lng)
+        };
         return $.ajax({
           url: OSM.GRAPHHOPPER_URL,
-          data: {
-            vehicle: vehicleType,
-            locale: I18n.currentLocale(),
-            key: "LijBPDQGfu7Iiq80w3HzwB4RUDJbMbhs6BU0dEnn",
-            elevation: false,
-            instructions: true,
-            turn_costs: vehicleType === "car",
-            point: points.map(function (p) { return p.lat + "," + p.lng; })
-          },
+          data,
           traditional: true,
           dataType: "json",
-          success: function (data) {
-            if (!data.paths || data.paths.length === 0) {
+          success: function ({ paths }) {
+            if (!paths || paths.length === 0) {
               return callback(true);
             }
-
-            var path = data.paths[0];
-            var line = L.PolylineUtil.decode(path.points);
-
-            var steps = [];
-            var len = path.instructions.length;
-            for (var i = 0; i < len; i++) {
-              var instr = path.instructions[i];
-              var instrCode = (i === len - 1) ? 14 : GH_INSTR_MAP[instr.sign];
-              var instrText = "<b>" + (i + 1) + ".</b> ";
-              instrText += instr.text;
-              var latLng = line[instr.interval[0]];
-              var distInMeter = instr.distance;
-              var lineseg = [];
-              for (var j = instr.interval[0]; j <= instr.interval[1]; j++) {
-                lineseg.push({ lat: line[j][0], lng: line[j][1] });
-              }
-              steps.push([
-                { lat: latLng[0], lng: latLng[1] },
-                instrCode,
-                instrText,
-                distInMeter,
-                lineseg
-              ]); // TODO does graphhopper map instructions onto line indices?
-            }
-
-            callback(false, {
-              line: line,
-              steps: steps,
-              distance: path.distance,
-              time: path.time / 1000,
-              ascend: path.ascend,
-              descend: path.descend
-            });
+            callback(false, _processDirections(paths[0]));
           },
           error: function () {
             callback(true);


### PR DESCRIPTION
Untangling `FOSSGISOSRMEngine` and moving from `push`ing `for` loops to `.map()` for the other engines.

### Description
The three routing engines' code now follows a similar structure:
```js
function ...Engine (id, ...) {
  function _processDirections(...) {...}

  return {
    ...,
    getRoute: function (points, callback) {
      data = {...};
      return $.ajax({
        ...,
        success: function // that calls the callback with _processDirections
      });
    }
  };
};
```

### How has this been tested?
Creating a conditional dev tools breakpoint and shoving it all in there.
