### PR TITLE
Remove some unnecessary calls to clear the mail queue

### DIFF
--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -121,7 +121,6 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal user.new_email, email.to.first
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_private_account

--- a/test/controllers/api/changeset_comments_controller_test.rb
+++ b/test/controllers/api/changeset_comments_controller_test.rb
@@ -236,8 +236,6 @@ module Api
       assert_equal 1, email.to.length
       assert_equal "[OpenStreetMap] #{commenter_user.display_name} has commented on one of your changesets", email.subject
       assert_equal creator_user.email, email.to.first
-
-      ActionMailer::Base.deliveries.clear
     end
 
     def test_create_on_changeset_with_changeset_creator_and_other_user_subscribers
@@ -267,8 +265,6 @@ module Api
       assert_not_nil email
       assert_equal 1, email.to.length
       assert_equal "[OpenStreetMap] #{commenter_user.display_name} has commented on a changeset you are interested in", email.subject
-
-      ActionMailer::Base.deliveries.clear
     end
 
     ##

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -330,8 +330,6 @@ module Api
       assert_equal "commented", js["properties"]["comments"].last["action"]
       assert_equal "This is an additional comment", js["properties"]["comments"].last["text"]
       assert_equal third_user.display_name, js["properties"]["comments"].last["user"]
-
-      ActionMailer::Base.deliveries.clear
     end
 
     def test_comment_with_notifications_success
@@ -395,8 +393,6 @@ module Api
       assert_equal "commented", js["properties"]["comments"].last["action"]
       assert_equal "This is an additional comment", js["properties"]["comments"].last["text"]
       assert_equal third_user.display_name, js["properties"]["comments"].last["user"]
-
-      ActionMailer::Base.deliveries.clear
     end
 
     def test_comment_twice_success

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -204,8 +204,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     email = ActionMailer::Base.deliveries.last
 
     assert_equal user.email, email.to.first
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_confirm_resend_deleted

--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -72,7 +72,6 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "[OpenStreetMap] #{other_user.display_name} commented on a diary entry", email.subject
     assert_match(/New comment/, email.text_part.decoded)
     assert_match(/New comment/, email.html_part.decoded)
-    ActionMailer::Base.deliveries.clear
     assert_equal entry.id, comment.diary_entry_id
     assert_equal other_user.id, comment.user_id
     assert_equal "New comment", comment.body
