### PR TITLE
Added prefix for busways in en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -942,6 +942,7 @@ en:
           bridleway: "Bridleway"
           bus_guideway: "Guided Bus Lane"
           bus_stop: "Bus Stop"
+          busway: "Busway"
           construction: "Highway under Construction"
           corridor: "Corridor"
           crossing: "Crossing"


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
Fixed issue #5258 by adding `busway: "Busway"` into the highway section of en.yml. When querying features, busways no longer show the prefix "Yes".

![image](https://github.com/user-attachments/assets/51a096d7-8244-4f6e-9671-b71d1c29745f)
