### PR TITLE
Create integration tests for element versions

### DIFF
--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -70,7 +70,35 @@ module Api
                     "redacted node #{node_v1.node_id} version #{node_v1.version} shouldn't be present in the history, even when logged in."
     end
 
-    # TODO: test_show
+    def test_show
+      node = create(:node, :version => 2)
+      create(:old_node, :node_id => node.id, :version => 1, :latitude => 60 * OldNode::SCALE, :longitude => 30 * OldNode::SCALE)
+      create(:old_node, :node_id => node.id, :version => 2, :latitude => 61 * OldNode::SCALE, :longitude => 31 * OldNode::SCALE)
+
+      get api_node_version_path(node, 1)
+
+      assert_response :success
+      assert_dom "osm:root", 1 do
+        assert_dom "> node", 1 do
+          assert_dom "> @id", node.id.to_s
+          assert_dom "> @version", "1"
+          assert_dom "> @lat", "60.0000000"
+          assert_dom "> @lon", "30.0000000"
+        end
+      end
+
+      get api_node_version_path(node, 2)
+
+      assert_response :success
+      assert_dom "osm:root", 1 do
+        assert_dom "> node", 1 do
+          assert_dom "> @id", node.id.to_s
+          assert_dom "> @version", "2"
+          assert_dom "> @lat", "61.0000000"
+          assert_dom "> @lon", "31.0000000"
+        end
+      end
+    end
 
     def test_show_not_found
       check_not_found_id_version(70000, 312344)

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -70,128 +70,7 @@ module Api
                     "redacted node #{node_v1.node_id} version #{node_v1.version} shouldn't be present in the history, even when logged in."
     end
 
-    ##
-    # test the version call by submitting several revisions of a new node
-    # to the API and ensuring that later calls to version return the
-    # matching versions of the object.
-    #
-    ##
-    # FIXME: Move this test to being an integration test since it spans multiple controllers
-    def test_show
-      private_user = create(:user, :data_public => false)
-      private_node = create(:node, :with_history, :version => 4, :lat => 0, :lon => 0, :changeset => create(:changeset, :user => private_user))
-      user = create(:user)
-      node = create(:node, :with_history, :version => 4, :lat => 0, :lon => 0, :changeset => create(:changeset, :user => user))
-      create_list(:node_tag, 2, :node => node)
-      # Ensure that the current tags are propagated to the history too
-      propagate_tags(node, node.old_nodes.last)
-
-      ## First try this with a non-public user
-      auth_header = bearer_authorization_header private_user
-
-      # setup a simple XML node
-      xml_doc = xml_for_node(private_node)
-      xml_node = xml_doc.find("//osm/node").first
-      nodeid = private_node.id
-
-      # keep a hash of the versions => string, as we'll need something
-      # to test against later
-      versions = {}
-
-      # save a version for later checking
-      versions[xml_node["version"]] = xml_doc.to_s
-
-      # randomly move the node about
-      3.times do
-        # move the node somewhere else
-        xml_node["lat"] = precision(rand - 0.5).to_s
-        xml_node["lon"] = precision(rand - 0.5).to_s
-        with_controller(NodesController.new) do
-          put api_node_path(nodeid), :params => xml_doc.to_s, :headers => auth_header
-          assert_response :forbidden, "Should have rejected node update"
-          xml_node["version"] = @response.body.to_s
-        end
-        # save a version for later checking
-        versions[xml_node["version"]] = xml_doc.to_s
-      end
-
-      # add a bunch of random tags
-      3.times do
-        xml_tag = XML::Node.new("tag")
-        xml_tag["k"] = random_string
-        xml_tag["v"] = random_string
-        xml_node << xml_tag
-        with_controller(NodesController.new) do
-          put api_node_path(nodeid), :params => xml_doc.to_s, :headers => auth_header
-          assert_response :forbidden,
-                          "should have rejected node #{nodeid} (#{@response.body}) with forbidden"
-          xml_node["version"] = @response.body.to_s
-        end
-        # save a version for later checking
-        versions[xml_node["version"]] = xml_doc.to_s
-      end
-
-      # probably should check that they didn't get written to the database
-
-      ## Now do it with the public user
-      auth_header = bearer_authorization_header user
-
-      # setup a simple XML node
-
-      xml_doc = xml_for_node(node)
-      xml_node = xml_doc.find("//osm/node").first
-      nodeid = node.id
-
-      # keep a hash of the versions => string, as we'll need something
-      # to test against later
-      versions = {}
-
-      # save a version for later checking
-      versions[xml_node["version"]] = xml_doc.to_s
-
-      # randomly move the node about
-      3.times do
-        # move the node somewhere else
-        xml_node["lat"] = precision(rand - 0.5).to_s
-        xml_node["lon"] = precision(rand - 0.5).to_s
-        with_controller(NodesController.new) do
-          put api_node_path(nodeid), :params => xml_doc.to_s, :headers => auth_header
-          assert_response :success
-          xml_node["version"] = @response.body.to_s
-        end
-        # save a version for later checking
-        versions[xml_node["version"]] = xml_doc.to_s
-      end
-
-      # add a bunch of random tags
-      3.times do
-        xml_tag = XML::Node.new("tag")
-        xml_tag["k"] = random_string
-        xml_tag["v"] = random_string
-        xml_node << xml_tag
-        with_controller(NodesController.new) do
-          put api_node_path(nodeid), :params => xml_doc.to_s, :headers => auth_header
-          assert_response :success,
-                          "couldn't update node #{nodeid} (#{@response.body})"
-          xml_node["version"] = @response.body.to_s
-        end
-        # save a version for later checking
-        versions[xml_node["version"]] = xml_doc.to_s
-      end
-
-      # check all the versions
-      versions.each_key do |key|
-        get api_node_version_path(nodeid, key.to_i)
-
-        assert_response :success,
-                        "couldn't get version #{key.to_i} of node #{nodeid}"
-
-        check_node = Node.from_xml(versions[key])
-        api_node = Node.from_xml(@response.body.to_s)
-
-        assert_nodes_are_equal check_node, api_node
-      end
-    end
+    # TODO: test_show
 
     def test_show_not_found
       check_not_found_id_version(70000, 312344)
