### PR TITLE
Sticky close button v2

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -398,7 +398,7 @@ $(function () {
     }
   });
 
-  $(document).on("click", "#sidebar_content .btn-close", function () {
+  $(document).on("click", "#sidebar .sidebar-close-controls button", function () {
     OSM.router.route("/" + OSM.formatHash(map));
   });
 });

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -294,7 +294,7 @@ OSM.Directions = function (map) {
   }
 
   function enableListeners() {
-    $("#sidebar_content").on("click", ".btn-close", hideRoute);
+    $("#sidebar .sidebar-close-controls button").on("click", hideRoute);
 
     $("#map").on("dragend dragover", function (e) {
       e.preventDefault();
@@ -350,7 +350,7 @@ OSM.Directions = function (map) {
     $(".search_form").show();
     $(".directions_form").hide();
 
-    $("#sidebar_content").off("click", ".btn-close", hideRoute);
+    $("#sidebar .sidebar-close-controls button").off("click", hideRoute);
     $("#map").off("dragend dragover drop");
     map.off("locationfound", sendstartinglocation);
 

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -20,14 +20,9 @@ L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
     const $ui = $("<div>")
       .attr("class", uiClass + "-ui");
 
-    $("<div class='d-flex p-3 pb-0'>")
-      .appendTo($ui)
-      .append($("<h2 class='flex-grow-1 text-break'>")
-        .text(I18n.t(paneTitle)))
-      .append($("<div>")
-        .append($("<button type='button' class='btn-close'>")
-          .attr("aria-label", I18n.t("javascripts.close"))
-          .bind("click", toggle)));
+    $("<h2 class='p-3 pb-0 pe-5 text-break'>")
+      .text(I18n.t(paneTitle))
+      .appendTo($ui);
 
     options.sidebar.addPane($ui);
 

--- a/app/assets/javascripts/leaflet.sidebar-pane.js
+++ b/app/assets/javascripts/leaflet.sidebar-pane.js
@@ -18,7 +18,7 @@ L.OSM.sidebarPane = function (options, uiClass, buttonTitle, paneTitle) {
     button.appendTo($container);
 
     const $ui = $("<div>")
-      .attr("class", uiClass + "-ui");
+      .attr("class", `${uiClass}-ui position-relative z-n1`);
 
     $("<h2 class='p-3 pb-0 pe-5 text-break'>")
       .text(I18n.t(paneTitle))

--- a/app/assets/javascripts/leaflet.sidebar.js
+++ b/app/assets/javascripts/leaflet.sidebar.js
@@ -59,5 +59,9 @@ L.OSM.sidebar = function (selector) {
       .addClass("active");
   };
 
+  sidebar.find(".sidebar-close-controls button").on("click", () => {
+    control.togglePane(current, currentButton);
+  });
+
   return control;
 };

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -351,6 +351,7 @@ body.small-nav {
       display: block;
     }
 
+    .sidebar-close-controls,
     #sidebar_loader,
     #sidebar_content {
       display: none;

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -1,6 +1,1 @@
-<div class="d-flex">
-  <h2 class="flex-grow-1 text-break"><%= title %></h2>
-  <div>
-    <button type="button" class="btn-close" aria-label="<%= t("javascripts.close") %>"></button>
-  </div>
-</div>
+<h2 class="me-4 text-break"><%= title %></h2>

--- a/app/views/layouts/_sidebar_close.html.erb
+++ b/app/views/layouts/_sidebar_close.html.erb
@@ -1,5 +1,14 @@
-<div class="sidebar-close-controls">
-  <div class="position-absolute end-0 m-2">
-    <button type="button" class="btn-close d-block p-2" aria-label="<%= t("javascripts.close") %>"></button>
+<div class="sidebar-close-controls sticky-top z-0">
+  <div class="position-absolute end-0 m-2 rounded-5 bg-body-tertiary shadow-sm">
+    <button type="button" disabled class="btn-close d-block p-2 invisible"></button>
+  </div>
+</div>
+<div class="sidebar-close-controls sticky-top">
+  <div class="position-absolute end-0 m-2 rounded-5">
+    <button type="button" class="btn-close d-block p-2 rounded-5" aria-label="<%= t("javascripts.close") %>"></button>
+  </div>
+</div>
+<div class="sidebar-close-controls position-relative">
+  <div class="position-absolute end-0 bg-body p-4">
   </div>
 </div>

--- a/app/views/layouts/_sidebar_close.html.erb
+++ b/app/views/layouts/_sidebar_close.html.erb
@@ -1,0 +1,5 @@
+<div class="sidebar-close-controls">
+  <div class="position-absolute end-0 m-2">
+    <button type="button" class="btn-close d-block p-2" aria-label="<%= t("javascripts.close") %>"></button>
+  </div>
+</div>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -62,6 +62,11 @@
   </noscript>
 
   <div id="map-ui" class="bg-body z-2">
+    <div class="sidebar-close-controls">
+      <div class="position-absolute end-0 m-2">
+        <button type="button" class="btn-close d-block p-2" aria-label="<%= t("javascripts.close") %>"></button>
+      </div>
+    </div>
   </div>
 
   <div id="map" tabindex="2" class="bg-body-secondary z-0">

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -26,7 +26,7 @@
       </div>
     </div>
 
-    <div id="sidebar_content" class="p-3">
+    <div id="sidebar_content" class="p-3 position-relative z-n1">
       <%= yield %>
     </div>
 

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -18,6 +18,12 @@
 
     <div id="browse_status"></div>
 
+    <div class="sidebar-close-controls">
+      <div class="position-absolute end-0 m-2">
+        <button type="button" class="btn-close d-block p-2" aria-label="<%= t("javascripts.close") %>"></button>
+      </div>
+    </div>
+
     <div id="sidebar_loader" class="my-3 text-center loader" hidden>
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -29,8 +29,9 @@
     </div>
 
     <% unless current_user %>
-      <div class="welcome p-3" hidden>
-        <%= render "sidebar_header", :title => t("layouts.intro_header") %>
+      <div class="welcome position-relative p-3" hidden>
+        <button type="button" class="btn-close position-absolute end-0 top-0 m-2 rounded-5 p-2" aria-label="<%= t("javascripts.close") %>"></button>
+        <h2 class="me-4 text-break"><%= t "layouts.intro_header" %></h2>
         <p class="fs-6 fw-light"><%= t "layouts.intro_text" %></p>
         <p class="fs-6 fw-light"><%= t "layouts.hosting_partners_2024_html",
                                        :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -18,11 +18,7 @@
 
     <div id="browse_status"></div>
 
-    <div class="sidebar-close-controls">
-      <div class="position-absolute end-0 m-2">
-        <button type="button" class="btn-close d-block p-2" aria-label="<%= t("javascripts.close") %>"></button>
-      </div>
-    </div>
+    <%= render :partial => "layouts/sidebar_close" %>
 
     <div id="sidebar_loader" class="my-3 text-center loader" hidden>
       <div class="spinner-border" role="status">
@@ -62,11 +58,7 @@
   </noscript>
 
   <div id="map-ui" class="bg-body z-2">
-    <div class="sidebar-close-controls">
-      <div class="position-absolute end-0 m-2">
-        <button type="button" class="btn-close d-block p-2" aria-label="<%= t("javascripts.close") %>"></button>
-      </div>
-    </div>
+    <%= render :partial => "layouts/sidebar_close" %>
   </div>
 
   <div id="map" tabindex="2" class="bg-body-secondary z-0">

--- a/test/system/directions_test.rb
+++ b/test/system/directions_test.rb
@@ -22,9 +22,7 @@ class DirectionsSystemTest < ApplicationSystemTestCase
       assert_content "Start popup text"
     end
 
-    within_sidebar do
-      find("button[aria-label='Close']").click
-    end
+    find("#sidebar .sidebar-close-controls button[aria-label='Close']").click
 
     within "#map" do
       assert_no_content "Start popup text"

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -16,7 +16,7 @@ class IndexTest < ApplicationSystemTestCase
     visit node_path(node)
     find(".icon.share").click
     assert_no_selector "#content.overlay-right-sidebar"
-    find(".share-ui .btn-close").click
+    find("#map-ui .btn-close").click
     assert_selector "#content.overlay-right-sidebar"
   end
 


### PR DESCRIPTION
Previous version: #4825

The changes are:
- https://github.com/openstreetmap/openstreetmap-website/pull/4825#issuecomment-2123914398, light gray background when scrolled, but with a shadow instead of a border for some separation.
- https://github.com/openstreetmap/openstreetmap-website/pull/4825#issuecomment-2131233781, the transparent area around the button was supposedly suggesting that it's clickable, therefore I removed it. Now I'm using a smaller non-transparent area that is clickable.

So I went from a larger transparent area to a smaller area with a shadow to indicate that the button is floating above the scrolled sidebar content.

Looks as usual when the sidebar contents is not scrolled:
![image](https://github.com/user-attachments/assets/657128a1-bd0c-40fa-8ad1-c39544b338a7)

Gets a slightly gray background and a shadow when scrolled:
![image](https://github.com/user-attachments/assets/a6edaece-4a65-49d5-9b93-c181a0886fb1)

Focus:
![image](https://github.com/user-attachments/assets/7cdda134-fb77-49db-a8c9-646e4a0b5259)

Dark mode:
![image](https://github.com/user-attachments/assets/1f3cf6d1-25be-452f-89fa-89c782674e5d)

Right sidebar:
![image](https://github.com/user-attachments/assets/4f81fde5-a351-4c54-9728-55a672b6f1b2)

Fixes https://github.com/openstreetmap/openstreetmap-website/issues/2174.
