### PR TITLE
Don't crop coordinates when replacing directions url

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -145,7 +145,7 @@ OSM.Directions = function (map) {
 
     OSM.router.replace("/directions?" + new URLSearchParams({
       engine: chosenEngine.id,
-      route: points.map(p => OSM.cropLocation(p, map.getZoom()).join()).join(";")
+      route: points.map(p => `${p.lat},${p.lng}`).join(";")
     }));
 
     // copy loading item to sidebar and display it. we copy it, rather than


### PR DESCRIPTION
Here's some strange behavior:

1. Zoom in close enough.
2. Build a route, like [this one](https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=48.861246%2C2.345002%3B48.862012%2C2.341391#map=18/48.861833/2.343210).
3. Look at the browser location bar. It's going to contain the coordinates of endpoints. Notice that they have 5-6 digits after decimal point.
4. Zoom out to see the entire planet.
5. Click *Go* to rebuild the route. This will zoom you back to the same route.
6. Look at the location bar again. Now the coordinates have only one digit after decimal point and they are the same for starting/ending points. That can't be right.
7. Click *Reload* and you'll be taken to some other place and the route will be gone.

The `OSM.cropLocation` that I'm removing (and whatever preceded it for years) makes no sense. It means *build a route using one set of coordinates, but put something else in the url*. The coordinates are already limited to zoom-dependent precisions when endpoint markers are placed. There's no need to crop them again.