### PR TITLE
Extend user list to allow searching by name or email

### DIFF
--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -13,10 +13,11 @@ module Users
     ##
     # display a list of users matching specified criteria
     def show
-      @params = params.permit(:status, :ip, :before, :after)
+      @params = params.permit(:status, :username, :ip, :before, :after)
 
       users = User.all
       users = users.where(:status => @params[:status]) if @params[:status].present?
+      users = users.where("LOWER(email) = LOWER(?) OR LOWER(NORMALIZE(display_name, NFKC)) = LOWER(NORMALIZE(?, NFKC))", @params[:username], @params[:username]) if @params[:username].present?
       users = users.where("creation_address <<= ?", @params[:ip]) if @params[:ip].present?
 
       @users_count = users.limit(501).count

--- a/app/views/users/lists/show.html.erb
+++ b/app/views/users/lists/show.html.erb
@@ -18,6 +18,13 @@
                      :class => "form-select" %>
     </div>
     <div class="mb-3 col-md">
+      <%= text_field_tag :username,
+                         params[:username],
+                         :placeholder => t(".name_or_email"),
+                         :autocomplete => "on",
+                         :class => "form-control" %>
+    </div>
+    <div class="mb-3 col-md">
       <%= text_field_tag :ip,
                          params[:ip],
                          :placeholder => t(".ip_address"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2897,6 +2897,7 @@ en:
           confirmed: Confirmed
           suspended: Suspended
           deleted: Deleted
+        name_or_email: Name or Email
         ip_address: IP Address
         search: Search
       page:

--- a/test/controllers/users/lists_controller_test.rb
+++ b/test/controllers/users/lists_controller_test.rb
@@ -28,11 +28,13 @@ module Users
       moderator_user = create(:moderator_user)
       administrator_user = create(:administrator_user)
       suspended_user = create(:user, :suspended)
+      name_user = create(:user, :display_name => "Test User")
+      email_user = create(:user, :email => "test@example.com")
       ip_user = create(:user, :creation_address => "1.2.3.4")
 
-      # There are now 7 users - the five above, plus two extra "granters" for the
+      # There are now 9 users - the 7 above, plus two extra "granters" for the
       # moderator_user and administrator_user
-      assert_equal 7, User.count
+      assert_equal 9, User.count
 
       # Shouldn't work when not logged in
       get users_list_path
@@ -57,7 +59,7 @@ module Users
       get users_list_path
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 7
+      assert_select "table#user_list tbody tr", :count => 9
 
       # Should be able to limit by status
       get users_list_path, :params => { :status => "suspended" }
@@ -65,6 +67,38 @@ module Users
       assert_template :show
       assert_select "table#user_list tbody tr", :count => 1 do
         assert_select "a[href='#{user_path(suspended_user)}']", :count => 1
+      end
+
+      # Should be able to limit by name
+      get users_list_path, :params => { :username => "Test User" }
+      assert_response :success
+      assert_template :show
+      assert_select "table#user_list tbody tr", :count => 1 do
+        assert_select "a[href='#{user_path(name_user)}']", :count => 1
+      end
+
+      # Should be able to limit by name ignoring case
+      get users_list_path, :params => { :username => "test user" }
+      assert_response :success
+      assert_template :show
+      assert_select "table#user_list tbody tr", :count => 1 do
+        assert_select "a[href='#{user_path(name_user)}']", :count => 1
+      end
+
+      # Should be able to limit by email
+      get users_list_path, :params => { :username => "test@example.com" }
+      assert_response :success
+      assert_template :show
+      assert_select "table#user_list tbody tr", :count => 1 do
+        assert_select "a[href='#{user_path(email_user)}']", :count => 1
+      end
+
+      # Should be able to limit by email ignoring case
+      get users_list_path, :params => { :username => "TEST@example.com" }
+      assert_response :success
+      assert_template :show
+      assert_select "table#user_list tbody tr", :count => 1 do
+        assert_select "a[href='#{user_path(email_user)}']", :count => 1
       end
 
       # Should be able to limit by IP address

--- a/test/controllers/users/lists_controller_test.rb
+++ b/test/controllers/users/lists_controller_test.rb
@@ -27,8 +27,8 @@ module Users
       user = create(:user)
       moderator_user = create(:moderator_user)
       administrator_user = create(:administrator_user)
-      _suspended_user = create(:user, :suspended)
-      _ip_user = create(:user, :creation_address => "1.2.3.4")
+      suspended_user = create(:user, :suspended)
+      ip_user = create(:user, :creation_address => "1.2.3.4")
 
       # There are now 7 users - the five above, plus two extra "granters" for the
       # moderator_user and administrator_user
@@ -63,13 +63,17 @@ module Users
       get users_list_path, :params => { :status => "suspended" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1
+      assert_select "table#user_list tbody tr", :count => 1 do
+        assert_select "a[href='#{user_path(suspended_user)}']", :count => 1
+      end
 
       # Should be able to limit by IP address
       get users_list_path, :params => { :ip => "1.2.3.4" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1
+      assert_select "table#user_list tbody tr", :count => 1 do
+        assert_select "a[href='#{user_path(ip_user)}']", :count => 1
+      end
     end
 
     def test_show_paginated


### PR DESCRIPTION
Extends the user list interface used by administrators to allow searching by name or email which will be one less thing I have to in database directly.