### PR TITLE
Order issue reports by id

### DIFF
--- a/app/controllers/issues/reporters_controller.rb
+++ b/app/controllers/issues/reporters_controller.rb
@@ -11,7 +11,7 @@ module Issues
     def index
       @issue = Issue.visible_to(current_user).find(params[:issue_id])
 
-      user_ids = @issue.reports.order(:created_at => :desc).pluck(:user_id).uniq
+      user_ids = @issue.reports.reorder(:created_at => :desc).pluck(:user_id).uniq
       @unique_reporters = {
         @issue.id => {
           :count => user_ids.size,

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -47,7 +47,7 @@ class IssuesController < ApplicationController
 
     @unique_reporters_limit = 3
     @unique_reporters = @issues.each_with_object({}) do |issue, reporters|
-      user_ids = issue.reports.order(:created_at => :desc).pluck(:user_id).uniq
+      user_ids = issue.reports.reorder(:created_at => :desc).pluck(:user_id).uniq
       reporters[issue.id] = {
         :count => user_ids.size,
         :users => User.in_order_of(:id, user_ids.first(@unique_reporters_limit))

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -36,7 +36,7 @@ class Issue < ApplicationRecord
   belongs_to :user_resolved, :class_name => "User", :foreign_key => :resolved_by, :optional => true
   belongs_to :user_updated, :class_name => "User", :foreign_key => :updated_by, :optional => true
 
-  has_many :reports, :dependent => :destroy
+  has_many :reports, -> { order(:id) }, :dependent => :destroy
   has_many :comments, :class_name => "IssueComment", :dependent => :destroy
 
   validates :reportable_id, :uniqueness => { :scope => [:reportable_type] }


### PR DESCRIPTION
Reports on `/issues/:id` weren't sorted in any particular order. This is usually unnoticeable because typically they come in the creation order from the db. But that doesn't always happen.

![image](https://github.com/user-attachments/assets/6222ec71-9e42-4b63-89fc-2f4da6690c7e)

This PR sorts the reports by id explicitly.

I don't know if we need an index on (issue_id, report_id). If there aren't many reports per issue, maybe not.

Same thing is probably required for issue comments.