### PR TITLE
Remove obsolete element from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   web:
     build:


### PR DESCRIPTION
### Description

The 'version' top-level Docker Compose element is deprecated since April 2024: https://github.com/docker/docs/commit/007ac90154c05f34045f607631b93a95c81d4807#diff-948ba582fe1c0dd6e8a5446ed8d8831e8ff65d0df7552f0eaa22b9ff7945b3e3R7

### How has this been tested?

On my Mac using the latest Docker Desktop app. I got no warnings and it still builds successfully!
