### PR TITLE
API element resources - nested elements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -129,13 +129,10 @@ Rails/SpecificActionNames:
     # This is a todo list, but is currently too long for `rubocop --auto-gen-config`
     - 'app/controllers/api/changeset_comments_controller.rb'
     - 'app/controllers/api/changesets_controller.rb'
-    - 'app/controllers/api/nodes_controller.rb'
     - 'app/controllers/api/notes_controller.rb'
     - 'app/controllers/api/old_elements_controller.rb'
-    - 'app/controllers/api/relations_controller.rb'
     - 'app/controllers/api/user_preferences_controller.rb'
     - 'app/controllers/api/users_controller.rb'
-    - 'app/controllers/api/ways_controller.rb'
     - 'app/controllers/browse_controller.rb'
     - 'app/controllers/changesets_controller.rb'
     - 'app/controllers/confirmations_controller.rb'

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -15,8 +15,7 @@ class ApiAbility
       can [:read, :download], Changeset
       can :read, Tracepoint
       can :read, User
-      can :read, Node
-      can [:read, :ways_for_node], Way
+      can :read, [Node, Way]
       can [:read, :relations_for_node, :relations_for_way, :relations_for_relation], Relation
       can [:history, :read], [OldNode, OldWay, OldRelation]
       can :read, UserBlock

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -16,7 +16,7 @@ class ApiAbility
       can :read, Tracepoint
       can :read, User
       can :read, [Node, Way]
-      can [:read, :relations_for_node, :relations_for_way, :relations_for_relation], Relation
+      can [:read, :relations_for_way, :relations_for_relation], Relation
       can [:history, :read], [OldNode, OldWay, OldRelation]
       can :read, UserBlock
 

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -16,7 +16,7 @@ class ApiAbility
       can :read, Tracepoint
       can :read, User
       can :read, [Node, Way]
-      can [:read, :relations_for_way, :relations_for_relation], Relation
+      can [:read, :relations_for_relation], Relation
       can [:history, :read], [OldNode, OldWay, OldRelation]
       can :read, UserBlock
 

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -15,8 +15,7 @@ class ApiAbility
       can [:read, :download], Changeset
       can :read, Tracepoint
       can :read, User
-      can :read, [Node, Way]
-      can [:read, :relations_for_relation], Relation
+      can :read, [Node, Way, Relation]
       can [:history, :read], [OldNode, OldWay, OldRelation]
       can :read, UserBlock
 

--- a/app/controllers/api/nodes/relations_controller.rb
+++ b/app/controllers/api/nodes/relations_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module Nodes
+    class RelationsController < ApiController
+      authorize_resource
+
+      before_action :set_request_formats
+
+      def index
+        relation_ids = RelationMember.where(:member_type => "Node", :member_id => params[:node_id]).collect(&:relation_id).uniq
+
+        @relations = []
+
+        Relation.find(relation_ids).each do |relation|
+          @relations << relation if relation.visible
+        end
+
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/nodes/ways_controller.rb
+++ b/app/controllers/api/nodes/ways_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module Nodes
+    class WaysController < ApiController
+      authorize_resource
+
+      before_action :set_request_formats
+
+      ##
+      # returns all the ways which are currently using the node given in the
+      # :node_id parameter. note that this used to return deleted ways as well, but
+      # this seemed not to be the expected behaviour, so it was removed.
+      def index
+        way_ids = WayNode.where(:node_id => params[:node_id]).collect { |ws| ws.id[0] }.uniq
+
+        @ways = Way.where(:id => way_ids, :visible => true)
+
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/relations/relations_controller.rb
+++ b/app/controllers/api/relations/relations_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module Relations
+    class RelationsController < ApiController
+      authorize_resource
+
+      before_action :set_request_formats
+
+      def index
+        relation_ids = RelationMember.where(:member_type => "Relation", :member_id => params[:relation_id]).collect(&:relation_id).uniq
+
+        @relations = []
+
+        Relation.find(relation_ids).each do |relation|
+          @relations << relation if relation.visible
+        end
+
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -127,10 +127,6 @@ module Api
       relations_for_object("Way")
     end
 
-    def relations_for_node
-      relations_for_object("Node")
-    end
-
     def relations_for_relation
       relations_for_object("Relation")
     end

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -123,10 +123,6 @@ module Api
       end
     end
 
