### PR TITLE
I18n fallback fixes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,7 +21,6 @@
 
   I18n.default_locale = OSM.DEFAULT_LOCALE;
   I18n.locale = locale;
-  I18n.fallbacks = true;
 
   // '-' are replaced with '_' in https://github.com/eemeli/make-plural/tree/main/packages/plurals
   const pluralizer = plurals[locale.replace(/\W+/g, "_")] || plurals[locale.split("-")[0]];

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -29,8 +29,6 @@ I18n::Backend::Simple.prepend(OpenStreetMap::I18n::NormaliseLocales)
 I18n::Backend::Simple.include(I18n::Backend::PluralizationFallback)
 I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
 
-I18n.fallbacks.map("no" => "nb")
-
 I18n.enforce_available_locales = false
 
 if Rails.env.test?

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -21,19 +21,10 @@ module OpenStreetMap
         super
       end
     end
-
-    module ValidateLocales
-      def default_fallbacks
-        super.select do |locale|
-          ::I18n.available_locales.include?(locale)
-        end
-      end
-    end
   end
 end
 
 I18n::Backend::Simple.prepend(OpenStreetMap::I18n::NormaliseLocales)
-I18n::JS::FallbackLocales.prepend(OpenStreetMap::I18n::ValidateLocales)
 
 I18n::Backend::Simple.include(I18n::Backend::PluralizationFallback)
 I18n::Backend::Simple.include(I18n::Backend::Fallbacks)


### PR DESCRIPTION
A few fixes and cleanups for I18n fallback:

* Disable client side fallback in javascript that isn't doing anything as we only load one locale - note that in the embed view the story is different as we load all locales there.
* Drop an old monkey patch that no longer seems to be needed.
* Fix the Norwegian fallback to work - currently it is being overwritten after it is added.