### PR TITLE
Register startinglocation listener as a named function

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -273,13 +273,15 @@ OSM.Directions = function (map) {
     map.fire("startinglocation", { latlng: [lat, lng] });
   }
 
+  function startingLocationListener({ latlng }) {
+    if (endpoints[0].value) return;
+    endpoints[0].setValue(latlng.join(", "));
+  }
+
   map.on("locationfound", ({ latlng: { lat, lng } }) =>
     lastLocation = [lat, lng]
   ).on("locateactivate", () => {
-    map.once("startinglocation", ({ latlng }) => {
-      if (endpoints[0].value) return;
-      endpoints[0].setValue(latlng.join(", "));
-    });
+    map.once("startinglocation", startingLocationListener);
   });
 
   const page = {};


### PR DESCRIPTION
The listener is not going to be run once if it's constructed inside the `locateactivate` listener. It's going to be run however many times `locateactivate` happens.

Actually neither this custom event nor `locateactivate` is required, but that's for the next pull request.