### PR TITLE
Add pluralizers to I18n

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,15 +11,23 @@
 //= require leaflet.zoom
 //= require leaflet.locationfilter
 //= require i18n
+//= require make-plural/cardinals
 //= require matomo
 //= require richtext
 
 {
   const application_data = $("head").data();
+  const locale = application_data.locale;
 
   I18n.default_locale = OSM.DEFAULT_LOCALE;
-  I18n.locale = application_data.locale;
+  I18n.locale = locale;
   I18n.fallbacks = true;
+
+  // '-' are replaced with '_' in https://github.com/eemeli/make-plural/tree/main/packages/plurals
+  const pluralizer = plurals[locale.replace(/\W+/g, "_")] || plurals[locale.split("-")[0]];
+  if (pluralizer) {
+    I18n.pluralization[locale] = (count) => [pluralizer(count), "other"];
+  }
 
   OSM.preferred_editor = application_data.preferredEditor;
   OSM.preferred_languages = application_data.preferredLanguages;

--- a/config/eslint.config.mjs
+++ b/config/eslint.config.mjs
@@ -30,6 +30,7 @@ export default [
         Matomo: "readonly",
         OSM: "writable",
         Turbo: "readonly",
+        plurals: "readonly",
         updateLinks: "readonly"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "js-cookie": "^3.0.0",
     "leaflet": "^1.8.0",
     "leaflet.locatecontrol": "^0.83.0",
+    "make-plural": "^7.4.0",
     "osm-community-index": "^5.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -509,6 +509,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+make-plural@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-7.4.0.tgz#fa6990dd550dea4de6b20163f74e5ed83d8a8d6d"
+  integrity sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg==
+
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"


### PR DESCRIPTION
Required to correctly translate tooltips in #5402.

Actually it's already required for "Show My Location" tooltips.

Adds pluralizers from [make-plural](https://github.com/eemeli/make-plural/) as recommended by [i18n-js docs](https://fnando.github.io/i18n/v4.5.1/classes/Pluralization.html). Not exactly like on that page because we're still using an older version of i18n-js which is [not compatible with the new one](https://github.com/fnando/i18n-js/blob/main/MIGRATING_FROM_V3_TO_V4.md).

I'm not sure if pluralization in i18n-js v3 is documented anywhere. [This comment](https://github.com/fnando/i18n-js/issues/133#issuecomment-41999391) has an outdated link to the source code, but I think the entire repository was overwritten since.