### PR TITLE
Added WebP as new output format for map download

### DIFF
--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -159,6 +159,7 @@ L.OSM.share = function (options) {
           .attr("class", "form-select w-auto")
           .append($("<option>").val("png").text("PNG").prop("selected", true))
           .append($("<option>").val("jpeg").text("JPEG"))
+          .append($("<option>").val("webp").text("WEBP"))
           .append($("<option>").val("svg").text("SVG"))
           .append($("<option>").val("pdf").text("PDF"))));
 


### PR DESCRIPTION
We're supporting WebP format for map downloads now. The change is a left over from https://github.com/openstreetmap/openstreetmap-website/pull/5607#issuecomment-2660979843

