### PR TITLE
Use subqueries to find nested members more efficiently

### DIFF
--- a/app/controllers/api/nodes/relations_controller.rb
+++ b/app/controllers/api/nodes/relations_controller.rb
@@ -6,13 +6,12 @@ module Api
       before_action :set_request_formats
 
       def index
-        relation_ids = RelationMember.where(:member_type => "Node", :member_id => params[:node_id]).collect(&:relation_id).uniq
-
-        @relations = []
-
-        Relation.find(relation_ids).each do |relation|
-          @relations << relation if relation.visible
-        end
+        @relations = Relation
+                     .visible
+                     .where(:id => RelationMember.where(
+                       :member_type => "Node",
+                       :member_id => params[:node_id]
+                     ).select(:relation_id))
 
         # Render the result
         respond_to do |format|

--- a/app/controllers/api/nodes/ways_controller.rb
+++ b/app/controllers/api/nodes/ways_controller.rb
@@ -10,9 +10,11 @@ module Api
       # :node_id parameter. note that this used to return deleted ways as well, but
       # this seemed not to be the expected behaviour, so it was removed.
       def index
-        way_ids = WayNode.where(:node_id => params[:node_id]).collect { |ws| ws.id[0] }.uniq
-
-        @ways = Way.where(:id => way_ids, :visible => true)
+        @ways = Way
+                .visible
+                .where(:id => WayNode.where(
+                  :node_id => params[:node_id]
+                ).select(:way_id))
 
         # Render the result
         respond_to do |format|

--- a/app/controllers/api/relations/relations_controller.rb
+++ b/app/controllers/api/relations/relations_controller.rb
@@ -6,13 +6,12 @@ module Api
       before_action :set_request_formats
 
       def index
-        relation_ids = RelationMember.where(:member_type => "Relation", :member_id => params[:relation_id]).collect(&:relation_id).uniq
-
-        @relations = []
-
-        Relation.find(relation_ids).each do |relation|
-          @relations << relation if relation.visible
-        end
+        @relations = Relation
+                     .visible
+                     .where(:id => RelationMember.where(
+                       :member_type => "Relation",
+                       :member_id => params[:relation_id]
+                     ).select(:relation_id))
 
         # Render the result
         respond_to do |format|

--- a/app/controllers/api/ways/relations_controller.rb
+++ b/app/controllers/api/ways/relations_controller.rb
@@ -6,13 +6,12 @@ module Api
       before_action :set_request_formats
 
       def index
-        relation_ids = RelationMember.where(:member_type => "Way", :member_id => params[:way_id]).collect(&:relation_id).uniq
-
-        @relations = []
-
-        Relation.find(relation_ids).each do |relation|
-          @relations << relation if relation.visible
-        end
+        @relations = Relation
+                     .visible
+                     .where(:id => RelationMember.where(
+                       :member_type => "Way",
+                       :member_id => params[:way_id]
+                     ).select(:relation_id))
 
         # Render the result
         respond_to do |format|


### PR DESCRIPTION
Use subqueries to do the selection in one go in the database which also avoids to deduplicate in rails.

Also pushes all visibility filtering into the query.