### PR TITLE
Pre-center objects with embed-data

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -13,15 +13,18 @@ $(document).ready(function () {
   const hashArgs = OSM.parseHash(location.hash);
   const mapParams = OSM.mapParams();
   const params = new URLSearchParams();
-  let { zoom, lat, lon } = mapParams;
+  let zoom, lat, lon;
 
+  if (idData.lat && idData.lon) {
+    ({ zoom, lat, lon } = { zoom: 16, ...idData });
+  } else if (!mapParams.object) {
+    ({ zoom, lat, lon } = mapParams);
+  }
   if (mapParams.object) {
     params.set("id", mapParams.object.type + "/" + mapParams.object.id);
     if (hashArgs.center) ({ zoom, center: { lat, lng: lon } } = hashArgs);
-  } else if (idData.lat && idData.lon) {
-    ({ zoom, lat, lon } = { zoom: 16, ...idData });
   }
-  params.set("map", [zoom || 17, lat, lon].join("/"));
+  if (lat && lon) params.set("map", [zoom || 17, lat, lon].join("/"));
 
   const passThroughKeys = ["background", "comment", "disable_features", "gpx", "hashtags", "locale", "maprules", "notes", "offset", "photo", "photo_dates", "photo_overlay", "photo_username", "presets", "source", "validationDisable", "validationWarning", "validationError", "walkthrough"];
   for (const key of passThroughKeys) {


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/iD/issues/10779, closes #5698
Before the regression from #5632, the location source table was:

typ |           |          | hash-loc | !hash-loc
:-: |  :------: |  :-----: | :------: | :------:
n/w |  data-loc |  map-obj | hash-loc | nil
rel | !data-loc |  map-obj | hash-loc | nil
gpx |  data-loc | !map-obj | data-loc | data-loc
nil | !data-loc | !map-obj | map-loc  | map-loc

I changed it to this:

typ |           |          | hash-loc | !hash-loc
:-: |  :------: |  :-----: | :------: | :------:
n/w |  data-loc |  map-obj | hash-loc | data-loc
rel | !data-loc |  map-obj | hash-loc | nil
gpx |  data-loc | !map-obj | data-loc | data-loc
nil | !data-loc | !map-obj | map-loc  | map-loc

And I took the opportunity to restructure the conditions in the spirit of #5632.