@@ -215,32 +94,6 @@ module Api
       auth_header = bearer_authorization_header
       get api_node_version_path(node_v1.node_id, node_v1.version), :headers => auth_header
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API, even when logged in."
-    end
-
-    ##
-    # Test that getting the current version is identical to picking
-    # that version with the version URI call.
-    def test_current_version
-      node = create(:node, :with_history)
-      used_node = create(:node, :with_history)
-      create(:way_node, :node => used_node)
-      node_used_by_relationship = create(:node, :with_history)
-      create(:relation_member, :member => node_used_by_relationship)
-      node_with_versions = create(:node, :with_history, :version => 4)
-
-      create(:node_tag, :node => node)
-      create(:node_tag, :node => used_node)
-      create(:node_tag, :node => node_used_by_relationship)
-      create(:node_tag, :node => node_with_versions)
-      propagate_tags(node, node.old_nodes.last)
-      propagate_tags(used_node, used_node.old_nodes.last)
-      propagate_tags(node_used_by_relationship, node_used_by_relationship.old_nodes.last)
-      propagate_tags(node_with_versions, node_with_versions.old_nodes.last)
-
-      check_current_version(node)
-      check_current_version(used_node)
-      check_current_version(node_used_by_relationship)
-      check_current_version(node_with_versions)
     end
 
     # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05
@@ -452,54 +305,11 @@ module Api
       post node_version_redact_path(node.node_id, node.version), :params => { :redaction => redaction.id }, :headers => headers
     end
 
