### PR TITLE
API changeset download resource

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -10,7 +10,7 @@ class ApiAbility
       can [:read, :feed, :search], Note
       can :create, Note unless user
 
-      can [:read, :download], Changeset
+      can :read, Changeset
       can :read, ChangesetComment
       can :read, Tracepoint
       can :read, User

--- a/app/controllers/api/changesets/downloads_controller.rb
+++ b/app/controllers/api/changesets/downloads_controller.rb
@@ -1,0 +1,61 @@
+module Api
+  module Changesets
+    class DownloadsController < ApiController
+      authorize_resource :changeset
+
+      before_action :set_request_formats
+
+      ##
+      # download the changeset as an osmChange document.
+      #
+      # to make it easier to revert diffs it would be better if the osmChange
+      # format were reversible, i.e: contained both old and new versions of
+      # modified elements. but it doesn't at the moment...
+      #
+      # this method cannot order the database changes fully (i.e: timestamp and
+      # version number may be too coarse) so the resulting diff may not apply
+      # to a different database. however since changesets are not atomic this
+      # behaviour cannot be guaranteed anyway and is the result of a design
+      # choice.
+      def show
+        changeset = Changeset.find(params[:changeset_id])
+
+        # get all the elements in the changeset which haven't been redacted
+        # and stick them in a big array.
+        elements = [changeset.old_nodes.unredacted,
+                    changeset.old_ways.unredacted,
+                    changeset.old_relations.unredacted].flatten
+
+        # sort the elements by timestamp and version number, as this is the
+        # almost sensible ordering available. this would be much nicer if
+        # global (SVN-style) versioning were used - then that would be
+        # unambiguous.
+        elements.sort_by! { |e| [e.timestamp, e.version] }
+
+        # generate an output element for each operation. note: we avoid looking
+        # at the history because it is simpler - but it would be more correct to
+        # check these assertions.
+        @created = []
+        @modified = []
+        @deleted = []
+
+        elements.each do |elt|
+          if elt.version == 1
+            # first version, so it must be newly-created.
+            @created << elt
+          elsif elt.visible
+            # must be a modify
+            @modified << elt
+          else
+            # if the element isn't visible then it must have been deleted
+            @deleted << elt
+          end
+        end
+
+        respond_to do |format|
+          format.xml
+        end
+      end
+    end
+  end
+end

--- a/app/views/api/changesets/downloads/show.xml.builder
+++ b/app/views/api/changesets/downloads/show.xml.builder
@@ -3,17 +3,17 @@ xml.instruct! :xml, :version => "1.0"
 xml.osmChange(OSM::API.new.xml_root_attributes) do |osm|
   @created.each do |elt|
     osm.create do |create|
-      create << render(elt)
+      create << render(:partial => "api/#{elt.to_partial_path}", :object => elt)
     end
   end
   @modified.each do |elt|
     osm.modify do |modify|
-      modify << render(elt)
+      modify << render(:partial => "api/#{elt.to_partial_path}", :object => elt)
     end
   end
   @deleted.each do |elt|
     osm.delete do |delete|
-      delete << render(elt)
+      delete << render(:partial => "api/#{elt.to_partial_path}", :object => elt)
     end
   end
 end

