### PR TITLE
Remove SVG symbol tags

### DIFF
--- a/app/views/directions/show.html.erb
+++ b/app/views/directions/show.html.erb
@@ -1,79 +1,47 @@
 <% content_for(:content_class) { "overlay-sidebar" } %>
 
 <svg width="20" height="20" class="d-none">
-  <symbol id="routing-sprite-start" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M10 16 a1 1 0 1 0 0 -2 1 1 0 1 0 0 2 m0 -4 v-8 m2.5 2 l-2.5 -2.5 -2.5 2.5 z" />
-  </symbol>
-  <symbol id="routing-sprite-destination" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M10 5 a1 1 0 1 0 0 -2 1 1 0 1 0 0 2 m0 12 v-8 m2.5 2 l-2.5 -2.5 -2.5 2.5 z" />
-  </symbol>
+  <path id="routing-sprite-start" fill="none" stroke="currentColor" stroke-width="2" d="M10 16 a1 1 0 1 0 0 -2 1 1 0 1 0 0 2 m0 -4 v-8 m2.5 2 l-2.5 -2.5 -2.5 2.5 z" />
+  <path id="routing-sprite-destination" fill="none" stroke="currentColor" stroke-width="2" d="M10 5 a1 1 0 1 0 0 -2 1 1 0 1 0 0 2 m0 12 v-8 m2.5 2 l-2.5 -2.5 -2.5 2.5 z" />
 
-  <symbol id="routing-sprite-straight" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M10 17 v-13 m2.5 2 l-2.5 -2.5 -2.5 2.5 z" />
-  </symbol>
-  <symbol id="routing-sprite-slight-right" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M7 17 v-3 q0 -2 2 -4 l5 -5 m0 0 h-3 l3 3 z" />
-  </symbol>
-  <symbol id="routing-sprite-right" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M8 17 v-5 q0 -3 3 -3 h4 m-2 2.5 l2.5 -2.5 -2.5 -2.5 z" />
-  </symbol>
-  <symbol id="routing-sprite-sharp-right" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M8 17 v-7 q0 -6 6 0 l2 2 m0 0 v-3 l-3 3 z" />
-  </symbol>
-  <symbol id="routing-sprite-u-turn-right" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M4 17 v-7 a4.5 4.5 0 0 1 9 0 v5 m2.5 -2 l-2.5 2.5 -2.5 -2.5 z" />
-  </symbol>
-  <symbol id="routing-sprite-slight-left">
-    <use href="#routing-sprite-slight-right" transform="matrix(-1 0 0 1 20 0)" />
-  </symbol>
-  <symbol id="routing-sprite-left">
-    <use href="#routing-sprite-right" transform="matrix(-1 0 0 1 21 0)" />
-  </symbol>
-  <symbol id="routing-sprite-sharp-left">
-    <use href="#routing-sprite-sharp-right" transform="matrix(-1 0 0 1 21 0)" />
-  </symbol>
-  <symbol id="routing-sprite-u-turn-left">
-    <use href="#routing-sprite-u-turn-right" transform="matrix(-1 0 0 1 20 0)" />
-  </symbol>
+  <path id="routing-sprite-straight" fill="none" stroke="currentColor" stroke-width="2" d="M10 17 v-13 m2.5 2 l-2.5 -2.5 -2.5 2.5 z" />
+  <path id="routing-sprite-slight-right" fill="none" stroke="currentColor" stroke-width="2" d="M7 17 v-3 q0 -2 2 -4 l5 -5 m0 0 h-3 l3 3 z" />
+  <path id="routing-sprite-right" fill="none" stroke="currentColor" stroke-width="2" d="M8 17 v-5 q0 -3 3 -3 h4 m-2 2.5 l2.5 -2.5 -2.5 -2.5 z" />
+  <path id="routing-sprite-sharp-right" fill="none" stroke="currentColor" stroke-width="2" d="M8 17 v-7 q0 -6 6 0 l2 2 m0 0 v-3 l-3 3 z" />
+  <path id="routing-sprite-u-turn-right" fill="none" stroke="currentColor" stroke-width="2" d="M4 17 v-7 a4.5 4.5 0 0 1 9 0 v5 m2.5 -2 l-2.5 2.5 -2.5 -2.5 z" />
+  <use id="routing-sprite-slight-left" href="#routing-sprite-slight-right" transform="matrix(-1 0 0 1 20 0)" />
+  <use id="routing-sprite-left" href="#routing-sprite-right" transform="matrix(-1 0 0 1 21 0)" />
+  <use id="routing-sprite-sharp-left" href="#routing-sprite-sharp-right" transform="matrix(-1 0 0 1 21 0)" />
+  <use id="routing-sprite-u-turn-left" href="#routing-sprite-u-turn-right" transform="matrix(-1 0 0 1 20 0)" />
 
