### PR TITLE
Fix wget command for Windows installation guide

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -116,7 +116,11 @@ For example, let's download the District of Columbia from Geofabrik or [any othe
 ```
 wget https://download.geofabrik.de/north-america/us/district-of-columbia-latest.osm.pbf
 ```
+**Windows users:** On some Windows configurations, the downloaded file may not be saved properly. If you encounter issues, try using an explicit output filename with `-OutFile` in the wget command:
 
+```
+wget https://download.geofabrik.de/north-america/us/district-of-columbia-latest.osm.pbf -OutFile district-of-columbia-latest.osm.pbf
+```
 You can now use Docker to load this extract into your local Docker-based OSM instance:
 
 ```


### PR DESCRIPTION
### Description
In Window Shell, I directed to `cd openstreetmap-website` > `ls` but cannot see data file for District of Columbia although the download StatusCode : 200 and StatusDescription : OK.

Added a note in DOCKER.md for Windows users regarding potential issues when downloading OSM extracts using wget. Some Windows configurations do not properly save the file unless -OutFile is explicitly specified.

### How has this been tested?
Tested on Windows 11 PowerShell using wget with and without -OutFile.
Verified that using -OutFile ensures the file is properly saved and can be found in the directory.