### PR TITLE
Check user instead of scope when getting note author info

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -387,7 +387,7 @@ module Api
     ##
     # Get author's information (for logged in users - user_id, for logged out users - IP address)
     def author_info
-      if scope_enabled?(:write_notes)
+      if current_user
         { :user_id => current_user.id }
       else
         { :user_ip => request.remote_ip }


### PR DESCRIPTION
Previously it was possible to create a note while authorized but having no write_notes scope. The scope check was added to fix #4362.

Currently it's not possible to create notes in this manner and there's a test for that:
https://github.com/openstreetmap/openstreetmap-website/blob/f5af8befa9ffe0c95f4a3c58d2fbb63a2e971ab0/test/controllers/api/notes_controller_test.rb#L233-L242