-    def check_current_version(node_id)
-      # get the current version of the node
-      current_node = with_controller(NodesController.new) do
-        get api_node_path(node_id)
-        assert_response :success, "cant get current node #{node_id}"
-        Node.from_xml(@response.body)
-      end
-      assert_not_nil current_node, "getting node #{node_id} returned nil"
-
-      # get the "old" version of the node from the old_node interface
-      get api_node_version_path(node_id, current_node.version)
-      assert_response :success, "cant get old node #{node_id}, v#{current_node.version}"
-      old_node = Node.from_xml(@response.body)
-
-      # check the nodes are the same
-      assert_nodes_are_equal current_node, old_node
-    end
-
     def check_not_found_id_version(id, version)
       get api_node_version_path(id, version)
       assert_response :not_found
     rescue ActionController::UrlGenerationError => e
       assert_match(/No route matches/, e.to_s)
-    end
-
-    ##
-    # returns a 16 character long string with some nasty characters in it.
-    # this ought to stress-test the tag handling as well as the versioning.
-    def random_string
-      letters = [["!", '"', "$", "&", ";", "@"],
-                 ("a".."z").to_a,
-                 ("A".."Z").to_a,
-                 ("0".."9").to_a].flatten
-      (1..16).map { letters[rand(letters.length)] }.join
-    end
-
-    ##
-    # truncate a floating point number to the scale that it is stored in
-    # the database. otherwise rounding errors can produce failing unit
-    # tests when they shouldn't.
-    def precision(f)
-      (f * GeoRecord::SCALE).round.to_f / GeoRecord::SCALE
-    end
-
-    def propagate_tags(node, old_node)
-      node.tags.each do |k, v|
-        create(:old_node_tag, :old_node => old_node, :k => k, :v => v)
-      end
     end
   end
 end

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -80,7 +80,29 @@ module Api
                     "redacted node #{way_v1.way_id} version #{way_v1.version} shouldn't be present in the history, even when logged in."
     end
 
-    # TODO: test_show
+    def test_show
+      way = create(:way, :with_history, :version => 2)
+
+      get api_way_version_path(way, 1)
+
+      assert_response :success
+      assert_dom "osm:root", 1 do
+        assert_dom "> way", 1 do
+          assert_dom "> @id", way.id.to_s
+          assert_dom "> @version", "1"
+        end
+      end
+
+      get api_way_version_path(way, 2)
+
+      assert_response :success
+      assert_dom "osm:root", 1 do
+        assert_dom "> way", 1 do
+          assert_dom "> @id", way.id.to_s
+          assert_dom "> @version", "2"
+        end
+      end
+    end
 
     ##
     # test that redacted ways aren't visible, regardless of