-  <symbol id="routing-sprite-roundabout" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M8 17 v-3 a 3 3 0 1 0 0 -6 3 3 0 1 0 0 6 m2 -4 l5 -5 m0 0 h-3 l3 3 z" />
-  </symbol>
+  <path id="routing-sprite-roundabout" fill="none" stroke="currentColor" stroke-width="2" d="M8 17 v-3 a 3 3 0 1 0 0 -6 3 3 0 1 0 0 6 m2 -4 l5 -5 m0 0 h-3 l3 3 z" />
 
-  <symbol id="routing-sprite-fork-right" fill="none" stroke="currentColor" stroke-width="2">
+  <g id="routing-sprite-fork-right" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M9 14 q0 -2 -2 -4 l-3 -3" opacity=".5" />
     <path d="M9 17 v-3 q0 -2 2 -4 l5 -5 m0 0 h-3 l3 3 z" />
-  </symbol>
-  <symbol id="routing-sprite-fork-left">
-    <use href="#routing-sprite-fork-right" transform="matrix(-1 0 0 1 20 0)" />
-  </symbol>
-  <symbol id="routing-sprite-merge-left" fill="none" stroke="currentColor" stroke-width="2">
+  </g>
+  <use id="routing-sprite-fork-left" href="#routing-sprite-fork-right" transform="matrix(-1 0 0 1 20 0)" />
+  <g id="routing-sprite-merge-left" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M8 7 q0 2 -2 4 l-3 3" opacity=".5" />
     <path d="M8 4 v3 q0 2 2 4 l5 5 m-5 -5 h3 l-3 3 z" />
-  </symbol>
-  <symbol id="routing-sprite-merge-right">
-    <use href="#routing-sprite-merge-left" transform="matrix(-1 0 0 1 20 0)" />
-  </symbol>
-  <symbol id="routing-sprite-end-of-road-right" fill="none" stroke="currentColor" stroke-width="2">
+  </g>
+  <use id="routing-sprite-merge-right" href="#routing-sprite-merge-left" transform="matrix(-1 0 0 1 20 0)" />
+  <g id="routing-sprite-end-of-road-right" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M2 9 h10" opacity=".5" />
     <path d="M9 17 v-5 q0 -3 3 -3 h4 m-2 2.5 l2.5 -2.5 -2.5 -2.5 z" />
-  </symbol>
-  <symbol id="routing-sprite-end-of-road-left">
-    <use href="#routing-sprite-end-of-road-right" transform="matrix(-1 0 0 1 20 0)" />
-  </symbol>
-  <symbol id="routing-sprite-exit-right" fill="none" stroke="currentColor" stroke-width="2">
+  </g>
+  <use id="routing-sprite-end-of-road-left" href="#routing-sprite-end-of-road-right" transform="matrix(-1 0 0 1 20 0)" />
+  <g id="routing-sprite-exit-right" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M9 14 v-8" opacity=".5" />
     <path d="M9 17 v-3 q0 -2 2 -4 l5 -5 m0 0 h-3 l3 3 z" />
-  </symbol>
-  <symbol id="routing-sprite-exit-left">
-    <use href="#routing-sprite-exit-right" transform="matrix(-1 0 0 1 20 0)" />
-  </symbol>
+  </g>
+  <use id="routing-sprite-exit-left" href="#routing-sprite-exit-right" transform="matrix(-1 0 0 1 20 0)" />
 
-  <symbol id="routing-sprite-ferry" fill="none" stroke="currentColor" stroke-width="1">
+  <g id="routing-sprite-ferry" fill="none" stroke="currentColor" stroke-width="1">
     <path d="M10.5 8 l-6 2 l2.5 2 v1.5 a2.828 2.828 0 0 1 1.5 1 a2.828 2.828 0 0 1 4 0 a2.828 2.828 0 0 1 1.5 -1 v-1.5 l2.5 -2 z" fill="currentColor" />
     <path d="M6.5 9.5 v-5 h8 v5 m-5.5 -6 h3" />
     <path d="M5.5 16.5 a1.414 2.828 0 0 1 2 0 a1.414 2.828 0 0 0 2 0 a1.414 2.828 0 0 1 2 0 a1.414 2.828 0 0 0 2 0 a1.414 2.828 0 0 1 2 0" />
-  </symbol>
+  </g>
 </svg>
 
 <%= render "sidebar_header", :title => t(".title") %>


### PR DESCRIPTION
The routing icons currently use the `symbol` element but use none of the structure and semantics that would justify these.
Also none of the SVG `symbol` specific tags - `width`, `height`, `x`, `y`, `refX`, `refY`, `preserveAspectRatio`, or `viewBox` - are used.
This PR removes this unnecessary extra layer introduced in #5753 and uses basic groups if needed.