### PR TITLE
Append one table per route leg

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -155,22 +155,25 @@ OSM.Directions = function (map) {
           I18n.t("javascripts.directions.descend") + ": " + formatHeight(route.descend) + ".");
       }
 
-      const turnByTurnTable = $("<table class='table table-hover table-sm mb-3'>")
-        .append($("<tbody>"));
+      const turnByTurnTables = route.legs.map(steps =>
+        $("<table class='table table-hover table-sm mb-3'>")
+          .append($("<tbody>").append(steps.map(stepToRow)))
+      );
 
-      // Add each row
-      route.steps.forEach(function (step) {
+      function stepToRow(step) {
         const [ll, direction, instruction, dist, lineseg] = step;
 
         const row = $("<tr class='turn'/>");
-        row.append("<td class='border-0'><div class='direction i" + direction + "'/></td> ");
-        row.append("<td>" + instruction);
-        row.append("<td class='distance text-body-secondary text-end'>" + getDistText(dist));
+        row.append(
+          `<td class='border-0'><div class='direction i${direction}'/></td>`,
+          `<td>${instruction}</td>`,
+          `<td class='distance text-body-secondary text-end'>${getDistText(dist)}</td>`
+        );
 
         row.on("click", function () {
           popup
             .setLatLng(ll)
-            .setContent("<p>" + instruction + "</p>")
+            .setContent(`<p>${instruction}</p>`)
             .openOn(map);
         });
 
@@ -182,8 +185,8 @@ OSM.Directions = function (map) {
           map.removeLayer(highlight);
         });
 
-        turnByTurnTable.append(row);
-      });
+        return row;
+      }
 
       const blob = new Blob([JSON.stringify(polyline.toGeoJSON())], { type: "application/json" });
       URL.revokeObjectURL(downloadURL);
