### PR TITLE
Comment changesets scope

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -3,7 +3,7 @@
 class ApiAbility
   include CanCan::Ability
 
-  def initialize(user, token)
+  def initialize(user, scopes)
     can :read, [:version, :capability, :permission, :map]
 
     if Settings.status != "database_offline"
@@ -17,31 +17,31 @@ class ApiAbility
       can :read, UserBlock
 
       if user&.active?
-        can [:create, :comment, :close, :reopen], Note if scope?(token, :write_notes)
-        can [:create, :destroy], NoteSubscription if scope?(token, :write_notes)
+        can [:create, :comment, :close, :reopen], Note if scopes.include?("write_notes")
+        can [:create, :destroy], NoteSubscription if scopes.include?("write_notes")
 
-        can :read, Trace if scope?(token, :read_gpx)
-        can [:create, :update, :destroy], Trace if scope?(token, :write_gpx)
+        can :read, Trace if scopes.include?("read_gpx")
+        can [:create, :update, :destroy], Trace if scopes.include?("write_gpx")
 
-        can :details, User if scope?(token, :read_prefs)
-        can :read, UserPreference if scope?(token, :read_prefs)
-        can [:update, :update_all, :destroy], UserPreference if scope?(token, :write_prefs)
+        can :details, User if scopes.include?("read_prefs")
+        can :read, UserPreference if scopes.include?("read_prefs")
+        can [:update, :update_all, :destroy], UserPreference if scopes.include?("write_prefs")
 
-        can [:read, :update, :destroy], Message if scope?(token, :consume_messages)
-        can :create, Message if scope?(token, :send_messages)
+        can [:read, :update, :destroy], Message if scopes.include?("consume_messages")
+        can :create, Message if scopes.include?("send_messages")
 
         if user.terms_agreed?
-          can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset if scope?(token, :write_api)
-          can :create, ChangesetComment if scope?(token, :write_api)
-          can [:create, :update, :destroy], [Node, Way, Relation] if scope?(token, :write_api)
+          can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset if scopes.include?("write_api")
+          can :create, ChangesetComment if scopes.include?("write_api")
+          can [:create, :update, :destroy], [Node, Way, Relation] if scopes.include?("write_api")
         end
 
         if user.moderator?
-          can [:destroy, :restore], ChangesetComment if scope?(token, :write_api)
+          can [:destroy, :restore], ChangesetComment if scopes.include?("write_api")
 
-          can :destroy, Note if scope?(token, :write_notes)
+          can :destroy, Note if scopes.include?("write_notes")
 
-          can :redact, [OldNode, OldWay, OldRelation] if user&.terms_agreed? && scope?(token, :write_redactions)
+          can :redact, [OldNode, OldWay, OldRelation] if user&.terms_agreed? && scopes.include?("write_redactions")
         end
       end
     end
@@ -72,11 +72,5 @@ class ApiAbility
     #
     # See the wiki for details:
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
-  end
-
-  private
-
-  def scope?(token, scope)
-    token&.includes_scope?(scope)
   end
 end

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -3,14 +3,12 @@
 class ApiAbility
   include CanCan::Ability
 
-  def initialize(token)
+  def initialize(user, token)
     can :read, [:version, :capability, :permission, :map]
 
     if Settings.status != "database_offline"
-      user = User.find(token.resource_owner_id) if token
-
       can [:read, :feed, :search], Note
-      can :create, Note unless token
+      can :create, Note unless user
 
       can [:read, :download], Changeset
       can :read, Tracepoint

--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -31,13 +31,13 @@ class ApiAbility
         can :create, Message if scopes.include?("send_messages")
 
         if user.terms_agreed?
-          can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset if scopes.include?("write_api")
-          can :create, ChangesetComment if scopes.include?("write_api")
-          can [:create, :update, :destroy], [Node, Way, Relation] if scopes.include?("write_api")
+          can [:create, :update, :upload, :close, :subscribe, :unsubscribe], Changeset if scopes.include?("write_map")
+          can :create, ChangesetComment if scopes.include?("write_changeset_comments")
+          can [:create, :update, :destroy], [Node, Way, Relation] if scopes.include?("write_map")
         end
 
         if user.moderator?
