### PR TITLE
Write directions sidebar header using .erb template

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -37,7 +37,7 @@ $(function () {
 
     map.setSidebarOverlaid(false);
 
-    $("#sidebar_loader").show().addClass("delayed-fade-in");
+    $("#sidebar_loader").prop("hidden", false).addClass("delayed-fade-in");
 
     // Prevent caching the XHR response as a full-page URL
     // https://github.com/openstreetmap/openstreetmap-website/issues/5663
@@ -53,7 +53,7 @@ $(function () {
     fetch(content_path, { headers: { "accept": "text/html", "x-requested-with": "XMLHttpRequest" } })
       .then(response => {
         $("#flash").empty();
-        $("#sidebar_loader").removeClass("delayed-fade-in").hide();
+        $("#sidebar_loader").removeClass("delayed-fade-in").prop("hidden", true);
 
         const title = response.headers.get("X-Page-Title");
         if (title) document.title = decodeURIComponent(title);

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -14,23 +14,16 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     autoPan: true
   });
 
-  endpoint.enable = function () {
+  endpoint.enableListeners = function () {
     endpoint.marker.on("drag dragend", markerDragListener);
     input.on("keydown", inputKeydownListener);
     input.on("change", inputChangeListener);
   };
 
-  endpoint.disable = function () {
+  endpoint.disableListeners = function () {
     endpoint.marker.off("drag dragend", markerDragListener);
     input.off("keydown", inputKeydownListener);
     input.off("change", inputChangeListener);
-
-    if (endpoint.geocodeRequest) endpoint.geocodeRequest.abort();
-    delete endpoint.geocodeRequest;
-    removeLatLng();
-    delete endpoint.value;
-    input.val("");
-    map.removeLayer(endpoint.marker);
   };
 
   function markerDragListener(e) {
@@ -89,6 +82,15 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, iconUrl, dragCallback, ch
     } else if (endpoint.value) {
       getGeocode();
     }
+  };
+
+  endpoint.clearValue = function () {
+    if (endpoint.geocodeRequest) endpoint.geocodeRequest.abort();
+    delete endpoint.geocodeRequest;
+    removeLatLng();
+    delete endpoint.value;
+    input.val("");
+    map.removeLayer(endpoint.marker);
   };
 
   endpoint.swapCachedReverseGeocodes = function (otherEndpoint) {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -284,9 +284,21 @@ OSM.Directions = function (map) {
     map.once("startinglocation", startingLocationListener);
   });
 
+  function initializeFromParams() {
+    const params = new URLSearchParams(location.search),
+          route = (params.get("route") || "").split(";");
+
+    if (params.has("engine")) setEngine(params.get("engine"));
+
+    endpoints[0].setValue(params.get("from") || route[0] || lastLocation.join(", "));
+    endpoints[1].setValue(params.get("to") || route[1] || "");
+  }
+
   const page = {};
 
   page.pushstate = page.popstate = function () {
+    initializeFromParams();
+
     $(".search_form").hide();
     $(".directions_form").show();
 
@@ -310,14 +322,6 @@ OSM.Directions = function (map) {
 
     endpoints[0].enableListeners();
     endpoints[1].enableListeners();
-
-    const params = new URLSearchParams(location.search),
-          route = (params.get("route") || "").split(";");
-
-    if (params.has("engine")) setEngine(params.get("engine"));
-
-    endpoints[0].setValue(params.get("from") || route[0] || lastLocation.join(", "));
-    endpoints[1].setValue(params.get("to") || route[1] || "");
 
     map.setSidebarOverlaid(!endpoints[0].latlng || !endpoints[1].latlng);
   };

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -308,8 +308,8 @@ OSM.Directions = function (map) {
 
     map.on("locationfound", sendstartinglocation);
 
-    endpoints[0].enable();
-    endpoints[1].enable();
+    endpoints[0].enableListeners();
+    endpoints[1].enableListeners();
 
     const params = new URLSearchParams(location.search),
           route = (params.get("route") || "").split(";");
@@ -332,8 +332,11 @@ OSM.Directions = function (map) {
     $("#map").off("dragend dragover drop");
     map.off("locationfound", sendstartinglocation);
 
-    endpoints[0].disable();
-    endpoints[1].disable();
+    endpoints[0].disableListeners();
+    endpoints[1].disableListeners();
+
+    endpoints[0].clearValue();
+    endpoints[1].clearValue();
 
     map
       .removeLayer(popup)

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -294,14 +294,7 @@ OSM.Directions = function (map) {
     endpoints[1].setValue(params.get("to") || route[1] || "");
   }
 
-  const page = {};
-
-  page.pushstate = page.popstate = function () {
-    initializeFromParams();
-
-    $(".search_form").hide();
-    $(".directions_form").show();
-
+  function enableListeners() {
     $("#map").on("dragend dragover", function (e) {
       e.preventDefault();
     });
@@ -322,6 +315,17 @@ OSM.Directions = function (map) {
 
     endpoints[0].enableListeners();
     endpoints[1].enableListeners();
+  }
+
+  const page = {};
+
+  page.pushstate = page.popstate = function () {
+    initializeFromParams();
+
+    $(".search_form").hide();
+    $(".directions_form").show();
+
+    enableListeners();
 
     map.setSidebarOverlaid(!endpoints[0].latlng || !endpoints[1].latlng);
   };

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -336,10 +336,6 @@ body.small-nav {
   #sidebar {
     float: left;
     width: $sidebarWidth;
-
-    #sidebar_loader {
-      display: none;
-    }
   }
 
   .overlay-sidebar #sidebar {
@@ -355,6 +351,7 @@ body.small-nav {
       display: block;
     }
 
+    #sidebar_loader,
     #sidebar_content {
       display: none;
     }

--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -1,1 +1,5 @@
 <% content_for(:content_class) { "overlay-sidebar" } %>
+
+<%= render "sidebar_header", :title => t("javascripts.directions.directions") %>
+
+<div id="directions_content"></div>

--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:content_class) { "overlay-sidebar" } %>
 
-<%= render "sidebar_header", :title => t("javascripts.directions.directions") %>
+<%= render "sidebar_header", :title => t(".title") %>
 
 <div id="directions_content"></div>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -18,7 +18,7 @@
 
     <div id="browse_status"></div>
 
-    <div id="sidebar_loader" class="my-3 text-center loader">
+    <div id="sidebar_loader" class="my-3 text-center loader" hidden>
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1509,6 +1509,9 @@ en:
     results:
       no_results: "No results found"
       more_results: "More results"
+  directions:
+    search:
+      title: Directions
   issues:
     index:
       title: Issues
@@ -3245,7 +3248,6 @@ en:
     directions:
       ascend: "Ascend"
       descend: "Descend"
-      directions: "Directions"
       distance: "Distance"
       distance_m: "%{distance}m"
       distance_km: "%{distance}km"


### PR DESCRIPTION
Other sidebar pages have at least a heading and some placeholder in their `.html.erb` template, for example [geocoder search](https://github.com/openstreetmap/openstreetmap-website/blob/84aa7f455ae58b4b051368e35dbc43f780b3aa0f/app/views/geocoder/search.html.erb). Directions search is the exception, it's template is [essentially empty](https://github.com/openstreetmap/openstreetmap-website/blob/84aa7f455ae58b4b051368e35dbc43f780b3aa0f/app/views/directions/search.html.erb). Instead everything is written by `directions.js`.

Here I'm moving the directions heading to `.html.erb`.

This is a prerequisite for:
- Also putting routing icons into the erb template. This allows to remove the routing sprite and its css where the icons are referenced by numbers instead of names, and remove the dark mode css invert for the icons because inline icons use current color. See #5753.
- Sort out #4825. The heading also contains the close button. Every other page has its close button in its erb template along with the heading.