### PR TITLE
Enable exporting direction paths

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -36,6 +36,8 @@ OSM.Directions = function (map) {
     OSM.DirectionsEndpoint(map, $("input[name='route_to']"), OSM.MARKER_RED, endpointDragCallback, endpointChangeCallback)
   ];
 
+  let downloadURL = null;
+
   const expiry = new Date();
   expiry.setYear(expiry.getFullYear() + 10);
 
@@ -188,6 +190,16 @@ OSM.Directions = function (map) {
 
         turnByTurnTable.append(row);
       });
+
+      const blob = new Blob([JSON.stringify(polyline.toGeoJSON())], { type: "application/json" });
+      URL.revokeObjectURL(downloadURL);
+      downloadURL = URL.createObjectURL(blob);
+
+      $("#sidebar_content").append(`<p class="text-center"><a href="${downloadURL}" download="${
+        I18n.t("javascripts.directions.filename")
+      }">${
+        I18n.t("javascripts.directions.download")
+      }</a></p>`);
 
       $("#sidebar_content").append("<p class=\"text-center\">" +
         I18n.t("javascripts.directions.instructions.courtesy", { link: chosenEngine.creditline }) +

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3312,6 +3312,8 @@ en:
           ninth: "9th"
           tenth: "10th"
       time: "Time"
+      download: "Download track as GeoJSON"
+      filename: "route"
     query:
       node: Node
       way: Way

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3312,7 +3312,7 @@ en:
           ninth: "9th"
           tenth: "10th"
       time: "Time"
-      download: "Download track as GeoJSON"
+      download: "Download route as GeoJSON"
       filename: "route"
     query:
       node: Node


### PR DESCRIPTION
### Description
Closes #5224 by adding a link below the instructions table to download the route as a geoJSON:

![image](https://github.com/user-attachments/assets/1c198644-1ca0-4154-b7c2-9b0d774d0ddf)

### How has this been tested?
The functionality? Locally.
The translation? Changed on Thursday.