@@ -203,7 +206,7 @@ OSM.Directions = function (map) {
         .append(
           heading,
           distanceText,
-          turnByTurnTable,
+          turnByTurnTables,
           downloadline,
           creditline
         );

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -138,6 +138,13 @@ OSM.Directions = function (map) {
         map.fitBounds(polyline.getBounds().pad(0.05));
       }
 
+      const directionsCloseButton = $("<button type='button' class='btn-close'>")
+        .attr("aria-label", I18n.t("javascripts.close"));
+      const heading = $("<div class='d-flex'>").append(
+        $("<h2 class='flex-grow-1 text-break'>")
+          .text(I18n.t("javascripts.directions.directions")),
+        $("<div>").append(directionsCloseButton));
+
       const distanceText = $("<p>").append(
         I18n.t("javascripts.directions.distance") + ": " + formatDistance(route.distance) + ". " +
         I18n.t("javascripts.directions.time") + ": " + formatTime(route.time) + ".");
@@ -150,19 +157,6 @@ OSM.Directions = function (map) {
 
       const turnByTurnTable = $("<table class='table table-hover table-sm mb-3'>")
         .append($("<tbody>"));
-      const directionsCloseButton = $("<button type='button' class='btn-close'>")
-        .attr("aria-label", I18n.t("javascripts.close"));
-
-      $("#sidebar_content")
-        .empty()
-        .append(
-          $("<div class='d-flex'>").append(
-            $("<h2 class='flex-grow-1 text-break'>")
-              .text(I18n.t("javascripts.directions.directions")),
-            $("<div>").append(directionsCloseButton)),
-          distanceText,
-          turnByTurnTable
-        );
 
       // Add each row
       route.steps.forEach(function (step) {
@@ -194,16 +188,25 @@ OSM.Directions = function (map) {
       const blob = new Blob([JSON.stringify(polyline.toGeoJSON())], { type: "application/json" });
       URL.revokeObjectURL(downloadURL);
       downloadURL = URL.createObjectURL(blob);
-
-      $("#sidebar_content").append(`<p class="text-center"><a href="${downloadURL}" download="${
+      const downloadline = $(`<p class="text-center"><a href="${downloadURL}" download="${
         I18n.t("javascripts.directions.filename")
       }">${
         I18n.t("javascripts.directions.download")
       }</a></p>`);
 
-      $("#sidebar_content").append("<p class=\"text-center\">" +
-        I18n.t("javascripts.directions.instructions.courtesy", { link: chosenEngine.creditline }) +
-        "</p>");
+      const creditline = $(`<p class="text-center">${
+        I18n.t("javascripts.directions.instructions.courtesy", { link: chosenEngine.creditline })
+      }</p>`);
+
+      $("#sidebar_content")
+        .empty()
+        .append(
+          heading,
+          distanceText,
+          turnByTurnTable,
+          downloadline,
+          creditline
+        );
 
       directionsCloseButton.on("click", function () {
         map.removeLayer(polyline);
@@ -215,7 +218,7 @@ OSM.Directions = function (map) {
     }).catch(function () {
       map.removeLayer(polyline);
       if (reportErrors) {
-        $("#sidebar_content").html("<div class=\"alert alert-danger\">" + I18n.t("javascripts.directions.errors.no_route") + "</div>");
+        $("#sidebar_content").html(`<div class="alert alert-danger">${I18n.t("javascripts.directions.errors.no_route")}</div>`);
       }
     }).finally(function () {
       controller = null;

--- a/app/assets/javascripts/index/directions/fossgis_osrm.js
+++ b/app/assets/javascripts/index/directions/fossgis_osrm.js
@@ -88,7 +88,7 @@
         }
       }
 
-      const steps = route.legs.flatMap(
+      const legs = route.legs.map(
         leg => leg.steps.map(function (step, idx) {
           const maneuver_id = getManeuverId(step.maneuver);
 
@@ -137,13 +137,19 @@
           } else {
             instText += I18n.t(template + "_without_exit", { name: name });
           }
-          return [[step.maneuver.location[1], step.maneuver.location[0]], ICON_MAP[maneuver_id], instText, step.distance, step_geometry];
+          return [
+            [step.maneuver.location[1], step.maneuver.location[0]],
+            ICON_MAP[maneuver_id],
+            instText,
+            step.distance,
+            step_geometry
+          ];
         })
       );
 
       return {
-        line: steps.flatMap(step => step[4]),
-        steps,
+        line: legs.flat().flatMap(step => step[4]),
+        legs,
         distance: route.distance,
         time: route.duration
       };

--- a/app/assets/javascripts/index/directions/fossgis_valhalla.js
+++ b/app/assets/javascripts/index/directions/fossgis_valhalla.js
@@ -44,7 +44,7 @@
 
     function _processDirections(tripLegs) {
       let line = [];
-      let steps = [];
+      const legs = [];
       let distance = 0;
       let time = 0;
 
@@ -68,14 +68,14 @@
         });
 
         line = line.concat(legLine);
-        steps = steps.concat(legSteps);
+        legs.push(legSteps);
         distance += leg.summary.length;
         time += leg.summary.time;
       }
 
       return {
-        line: line,
-        steps: steps,
+        line,
+        legs,
         distance: distance * 1000,
         time: time
       };

--- a/test/system/directions_test.rb
+++ b/test/system/directions_test.rb
@@ -39,10 +39,10 @@ class DirectionsSystemTest < ApplicationSystemTestCase
       const time = distance * 30;
       return Promise.resolve({
         line: points,
-        steps: [
+        legs: [[
           [points[0],  8, "<b>1.</b> #{start_instruction}", distance, points],
           [points[1], 14, "<b>2.</b> #{finish_instruction}", 0, [points[1]]]
-        ],
+        ]],
         distance,
         time
       });


### PR DESCRIPTION
### Description
I modified the directions engine interface to return the steps grouped into legs and create a turn instruction table for each leg. This change isn't visible to the user, as there isn't a third endpoint yet.
### How has this been tested?
So much browser-based that I initially forgot to update the testing stub