### PR TITLE
Set the environment variable in teaspoon example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ bundle exec rails test:all
 You can run javascript tests with:
 
 ```
-bundle exec teaspoon
+RAILS_ENV=test bundle exec teaspoon
 ```
 
 You can view test coverage statistics by browsing the `coverage` directory.


### PR DESCRIPTION
See #5672.

It didn't take me long to forget how to run teaspoon, go to the docs, copy the command and see it fail.