--- a/test/integration/node_versions_test.rb
+++ b/test/integration/node_versions_test.rb
@@ -1,0 +1,194 @@
+require "test_helper"
+
+class NodeVersionsTest < ActionDispatch::IntegrationTest
+  ##
+  # test the version call by submitting several revisions of a new node
+  # to the API and ensuring that later calls to version return the
+  # matching versions of the object.
+  def test_version
+    private_user = create(:user, :data_public => false)
+    private_node = create(:node, :with_history, :version => 4, :lat => 0, :lon => 0, :changeset => create(:changeset, :user => private_user))
+    user = create(:user)
+    node = create(:node, :with_history, :version => 4, :lat => 0, :lon => 0, :changeset => create(:changeset, :user => user))
+    create_list(:node_tag, 2, :node => node)
+    # Ensure that the current tags are propagated to the history too
+    propagate_tags(node, node.old_nodes.last)
+
+    ## First try this with a non-public user
+    auth_header = bearer_authorization_header private_user
+
+    # setup a simple XML node
+    xml_doc = xml_for_node(private_node)
+    xml_node = xml_doc.find("//osm/node").first
+    node_id = private_node.id
+
+    # keep a hash of the versions => string, as we'll need something
+    # to test against later
+    versions = {}
+
+    # save a version for later checking
+    versions[xml_node["version"]] = xml_doc.to_s
+
+    # randomly move the node about
+    3.times do
+      # move the node somewhere else
+      xml_node["lat"] = precision(rand - 0.5).to_s
+      xml_node["lon"] = precision(rand - 0.5).to_s
+      with_controller(NodesController.new) do
+        put api_node_path(node_id), :params => xml_doc.to_s, :headers => auth_header
+        assert_response :forbidden, "Should have rejected node update"
+        xml_node["version"] = @response.body.to_s
+      end
+      # save a version for later checking
+      versions[xml_node["version"]] = xml_doc.to_s
+    end
+
+    # add a bunch of random tags
+    3.times do
+      xml_tag = XML::Node.new("tag")
+      xml_tag["k"] = random_string
+      xml_tag["v"] = random_string
+      xml_node << xml_tag
+      with_controller(NodesController.new) do
+        put api_node_path(node_id), :params => xml_doc.to_s, :headers => auth_header
+        assert_response :forbidden,
+                        "should have rejected node #{node_id} (#{@response.body}) with forbidden"
+        xml_node["version"] = @response.body.to_s
+      end
+      # save a version for later checking
+      versions[xml_node["version"]] = xml_doc.to_s
+    end
+
+    # probably should check that they didn't get written to the database
+
+    ## Now do it with the public user
+    auth_header = bearer_authorization_header user
+
+    # setup a simple XML node
+
+    xml_doc = xml_for_node(node)
+    xml_node = xml_doc.find("//osm/node").first
+    node_id = node.id
+
+    # keep a hash of the versions => string, as we'll need something
+    # to test against later
+    versions = {}
+
+    # save a version for later checking
+    versions[xml_node["version"]] = xml_doc.to_s
+
+    # randomly move the node about
+    3.times do
+      # move the node somewhere else
+      xml_node["lat"] = precision(rand - 0.5).to_s
+      xml_node["lon"] = precision(rand - 0.5).to_s
+      with_controller(NodesController.new) do
+        put api_node_path(node_id), :params => xml_doc.to_s, :headers => auth_header
+        assert_response :success
+        xml_node["version"] = @response.body.to_s
+      end
+      # save a version for later checking
+      versions[xml_node["version"]] = xml_doc.to_s
+    end
+
+    # add a bunch of random tags
+    3.times do
+      xml_tag = XML::Node.new("tag")
+      xml_tag["k"] = random_string
+      xml_tag["v"] = random_string
+      xml_node << xml_tag
+      with_controller(NodesController.new) do
+        put api_node_path(node_id), :params => xml_doc.to_s, :headers => auth_header
+        assert_response :success,
+                        "couldn't update node #{node_id} (#{@response.body})"
+        xml_node["version"] = @response.body.to_s
+      end
+      # save a version for later checking
+      versions[xml_node["version"]] = xml_doc.to_s
+    end
+
+    # check all the versions
+    versions.each_key do |key|
+      get api_node_version_path(node_id, key.to_i)
+
+      assert_response :success,
+                      "couldn't get version #{key.to_i} of node #{node_id}"
+
+      check_node = Node.from_xml(versions[key])
+      api_node = Node.from_xml(@response.body.to_s)
+
+      assert_nodes_are_equal check_node, api_node
+    end
+  end
+
+  ##
+  # Test that getting the current version is identical to picking
+  # that version with the version URI call.
+  def test_current_version
+    node = create(:node, :with_history)
+    used_node = create(:node, :with_history)
+    create(:way_node, :node => used_node)
+    node_used_by_relationship = create(:node, :with_history)
+    create(:relation_member, :member => node_used_by_relationship)
+    node_with_versions = create(:node, :with_history, :version => 4)
+
+    create(:node_tag, :node => node)
+    create(:node_tag, :node => used_node)
+    create(:node_tag, :node => node_used_by_relationship)
+    create(:node_tag, :node => node_with_versions)
+    propagate_tags(node, node.old_nodes.last)
+    propagate_tags(used_node, used_node.old_nodes.last)
+    propagate_tags(node_used_by_relationship, node_used_by_relationship.old_nodes.last)
+    propagate_tags(node_with_versions, node_with_versions.old_nodes.last)
+
+    check_current_version(node)
+    check_current_version(used_node)
+    check_current_version(node_used_by_relationship)
+    check_current_version(node_with_versions)
+  end
+
+  private
+
+  def check_current_version(node_id)
+    # get the current version of the node
+    current_node = with_controller(NodesController.new) do
+      get api_node_path(node_id)
+      assert_response :success, "cant get current node #{node_id}"
+      Node.from_xml(@response.body)
+    end
+    assert_not_nil current_node, "getting node #{node_id} returned nil"
+
+    # get the "old" version of the node from the old_node interface
+    get api_node_version_path(node_id, current_node.version)
+    assert_response :success, "cant get old node #{node_id}, v#{current_node.version}"
+    old_node = Node.from_xml(@response.body)
+
+    # check the nodes are the same
+    assert_nodes_are_equal current_node, old_node
+  end
+
+  ##
+  # returns a 16 character long string with some nasty characters in it.
+  # this ought to stress-test the tag handling as well as the versioning.
+  def random_string
+    letters = [["!", '"', "$", "&", ";", "@"],
+               ("a".."z").to_a,
+               ("A".."Z").to_a,
+               ("0".."9").to_a].flatten
+    (1..16).map { letters[rand(letters.length)] }.join
+  end
+
+  ##
+  # truncate a floating point number to the scale that it is stored in
+  # the database. otherwise rounding errors can produce failing unit
+  # tests when they shouldn't.
+  def precision(f)
+    (f * GeoRecord::SCALE).round.to_f / GeoRecord::SCALE
+  end
+
+  def propagate_tags(node, old_node)
+    node.tags.each do |k, v|
+      create(:old_node_tag, :old_node => old_node, :k => k, :v => v)
+    end
+  end
+end

