### PR TITLE
Add option to use headless Firefox in system tests

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -53,5 +53,7 @@ doorkeeper_signing_key: |
   cK1+/2V+OkM/0nXjxPwPj7LiOediUyZNUn48r29uGOL1S83PSUdyST207CP6mZjc
   K8aJmnGsVEAcWPzbpNh14q/c
   -----END PRIVATE KEY-----
+# Run system tests using headless Firefox
+system_test_headless: true
 # Override Firefox binary used in system tests
 #system_test_firefox_binary:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,7 +7,7 @@ ActiveSupport.on_load(:action_dispatch_system_test_case) do
 end
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, :using => :headless_firefox do |options|
+  driven_by :selenium, :using => Settings.system_test_headless ? :headless_firefox : :firefox do |options|
     options.add_preference("intl.accept_languages", "en")
     options.binary = Settings.system_test_firefox_binary if Settings.system_test_firefox_binary
   end

--- a/test/teaspoon_env.rb
+++ b/test/teaspoon_env.rb
@@ -100,7 +100,8 @@ Teaspoon.configure do |config|
   # Capybara Webkit: https://github.com/jejacks0n/teaspoon/wiki/Using-Capybara-Webkit
   require "selenium-webdriver"
   config.driver = :selenium
-  firefox_options = Selenium::WebDriver::Firefox::Options.new(:args => ["-headless"])
+  firefox_options = Selenium::WebDriver::Firefox::Options.new
+  firefox_options.args = ["-headless"] if Settings.system_test_headless
   firefox_options.binary = Settings.system_test_firefox_binary if Settings.system_test_firefox_binary
   config.driver_options = {
     :client_driver => :firefox,


### PR DESCRIPTION
Continues #5672.

System test normally run in a headless browser, which is what you want if you run the entire test suite. But when writing and running a single test, it's useful to see what's happening. This PR adds a setting to choose whether tests should run in a headless Firefox.