### PR TITLE
Use ubuntu-latest for all workflows

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   danger:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   test:
     name: Docker
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout source
       uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
-  os: ubuntu-22.04
   ruby: '3.1'
 jobs:
   rubocop:
     name: RuboCop
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,12 +50,9 @@ jobs:
         rubygems: 3.4.10
         bundler-cache: true
     - name: Cache node modules
-      uses: actions/cache@v4
+      uses: actions/setup-node@v4
       with:
-        path: node_modules
-        key: yarn-${{ env.os }}-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          yarn-${{ env.os }}-
+        cache: yarn
     - name: Install node modules
       run: bundle exec bin/yarn install
     - name: Create dummy database configuration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,12 +7,11 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    name: Ubuntu ${{ matrix.ubuntu }}, Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ubuntu: [22.04, 24.04]
         ruby: ['3.1', '3.2', '3.3', '3.4']
-    runs-on: ubuntu-${{ matrix.ubuntu }}
+    runs-on: ubuntu-latest
     env:
       RAILS_ENV: test
       OPENSTREETMAP_MEMCACHE_SERVERS: 127.0.0.1
@@ -65,7 +64,7 @@ jobs:
       uses: coverallsapp/github-action@v2.3.6
       with:
         github-token: ${{ secrets.github_token }}
-        flag-name: ubuntu-${{ matrix.ubuntu }}-ruby-${{ matrix.ruby }}
+        flag-name: ruby-${{ matrix.ruby }}
         format: lcov
         parallel: true
   finish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,9 @@ jobs:
         rubygems: 3.4.10
         bundler-cache: true
     - name: Cache node modules
-      uses: actions/cache@v4
+      uses: actions/setup-node@v4
       with:
-        path: node_modules
-        key: yarn-ubuntu-${{ matrix.ubuntu }}-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          yarn-ubuntu-${{ matrix.ubuntu }}-
+        cache: yarn
     - name: Install packages
       run: |
         sudo apt-get -yqq update


### PR DESCRIPTION
There's generally no point running on multiple versions as the important things like ruby are not the OS versions in any case and production runs on Debian now not Ubuntu.