### PR TITLE
Include spam reports on unresolved issues in the spam score

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -359,11 +359,13 @@ class User < ApplicationRecord
     trace_score = traces.size * 50
     diary_entry_score = diary_entries.visible.inject(0) { |acc, elem| acc + elem.body.spam_score }
     diary_comment_score = diary_comments.visible.inject(0) { |acc, elem| acc + elem.body.spam_score }
+    report_score = Report.where(:category => "spam", :issue => issues.with_status("open")).count * 20
 
     score = description.spam_score / 4.0
     score += diary_entries.visible.where("created_at > ?", 1.day.ago).count * 10
     score += diary_entry_score / diary_entries.visible.length unless diary_entries.visible.empty?
     score += diary_comment_score / diary_comments.visible.length unless diary_comments.visible.empty?
+    score += report_score
     score -= changeset_score
     score -= trace_score
 


### PR DESCRIPTION
I think this should be reasonably safe - it will need three reports to trigger a suspension or possibly less if there are already links in the content adding to a score.

Given the negative influence of edits on the score it's unlikely that people reporting users for map spam will manage to trigger this, leaving the normal DWG management and edit rate limits to deal with those.