### PR TITLE
Make API old element show paths resourceful

### DIFF
--- a/app/controllers/api/old_nodes_controller.rb
+++ b/app/controllers/api/old_nodes_controller.rb
@@ -3,7 +3,7 @@ module Api
     private
 
     def lookup_old_element
-      @old_element = OldNode.find([params[:id], params[:version]])
+      @old_element = OldNode.find([params[:node_id], params[:version]])
     end
 
     def lookup_old_element_versions

--- a/app/controllers/api/old_relations_controller.rb
+++ b/app/controllers/api/old_relations_controller.rb
@@ -3,7 +3,7 @@ module Api
     private
 
     def lookup_old_element
-      @old_element = OldRelation.find([params[:id], params[:version]])
+      @old_element = OldRelation.find([params[:relation_id], params[:version]])
     end
 
     def lookup_old_element_versions

--- a/app/controllers/api/old_ways_controller.rb
+++ b/app/controllers/api/old_ways_controller.rb
@@ -3,7 +3,7 @@ module Api
     private
 
     def lookup_old_element
-      @old_element = OldWay.find([params[:id], params[:version]])
+      @old_element = OldWay.find([params[:way_id], params[:version]])
     end
 
     def lookup_old_element_versions

--- a/app/views/old_elements/_actions.html.erb
+++ b/app/views/old_elements/_actions.html.erb
@@ -2,7 +2,7 @@
   <%= link_to t("browse.view_details"), :controller => @type.pluralize, :action => :show %>
   <% if !@feature.redacted? %>
     &middot;
-    <%= link_to t("browse.download_xml"), :controller => "api/old_#{@type.pluralize}", :action => :show %>
+    <%= link_to t("browse.download_xml"), send(:"api_#{@type}_version_path", *@feature.id) %>
   <% elsif current_user&.moderator? %>
     &middot;
     <% if !params[:show_redactions] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,14 +30,11 @@ OpenStreetMap::Application.routes.draw do
     post "changeset/comment/:id/hide" => "changeset_comments#destroy", :as => :changeset_comment_hide, :id => /\d+/
     post "changeset/comment/:id/unhide" => "changeset_comments#restore", :as => :changeset_comment_unhide, :id => /\d+/
 
-    post "node/:id/:version/redact" => "old_nodes#redact", :as => :node_version_redact, :version => /\d+/, :id => /\d+/
-    get "node/:id/:version" => "old_nodes#show", :as => :api_old_node, :id => /\d+/, :version => /\d+/
+    post "node/:node_id/:version/redact" => "old_nodes#redact", :as => :node_version_redact, :version => /\d+/, :node_id => /\d+/
 
-    post "way/:id/:version/redact" => "old_ways#redact", :as => :way_version_redact, :version => /\d+/, :id => /\d+/
-    get "way/:id/:version" => "old_ways#show", :as => :api_old_way, :id => /\d+/, :version => /\d+/
+    post "way/:way_id/:version/redact" => "old_ways#redact", :as => :way_version_redact, :version => /\d+/, :id => /\d+/
 
-    post "relation/:id/:version/redact" => "old_relations#redact", :as => :relation_version_redact, :version => /\d+/, :id => /\d+/
-    get "relation/:id/:version" => "old_relations#show", :as => :api_old_relation, :id => /\d+/, :version => /\d+/
+    post "relation/:relation_id/:version/redact" => "old_relations#redact", :as => :relation_version_redact, :version => /\d+/, :id => /\d+/
   end
 
   namespace :api, :path => "api/0.6" do
@@ -48,6 +45,7 @@ OpenStreetMap::Application.routes.draw do
         resources :relations, :only => :index
       end
       resources :versions, :path => "history", :controller => :old_nodes, :only => :index
+      resources :versions, :path => "", :version => /\d+/, :param => :version, :controller => :old_nodes, :only => :show
     end
     put "node/create" => "nodes#create", :as => nil
 
@@ -60,6 +58,7 @@ OpenStreetMap::Application.routes.draw do
         resources :relations, :only => :index
       end
       resources :versions, :path => "history", :controller => :old_ways, :only => :index
+      resources :versions, :path => "", :version => /\d+/, :param => :version, :controller => :old_ways, :only => :show
     end
     put "way/create" => "ways#create", :as => nil
 
@@ -72,6 +71,7 @@ OpenStreetMap::Application.routes.draw do
         resources :relations, :only => :index
       end
       resources :versions, :path => "history", :controller => :old_relations, :only => :index
+      resources :versions, :path => "", :version => /\d+/, :param => :version, :controller => :old_relations, :only => :show
     end
     put "relation/create" => "relations#create", :as => nil
 

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -782,7 +782,7 @@ module Api
 
       # check the ordering in the history tables:
       with_controller(OldRelationsController.new) do
-        get api_old_relation_path(relation_id, 2)
+        get api_relation_version_path(relation_id, 2)
         assert_response :success, "can't read back version 2 of the relation #{relation_id}"
         check_ordering(doc, @response.body)
       end