--- a/app/views/changesets/index.atom.builder
+++ b/app/views/changesets/index.atom.builder
@@ -21,7 +21,7 @@ atom_feed(:language => I18n.locale, :schema_date => 2009,
                  :href => api_changeset_url(changeset, :only_path => false),
                  :type => "application/osm+xml"
       entry.link :rel => "alternate",
-                 :href => changeset_download_url(changeset, :only_path => false),
+                 :href => api_changeset_download_url(changeset, :only_path => false),
                  :type => "application/osmChange+xml"
 
       if !changeset.tags.empty? && changeset.tags.key?("comment")

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -107,7 +107,7 @@
 <div class='secondary-actions'>
   <%= link_to t(".changesetxml"), api_changeset_path(@changeset) %>
   &middot;
-  <%= link_to(t(".osmchangexml"), :controller => "api/changesets", :action => "download") %>
+  <%= link_to t(".osmchangexml"), api_changeset_download_path(@changeset) %>
 </div>
 
 <% if @next_by_user || @prev_by_user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,6 @@ OpenStreetMap::Application.routes.draw do
     get "permissions" => "permissions#show"
 
     post "changeset/:id/upload" => "changesets#upload", :as => :changeset_upload, :id => /\d+/
-    get "changeset/:id/download" => "changesets#download", :as => :changeset_download, :id => /\d+/
     post "changeset/:id/subscribe" => "changesets#subscribe", :as => :api_changeset_subscribe, :id => /\d+/
     post "changeset/:id/unsubscribe" => "changesets#unsubscribe", :as => :api_changeset_unsubscribe, :id => /\d+/
     put "changeset/:id/close" => "changesets#close", :as => :changeset_close, :id => /\d+/
@@ -29,7 +28,9 @@ OpenStreetMap::Application.routes.draw do
 
   namespace :api, :path => "api/0.6" do
     resources :changesets, :only => [:index, :create]
-    resources :changesets, :path => "changeset", :id => /\d+/, :only => [:show, :update]
+    resources :changesets, :path => "changeset", :id => /\d+/, :only => [:show, :update] do
+      resource :download, :module => :changesets, :only => :show
+    end
     put "changeset/create" => "changesets#create", :as => nil
 
     resources :changeset_comments, :only => :index

--- a/test/controllers/api/changesets/downloads_controller_test.rb
+++ b/test/controllers/api/changesets/downloads_controller_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+module Api
+  module Changesets
+    class DownloadsControllerTest < ActionDispatch::IntegrationTest
+      ##
+      # test all routes which lead to this controller
+      def test_routes
+        assert_routing(
+          { :path => "/api/0.6/changeset/1/download", :method => :get },
+          { :controller => "api/changesets/downloads", :action => "show", :changeset_id => "1" }
+        )
+      end
+
+      def test_show
+        changeset = create(:changeset)
+        node = create(:node, :with_history, :version => 1, :changeset => changeset)
+        tag = create(:old_node_tag, :old_node => node.old_nodes.find_by(:version => 1))
+        node2 = create(:node, :with_history, :version => 1, :changeset => changeset)
+        _node3 = create(:node, :with_history, :deleted, :version => 1, :changeset => changeset)
+        _relation = create(:relation, :with_history, :version => 1, :changeset => changeset)
+        _relation2 = create(:relation, :with_history, :deleted, :version => 1, :changeset => changeset)
+
+        get api_changeset_download_path(changeset)
+
+        assert_response :success
+        # FIXME: needs more assert_select tests
+        assert_select "osmChange[version='#{Settings.api_version}'][generator='#{Settings.generator}']" do
+          assert_select "create", :count => 5
+          assert_select "create>node[id='#{node.id}'][visible='#{node.visible?}'][version='#{node.version}']" do
+            assert_select "tag[k='#{tag.k}'][v='#{tag.v}']"
+          end
+          assert_select "create>node[id='#{node2.id}']"
+        end
+      end
+
+      def test_show_should_sort_by_timestamp
+        changeset = create(:changeset)
+        node1 = create(:old_node, :version => 2, :timestamp => "2020-02-01", :changeset => changeset)
+        node0 = create(:old_node, :version => 2, :timestamp => "2020-01-01", :changeset => changeset)
+
+        get api_changeset_download_path(changeset)
+
+        assert_response :success
+        assert_dom "modify", :count => 2 do |modify|
+          assert_dom modify[0], ">node", :count => 1 do |node|
+            assert_dom node, ">@id", node0.node_id.to_s
+          end
+          assert_dom modify[1], ">node", :count => 1 do |node|
+            assert_dom node, ">@id", node1.node_id.to_s
+          end
+        end
+      end
+
+      def test_show_should_sort_by_version
+        changeset = create(:changeset)
+        node1 = create(:old_node, :version => 3, :timestamp => "2020-01-01", :changeset => changeset)
+        node0 = create(:old_node, :version => 2, :timestamp => "2020-01-01", :changeset => changeset)
+
+        get api_changeset_download_path(changeset)
+
+        assert_response :success
+        assert_dom "modify", :count => 2 do |modify|
+          assert_dom modify[0], ">node", :count => 1 do |node|
+            assert_dom node, ">@id", node0.node_id.to_s
+          end
+          assert_dom modify[1], ">node", :count => 1 do |node|
+            assert_dom node, ">@id", node1.node_id.to_s
+          end
+        end
+      end
+
+      ##
+      # check that the changeset download for a changeset with a redacted
+      # element in it doesn't contain that element.
+      def test_show_redacted
+        changeset = create(:changeset)
+        node = create(:node, :with_history, :version => 2, :changeset => changeset)
+        node_v1 = node.old_nodes.find_by(:version => 1)
+        node_v1.redact!(create(:redaction))
+
+        get api_changeset_download_path(changeset)
+        assert_response :success
+
+        assert_select "osmChange", 1
+        # this changeset contains the node in versions 1 & 2, but 1 should
+        # be hidden.
+        assert_select "osmChange node[id='#{node.id}']", 1
+        assert_select "osmChange node[id='#{node.id}'][version='1']", 0
+      end
+    end
+  end
+end

--- a/test/controllers/api/changesets/downloads_controller_test.rb
+++ b/test/controllers/api/changesets/downloads_controller_test.rb
@@ -12,25 +12,193 @@ module Api
         )
       end
 
