### PR TITLE
Update minimum ruby version to 3.2

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
           rubygems: 3.4.10
           bundler-cache: true
       - name: Create base branch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 env:
-  ruby: '3.1'
+  ruby: '3.2'
 jobs:
   rubocop:
     name: RuboCop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ['3.1', '3.2', '3.3', '3.4']
+        ruby: ['3.2', '3.3', '3.4']
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ require:
   - ./.rubocop/specific_action_names.rb
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     - 'vendor/**/*'
@@ -107,6 +107,10 @@ Style/MixinUsage:
   Exclude:
     - 'bin/setup'
     - 'bin/update'
+
+Style/RaiseArgs:
+  Exclude:
+    - 'lib/osm.rb'
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM ruby:3.2-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ gem "bootstrap_form", "~> 5.0"
 gem "cancancan"
 gem "config"
 gem "delayed_job_active_record"
-gem "dry-schema", "< 1.14.0" # see https://github.com/openstreetmap/openstreetmap-website/issues/5482
 gem "dry-validation"
 gem "frozen_record"
 gem "http_accept_language", "~> 2.1.1"
@@ -138,9 +137,6 @@ gem "image_processing"
 
 # Used to validate widths
 gem "unicode-display_width"
-
-# Lock some modules to old versions for ruby 3.1 support
-gem "zeitwerk", "< 2.7"
 
 # Gems useful for development
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,13 +231,13 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-schema (1.13.4)
+    dry-schema (1.14.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 1.0, >= 1.0.1)
-      dry-core (~> 1.0, < 2)
-      dry-initializer (~> 3.0)
-      dry-logic (>= 1.4, < 2)
-      dry-types (>= 1.7, < 2)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-logic (~> 1.5)
+      dry-types (~> 1.8)
       zeitwerk (~> 2.6)
     dry-types (1.8.2)
       bigdecimal (~> 3.0)
@@ -671,7 +671,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.2)
 
 PLATFORMS
   ruby
@@ -708,7 +708,6 @@ DEPENDENCIES
   doorkeeper
   doorkeeper-i18n
   doorkeeper-openid_connect
-  dry-schema (< 1.14.0)
   dry-validation
   erb_lint
   factory_bot_rails
@@ -782,7 +781,6 @@ DEPENDENCIES
   validates_email_format_of (>= 1.5.1)
   vendorer
   webmock
-  zeitwerk (< 2.7)
 
 BUNDLED WITH
    2.5.22

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ of packages required before you can get the various gems installed.
 
 ## Minimum requirements
 
-* Ruby 3.1+
+* Ruby 3.2+
 * PostgreSQL 13+
 * Bundler (see note below about [developer Ruby setup](#rbenv))
 * Javascript Runtime

--- a/app/helpers/svg_helper.rb
+++ b/app/helpers/svg_helper.rb
@@ -5,12 +5,12 @@ module SvgHelper
     tag.svg path_tag, :width => 16, :height => 16
   end
 
-  def previous_page_svg_tag(**options)
-    adjacent_page_svg_tag(dir == "rtl" ? 1 : -1, **options)
+  def previous_page_svg_tag(**)
+    adjacent_page_svg_tag(dir == "rtl" ? 1 : -1, **)
   end
 
-  def next_page_svg_tag(**options)
-    adjacent_page_svg_tag(dir == "rtl" ? -1 : 1, **options)
+  def next_page_svg_tag(**)
+    adjacent_page_svg_tag(dir == "rtl" ? -1 : 1, **)
   end
 
   def key_svg_tag(**options)

--- a/bin/setup
+++ b/bin/setup
@@ -4,8 +4,8 @@ require "fileutils"
 APP_ROOT = File.expand_path("..", __dir__)
 APP_NAME = "openstreetmap".freeze
 
-def system!(*args)
-  system(*args, :exception => true)
+def system!(*)
+  system(*, :exception => true)
 end
 
 FileUtils.chdir APP_ROOT do

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -506,10 +506,10 @@ module OSM
   end
 
   # Parse a float, raising a specified exception on failure
-  def self.parse_float(str, klass, *args)
+  def self.parse_float(str, klass, *)
     Float(str)
   rescue StandardError
-    raise klass.new(*args)
+    raise klass.new(*)
   end
 
   # Construct a random token of a given length


### PR DESCRIPTION
We are now running ruby 3.4 in production so there's no longer any need to keep 3.1 support and dropping it enables us to stop holding back several gems and opens the path to a rails 8 upgrade.