### PR TITLE
Transition more requests to fetch

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -41,19 +41,18 @@ $(document).ready(function () {
     $("#sidebar_content")
       .empty();
 
-    $.ajax({
-      url: content_path,
-      dataType: "html",
-      complete: function (xhr) {
+    fetch(content_path, { headers: { "accept": "text/html", "x-requested-with": "XMLHttpRequest" } })
+      .then(response => {
         $("#flash").empty();
         $("#sidebar_loader").removeClass("delayed-fade-in").hide();
 
-        var content = $(xhr.responseText);
+        const title = response.headers.get("X-Page-Title");
+        if (title) document.title = decodeURIComponent(title);
 
-        if (xhr.getResponseHeader("X-Page-Title")) {
-          var title = xhr.getResponseHeader("X-Page-Title");
-          document.title = decodeURIComponent(title);
-        }
+        return response.text();
+      })
+      .then(html => {
+        const content = $(html);
 
         $("head")
           .find("link[type=\"application/atom+xml\"]")
@@ -67,8 +66,7 @@ $(document).ready(function () {
         if (callback) {
           callback();
         }
-      }
-    });
+      });
   };
 
   var params = OSM.mapParams();

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -56,24 +56,23 @@ OSM.History = function (map) {
   }
 
   function update() {
-    var data = { list: "1" };
+    const data = new URLSearchParams();
 
     if (window.location.pathname === "/history") {
-      data.bbox = map.getBounds().wrap().toBBoxString();
+      data.set("bbox", map.getBounds().wrap().toBBoxString());
       var feedLink = $("link[type=\"application/atom+xml\"]"),
           feedHref = feedLink.attr("href").split("?")[0];
-      feedLink.attr("href", feedHref + "?bbox=" + data.bbox);
+      feedLink.attr("href", feedHref + "?" + data);
     }
 
-    $.ajax({
-      url: window.location.pathname,
-      method: "GET",
-      data: data,
-      success: function (html) {
+    data.set("list", "1");
+
+    fetch(window.location.pathname + "?" + data)
+      .then(response => response.text())
+      .then(function (html) {
         displayFirstChangesets(html);
         updateMap();
-      }
-    });
+      });
   }
 
   function loadMore(e) {

--- a/app/assets/javascripts/index/layers/notes.js
+++ b/app/assets/javascripts/index/layers/notes.js
@@ -75,10 +75,12 @@ OSM.initializeNotesLayer = function (map) {
 
       if (noteLoader) noteLoader.abort();
 
-      noteLoader = $.ajax({
-        url: url,
-        success: success
-      });
+      noteLoader = new AbortController();
+      fetch(url, { signal: noteLoader.signal })
+        .then(response => response.json())
+        .then(success)
+        .catch(() => {})
+        .finally(() => noteLoader = null);
     }
 
     function success(json) {
@@ -93,8 +95,6 @@ OSM.initializeNotesLayer = function (map) {
       for (var id in oldNotes) {
         noteLayer.removeLayer(oldNotes[id]);
       }
-
-      noteLoader = null;
     }
   }
 };

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -47,21 +47,19 @@ OSM.Search = function (map) {
     var div = $(this).parents(".search_more"),
         csrf_param = $("meta[name=csrf-param]").attr("content"),
         csrf_token = $("meta[name=csrf-token]").attr("content"),
-        params = {};
+        params = new URLSearchParams();
 
     $(this).hide();
     div.find(".loader").show();
 
-    params[csrf_param] = csrf_token;
+    params.set(csrf_param, csrf_token);
 
-    $.ajax({
-      url: $(this).attr("href"),
+    fetch($(this).attr("href"), {
       method: "POST",
-      data: params,
-      success: function (data) {
-        div.replaceWith(data);
-      }
-    });
+      body: params
+    })
+      .then(response => response.text())
+      .then(data => div.replaceWith(data));
   }
 
   function showSearchResult() {
@@ -125,19 +123,20 @@ OSM.Search = function (map) {
       var entry = $(this),
           csrf_param = $("meta[name=csrf-param]").attr("content"),
           csrf_token = $("meta[name=csrf-token]").attr("content"),
-          params = {
+          params = new URLSearchParams({
             zoom: map.getZoom(),
             minlon: map.getBounds().getWest(),
             minlat: map.getBounds().getSouth(),
             maxlon: map.getBounds().getEast(),
             maxlat: map.getBounds().getNorth()
-          };
-      params[csrf_param] = csrf_token;
-      $.ajax({
-        url: entry.data("href"),
+          });
+      params.set(csrf_param, csrf_token);
+      fetch(entry.data("href"), {
         method: "POST",
-        data: params,
-        success: function (html) {
+        body: params
+      })
+        .then(response => response.text())
+        .then(function (html) {
           entry.html(html);
           // go to first result of first geocoder
           if (index === 0) {
@@ -146,8 +145,7 @@ OSM.Search = function (map) {
               panToSearchResult(firstResult.data());
             }
           }
-        }
-      });
+        });
     });
 
     return map.getState();


### PR DESCRIPTION
### Description
Moves all AJAX requests that don't need OAuth to fetch. (except Matomo as this fetches a script)

### How has this been tested?
Logpoints and quite a bit of erratic map movement to check for aborts
