### PR TITLE
Removes optional using first comments records

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -92,22 +92,9 @@ class Note < ApplicationRecord
     closed_at + DEFAULT_FRESHLY_CLOSED_LIMIT
   end
 
-  # Return the note's description, derived from the first comment
+  # Return the note's description
   def description
-    if user_ip.nil? && user_id.nil?
-      all_comments.first.body if all_comments.first&.event == "opened"
-    else
-      RichText.new("text", super)
-    end
-  end
-
-  # Return the note's author object, derived from the first comment
-  def author
-    if user_ip.nil? && user_id.nil?
-      all_comments.first.author if all_comments.first&.event == "opened"
-    else
-      super
-    end
+    RichText.new("text", super)
   end
 
   private

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -338,7 +338,7 @@ module Api
       second_user = create(:user)
       third_user = create(:user)
 
-      note_with_comments_by_users = create(:note) do |note|
+      note_with_comments_by_users = create(:note, :author => first_user) do |note|
         create(:note_comment, :note => note, :author => first_user)
         create(:note_comment, :note => note, :author => second_user)
       end

--- a/test/factories/note_comments.rb
+++ b/test/factories/note_comments.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :note_comment do
     sequence(:body) { |n| "This is note comment #{n}" }
     visible { true }
-    event { "opened" }
+    event { "commented" }
     note
   end
 end

--- a/test/factories/notes.rb
+++ b/test/factories/notes.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :note do
     latitude { 1 * GeoRecord::SCALE }
     longitude { 1 * GeoRecord::SCALE }
-    # tile { QuadTile.tile_for_point(1,1) }
+    description { "Default note's description" }
 
     trait :closed do
       transient do
@@ -23,7 +23,8 @@ FactoryBot.define do
       end
 
       after(:create) do |note, evaluator|
-        create_list(:note_comment, evaluator.comments_count, :note => note)
+        create(:note_comment, :event => "opened", :note => note)
+        create_list(:note_comment, evaluator.comments_count - 1, :note => note)
       end
     end
   end

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -12,8 +12,8 @@ class IssueTest < ActiveSupport::TestCase
   def test_reported_user
     create(:language, :code => "en")
     user = create(:user)
-    note = create(:note_comment, :author => create(:user)).note
-    anonymous_note = create(:note_comment, :author => nil).note
+    note = create(:note, :author => create(:user))
+    anonymous_note = create(:note, :author => nil)
     diary_entry = create(:diary_entry)
     diary_comment = create(:diary_comment, :diary_entry => diary_entry)
 

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -48,20 +48,29 @@ class NoteTest < ActiveSupport::TestCase
   end
 
   def test_description
-    comment = create(:note_comment)
-    assert_equal comment.body, comment.note.description
+    note = create(:note)
+    assert_equal "Default note's description", note.description
 
-    user = create(:user)
-    comment = create(:note_comment, :author => user)
-    assert_equal comment.body, comment.note.description
+    note = create(:note, :description => "Test description #1")
+    assert_equal "Test description #1", note.description
+
+    comment = create(:note_comment)
+    assert_equal "Default note's description", comment.note.description
+
+    comment = create(:note_comment, :note => build(:note, :description => "Test description #2"))
+    assert_equal "Test description #2", comment.note.description
   end
 
   def test_author
+    user = create(:user)
+
+    note = create(:note, :author => user)
+    assert_equal user, note.author
+
     comment = create(:note_comment)
     assert_nil comment.note.author
 
-    user = create(:user)
-    comment = create(:note_comment, :author => user)
+    comment = create(:note_comment, :author => user, :note => build(:note, :author => user))
     assert_equal user, comment.note.author
   end
 

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -56,20 +56,20 @@ class IndexTest < ApplicationSystemTestCase
 
   test "can navigate from hidden note to visible note" do
     sign_in_as(create(:moderator_user))
