### PR TITLE
Remove current_user branch from ApiController#deny_access

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -82,8 +82,6 @@ class ApiController < ApplicationController
     if doorkeeper_token
       set_locale
       report_error t("oauth.permissions.missing"), :forbidden
-    elsif current_user
-      head :forbidden
     else
       head :unauthorized
     end


### PR DESCRIPTION
Unreachable because if there's no `doorkeeper_token`, there's also no `current_user`.

This is the only place in the api where `current_user` is set:
https://github.com/openstreetmap/openstreetmap-website/blob/f5af8befa9ffe0c95f4a3c58d2fbb63a2e971ab0/app/controllers/api_controller.rb#L105