### PR TITLE
Convert reportable_dates helper into heading helper

### DIFF
--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -25,18 +25,20 @@ module IssuesHelper
     end
   end
 
-  def reportable_dates(reportable)
+  def reportable_heading(reportable)
+    heading_params = { :title => link_to(reportable_title(reportable), reportable_url(reportable)) }
+    heading_params[:datetime_created] = reportable_heading_time(reportable.created_at)
+    heading_params[:datetime_updated] = reportable_heading_time(reportable.updated_at) unless reportable.is_a? User
+
     case reportable
-    when DiaryEntry, DiaryComment, Note
-      created_at_time = tag.time l(reportable.created_at.to_datetime, :format => :friendly),
-                                 :datetime => reportable.created_at.xmlschema
-      updated_at_time = tag.time l(reportable.updated_at.to_datetime, :format => :friendly),
-                                 :datetime => reportable.updated_at.xmlschema
-      t "issues.helper.reportable_dates.created_on_updated_on_html", :datetime_created => created_at_time, :datetime_updated => updated_at_time
+    when DiaryComment
+      t "issues.helper.reportable_heading.diary_comment_html", **heading_params
+    when DiaryEntry
+      t "issues.helper.reportable_heading.diary_entry_html", **heading_params
+    when Note
+      t "issues.helper.reportable_heading.note_html", **heading_params
     when User
-      created_at_time = tag.time l(reportable.created_at.to_datetime, :format => :friendly),
-                                 :datetime => reportable.created_at.xmlschema
-      t "issues.helper.reportable_dates.created_on_html", :datetime_created => created_at_time
+      t "issues.helper.reportable_heading.user_html", **heading_params
     end
   end
 
@@ -47,5 +49,11 @@ module IssuesHelper
     elsif count.positive?
       tag.span(count, :class => "badge count-number")
     end
+  end
+
+  private
+
+  def reportable_heading_time(datetime)
+    tag.time l(datetime.to_datetime, :format => :friendly), :datetime => datetime.xmlschema
   end
 end

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,10 +1,6 @@
 <% content_for :heading do %>
 <h1><%= @title %></h1>
-<p>
-  <%= @issue.reportable.model_name.human %> :
-  <%= link_to reportable_title(@issue.reportable), reportable_url(@issue.reportable) %> :
-  <%= reportable_dates(@issue.reportable) %>
-</p>
+<p><%= reportable_heading @issue.reportable %></p>
 <p class="text-body-secondary">
   <small>
     <%= @issue.assigned_role %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1607,9 +1607,11 @@ en:
       reportable_title:
         diary_comment: "%{entry_title}, comment #%{comment_id}"
         note: "Note #%{note_id}"
-      reportable_dates:
-        created_on_html: "created on %{datetime_created}"
-        created_on_updated_on_html: "created on %{datetime_created}, updated on %{datetime_updated}"
+      reportable_heading:
+        diary_comment_html: "Diary Comment %{title} created on %{datetime_created}, updated on %{datetime_updated}"
+        diary_entry_html: "Diary Entry %{title} created on %{datetime_created}, updated on %{datetime_updated}"
+        note_html: "%{title} created on %{datetime_created}, updated on %{datetime_updated}"
+        user_html: "User %{title} created on %{datetime_created}"
     reporters:
       index:
         title: "Issue #%{issue_id} Reporters"

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -3,22 +3,55 @@ require "test_helper"
 class IssuesHelperTest < ActionView::TestCase
   attr_accessor :current_user
 
-  def test_reportable_dates_note
-    note = create(:note, :created_at => "2020-03-14", :updated_at => "2021-05-16")
+  def test_reportable_heading_diary_comment
+    create(:language, :code => "en")
+    diary_entry = create(:diary_entry, :title => "A Discussion")
+    diary_comment = create(:diary_comment, :diary_entry => diary_entry, :created_at => "2020-03-15", :updated_at => "2021-05-17")
 
-    dates = reportable_dates note
+    heading = reportable_heading diary_comment
 
-    dom_dates = Rails::Dom::Testing.html_document_fragment.parse "<p>#{dates}</p>"
-    assert_dom dom_dates, ":root", "created on 14 March 2020 at 00:00, updated on 16 May 2021 at 00:00"
+    dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
+    assert_dom dom_heading, ":root", "Diary Comment A Discussion, comment ##{diary_comment.id} created on 15 March 2020 at 00:00, updated on 17 May 2021 at 00:00"
+    assert_dom dom_heading, "a", 1 do
+      assert_dom "> @href", diary_entry_url(diary_entry.user, diary_entry, :anchor => "comment#{diary_comment.id}")
+    end
   end
 
-  def test_reportable_dates_user
-    user = create(:user, :created_at => "2020-07-18")
+  def test_reportable_heading_diary_entry
+    create(:language, :code => "en")
+    diary_entry = create(:diary_entry, :title => "Important Subject", :created_at => "2020-03-24", :updated_at => "2021-05-26")
 
-    dates = reportable_dates user
+    heading = reportable_heading diary_entry
 
-    dom_dates = Rails::Dom::Testing.html_document_fragment.parse "<p>#{dates}</p>"
-    assert_dom dom_dates, ":root", "created on 18 July 2020 at 00:00"
+    dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
+    assert_dom dom_heading, ":root", "Diary Entry Important Subject created on 24 March 2020 at 00:00, updated on 26 May 2021 at 00:00"
+    assert_dom dom_heading, "a", 1 do
+      assert_dom "> @href", diary_entry_url(diary_entry.user, diary_entry)
+    end
+  end
+
+  def test_reportable_heading_note
+    note = create(:note, :created_at => "2020-03-14", :updated_at => "2021-05-16")
+
+    heading = reportable_heading note
+
+    dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
+    assert_dom dom_heading, ":root", "Note ##{note.id} created on 14 March 2020 at 00:00, updated on 16 May 2021 at 00:00"
+    assert_dom dom_heading, "a", 1 do
+      assert_dom "> @href", note_url(note)
+    end
+  end
+
+  def test_reportable_heading_user
+    user = create(:user, :display_name => "Someone", :created_at => "2020-07-18")
+
+    heading = reportable_heading user
+
+    dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
+    assert_dom dom_heading, ":root", "User Someone created on 18 July 2020 at 00:00"
+    assert_dom dom_heading, "a", 1 do
+      assert_dom "> @href", user_url(user)
+    end
   end
 
   def test_issues_count


### PR DESCRIPTION
In #5787 I appended `created on %{datetime_created} ...` to the reported item in the heading. That can't be translated correctly because I'm constructing a sentence and "created"/"updated" need to agree with the subject in grammatical gender etc. The entire subheading needs to be translated together.

I'm also removing the double "Note":

Before:
![image](https://github.com/user-attachments/assets/95a30795-4eb9-49e4-bde5-9316d44e5dd7)

After:
![image](https://github.com/user-attachments/assets/d4f8a2d4-6318-4a5b-bb62-146015a32698)