@@ -862,7 +862,7 @@ module Api
 
       # check the ordering in the history tables:
       with_controller(OldRelationsController.new) do
-        get api_old_relation_path(relation_id, 1)
+        get api_relation_version_path(relation_id, 1)
         assert_response :success, "can't read back version 1 of the relation: #{@response.body}"
         check_ordering(doc, @response.body)
       end
@@ -1084,7 +1084,7 @@ module Api
         get api_relation_path(id)
       else
         with_controller(OldRelationsController.new) do
-          get api_old_relation_path(id, ver)
+          get api_relation_version_path(id, ver)
         end
       end
       assert_response :success

--- a/test/controllers/old_nodes_controller_test.rb
+++ b/test/controllers/old_nodes_controller_test.rb
@@ -114,7 +114,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_node_path node, 1}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_node_path node, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_node_version_path node, 1}']", :count => 1
     assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
@@ -129,7 +129,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_node_path node, 1}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_node_path node, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_node_version_path node, 1}']", :count => 1
     assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 2}']", :count => 1
@@ -141,7 +141,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_node_path node, 2}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_node_path node, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_node_version_path node, 2}']", :count => 1
     assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{node_history_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 1
@@ -157,7 +157,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_node_path node, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_node_version_path node, 1}']", :count => 0
   end
 
   test "show unrevealed redacted versions to regular users" do
@@ -171,7 +171,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_node_path node, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_node_version_path node, 1}']", :count => 0
   end
 
   test "show unrevealed redacted versions to moderators" do
@@ -185,7 +185,7 @@ class OldNodesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{node_path node}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 1, :params => { :show_redactions => true }}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_node_path node, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_node_path node, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_node_version_path node, 1}']", :count => 0
   end
 
   test "don't reveal redacted versions to anonymous users" do

--- a/test/controllers/old_relations_controller_test.rb
+++ b/test/controllers/old_relations_controller_test.rb
@@ -64,7 +64,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_relation_path relation, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_relation_version_path relation, 1}']", :count => 1
     assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
@@ -79,7 +79,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_relation_path relation, 1}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_relation_path relation, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_relation_version_path relation, 1}']", :count => 1
     assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 2}']", :count => 1
@@ -91,7 +91,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_relation_path relation, 2}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_relation_path relation, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_relation_version_path relation, 2}']", :count => 1
     assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{relation_history_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 1
@@ -116,7 +116,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_relation_path relation, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_relation_version_path relation, 1}']", :count => 0
   end
 
   test "show unrevealed redacted versions to regular users" do
@@ -130,7 +130,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_relation_path relation, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_relation_version_path relation, 1}']", :count => 0
   end
 
   test "show unrevealed redacted versions to moderators" do
@@ -144,7 +144,7 @@ class OldRelationsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{relation_path relation}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1, :params => { :show_redactions => true }}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_relation_path relation, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_relation_path relation, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_relation_version_path relation, 1}']", :count => 0
   end
 
   test "don't reveal redacted versions to anonymous users" do

--- a/test/controllers/old_ways_controller_test.rb
+++ b/test/controllers/old_ways_controller_test.rb
@@ -64,7 +64,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_way_path way, 1}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_way_path way, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_way_version_path way, 1}']", :count => 1
     assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
@@ -79,7 +79,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_way_path way, 1}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_way_path way, 1}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_way_version_path way, 1}']", :count => 1
     assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 2}']", :count => 1
@@ -91,7 +91,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", /^Version/ do
       assert_select "a[href='#{old_way_path way, 2}']", :count => 0
     end
-    assert_select ".secondary-actions a[href='#{api_old_way_path way, 2}']", :count => 1
+    assert_select ".secondary-actions a[href='#{api_way_version_path way, 2}']", :count => 1
     assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{way_history_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 1
@@ -121,7 +121,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_way_path way, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_way_version_path way, 1}']", :count => 0
   end
 
   test "show unrevealed redacted versions to regular users" do
@@ -135,7 +135,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1, :params => { :show_redactions => true }}']", :count => 0
     assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_way_path way, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_way_version_path way, 1}']", :count => 0
   end
 
   test "show unrevealed redacted versions to moderators" do
@@ -149,7 +149,7 @@ class OldWaysControllerTest < ActionDispatch::IntegrationTest
     assert_select ".secondary-actions a[href='#{way_path way}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1, :params => { :show_redactions => true }}']", :count => 1
     assert_select ".secondary-actions a[href='#{old_way_path way, 1}']", :count => 0
-    assert_select ".secondary-actions a[href='#{api_old_way_path way, 1}']", :count => 0
+    assert_select ".secondary-actions a[href='#{api_way_version_path way, 1}']", :count => 0
   end
 
   test "don't reveal redacted versions to anonymous users" do


### PR DESCRIPTION
Declares `versions` resources with `show` action on these API paths: `node/:id/:version`, `way/:id/:version`, `relation/:id/:version`.