### PR TITLE
Move eslint ignore rules to the configuration file

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -7,6 +7,14 @@ module.exports = [
   js.configs.recommended,
   erb.configs.recommended,
   {
+    ignores: [
+      "app/assets/javascripts/i18n/",
+      "coverage/assets/",
+      "public/assets/",
+      "vendor/"
+    ]
+  },
+  {
     plugins: {
       "@stylistic": stylisticJs
     },

--- a/lib/tasks/eslint.rake
+++ b/lib/tasks/eslint.rake
@@ -8,18 +8,12 @@ def config_file
   Rails.root.join("config/eslint.js").to_s
 end
 
-def js_files
-  Rails.application.assets.each_file.select do |file|
-    (file.ends_with?(".js") || file.ends_with?(".js.erb")) && !file.match?(%r{/(gems|vendor|i18n|node_modules)/})
-  end
-end
-
 namespace "eslint" do
   task :check => :environment do
-    system(yarn_path, "run", "eslint", "-c", config_file, *js_files) || abort
+    system(yarn_path, "run", "eslint", "-c", config_file, "--no-warn-ignored", Rails.root.to_s) || abort
   end
 
   task :fix => :environment do
-    system(yarn_path, "run", "eslint", "-c", config_file, "--fix", *js_files) || abort
+    system(yarn_path, "run", "eslint", "-c", config_file, "--no-warn-ignored", "--fix", Rails.root.to_s) || abort
   end
 end


### PR DESCRIPTION
Following on from @AntonKhorev's observation in #5631 this moves eslint ignore rules to the configuration.

Instead of having the rake task select which files to check, we just check the whole tree and have eslint ignore third party files and generated files that we don't control.