### PR TITLE
Use browser default color for visited changeset links in history

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -635,6 +635,10 @@ tr.turn {
       position: relative;
       z-index: 2; /* needs to be higher than Bootstrap's stretched link ::after z-index */
     }
+
+    a.changeset_id:visited {
+      color: revert !important;
+    }
   }
 
   .changeset_more .loader {


### PR DESCRIPTION
Typically we don't color visited links differently, but I think it would make sense for *history* pages. Most of the changeset links you'll see there are not going to be visited, but you'd like to be able to see those few that were visited.

Looks like there's no Bootstrap class for visited links. I'm reverting to the browser default color for visited changeset links in css.

![image](https://github.com/user-attachments/assets/40f4a40f-5e51-4754-b674-4e21c2fbafaf)
![image](https://github.com/user-attachments/assets/063eaf2d-53a1-4feb-bd06-b99de444d1d1)

Fixes #604.