### PR TITLE
Improvements for notes with deleted authors

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -43,7 +43,7 @@ class NotesController < ApplicationController
 
     @note_includes_anonymous = @note.author.nil? || @note_comments.find { |comment| comment.author.nil? }
 
-    @note_comments = @note_comments.drop(1) unless !@note.author.nil? && @note.author.status == "deleted"
+    @note_comments = @note_comments.drop(1) if @note.author.nil? || @note.author.active?
   rescue ActiveRecord::RecordNotFound
     render :template => "browse/not_found", :status => :not_found
   end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -152,6 +152,15 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_select "div.note-comments ul li", :count => 1
   end
 
+  def test_read_note_hidden_opener
+    hidden_user = create(:user, :deleted)
+    note_with_hidden_opener = create(:note)
+    create(:note_comment, :author => hidden_user, :note => note_with_hidden_opener)
+
+    sidebar_browse_check :note_path, note_with_hidden_opener.id, "notes/show"
+    assert_select "div.note-comments ul li", :count => 0
+  end
+
   def test_read_closed_note
     user = create(:user)
     closed_note = create(:note_with_comments, :closed, :closed_by => user, :comments_count => 2)


### PR DESCRIPTION
This is a follow on to #5609 that does a couple of things.

Firstly it adds a test for a note whose original author has been deleted.

Secondly it corrects the test for whether to drop the first comment to align with what the note model does in the `comments` association so that the first comment is only dropped if the author was active because in other cases the model will already have excluded it. This primarily affects users in state `suspended` I think.