### PR TITLE
Updates notes filtering to search description too

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -263,7 +263,9 @@ module Api
       end
 
       # Add any text filter
-      @notes = @notes.joins(:comments).where("to_tsvector('english', note_comments.body) @@ plainto_tsquery('english', ?)", params[:q]) if params[:q]
+      if params[:q]
+        @notes = @notes.joins(:comments).where("to_tsvector('english', note_comments.body) @@ plainto_tsquery('english', ?) OR to_tsvector('english', notes.description) @@ plainto_tsquery('english', ?)", params[:q], params[:q])
+      end
 
       # Add any date filter
       if params[:from]

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -16,9 +16,10 @@
 #
 # Indexes
 #
-#  notes_created_at_idx   (created_at)
-#  notes_tile_status_idx  (tile,status)
-#  notes_updated_at_idx   (updated_at)
+#  index_notes_on_description  (to_tsvector('english'::regconfig, description)) USING gin
+#  notes_created_at_idx        (created_at)
+#  notes_tile_status_idx       (tile,status)
+#  notes_updated_at_idx        (updated_at)
 #
 # Foreign Keys
 #

--- a/db/migrate/20250206202905_add_text_index_to_notes.rb
+++ b/db/migrate/20250206202905_add_text_index_to_notes.rb
@@ -1,0 +1,7 @@
+class AddTextIndexToNotes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :notes, "to_tsvector('english', description)", :using => "GIN", :name => "index_notes_on_description", :algorithm => :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2541,6 +2541,13 @@ CREATE INDEX index_note_subscriptions_on_note_id ON public.note_subscriptions US
 
 
 --
+-- Name: index_notes_on_description; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_notes_on_description ON public.notes USING gin (to_tsvector('english'::regconfig, description));
+
+
+--
 -- Name: index_oauth_access_grants_on_application_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3422,6 +3429,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20250206202905'),
 ('20250121191749'),
 ('20250105154621'),
 ('20250104140952'),


### PR DESCRIPTION
### Description

PR updates notes filtering (querying) to search for query text in both note comments and note's description.

### How has this been tested?

Using automated tests before and after migration plus manual tests before and after migration.