-    hidden_note = create(:note, :status => "hidden")
-    create(:note_comment, :note => hidden_note, :body => "this-is-a-hidden-note")
+    hidden_note = create(:note, :status => "hidden", :description => "Hidden Note Description")
+    create(:note_comment, :note => hidden_note, :body => "this-is-a-hidden-note", :event => "opened")
     position = (1.003 * GeoRecord::SCALE).to_i
-    visible_note = create(:note, :latitude => position, :longitude => position)
-    create(:note_comment, :note => visible_note, :body => "this-is-a-visible-note")
+    visible_note = create(:note, :latitude => position, :longitude => position, :description => "Visible Note Description")
+    create(:note_comment, :note => visible_note, :body => "this-is-a-visible-note", :event => "opened")
 
     visit root_path(:anchor => "map=15/1/1") # view place of hidden note in case it is not rendered during note_path(hidden_note)
     visit note_path(hidden_note)
     find(".leaflet-control.control-layers .control-button").click
     find("#map-ui .overlay-layers .form-check-label", :text => "Map Notes").click
     visible_note_marker = find(".leaflet-marker-icon[title=this-is-a-visible-note]")
-    assert_selector "#sidebar", :text => "this-is-a-hidden-note"
+    assert_selector "#sidebar", :text => "Hidden Note Description"
 
     visible_note_marker.click
-    assert_selector "#sidebar", :text => "this-is-a-visible-note"
+    assert_selector "#sidebar", :text => "Visible Note Description"
   end
 end

--- a/test/system/note_layer_test.rb
+++ b/test/system/note_layer_test.rb
@@ -4,7 +4,7 @@ class NoteLayerTest < ApplicationSystemTestCase
   test "note marker should have description as a title" do
     position = (1.1 * GeoRecord::SCALE).to_i
     create(:note, :latitude => position, :longitude => position) do |note|
-      create(:note_comment, :note => note, :body => "Note description")
+      create(:note_comment, :note => note, :body => "Note description", :event => "opened")
     end
 
     visit root_path(:anchor => "map=18/1.1/1.1&layers=N")
@@ -16,8 +16,8 @@ class NoteLayerTest < ApplicationSystemTestCase
   test "note marker should not have a title if the note has no visible description" do
     position = (1.1 * GeoRecord::SCALE).to_i
     create(:note, :latitude => position, :longitude => position) do |note|
-      create(:note_comment, :note => note, :body => "Note description is hidden", :visible => false)
-      create(:note_comment, :note => note, :body => "Note comment visible", :event => "commented")
+      create(:note_comment, :note => note, :body => "Note description is hidden", :event => "opened", :visible => false)
+      create(:note_comment, :note => note, :body => "Note comment visible")
     end
 
     visit root_path(:anchor => "map=18/1.1/1.1&layers=N")
@@ -29,7 +29,7 @@ class NoteLayerTest < ApplicationSystemTestCase
   test "note marker should not have a title if the note has no visible description and comments" do
     position = (1.1 * GeoRecord::SCALE).to_i
     create(:note, :latitude => position, :longitude => position) do |note|
-      create(:note_comment, :note => note, :body => "Note description is hidden", :visible => false)
+      create(:note_comment, :note => note, :body => "Note description is hidden", :event => "opened", :visible => false)
     end
 
     visit root_path(:anchor => "map=18/1.1/1.1&layers=N")

--- a/test/system/report_note_test.rb
+++ b/test/system/report_note_test.rb
@@ -31,7 +31,8 @@ class ReportNoteTest < ApplicationSystemTestCase
   end
 
   def test_can_report_notes_with_author
-    note = create(:note_comment, :author => create(:user)).note
+    user = create(:user)
+    note = create(:note_comment, :author => user, :note => build(:note, :author => user)).note
     sign_in_as(create(:user))
     visit note_path(note)
 


### PR DESCRIPTION
### Description

PR removes optional using of note's first comments records for retrieving note's description and author in Note model file. 

Also, adds note's initializing when created using `note_comments` factory by initializing note's `description`, `user_ip` and `user_id` from note's comment (this is used only when notes are created by `create(:note_comment, ...)`) in unit tests.

### How has this been tested?

Automated unit tests and manual testing on previously created set of notes (with special cases).