-          can [:destroy, :restore], ChangesetComment if scopes.include?("write_api")
+          can [:destroy, :restore], ChangesetComment if scopes.include?("write_changeset_comments")
 
           can :destroy, Note if scopes.include?("write_notes")
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -65,9 +65,10 @@ class ApiController < ApplicationController
   def current_ability
     # Use capabilities from the oauth token if it exists and is a valid access token
     if doorkeeper_token&.accessible?
-      ApiAbility.new(doorkeeper_token)
+      user = User.find(doorkeeper_token.resource_owner_id)
+      ApiAbility.new(user, doorkeeper_token)
     else
-      ApiAbility.new(nil)
+      ApiAbility.new(nil, nil)
     end
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -66,9 +66,10 @@ class ApiController < ApplicationController
     # Use capabilities from the oauth token if it exists and is a valid access token
     if doorkeeper_token&.accessible?
       user = User.find(doorkeeper_token.resource_owner_id)
-      ApiAbility.new(user, doorkeeper_token)
+      scopes = Set.new doorkeeper_token.scopes
+      ApiAbility.new(user, scopes)
     else
-      ApiAbility.new(nil, nil)
+      ApiAbility.new(nil, Set.new)
     end
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -67,6 +67,11 @@ class ApiController < ApplicationController
     if doorkeeper_token&.accessible?
       user = User.find(doorkeeper_token.resource_owner_id)
       scopes = Set.new doorkeeper_token.scopes
+      if scopes.include?("write_api")
+        scopes.add("write_map")
+        scopes.add("write_changeset_comments")
+        scopes.delete("write_api")
+      end
       ApiAbility.new(user, scopes)
     else
       ApiAbility.new(nil, Set.new)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,12 +87,13 @@ en:
         url: Main Application URL (Required)
         callback_url: Callback URL
         support_url: Support URL
-        allow_read_prefs:  read their user preferences
+        allow_read_prefs: read their user preferences
         allow_write_prefs: modify their user preferences
         allow_write_diary: create diary entries and comments
-        allow_write_api:   modify the map
-        allow_read_gpx:    read their private GPS traces
-        allow_write_gpx:   upload GPS traces
+        allow_write_api: modify the map
+        allow_write_changeset_comments: comment on changesets
+        allow_read_gpx: read their private GPS traces
+        allow_write_gpx: upload GPS traces
         allow_write_notes: modify notes
       diary_comment:
         body: "Body"
@@ -2697,6 +2698,7 @@ en:
       write_prefs: Modify user preferences
       write_diary: Create diary entries and comments
       write_api: Modify the map
+      write_changeset_comments: Comment on changesets
       read_gpx: Read private GPS traces
       write_gpx: Upload GPS traces
       write_notes: Modify notes

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -1,7 +1,7 @@
 module Oauth
   SCOPES = %w[
     read_prefs write_prefs write_diary
-    write_api read_gpx write_gpx write_notes write_redactions
+    write_api write_changeset_comments read_gpx write_gpx write_notes write_redactions
     consume_messages send_messages openid
   ].freeze
   PRIVILEGED_SCOPES = %w[read_email skip_authorization].freeze

--- a/test/abilities/api_abilities_test.rb
+++ b/test/abilities/api_abilities_test.rb
@@ -7,7 +7,7 @@ end
 
 class GuestApiAbilityTest < ApiAbilityTest
   test "note permissions for a guest" do
-    ability = ApiAbility.new nil
+    ability = ApiAbility.new nil, nil
 
     [:index, :create, :feed, :show, :search].each do |action|
       assert ability.can?(action, Note), "should be able to #{action} Notes"
@@ -21,8 +21,9 @@ end
 
 class UserApiAbilityTest < ApiAbilityTest
   test "Note permissions" do
-    token = create(:oauth_access_token, :scopes => %w[write_notes])
-    ability = ApiAbility.new token
+    user = create(:user)
+    token = create(:oauth_access_token, :user => user, :scopes => %w[write_notes])
+    ability = ApiAbility.new user, token
 
     [:index, :create, :comment, :feed, :show, :search, :close, :reopen].each do |action|
       assert ability.can?(action, Note), "should be able to #{action} Notes"
