### PR TITLE
API changeset resources - index path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ OpenStreetMap::Application.routes.draw do
     get "capabilities" => "capabilities#show"
     get "permissions" => "permissions#show"
 
-    put "changeset/create" => "changesets#create"
     post "changeset/:id/upload" => "changesets#upload", :as => :changeset_upload, :id => /\d+/
     get "changeset/:id/download" => "changesets#download", :as => :changeset_download, :id => /\d+/
     get "changeset/:id" => "changesets#show", :as => :changeset_show, :id => /\d+/
@@ -32,6 +31,9 @@ OpenStreetMap::Application.routes.draw do
   end
 
   namespace :api, :path => "api/0.6" do
+    resources :changesets, :only => :create
+    put "changeset/create" => "changesets#create", :as => nil
+
     resources :changeset_comments, :only => :index
 
     resources :nodes, :only => [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,14 +24,13 @@ OpenStreetMap::Application.routes.draw do
     post "changeset/:id/unsubscribe" => "changesets#unsubscribe", :as => :api_changeset_unsubscribe, :id => /\d+/
     put "changeset/:id" => "changesets#update", :id => /\d+/
     put "changeset/:id/close" => "changesets#close", :as => :changeset_close, :id => /\d+/
-    get "changesets" => "changesets#index"
     post "changeset/:id/comment" => "changeset_comments#create", :as => :changeset_comment, :id => /\d+/
     post "changeset/comment/:id/hide" => "changeset_comments#destroy", :as => :changeset_comment_hide, :id => /\d+/
     post "changeset/comment/:id/unhide" => "changeset_comments#restore", :as => :changeset_comment_unhide, :id => /\d+/
   end
 
   namespace :api, :path => "api/0.6" do
-    resources :changesets, :only => :create
+    resources :changesets, :only => [:index, :create]
     put "changeset/create" => "changesets#create", :as => nil
 
     resources :changeset_comments, :only => :index

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -6,6 +6,14 @@ module Api
     # test all routes which lead to this controller
     def test_routes
       assert_routing(
+        { :path => "/api/0.6/changesets", :method => :get },
+        { :controller => "api/changesets", :action => "index" }
+      )
+      assert_routing(
+        { :path => "/api/0.6/changesets.json", :method => :get },
+        { :controller => "api/changesets", :action => "index", :format => "json" }
+      )
+      assert_routing(
         { :path => "/api/0.6/changesets", :method => :post },
         { :controller => "api/changesets", :action => "create" }
       )
@@ -49,19 +57,254 @@ module Api
         { :path => "/api/0.6/changeset/1/close", :method => :put },
         { :controller => "api/changesets", :action => "close", :id => "1" }
       )
-      assert_routing(
-        { :path => "/api/0.6/changesets", :method => :get },
-        { :controller => "api/changesets", :action => "index" }
-      )
-      assert_routing(
-        { :path => "/api/0.6/changesets.json", :method => :get },
-        { :controller => "api/changesets", :action => "index", :format => "json" }
-      )
 
       assert_recognizes(
         { :controller => "api/changesets", :action => "create" },
         { :path => "/api/0.6/changeset/create", :method => :put }
       )
