### PR TITLE
Monkey patch Selenium to allocate unique bidi ports

### DIFF
--- a/config/initializers/selenium.rb
+++ b/config/initializers/selenium.rb
@@ -1,0 +1,35 @@
+if Rails.env.test?
+  require "active_support/testing/parallelization"
+
+  module OpenStreetMap
+    module Selenium
+      module BidiPort
+        module ClassMethods
+          attr_accessor :websocket_port
+        end
+
+        def self.prepended(base)
+          class << base
+            prepend ClassMethods
+          end
+
+          base.websocket_port = 10000
+
+          ActiveSupport::Testing::Parallelization.after_fork_hook do |worker|
+            base.websocket_port = 10000 + worker
+          end
+        end
+
+        def initialize(config)
+          super
+
+          @extra_args = Array(@extra_args) << "--websocket-port=#{self.class.websocket_port}"
+
+          self.class.websocket_port += 256
+        end
+      end
+    end
+  end
+
+  Selenium::WebDriver::ServiceManager.prepend(OpenStreetMap::Selenium::BidiPort)
+end


### PR DESCRIPTION
Firefox 136 has started binding an extra port at startup when running via selenium but unfortunately it always uses port 9222 which causes problems running tests in parallel as discussed in https://github.com/mozilla/geckodriver/issues/2218.

This monkey patches things to try and allocate unique ports.

I believe this is the cause of the sporadic test failures we've been seeing the last few days - on my machine it happens basically every time since 136 came out but I probably have much high parallelism than Actions.