### PR TITLE
Show dates of reported items on issue pages

### DIFF
--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -25,6 +25,21 @@ module IssuesHelper
     end
   end
 
+  def reportable_dates(reportable)
+    case reportable
+    when DiaryEntry, DiaryComment, Note
+      created_at_time = tag.time l(reportable.created_at.to_datetime, :format => :friendly),
+                                 :datetime => reportable.created_at.xmlschema
+      updated_at_time = tag.time l(reportable.updated_at.to_datetime, :format => :friendly),
+                                 :datetime => reportable.updated_at.xmlschema
+      t "issues.helper.reportable_dates.created_on_updated_on_html", :datetime_created => created_at_time, :datetime_updated => updated_at_time
+    when User
+      created_at_time = tag.time l(reportable.created_at.to_datetime, :format => :friendly),
+                                 :datetime => reportable.created_at.xmlschema
+      t "issues.helper.reportable_dates.created_on_html", :datetime_created => created_at_time
+    end
+  end
+
   def open_issues_count
     count = Issue.visible_to(current_user).open.limit(Settings.max_issues_count).size
     if count >= Settings.max_issues_count

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,6 +1,10 @@
 <% content_for :heading do %>
 <h1><%= @title %></h1>
-<p><%= @issue.reportable.model_name.human %> : <%= link_to reportable_title(@issue.reportable), reportable_url(@issue.reportable) %></p>
+<p>
+  <%= @issue.reportable.model_name.human %> :
+  <%= link_to reportable_title(@issue.reportable), reportable_url(@issue.reportable) %> :
+  <%= reportable_dates(@issue.reportable) %>
+</p>
 <p class="text-body-secondary">
   <small>
     <%= @issue.assigned_role %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1607,6 +1607,9 @@ en:
       reportable_title:
         diary_comment: "%{entry_title}, comment #%{comment_id}"
         note: "Note #%{note_id}"
+      reportable_dates:
+        created_on_html: "created on %{datetime_created}"
+        created_on_updated_on_html: "created on %{datetime_created}, updated on %{datetime_updated}"
     reporters:
       index:
         title: "Issue #%{issue_id} Reporters"

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -3,6 +3,24 @@ require "test_helper"
 class IssuesHelperTest < ActionView::TestCase
   attr_accessor :current_user
 
+  def test_reportable_dates_note
+    note = create(:note, :created_at => "2020-03-14", :updated_at => "2021-05-16")
+
+    dates = reportable_dates note
+
+    dom_dates = Rails::Dom::Testing.html_document_fragment.parse "<p>#{dates}</p>"
+    assert_dom dom_dates, ":root", "created on 14 March 2020 at 00:00, updated on 16 May 2021 at 00:00"
+  end
+
+  def test_reportable_dates_user
+    user = create(:user, :created_at => "2020-07-18")
+
+    dates = reportable_dates user
+
+    dom_dates = Rails::Dom::Testing.html_document_fragment.parse "<p>#{dates}</p>"
+    assert_dom dom_dates, ":root", "created on 18 July 2020 at 00:00"
+  end
+
   def test_issues_count
     target_user = create(:user)
     self.current_user = create(:moderator_user)


### PR DESCRIPTION
Allows to see if the reported item wasn't created/changed recently. For reported users shows only the account creation date.

Before:
![image](https://github.com/user-attachments/assets/348edca8-68ea-4239-83ee-0f60f436125d)

After:
![image](https://github.com/user-attachments/assets/02842e32-4fe2-4712-a931-f9e473d0b11f)
