### PR TITLE
Create last managing user column in issues table

### DIFF
--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -15,6 +15,7 @@
           <th><%= t ".reported_user" %></th>
           <th class="reporting_users"><%= t ".reporting_users" %></th>
           <th><%= t ".last_updated" %></th>
+          <th><%= t ".last_managed" %></th>
         </tr>
       </thead>
       <tbody>
@@ -33,12 +34,10 @@
               <% end %>
             </td>
             <td>
-              <% if issue.user_updated %>
-                <%= t ".last_updated_time_ago_user_html", :user => link_to(issue.user_updated.display_name, issue.user_updated),
-                                                          :time_ago => friendly_date_ago(issue.updated_at) %>
-              <% else %>
-                <%= friendly_date_ago(issue.updated_at) %>
-              <% end %>
+              <%= friendly_date_ago(issue.updated_at) %>
+            </td>
+            <td>
+              <%= link_to(issue.user_updated.display_name, issue.user_updated) if issue.user_updated %>
             </td>
           </tr>
         <% end %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -29,8 +29,8 @@
     </div>
     <div class="mb-3 col-md-auto">
       <%= select_tag :last_updated_by,
-                     options_for_select(@users.all.collect { |f| [f.display_name, f.id] } << [t(".not_updated"), "nil"], params[:last_updated_by]),
-                     :include_blank => t(".select_last_updated_by"),
+                     options_for_select(@users.all.collect { |f| [f.display_name, f.id] } << [t(".not_managed"), "nil"], params[:last_updated_by]),
+                     :include_blank => t(".select_last_managed_by"),
                      :data => { :behavior => "category_dropdown" },
                      :class => "form-select" %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1517,9 +1517,9 @@ en:
       title: Issues
       select_status: Select Status
       select_type: Select Type
-      select_last_updated_by: Select Last Updated By
+      select_last_managed_by: Select Last Managed By
       reported_user: Reported User
-      not_updated: Not Updated
+      not_managed: Not Managed
       search: Search
       search_guidance: "Search Issues:"
       states:
@@ -1533,7 +1533,7 @@ en:
       status: Status
       reports: Reports
       last_updated: Last Updated
-      last_updated_time_ago_user_html: "%{time_ago} by %{user}"
+      last_managed: Last Managed
       reporting_users: Reporting Users
       reports_count:
         one: "%{count} Report"

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -269,4 +269,33 @@ class IssuesTest < ApplicationSystemTestCase
       assert_no_content issue.reports[n].user.display_name
     end
   end
+
+  def test_view_managed_issue
+    issue = create(:issue, :assigned_role => "moderator")
+    issue.reports << create(:report)
+    moderator_user = create(:moderator_user)
+
+    sign_in_as(moderator_user)
+    visit issues_path
+
+    within_content_body do
+      assert_no_link moderator_user.display_name
+
+      click_on "1 Report"
+    end
+
+    within_content_heading do
+      assert_content "Open Issue ##{issue.id}"
+
+      click_on "Resolve"
+
+      assert_content "Resolved Issue ##{issue.id}"
+    end
+
+    visit issues_path
+
+    within_content_body do
+      assert_link moderator_user.display_name
+    end
+  end
 end


### PR DESCRIPTION
Issues have `updated_at` and `user_updated` attributes. They are updated separately, sometimes without new `user_updated` being written. This makes "Last Updated / (date) by (user)" statements as they are shown in issue tables possibly incorrect:

![image](https://github.com/user-attachments/assets/8376a4f3-9ca2-4163-bb5f-7330ce290fc9)

Various solutions were discussed, some in #3211, but it's still not obvious which one is the best. The simplest one however is to stop claiming that the user from `user_updated` did their update at `updated_at`. This can be done by displaying the user in another column:

![image](https://github.com/user-attachments/assets/32f5581c-1c7a-481d-9096-61a1451cabc5)

The column title suggested by @SomeoneElseOSM was "last managed by" but I don't want to stretch the table too much horizontally. Or we might need a wider table.