### PR TITLE
Use title case consistently for nav tab labels

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1922,7 +1922,7 @@ en:
       failure: Couldn't update profile.
   sessions:
     new:
-      tab_title: "Log in"
+      tab_title: "Log In"
       login_to_authorize_html: "Log in to OpenStreetMap to access %{client_app_name}."
       email or username: "Email Address or Username"
       password: "Password"
@@ -2653,8 +2653,8 @@ en:
       need_to_see_terms: "Your access to the API is temporarily suspended. Please log-in to the web interface to view the Contributor Terms. You do not need to agree, but you must view them."
     settings_menu:
       account_settings: Account Settings
-      oauth2_applications: OAuth 2 applications
-      oauth2_authorizations: OAuth 2 authorizations
+      oauth2_applications: OAuth 2 Applications
+      oauth2_authorizations: OAuth 2 Authorizations
       muted_users: Muted Users
     auth_providers:
       openid_url: "OpenID URL"
@@ -2770,7 +2770,7 @@ en:
   users:
     new:
       title: "Sign Up"
-      tab_title: "Sign up"
+      tab_title: "Sign Up"
       signup_to_authorize_html: "Sign up with OpenStreetMap to access %{client_app_name}."
       no_auto_account_create: "Unfortunately we are not currently able to create an account for you automatically."
       please_contact_support_html: 'Please contact %{support_link} to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
@@ -2903,7 +2903,7 @@ en:
       index:
         heading_html: "%{user}'s Comments"
         changesets: "Changesets"
-        diary_entries: "Diary entries"
+        diary_entries: "Diary Entries"
         no_comments: "No comments"
     changeset_comments:
       index:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -45,4 +45,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def within_content_body(&)
     within("#content > .content-body", &)
   end
+
+  def within_content_heading(&)
+    within("#content > .content-heading", &)
+  end
 end

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -5,7 +5,10 @@ class IssuesTest < ApplicationSystemTestCase
 
   def test_view_issues_not_logged_in
     visit issues_path
-    assert_content "Log in"
+
+    within_content_heading do
+      assert_content "Log In"
+    end
   end
 
   def test_view_issues_normal_user

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -79,7 +79,9 @@ class UserSignupTest < ApplicationSystemTestCase
   test "Sign up from login page" do
     visit login_path
 
-    click_on "Sign up"
+    within_content_heading do
+      click_on "Sign Up"
+    end
 
     within_content_body do
       assert_content "Confirm Password"


### PR DESCRIPTION
In almost all tab navs we already use [title case](https://en.wikipedia.org/wiki/Title_case), and this PR changes the remaining few to match.