@@ -36,8 +37,9 @@ end
 
 class ModeratorApiAbilityTest < ApiAbilityTest
   test "Note permissions" do
-    token = create(:oauth_access_token, :scopes => %w[write_notes], :user => create(:moderator_user))
-    ability = ApiAbility.new token
+    user = create(:moderator_user)
+    token = create(:oauth_access_token, :user => user, :scopes => %w[write_notes])
+    ability = ApiAbility.new user, token
 
     [:index, :create, :comment, :feed, :show, :search, :close, :reopen, :destroy].each do |action|
       assert ability.can?(action, Note), "should be able to #{action} Notes"

--- a/test/abilities/api_abilities_test.rb
+++ b/test/abilities/api_abilities_test.rb
@@ -7,7 +7,8 @@ end
 
 class GuestApiAbilityTest < ApiAbilityTest
   test "note permissions for a guest" do
-    ability = ApiAbility.new nil, nil
+    scopes = Set.new
+    ability = ApiAbility.new nil, scopes
 
     [:index, :create, :feed, :show, :search].each do |action|
       assert ability.can?(action, Note), "should be able to #{action} Notes"
@@ -22,8 +23,8 @@ end
 class UserApiAbilityTest < ApiAbilityTest
   test "Note permissions" do
     user = create(:user)
-    token = create(:oauth_access_token, :user => user, :scopes => %w[write_notes])
-    ability = ApiAbility.new user, token
+    scopes = Set.new %w[write_notes]
+    ability = ApiAbility.new user, scopes
 
     [:index, :create, :comment, :feed, :show, :search, :close, :reopen].each do |action|
       assert ability.can?(action, Note), "should be able to #{action} Notes"
@@ -38,8 +39,8 @@ end
 class ModeratorApiAbilityTest < ApiAbilityTest
   test "Note permissions" do
     user = create(:moderator_user)
-    token = create(:oauth_access_token, :user => user, :scopes => %w[write_notes])
-    ability = ApiAbility.new user, token
+    scopes = Set.new %w[write_notes]
+    ability = ApiAbility.new user, scopes
 
     [:index, :create, :comment, :feed, :show, :search, :close, :reopen, :destroy].each do |action|
       assert ability.can?(action, Note), "should be able to #{action} Notes"

--- a/test/abilities/api_capability_test.rb
+++ b/test/abilities/api_capability_test.rb
@@ -4,8 +4,9 @@ require "test_helper"
 
 class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
   test "as a normal user with permissionless token" do
-    token = create(:oauth_access_token)
-    ability = ApiAbility.new token
+    user = create(:user)
+    token = create(:oauth_access_token, :user => user)
+    ability = ApiAbility.new user, token
 
     [:create, :destroy, :restore].each do |action|
       assert ability.cannot? action, ChangesetComment
@@ -13,8 +14,9 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a normal user with write_api token" do
-    token = create(:oauth_access_token, :scopes => %w[write_api])
-    ability = ApiAbility.new token
+    user = create(:user)
+    token = create(:oauth_access_token, :user => user, :scopes => %w[write_api])
+    ability = ApiAbility.new user, token
 
     [:destroy, :restore].each do |action|
       assert ability.cannot? action, ChangesetComment
@@ -26,8 +28,9 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with permissionless token" do
-    token = create(:oauth_access_token, :user => create(:moderator_user))
-    ability = ApiAbility.new token
+    user = create(:moderator_user)
+    token = create(:oauth_access_token, :user => user)
+    ability = ApiAbility.new user, token
 
     [:create, :destroy, :restore].each do |action|
       assert ability.cannot? action, ChangesetComment
@@ -35,8 +38,9 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with write_api token" do
-    token = create(:oauth_access_token, :user => create(:moderator_user), :scopes => %w[write_api])
-    ability = ApiAbility.new token
+    user = create(:moderator_user)
+    token = create(:oauth_access_token, :user => user, :scopes => %w[write_api])
+    ability = ApiAbility.new user, token
 
     [:create, :destroy, :restore].each do |action|
       assert ability.can? action, ChangesetComment
@@ -46,8 +50,9 @@ end
 
 class NoteApiCapabilityTest < ActiveSupport::TestCase
   test "as a normal user with permissionless token" do
