### PR TITLE
Fixed the grammatical mistake regarding the hyphen in "sign-up" and "log-in" mentioned in Issue #5772

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2701,8 +2701,8 @@ en:
       cookies_needed: "You appear to have cookies disabled - please enable cookies in your browser before continuing."
     setup_user_auth:
       blocked_zero_hour: "You have an urgent message on the OpenStreetMap website. You need to read the message before you will be able to save your edits."
-      blocked: "Your access to the API has been blocked. Please log-in to the web interface to find out more."
-      need_to_see_terms: "Your access to the API is temporarily suspended. Please log-in to the web interface to view the Contributor Terms. You do not need to agree, but you must view them."
+      blocked: "Your access to the API has been blocked. Please log in to the web interface to find out more."
+      need_to_see_terms: "Your access to the API is temporarily suspended. Please log in to the web interface to view the Contributor Terms. You do not need to agree, but you must view them."
     settings_menu:
       account_settings: Account Settings
       oauth2_applications: OAuth 2 Applications
@@ -2755,7 +2755,7 @@ en:
     permissions:
       missing: "You have not permitted the application access to this facility"
     scopes:
-      openid: Sign-in using OpenStreetMap
+      openid: Sign in using OpenStreetMap
       read_prefs: Read user preferences
       write_prefs: Modify user preferences
       write_diary: Create diary entries and comments


### PR DESCRIPTION
### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->

I've sent up this change again as I messed up the Git flow for my last PR. Hopefully this will not need any further changes!

This Pull Request is to tackle the grammatical mistake mentioned in Issue #5772. In particular, the use of "sign-in" and "log-in" as a noun in this context is incorrect, as it is inconsistent with the other verbs within the permission list.

Fixes:

- "Sign-in" has been changed to "sign in" (without the hyphen).
- "Log-in" has been changed to "log in" (without the hyphen).

Required citations, credited to @maro-21 in the comment of the original issue, are as follows:

- https://www.oxfordlearnersdictionaries.com/definition/english/sign-in?q=sign-in
- https://en.wiktionary.org/wiki/sign-in
- https://www.dictionary.com/browse/sign-in
- https://www.oed.com/dictionary/sign-in_adj?tl=true

Thank you to those who have offered me tips to clean up my Git flow in the last PR!
### How has this been tested?
<!--Explain the steps you took to test your code.-->
Since this is a grammatical fix for a text, testing is not required.