-    def relations_for_way
-      relations_for_object("Way")
-    end
-
     def relations_for_relation
       relations_for_object("Relation")
     end

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -123,10 +123,6 @@ module Api
       end
     end
 
-    def relations_for_relation
-      relations_for_object("Relation")
-    end
-
     private
 
     def relations_for_object(objtype)

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -122,23 +122,5 @@ module Api
         head :bad_request
       end
     end
-
-    private
-
-    def relations_for_object(objtype)
-      relationids = RelationMember.where(:member_type => objtype, :member_id => params[:id]).collect(&:relation_id).uniq
-
-      @relations = []
-
-      Relation.find(relationids).each do |relation|
-        @relations << relation if relation.visible
-      end
-
-      # Render the result
-      respond_to do |format|
-        format.xml
-        format.json
-      end
-    end
   end
 end

--- a/app/controllers/api/ways/relations_controller.rb
+++ b/app/controllers/api/ways/relations_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module Ways
+    class RelationsController < ApiController
+      authorize_resource
+
+      before_action :set_request_formats
+
+      def index
+        relation_ids = RelationMember.where(:member_type => "Way", :member_id => params[:way_id]).collect(&:relation_id).uniq
+
+        @relations = []
+
+        Relation.find(relation_ids).each do |relation|
+          @relations << relation if relation.visible
+        end
+
+        # Render the result
+        respond_to do |format|
+          format.xml
+          format.json
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -80,21 +80,5 @@ module Api
         head :bad_request
       end
     end
-
-    ##
-    # returns all the ways which are currently using the node given in the
-    # :id parameter. note that this used to return deleted ways as well, but
-    # this seemed not to be the expected behaviour, so it was removed.
-    def ways_for_node
-      wayids = WayNode.where(:node_id => params[:id]).collect { |ws| ws.id[0] }.uniq
-
-      @ways = Way.where(:id => wayids, :visible => true)
-
-      # Render the result
-      respond_to do |format|
-        format.xml
-        format.json
-      end
-    end
   end
 end

--- a/app/views/api/nodes/relations/index.json.jbuilder
+++ b/app/views/api/nodes/relations/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "api/root_attributes"
+
+json.elements do
+  json.array! @relations, :partial => "api/relations/relation", :as => :relation
+end

--- a/app/views/api/nodes/relations/index.xml.builder
+++ b/app/views/api/nodes/relations/index.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/relations/relation", :collection => @relations) || "")
+end

--- a/app/views/api/nodes/ways/index.json.jbuilder
+++ b/app/views/api/nodes/ways/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "api/root_attributes"
+
+json.elements do
+  json.array! @ways, :partial => "api/ways/way", :as => :way
+end

--- a/app/views/api/nodes/ways/index.xml.builder
+++ b/app/views/api/nodes/ways/index.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/ways/way", :collection => @ways) || "")
+end

--- a/app/views/api/relations/relations/index.json.jbuilder
+++ b/app/views/api/relations/relations/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "api/root_attributes"
+
+json.elements do
+  json.array! @relations, :partial => "api/relations/relation", :as => :relation
+end

--- a/app/views/api/relations/relations/index.xml.builder
+++ b/app/views/api/relations/relations/index.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/relations/relation", :collection => @relations) || "")
+end

--- a/app/views/api/relations/relations_for_node.json.jbuilder
+++ b/app/views/api/relations/relations_for_node.json.jbuilder
@@ -1,5 +1,0 @@
-json.partial! "api/root_attributes"
-
-json.elements do
-  json.array! @relations, :partial => "relation", :as => :relation
-end

--- a/app/views/api/relations/relations_for_node.xml.builder
+++ b/app/views/api/relations/relations_for_node.xml.builder
@@ -1,5 +1,0 @@
-xml.instruct!
-
-xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@relations) || "")
-end

--- a/app/views/api/relations/relations_for_relation.json.jbuilder
+++ b/app/views/api/relations/relations_for_relation.json.jbuilder
@@ -1,5 +1,0 @@
-json.partial! "api/root_attributes"
-
-json.elements do
-  json.array! @relations, :partial => "relation", :as => :relation
-end

--- a/app/views/api/relations/relations_for_relation.xml.builder
+++ b/app/views/api/relations/relations_for_relation.xml.builder
@@ -1,5 +1,0 @@
-xml.instruct!
-
-xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@relations) || "")
-end

