### PR TITLE
Workaround for iD "bug" #10761

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -33,5 +33,5 @@ $(document).ready(function () {
 
   if (id.data("gpx")) params.set("gpx", id.data("gpx"));
 
-  id.attr("src", id.data("url") + "#" + params);
+  id.attr("src", id.data("url") + "#" + params.toString().replace('+', '%20'));
 });

--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -33,5 +33,5 @@ $(document).ready(function () {
 
   if (id.data("gpx")) params.set("gpx", id.data("gpx"));
 
-  id.attr("src", id.data("url") + "#" + params.toString().replace("+", "%20"));
+  id.attr("src", id.data("url") + "#" + params.toString().replace(/\+/g, "%20"));
 });

--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -33,5 +33,5 @@ $(document).ready(function () {
 
   if (id.data("gpx")) params.set("gpx", id.data("gpx"));
 
-  id.attr("src", id.data("url") + "#" + params.toString().replace('+', '%20'));
+  id.attr("src", id.data("url") + "#" + params.toString().replace("+", "%20"));
 });


### PR DESCRIPTION
The current version of iD (v2.31, before the fix for https://github.com/openstreetmap/iD/issues/10761: https://github.com/openstreetmap/iD/pull/10766), does not fully support `x-www-form-urlencoded` "query-style" strings in the hash: Specifically, spaces encoded as `+` will not be decoded back to ` `.

This workaround essentially temporarily reverts the behaviour of the website to the state before #5592, and can be dropped again with the next minor version upgrade of iD (`v2.32`).