-      def test_show
+      def test_show_empty
         changeset = create(:changeset)
-        node = create(:node, :with_history, :version => 1, :changeset => changeset)
-        tag = create(:old_node_tag, :old_node => node.old_nodes.find_by(:version => 1))
-        node2 = create(:node, :with_history, :version => 1, :changeset => changeset)
-        _node3 = create(:node, :with_history, :deleted, :version => 1, :changeset => changeset)
-        _relation = create(:relation, :with_history, :version => 1, :changeset => changeset)
-        _relation2 = create(:relation, :with_history, :deleted, :version => 1, :changeset => changeset)
 
         get api_changeset_download_path(changeset)
 
         assert_response :success
-        # FIXME: needs more assert_select tests
-        assert_select "osmChange[version='#{Settings.api_version}'][generator='#{Settings.generator}']" do
-          assert_select "create", :count => 5
-          assert_select "create>node[id='#{node.id}'][visible='#{node.visible?}'][version='#{node.version}']" do
-            assert_select "tag[k='#{tag.k}'][v='#{tag.v}']"
+        assert_dom "osmChange[version='#{Settings.api_version}'][generator='#{Settings.generator}']" do
+          assert_dom "create", 0
+          assert_dom "modify", 0
+          assert_dom "delete", 0
+        end
+      end
+
+      def test_show_created_elements
+        changeset = create(:changeset)
+        old_node1 = create(:old_node, :changeset => changeset, :version => 1, :latitude => (60.12345 * OldNode::SCALE).to_i, :longitude => (30.54321 * OldNode::SCALE).to_i)
+        create(:old_node_tag, :old_node => old_node1, :k => "highway", :v => "crossing")
+        create(:old_node_tag, :old_node => old_node1, :k => "crossing", :v => "marked")
+        old_node2 = create(:old_node, :changeset => changeset, :version => 1, :latitude => (60.23456 * OldNode::SCALE).to_i, :longitude => (30.65432 * OldNode::SCALE).to_i)
+        create(:old_node_tag, :old_node => old_node2, :k => "highway", :v => "traffic_signals")
+        old_way = create(:old_way, :changeset => changeset, :version => 1)
+        create(:old_way_tag, :old_way => old_way, :k => "highway", :v => "secondary")
+        create(:old_way_tag, :old_way => old_way, :k => "name", :v => "Some Street")
+        create(:old_way_node, :old_way => old_way, :node => old_node1.current_node, :sequence_id => 1)
+        create(:old_way_node, :old_way => old_way, :node => old_node2.current_node, :sequence_id => 2)
+        old_relation = create(:old_relation, :changeset => changeset, :version => 1)
+        create(:old_relation_tag, :old_relation => old_relation, :k => "type", :v => "restriction")
+        create(:old_relation_member, :old_relation => old_relation, :member => old_way.current_way, :member_role => "from", :sequence_id => 1)
+        create(:old_relation_member, :old_relation => old_relation, :member => old_node2.current_node, :member_role => "via", :sequence_id => 2)
+
+        get api_changeset_download_path(changeset)
+
+        assert_response :success
+        assert_dom "osmChange[version='#{Settings.api_version}'][generator='#{Settings.generator}']" do
+          assert_dom "create", 4 do
+            assert_dom "node", 2
+            assert_dom "node[id='#{old_node1.node_id}']", 1 do
+              assert_dom "> @version", "1"
+              assert_dom "> @visible", "true"
+              assert_dom "tag", 2
+              assert_dom "tag[k='highway'][v='crossing']"
+              assert_dom "tag[k='crossing'][v='marked']"
+              assert_dom "> @lat", "60.1234500"
+              assert_dom "> @lon", "30.5432100"
+            end
+            assert_dom "node[id='#{old_node2.node_id}']", 1 do
+              assert_dom "> @version", "1"
+              assert_dom "> @visible", "true"
+              assert_dom "tag", 1
+              assert_dom "tag[k='highway'][v='traffic_signals']"
+              assert_dom "> @lat", "60.2345600"
+              assert_dom "> @lon", "30.6543200"
+            end
+            assert_dom "way", 1
+            assert_dom "way[id='#{old_way.way_id}']", 1 do
+              assert_dom "> @version", "1"
+              assert_dom "> @visible", "true"
+              assert_dom "tag", 2
+              assert_dom "tag[k='highway'][v='secondary']"
+              assert_dom "tag[k='name'][v='Some Street']"
+              assert_dom "nd", 2 do |dom_nds|
+                assert_dom dom_nds[0], "> @ref", old_node1.node_id.to_s
+                assert_dom dom_nds[1], "> @ref", old_node2.node_id.to_s
+              end
+            end
+            assert_dom "relation", 1
+            assert_dom "relation[id='#{old_relation.relation_id}']", 1 do
+              assert_dom "> @version", "1"
+              assert_dom "> @visible", "true"
+              assert_dom "tag", 1
+              assert_dom "tag[k='type'][v='restriction']"
+              assert_dom "member", 2 do |dom_members|
+                assert_dom dom_members[0], "> @type", "way"
+                assert_dom dom_members[0], "> @ref", old_way.way_id.to_s
+                assert_dom dom_members[0], "> @role", "from"
+                assert_dom dom_members[1], "> @type", "node"
+                assert_dom dom_members[1], "> @ref", old_node2.node_id.to_s
+                assert_dom dom_members[1], "> @role", "via"
+              end
+            end
           end
