### PR TITLE
Disable asynchronous object layer loading

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -306,8 +306,7 @@ L.OSM.Map = L.Map.extend({
               way: objectStyle,
               area: objectStyle,
               changeset: changesetStyle
-            },
-            asynchronous: true
+            }
           });
 
           map._objectLayer.interestingNode = function (node, wayNodes, relationNodes) {

--- a/test/system/browse_test.rb
+++ b/test/system/browse_test.rb
@@ -10,4 +10,14 @@ class BrowseTest < ApplicationSystemTestCase
 
     assert_selector "#map .leaflet-overlay-pane path"
   end
+
+  test "map should center on a viewed node" do
+    node = create(:node, :lat => 59.55555, :lon => 29.55555)
+
+    visit node_path(node)
+
+    find("#map [aria-label='Share']").click
+    share_url = find_by_id("long_input").value
+    assert_match %r{map=\d+/59\.\d+/29\.\d+}, share_url
+  end
 end


### PR DESCRIPTION
Fixes #5798.

I see #5009 and its commit mentioning only "Map Data checkbox". The object layer is not related to that checkbox and the code that uses the object layer doesn't expect async loading.