@@ -114,7 +113,6 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "[OpenStreetMap] #{other_user.display_name} commented on a diary entry", email.subject
     assert_match %r{http://example.com/spam}, email.text_part.decoded
     assert_match %r{http://example.com/spam}, email.html_part.decoded
-    ActionMailer::Base.deliveries.clear
     assert_equal entry.id, comment.diary_entry_id
     assert_equal other_user.id, comment.user_id
     assert_equal spammy_text, comment.body

--- a/test/controllers/follows_controller_test.rb
+++ b/test/controllers/follows_controller_test.rb
@@ -56,7 +56,6 @@ class FollowsControllerTest < ActionDispatch::IntegrationTest
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal follow.email, email.to.first
-    ActionMailer::Base.deliveries.clear
 
     # A second POST should report that the follow already exists
     assert_no_difference "ActionMailer::Base.deliveries.size" do
@@ -97,7 +96,6 @@ class FollowsControllerTest < ActionDispatch::IntegrationTest
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal follow.email, email.to.first
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_follow_unknown_user

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -167,7 +167,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Test message body/, e.text_part.decoded)
     assert_match(/Test message body/, e.html_part.decoded)
     assert_match %r{#{Settings.server_url}/messages/[0-9]+}, e.text_part.decoded
-    ActionMailer::Base.deliveries.clear
+
     m = Message.last
     assert_equal user.id, m.from_user_id
     assert_equal recipient_user.id, m.to_user_id

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -118,7 +118,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     email = ActionMailer::Base.deliveries.first
     assert_equal 1, email.to.count
     assert_equal third_user.email, email.to.first
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_reset_password

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -87,8 +87,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     # Check the page
     assert_redirected_to :controller => :confirmations, :action => :confirm, :display_name => user.display_name
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_create_duplicate_email
@@ -189,8 +187,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         perform_enqueued_jobs
       end
     end
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_go_public

--- a/test/integration/user_creation_test.rb
+++ b/test/integration/user_creation_test.rb
@@ -153,7 +153,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     found_confirmation_url = register_email.parts.first.parts.first.to_s =~ %r{\shttp://test.host(/\S+)\s}
     assert found_confirmation_url
     confirmation_url = Regexp.last_match(1)
-    ActionMailer::Base.deliveries.clear
 
     post confirmation_url
 
@@ -211,8 +210,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "confirmations/confirm"
 
-    ActionMailer::Base.deliveries.clear
-
     # Go to the confirmation page
     get "/user/#{display_name}/confirm", :params => { :referer => "/welcome", :confirm_string => confirm_string }
     assert_response :success
@@ -255,8 +252,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
 
     # Check the page
     assert_redirected_to :controller => :confirmations, :action => :confirm, :display_name => display_name
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_openid_duplicate_email
@@ -278,8 +273,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "users/new"
     assert_select "form > div > input.is-invalid#user_email"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_openid_failure
@@ -296,8 +289,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         end
       end
     end
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_openid_redirect
@@ -343,8 +334,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     # Check the page
     assert_response :success
     assert_template "confirmations/confirm"
-
-    ActionMailer::Base.deliveries.clear
 
     # Go to the confirmation page
     get "/user/#{display_name}/confirm", :params => { :referer => "/welcome", :confirm_string => confirm_string }
@@ -395,8 +384,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     # Check the page
     assert_response :success
     assert_template "site/welcome"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_google_duplicate_email
@@ -420,8 +407,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "users/new"
     assert_select "form > div > input.is-invalid#user_email"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_google_failure
@@ -439,8 +424,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         end
       end
     end
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_google_redirect
@@ -492,8 +475,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "confirmations/confirm"
 
-    ActionMailer::Base.deliveries.clear
-
     # Go to the confirmation page
     get "/user/#{display_name}/confirm", :params => { :referer => "/welcome", :confirm_string => confirm_string }
     assert_response :success
@@ -542,8 +523,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     # Check the page
     assert_response :success
     assert_template "site/welcome"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_facebook_duplicate_email
@@ -566,8 +545,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "users/new"
     assert_select "form > div > input.is-invalid#user_email"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_facebook_failure
@@ -585,8 +562,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         end
       end
     end
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_facebook_redirect
@@ -639,8 +614,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "confirmations/confirm"
 
-    ActionMailer::Base.deliveries.clear
-
     # Go to the confirmation page
     get "/user/#{display_name}/confirm", :params => { :referer => "/welcome", :confirm_string => confirm_string }
     assert_response :success
@@ -688,8 +661,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     # Check the page
     assert_response :success
     assert_template "site/welcome"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_microsoft_duplicate_email
@@ -712,8 +683,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "users/new"
     assert_select "form > div > input.is-invalid#user_email"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_microsoft_failure
@@ -731,8 +700,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         end
       end
     end
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_microsoft_redirect
@@ -783,8 +750,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     # Check the page
     assert_response :success
     assert_template "confirmations/confirm"
-
-    ActionMailer::Base.deliveries.clear
 
     # Go to the confirmation page
     get "/user/#{display_name}/confirm", :params => { :referer => "/welcome", :confirm_string => confirm_string }
@@ -839,8 +804,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     # Check the page
     assert_response :success
     assert_template "site/welcome"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_github_duplicate_email
@@ -864,8 +827,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "users/new"
     assert_select "form > div > input.is-invalid#user_email"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_github_failure
@@ -882,8 +843,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         end
       end
     end
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_github_redirect
@@ -933,8 +892,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     # Check the page
     assert_response :success
     assert_template "confirmations/confirm"
-
-    ActionMailer::Base.deliveries.clear
 
     # Go to the confirmation page
     get "/user/#{display_name}/confirm", :params => { :referer => "/welcome", :confirm_string => confirm_string }
@@ -1010,8 +967,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_template "users/new"
     assert_select "form > div > input.is-invalid#user_email"
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_wikipedia_failure
@@ -1029,8 +984,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
         end
       end
     end
-
-    ActionMailer::Base.deliveries.clear
   end
 
   def test_user_create_wikipedia_redirect
@@ -1082,8 +1035,6 @@ class UserCreationTest < ActionDispatch::IntegrationTest
     # Check the page
     assert_response :success
     assert_template "confirmations/confirm"
-
-    ActionMailer::Base.deliveries.clear
 
     # Go to the confirmation page
     get "/user/#{display_name}/confirm", :params => { :referer => "/welcome", :confirm_string => confirm_string }

--- a/test/system/user_email_change_test.rb
+++ b/test/system/user_email_change_test.rb
@@ -29,7 +29,5 @@ class UserEmailChangeTest < ApplicationSystemTestCase
     end
 
     assert_equal "new_tester@example.com", user.reload.email
-
-    ActionMailer::Base.deliveries.clear
   end
 end


### PR DESCRIPTION
These were not needed at the end of most tests for quite some time, since rails clears them by default for controller and integration tests, and also no longer required in system tests after #5691

There's still some calls that could be removed, for example by also automatically clearing `job` tests and by slightly reworking one of the mega tests in the `passwords_controller_test`.