### PR TITLE
Fix heatmap month titles in Western Hemisphere

### DIFF
--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -33,7 +33,7 @@ document.addEventListener("DOMContentLoaded", () => {
         type: "month",
         gutter: 4,
         label: {
-          text: (timestamp) => monthNames[new Date(timestamp).getMonth() + 1],
+          text: (timestamp) => monthNames[new Date(timestamp).getUTCMonth() + 1],
           position: "top",
           textAlign: "middle"
         },


### PR DESCRIPTION
Fixes #5802

Before when simulating some place in the US (Chrome dev tools > Sensors > Location):
![image](https://github.com/user-attachments/assets/321191ac-6ce5-46f5-86d5-78bc54aa868c)

After:
![image](https://github.com/user-attachments/assets/bfafc18d-5c05-4217-9b51-2ba5f52ada83)