-    token = create(:oauth_access_token)
-    ability = ApiAbility.new token
+    user = create(:user)
+    token = create(:oauth_access_token, :user => user)
+    ability = ApiAbility.new user, token
 
     [:create, :comment, :close, :reopen, :destroy].each do |action|
       assert ability.cannot? action, Note
@@ -55,8 +60,9 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a normal user with write_notes token" do
-    token = create(:oauth_access_token, :scopes => %w[write_notes])
-    ability = ApiAbility.new token
+    user = create(:user)
+    token = create(:oauth_access_token, :user => user, :scopes => %w[write_notes])
+    ability = ApiAbility.new user, token
 
     [:destroy].each do |action|
       assert ability.cannot? action, Note
@@ -68,8 +74,9 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with permissionless token" do
-    token = create(:oauth_access_token, :user => create(:moderator_user))
-    ability = ApiAbility.new token
+    user = create(:moderator_user)
+    token = create(:oauth_access_token, :user => user)
+    ability = ApiAbility.new user, token
 
     [:destroy].each do |action|
       assert ability.cannot? action, Note
@@ -77,8 +84,9 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
   end
 
   test "as a moderator with write_notes token" do
-    token = create(:oauth_access_token, :user => create(:moderator_user), :scopes => %w[write_notes])
-    ability = ApiAbility.new token
+    user = create(:moderator_user)
+    token = create(:oauth_access_token, :user => user, :scopes => %w[write_notes])
+    ability = ApiAbility.new user, token
 
     [:destroy].each do |action|
       assert ability.can? action, Note
@@ -89,15 +97,16 @@ end
 class UserApiCapabilityTest < ActiveSupport::TestCase
   test "user preferences" do
     # A user with empty tokens
-    token = create(:oauth_access_token)
-    ability = ApiAbility.new token
+    user = create(:user)
+    token = create(:oauth_access_token, :user => user)
+    ability = ApiAbility.new user, token
 
     [:index, :show, :update_all, :update, :destroy].each do |act|
       assert ability.cannot? act, UserPreference
     end
 
-    token = create(:oauth_access_token, :scopes => %w[read_prefs])
-    ability = ApiAbility.new token
+    token = create(:oauth_access_token, :user => user, :scopes => %w[read_prefs])
+    ability = ApiAbility.new user, token
 
     [:update_all, :update, :destroy].each do |act|
       assert ability.cannot? act, UserPreference
@@ -107,8 +116,8 @@ class UserApiCapabilityTest < ActiveSupport::TestCase
       assert ability.can? act, UserPreference
     end
 
-    token = create(:oauth_access_token, :scopes => %w[write_prefs])
-    ability = ApiAbility.new token
+    token = create(:oauth_access_token, :user => user, :scopes => %w[write_prefs])
+    ability = ApiAbility.new user, token
 
     [:index, :show].each do |act|
       assert ability.cannot? act, UserPreference

--- a/test/abilities/api_capability_test.rb
+++ b/test/abilities/api_capability_test.rb
@@ -13,9 +13,9 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "as a normal user with write_api scope" do
+  test "as a normal user with write_changeset_comments scope" do
     user = create(:user)
-    scopes = Set.new %w[write_api]
+    scopes = Set.new %w[write_changeset_comments]
     ability = ApiAbility.new user, scopes
 
     [:destroy, :restore].each do |action|
@@ -37,9 +37,9 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "as a moderator with write_api scope" do
+  test "as a moderator with write_changeset_comments scope" do
     user = create(:moderator_user)
-    scopes = Set.new %w[write_api]
+    scopes = Set.new %w[write_changeset_comments]
     ability = ApiAbility.new user, scopes
 
     [:create, :destroy, :restore].each do |action|

--- a/test/abilities/api_capability_test.rb
+++ b/test/abilities/api_capability_test.rb
@@ -3,20 +3,20 @@
 require "test_helper"
 
 class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
-  test "as a normal user with permissionless token" do
+  test "as a normal user without scopes" do
     user = create(:user)
