### PR TITLE
User list fixes

### DIFF
--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -38,7 +38,7 @@ module Users
       User.where(:id => ids).update_all(:status => "confirmed") if params[:confirm]
       User.where(:id => ids).update_all(:status => "deleted") if params[:hide]
 
-      redirect_to url_for(params.permit(:status, :ip, :before, :after))
+      redirect_to url_for(params.permit(:status, :username, :ip, :edits, :before, :after))
     end
   end
 end

--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -33,7 +33,7 @@ module Users
     ##
     # update status of selected users
     def update
-      ids = params[:user].keys.collect(&:to_i)
+      ids = params.fetch(:user, {}).keys.collect(&:to_i)
 
       User.where(:id => ids).update_all(:status => "confirmed") if params[:confirm]
       User.where(:id => ids).update_all(:status => "deleted") if params[:hide]

--- a/app/views/users/lists/_page.html.erb
+++ b/app/views/users/lists/_page.html.erb
@@ -14,7 +14,9 @@
       <div>
 
       <%= hidden_field_tag :status, params[:status] if params[:status] %>
+      <%= hidden_field_tag :username, params[:username] if params[:username] %>
       <%= hidden_field_tag :ip, params[:ip] if params[:ip] %>
+      <%= hidden_field_tag :edits, params[:edits] if params[:edits] %>
       <%= hidden_field_tag :page, params[:page] if params[:page] %>
       <table id="user_list" class="table table-borderless table-striped">
         <thead>

--- a/app/views/users/lists/_page.html.erb
+++ b/app/views/users/lists/_page.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <% unless @users.empty? %>
-    <%= form_tag @params, :method => :put do %>
+    <%= form_tag users_list_path, :method => :put do %>
       <div class="row">
         <div class="col">
           <%= render "shared/pagination",

--- a/test/controllers/users/lists_controller_test.rb
+++ b/test/controllers/users/lists_controller_test.rb
@@ -210,6 +210,14 @@ module Users
 
       session_for(create(:administrator_user))
 
+      # Should do nothing when no users selected
+      assert_no_difference "User.active.count" do
+        put users_list_path, :params => { :confirm => 1 }
+      end
+      assert_redirected_to :action => :show
+      assert_equal "pending", inactive_user.reload.status
+      assert_equal "suspended", suspended_user.reload.status
+
       # Should work when logged in as an administrator
       assert_difference "User.active.count", 2 do
         put users_list_path, :params => { :confirm => 1, :user => { inactive_user.id => 1, suspended_user.id => 1 } }
@@ -253,6 +261,14 @@ module Users
       assert_equal "confirmed", confirmed_user.reload.status
 
       session_for(create(:administrator_user))
+
+      # Should do nothing when no users selected
+      assert_no_difference "User.active.count" do
+        put users_list_path, :params => { :hide => 1 }
+      end
+      assert_redirected_to :action => :show
+      assert_equal "active", normal_user.reload.status
+      assert_equal "confirmed", confirmed_user.reload.status
 
       # Should work when logged in as an administrator
       assert_difference "User.active.count", -2 do

--- a/test/controllers/users/lists_controller_test.rb
+++ b/test/controllers/users/lists_controller_test.rb
@@ -67,64 +67,88 @@ module Users
       get users_list_path, :params => { :status => "suspended" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1 do
-        assert_select "a[href='#{user_path(suspended_user)}']", :count => 1
+      assert_select "turbo-frame#pagination", :count => 1 do
+        assert_select "input[type='hidden'][name='status'][value='suspended']", :count => 1
+        assert_select "table#user_list tbody tr", :count => 1 do
+          assert_select "a[href='#{user_path(suspended_user)}']", :count => 1
+        end
       end
 
       # Should be able to limit by name
       get users_list_path, :params => { :username => "Test User" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1 do
-        assert_select "a[href='#{user_path(name_user)}']", :count => 1
+      assert_select "turbo-frame#pagination", :count => 1 do
+        assert_select "input[type='hidden'][name='username'][value='Test User']", :count => 1
+        assert_select "table#user_list tbody tr", :count => 1 do
+          assert_select "a[href='#{user_path(name_user)}']", :count => 1
+        end
       end
 
       # Should be able to limit by name ignoring case
       get users_list_path, :params => { :username => "test user" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1 do
-        assert_select "a[href='#{user_path(name_user)}']", :count => 1
+      assert_select "turbo-frame#pagination", :count => 1 do
+        assert_select "input[type='hidden'][name='username'][value='test user']", :count => 1
+        assert_select "table#user_list tbody tr", :count => 1 do
+          assert_select "a[href='#{user_path(name_user)}']", :count => 1
+        end
       end
 
       # Should be able to limit by email
       get users_list_path, :params => { :username => "test@example.com" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1 do
-        assert_select "a[href='#{user_path(email_user)}']", :count => 1
+      assert_select "turbo-frame#pagination", :count => 1 do
+        assert_select "input[type='hidden'][name='username'][value='test@example.com']", :count => 1
+        assert_select "table#user_list tbody tr", :count => 1 do
+          assert_select "a[href='#{user_path(email_user)}']", :count => 1
+        end
       end
 
       # Should be able to limit by email ignoring case
       get users_list_path, :params => { :username => "TEST@example.com" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1 do
-        assert_select "a[href='#{user_path(email_user)}']", :count => 1
+      assert_select "turbo-frame#pagination", :count => 1 do
+        assert_select "input[type='hidden'][name='username'][value='TEST@example.com']", :count => 1
+        assert_select "table#user_list tbody tr", :count => 1 do
+          assert_select "a[href='#{user_path(email_user)}']", :count => 1
+        end
       end
 
       # Should be able to limit by IP address
       get users_list_path, :params => { :ip => "1.2.3.4" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1 do
-        assert_select "a[href='#{user_path(ip_user)}']", :count => 1
+      assert_select "turbo-frame#pagination", :count => 1 do
+        assert_select "input[type='hidden'][name='ip'][value='1.2.3.4']", :count => 1
+        assert_select "table#user_list tbody tr", :count => 1 do
+          assert_select "a[href='#{user_path(ip_user)}']", :count => 1
+        end
       end
 
       # Should be able to limit to users with edits
       get users_list_path, :params => { :edits => "yes" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 1 do
-        assert_select "a[href='#{user_path(edits_user)}']", :count => 1
+      assert_select "turbo-frame#pagination", :count => 1 do
+        assert_select "input[type='hidden'][name='edits'][value='yes']", :count => 1
+        assert_select "table#user_list tbody tr", :count => 1 do
+          assert_select "a[href='#{user_path(edits_user)}']", :count => 1
+        end
       end
 
       # Should be able to limit to users with no edits
       get users_list_path, :params => { :edits => "no" }
       assert_response :success
       assert_template :show
-      assert_select "table#user_list tbody tr", :count => 9 do
-        assert_select "a[href='#{user_path(edits_user)}']", :count => 0
+      assert_select "turbo-frame#pagination", :count => 1 do
+        assert_select "input[type='hidden'][name='edits'][value='no']", :count => 1
+        assert_select "table#user_list tbody tr", :count => 9 do
+          assert_select "a[href='#{user_path(edits_user)}']", :count => 0
+        end
       end
     end
 


### PR DESCRIPTION
Some fixes for the user list view:

* Fix a server error if the user hits confirm or hide without selecting any users
* Preserve the user and edit filters across a confirm or hide action
* Drop redundant parameters from a form URL that duplicate hidden fields