--- a/test/integration/way_versions_test.rb
+++ b/test/integration/way_versions_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class WayVersionsTest < ActionDispatch::IntegrationTest
+  ##
+  # check that we can retrieve versions of a way
+  def test_version
+    way = create(:way, :with_history)
+    used_way = create(:way, :with_history)
+    create(:relation_member, :member => used_way)
+    way_with_versions = create(:way, :with_history, :version => 4)
+
+    create(:way_tag, :way => way)
+    create(:way_tag, :way => used_way)
+    create(:way_tag, :way => way_with_versions)
+    propagate_tags(way, way.old_ways.last)
+    propagate_tags(used_way, used_way.old_ways.last)
+    propagate_tags(way_with_versions, way_with_versions.old_ways.last)
+
+    check_current_version(way.id)
+    check_current_version(used_way.id)
+    check_current_version(way_with_versions.id)
+  end
+
+  private
+
+  ##
+  # check that the current version of a way is equivalent to the
+  # version which we're getting from the versions call.
+  def check_current_version(way_id)
+    # get the current version
+    current_way = with_controller(WaysController.new) do
+      get api_way_path(way_id)
+      assert_response :success, "can't get current way #{way_id}"
+      Way.from_xml(@response.body)
+    end
+    assert_not_nil current_way, "getting way #{way_id} returned nil"
+
+    # get the "old" version of the way from the version method
+    get api_way_version_path(way_id, current_way.version)
+    assert_response :success, "can't get old way #{way_id}, v#{current_way.version}"
+    old_way = Way.from_xml(@response.body)
+
+    # check that the ways are identical
+    assert_ways_are_equal current_way, old_way
+  end
+
+  def propagate_tags(way, old_way)
+    way.tags.each do |k, v|
+      create(:old_way_tag, :old_way => old_way, :k => k, :v => v)
+    end
+  end
+end


### PR DESCRIPTION
The only non-resourceful thing in the elements API is `redact` action. However before I can do anything with it I need to take care of tests.

You'd expect controller action tests to first set up the state of the elements, then perform the request and finally check the response and the new state. Unfortunately tests for redacting/unredacting element versions don't do that. Instead of checking the state after the action they do new show/index requests and check responses to those. This is double-checking show/index actions for redacted/unredacted states which is already done. But what's worse, if I'm to move (un)redacting to a different controller, the test would check actions of different controllers. They'll become integration tests.

But wait, some would-be integration tests already exist for different actions. You can see "FIXME: Move this test to being an integration test" on `test_show` in `old_nodes_controller_test.rb`. And you can see `with_controller` inside the tests. Also there's a similar situation in old ways controller.

This PR moves `test_show` tests to integration tests and replaces them with tests that just check the show action.