-    token = create(:oauth_access_token, :user => user)
-    ability = ApiAbility.new user, token
+    scopes = Set.new
+    ability = ApiAbility.new user, scopes
 
     [:create, :destroy, :restore].each do |action|
       assert ability.cannot? action, ChangesetComment
     end
   end
 
-  test "as a normal user with write_api token" do
+  test "as a normal user with write_api scope" do
     user = create(:user)
-    token = create(:oauth_access_token, :user => user, :scopes => %w[write_api])
-    ability = ApiAbility.new user, token
+    scopes = Set.new %w[write_api]
+    ability = ApiAbility.new user, scopes
 
     [:destroy, :restore].each do |action|
       assert ability.cannot? action, ChangesetComment
@@ -27,20 +27,20 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "as a moderator with permissionless token" do
+  test "as a moderator without scopes" do
     user = create(:moderator_user)
-    token = create(:oauth_access_token, :user => user)
-    ability = ApiAbility.new user, token
+    scopes = Set.new
+    ability = ApiAbility.new user, scopes
 
     [:create, :destroy, :restore].each do |action|
       assert ability.cannot? action, ChangesetComment
     end
   end
 
-  test "as a moderator with write_api token" do
+  test "as a moderator with write_api scope" do
     user = create(:moderator_user)
-    token = create(:oauth_access_token, :user => user, :scopes => %w[write_api])
-    ability = ApiAbility.new user, token
+    scopes = Set.new %w[write_api]
+    ability = ApiAbility.new user, scopes
 
     [:create, :destroy, :restore].each do |action|
       assert ability.can? action, ChangesetComment
@@ -49,20 +49,20 @@ class ChangesetCommentApiCapabilityTest < ActiveSupport::TestCase
 end
 
 class NoteApiCapabilityTest < ActiveSupport::TestCase
-  test "as a normal user with permissionless token" do
+  test "as a normal user without scopes" do
     user = create(:user)
-    token = create(:oauth_access_token, :user => user)
-    ability = ApiAbility.new user, token
+    scopes = Set.new
+    ability = ApiAbility.new user, scopes
 
     [:create, :comment, :close, :reopen, :destroy].each do |action|
       assert ability.cannot? action, Note
     end
   end
 
-  test "as a normal user with write_notes token" do
+  test "as a normal user with write_notes scope" do
     user = create(:user)
-    token = create(:oauth_access_token, :user => user, :scopes => %w[write_notes])
-    ability = ApiAbility.new user, token
+    scopes = Set.new %w[write_notes]
+    ability = ApiAbility.new user, scopes
 
     [:destroy].each do |action|
       assert ability.cannot? action, Note
@@ -73,20 +73,20 @@ class NoteApiCapabilityTest < ActiveSupport::TestCase
     end
   end
 
-  test "as a moderator with permissionless token" do
+  test "as a moderator without scopes" do
     user = create(:moderator_user)
-    token = create(:oauth_access_token, :user => user)
-    ability = ApiAbility.new user, token
+    scopes = Set.new
+    ability = ApiAbility.new user, scopes
 
     [:destroy].each do |action|
       assert ability.cannot? action, Note
     end
   end
 
-  test "as a moderator with write_notes token" do
+  test "as a moderator with write_notes scope" do
     user = create(:moderator_user)
-    token = create(:oauth_access_token, :user => user, :scopes => %w[write_notes])
-    ability = ApiAbility.new user, token
+    scopes = Set.new %w[write_notes]
+    ability = ApiAbility.new user, scopes
 
     [:destroy].each do |action|
       assert ability.can? action, Note
@@ -96,17 +96,16 @@ end
 
 class UserApiCapabilityTest < ActiveSupport::TestCase
   test "user preferences" do
-    # A user with empty tokens
     user = create(:user)
-    token = create(:oauth_access_token, :user => user)
-    ability = ApiAbility.new user, token
+    scopes = Set.new
+    ability = ApiAbility.new user, scopes
 
     [:index, :show, :update_all, :update, :destroy].each do |act|
       assert ability.cannot? act, UserPreference
     end
 
-    token = create(:oauth_access_token, :user => user, :scopes => %w[read_prefs])
-    ability = ApiAbility.new user, token
+    scopes = Set.new %w[read_prefs]
+    ability = ApiAbility.new user, scopes
 
     [:update_all, :update, :destroy].each do |act|
       assert ability.cannot? act, UserPreference
