### PR TITLE
Add links to days in user history from heatmap

### DIFF
--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -70,6 +70,10 @@ document.addEventListener("DOMContentLoaded", () => {
       }]
     ]);
 
+    cal.on("mouseover", (event, _timestamp, value) => {
+      if (value) event.target.style.cursor = "pointer";
+    });
+
     cal.on("click", (_event, timestamp) => {
       if (!displayName) return;
       for (const { date, max_id } of heatmapData) {

--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   const heatmapData = heatmapElement.dataset.heatmap ? JSON.parse(heatmapElement.dataset.heatmap) : [];
+  const displayName = heatmapElement.dataset.displayName;
   const colorScheme = document.documentElement.getAttribute("data-bs-theme") ?? "auto";
   const rangeColors = ["#14432a", "#166b34", "#37a446", "#4dd05a"];
   const startDate = new Date(Date.now() - (365 * 24 * 60 * 60 * 1000));
@@ -68,6 +69,16 @@ document.addEventListener("DOMContentLoaded", () => {
         text: (date, value) => getTooltipText(date, value)
       }]
     ]);
+
+    cal.on("click", (_event, timestamp) => {
+      if (!displayName) return;
+      for (const { date, max_id } of heatmapData) {
+        if (!max_id) continue;
+        if (timestamp !== Date.parse(date)) continue;
+        const params = new URLSearchParams([["before", max_id + 1]]);
+        location = `/user/${encodeURIComponent(displayName)}/history?${params}`;
+      }
+    });
   }
 
   function getTooltipText(date, value) {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -57,6 +57,7 @@ OSM.History = function (map) {
 
   function update() {
     const data = new URLSearchParams();
+    const params = new URLSearchParams(location.search);
 
     if (location.pathname === "/history") {
       data.set("bbox", map.getBounds().wrap().toBBoxString());
@@ -66,6 +67,10 @@ OSM.History = function (map) {
     }
 
     data.set("list", "1");
+
+    if (params.has("before")) {
+      data.set("before", params.get("before"));
+    }
 
     fetch(location.pathname + "?" + data)
       .then(response => response.text())

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -17,12 +17,12 @@ class ChangesetsController < ApplicationController
   ##
   # list non-empty changesets in reverse chronological order
   def index
-    param! :max_id, Integer, :min => 1
+    param! :before, Integer, :min => 1
 
-    @params = params.permit(:display_name, :bbox, :friends, :nearby, :max_id, :list)
+    @params = params.permit(:display_name, :bbox, :friends, :nearby, :before, :list)
 
-    if request.format == :atom && @params[:max_id]
-      redirect_to url_for(@params.merge(:max_id => nil)), :status => :moved_permanently
+    if request.format == :atom && @params[:before]
+      redirect_to url_for(@params.merge(:before => nil)), :status => :moved_permanently
       return
     end
 
@@ -59,7 +59,7 @@ class ChangesetsController < ApplicationController
         changesets = changesets.where(:user => current_user.nearby)
       end
 
-      changesets = changesets.where(:changesets => { :id => ..@params[:max_id] }) if @params[:max_id]
+      changesets = changesets.where(:changesets => { :id => ...@params[:before] }) if @params[:before]
 
       @changesets = changesets.order("changesets.id DESC").limit(20).preload(:user, :changeset_tags, :comments)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
     if @user && (@user.visible? || current_user&.administrator?)
       @title = @user.display_name
 
-      @heatmap_data = Rails.cache.fetch("heatmap_data_user_#{@user.id}", :expires_in => 1.day) do
+      @heatmap_data = Rails.cache.fetch("heatmap_data_with_ids_user_#{@user.id}", :expires_in => 1.day) do
         one_year_ago = 1.year.ago.beginning_of_day
         today = Time.zone.now.end_of_day
 
@@ -33,12 +33,13 @@ class UsersController < ApplicationController
           .where(:created_at => one_year_ago..today)
           .where(:num_changes => 1..)
           .group("date_trunc('day', created_at)")
-          .select("date_trunc('day', created_at) AS date, SUM(num_changes) AS total_changes")
+          .select("date_trunc('day', created_at) AS date, SUM(num_changes) AS total_changes, MAX(id) AS max_id")
           .order("date")
           .map do |changeset|
             {
               :date => changeset.date.to_date.to_s,
-              :total_changes => changeset.total_changes.to_i
+              :total_changes => changeset.total_changes.to_i,
+              :max_id => changeset.max_id
             }
           end
       end

--- a/app/views/changesets/history.html.erb
+++ b/app/views/changesets/history.html.erb
@@ -1,6 +1,6 @@
 <% content_for :auto_discovery_link_tag do -%>
   <% unless params[:friends] or params[:nearby] -%>
-    <%= auto_discovery_link_tag :atom, @params.to_h.merge(:max_id => nil, :xhr => nil, :action => :feed) %>
+    <%= auto_discovery_link_tag :atom, @params.to_h.merge(:before => nil, :xhr => nil, :action => :feed) %>
   <% end -%>
 <% end -%>
 

--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -4,7 +4,7 @@
   </ol>
 <% if @changesets.size == 20 -%>
   <div class="changeset_more mt-3 text-center">
-    <%= link_to t(".load_more"), url_for(@params.merge(:max_id => @changesets.last.id - 1)), :class => "btn btn-primary" %>
+    <%= link_to t(".load_more"), url_for(@params.merge(:before => @changesets.last.id)), :class => "btn btn-primary" %>
     <div class="text-center loader">
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
@@ -13,9 +13,9 @@
   </div>
 <% end -%>
 <% elsif params[:bbox] %>
-  <p class="mx-3"><%= params[:max_id] ? t(".no_more_area") : t(".empty_area") %></p>
+  <p class="mx-3"><%= params[:before] ? t(".no_more_area") : t(".empty_area") %></p>
 <% elsif params[:display_name] %>
-  <p class="mx-3"><%= params[:max_id] ? t(".no_more_user") : t(".empty_user") %></p>
+  <p class="mx-3"><%= params[:before] ? t(".no_more_user") : t(".empty_user") %></p>
 <% else %>
-  <p class="mx-3"><%= params[:max_id] ? t(".no_more") : t(".empty") %></p>
+  <p class="mx-3"><%= params[:before] ? t(".no_more") : t(".empty") %></p>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -253,7 +253,7 @@
         </ul>
         <!-- Heatmap -->
         <div id="cal-heatmap" class="ms-2"
-          data-heatmap="<%= @heatmap_data.to_json %>">
+          data-heatmap="<%= @heatmap_data.to_json %>" data-display-name="<%= @user.display_name %>">
         </div>
       </div>
     </div>

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -80,7 +80,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
   # This should report an error
   def test_index_invalid_xhr
     %w[-1 0 fred].each do |id|
-      get history_path(:format => "html", :list => "1", :max_id => id)
+      get history_path(:format => "html", :list => "1", :before => id)
       assert_redirected_to :controller => :errors, :action => :bad_request
     end
   end
@@ -221,21 +221,21 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
 
   ##
   # Check that we can't request later pages of the changesets index
-  def test_index_max_id
-    changeset = create(:changeset, :num_changes => 1)
-    _changeset2 = create(:changeset, :num_changes => 1)
+  def test_index_before_id
+    changeset1 = create(:changeset, :num_changes => 1)
+    changeset2 = create(:changeset, :num_changes => 1)
 
-    get history_path(:format => "html", :max_id => changeset.id), :xhr => true
+    get history_path(:format => "html", :before => changeset2.id), :xhr => true
     assert_response :success
     assert_template "history"
     assert_template :layout => "xhr"
     assert_select "h2", :text => "Changesets", :count => 1
 
-    get history_path(:format => "html", :list => "1", :max_id => changeset.id), :xhr => true
+    get history_path(:format => "html", :list => "1", :before => changeset2.id), :xhr => true
     assert_response :success
     assert_template "index"
 
-    check_index_result([changeset])
+    check_index_result [changeset1]
   end
 
   ##
@@ -411,8 +411,8 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
 
   ##
   # Check that we can't request later pages of the changesets feed
-  def test_feed_max_id
-    get history_feed_path(:format => "atom", :max_id => 100)
+  def test_feed_before
+    get history_feed_path(:format => "atom", :before => 100)
     assert_redirected_to :action => :feed
   end
 

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -53,6 +53,36 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
+  test "user history starts before specified changeset" do
+    user = create(:user)
+    changeset1 = create_visible_changeset(user, "1st-changeset-in-history")
+    changeset2 = create_visible_changeset(user, "2nd-changeset-in-history")
+    changeset3 = create(:changeset)
+
+    visit "#{user_path user}/history?before=#{changeset1.id}"
+
+    within_sidebar do
+      assert_no_link "1st-changeset-in-history"
+      assert_no_link "2nd-changeset-in-history"
+    end
+
+    visit "#{user_path user}/history?before=#{changeset2.id}"
+
+    within_sidebar do
+      assert_link "1st-changeset-in-history"
+      assert_no_link "2nd-changeset-in-history"
+    end
+
+    visit "#{user_path user}/history?before=#{changeset3.id}"
+
+    within_sidebar do
+      assert_link "1st-changeset-in-history"
+      assert_link "2nd-changeset-in-history"
+    end
+  end
+
+  private
+
   def create_visible_changeset(user, comment)
     create(:changeset, :user => user, :num_changes => 1) do |changeset|
       create(:changeset_tag, :changeset => changeset, :k => "comment", :v => comment)


### PR DESCRIPTION
Because navigating through user history is difficult, I wanted this: https://github.com/openstreetmap/openstreetmap-website/issues/5804#issuecomment-2726693156

This PR makes it that clicking on a nonempty calendar cell takes you to the corresponding day in the user's changeset history.

![image](https://github.com/user-attachments/assets/d000be00-10ce-4018-9084-87cf468f13d2)