--- a/app/views/api/relations/relations_for_way.json.jbuilder
+++ b/app/views/api/relations/relations_for_way.json.jbuilder
@@ -1,5 +1,0 @@
-json.partial! "api/root_attributes"
-
-json.elements do
-  json.array! @relations, :partial => "relation", :as => :relation
-end

--- a/app/views/api/relations/relations_for_way.xml.builder
+++ b/app/views/api/relations/relations_for_way.xml.builder
@@ -1,5 +1,0 @@
-xml.instruct!
-
-xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@relations) || "")
-end

--- a/app/views/api/ways/relations/index.json.jbuilder
+++ b/app/views/api/ways/relations/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "api/root_attributes"
+
+json.elements do
+  json.array! @relations, :partial => "api/relations/relation", :as => :relation
+end

--- a/app/views/api/ways/relations/index.xml.builder
+++ b/app/views/api/ways/relations/index.xml.builder
@@ -1,0 +1,5 @@
+xml.instruct!
+
+xml.osm(OSM::API.new.xml_root_attributes) do |osm|
+  osm << (render(:partial => "api/relations/relation", :collection => @relations) || "")
+end

--- a/app/views/api/ways/ways_for_node.json.jbuilder
+++ b/app/views/api/ways/ways_for_node.json.jbuilder
@@ -1,5 +1,0 @@
-json.partial! "api/root_attributes"
-
-json.elements do
-  json.array! @ways, :partial => "way", :as => :way
-end

--- a/app/views/api/ways/ways_for_node.xml.builder
+++ b/app/views/api/ways/ways_for_node.xml.builder
@@ -1,5 +1,0 @@
-xml.instruct!
-
-xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@ways) || "")
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,6 @@ OpenStreetMap::Application.routes.draw do
     post "changeset/comment/:id/hide" => "changeset_comments#destroy", :as => :changeset_comment_hide, :id => /\d+/
     post "changeset/comment/:id/unhide" => "changeset_comments#restore", :as => :changeset_comment_unhide, :id => /\d+/
 
-    get "node/:id/ways" => "ways#ways_for_node", :as => :node_ways, :id => /\d+/
     get "node/:id/relations" => "relations#relations_for_node", :as => :node_relations, :id => /\d+/
     get "node/:id/history" => "old_nodes#history", :as => :api_node_history, :id => /\d+/
     post "node/:id/:version/redact" => "old_nodes#redact", :as => :node_version_redact, :version => /\d+/, :id => /\d+/
@@ -49,7 +48,11 @@ OpenStreetMap::Application.routes.draw do
 
   namespace :api, :path => "api/0.6" do
     resources :nodes, :only => [:index, :create]