@@ -116,8 +115,8 @@ class UserApiCapabilityTest < ActiveSupport::TestCase
       assert ability.can? act, UserPreference
     end
 
-    token = create(:oauth_access_token, :user => user, :scopes => %w[write_prefs])
-    ability = ApiAbility.new user, token
+    scopes = Set.new %w[write_prefs]
+    ability = ApiAbility.new user, scopes
 
     [:index, :show].each do |act|
       assert ability.cannot? act, UserPreference

--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -98,38 +98,39 @@ module Api
       ActionMailer::Base.deliveries.clear
     end
 
-    ##
-    # create comment fail
-    def test_create_fail
-      # unauthorized
-      post changeset_comment_path(create(:changeset, :closed), :text => "This is a comment")
-      assert_response :unauthorized
-
-      auth_header = bearer_authorization_header
-
-      # bad changeset id
+    def test_create_by_unauthorized
       assert_no_difference "ChangesetComment.count" do
-        post changeset_comment_path(999111, :text => "This is a comment"), :headers => auth_header
+        post changeset_comment_path(create(:changeset, :closed), :text => "This is a comment")
+        assert_response :unauthorized
       end
-      assert_response :not_found
+    end
 
-      # not closed changeset
+    def test_create_on_missing_changeset
       assert_no_difference "ChangesetComment.count" do
-        post changeset_comment_path(create(:changeset), :text => "This is a comment"), :headers => auth_header
+        post changeset_comment_path(999111, :text => "This is a comment"), :headers => bearer_authorization_header
+        assert_response :not_found
       end
-      assert_response :conflict
+    end
 
-      # no text
+    def test_create_on_open_changeset
       assert_no_difference "ChangesetComment.count" do
-        post changeset_comment_path(create(:changeset, :closed)), :headers => auth_header
+        post changeset_comment_path(create(:changeset), :text => "This is a comment"), :headers => bearer_authorization_header
+        assert_response :conflict
       end
-      assert_response :bad_request
+    end
 
-      # empty text
+    def test_create_without_text
       assert_no_difference "ChangesetComment.count" do
-        post changeset_comment_path(create(:changeset, :closed), :text => ""), :headers => auth_header
+        post changeset_comment_path(create(:changeset, :closed)), :headers => bearer_authorization_header
+        assert_response :bad_request
       end
-      assert_response :bad_request
+    end
+
+    def test_create_with_empty_text
+      assert_no_difference "ChangesetComment.count" do
+        post changeset_comment_path(create(:changeset, :closed), :text => ""), :headers => bearer_authorization_header
+        assert_response :bad_request
+      end
     end
 
     ##

--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -33,7 +33,7 @@ module Api
 
     ##
     # create comment success
-    def test_create_comment_success
+    def test_create
       user = create(:user)
       user2 = create(:user)
       private_user = create(:user, :data_public => false)
@@ -100,7 +100,7 @@ module Api
 
     ##
     # create comment fail
-    def test_create_comment_fail
+    def test_create_fail
       # unauthorized
       post changeset_comment_path(create(:changeset, :closed), :text => "This is a comment")
       assert_response :unauthorized
@@ -134,7 +134,7 @@ module Api
 
     ##
     # create comment rate limit for new users
-    def test_create_comment_new_user_rate_limit
+    def test_create_by_new_user_with_rate_limit
       changeset = create(:changeset, :closed)
       user = create(:user)
 
@@ -155,7 +155,7 @@ module Api
 
     ##
     # create comment rate limit for experienced users
-    def test_create_comment_experienced_user_rate_limit
+    def test_create_by_experienced_user_with_rate_limit
       changeset = create(:changeset, :closed)
       user = create(:user)
       create_list(:changeset_comment, Settings.comments_to_max_changeset_comments, :author_id => user.id, :created_at => Time.now.utc - 1.day)
@@ -177,7 +177,7 @@ module Api
 
     ##
     # create comment rate limit for reported users
-    def test_create_comment_reported_user_rate_limit
+    def test_create_by_reported_user_with_rate_limit
       changeset = create(:changeset, :closed)
       user = create(:user)
       create(:issue_with_reports, :reportable => user, :reported_user => user)
