### PR TITLE
Use location instead of window.location and document.location

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -16,7 +16,7 @@ I18n.default_locale = <%= I18n.default_locale.to_json %>;
 I18n.fallbacks = true;
 
 window.onload = function () {
-  const args = Object.fromEntries(new URLSearchParams(window.location.search));
+  const args = Object.fromEntries(new URLSearchParams(location.search));
 
   const tileOptions = {
     mapnik: {

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -311,7 +311,7 @@ $(document).ready(function () {
     };
 
     function addObject(type, id, version, center) {
-      const hashParams = OSM.parseHash(window.location.hash);
+      const hashParams = OSM.parseHash(location.hash);
       map.addObject({ type: type, id: parseInt(id, 10), version: version && parseInt(version, 10) }, function (bounds) {
         if (!hashParams.center && bounds.isValid() &&
             (center || !map.getBounds().contains(bounds))) {
@@ -363,7 +363,7 @@ $(document).ready(function () {
     "/account/home": OSM.Home(map)
   });
 
-  if (OSM.preferred_editor === "remote" && document.location.pathname === "/edit") {
+  if (OSM.preferred_editor === "remote" && location.pathname === "/edit") {
     remoteEditHandler(map.getBounds(), params.object);
     OSM.router.setCurrentPath("/");
   }

--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -12,7 +12,7 @@ OSM.Changeset = function (map) {
     const changesetData = content.find("[data-changeset]").data("changeset");
     changesetData.type = "changeset";
 
-    const hashParams = OSM.parseHash(window.location.hash);
+    const hashParams = OSM.parseHash(location.hash);
     initialize();
     map.addObject(changesetData, function (bounds) {
       if (!hashParams.center && bounds.isValid()) {
@@ -45,7 +45,7 @@ OSM.Changeset = function (map) {
         });
       })
       .then(() => {
-        OSM.loadSidebarContent(window.location.pathname, page.load);
+        OSM.loadSidebarContent(location.pathname, page.load);
       })
       .catch(error => {
         content.find("button[data-method][data-url]").prop("disabled", false);

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -344,7 +344,7 @@ OSM.Directions = function (map) {
 OSM.Directions.engines = [];
 
 OSM.Directions.addEngine = function (engine, supportsHTTPS) {
-  if (document.location.protocol === "http:" || supportsHTTPS) {
+  if (location.protocol === "http:" || supportsHTTPS) {
     engine.id = engine.provider + "_" + engine.mode;
     OSM.Directions.engines.push(engine);
   }

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -58,7 +58,7 @@ OSM.History = function (map) {
   function update() {
     const data = new URLSearchParams();
 
-    if (window.location.pathname === "/history") {
+    if (location.pathname === "/history") {
       data.set("bbox", map.getBounds().wrap().toBBoxString());
       const feedLink = $("link[type=\"application/atom+xml\"]"),
             feedHref = feedLink.attr("href").split("?")[0];
@@ -67,7 +67,7 @@ OSM.History = function (map) {
 
     data.set("list", "1");
 
-    fetch(window.location.pathname + "?" + data)
+    fetch(location.pathname + "?" + data)
       .then(response => response.text())
       .then(function (html) {
         displayFirstChangesets(html);
@@ -137,7 +137,7 @@ OSM.History = function (map) {
 
     updateBounds();
 
-    if (window.location.pathname !== "/history") {
+    if (location.pathname !== "/history") {
       const bounds = group.getBounds();
       if (bounds.isValid()) map.fitBounds(bounds);
     }
@@ -150,7 +150,7 @@ OSM.History = function (map) {
   page.load = function () {
     map.addLayer(group);
 
-    if (window.location.pathname === "/history") {
+    if (location.pathname === "/history") {
       map.on("moveend", update);
     }
 

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -79,7 +79,7 @@ OSM.Note = function (map) {
     const data = $(".details").data();
 
     if (data) {
-      const hashParams = OSM.parseHash(window.location.hash);
+      const hashParams = OSM.parseHash(location.hash);
       map.addObject({
         type: "note",
         id: parseInt(id, 10),

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -326,7 +326,7 @@ OSM.Query = function (map) {
     const params = new URLSearchParams(path.substring(path.indexOf("?"))),
           latlng = L.latLng(params.get("lat"), params.get("lon"));
 
-    if (!window.location.hash && !noCentre && !map.getBounds().contains(latlng)) {
+    if (!location.hash && !noCentre && !map.getBounds().contains(latlng)) {
       OSM.router.withoutMoveListener(function () {
         map.setView(latlng, 15);
       });

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -155,7 +155,7 @@ L.OSM.Map = L.Map.extend({
       [params.mlat, params.mlon] = OSM.cropLocation(marker.getLatLng(), this.getZoom());
     }
 
-    let url = window.location.protocol + "//" + OSM.SERVER_URL + "/";
+    let url = location.protocol + "//" + OSM.SERVER_URL + "/";
     const query = new URLSearchParams(params),
           hash = OSM.formatHash(this);
 
@@ -176,7 +176,7 @@ L.OSM.Map = L.Map.extend({
           // and drops the last 4 bits of the full 64 bit Morton code.
           c1 = interlace(x >>> 17, y >>> 17),
           c2 = interlace((x >>> 2) & 0x7fff, (y >>> 2) & 0x7fff);
-    let str = window.location.protocol + "//" + window.location.hostname.replace(/^www\.openstreetmap\.org/i, "osm.org") + "/go/";
+    let str = location.protocol + "//" + location.hostname.replace(/^www\.openstreetmap\.org/i, "osm.org") + "/go/";
 
     for (let i = 0; i < Math.ceil((zoom + 8) / 3.0) && i < 5; ++i) {
       const digit = (c1 >> (24 - (6 * i))) & 0x3f;

--- a/app/assets/javascripts/login.js
+++ b/app/assets/javascripts/login.js
@@ -1,6 +1,6 @@
 $(document).ready(function () {
   // Preserve location hash in referer
-  if (window.location.hash) {
-    $("#referer").val($("#referer").val() + window.location.hash);
+  if (location.hash) {
+    $("#referer").val($("#referer").val() + location.hash);
   }
 });

--- a/app/assets/javascripts/matomo.js
+++ b/app/assets/javascripts/matomo.js
@@ -1,6 +1,6 @@
 if (OSM.MATOMO) {
   $(document).ready(function () {
-    const base = document.location.protocol + "//" + OSM.MATOMO.location + "/";
+    const base = location.protocol + "//" + OSM.MATOMO.location + "/";
     let matomoTracker;
 
     const matomoLoader = $.ajax({

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -57,7 +57,7 @@ OSM = {
   },
 
   params: function (search) {
-    const query = search || window.location.search;
+    const query = search || location.search;
     return Object.fromEntries(new URLSearchParams(query));
   },
 

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -93,7 +93,7 @@ OSM.Router = function (map, rts) {
     }
   };
 
-  let currentPath = window.location.pathname.replace(/(.)\/$/, "$1") + window.location.search,
+  let currentPath = location.pathname.replace(/(.)\/$/, "$1") + location.search,
       currentRoute = routes.recognize(currentPath),
       currentHash = location.hash || OSM.formatHash(map);
 
@@ -101,7 +101,7 @@ OSM.Router = function (map, rts) {
 
   function updateSecondaryNav() {
     $("header nav.secondary > ul > li > a").each(function () {
-      const active = $(this).attr("href") === window.location.pathname;
+      const active = $(this).attr("href") === location.pathname;
 
       $(this)
         .toggleClass("text-secondary", !active)
@@ -111,7 +111,7 @@ OSM.Router = function (map, rts) {
 
   $(window).on("popstate", function (e) {
     if (!e.originalEvent.state) return; // Is it a real popstate event or just a hash change?
-    const path = window.location.pathname + window.location.search,
+    const path = location.pathname + location.search,
           route = routes.recognize(path);
     if (path === currentPath) return;
     currentRoute.run("unload", null, route === currentRoute);
@@ -142,7 +142,7 @@ OSM.Router = function (map, rts) {
   };
 
   router.stateChange = function (state) {
-    const url = state.center ? OSM.formatHash(state) : window.location;
+    const url = state.center ? OSM.formatHash(state) : location;
     window.history.replaceState(state, document.title, url);
   };
 

--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -27,7 +27,7 @@ $(document).ready(function () {
   }
 
   function geoSuccess(position) {
-    window.location = "/edit" + OSM.formatHash({
+    location = "/edit" + OSM.formatHash({
       zoom: 17,
       lat: position.coords.latitude,
       lon: position.coords.longitude
@@ -35,6 +35,6 @@ $(document).ready(function () {
   }
 
   function manualEdit() {
-    window.location = "/?edit_help=1";
+    location = "/?edit_help=1";
   }
 });

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -33,7 +33,7 @@ describe("OSM", function () {
     beforeEach(function () {
       delete OSM.home;
       delete OSM.location;
-      document.location.hash = "";
+      location.hash = "";
       document.cookie = "_osm_location=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 
       // Test with another cookie set.
@@ -83,7 +83,7 @@ describe("OSM", function () {
     });
 
     it("parses lat/lon/zoom from the hash", function () {
-      document.location.hash = "#map=16/57.6247/-3.6845";
+      location.hash = "#map=16/57.6247/-3.6845";
       const params = OSM.mapParams("?");
       expect(params).to.have.property("lat", 57.6247);
       expect(params).to.have.property("lon", -3.6845);
@@ -133,7 +133,7 @@ describe("OSM", function () {
       params = OSM.mapParams("?");
       expect(params).to.have.property("layers", "C");
 
-      document.location.hash = "#map=5/57.6247/-3.6845&layers=M";
+      location.hash = "#map=5/57.6247/-3.6845&layers=M";
       params = OSM.mapParams("?");
       expect(params).to.have.property("layers", "M");
     });


### PR DESCRIPTION
Currently we have in use:
- `location`
- `window.location`
- `document.location`

The only one that's missing is `window.document.location`. These are [mostly the same](https://stackoverflow.com/questions/2430936/whats-the-difference-between-window-location-and-document-location).

We can just use `location` everywhere because it's shorter.