### PR TITLE
Split directions engine select into modes and providers

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -310,7 +310,11 @@ OSM.Directions.engines = [];
 OSM.Directions.addEngine = function (engine, supportsHTTPS) {
   if (document.location.protocol === "http:" || supportsHTTPS) {
     engine.id = engine.provider + "_" + engine.mode;
-    engine.localeId = I18n.t("javascripts.directions.engines." + engine.id);
+    engine.localeId = `${
+      I18n.t("site.search.modes." + engine.mode)
+    } (${
+      I18n.t("site.search.providers." + engine.provider)
+    })`;
     OSM.Directions.engines.push(engine);
   }
 };

--- a/app/assets/javascripts/index/directions/fossgis_osrm.js
+++ b/app/assets/javascripts/index/directions/fossgis_osrm.js
@@ -2,7 +2,7 @@
 // Doesn't yet support hints
 
 (function () {
-  function FOSSGISOSRMEngine(id, vehicleType) {
+  function FOSSGISOSRMEngine(modeId, vehicleType) {
     let cachedHints = [];
 
     function _processDirections(route) {
@@ -150,7 +150,8 @@
     }
 
     return {
-      id: id,
+      mode: modeId,
+      provider: "fossgis_osrm",
       creditline: "<a href=\"https://routing.openstreetmap.de/about.html\" target=\"_blank\">OSRM (FOSSGIS)</a>",
       draggable: true,
 
@@ -181,7 +182,7 @@
     };
   }
 
-  OSM.Directions.addEngine(new FOSSGISOSRMEngine("fossgis_osrm_car", "car"), true);
-  OSM.Directions.addEngine(new FOSSGISOSRMEngine("fossgis_osrm_bike", "bike"), true);
-  OSM.Directions.addEngine(new FOSSGISOSRMEngine("fossgis_osrm_foot", "foot"), true);
+  OSM.Directions.addEngine(new FOSSGISOSRMEngine("car", "car"), true);
+  OSM.Directions.addEngine(new FOSSGISOSRMEngine("bicycle", "bike"), true);
+  OSM.Directions.addEngine(new FOSSGISOSRMEngine("foot", "foot"), true);
 }());

--- a/app/assets/javascripts/index/directions/fossgis_valhalla.js
+++ b/app/assets/javascripts/index/directions/fossgis_valhalla.js
@@ -1,5 +1,5 @@
 (function () {
-  function FOSSGISValhallaEngine(id, costing) {
+  function FOSSGISValhallaEngine(modeId, costing) {
     const INSTR_MAP = [
       0, // kNone = 0;
       8, // kStart = 1;
@@ -82,7 +82,8 @@
     }
 
     return {
-      id: id,
+      mode: modeId,
+      provider: "fossgis_valhalla",
       creditline:
       "<a href='https://gis-ops.com/global-open-valhalla-server-online/' target='_blank'>Valhalla (FOSSGIS)</a>",
       draggable: false,
@@ -110,7 +111,7 @@
     };
   }
 
-  OSM.Directions.addEngine(new FOSSGISValhallaEngine("fossgis_valhalla_car", "auto"), true);
-  OSM.Directions.addEngine(new FOSSGISValhallaEngine("fossgis_valhalla_bicycle", "bicycle"), true);
-  OSM.Directions.addEngine(new FOSSGISValhallaEngine("fossgis_valhalla_foot", "pedestrian"), true);
+  OSM.Directions.addEngine(new FOSSGISValhallaEngine("car", "auto"), true);
+  OSM.Directions.addEngine(new FOSSGISValhallaEngine("bicycle", "bicycle"), true);
+  OSM.Directions.addEngine(new FOSSGISValhallaEngine("foot", "pedestrian"), true);
 }());

--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -1,5 +1,5 @@
 (function () {
-  function GraphHopperEngine(id, vehicleType) {
+  function GraphHopperEngine(modeId, vehicleType) {
     const GH_INSTR_MAP = {
       "-3": 7, // sharp left
       "-2": 6, // left
@@ -47,7 +47,8 @@
     }
 
     return {
-      id: id,
+      mode: modeId,
+      provider: "graphhopper",
       creditline: "<a href=\"https://www.graphhopper.com/\" target=\"_blank\">GraphHopper</a>",
       draggable: false,
 
@@ -73,7 +74,7 @@
     };
   }
 
-  OSM.Directions.addEngine(new GraphHopperEngine("graphhopper_car", "car"), true);
-  OSM.Directions.addEngine(new GraphHopperEngine("graphhopper_bicycle", "bike"), true);
-  OSM.Directions.addEngine(new GraphHopperEngine("graphhopper_foot", "foot"), true);
+  OSM.Directions.addEngine(new GraphHopperEngine("car", "car"), true);
+  OSM.Directions.addEngine(new GraphHopperEngine("bicycle", "bike"), true);
+  OSM.Directions.addEngine(new GraphHopperEngine("foot", "foot"), true);
 }());

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -39,7 +39,7 @@
   <form method="GET" action="<%= directions_path %>" class="directions_form bg-body-secondary pb-2">
     <div class="d-flex flex-row-reverse px-3 pt-3 pb-1"><button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button></div>
 
-    <div class="d-flex flex-column mx-2 gap-1">
+    <div class="d-flex flex-column mx-2 gap-2">
       <div class="d-flex gap-1 align-items-center">
         <div class="d-flex flex-column gap-1 flex-grow-1">
           <div class="d-flex gap-2 align-items-center">
@@ -66,7 +66,31 @@
       </div>
       <div class="d-flex gap-2 align-items-center">
         <div class="routing_marker_column flex-shrink-0"></div>
-        <select class="routing_engines form-select py-1 px-2" name="routing_engines"></select>
+        <div class="btn-group routing_modes" role="group">
+          <input type="radio" class="btn-check" name="modes" id="car" autocomplete="off" disabled>
+          <label class="btn btn-outline-secondary px-2" for="car" title="<%= t("site.search.modes.car") %>">
+            <svg class="d-block" width="16" height="16" fill="currentColor">
+              <path d="M2.52 3.515A2.5 2.5 0 0 1 4.82 2h6.362c1 0 1.904.596 2.298 1.515l.792 1.848c.075.175.21.319.38.404.5.25.855.715.965 1.262l.335 1.679q.05.242.049.49v.413c0 .814-.39 1.543-1 1.997V13.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-1.338c-1.292.048-2.745.088-4 .088s-2.708-.04-4-.088V13.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-1.892c-.61-.454-1-1.183-1-1.997v-.413a2.5 2.5 0 0 1 .049-.49l.335-1.68c.11-.546.465-1.012.964-1.261a.8.8 0 0 0 .381-.404l.792-1.848ZM3 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2m10 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2M6 8a1 1 0 0 0 0 2h4a1 1 0 1 0 0-2zM2.906 5.189a.51.51 0 0 0 .497.731c.91-.073 3.35-.17 4.597-.17s3.688.097 4.597.17a.51.51 0 0 0 .497-.731l-.956-1.913A.5.5 0 0 0 11.691 3H4.309a.5.5 0 0 0-.447.276L2.906 5.19Z" />
+            </svg>
+          </label>
+          <input type="radio" class="btn-check" name="modes" id="bicycle" autocomplete="off" disabled>
+          <label class="btn btn-outline-secondary px-2" for="bicycle" title="<%= t("site.search.modes.bicycle") %>">
+            <svg class="d-block" width="16" height="16" fill="currentColor">
+              <path d="M4 4.5a.5.5 0 0 1 .5-.5H6a.5.5 0 0 1 0 1v.5h4.14l.386-1.158A.5.5 0 0 1 11 4h1a.5.5 0 0 1 0 1h-.64l-.311.935.807 1.29a3 3 0 1 1-.848.53l-.508-.812-2.076 3.322A.5.5 0 0 1 8 10.5H5.959a3 3 0 1 1-1.815-3.274L5 5.856V5h-.5a.5.5 0 0 1-.5-.5m1.5 2.443-.508.814c.5.444.85 1.054.967 1.743h1.139zM8 9.057 9.598 6.5H6.402zM4.937 9.5a2 2 0 0 0-.487-.877l-.548.877zM3.603 8.092A2 2 0 1 0 4.937 10.5H3a.5.5 0 0 1-.424-.765zm7.947.53a2 2 0 1 0 .848-.53l1.026 1.643a.5.5 0 1 1-.848.53z" />
+            </svg>
+          </label>
+          <input type="radio" class="btn-check" name="modes" id="foot" autocomplete="off" disabled>
+          <label class="btn btn-outline-secondary px-2" for="foot" title="<%= t("site.search.modes.foot") %>">
+            <svg class="d-block" width="16" height="16" fill="currentColor">
+              <path d="M9.5 1.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0M6.44 3.752A.75.75 0 017 3.5h1.445c.742 0 1.32.643 1.243 1.38l-.43 4.083a1.8 1.8 0 01-.088.395l-.318.906.213.242a.8.8 0 01.114.175l2 4.25a.75.75 0 11-1.357.638l-1.956-4.154-1.68-1.921A.75.75 0 016 8.96l.138-2.613-.435.489-.464 2.786a.75.75 0 11-1.48-.246l.5-3a.75.75 0 01.18-.375l2-2.25zm-.19 7.993v-1.418l1.204 1.375.261.524a.8.8 0 01-.12.231l-2.5 3.25a.75.75 0 11-1.19-.914zm4.22-4.215-.494-.494.205-1.843.006-.067 1.124 1.124h1.44a.75.75 0 010 1.5H11a.75.75 0 01-.531-.22Z" />
+            </svg>
+          </label>
+        </div>
+        <select class="routing_engines form-select py-1 px-2" name="routing_engines">
+          <option value="graphhopper" disabled><%= t("site.search.providers.graphhopper") %></option>
+          <option value="fossgis_osrm" disabled><%= t("site.search.providers.fossgis_osrm") %></option>
+          <option value="fossgis_valhalla" disabled><%= t("site.search.providers.fossgis_valhalla") %></option>
+        </select>
         <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-primary py-1 px-2", :data => { :disable_with => false } %>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2382,6 +2382,14 @@ en:
       where_am_i_title: Describe the current location using the search engine
       submit_text: "Go"
       reverse_directions_text: "Reverse Directions"
+      modes:
+        bicycle: "Bicycle"
+        car: "Car"
+        foot: "Foot"
+      providers:
+        fossgis_osrm: "OSRM"
+        graphhopper: "GraphHopper"
+        fossgis_valhalla: "Valhalla"
     key:
       table:
         entry:
@@ -3227,16 +3235,6 @@ en:
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
       ascend: "Ascend"
-      engines:
-        fossgis_osrm_bike: "Bicycle (OSRM)"
-        fossgis_osrm_car: "Car (OSRM)"
-        fossgis_osrm_foot: "Foot (OSRM)"
-        graphhopper_bicycle: "Bicycle (GraphHopper)"
-        graphhopper_car: "Car (GraphHopper)"
-        graphhopper_foot: "Foot (GraphHopper)"
-        fossgis_valhalla_bicycle: "Bicycle (Valhalla)"
-        fossgis_valhalla_car: "Car (Valhalla)"
-        fossgis_valhalla_foot: "Foot (Valhalla)"
       descend: "Descend"
       directions: "Directions"
       distance: "Distance"


### PR DESCRIPTION
Attempt to fix #5629.
Splits the directions engine select into a radio button group for modes and a smaller select for routing providers.
| before | after |
|-|-|
| ![before](https://github.com/user-attachments/assets/47624340-f035-40ed-b731-bf6a311c4af4) | ![after](https://github.com/user-attachments/assets/7aca4f16-75c7-4621-bcde-894c8cdbc153) |

Includes tooltips for the mode radio button group:
![image](https://github.com/user-attachments/assets/9c860075-8638-4933-9009-97bb6648b9f3)