### PR TITLE
Increase contrast of comments/changes counters in history

### DIFF
--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -12,7 +12,7 @@
         #<%= changeset.id %>
       </a>
     </div>
-    <div class="col-auto d-flex flex-column justify-content-end align-items-end text-secondary">
+    <div class="col-auto d-flex flex-column justify-content-end align-items-end text-body-secondary">
       <%= tag.div :class => ["d-flex align-items-baseline gap-1", { "opacity-50" => changeset.comments.empty? }],
                   :title => t(".comments", :count => changeset.comments.length) do %>
         <%= changeset.comments.length %>


### PR DESCRIPTION
Addresses https://github.com/openstreetmap/openstreetmap-website/issues/5329#issuecomment-2704353857, although it's not a dark mode issue and not a recent change issue. Contrast was low all along.

Before:
![image](https://github.com/user-attachments/assets/83dfdd3a-4c57-450c-9e37-1a75543380b2)
![image](https://github.com/user-attachments/assets/732ff5db-e9ac-41b5-80f7-3a015fd2f02d)

After:
![image](https://github.com/user-attachments/assets/7621e3b9-dee1-420f-91f9-accb0f351e85)
![image](https://github.com/user-attachments/assets/24359a4f-072b-4021-a6a0-6794aa7ed5f9)