+    end
+
+    ##
+    # test the query functionality of changesets
+    def test_index
+      private_user = create(:user, :data_public => false)
+      private_user_changeset = create(:changeset, :user => private_user)
+      private_user_closed_changeset = create(:changeset, :closed, :user => private_user)
+      user = create(:user)
+      changeset = create(:changeset, :user => user)
+      closed_changeset = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 1, 1, 0, 0, 0), :closed_at => Time.utc(2008, 1, 2, 0, 0, 0))
+      changeset2 = create(:changeset, :min_lat => (5 * GeoRecord::SCALE).round, :min_lon => (5 * GeoRecord::SCALE).round, :max_lat => (15 * GeoRecord::SCALE).round, :max_lon => (15 * GeoRecord::SCALE).round)
+      changeset3 = create(:changeset, :min_lat => (4.5 * GeoRecord::SCALE).round, :min_lon => (4.5 * GeoRecord::SCALE).round, :max_lat => (5 * GeoRecord::SCALE).round, :max_lon => (5 * GeoRecord::SCALE).round)
+
+      get changesets_path(:bbox => "-10,-10, 10, 10")
+      assert_response :success, "can't get changesets in bbox"
+      assert_changesets_in_order [changeset3, changeset2]
+
+      get changesets_path(:bbox => "4.5,4.5,4.6,4.6")
+      assert_response :success, "can't get changesets in bbox"
+      assert_changesets_in_order [changeset3]
+
+      # not found when looking for changesets of non-existing users
+      get changesets_path(:user => User.maximum(:id) + 1)
+      assert_response :not_found
+      assert_equal "text/plain", @response.media_type
+      get changesets_path(:display_name => " ")
+      assert_response :not_found
+      assert_equal "text/plain", @response.media_type
+
+      # can't get changesets of user 1 without authenticating
+      get changesets_path(:user => private_user.id)
+      assert_response :not_found, "shouldn't be able to get changesets by non-public user (ID)"
+      get changesets_path(:display_name => private_user.display_name)
+      assert_response :not_found, "shouldn't be able to get changesets by non-public user (name)"
+
+      # but this should work
+      auth_header = bearer_authorization_header private_user
+      get changesets_path(:user => private_user.id), :headers => auth_header
+      assert_response :success, "can't get changesets by user ID"
+      assert_changesets_in_order [private_user_changeset, private_user_closed_changeset]
+
+      get changesets_path(:display_name => private_user.display_name), :headers => auth_header
+      assert_response :success, "can't get changesets by user name"
+      assert_changesets_in_order [private_user_changeset, private_user_closed_changeset]
+
+      # test json endpoint
+      get changesets_path(:display_name => private_user.display_name), :headers => auth_header, :params => { :format => "json" }
+      assert_response :success, "can't get changesets by user name"
+
+      js = ActiveSupport::JSON.decode(@response.body)
+      assert_not_nil js
+
+      assert_equal Settings.api_version, js["version"]
+      assert_equal Settings.generator, js["generator"]
+      assert_equal 2, js["changesets"].count
+
+      # check that the correct error is given when we provide both UID and name
+      get changesets_path(:user => private_user.id,
+                          :display_name => private_user.display_name), :headers => auth_header
+      assert_response :bad_request, "should be a bad request to have both ID and name specified"
+
+      get changesets_path(:user => private_user.id, :open => true), :headers => auth_header
+      assert_response :success, "can't get changesets by user and open"
+      assert_changesets_in_order [private_user_changeset]
+
+      get changesets_path(:time => "2007-12-31"), :headers => auth_header
+      assert_response :success, "can't get changesets by time-since"
+      assert_changesets_in_order [changeset3, changeset2, changeset, private_user_changeset, private_user_closed_changeset, closed_changeset]
+
+      get changesets_path(:time => "2008-01-01T12:34Z"), :headers => auth_header
+      assert_response :success, "can't get changesets by time-since with hour"
+      assert_changesets_in_order [changeset3, changeset2, changeset, private_user_changeset, private_user_closed_changeset, closed_changeset]
+
+      get changesets_path(:time => "2007-12-31T23:59Z,2008-01-02T00:01Z"), :headers => auth_header
+      assert_response :success, "can't get changesets by time-range"
+      assert_changesets_in_order [closed_changeset]
+
+      get changesets_path(:open => "true"), :headers => auth_header
+      assert_response :success, "can't get changesets by open-ness"
+      assert_changesets_in_order [changeset3, changeset2, changeset, private_user_changeset]
+
+      get changesets_path(:closed => "true"), :headers => auth_header
+      assert_response :success, "can't get changesets by closed-ness"
+      assert_changesets_in_order [private_user_closed_changeset, closed_changeset]
+
+      get changesets_path(:closed => "true", :user => private_user.id), :headers => auth_header
+      assert_response :success, "can't get changesets by closed-ness and user"
+      assert_changesets_in_order [private_user_closed_changeset]
+
+      get changesets_path(:closed => "true", :user => user.id), :headers => auth_header
+      assert_response :success, "can't get changesets by closed-ness and user"
+      assert_changesets_in_order [closed_changeset]
+
+      get changesets_path(:changesets => "#{private_user_changeset.id},#{changeset.id},#{closed_changeset.id}"), :headers => auth_header
+      assert_response :success, "can't get changesets by id (as comma-separated string)"
+      assert_changesets_in_order [changeset, private_user_changeset, closed_changeset]
+
+      get changesets_path(:changesets => ""), :headers => auth_header
+      assert_response :bad_request, "should be a bad request since changesets is empty"
+    end
+
+    ##
+    # test the query functionality of changesets with the limit parameter
+    def test_index_limit
+      user = create(:user)
+      changeset1 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 1, 1, 0, 0, 0), :closed_at => Time.utc(2008, 1, 2, 0, 0, 0))
+      changeset2 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 2, 1, 0, 0, 0), :closed_at => Time.utc(2008, 2, 2, 0, 0, 0))
+      changeset3 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 3, 1, 0, 0, 0), :closed_at => Time.utc(2008, 3, 2, 0, 0, 0))
+      changeset4 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 4, 1, 0, 0, 0), :closed_at => Time.utc(2008, 4, 2, 0, 0, 0))
+      changeset5 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 5, 1, 0, 0, 0), :closed_at => Time.utc(2008, 5, 2, 0, 0, 0))
+
+      get changesets_path
+      assert_response :success
+      assert_changesets_in_order [changeset5, changeset4, changeset3, changeset2, changeset1]
+
+      get changesets_path(:limit => "3")
+      assert_response :success
+      assert_changesets_in_order [changeset5, changeset4, changeset3]
+
+      get changesets_path(:limit => "0")
+      assert_response :bad_request
+
+      get changesets_path(:limit => Settings.max_changeset_query_limit)
+      assert_response :success
+      assert_changesets_in_order [changeset5, changeset4, changeset3, changeset2, changeset1]
+
+      get changesets_path(:limit => Settings.max_changeset_query_limit + 1)
+      assert_response :bad_request
+    end
+
+    ##
+    # test the query functionality of sequential changesets with order and time parameters
+    def test_index_order
+      user = create(:user)
+      changeset1 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 1, 1, 0, 0, 0), :closed_at => Time.utc(2008, 1, 2, 0, 0, 0))
+      changeset2 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 2, 1, 0, 0, 0), :closed_at => Time.utc(2008, 2, 2, 0, 0, 0))
+      changeset3 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 3, 1, 0, 0, 0), :closed_at => Time.utc(2008, 3, 2, 0, 0, 0))
+      changeset4 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 4, 1, 0, 0, 0), :closed_at => Time.utc(2008, 4, 2, 0, 0, 0))
+      changeset5 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 5, 1, 0, 0, 0), :closed_at => Time.utc(2008, 5, 2, 0, 0, 0))
+      changeset6 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 6, 1, 0, 0, 0), :closed_at => Time.utc(2008, 6, 2, 0, 0, 0))
+
+      get changesets_path
+      assert_response :success
+      assert_changesets_in_order [changeset6, changeset5, changeset4, changeset3, changeset2, changeset1]
+
+      get changesets_path(:order => "oldest")
+      assert_response :success
+      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4, changeset5, changeset6]
+
+      [
+        # lower time bound at the opening time of a changeset
+        ["2008-02-01T00:00:00Z", "2008-05-15T00:00:00Z", [changeset5, changeset4, changeset3, changeset2], [changeset5, changeset4, changeset3, changeset2]],
+        # lower time bound in the middle of a changeset
+        ["2008-02-01T12:00:00Z", "2008-05-15T00:00:00Z", [changeset5, changeset4, changeset3, changeset2], [changeset5, changeset4, changeset3]],
+        # lower time bound at the closing time of a changeset
+        ["2008-02-02T00:00:00Z", "2008-05-15T00:00:00Z", [changeset5, changeset4, changeset3, changeset2], [changeset5, changeset4, changeset3]],
+        # lower time bound after the closing time of a changeset
+        ["2008-02-02T00:00:01Z", "2008-05-15T00:00:00Z", [changeset5, changeset4, changeset3], [changeset5, changeset4, changeset3]],
+        # upper time bound in the middle of a changeset
+        ["2007-09-09T12:00:00Z", "2008-04-01T12:00:00Z", [changeset4, changeset3, changeset2, changeset1], [changeset4, changeset3, changeset2, changeset1]],
+        # empty range
+        ["2009-02-02T00:00:01Z", "2018-05-15T00:00:00Z", [], []]
+      ].each do |from, to, interval_changesets, point_changesets|
+        get changesets_path(:time => "#{from},#{to}")
+        assert_response :success
+        assert_changesets_in_order interval_changesets
+
+        get changesets_path(:from => from, :to => to)
+        assert_response :success
+        assert_changesets_in_order point_changesets
+
+        get changesets_path(:from => from, :to => to, :order => "oldest")
+        assert_response :success
+        assert_changesets_in_order point_changesets.reverse
+      end
+    end
+
+    ##
+    # test the query functionality of overlapping changesets with order and time parameters
+    def test_index_order_overlapping
+      user = create(:user)
+      changeset1 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 17, 0, 0), :closed_at => Time.utc(2015, 6, 4, 17, 0, 0))
+      changeset2 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 16, 0, 0), :closed_at => Time.utc(2015, 6, 4, 18, 0, 0))
+      changeset3 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 14, 0, 0), :closed_at => Time.utc(2015, 6, 4, 20, 0, 0))
+      changeset4 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 3, 23, 0, 0), :closed_at => Time.utc(2015, 6, 4, 23, 0, 0))
+      create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 2, 23, 0, 0), :closed_at => Time.utc(2015, 6, 3, 23, 0, 0))
+
+      get changesets_path(:time => "2015-06-04T00:00:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4]
+
+      get changesets_path(:from => "2015-06-04T00:00:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset1, changeset2, changeset3]
+
+      get changesets_path(:from => "2015-06-04T00:00:00Z", :order => "oldest")
+      assert_response :success
+      assert_changesets_in_order [changeset3, changeset2, changeset1]
+
+      get changesets_path(:time => "2015-06-04T16:00:00Z,2015-06-04T17:30:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4]
+
+      get changesets_path(:from => "2015-06-04T16:00:00Z", :to => "2015-06-04T17:30:00Z")
+      assert_response :success
+      assert_changesets_in_order [changeset1, changeset2]
+
+      get changesets_path(:from => "2015-06-04T16:00:00Z", :to => "2015-06-04T17:30:00Z", :order => "oldest")
+      assert_response :success
+      assert_changesets_in_order [changeset2, changeset1]
+    end
+
+    ##
+    # check that errors are returned if garbage is inserted
+    # into query strings
+    def test_index_invalid
+      ["abracadabra!",
+       "1,2,3,F",
+       ";drop table users;"].each do |bbox|
+        get changesets_path(:bbox => bbox)
+        assert_response :bad_request, "'#{bbox}' isn't a bbox"
+      end
+
+      ["now()",
+       "00-00-00",
+       ";drop table users;",
+       ",",
+       "-,-"].each do |time|
+        get changesets_path(:time => time)
+        assert_response :bad_request, "'#{time}' isn't a valid time range"
+      end
+
+      ["me",
+       "foobar",
+       "-1",
+       "0"].each do |uid|
+        get changesets_path(:user => uid)
+        assert_response :bad_request, "'#{uid}' isn't a valid user ID"
+      end
+
+      get changesets_path(:order => "oldest", :time => "2008-01-01T00:00Z,2018-01-01T00:00Z")
+      assert_response :bad_request, "cannot use order=oldest with time"
     end
 
     # -----------------------
@@ -2185,249 +2428,6 @@ module Api
       assert_select "osm>changeset[max_lon='0.3000000']", 1
       assert_select "osm>changeset[min_lat='0.1000000']", 1
       assert_select "osm>changeset[max_lat='0.3000000']", 1
-    end
-
-    ##
-    # test the query functionality of changesets
-    def test_query
-      private_user = create(:user, :data_public => false)
-      private_user_changeset = create(:changeset, :user => private_user)
-      private_user_closed_changeset = create(:changeset, :closed, :user => private_user)
-      user = create(:user)
-      changeset = create(:changeset, :user => user)
-      closed_changeset = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 1, 1, 0, 0, 0), :closed_at => Time.utc(2008, 1, 2, 0, 0, 0))
-      changeset2 = create(:changeset, :min_lat => (5 * GeoRecord::SCALE).round, :min_lon => (5 * GeoRecord::SCALE).round, :max_lat => (15 * GeoRecord::SCALE).round, :max_lon => (15 * GeoRecord::SCALE).round)
-      changeset3 = create(:changeset, :min_lat => (4.5 * GeoRecord::SCALE).round, :min_lon => (4.5 * GeoRecord::SCALE).round, :max_lat => (5 * GeoRecord::SCALE).round, :max_lon => (5 * GeoRecord::SCALE).round)
-
-      get changesets_path(:bbox => "-10,-10, 10, 10")
-      assert_response :success, "can't get changesets in bbox"
-      assert_changesets_in_order [changeset3, changeset2]
-
-      get changesets_path(:bbox => "4.5,4.5,4.6,4.6")
-      assert_response :success, "can't get changesets in bbox"
-      assert_changesets_in_order [changeset3]
-
-      # not found when looking for changesets of non-existing users
-      get changesets_path(:user => User.maximum(:id) + 1)
-      assert_response :not_found
-      assert_equal "text/plain", @response.media_type
-      get changesets_path(:display_name => " ")
-      assert_response :not_found
-      assert_equal "text/plain", @response.media_type
-
-      # can't get changesets of user 1 without authenticating
-      get changesets_path(:user => private_user.id)
-      assert_response :not_found, "shouldn't be able to get changesets by non-public user (ID)"
-      get changesets_path(:display_name => private_user.display_name)
-      assert_response :not_found, "shouldn't be able to get changesets by non-public user (name)"
-
-      # but this should work
-      auth_header = bearer_authorization_header private_user
-      get changesets_path(:user => private_user.id), :headers => auth_header
-      assert_response :success, "can't get changesets by user ID"
-      assert_changesets_in_order [private_user_changeset, private_user_closed_changeset]
-
-      get changesets_path(:display_name => private_user.display_name), :headers => auth_header
-      assert_response :success, "can't get changesets by user name"
-      assert_changesets_in_order [private_user_changeset, private_user_closed_changeset]
-
-      # test json endpoint
-      get changesets_path(:display_name => private_user.display_name), :headers => auth_header, :params => { :format => "json" }
-      assert_response :success, "can't get changesets by user name"
-
-      js = ActiveSupport::JSON.decode(@response.body)
-      assert_not_nil js
-
-      assert_equal Settings.api_version, js["version"]
-      assert_equal Settings.generator, js["generator"]
-      assert_equal 2, js["changesets"].count
-
-      # check that the correct error is given when we provide both UID and name
-      get changesets_path(:user => private_user.id,
-                          :display_name => private_user.display_name), :headers => auth_header
-      assert_response :bad_request, "should be a bad request to have both ID and name specified"
-
-      get changesets_path(:user => private_user.id, :open => true), :headers => auth_header
-      assert_response :success, "can't get changesets by user and open"
-      assert_changesets_in_order [private_user_changeset]
-
-      get changesets_path(:time => "2007-12-31"), :headers => auth_header
-      assert_response :success, "can't get changesets by time-since"
-      assert_changesets_in_order [changeset3, changeset2, changeset, private_user_changeset, private_user_closed_changeset, closed_changeset]
-
-      get changesets_path(:time => "2008-01-01T12:34Z"), :headers => auth_header
-      assert_response :success, "can't get changesets by time-since with hour"
-      assert_changesets_in_order [changeset3, changeset2, changeset, private_user_changeset, private_user_closed_changeset, closed_changeset]
-
-      get changesets_path(:time => "2007-12-31T23:59Z,2008-01-02T00:01Z"), :headers => auth_header
-      assert_response :success, "can't get changesets by time-range"
-      assert_changesets_in_order [closed_changeset]
-
-      get changesets_path(:open => "true"), :headers => auth_header
-      assert_response :success, "can't get changesets by open-ness"
-      assert_changesets_in_order [changeset3, changeset2, changeset, private_user_changeset]
-
-      get changesets_path(:closed => "true"), :headers => auth_header
-      assert_response :success, "can't get changesets by closed-ness"
-      assert_changesets_in_order [private_user_closed_changeset, closed_changeset]
-
-      get changesets_path(:closed => "true", :user => private_user.id), :headers => auth_header
-      assert_response :success, "can't get changesets by closed-ness and user"
-      assert_changesets_in_order [private_user_closed_changeset]
-
-      get changesets_path(:closed => "true", :user => user.id), :headers => auth_header
-      assert_response :success, "can't get changesets by closed-ness and user"
-      assert_changesets_in_order [closed_changeset]
-
-      get changesets_path(:changesets => "#{private_user_changeset.id},#{changeset.id},#{closed_changeset.id}"), :headers => auth_header
-      assert_response :success, "can't get changesets by id (as comma-separated string)"
-      assert_changesets_in_order [changeset, private_user_changeset, closed_changeset]
-
-      get changesets_path(:changesets => ""), :headers => auth_header
-      assert_response :bad_request, "should be a bad request since changesets is empty"
-    end
-
-    ##
-    # test the query functionality of changesets with the limit parameter
-    def test_query_limit
-      user = create(:user)
-      changeset1 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 1, 1, 0, 0, 0), :closed_at => Time.utc(2008, 1, 2, 0, 0, 0))
-      changeset2 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 2, 1, 0, 0, 0), :closed_at => Time.utc(2008, 2, 2, 0, 0, 0))
-      changeset3 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 3, 1, 0, 0, 0), :closed_at => Time.utc(2008, 3, 2, 0, 0, 0))
-      changeset4 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 4, 1, 0, 0, 0), :closed_at => Time.utc(2008, 4, 2, 0, 0, 0))
-      changeset5 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 5, 1, 0, 0, 0), :closed_at => Time.utc(2008, 5, 2, 0, 0, 0))
-
-      get changesets_path
-      assert_response :success
-      assert_changesets_in_order [changeset5, changeset4, changeset3, changeset2, changeset1]
-
-      get changesets_path(:limit => "3")
-      assert_response :success
-      assert_changesets_in_order [changeset5, changeset4, changeset3]
-
-      get changesets_path(:limit => "0")
-      assert_response :bad_request
-
-      get changesets_path(:limit => Settings.max_changeset_query_limit)
-      assert_response :success
-      assert_changesets_in_order [changeset5, changeset4, changeset3, changeset2, changeset1]
-
-      get changesets_path(:limit => Settings.max_changeset_query_limit + 1)
-      assert_response :bad_request
-    end
-
-    ##
-    # test the query functionality of sequential changesets with order and time parameters
-    def test_query_order
-      user = create(:user)
-      changeset1 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 1, 1, 0, 0, 0), :closed_at => Time.utc(2008, 1, 2, 0, 0, 0))
-      changeset2 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 2, 1, 0, 0, 0), :closed_at => Time.utc(2008, 2, 2, 0, 0, 0))
-      changeset3 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 3, 1, 0, 0, 0), :closed_at => Time.utc(2008, 3, 2, 0, 0, 0))
-      changeset4 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 4, 1, 0, 0, 0), :closed_at => Time.utc(2008, 4, 2, 0, 0, 0))
-      changeset5 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 5, 1, 0, 0, 0), :closed_at => Time.utc(2008, 5, 2, 0, 0, 0))
-      changeset6 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2008, 6, 1, 0, 0, 0), :closed_at => Time.utc(2008, 6, 2, 0, 0, 0))
-
-      get changesets_path
-      assert_response :success
-      assert_changesets_in_order [changeset6, changeset5, changeset4, changeset3, changeset2, changeset1]
-
-      get changesets_path(:order => "oldest")
-      assert_response :success
-      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4, changeset5, changeset6]
-
-      [
-        # lower time bound at the opening time of a changeset
-        ["2008-02-01T00:00:00Z", "2008-05-15T00:00:00Z", [changeset5, changeset4, changeset3, changeset2], [changeset5, changeset4, changeset3, changeset2]],
-        # lower time bound in the middle of a changeset
-        ["2008-02-01T12:00:00Z", "2008-05-15T00:00:00Z", [changeset5, changeset4, changeset3, changeset2], [changeset5, changeset4, changeset3]],
-        # lower time bound at the closing time of a changeset
-        ["2008-02-02T00:00:00Z", "2008-05-15T00:00:00Z", [changeset5, changeset4, changeset3, changeset2], [changeset5, changeset4, changeset3]],
-        # lower time bound after the closing time of a changeset
-        ["2008-02-02T00:00:01Z", "2008-05-15T00:00:00Z", [changeset5, changeset4, changeset3], [changeset5, changeset4, changeset3]],
-        # upper time bound in the middle of a changeset
-        ["2007-09-09T12:00:00Z", "2008-04-01T12:00:00Z", [changeset4, changeset3, changeset2, changeset1], [changeset4, changeset3, changeset2, changeset1]],
-        # empty range
-        ["2009-02-02T00:00:01Z", "2018-05-15T00:00:00Z", [], []]
-      ].each do |from, to, interval_changesets, point_changesets|
-        get changesets_path(:time => "#{from},#{to}")
-        assert_response :success
-        assert_changesets_in_order interval_changesets
-
-        get changesets_path(:from => from, :to => to)
-        assert_response :success
-        assert_changesets_in_order point_changesets
-
-        get changesets_path(:from => from, :to => to, :order => "oldest")
-        assert_response :success
-        assert_changesets_in_order point_changesets.reverse
-      end
-    end
-
-    ##
-    # test the query functionality of overlapping changesets with order and time parameters
-    def test_query_order_overlapping
-      user = create(:user)
-      changeset1 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 17, 0, 0), :closed_at => Time.utc(2015, 6, 4, 17, 0, 0))
-      changeset2 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 16, 0, 0), :closed_at => Time.utc(2015, 6, 4, 18, 0, 0))
-      changeset3 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 4, 14, 0, 0), :closed_at => Time.utc(2015, 6, 4, 20, 0, 0))
-      changeset4 = create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 3, 23, 0, 0), :closed_at => Time.utc(2015, 6, 4, 23, 0, 0))
-      create(:changeset, :closed, :user => user, :created_at => Time.utc(2015, 6, 2, 23, 0, 0), :closed_at => Time.utc(2015, 6, 3, 23, 0, 0))
-
-      get changesets_path(:time => "2015-06-04T00:00:00Z")
-      assert_response :success
-      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4]
-
-      get changesets_path(:from => "2015-06-04T00:00:00Z")
-      assert_response :success
-      assert_changesets_in_order [changeset1, changeset2, changeset3]
-
-      get changesets_path(:from => "2015-06-04T00:00:00Z", :order => "oldest")
-      assert_response :success
-      assert_changesets_in_order [changeset3, changeset2, changeset1]
-
-      get changesets_path(:time => "2015-06-04T16:00:00Z,2015-06-04T17:30:00Z")
-      assert_response :success
-      assert_changesets_in_order [changeset1, changeset2, changeset3, changeset4]
-
-      get changesets_path(:from => "2015-06-04T16:00:00Z", :to => "2015-06-04T17:30:00Z")
-      assert_response :success
-      assert_changesets_in_order [changeset1, changeset2]
-
-      get changesets_path(:from => "2015-06-04T16:00:00Z", :to => "2015-06-04T17:30:00Z", :order => "oldest")
-      assert_response :success
-      assert_changesets_in_order [changeset2, changeset1]
-    end
-
-    ##
-    # check that errors are returned if garbage is inserted
-    # into query strings
-    def test_query_invalid
-      ["abracadabra!",
-       "1,2,3,F",
-       ";drop table users;"].each do |bbox|
-        get changesets_path(:bbox => bbox)
-        assert_response :bad_request, "'#{bbox}' isn't a bbox"
-      end
-
-      ["now()",
-       "00-00-00",
-       ";drop table users;",
-       ",",
-       "-,-"].each do |time|
-        get changesets_path(:time => time)
-        assert_response :bad_request, "'#{time}' isn't a valid time range"
-      end
-
-      ["me",
-       "foobar",
-       "-1",
-       "0"].each do |uid|
-        get changesets_path(:user => uid)
-        assert_response :bad_request, "'#{uid}' isn't a valid user ID"
-      end
-
-      get changesets_path(:order => "oldest", :time => "2008-01-01T00:00Z,2018-01-01T00:00Z")
-      assert_response :bad_request, "cannot use order=oldest with time"
     end
 
     ##

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -1043,7 +1043,7 @@ module Api
       # that the bounding box will be newly-generated.
       with_controller(Api::ChangesetsController.new) do
         xml = "<osm><changeset/></osm>"
-        put changeset_create_path, :params => xml, :headers => auth_header
+        post api_changesets_path, :params => xml, :headers => auth_header
         assert_response :forbidden, "shouldn't be able to create changeset for modify test, as should get forbidden"
       end
 
@@ -1054,7 +1054,7 @@ module Api
       # that the bounding box will be newly-generated.
       changeset_id = with_controller(Api::ChangesetsController.new) do
         xml = "<osm><changeset/></osm>"
-        put changeset_create_path, :params => xml, :headers => auth_header
+        post api_changesets_path, :params => xml, :headers => auth_header
         assert_response :success, "couldn't create changeset for modify test"
         @response.body.to_i
       end


### PR DESCRIPTION
Like #5591 but for changesets, with the same modification for `create` action.