### PR TITLE
Align bottoms of date-username-changeset_id and counters in history

### DIFF
--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -4,7 +4,7 @@
       <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>
     </a>
   </p>
-  <div class="d-flex flex-nowrap gap-3 justify-content-between">
+  <div class="d-flex flex-nowrap gap-3 justify-content-between align-items-end">
     <div class="overflow-hidden pt-3">
       <%= changeset_details(changeset) %>
       &middot;
@@ -12,7 +12,7 @@
         #<%= changeset.id %>
       </a>
     </div>
-    <div class="d-flex flex-column justify-content-end align-items-end text-body-secondary">
+    <div class="d-flex flex-column align-items-end text-body-secondary">
       <%= tag.div :class => ["d-flex align-items-baseline gap-1", { "opacity-50" => changeset.comments.empty? }],
                   :title => t(".comments", :count => changeset.comments.length) do %>
         <%= changeset.comments.length %>


### PR DESCRIPTION
Moves "Closed (date) by (user)" lines down slightly if necessary to align with edit counters.

Before / after for different users:
![image](https://github.com/user-attachments/assets/5785f5e8-8b4d-4b05-b9c3-4f56a471a5ae) ![image](https://github.com/user-attachments/assets/7c4c2e50-dcd5-4821-bb13-586bb86c3af7)

Before / after for a single user:
![image](https://github.com/user-attachments/assets/9f86ec3f-d2c1-41f3-9d81-05ae196c865a) ![image](https://github.com/user-attachments/assets/318d305f-1af3-4733-abbd-63e31b940347)
