### PR TITLE
Translate step distance units

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -80,6 +80,14 @@ OSM.Directions = function (map) {
     }
   }
 
+  function getDistText(dist) {
+    if (dist < 5) return "";
+    if (dist < 200) return String(Math.round(dist / 10) * 10) + "m";
+    if (dist < 1500) return String(Math.round(dist / 100) * 100) + "m";
+    if (dist < 5000) return String(Math.round(dist / 100) / 10) + "km";
+    return String(Math.round(dist / 1000)) + "km";
+  }
+
   function formatHeight(m) {
     return I18n.t("javascripts.directions.distance_m", { distance: Math.round(m) });
   }
@@ -221,14 +229,6 @@ OSM.Directions = function (map) {
     }).finally(function () {
       controller = null;
     });
-
-    function getDistText(dist) {
-      if (dist < 5) return "";
-      if (dist < 200) return String(Math.round(dist / 10) * 10) + "m";
-      if (dist < 1500) return String(Math.round(dist / 100) * 100) + "m";
-      if (dist < 5000) return String(Math.round(dist / 100) / 10) + "km";
-      return String(Math.round(dist / 1000)) + "km";
-    }
   }
 
   function hideRoute(e) {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -70,7 +70,7 @@ OSM.Directions = function (map) {
     OSM.router.route("/" + OSM.formatHash(map));
   });
 
-  function formatDistance(m) {
+  function formatTotalDistance(m) {
     if (m < 1000) {
       return I18n.t("javascripts.directions.distance_m", { distance: Math.round(m) });
     } else if (m < 10000) {
@@ -80,17 +80,17 @@ OSM.Directions = function (map) {
     }
   }
 
-  function getDistText(dist) {
-    if (dist < 5) {
+  function formatStepDistance(m) {
+    if (m < 5) {
       return "";
-    } else if (dist < 200) {
-      return String(Math.round(dist / 10) * 10) + "m";
-    } else if (dist < 1500) {
-      return String(Math.round(dist / 100) * 100) + "m";
-    } else if (dist < 5000) {
-      return String(Math.round(dist / 100) / 10) + "km";
+    } else if (m < 200) {
+      return String(Math.round(m / 10) * 10) + "m";
+    } else if (m < 1500) {
+      return String(Math.round(m / 100) * 100) + "m";
+    } else if (m < 5000) {
+      return String(Math.round(m / 100) / 10) + "km";
     } else {
-      return String(Math.round(dist / 1000)) + "km";
+      return String(Math.round(m / 1000)) + "km";
     }
   }
 
@@ -164,7 +164,7 @@ OSM.Directions = function (map) {
       }
 
       const distanceText = $("<p>").append(
-        I18n.t("javascripts.directions.distance") + ": " + formatDistance(route.distance) + ". " +
+        I18n.t("javascripts.directions.distance") + ": " + formatTotalDistance(route.distance) + ". " +
         I18n.t("javascripts.directions.time") + ": " + formatTime(route.time) + ".");
       if (typeof route.ascend !== "undefined" && typeof route.descend !== "undefined") {
         distanceText.append(
@@ -194,7 +194,7 @@ OSM.Directions = function (map) {
           row.append("<td class='border-0'>");
         }
         row.append("<td>" + instruction);
-        row.append("<td class='distance text-body-secondary text-end'>" + getDistText(dist));
+        row.append("<td class='distance text-body-secondary text-end'>" + formatStepDistance(dist));
 
         row.on("click", function () {
           popup

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -84,13 +84,13 @@ OSM.Directions = function (map) {
     if (m < 5) {
       return "";
     } else if (m < 200) {
-      return String(Math.round(m / 10) * 10) + "m";
+      return I18n.t("javascripts.directions.distance_m", { distance: String(Math.round(m / 10) * 10) });
     } else if (m < 1500) {
-      return String(Math.round(m / 100) * 100) + "m";
+      return I18n.t("javascripts.directions.distance_m", { distance: String(Math.round(m / 100) * 100) });
     } else if (m < 5000) {
-      return String(Math.round(m / 100) / 10) + "km";
+      return I18n.t("javascripts.directions.distance_km", { distance: String(Math.round(m / 100) / 10) });
     } else {
-      return String(Math.round(m / 1000)) + "km";
+      return I18n.t("javascripts.directions.distance_km", { distance: String(Math.round(m / 1000)) });
     }
   }
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -71,10 +71,13 @@ OSM.Directions = function (map) {
   });
 
   function formatDistance(m) {
-    const unitTemplate = "javascripts.directions.distance_";
-    if (m < 1000) return I18n.t(unitTemplate + "m", { distance: Math.round(m) });
-    if (m < 10000) return I18n.t(unitTemplate + "km", { distance: (m / 1000.0).toFixed(1) });
-    return I18n.t(unitTemplate + "km", { distance: Math.round(m / 1000) });
+    if (m < 1000) {
+      return I18n.t("javascripts.directions.distance_m", { distance: Math.round(m) });
+    } else if (m < 10000) {
+      return I18n.t("javascripts.directions.distance_km", { distance: (m / 1000.0).toFixed(1) });
+    } else {
+      return I18n.t("javascripts.directions.distance_km", { distance: Math.round(m / 1000) });
+    }
   }
 
   function formatHeight(m) {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -81,11 +81,17 @@ OSM.Directions = function (map) {
   }
 
   function getDistText(dist) {
-    if (dist < 5) return "";
-    if (dist < 200) return String(Math.round(dist / 10) * 10) + "m";
-    if (dist < 1500) return String(Math.round(dist / 100) * 100) + "m";
-    if (dist < 5000) return String(Math.round(dist / 100) / 10) + "km";
-    return String(Math.round(dist / 1000)) + "km";
+    if (dist < 5) {
+      return "";
+    } else if (dist < 200) {
+      return String(Math.round(dist / 10) * 10) + "m";
+    } else if (dist < 1500) {
+      return String(Math.round(dist / 100) * 100) + "m";
+    } else if (dist < 5000) {
+      return String(Math.round(dist / 100) / 10) + "km";
+    } else {
+      return String(Math.round(dist / 1000)) + "km";
+    }
   }
 
   function formatHeight(m) {

--- a/config/eslint.config.mjs
+++ b/config/eslint.config.mjs
@@ -102,7 +102,6 @@ export default [
       "no-caller": "error",
       "no-console": "warn",
       "no-div-regex": "error",
-      "no-else-return": ["error", { allowElseIf: false }],
       "no-eq-null": "error",
       "no-eval": "error",
       "no-extend-native": "error",


### PR DESCRIPTION
There was an issue #3888 that asked to make directions distances translatable. It was done, but not entirely. Step distances were still untranslatable after the issue was closed.

Before in Russian:

![image](https://github.com/user-attachments/assets/fea830d4-da1a-4d42-ab11-10faba1b45f9)
Notice that the total distance units are "км", but the first step has untranslated "km".

After:

![image](https://github.com/user-attachments/assets/cf03a322-5f30-4ae5-88da-6476a69f927a)

---

I undid some of the changes from #5633 that made it difficult to find where strings like `distance_km` are used. To do that I had to disable `no-else-return` eslint rule introduced in #5643. This is not one of the [recommended rules](https://eslint.org/docs/latest/rules/).