### PR TITLE
Add option to override Firefox binary used in system tests

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -53,3 +53,5 @@ doorkeeper_signing_key: |
   cK1+/2V+OkM/0nXjxPwPj7LiOediUyZNUn48r29uGOL1S83PSUdyST207CP6mZjc
   K8aJmnGsVEAcWPzbpNh14q/c
   -----END PRIVATE KEY-----
+# Override Firefox binary used in system tests
+#system_test_firefox_binary:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -9,6 +9,7 @@ end
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, :using => :headless_firefox do |options|
     options.add_preference("intl.accept_languages", "en")
+    options.binary = Settings.system_test_firefox_binary if Settings.system_test_firefox_binary
   end
 
   def before_setup

--- a/test/teaspoon_env.rb
+++ b/test/teaspoon_env.rb
@@ -100,10 +100,12 @@ Teaspoon.configure do |config|
   # Capybara Webkit: https://github.com/jejacks0n/teaspoon/wiki/Using-Capybara-Webkit
   require "selenium-webdriver"
   config.driver = :selenium
+  firefox_options = Selenium::WebDriver::Firefox::Options.new(:args => ["-headless"])
+  firefox_options.binary = Settings.system_test_firefox_binary if Settings.system_test_firefox_binary
   config.driver_options = {
     :client_driver => :firefox,
     :selenium_options => {
-      :options => Selenium::WebDriver::Firefox::Options.new(:args => ["-headless"])
+      :options => firefox_options
     }
   }
 


### PR DESCRIPTION
Addresses #5488 by providing a setting instead of workarounds such as modifying `test/application_system_test_case.rb`.

I'm also using these workarounds and it's annoying because you can accidentally commit them. But if there's a setting, I can put it in some file that's ignored by git, for example in `config/settings/test.local.yml` (assuming tests run in test environment; teaspoon tests by default don't but you can run them with `RAILS_ENV=test bundle exec teaspoon`).
