### PR TITLE
Put api keys directly in js layer definitions

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -18,7 +18,7 @@ I18n.fallbacks = true;
 window.onload = function () {
   const args = Object.fromEntries(new URLSearchParams(location.search));
 
-  const tileOptions = {
+  const options = {
     mapnik: {
 <% if Settings.key?(:tile_cdn_url) %>
       url: <%= Settings.tile_cdn_url.to_json %>
@@ -26,36 +26,16 @@ window.onload = function () {
     }
   };
 
-  const apiKeys = {
-<% if Settings.key?(:thunderforest_key) %>
-    THUNDERFOREST_KEY: <%= Settings.thunderforest_key.to_json %>
-<% end %>
-  };
-
   const map = L.map("map");
   map.attributionControl.setPrefix("");
   map.removeControl(map.attributionControl);
 
   const isDarkTheme = args.theme === "dark" || (args.theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
-  const layers = <%=
-    YAML.load_file(Rails.root.join("config/layers.yml"))
-      .select { |entry| entry["canEmbed"] }
-      .each_with_object({}) do |entry, obj|
-        obj[entry["layerId"]] = {
-          layer: entry["leafletOsmId"],
-          darkLayer: entry["leafletOsmDarkId"],
-          apiKeyId: entry["apiKeyId"]
-        }.compact
-      end.to_json
-    %>;
+  const layers = <%= MapLayers::embed_definitions("config/layers.yml").to_json %>;
   const layerId = (args.layer || "").replaceAll(" ", "");
   const layerConfig = layers[layerId] || layers.mapnik;
-  const { layer, ...options } = {
-    layer: layerConfig.darkLayer && isDarkTheme ? layerConfig.darkLayer : layerConfig.layer,
-    apikey: apiKeys[layerConfig.apiKeyId],
-    ...tileOptions[layerId]
-  };
-  new L.OSM[layer](options).addTo(map);
+  const layer = (isDarkTheme && layerConfig.leafletOsmDarkId) || layerConfig.leafletOsmId;
+  new L.OSM[layer]({ apikey: layerConfig.apikey, ...options[layerId] }).addTo(map);
 
   if (args.marker) {
     L.marker(args.marker.split(","), { icon: L.icon({

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -16,8 +16,6 @@ L.OSM.Map = L.Map.extend({
     this.baseLayers = [];
 
     for (const layerDefinition of OSM.LAYER_DEFINITIONS) {
-      if (layerDefinition.apiKeyId && !OSM[layerDefinition.apiKeyId]) continue;
-
       let layerConstructor = L.OSM.TileLayer;
       const layerOptions = {};
 
@@ -26,8 +24,6 @@ L.OSM.Map = L.Map.extend({
           layerOptions.attribution = makeAttribution(value);
         } else if (property === "nameId") {
           layerOptions.name = I18n.t(`javascripts.map.base.${value}`);
-        } else if (property === "apiKeyId") {
-          layerOptions.apikey = OSM[value];
         } else if (property === "leafletOsmId") {
           layerConstructor = L.OSM[value];
         } else if (property === "leafletOsmDarkId" && OSM.isDarkMap() && L.OSM[value]) {

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -19,8 +19,6 @@ OSM = {
       graphhopper_url
       fossgis_osrm_url
       fossgis_valhalla_url
-      thunderforest_key
-      tracestrack_key
     ]
       .each_with_object({}) do |key, hash|
         hash[key.to_s.upcase] = Settings.send(key) if Settings.respond_to?(key)
@@ -29,7 +27,7 @@ OSM = {
 
   DEFAULT_LOCALE: <%= I18n.default_locale.to_json %>,
 
-  LAYER_DEFINITIONS: <%= YAML.load_file(Rails.root.join("config/layers.yml")).to_json %>,
+  LAYER_DEFINITIONS: <%= MapLayers::full_definitions("config/layers.yml").to_json %>,
   LAYERS_WITH_MAP_KEY: <%= YAML.load_file(Rails.root.join("config/key.yml")).keys.to_json %>,
 
   MARKER_GREEN: <%= image_path("marker-green.png").to_json %>,

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -28,7 +28,7 @@
   code: "C"
   layerId: "cyclemap"
   nameId: "cycle_map"
-  apiKeyId: "THUNDERFOREST_KEY"
+  apiKeyId: "thunderforest_key"
   canEmbed: true
   canDownloadImage: true
   credit:
@@ -43,7 +43,7 @@
   code: "T"
   layerId: "transportmap"
   nameId: "transport_map"
-  apiKeyId: "THUNDERFOREST_KEY"
+  apiKeyId: "thunderforest_key"
   canEmbed: true
   canDownloadImage: true
   credit:
@@ -57,7 +57,7 @@
   code: "P"
   layerId: "tracestracktopo"
   nameId: "tracestracktop_topo"
-  apiKeyId: "TRACESTRACK_KEY"
+  apiKeyId: "tracestrack_key"
   credit:
     id: "tracestrack_credit"
     children:

--- a/lib/map_layers.rb
+++ b/lib/map_layers.rb
@@ -1,0 +1,19 @@
+module MapLayers
+  def self.full_definitions(layers_filename)
+    YAML.load_file(Rails.root.join(layers_filename))
+        .reject { |layer| layer["apiKeyId"] && !Settings[layer["apiKeyId"]] }
+        .map do |layer|
+          if layer["apiKeyId"]
+            layer["apikey"] = Settings[layer["apiKeyId"]]
+            layer.delete "apiKeyId"
+          end
+          layer
+        end
+  end
+
+  def self.embed_definitions(layers_filename)
+    full_definitions(layers_filename)
+      .select { |entry| entry["canEmbed"] }
+      .to_h { |entry| [entry["layerId"], entry.slice("leafletOsmId", "leafletOsmDarkId", "apikey").compact] }
+  end
+end


### PR DESCRIPTION
### Description
This PR expands on and closes #5352, building onto the `MapLayers` library and also reusing the keys for the embed layer selection (`leafletOsmId` instead of `layer`).

### How has this been tested?
Only the difference to #5352