@@ -199,7 +199,7 @@ module Api
 
     ##
     # create comment rate limit for moderator users
-    def test_create_comment_moderator_user_rate_limit
+    def test_create_by_moderator_user_with_rate_limit
       changeset = create(:changeset, :closed)
       user = create(:moderator_user)
 
@@ -220,7 +220,7 @@ module Api
 
     ##
     # test hide comment fail
-    def test_destroy_comment_fail
+    def test_hide_fail
       # unauthorized
       comment = create(:changeset_comment)
       assert comment.visible
@@ -246,7 +246,7 @@ module Api
 
     ##
     # test hide comment succes
-    def test_hide_comment_success
+    def test_hide
       comment = create(:changeset_comment)
       assert comment.visible
 
@@ -259,7 +259,7 @@ module Api
 
     ##
     # test unhide comment fail
-    def test_restore_comment_fail
+    def test_unhide_fail
       # unauthorized
       comment = create(:changeset_comment, :visible => false)
       assert_not comment.visible
@@ -285,7 +285,7 @@ module Api
 
     ##
     # test unhide comment succes
-    def test_unhide_comment_success
+    def test_unhide
       comment = create(:changeset_comment, :visible => false)
       assert_not comment.visible
 

--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -153,6 +153,12 @@ module Api
         post changeset_comment_path(changeset), :params => { :text => "This is a comment" }, :headers => auth_header
         assert_response :success
       end
+
+      comment = ChangesetComment.last
+      assert_equal changeset.id, comment.changeset_id
+      assert_equal user.id, comment.author_id
+      assert_equal "This is a comment", comment.body
+      assert comment.visible
     end
 
     ##

--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -281,30 +281,31 @@ module Api
       end
     end
 
-    ##
-    # test hide comment fail
-    def test_hide_fail
-      # unauthorized
+    def test_hide_by_unauthorized
       comment = create(:changeset_comment)
-      assert comment.visible
 
       post changeset_comment_hide_path(comment)
+
       assert_response :unauthorized
       assert comment.reload.visible
+    end
 
+    def test_hide_by_normal_user
+      comment = create(:changeset_comment)
       auth_header = bearer_authorization_header
 
-      # not a moderator
       post changeset_comment_hide_path(comment), :headers => auth_header
+
       assert_response :forbidden
       assert comment.reload.visible
+    end
 
+    def test_hide_missing_comment
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      # bad comment id
       post changeset_comment_hide_path(999111), :headers => auth_header
+
       assert_response :not_found
-      assert comment.reload.visible
     end
 
     ##

--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -321,30 +321,31 @@ module Api
       assert_not comment.reload.visible
     end
 
-    ##
-    # test unhide comment fail
-    def test_unhide_fail
-      # unauthorized
+    def test_unhide_by_unauthorized
       comment = create(:changeset_comment, :visible => false)
-      assert_not comment.visible
 
       post changeset_comment_unhide_path(comment)
+
       assert_response :unauthorized
       assert_not comment.reload.visible
+    end
 
+    def test_unhide_by_normal_user
+      comment = create(:changeset_comment, :visible => false)
       auth_header = bearer_authorization_header
 
-      # not a moderator
       post changeset_comment_unhide_path(comment), :headers => auth_header
+
       assert_response :forbidden
       assert_not comment.reload.visible
+    end
 
+    def test_unhide_missing_comment
       auth_header = bearer_authorization_header create(:moderator_user)
 
-      # bad comment id
       post changeset_comment_unhide_path(999111), :headers => auth_header
+
       assert_response :not_found
-      assert_not comment.reload.visible
     end
 
     ##


### PR DESCRIPTION
This PR introduces `write_changeset_comments` OAuth scope that allows creating changeset comments (and hiding/unhiding them for moderators). This is a subset of what `write_api` allows.

`write_api` still works as before looking from outside. Internally it's translated to `write_changeset_comments` and `write_map`. `write_map` is not exposed anywhere, it's only known to `ApiController` and `ApiAbility`. Doorkeeper doesn't know about it. Later it can be added as a selectable scope, but that would require updating cgimap.

Fixes #2631.