### PR TITLE
Revise search forms

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -597,6 +597,8 @@ tr.turn {
 }
 
 .routing_marker_column {
+  margin-left: .35rem;
+  margin-right: .35rem;
   width: 15px;
 
   img {

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -5,67 +5,60 @@
                   end %>
 
 <div class="search_forms">
-  <form method="GET" action="<%= search_path %>" class="search_form bg-body-secondary px-1 py-2">
-    <div class="row gx-2 mx-0">
-      <div class="col">
-        <div class="input-group flex-nowrap">
-          <%= text_field_tag "query", search_query, :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control z-0 py-1 px-2", :dir => "auto" %>
-          <div class="input-group-text border-start-0 p-0 position-relative">
-            <%= button_tag t("site.search.where_am_i"), :type => "button", :class => "describe_location position-absolute end-0 top-0 bottom-0 m-1 btn btn-outline-primary border-0 p-1 bg-transparent text-primary link-body-emphasis link-opacity-100-hover", :title => t("site.search.where_am_i_title") %>
-          </div>
-          <%= button_tag :class => "btn btn-primary p-1", :title => t("site.search.submit_text") do %>
-            <svg width="24" height="20">
-              <circle cx="13" cy="7" r="6.5" fill="#fff8" stroke="#fff" />
-              <path d="M9.75 12.629 A6.5 6.5 0 0 1 7.371 10.25" fill="none" stroke="#fff" stroke-width="1.5" />
-              <line x1="1" y1="19" x2="1.5" y2="18.5" stroke="#fff8" stroke-width="2" />
-              <line x1="1.5" y1="18.5" x2="6" y2="14" stroke="#fff" stroke-width="2.5" />
-              <line x1="6" y1="14" x2="6.5" y2="13.5" stroke="#fff8" stroke-width="2" />
-              <line x1="6.5" y1="13.5" x2="8.5" y2="11.5" stroke="#fff" stroke-width="1.5" />
-            </svg>
-          <% end %>
+  <form method="GET" action="<%= search_path %>" class="search_form bg-body-secondary p-2">
+    <div class="d-flex gap-2">
+      <div class="input-group flex-nowrap">
+        <%= text_field_tag "query", search_query, :placeholder => t("site.search.search"), :autofocus => autofocus, :autocomplete => "on", :class => "form-control z-0 py-1 px-2", :dir => "auto" %>
+        <div class="input-group-text border-start-0 p-0 position-relative">
+          <%= button_tag t("site.search.where_am_i"), :type => "button", :class => "describe_location position-absolute end-0 m-1 btn btn-outline-primary border-0 p-1 text-primary link-body-emphasis link-opacity-100-hover", :title => t("site.search.where_am_i_title") %>
         </div>
-      </div>
-      <div class="col-auto">
-        <%= link_to directions_path, :class => "btn btn-primary p-1 switch_link", :title => t("site.search.get_directions_title") do %>
-          <svg width="28" height="24" viewBox="0 -2 28 24" class="align-bottom">
-            <path d="M11.5 9.5 v-3h3v-1l-5 -5l-5 5v1h3v6" fill="none" stroke="#fff8" />
-            <path d="M7.5 19.5h4v-5a1 1 0 0 1 1 -1h5v3h1l5 -5l-5 -5h-1v3h-6a4 4 0 0 0 -4 4z" fill="#fff8" stroke="#fff" />
+        <%= button_tag :class => "btn btn-primary p-1", :title => t("site.search.submit_text") do %>
+          <svg width="24" height="20">
+            <circle cx="13" cy="7" r="6.5" fill="#fff8" stroke="#fff" />
+            <path d="M9.75 12.629 A6.5 6.5 0 0 1 7.371 10.25" fill="none" stroke="#fff" stroke-width="1.5" />
+            <line x1="1" y1="19" x2="1.5" y2="18.5" stroke="#fff8" stroke-width="2" />
+            <line x1="1.5" y1="18.5" x2="6" y2="14" stroke="#fff" stroke-width="2.5" />
+            <line x1="6" y1="14" x2="6.5" y2="13.5" stroke="#fff8" stroke-width="2" />
+            <line x1="6.5" y1="13.5" x2="8.5" y2="11.5" stroke="#fff" stroke-width="1.5" />
           </svg>
         <% end %>
       </div>
+      <%= link_to directions_path, :class => "btn btn-primary p-1 switch_link", :title => t("site.search.get_directions_title") do %>
+        <svg width="28" height="24" class="align-bottom">
+          <path d="M11.5 11.5v-3h3v-1l-5-5-5 5v1h3v6" fill="none" stroke="#fff8" />
+          <path d="M7.5 21.5h4v-5a1 1 0 0 1 1-1h5v3h1l5-5-5-5h-1v3h-6a4 4 0 0 0-4 4z" fill="#fff8" stroke="#fff" />
+        </svg>
+      <% end %>
     </div>
   </form>
 
-  <form method="GET" action="<%= directions_path %>" class="directions_form bg-body-secondary pb-2">
-    <div class="d-flex flex-row-reverse px-3 pt-3 pb-1"><button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button></div>
+  <form method="GET" action="<%= directions_path %>" class="directions_form bg-body-secondary p-2">
+    <div class="d-flex flex-row-reverse p-2"><button type="button" class="btn-close position-absolute" aria-label="<%= t("javascripts.close") %>"></button></div>
 
-    <div class="d-flex flex-column mx-2 gap-2">
+    <div class="d-flex flex-column gap-2">
       <div class="d-flex gap-1 align-items-center">
         <div class="d-flex flex-column gap-1 flex-grow-1">
           <div class="d-flex gap-2 align-items-center">
-            <div class="routing_marker_column flex-shrink-0">
+            <div class="routing_marker_column position-absolute">
               <%= image_tag "marker-green.png", :class => "img-fluid", :data => { :type => "from" }, :draggable => "true" %>
             </div>
-            <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
+            <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2 ps-4", :dir => "auto" %>
           </div>
           <div class="d-flex gap-2 align-items-center">
-            <div class="routing_marker_column flex-shrink-0">
+            <div class="routing_marker_column position-absolute">
               <%= image_tag "marker-red.png", :class => "img-fluid", :data => { :type => "to" }, :draggable => "true" %>
             </div>
-            <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control py-1 px-2", :dir => "auto" %>
+            <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control py-1 px-2 ps-4", :dir => "auto" %>
           </div>
         </div>
-        <div>
-          <button type="button" class="reverse_directions btn btn-outline-secondary border-0 p-2" title="<%= t("site.search.reverse_directions_text") %>">
-            <svg class="d-block" width="20" height="20" viewBox="-10 -10 20 20" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="m-4 -2 0 10 m-4 -4 4 4 4 -4" />
-              <path d="m4 2 0 -10 m4 4 -4 -4 -4 4" />
-            </svg>
-          </button>
-        </div>
+        <button type="button" class="reverse_directions btn btn-outline-secondary border-0 p-2" title="<%= t("site.search.reverse_directions_text") %>">
+          <svg class="d-block" width="20" height="20" viewBox="-10 -10 20 20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="m-4 -2 0 10 m-4 -4 4 4 4 -4" />
+            <path d="m4 2 0 -10 m4 4 -4 -4 -4 4" />
+          </svg>
+        </button>
       </div>
       <div class="d-flex gap-2 align-items-center">
-        <div class="routing_marker_column flex-shrink-0"></div>
         <div class="btn-group routing_modes" role="group">
           <input type="radio" class="btn-check" name="modes" id="car" autocomplete="off" disabled>
           <label class="btn btn-outline-secondary px-2" for="car" title="<%= t("site.search.modes.car") %>">


### PR DESCRIPTION
### Description
- Changes search form to explicit display-flex, removing the need for col divs.
- Moves the directions form's routing markers inside the input field to be more compact.

before:
![openstreetmap org_directions](https://github.com/user-attachments/assets/ef90daf3-c550-4d82-b529-44e14ff7de51)
after:
![openstreetmap org_directions](https://github.com/user-attachments/assets/21770294-f5fc-4e90-ac7f-b48d81678578)

and in rtl:
![openstreetmap org_directions](https://github.com/user-attachments/assets/f1ad19fc-93ac-42a4-9326-f2ff198bfece)
