### PR TITLE
Refactor API old element redaction tests

### DIFF
--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -213,11 +213,11 @@ module Api
     # test that, even as moderator, the current version of a node
     # can't be redacted.
     def test_redact_node_current_version
-      node = create(:node, :with_history, :version => 4)
+      node = create(:node, :with_history, :version => 2)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post node_version_redact_path(node, 4), :params => { :redaction => redaction.id }, :headers => auth_header
+      post node_version_redact_path(node, 2), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
     end
@@ -250,17 +250,17 @@ module Api
     # test the redaction of an old version of a node, while being
     # authorised as a moderator.
     def test_redact_node_moderator
-      node = create(:node, :with_history, :version => 4)
-      node_v3 = node.old_nodes.find_by(:version => 3)
+      node = create(:node, :with_history, :version => 2)
+      node_v1 = node.old_nodes.find_by(:version => 1)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post node_version_redact_path(*node_v3.id), :params => { :redaction => redaction.id }, :headers => auth_header
+      post node_version_redact_path(*node_v1.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :success, "should be OK to redact old version as moderator."
-      node_v3.reload
-      assert_predicate node_v3, :redacted?
-      assert_equal redaction, node_v3.redaction
+      node_v1.reload
+      assert_predicate node_v1, :redacted?
+      assert_equal redaction, node_v1.redaction
     end
 
     ##
@@ -331,10 +331,10 @@ module Api
     private
 
     def do_redact_redactable_node(headers = {})
-      node = create(:node, :with_history, :version => 4)
+      node = create(:node, :with_history, :version => 2)
       redaction = create(:redaction)
 
-      post node_version_redact_path(node, 3), :params => { :redaction => redaction.id }, :headers => headers
+      post node_version_redact_path(node, 1), :params => { :redaction => redaction.id }, :headers => headers
     end
 
     def check_not_found_id_version(id, version)

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -151,6 +151,10 @@ module Api
       get api_node_version_path(node, 1)
 
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
+
+      get api_node_version_path(node, 1, :show_redactions => "true")
+
+      assert_response :forbidden, "Redacted node shouldn't be visible via the version API when passing flag."
     end
 
     def test_show_redacted_normal_user
@@ -160,6 +164,10 @@ module Api
       get api_node_version_path(node, 1), :headers => bearer_authorization_header
 
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API, even when logged in."
+
+      get api_node_version_path(node, 1, :show_redactions => "true"), :headers => bearer_authorization_header
+
+      assert_response :forbidden, "Redacted node shouldn't be visible via the version API, even when logged in and passing flag."
     end
 
     # Ensure the lat/lon is formatted as a decimal e.g. not 4.0e-05

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -289,12 +289,11 @@ module Api
     # test the unredaction of an old version of a node, while being
     # authorised as a normal user.
     def test_unredact_node_normal_user
-      user = create(:user)
       node = create(:node, :with_history, :version => 2)
       old_node = node.old_nodes.find_by(:version => 1)
       redaction = create(:redaction)
       old_node.redact!(redaction)
-      auth_header = bearer_authorization_header user
+      auth_header = bearer_authorization_header
 
       post node_version_redact_path(*old_node.id), :headers => auth_header
 
@@ -306,11 +305,10 @@ module Api
     # test the unredaction of an old version of a node, while being
     # authorised as a moderator.
     def test_unredact_node_moderator
-      moderator_user = create(:moderator_user)
       node = create(:node, :with_history, :version => 2)
       old_node = node.old_nodes.find_by(:version => 1)
       old_node.redact!(create(:redaction))
-      auth_header = bearer_authorization_header moderator_user
+      auth_header = bearer_authorization_header create(:moderator_user)
 
       post node_version_redact_path(*old_node.id), :headers => auth_header
 

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -194,20 +194,6 @@ module Api
     end
 
     ##
-    # test the redaction of an old version of a node, while not being
-    # authorised.
-    def test_redact_node_unauthorised
-      node = create(:node, :with_history, :version => 2)
-      old_node = node.old_nodes.find_by(:version => 1)
-      redaction = create(:redaction)
-
-      post node_version_redact_path(*old_node.id), :params => { :redaction => redaction.id }
-
-      assert_response :unauthorized, "should need to be authenticated to redact."
-      assert_nil old_node.reload.redaction
-    end
-
-    ##
     # test that, even as moderator, the current version of a node
     # can't be redacted.
     def test_redact_node_current_version
@@ -219,6 +205,20 @@ module Api
       post node_version_redact_path(*old_node.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
+      assert_nil old_node.reload.redaction
+    end
+
+    ##
+    # test the redaction of an old version of a node, while not being
+    # authorised.
+    def test_redact_node_unauthorised
+      node = create(:node, :with_history, :version => 2)
+      old_node = node.old_nodes.find_by(:version => 1)
+      redaction = create(:redaction)
+
+      post node_version_redact_path(*old_node.id), :params => { :redaction => redaction.id }
+
+      assert_response :unauthorized, "should need to be authenticated to redact."
       assert_nil old_node.reload.redaction
     end
 

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -251,16 +251,16 @@ module Api
     # authorised as a moderator.
     def test_redact_node_moderator
       node = create(:node, :with_history, :version => 2)
-      node_v1 = node.old_nodes.find_by(:version => 1)
+      old_node = node.old_nodes.find_by(:version => 1)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post node_version_redact_path(*node_v1.id), :params => { :redaction => redaction.id }, :headers => auth_header
+      post node_version_redact_path(*old_node.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :success, "should be OK to redact old version as moderator."
-      node_v1.reload
-      assert_predicate node_v1, :redacted?
-      assert_equal redaction, node_v1.redaction
+      old_node.reload
+      assert_predicate old_node, :redacted?
+      assert_equal redaction, old_node.redaction
     end
 
     ##
@@ -268,14 +268,14 @@ module Api
     # authorised.
     def test_unredact_node_unauthorised
       node = create(:node, :with_history, :version => 2)
-      node_v1 = node.old_nodes.find_by(:version => 1)
+      old_node = node.old_nodes.find_by(:version => 1)
       redaction = create(:redaction)
-      node_v1.redact!(redaction)
+      old_node.redact!(redaction)
 
-      post node_version_redact_path(node_v1.node_id, node_v1.version)
+      post node_version_redact_path(*old_node.id)
 
       assert_response :unauthorized, "should need to be authenticated to unredact."
-      assert_equal redaction, node_v1.reload.redaction
+      assert_equal redaction, old_node.reload.redaction
     end
 
     ##
@@ -284,15 +284,15 @@ module Api
     def test_unredact_node_normal_user
       user = create(:user)
       node = create(:node, :with_history, :version => 2)
-      node_v1 = node.old_nodes.find_by(:version => 1)
+      old_node = node.old_nodes.find_by(:version => 1)
       redaction = create(:redaction)
-      node_v1.redact!(redaction)
+      old_node.redact!(redaction)
       auth_header = bearer_authorization_header user
 
-      post node_version_redact_path(node_v1.node_id, node_v1.version), :headers => auth_header
+      post node_version_redact_path(*old_node.id), :headers => auth_header
 
       assert_response :forbidden, "should need to be moderator to unredact."
-      assert_equal redaction, node_v1.reload.redaction
+      assert_equal redaction, old_node.reload.redaction
     end
 
     ##
@@ -301,14 +301,14 @@ module Api
     def test_unredact_node_moderator
       moderator_user = create(:moderator_user)
       node = create(:node, :with_history, :version => 2)
-      node_v1 = node.old_nodes.find_by(:version => 1)
-      node_v1.redact!(create(:redaction))
+      old_node = node.old_nodes.find_by(:version => 1)
+      old_node.redact!(create(:redaction))
       auth_header = bearer_authorization_header moderator_user
 
-      post node_version_redact_path(node_v1.node_id, node_v1.version), :headers => auth_header
+      post node_version_redact_path(*old_node.id), :headers => auth_header
 
       assert_response :success, "should be OK to unredact old version as moderator."
-      assert_nil node_v1.reload.redaction
+      assert_nil old_node.reload.redaction
     end
 
     private

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -114,17 +114,21 @@ module Api
     ##
     # test that redacted nodes aren't visible, regardless of
     # authorisation except as moderator...
-    def test_show_redacted
+    def test_show_redacted_unauthorised
       node = create(:node, :with_history, :version => 2)
-      node_v1 = node.old_nodes.find_by(:version => 1)
-      node_v1.redact!(create(:redaction))
+      node.old_nodes.find_by(:version => 1).redact!(create(:redaction))
 
-      get api_node_version_path(node_v1.node_id, node_v1.version)
+      get api_node_version_path(node, 1)
+
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
+    end
 
-      # not even to a logged-in user
-      auth_header = bearer_authorization_header
-      get api_node_version_path(node_v1.node_id, node_v1.version), :headers => auth_header
+    def test_show_redacted_normal_user
+      node = create(:node, :with_history, :version => 2)
+      node.old_nodes.find_by(:version => 1).redact!(create(:redaction))
+
+      get api_node_version_path(node, 1), :headers => bearer_authorization_header
+
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API, even when logged in."
     end
 

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -228,7 +228,9 @@ module Api
       auth_header = bearer_authorization_header create(:moderator_user)
 
       do_redact_node(node_v3, create(:redaction), auth_header)
+
       assert_response :success, "should be OK to redact old version as moderator."
+      assert_predicate node_v3.reload, :redacted?
 
       # check moderator can still see the redacted data, when passing
       # the appropriate flag

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -86,6 +86,24 @@ module Api
                  "redacted node #{node.id} version 1 shouldn't be present in the history, even when logged in and passing flag."
     end
 
+    def test_index_redacted_moderator
+      node = create(:node, :with_history, :version => 2)
+      node.old_nodes.find_by(:version => 1).redact!(create(:redaction))
+      auth_header = bearer_authorization_header create(:moderator_user)
+
+      get api_node_versions_path(node), :headers => auth_header
+
+      assert_response :success, "Redaction shouldn't have stopped history working."
+      assert_dom "osm node[id='#{node.id}'][version='1']", 0,
+                 "node #{node.id} version 1 should not be present in the history for moderators when not passing flag."
+
+      get api_node_versions_path(node, :show_redactions => "true"), :headers => auth_header
+
+      assert_response :success, "Redaction shouldn't have stopped history working."
+      assert_dom "osm node[id='#{node.id}'][version='1']", 1,
+                 "node #{node.id} version 1 should still be present in the history for moderators when passing flag."
+    end
+
     def test_show
       node = create(:node, :version => 2)
       create(:old_node, :node_id => node.id, :version => 1, :latitude => 60 * OldNode::SCALE, :longitude => 30 * OldNode::SCALE)
@@ -238,16 +256,6 @@ module Api
       assert_response :forbidden, "After redaction, node should be gone for moderator, when flag not passed."
       get api_node_version_path(node_v3.node_id, node_v3.version, :show_redactions => "true"), :headers => auth_header
       assert_response :success, "After redaction, node should not be gone for moderator, when flag passed."
-
-      # and when accessed via history
-      get api_node_versions_path(node)
-      assert_response :success, "Redaction shouldn't have stopped history working."
-      assert_select "osm node[id='#{node_v3.node_id}'][version='#{node_v3.version}']", 0,
-                    "node #{node_v3.node_id} version #{node_v3.version} should not be present in the history for moderators when not passing flag."
-      get api_node_versions_path(node, :show_redactions => "true"), :headers => auth_header
-      assert_response :success, "Redaction shouldn't have stopped history working."
-      assert_select "osm node[id='#{node_v3.node_id}'][version='#{node_v3.version}']", 1,
-                    "node #{node_v3.node_id} version #{node_v3.version} should still be present in the history for moderators when passing flag."
     end
 
     # testing that if the moderator drops auth, he can't see the
@@ -266,12 +274,6 @@ module Api
       # check can't see the redacted data
       get api_node_version_path(node_v3.node_id, node_v3.version), :headers => auth_header
       assert_response :forbidden, "Redacted node shouldn't be visible via the version API."
-
-      # and when accessed via history
-      get api_node_versions_path(node), :headers => auth_header
-      assert_response :success, "Redaction shouldn't have stopped history working."
-      assert_select "osm node[id='#{node_v3.node_id}'][version='#{node_v3.version}']", 0,
-                    "redacted node #{node_v3.node_id} version #{node_v3.version} shouldn't be present in the history."
     end
 
     ##

--- a/test/controllers/api/old_nodes_controller_test.rb
+++ b/test/controllers/api/old_nodes_controller_test.rb
@@ -61,6 +61,12 @@ module Api
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_dom "osm node[id='#{node.id}'][version='1']", 0,
                  "redacted node #{node.id} version 1 shouldn't be present in the history."
+
+      get api_node_versions_path(node, :show_redactions => "true")
+
+      assert_response :success, "Redaction shouldn't have stopped history working."
+      assert_dom "osm node[id='#{node.id}'][version='1']", 0,
+                 "redacted node #{node.id} version 1 shouldn't be present in the history when passing flag."
     end
 
     def test_index_redacted_normal_user
@@ -72,6 +78,12 @@ module Api
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_dom "osm node[id='#{node.id}'][version='1']", 0,
                  "redacted node #{node.id} version 1 shouldn't be present in the history, even when logged in."
+
+      get api_node_versions_path(node, :show_redactions => "true"), :headers => bearer_authorization_header
+
+      assert_response :success, "Redaction shouldn't have stopped history working."
+      assert_dom "osm node[id='#{node.id}'][version='1']", 0,
+                 "redacted node #{node.id} version 1 shouldn't be present in the history, even when logged in and passing flag."
     end
 
     def test_show

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -204,11 +204,11 @@ module Api
     # test that, even as moderator, the current version of a relation
     # can't be redacted.
     def test_redact_relation_current_version
-      relation = create(:relation, :with_history, :version => 4)
+      relation = create(:relation, :with_history, :version => 2)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post relation_version_redact_path(relation, 4), :params => { :redaction => redaction.id }, :headers => auth_header
+      post relation_version_redact_path(relation, 2), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
     end
@@ -241,17 +241,17 @@ module Api
     # test the redaction of an old version of a relation, while being
     # authorised as a moderator.
     def test_redact_relation_moderator
-      relation = create(:relation, :with_history, :version => 4)
-      relation_v3 = relation.old_relations.find_by(:version => 3)
+      relation = create(:relation, :with_history, :version => 2)
+      relation_v1 = relation.old_relations.find_by(:version => 1)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post relation_version_redact_path(*relation_v3.id), :params => { :redaction => redaction.id }, :headers => auth_header
+      post relation_version_redact_path(*relation_v1.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :success, "should be OK to redact old version as moderator."
-      relation_v3.reload
-      assert_predicate relation_v3, :redacted?
-      assert_equal redaction, relation_v3.redaction
+      relation_v1.reload
+      assert_predicate relation_v1, :redacted?
+      assert_equal redaction, relation_v1.redaction
     end
 
     ##
@@ -320,10 +320,10 @@ module Api
     private
 
     def do_redact_redactable_relation(headers = {})
-      relation = create(:relation, :with_history, :version => 4)
+      relation = create(:relation, :with_history, :version => 2)
       redaction = create(:redaction)
 
-      post relation_version_redact_path(relation, 3), :params => { :redaction => redaction.id }, :headers => headers
+      post relation_version_redact_path(relation, 1), :params => { :redaction => redaction.id }, :headers => headers
     end
   end
 end

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -185,20 +185,6 @@ module Api
     end
 
     ##
-    # test the redaction of an old version of a relation, while not being
-    # authorised.
-    def test_redact_relation_unauthorised
-      relation = create(:relation, :with_history, :version => 2)
-      old_relation = relation.old_relations.find_by(:version => 1)
-      redaction = create(:redaction)
-
-      post relation_version_redact_path(*old_relation.id), :params => { :redaction => redaction.id }
-
-      assert_response :unauthorized, "should need to be authenticated to redact."
-      assert_nil old_relation.reload.redaction
-    end
-
-    ##
     # test that, even as moderator, the current version of a relation
     # can't be redacted.
     def test_redact_relation_current_version
@@ -210,6 +196,20 @@ module Api
       post relation_version_redact_path(*old_relation.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
+      assert_nil old_relation.reload.redaction
+    end
+
+    ##
+    # test the redaction of an old version of a relation, while not being
+    # authorised.
+    def test_redact_relation_unauthorised
+      relation = create(:relation, :with_history, :version => 2)
+      old_relation = relation.old_relations.find_by(:version => 1)
+      redaction = create(:redaction)
+
+      post relation_version_redact_path(*old_relation.id), :params => { :redaction => redaction.id }
+
+      assert_response :unauthorized, "should need to be authenticated to redact."
       assert_nil old_relation.reload.redaction
     end
 

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -151,6 +151,10 @@ module Api
       get api_relation_version_path(relation, 1)
 
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
+
+      get api_relation_version_path(relation, 1, :show_redactions => "true")
+
+      assert_response :forbidden, "Redacted relation shouldn't be visible via the version API when passing flag."
     end
 
     def test_show_redacted_normal_user
@@ -160,6 +164,10 @@ module Api
       get api_relation_version_path(relation, 1), :headers => bearer_authorization_header
 
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API, even when logged in."
+
+      get api_relation_version_path(relation, 1, :show_redactions => "true"), :headers => bearer_authorization_header
+
+      assert_response :forbidden, "Redacted relation shouldn't be visible via the version API, even when logged in and passing flag."
     end
 
     ##

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -242,16 +242,16 @@ module Api
     # authorised as a moderator.
     def test_redact_relation_moderator
       relation = create(:relation, :with_history, :version => 2)
-      relation_v1 = relation.old_relations.find_by(:version => 1)
+      old_relation = relation.old_relations.find_by(:version => 1)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post relation_version_redact_path(*relation_v1.id), :params => { :redaction => redaction.id }, :headers => auth_header
+      post relation_version_redact_path(*old_relation.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :success, "should be OK to redact old version as moderator."
-      relation_v1.reload
-      assert_predicate relation_v1, :redacted?
-      assert_equal redaction, relation_v1.redaction
+      old_relation.reload
+      assert_predicate old_relation, :redacted?
+      assert_equal redaction, old_relation.redaction
     end
 
     ##
@@ -259,14 +259,14 @@ module Api
     # authorised.
     def test_unredact_relation_unauthorised
       relation = create(:relation, :with_history, :version => 2)
-      relation_v1 = relation.old_relations.find_by(:version => 1)
+      old_relation = relation.old_relations.find_by(:version => 1)
       redaction = create(:redaction)
-      relation_v1.redact!(redaction)
+      old_relation.redact!(redaction)
 
-      post relation_version_redact_path(relation_v1.relation_id, relation_v1.version)
+      post relation_version_redact_path(*old_relation.id)
 
       assert_response :unauthorized, "should need to be authenticated to unredact."
-      assert_equal redaction, relation_v1.reload.redaction
+      assert_equal redaction, old_relation.reload.redaction
     end
 
     ##
@@ -274,15 +274,15 @@ module Api
     # authorised as a normal user.
     def test_unredact_relation_normal_user
       relation = create(:relation, :with_history, :version => 2)
-      relation_v1 = relation.old_relations.find_by(:version => 1)
+      old_relation = relation.old_relations.find_by(:version => 1)
       redaction = create(:redaction)
-      relation_v1.redact!(redaction)
+      old_relation.redact!(redaction)
       auth_header = bearer_authorization_header
 
-      post relation_version_redact_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
+      post relation_version_redact_path(*old_relation.id), :headers => auth_header
 
       assert_response :forbidden, "should need to be moderator to unredact."
-      assert_equal redaction, relation_v1.reload.redaction
+      assert_equal redaction, old_relation.reload.redaction
     end
 
     ##
@@ -290,14 +290,14 @@ module Api
     # authorised as a moderator.
     def test_unredact_relation_moderator
       relation = create(:relation, :with_history, :version => 2)
-      relation_v1 = relation.old_relations.find_by(:version => 1)
-      relation_v1.redact!(create(:redaction))
+      old_relation = relation.old_relations.find_by(:version => 1)
+      old_relation.redact!(create(:redaction))
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post relation_version_redact_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
+      post relation_version_redact_path(*old_relation.id), :headers => auth_header
 
       assert_response :success, "should be OK to unredact old version as moderator."
-      assert_nil relation_v1.reload.redaction
+      assert_nil old_relation.reload.redaction
     end
 
     private

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -114,17 +114,21 @@ module Api
     ##
     # test that redacted relations aren't visible, regardless of
     # authorisation except as moderator...
-    def test_show_redacted
+    def test_show_redacted_unauthorised
       relation = create(:relation, :with_history, :version => 2)
-      relation_v1 = relation.old_relations.find_by(:version => 1)
-      relation_v1.redact!(create(:redaction))
+      relation.old_relations.find_by(:version => 1).redact!(create(:redaction))
 
-      get api_relation_version_path(relation_v1.relation_id, relation_v1.version)
+      get api_relation_version_path(relation, 1)
+
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API."
+    end
 
-      # not even to a logged-in user
-      auth_header = bearer_authorization_header
-      get api_relation_version_path(relation_v1.relation_id, relation_v1.version), :headers => auth_header
+    def test_show_redacted_normal_user
+      relation = create(:relation, :with_history, :version => 2)
+      relation.old_relations.find_by(:version => 1).redact!(create(:redaction))
+
+      get api_relation_version_path(relation, 1), :headers => bearer_authorization_header
+
       assert_response :forbidden, "Redacted relation shouldn't be visible via the version API, even when logged in."
     end
 

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -64,6 +64,12 @@ module Api
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_dom "osm relation[id='#{relation.id}'][version='1']", 0,
                  "redacted relation #{relation.id} version 1 shouldn't be present in the history."
+
+      get api_relation_versions_path(relation, :show_redactions => "true")
+
+      assert_response :success, "Redaction shouldn't have stopped history working."
+      assert_dom "osm relation[id='#{relation.id}'][version='1']", 0,
+                 "redacted relation #{relation.id} version 1 shouldn't be present in the history when passing flag."
     end
 
     def test_index_redacted_normal_user
@@ -75,6 +81,12 @@ module Api
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_dom "osm relation[id='#{relation.id}'][version='1']", 0,
                  "redacted relation #{relation.id} version 1 shouldn't be present in the history, even when logged in."
+
+      get api_relation_versions_path(relation, :show_redactions => "true"), :headers => bearer_authorization_header
+
+      assert_response :success, "Redaction shouldn't have stopped history working."
+      assert_dom "osm relation[id='#{relation.id}'][version='1']", 0,
+                 "redacted relation #{relation.id} version 1 shouldn't be present in the history, even when logged in and passing flag."
     end
 
     def test_show

--- a/test/controllers/api/old_relations_controller_test.rb
+++ b/test/controllers/api/old_relations_controller_test.rb
@@ -215,7 +215,9 @@ module Api
       auth_header = bearer_authorization_header create(:moderator_user)
 
       do_redact_relation(relation_v3, create(:redaction), auth_header)
+
       assert_response :success, "should be OK to redact old version as moderator."
+      assert_predicate relation_v3.reload, :redacted?
 
       # check moderator can still see the redacted data, when passing
       # the appropriate flag

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -253,16 +253,16 @@ module Api
     # authorised as a moderator.
     def test_redact_way_moderator
       way = create(:way, :with_history, :version => 2)
-      way_v1 = way.old_ways.find_by(:version => 1)
+      old_way = way.old_ways.find_by(:version => 1)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post way_version_redact_path(*way_v1.id), :params => { :redaction => redaction.id }, :headers => auth_header
+      post way_version_redact_path(*old_way.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :success, "should be OK to redact old version as moderator."
-      way_v1.reload
-      assert_predicate way_v1, :redacted?
-      assert_equal redaction, way_v1.redaction
+      old_way.reload
+      assert_predicate old_way, :redacted?
+      assert_equal redaction, old_way.redaction
     end
 
     ##
@@ -270,14 +270,14 @@ module Api
     # authorised.
     def test_unredact_way_unauthorised
       way = create(:way, :with_history, :version => 2)
-      way_v1 = way.old_ways.find_by(:version => 1)
+      old_way = way.old_ways.find_by(:version => 1)
       redaction = create(:redaction)
-      way_v1.redact!(redaction)
+      old_way.redact!(redaction)
 
-      post way_version_redact_path(way_v1.way_id, way_v1.version)
+      post way_version_redact_path(*old_way.id)
 
       assert_response :unauthorized, "should need to be authenticated to unredact."
-      assert_equal redaction, way_v1.reload.redaction
+      assert_equal redaction, old_way.reload.redaction
     end
 
     ##
@@ -285,15 +285,15 @@ module Api
     # authorised as a normal user.
     def test_unredact_way_normal_user
       way = create(:way, :with_history, :version => 2)
-      way_v1 = way.old_ways.find_by(:version => 1)
+      old_way = way.old_ways.find_by(:version => 1)
       redaction = create(:redaction)
-      way_v1.redact!(redaction)
+      old_way.redact!(redaction)
       auth_header = bearer_authorization_header
 
-      post way_version_redact_path(way_v1.way_id, way_v1.version), :headers => auth_header
+      post way_version_redact_path(*old_way.id), :headers => auth_header
 
       assert_response :forbidden, "should need to be moderator to unredact."
-      assert_equal redaction, way_v1.reload.redaction
+      assert_equal redaction, old_way.reload.redaction
     end
 
     ##
@@ -302,14 +302,14 @@ module Api
     def test_unredact_way_moderator
       moderator_user = create(:moderator_user)
       way = create(:way, :with_history, :version => 2)
-      way_v1 = way.old_ways.find_by(:version => 1)
-      way_v1.redact!(create(:redaction))
+      old_way = way.old_ways.find_by(:version => 1)
+      old_way.redact!(create(:redaction))
       auth_header = bearer_authorization_header moderator_user
 
-      post way_version_redact_path(way_v1.way_id, way_v1.version), :headers => auth_header
+      post way_version_redact_path(*old_way.id), :headers => auth_header
 
       assert_response :success, "should be OK to unredact old version as moderator."
-      assert_nil way_v1.reload.redaction
+      assert_nil old_way.reload.redaction
     end
 
     private

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -215,11 +215,11 @@ module Api
     # test that, even as moderator, the current version of a way
     # can't be redacted.
     def test_redact_way_current_version
-      way = create(:way, :with_history, :version => 4)
+      way = create(:way, :with_history, :version => 2)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post way_version_redact_path(way, 4), :params => { :redaction => redaction.id }, :headers => auth_header
+      post way_version_redact_path(way, 2), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
     end
@@ -252,17 +252,17 @@ module Api
     # test the redaction of an old version of a way, while being
     # authorised as a moderator.
     def test_redact_way_moderator
-      way = create(:way, :with_history, :version => 4)
-      way_v3 = way.old_ways.find_by(:version => 3)
+      way = create(:way, :with_history, :version => 2)
+      way_v1 = way.old_ways.find_by(:version => 1)
       redaction = create(:redaction)
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      post way_version_redact_path(*way_v3.id), :params => { :redaction => redaction.id }, :headers => auth_header
+      post way_version_redact_path(*way_v1.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :success, "should be OK to redact old version as moderator."
-      way_v3.reload
-      assert_predicate way_v3, :redacted?
-      assert_equal redaction, way_v3.redaction
+      way_v1.reload
+      assert_predicate way_v1, :redacted?
+      assert_equal redaction, way_v1.redaction
     end
 
     ##
@@ -354,10 +354,10 @@ module Api
     end
 
     def do_redact_redactable_way(headers = {})
-      way = create(:way, :with_history, :version => 4)
+      way = create(:way, :with_history, :version => 2)
       redaction = create(:redaction)
 
-      post way_version_redact_path(way.id, 2), :params => { :redaction => redaction.id }, :headers => headers
+      post way_version_redact_path(way.id, 1), :params => { :redaction => redaction.id }, :headers => headers
     end
   end
 end

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -148,6 +148,10 @@ module Api
       get api_way_version_path(way, 1)
 
       assert_response :forbidden, "Redacted way shouldn't be visible via the version API."
+
+      get api_way_version_path(way, 1, :show_redactions => "true")
+
+      assert_response :forbidden, "Redacted way shouldn't be visible via the version API when passing flag."
     end
 
     def test_show_redacted_normal_user
@@ -157,6 +161,10 @@ module Api
       get api_way_version_path(way, 1), :headers => bearer_authorization_header
 
       assert_response :forbidden, "Redacted way shouldn't be visible via the version API, even when logged in."
+
+      get api_way_version_path(way, 1, :show_redactions => "true"), :headers => bearer_authorization_header
+
+      assert_response :forbidden, "Redacted way shouldn't be visible via the version API, even when logged in and passing flag."
     end
 
     ##

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -71,6 +71,12 @@ module Api
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_dom "osm way[id='#{way.id}'][version='1']", 0,
                  "redacted way #{way.id} version 1 shouldn't be present in the history."
+
+      get api_way_versions_path(way, :show_redactions => "true")
+
+      assert_response :success, "Redaction shouldn't have stopped history working."
+      assert_dom "osm way[id='#{way.id}'][version='1']", 0,
+                 "redacted way #{way.id} version 1 shouldn't be present in the history when passing flag."
     end
 
     def test_index_redacted_normal_user
@@ -82,6 +88,12 @@ module Api
       assert_response :success, "Redaction shouldn't have stopped history working."
       assert_dom "osm way[id='#{way.id}'][version='1']", 0,
                  "redacted node #{way.id} version 1 shouldn't be present in the history, even when logged in."
+
+      get api_way_versions_path(way, :show_redactions => "true"), :headers => bearer_authorization_header
+
+      assert_response :success, "Redaction shouldn't have stopped history working."
+      assert_dom "osm way[id='#{way.id}'][version='1']", 0,
+                 "redacted node #{way.id} version 1 shouldn't be present in the history, even when logged in and passing flag."
     end
 
     def test_show

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -223,7 +223,9 @@ module Api
       auth_header = bearer_authorization_header create(:moderator_user)
 
       do_redact_way(way_v3, create(:redaction), auth_header)
+
       assert_response :success, "should be OK to redact old version as moderator."
+      assert_predicate way_v3.reload, :redacted?
 
       # check moderator can still see the redacted data, when passing
       # the appropriate flag

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -307,11 +307,10 @@ module Api
     # test the unredaction of an old version of a way, while being
     # authorised as a moderator.
     def test_unredact_way_moderator
-      moderator_user = create(:moderator_user)
       way = create(:way, :with_history, :version => 2)
       old_way = way.old_ways.find_by(:version => 1)
       old_way.redact!(create(:redaction))
-      auth_header = bearer_authorization_header moderator_user
+      auth_header = bearer_authorization_header create(:moderator_user)
 
       post way_version_redact_path(*old_way.id), :headers => auth_header
 

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -111,17 +111,21 @@ module Api
     ##
     # test that redacted ways aren't visible, regardless of
     # authorisation except as moderator...
-    def test_show_redacted
+    def test_show_redacted_unauthorised
       way = create(:way, :with_history, :version => 2)
-      way_v1 = way.old_ways.find_by(:version => 1)
-      way_v1.redact!(create(:redaction))
+      way.old_ways.find_by(:version => 1).redact!(create(:redaction))
 
-      get api_way_version_path(way_v1.way_id, way_v1.version)
+      get api_way_version_path(way, 1)
+
       assert_response :forbidden, "Redacted way shouldn't be visible via the version API."
+    end
 
-      # not even to a logged-in user
-      auth_header = bearer_authorization_header
-      get api_way_version_path(way_v1.way_id, way_v1.version), :headers => auth_header
+    def test_show_redacted_normal_user
+      way = create(:way, :with_history, :version => 2)
+      way.old_ways.find_by(:version => 1).redact!(create(:redaction))
+
+      get api_way_version_path(way, 1), :headers => bearer_authorization_header
+
       assert_response :forbidden, "Redacted way shouldn't be visible via the version API, even when logged in."
     end
 

--- a/test/controllers/api/old_ways_controller_test.rb
+++ b/test/controllers/api/old_ways_controller_test.rb
@@ -196,20 +196,6 @@ module Api
     end
 
     ##
-    # test the redaction of an old version of a way, while not being
-    # authorised.
-    def test_redact_way_unauthorised
-      way = create(:way, :with_history, :version => 2)
-      old_way = way.old_ways.find_by(:version => 1)
-      redaction = create(:redaction)
-
-      post way_version_redact_path(*old_way.id), :params => { :redaction => redaction.id }
-
-      assert_response :unauthorized, "should need to be authenticated to redact."
-      assert_nil old_way.reload.redaction
-    end
-
-    ##
     # test that, even as moderator, the current version of a way
     # can't be redacted.
     def test_redact_way_current_version
@@ -221,6 +207,20 @@ module Api
       post way_version_redact_path(*old_way.id), :params => { :redaction => redaction.id }, :headers => auth_header
 
       assert_response :bad_request, "shouldn't be OK to redact current version as moderator."
+      assert_nil old_way.reload.redaction
+    end
+
+    ##
+    # test the redaction of an old version of a way, while not being
+    # authorised.
+    def test_redact_way_unauthorised
+      way = create(:way, :with_history, :version => 2)
+      old_way = way.old_ways.find_by(:version => 1)
+      redaction = create(:redaction)
+
+      post way_version_redact_path(*old_way.id), :params => { :redaction => redaction.id }
+
+      assert_response :unauthorized, "should need to be authenticated to redact."
       assert_nil old_way.reload.redaction
     end
 


### PR DESCRIPTION
This PR changes redact/unredact tests for the reasons stated in #5645.

Tests will have this structure:
```ruby
      node = create(:node, :with_history, :version => 2)
      old_node = node.old_nodes.find_by(:version => 1)
      redaction = create(:redaction)
      auth_header = ...

      post node_version_redact_path(*old_node.id), :params => { :redaction => redaction.id }, :headers => auth_header

      assert_response ...
      assert ... old_node.reload.redaction
```

Element redaction property is checked after every response. Previously it wasn't checked after failed responses.