### PR TITLE
fix map panning to objects when url hash is not empty but has no map location

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -309,8 +309,9 @@ $(document).ready(function () {
     };
 
     function addObject(type, id, center) {
+      var hashParams = OSM.parseHash(window.location.hash);
       map.addObject({ type: type, id: parseInt(id, 10) }, function (bounds) {
-        if (!window.location.hash && bounds.isValid() &&
+        if (!hashParams.center && bounds.isValid() &&
             (center || !map.getBounds().contains(bounds))) {
           OSM.router.withoutMoveListener(function () {
             map.fitBounds(bounds);

--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -12,9 +12,10 @@ OSM.Changeset = function (map) {
     const changesetData = content.find("[data-changeset]").data("changeset");
     changesetData.type = "changeset";
 
+    var hashParams = OSM.parseHash(window.location.hash);
     initialize();
     map.addObject(changesetData, function (bounds) {
-      if (!window.location.hash && bounds.isValid()) {
+      if (!hashParams.center && bounds.isValid()) {
         OSM.router.withoutMoveListener(function () {
           map.fitBounds(bounds);
         });

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -27,13 +27,16 @@ OSM.Note = function (map) {
       var data = $(".details").data();
       if (!data) return;
       var latLng = L.latLng(data.coordinates.split(","));
-      if (!map.getBounds().contains(latLng)) moveToNote();
+      if (!map.getBounds().contains(latLng)) {
+        OSM.router.withoutMoveListener(function () {
+          map.setView(latLng, 15, { reset: true });
+        });
+      }
     });
   };
 
   page.load = function (path, id) {
     initialize(path, id);
-    moveToNote();
   };
 
   function initialize(path, id) {
@@ -48,7 +51,6 @@ OSM.Note = function (map) {
         success: () => {
           OSM.loadSidebarContent(path, () => {
             initialize(path, id);
-            moveToNote();
           });
         },
         error: (xhr) => {
@@ -77,11 +79,19 @@ OSM.Note = function (map) {
     var data = $(".details").data();
 
     if (data) {
+      var hashParams = OSM.parseHash(window.location.hash);
       map.addObject({
         type: "note",
         id: parseInt(id, 10),
         latLng: L.latLng(data.coordinates.split(",")),
         icon: noteIcons[data.status]
+      }, function () {
+        if (!hashParams.center) {
+          var latLng = L.latLng(data.coordinates.split(","));
+          OSM.router.withoutMoveListener(function () {
+            map.setView(latLng, 15, { reset: true });
+          });
+        }
       });
     }
   }
@@ -96,18 +106,6 @@ OSM.Note = function (map) {
       commentButton.prop("disabled", true);
     } else {
       resolveButton.text(resolveButton.data("commentActionText"));
-    }
-  }
-
-  function moveToNote() {
-    var data = $(".details").data();
-    if (!data) return;
-    var latLng = L.latLng(data.coordinates.split(","));
-
-    if (!window.location.hash || window.location.hash.match(/^#?c[0-9]+$/)) {
-      OSM.router.withoutMoveListener(function () {
-        map.setView(latLng, 15, { reset: true });
-      });
     }
   }
 


### PR DESCRIPTION
Fix for #865. Unfortunately, the code is slightly different when handling OSM objects (nodes/ways/relations), notes or changesets. I tried to make it a little bit more coherent by always using the `map.addObject({}, callback)` approach to zoom to the location only if the `hash` parameters had no location information.