### PR TITLE
Allow user list to be filtered for the presence of edits

### DIFF
--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -13,12 +13,14 @@ module Users
     ##
     # display a list of users matching specified criteria
     def show
-      @params = params.permit(:status, :username, :ip, :before, :after)
+      @params = params.permit(:status, :username, :ip, :edits, :before, :after)
 
       users = User.all
       users = users.where(:status => @params[:status]) if @params[:status].present?
       users = users.where("LOWER(email) = LOWER(?) OR LOWER(NORMALIZE(display_name, NFKC)) = LOWER(NORMALIZE(?, NFKC))", @params[:username], @params[:username]) if @params[:username].present?
       users = users.where("creation_address <<= ?", @params[:ip]) if @params[:ip].present?
+      users = users.where(:changesets_count => 0) if @params[:edits] == "no"
+      users = users.where.not(:changesets_count => 0) if @params[:edits] == "yes"
 
       @users_count = users.limit(501).count
       @users_count = I18n.t("count.at_least_pattern", :count => 500) if @users_count > 500

--- a/app/views/users/lists/show.html.erb
+++ b/app/views/users/lists/show.html.erb
@@ -32,6 +32,13 @@
                          :class => "form-control" %>
     </div>
     <div class="mb-3 col-md-auto">
+      <%= select_tag :edits,
+                     options_for_select([[t(".has_edits"), "yes"], [t(".no_edits"), "no"]], params[:edits]),
+                     :include_blank => t(".edits"),
+                     :data => { :behavior => "category_dropdown" },
+                     :class => "form-select" %>
+    </div>
+    <div class="mb-3 col-md-auto">
       <%= submit_tag t(".search"), :name => nil, :class => "btn btn-primary" %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2948,6 +2948,9 @@ en:
           deleted: Deleted
         name_or_email: Name or Email
         ip_address: IP Address
+        edits: Edits?
+        has_edits: Has Edits
+        no_edits: No Edits
         search: Search
       page:
         found_users:

--- a/test/controllers/users/lists_controller_test.rb
+++ b/test/controllers/users/lists_controller_test.rb
@@ -31,10 +31,12 @@ module Users
       name_user = create(:user, :display_name => "Test User")
       email_user = create(:user, :email => "test@example.com")
       ip_user = create(:user, :creation_address => "1.2.3.4")
+      edits_user = create(:user)
+      create(:changeset, :user => edits_user)
 
-      # There are now 9 users - the 7 above, plus two extra "granters" for the
+      # There are now 10 users - the 8 above, plus two extra "granters" for the
       # moderator_user and administrator_user
-      assert_equal 9, User.count
+      assert_equal 10, User.count
 
       # Shouldn't work when not logged in
       get users_list_path
@@ -59,7 +61,7 @@ module Users
       get users_list_path
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 9
+      assert_select "table#user_list tbody tr", :count => 10
 
       # Should be able to limit by status
       get users_list_path, :params => { :status => "suspended" }
@@ -107,6 +109,22 @@ module Users
       assert_template :show
       assert_select "table#user_list tbody tr", :count => 1 do
         assert_select "a[href='#{user_path(ip_user)}']", :count => 1
+      end
+
+      # Should be able to limit to users with edits
+      get users_list_path, :params => { :edits => "yes" }
+      assert_response :success
+      assert_template :show
+      assert_select "table#user_list tbody tr", :count => 1 do
+        assert_select "a[href='#{user_path(edits_user)}']", :count => 1
+      end
+
+      # Should be able to limit to users with no edits
+      get users_list_path, :params => { :edits => "no" }
+      assert_response :success
+      assert_template :show
+      assert_select "table#user_list tbody tr", :count => 9 do
+        assert_select "a[href='#{user_path(edits_user)}']", :count => 0
       end
     end
 


### PR DESCRIPTION
This allows the user list that administrators use to be filtered by whether a user does, or does not, have edits as requested by @Firefishy.