-    resources :nodes, :path => "node", :id => /\d+/, :only => [:show, :update, :destroy]
+    resources :nodes, :path => "node", :id => /\d+/, :only => [:show, :update, :destroy] do
+      scope :module => :nodes do
+        resources :ways, :only => :index
+      end
+    end
     put "node/create" => "nodes#create", :as => nil
 
     resources :ways, :only => [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,6 @@ OpenStreetMap::Application.routes.draw do
     get "node/:id/:version" => "old_nodes#show", :as => :api_old_node, :id => /\d+/, :version => /\d+/
 
     get "way/:id/history" => "old_ways#history", :as => :api_way_history, :id => /\d+/
-    get "way/:id/relations" => "relations#relations_for_way", :as => :way_relations, :id => /\d+/
     post "way/:id/:version/redact" => "old_ways#redact", :as => :way_version_redact, :version => /\d+/, :id => /\d+/
     get "way/:id/:version" => "old_ways#show", :as => :api_old_way, :id => /\d+/, :version => /\d+/
 
@@ -59,6 +58,9 @@ OpenStreetMap::Application.routes.draw do
     resources :ways, :path => "way", :id => /\d+/, :only => [:show, :update, :destroy] do
       member do
         get :full, :action => :show, :full => true, :as => nil
+      end
+      scope :module => :ways do
+        resources :relations, :only => :index
       end
     end
     put "way/create" => "ways#create", :as => nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,6 @@ OpenStreetMap::Application.routes.draw do
     post "changeset/comment/:id/hide" => "changeset_comments#destroy", :as => :changeset_comment_hide, :id => /\d+/
     post "changeset/comment/:id/unhide" => "changeset_comments#restore", :as => :changeset_comment_unhide, :id => /\d+/
 
-    get "node/:id/relations" => "relations#relations_for_node", :as => :node_relations, :id => /\d+/
     get "node/:id/history" => "old_nodes#history", :as => :api_node_history, :id => /\d+/
     post "node/:id/:version/redact" => "old_nodes#redact", :as => :node_version_redact, :version => /\d+/, :id => /\d+/
     get "node/:id/:version" => "old_nodes#show", :as => :api_old_node, :id => /\d+/, :version => /\d+/
@@ -51,6 +50,7 @@ OpenStreetMap::Application.routes.draw do
     resources :nodes, :path => "node", :id => /\d+/, :only => [:show, :update, :destroy] do
       scope :module => :nodes do
         resources :ways, :only => :index
+        resources :relations, :only => :index
       end
     end
     put "node/create" => "nodes#create", :as => nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,6 @@ OpenStreetMap::Application.routes.draw do
     post "way/:id/:version/redact" => "old_ways#redact", :as => :way_version_redact, :version => /\d+/, :id => /\d+/
     get "way/:id/:version" => "old_ways#show", :as => :api_old_way, :id => /\d+/, :version => /\d+/
 
-    get "relation/:id/relations" => "relations#relations_for_relation", :as => :relation_relations, :id => /\d+/
     get "relation/:id/history" => "old_relations#history", :as => :api_relation_history, :id => /\d+/
     post "relation/:id/:version/redact" => "old_relations#redact", :as => :relation_version_redact, :version => /\d+/, :id => /\d+/
     get "relation/:id/:version" => "old_relations#show", :as => :api_old_relation, :id => /\d+/, :version => /\d+/
@@ -69,6 +68,9 @@ OpenStreetMap::Application.routes.draw do
     resources :relations, :path => "relation", :id => /\d+/, :only => [:show, :update, :destroy] do
       member do
         get :full, :action => :show, :full => true, :as => nil
+      end
+      scope :module => :relations do
+        resources :relations, :only => :index
       end
     end
     put "relation/create" => "relations#create", :as => nil

--- a/test/controllers/api/nodes/relations_controller_test.rb
+++ b/test/controllers/api/nodes/relations_controller_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+module Api
+  module Nodes
+    class RelationsControllerTest < ActionDispatch::IntegrationTest
+      ##
+      # test all routes which lead to this controller
+      def test_routes
+        assert_routing(
+          { :path => "/api/0.6/node/1/relations", :method => :get },
+          { :controller => "api/nodes/relations", :action => "index", :node_id => "1" }
+        )
+        assert_routing(
+          { :path => "/api/0.6/node/1/relations.json", :method => :get },
+          { :controller => "api/nodes/relations", :action => "index", :node_id => "1", :format => "json" }
+        )
+      end
+
+      ##
+      # check that all relations containing a particular node, and no extra
+      # relations, are returned.
+      def test_index
+        node = create(:node)
+        # should include relations with that node as a member
+        relation_with_node = create(:relation_member, :member => node).relation
+        # should ignore relations without that node as a member
+        _relation_without_node = create(:relation_member).relation
+        # should ignore relations with the node involved indirectly, via a way
+        way = create(:way_node, :node => node).way
+        _relation_with_way = create(:relation_member, :member => way).relation
+        # should ignore relations with the node involved indirectly, via a relation
+        second_relation = create(:relation_member, :member => node).relation
+        _super_relation = create(:relation_member, :member => second_relation).relation
+        # should combine multiple relation_member references into just one relation entry
+        create(:relation_member, :member => node, :relation => relation_with_node)
+        # should not include deleted relations
+        deleted_relation = create(:relation, :deleted)
+        create(:relation_member, :member => node, :relation => deleted_relation)
+
+        get api_node_relations_path(node)
+
+        assert_response :success
+
+        # count one osm element
+        assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", 1
+
+        # we should have only the expected number of relations
+        expected_relations = [relation_with_node, second_relation]
+        assert_select "osm>relation", expected_relations.size
+
+        # and each of them should contain the element we originally searched for
+        expected_relations.each do |containing_relation|
+          # The relation should appear once, but the element could appear multiple times
+          assert_select "osm>relation[id='#{containing_relation.id}']", 1
+          assert_select "osm>relation[id='#{containing_relation.id}']>member[type='node'][ref='#{node.id}']"
+        end
+      end
+
+      def test_index_json
+        node = create(:node)
+        containing_relation = create(:relation_member, :member => node).relation
+
+        get api_node_relations_path(node, :format => "json")
+
+        assert_response :success
+        js = ActiveSupport::JSON.decode(@response.body)
+        assert_not_nil js
+        assert_equal 1, js["elements"].count
+        js_relations = js["elements"].filter { |e| e["type"] == "relation" }
+        assert_equal 1, js_relations.count
+        assert_equal containing_relation.id, js_relations[0]["id"]
+      end
+    end
+  end
+end

--- a/test/controllers/api/nodes/ways_controller_test.rb
+++ b/test/controllers/api/nodes/ways_controller_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+module Api
+  module Nodes
+    class WaysControllerTest < ActionDispatch::IntegrationTest
+      ##
+      # test all routes which lead to this controller
+      def test_routes
+        assert_routing(
+          { :path => "/api/0.6/node/1/ways", :method => :get },
+          { :controller => "api/nodes/ways", :action => "index", :node_id => "1" }
+        )
+        assert_routing(
+          { :path => "/api/0.6/node/1/ways.json", :method => :get },
+          { :controller => "api/nodes/ways", :action => "index", :node_id => "1", :format => "json" }
+        )
+      end
+
+      ##
+      # test that a call to ways_for_node returns all ways that contain the node
+      # and none that don't.
+      def test_index
+        node = create(:node)
+        way1 = create(:way)
+        way2 = create(:way)
+        create(:way_node, :way => way1, :node => node)
+        create(:way_node, :way => way2, :node => node)
+        # create an unrelated way
+        create(:way_with_nodes, :nodes_count => 2)
+        # create a way which used to use the node
+        way3_v1 = create(:old_way, :version => 1)
+        _way3_v2 = create(:old_way, :current_way => way3_v1.current_way, :version => 2)
+        create(:old_way_node, :old_way => way3_v1, :node => node)
+
+        get api_node_ways_path(node)
+        assert_response :success
+        ways_xml = XML::Parser.string(@response.body).parse
+        assert_not_nil ways_xml, "failed to parse ways_for_node response"
+
+        # check that the set of IDs match expectations
+        expected_way_ids = [way1.id,
+                            way2.id]
+        found_way_ids = ways_xml.find("//osm/way").collect { |w| w["id"].to_i }
+        assert_equal expected_way_ids.sort, found_way_ids.sort,
+                     "expected ways for node #{node.id} did not match found"
+
+        # check the full ways to ensure we're not missing anything
+        expected_way_ids.each do |id|
+          way_xml = ways_xml.find("//osm/way[@id='#{id}']").first
+          assert_ways_are_equal(Way.find(id),
+                                Way.from_xml_node(way_xml))
+        end
+      end
+
+      def test_index_json
+        node = create(:node)
+        way = create(:way)
+        create(:way_node, :way => way, :node => node)
+
+        get api_node_ways_path(node, :format => "json")
+
+        assert_response :success
+        js = ActiveSupport::JSON.decode(@response.body)
+        assert_not_nil js
+        assert_equal 1, js["elements"].count
+        js_ways = js["elements"].filter { |e| e["type"] == "way" }
+        assert_equal 1, js_ways.count
+        assert_equal way.id, js_ways[0]["id"]
+      end
+    end
+  end
+end

--- a/test/controllers/api/relations/relations_controller_test.rb
+++ b/test/controllers/api/relations/relations_controller_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+module Api
+  module Relations
+    class RelationsControllerTest < ActionDispatch::IntegrationTest
+      ##
+      # test all routes which lead to this controller
+      def test_routes
+        assert_routing(
+          { :path => "/api/0.6/relation/1/relations", :method => :get },
+          { :controller => "api/relations/relations", :action => "index", :relation_id => "1" }
+        )
+        assert_routing(
+          { :path => "/api/0.6/relation/1/relations.json", :method => :get },
+          { :controller => "api/relations/relations", :action => "index", :relation_id => "1", :format => "json" }
+        )
+      end
+
+      def test_index
+        relation = create(:relation)
+        # should include relations with that relation as a member
+        relation_with_relation = create(:relation_member, :member => relation).relation
+        # should ignore any relation without that relation as a member
+        _relation_without_relation = create(:relation_member).relation
+        # should ignore relations with the relation involved indirectly, via a relation
+        second_relation = create(:relation_member, :member => relation).relation
+        _super_relation = create(:relation_member, :member => second_relation).relation
+        # should combine multiple relation_member references into just one relation entry
+        create(:relation_member, :member => relation, :relation => relation_with_relation)
+        # should not include deleted relations
+        deleted_relation = create(:relation, :deleted)
+        create(:relation_member, :member => relation, :relation => deleted_relation)
+
+        get api_relation_relations_path(relation)
+
+        assert_response :success
+
+        # count one osm element
+        assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", 1
+
+        # we should have only the expected number of relations
+        expected_relations = [relation_with_relation, second_relation]
+        assert_select "osm>relation", expected_relations.size
+
+        # and each of them should contain the element we originally searched for
+        expected_relations.each do |containing_relation|
+          # The relation should appear once, but the element could appear multiple times
+          assert_select "osm>relation[id='#{containing_relation.id}']", 1
+          assert_select "osm>relation[id='#{containing_relation.id}']>member[type='relation'][ref='#{relation.id}']"
+        end
+      end
+
+      def test_index_json
+        relation = create(:relation)
+        containing_relation = create(:relation_member, :member => relation).relation
+
+        get api_relation_relations_path(relation, :format => "json")
+
+        assert_response :success
+        js = ActiveSupport::JSON.decode(@response.body)
+        assert_not_nil js
+        assert_equal 1, js["elements"].count
+        js_relations = js["elements"].filter { |e| e["type"] == "relation" }
+        assert_equal 1, js_relations.count
+        assert_equal containing_relation.id, js_relations[0]["id"]
+      end
+    end
+  end
+end

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -43,16 +43,8 @@ module Api
       )
 
       assert_routing(
-        { :path => "/api/0.6/way/1/relations", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_way", :id => "1" }
-      )
-      assert_routing(
         { :path => "/api/0.6/relation/1/relations", :method => :get },
         { :controller => "api/relations", :action => "relations_for_relation", :id => "1" }
-      )
-      assert_routing(
-        { :path => "/api/0.6/way/1/relations.json", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_way", :id => "1", :format => "json" }
       )
       assert_routing(
         { :path => "/api/0.6/relation/1/relations.json", :method => :get },
@@ -218,26 +210,6 @@ module Api
       js_nodes = js["elements"].filter { |e| e["type"] == "node" }
       assert_equal 1, js_nodes.count
       assert_equal node.id, js_nodes[0]["id"]
-    end
-
-    def test_relations_for_way
-      way = create(:way)
-      # should include relations with that way as a member
-      relation_with_way = create(:relation_member, :member => way).relation
-      # should ignore relations without that way as a member
-      _relation_without_way = create(:relation_member).relation
-      # should ignore relations with the way involved indirectly, via a relation
-      second_relation = create(:relation_member, :member => way).relation
-      _super_relation = create(:relation_member, :member => second_relation).relation
-      # should combine multiple relation_member references into just one relation entry
-      create(:relation_member, :member => way, :relation => relation_with_way)
-      # should not include deleted relations
-      deleted_relation = create(:relation, :deleted)
-      create(:relation_member, :member => way, :relation => deleted_relation)
-
-      check_relations_for_element(way_relations_path(way), "way",
-                                  way.id,
-                                  [relation_with_way, second_relation])
     end
 
     def test_relations_for_relation

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -43,20 +43,12 @@ module Api
       )
 
       assert_routing(
-        { :path => "/api/0.6/node/1/relations", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_node", :id => "1" }
-      )
-      assert_routing(
         { :path => "/api/0.6/way/1/relations", :method => :get },
         { :controller => "api/relations", :action => "relations_for_way", :id => "1" }
       )
       assert_routing(
         { :path => "/api/0.6/relation/1/relations", :method => :get },
         { :controller => "api/relations", :action => "relations_for_relation", :id => "1" }
-      )
-      assert_routing(
-        { :path => "/api/0.6/node/1/relations.json", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_node", :id => "1", :format => "json" }
       )
       assert_routing(
         { :path => "/api/0.6/way/1/relations.json", :method => :get },
@@ -226,32 +218,6 @@ module Api
       js_nodes = js["elements"].filter { |e| e["type"] == "node" }
       assert_equal 1, js_nodes.count
       assert_equal node.id, js_nodes[0]["id"]
-    end
-
-    ##
-    # check that all relations containing a particular node, and no extra
-    # relations, are returned from the relations_for_node call.
-    def test_relations_for_node
-      node = create(:node)
-      # should include relations with that node as a member
-      relation_with_node = create(:relation_member, :member => node).relation
-      # should ignore relations without that node as a member
-      _relation_without_node = create(:relation_member).relation
-      # should ignore relations with the node involved indirectly, via a way
-      way = create(:way_node, :node => node).way
-      _relation_with_way = create(:relation_member, :member => way).relation
-      # should ignore relations with the node involved indirectly, via a relation
-      second_relation = create(:relation_member, :member => node).relation
-      _super_relation = create(:relation_member, :member => second_relation).relation
-      # should combine multiple relation_member references into just one relation entry
-      create(:relation_member, :member => node, :relation => relation_with_node)
-      # should not include deleted relations
-      deleted_relation = create(:relation, :deleted)
-      create(:relation_member, :member => node, :relation => deleted_relation)
-
-      check_relations_for_element(node_relations_path(node), "node",
-                                  node.id,
-                                  [relation_with_node, second_relation])
     end
 
     def test_relations_for_way

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -1013,25 +1013,6 @@ module Api
 
     private
 
-    def check_relations_for_element(path, type, id, expected_relations)
-      # check the "relations for relation" mode
-      get path
-      assert_response :success
-
-      # count one osm element
-      assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", 1
-
-      # we should have only the expected number of relations
-      assert_select "osm>relation", expected_relations.size
-
-      # and each of them should contain the element we originally searched for
-      expected_relations.each do |relation|
-        # The relation should appear once, but the element could appear multiple times
-        assert_select "osm>relation[id='#{relation.id}']", 1
-        assert_select "osm>relation[id='#{relation.id}']>member[type='#{type}'][ref='#{id}']"
-      end
-    end
-
     ##
     # checks that the XML document and the string arguments have
     # members in the same order.

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -42,15 +42,6 @@ module Api
         { :controller => "api/relations", :action => "destroy", :id => "1" }
       )
 
-      assert_routing(
-        { :path => "/api/0.6/relation/1/relations", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_relation", :id => "1" }
-      )
-      assert_routing(
-        { :path => "/api/0.6/relation/1/relations.json", :method => :get },
-        { :controller => "api/relations", :action => "relations_for_relation", :id => "1", :format => "json" }
-      )
-
       assert_recognizes(
         { :controller => "api/relations", :action => "create" },
         { :path => "/api/0.6/relation/create", :method => :put }
@@ -210,25 +201,6 @@ module Api
       js_nodes = js["elements"].filter { |e| e["type"] == "node" }
       assert_equal 1, js_nodes.count
       assert_equal node.id, js_nodes[0]["id"]
-    end
-
-    def test_relations_for_relation
-      relation = create(:relation)
-      # should include relations with that relation as a member
-      relation_with_relation = create(:relation_member, :member => relation).relation
-      # should ignore any relation without that relation as a member
-      _relation_without_relation = create(:relation_member).relation
-      # should ignore relations with the relation involved indirectly, via a relation
-      second_relation = create(:relation_member, :member => relation).relation
-      _super_relation = create(:relation_member, :member => second_relation).relation
-      # should combine multiple relation_member references into just one relation entry
-      create(:relation_member, :member => relation, :relation => relation_with_relation)
-      # should not include deleted relations
-      deleted_relation = create(:relation, :deleted)
-      create(:relation_member, :member => relation, :relation => deleted_relation)
-      check_relations_for_element(relation_relations_path(relation), "relation",
-                                  relation.id,
-                                  [relation_with_relation, second_relation])
     end
 
     # -------------------------------------

--- a/test/controllers/api/ways/relations_controller_test.rb
+++ b/test/controllers/api/ways/relations_controller_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+module Api
+  module Ways
+    class RelationsControllerTest < ActionDispatch::IntegrationTest
+      ##
+      # test all routes which lead to this controller
+      def test_routes
+        assert_routing(
+          { :path => "/api/0.6/way/1/relations", :method => :get },
+          { :controller => "api/ways/relations", :action => "index", :way_id => "1" }
+        )
+        assert_routing(
+          { :path => "/api/0.6/way/1/relations.json", :method => :get },
+          { :controller => "api/ways/relations", :action => "index", :way_id => "1", :format => "json" }
+        )
+      end
+
+      def test_index
+        way = create(:way)
+        # should include relations with that way as a member
+        relation_with_way = create(:relation_member, :member => way).relation
+        # should ignore relations without that way as a member
+        _relation_without_way = create(:relation_member).relation
+        # should ignore relations with the way involved indirectly, via a relation
+        second_relation = create(:relation_member, :member => way).relation
+        _super_relation = create(:relation_member, :member => second_relation).relation
+        # should combine multiple relation_member references into just one relation entry
+        create(:relation_member, :member => way, :relation => relation_with_way)
+        # should not include deleted relations
+        deleted_relation = create(:relation, :deleted)
+        create(:relation_member, :member => way, :relation => deleted_relation)
+
+        get api_way_relations_path(way)
+
+        assert_response :success
+
+        # count one osm element
+        assert_select "osm[version='#{Settings.api_version}'][generator='#{Settings.generator}']", 1
+
+        # we should have only the expected number of relations
+        expected_relations = [relation_with_way, second_relation]
+        assert_select "osm>relation", expected_relations.size
+
+        # and each of them should contain the element we originally searched for
+        expected_relations.each do |containing_relation|
+          # The relation should appear once, but the element could appear multiple times
+          assert_select "osm>relation[id='#{containing_relation.id}']", 1
+          assert_select "osm>relation[id='#{containing_relation.id}']>member[type='way'][ref='#{way.id}']"
+        end
+      end
+
+      def test_index_json
+        way = create(:way)
+        containing_relation = create(:relation_member, :member => way).relation
+
+        get api_way_relations_path(way, :format => "json")
+
+        assert_response :success
+        js = ActiveSupport::JSON.decode(@response.body)
+        assert_not_nil js
+        assert_equal 1, js["elements"].count
+        js_relations = js["elements"].filter { |e| e["type"] == "relation" }
+        assert_equal 1, js_relations.count
+        assert_equal containing_relation.id, js_relations[0]["id"]
+      end
+    end
+  end
+end

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -779,42 +779,6 @@ module Api
     end
 
     ##
-    # test that a call to ways_for_node returns all ways that contain the node
-    # and none that don't.
-    def test_ways_for_node
-      node = create(:node)
-      way1 = create(:way)
-      way2 = create(:way)
-      create(:way_node, :way => way1, :node => node)
-      create(:way_node, :way => way2, :node => node)
-      # create an unrelated way
-      create(:way_with_nodes, :nodes_count => 2)
-      # create a way which used to use the node
-      way3_v1 = create(:old_way, :version => 1)
-      _way3_v2 = create(:old_way, :current_way => way3_v1.current_way, :version => 2)
-      create(:old_way_node, :old_way => way3_v1, :node => node)
-
-      get node_ways_path(node)
-      assert_response :success
-      ways_xml = XML::Parser.string(@response.body).parse
-      assert_not_nil ways_xml, "failed to parse ways_for_node response"
-
-      # check that the set of IDs match expectations
-      expected_way_ids = [way1.id,
-                          way2.id]
-      found_way_ids = ways_xml.find("//osm/way").collect { |w| w["id"].to_i }
-      assert_equal expected_way_ids.sort, found_way_ids.sort,
-                   "expected ways for node #{node.id} did not match found"
-
-      # check the full ways to ensure we're not missing anything
-      expected_way_ids.each do |id|
-        way_xml = ways_xml.find("//osm/way[@id='#{id}']").first
-        assert_ways_are_equal(Way.find(id),
-                              Way.from_xml_node(way_xml))
-      end
-    end
-
-    ##
     # test initial rate limit
     def test_initial_rate_limit
       # create a user


### PR DESCRIPTION
Creates nested resources instead of the following actions: `ways_for_node`, `relations_for_node`, `relations_for_way`, `relations_for_relation`. After that there's no nonstandard actions in api element controllers for current versions of elements.

The current structure is a bit surprising too. Here's a route to get ways that include a given node for example:
```
get "node/:id/ways" => "ways#ways_for_node"
```
As you can see the action is not defined in the nodes controller, rather it's in the ways controller. The ways controller receives an id param that's not an id of a way. In this PR I'm adding another controller for ways that include a node, and three more controllers for relations that contain a node/way/relation.