### PR TITLE
Use 'My Account' for account pages

### DIFF
--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :heading do %>
-  <h1><%= t ".my settings" %></h1>
+  <h1><%= t ".my_account" %></h1>
 <% end %>
 
 <%= render :partial => "settings_menu" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -101,7 +101,7 @@
             <span class='badge count-number'><%= number_with_delimiter(current_user.new_messages.size) %></span>
           <% end %>
           <%= link_to t("users.show.my profile"), current_user, :class => "dropdown-item" %>
-          <%= link_to t("users.show.my settings"), edit_account_path, :class => "dropdown-item" %>
+          <%= link_to t("users.show.my_account"), edit_account_path, :class => "dropdown-item" %>
           <%= link_to t("users.show.my_preferences"), preferences_path, :class => "dropdown-item" %>
           <div class="dropdown-divider"></div>
           <%= yield :greeting %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,7 @@
               <span class='badge count-number'><%= number_with_delimiter(current_user.diary_comments.size) %></span>
             </li>
             <li>
-              <%= link_to t(".my settings"), edit_account_path %>
+              <%= link_to t(".my_account"), edit_account_path %>
             </li>
 
             <% if current_user.blocks.exists? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,7 +246,7 @@ en:
   accounts:
     edit:
       title: "Edit account"
-      my settings: My Settings
+      my_account: My Account
       current email address: "Current Email Address"
       external auth: "External Authentication"
       openid:
@@ -2809,7 +2809,7 @@ en:
       my notes: My Notes
       my messages: My Messages
       my profile: My Profile
-      my settings: My Settings
+      my_account: My Account
       my comments: My Comments
       my_preferences: My Preferences
       my_dashboard: My Dashboard

--- a/test/system/user_suspension_test.rb
+++ b/test/system/user_suspension_test.rb
@@ -5,7 +5,7 @@ class UserSuspensionTest < ApplicationSystemTestCase
     user = create(:user)
     sign_in_as(user)
     visit edit_account_path
-    assert_content "My Settings"
+    assert_content "My Account"
 
     user.suspend!
 


### PR DESCRIPTION
It's hard to make a distinction between 'Preferences' and 'Settings' in some languages, and many other sites use the term 'Account' for things like changing email.
