### PR TITLE
API changeset resources - show path

### DIFF
--- a/app/views/changesets/index.atom.builder
+++ b/app/views/changesets/index.atom.builder
@@ -18,7 +18,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
   @changesets.each do |changeset|
     feed.entry(changeset, :updated => changeset.closed_at, :id => changeset_url(changeset.id, :only_path => false)) do |entry|
       entry.link :rel => "alternate",
-                 :href => changeset_show_url(changeset, :only_path => false),
+                 :href => api_changeset_url(changeset, :only_path => false),
                  :type => "application/osm+xml"
       entry.link :rel => "alternate",
                  :href => changeset_download_url(changeset, :only_path => false),

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -105,7 +105,7 @@
 </div>
 
 <div class='secondary-actions'>
-  <%= link_to(t(".changesetxml"), :controller => "api/changesets", :action => "show") %>
+  <%= link_to t(".changesetxml"), api_changeset_path(@changeset) %>
   &middot;
   <%= link_to(t(".osmchangexml"), :controller => "api/changesets", :action => "download") %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,10 +19,8 @@ OpenStreetMap::Application.routes.draw do
 
     post "changeset/:id/upload" => "changesets#upload", :as => :changeset_upload, :id => /\d+/
     get "changeset/:id/download" => "changesets#download", :as => :changeset_download, :id => /\d+/
-    get "changeset/:id" => "changesets#show", :as => :changeset_show, :id => /\d+/
     post "changeset/:id/subscribe" => "changesets#subscribe", :as => :api_changeset_subscribe, :id => /\d+/
     post "changeset/:id/unsubscribe" => "changesets#unsubscribe", :as => :api_changeset_unsubscribe, :id => /\d+/
-    put "changeset/:id" => "changesets#update", :id => /\d+/
     put "changeset/:id/close" => "changesets#close", :as => :changeset_close, :id => /\d+/
     post "changeset/:id/comment" => "changeset_comments#create", :as => :changeset_comment, :id => /\d+/
     post "changeset/comment/:id/hide" => "changeset_comments#destroy", :as => :changeset_comment_hide, :id => /\d+/
@@ -31,6 +29,7 @@ OpenStreetMap::Application.routes.draw do
 
   namespace :api, :path => "api/0.6" do
     resources :changesets, :only => [:index, :create]
+    resources :changesets, :path => "changeset", :id => /\d+/, :only => [:show, :update]
     put "changeset/create" => "changesets#create", :as => nil
 
     resources :changeset_comments, :only => :index

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -1064,7 +1064,7 @@ module Api
 
       # now download the changeset to check its bounding box
       with_controller(Api::ChangesetsController.new) do
-        get changeset_show_path(changeset_id)
+        get api_changeset_path(changeset_id)
         assert_response :success, "can't re-read changeset for modify test"
         assert_select "osm>changeset", 1, "Changeset element doesn't exist in #{@response.body}"
         assert_select "osm>changeset[id='#{changeset_id}']", 1, "Changeset id=#{changeset_id} doesn't exist in #{@response.body}"


### PR DESCRIPTION
Continues #5713 by declaring changesets resources with `show` and `update` actions.