### PR TITLE
Fix comments/changes counts wrapping on history pages

### DIFF
--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -4,15 +4,15 @@
       <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>
     </a>
   </p>
-  <div class="row">
-    <div class="col pt-3">
+  <div class="d-flex flex-nowrap gap-3 justify-content-between">
+    <div class="overflow-hidden pt-3">
       <%= changeset_details(changeset) %>
       &middot;
       <a class="changeset_id link-body-emphasis" href="<%= changeset_path(changeset) %>">
         #<%= changeset.id %>
       </a>
     </div>
-    <div class="col-auto d-flex flex-column justify-content-end align-items-end text-body-secondary">
+    <div class="d-flex flex-column justify-content-end align-items-end text-body-secondary">
       <%= tag.div :class => ["d-flex align-items-baseline gap-1", { "opacity-50" => changeset.comments.empty? }],
                   :title => t(".comments", :count => changeset.comments.length) do %>
         <%= changeset.comments.length %>


### PR DESCRIPTION
Long usernames without spaces were causing flex container wraps, pushing comment/edit counts below.

Before:
![image](https://github.com/user-attachments/assets/056cdf15-5087-476f-a9e9-8b0224ca718f)

After:
![image](https://github.com/user-attachments/assets/e3f230fe-5504-4171-a447-9301551b2bb4)
