### PR TITLE
Clear test deliveries before and after system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,6 +7,8 @@ ActiveSupport.on_load(:action_dispatch_system_test_case) do
 end
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  include ActionMailer::TestCase::ClearTestDeliveries
+
   driven_by :selenium, :using => Settings.system_test_headless ? :headless_firefox : :firefox do |options|
     options.add_preference("intl.accept_languages", "en")
     options.binary = Settings.system_test_firefox_binary if Settings.system_test_firefox_binary


### PR DESCRIPTION
Make sure system tests clear deliveries before and after running as controller and integration tests already do.

Fixes #5687.