### PR TITLE
Fix overlap between left sidebar heading and close button

### DIFF
--- a/app/views/layouts/_sidebar_close.html.erb
+++ b/app/views/layouts/_sidebar_close.html.erb
@@ -9,6 +9,6 @@
   </div>
 </div>
 <div class="sidebar-close-controls position-relative">
-  <div class="position-absolute end-0 bg-body p-4">
+  <div class="position-absolute end-0 bg-body p-4 ps-3">
   </div>
 </div>


### PR DESCRIPTION
Sticky close buttons have a layer that covers their shadows when sidebars are not scrolled. That layer is slightly larger than it needs to be. It overlaps with the heading and can block out letters in the heading. I'm making the cover layer smaller in this PR.

Before:
![image](https://github.com/user-attachments/assets/51aec26c-b673-4624-90dc-5ef25b87ce82)
![image](https://github.com/user-attachments/assets/caded515-8ba3-4382-8f11-eec9f3817912)

After:
![image](https://github.com/user-attachments/assets/24dd4f19-da10-4d30-8ec5-3c5001c5dde0)
![image](https://github.com/user-attachments/assets/fcb39814-069e-42f1-b593-85e404751e81)

Actually with this PR the cover layer is slightly smaller than it needs to be to fully block the shadow, but hopefully it's unnoticeable. If it becomes a problem, I'll have to set sizes directly in css, currently they are set in Bootstrap units. There's also a tradeoff between not having this overlap and the heading width, given that the heading content is variable.