-          assert_select "create>node[id='#{node2.id}']"
+        end
+      end
+
+      def test_show_edited_elements
+        changeset = create(:changeset)
+        old_node1 = create(:old_node, :changeset => changeset, :version => 2, :latitude => (60.12345 * OldNode::SCALE).to_i, :longitude => (30.54321 * OldNode::SCALE).to_i)
+        create(:old_node_tag, :old_node => old_node1, :k => "highway", :v => "crossing")
+        create(:old_node_tag, :old_node => old_node1, :k => "crossing", :v => "marked")
+        old_node2 = create(:old_node, :changeset => changeset, :version => 2, :latitude => (60.23456 * OldNode::SCALE).to_i, :longitude => (30.65432 * OldNode::SCALE).to_i)
+        create(:old_node_tag, :old_node => old_node2, :k => "highway", :v => "traffic_signals")
+        old_way = create(:old_way, :changeset => changeset, :version => 2)
+        create(:old_way_tag, :old_way => old_way, :k => "highway", :v => "secondary")
+        create(:old_way_tag, :old_way => old_way, :k => "name", :v => "Some Street")
+        create(:old_way_node, :old_way => old_way, :node => old_node1.current_node, :sequence_id => 1)
+        create(:old_way_node, :old_way => old_way, :node => old_node2.current_node, :sequence_id => 2)
+        old_relation = create(:old_relation, :changeset => changeset, :version => 2)
+        create(:old_relation_tag, :old_relation => old_relation, :k => "type", :v => "restriction")
+        create(:old_relation_member, :old_relation => old_relation, :member => old_way.current_way, :member_role => "from", :sequence_id => 1)
+        create(:old_relation_member, :old_relation => old_relation, :member => old_node2.current_node, :member_role => "via", :sequence_id => 2)
+
+        get api_changeset_download_path(changeset)
+
+        assert_response :success
+        assert_dom "osmChange[version='#{Settings.api_version}'][generator='#{Settings.generator}']" do
+          assert_dom "modify", 4 do
+            assert_dom "node", 2
+            assert_dom "node[id='#{old_node1.node_id}']", 1 do
+              assert_dom "> @version", "2"
+              assert_dom "> @visible", "true"
+              assert_dom "tag", 2
+              assert_dom "tag[k='highway'][v='crossing']"
+              assert_dom "tag[k='crossing'][v='marked']"
+              assert_dom "> @lat", "60.1234500"
+              assert_dom "> @lon", "30.5432100"
+            end
+            assert_dom "node[id='#{old_node2.node_id}']", 1 do
+              assert_dom "> @version", "2"
+              assert_dom "> @visible", "true"
+              assert_dom "tag", 1
+              assert_dom "tag[k='highway'][v='traffic_signals']"
+              assert_dom "> @lat", "60.2345600"
+              assert_dom "> @lon", "30.6543200"
+            end
+            assert_dom "way", 1
+            assert_dom "way[id='#{old_way.way_id}']", 1 do
+              assert_dom "> @version", "2"
+              assert_dom "> @visible", "true"
+              assert_dom "tag", 2
+              assert_dom "tag[k='highway'][v='secondary']"
+              assert_dom "tag[k='name'][v='Some Street']"
+              assert_dom "nd", 2 do |dom_nds|
+                assert_dom dom_nds[0], "> @ref", old_node1.node_id.to_s
+                assert_dom dom_nds[1], "> @ref", old_node2.node_id.to_s
+              end
+            end
+            assert_dom "relation", 1
+            assert_dom "relation[id='#{old_relation.relation_id}']", 1 do
+              assert_dom "> @version", "2"
+              assert_dom "> @visible", "true"
+              assert_dom "tag", 1
+              assert_dom "tag[k='type'][v='restriction']"
+              assert_dom "member", 2 do |dom_members|
+                assert_dom dom_members[0], "> @type", "way"
+                assert_dom dom_members[0], "> @ref", old_way.way_id.to_s
+                assert_dom dom_members[0], "> @role", "from"
+                assert_dom dom_members[1], "> @type", "node"
+                assert_dom dom_members[1], "> @ref", old_node2.node_id.to_s
+                assert_dom dom_members[1], "> @role", "via"
+              end
+            end
+          end
+        end
+      end
+
+      def test_show_deleted_elements
+        changeset = create(:changeset)
+        old_node1 = create(:old_node, :changeset => changeset, :version => 3, :visible => false)
+        old_node2 = create(:old_node, :changeset => changeset, :version => 3, :visible => false)
+        old_way = create(:old_way, :changeset => changeset, :version => 3, :visible => false)
+        old_relation = create(:old_relation, :changeset => changeset, :version => 3, :visible => false)
+
+        get api_changeset_download_path(changeset)
+
+        assert_response :success
+        assert_dom "osmChange[version='#{Settings.api_version}'][generator='#{Settings.generator}']" do
+          assert_dom "delete", 4 do
+            assert_dom "node", 2
+            assert_dom "node[id='#{old_node1.node_id}']", 1 do
+              assert_dom "> @version", "3"
+              assert_dom "> @visible", "false"
+            end
+            assert_dom "node[id='#{old_node2.node_id}']", 1 do
+              assert_dom "> @version", "3"
+              assert_dom "> @visible", "false"
+            end
+            assert_dom "way", 1
+            assert_dom "way[id='#{old_way.way_id}']", 1 do
+              assert_dom "> @version", "3"
+              assert_dom "> @visible", "false"
+            end
+            assert_dom "relation", 1
+            assert_dom "relation[id='#{old_relation.relation_id}']", 1 do
+              assert_dom "> @version", "3"
+              assert_dom "> @visible", "false"
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Continues #5717.

Creates `download` resources on changesets instead of `download` actions.