### PR TITLE
don't re-pan the map when selecting another note that is already on screen

### DIFF
--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -44,7 +44,7 @@ OSM.Note = function (map) {
         oauth: true,
         success: () => {
           OSM.loadSidebarContent(path, () => {
-            initialize(path, id);
+            initialize(path, id, false);
           });
         },
         error: (xhr) => {

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -22,16 +22,10 @@ OSM.Note = function (map) {
 
   page.pushstate = page.popstate = function (path, id) {
     OSM.loadSidebarContent(path, function () {
-      initialize(path, id);
-
       var data = $(".details").data();
       if (!data) return;
       var latLng = L.latLng(data.coordinates.split(","));
-      if (!map.getBounds().contains(latLng)) {
-        OSM.router.withoutMoveListener(function () {
-          map.setView(latLng, 15, { reset: true });
-        });
-      }
+      initialize(path, id, map.getBounds().contains(latLng));
     });
   };
 
@@ -39,7 +33,7 @@ OSM.Note = function (map) {
     initialize(path, id);
   };
 
-  function initialize(path, id) {
+  function initialize(path, id, skipMoveToNote) {
     content.find("button[name]").on("click", function (e) {
       e.preventDefault();
       var data = $(e.target).data();
@@ -86,7 +80,7 @@ OSM.Note = function (map) {
         latLng: L.latLng(data.coordinates.split(",")),
         icon: noteIcons[data.status]
       }, function () {
-        if (!hashParams.center) {
+        if (!hashParams.center && !skipMoveToNote) {
           var latLng = L.latLng(data.coordinates.split(","));
           OSM.router.withoutMoveListener(function () {
             map.setView(latLng, 15, { reset: true });


### PR DESCRIPTION
Fixes #5683 (a regression in #5679): the problem was that when clicking on a new note on the map, the URL hash with the `map` parameter is cleared somewhere before  `pushstate` gets called, resulting in the map to be panned in `map.addObject` during the `initialize` step. It's now solved by passing an additional parameter to `initialize` and only do the map centering there.

This also allowed to fix #648 via 793757a6f.