### PR TITLE
Add 'Load more' button that loads newer changesets to history pages

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -47,12 +47,24 @@ OSM.History = function (map) {
     $("#sidebar_content .changesets").html(html);
   }
 
-  function displayMoreChangesets(html) {
-    $("#sidebar_content .changeset_more").replaceWith(html);
-    const oldList = $("#sidebar_content .changesets ol").first();
-    const newList = oldList.next("ol");
-    newList.children().appendTo(oldList);
-    newList.remove();
+  function displayMoreChangesets(div, html) {
+    const oldList = $("#sidebar_content .changesets ol");
+
+    div.replaceWith(html);
+
+    const prevNewList = oldList.prevAll("ol");
+    if (prevNewList.length) {
+      prevNewList.next(".changeset_more").remove();
+      prevNewList.children().prependTo(oldList);
+      prevNewList.remove();
+    }
+
+    const nextNewList = oldList.nextAll("ol");
+    if (nextNewList.length) {
+      nextNewList.prev(".changeset_more").remove();
+      nextNewList.children().appendTo(oldList);
+      nextNewList.remove();
+    }
   }
 
   function update() {
@@ -70,6 +82,9 @@ OSM.History = function (map) {
 
     if (params.has("before")) {
       data.set("before", params.get("before"));
+    }
+    if (params.has("after")) {
+      data.set("after", params.get("after"));
     }
 
     fetch(location.pathname + "?" + data)
@@ -90,7 +105,7 @@ OSM.History = function (map) {
     div.find(".loader").show();
 
     $.get($(this).attr("href"), function (html) {
-      displayMoreChangesets(html);
+      displayMoreChangesets(div, html);
       updateMap();
     });
   }

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -48,6 +48,9 @@ OSM.History = function (map) {
   }
 
   function displayMoreChangesets(div, html) {
+    const sidebar = $("#sidebar")[0];
+    const previousScrollHeightMinusTop = sidebar.scrollHeight - sidebar.scrollTop;
+
     const oldList = $("#sidebar_content .changesets ol");
 
     div.replaceWith(html);
@@ -57,6 +60,9 @@ OSM.History = function (map) {
       prevNewList.next(".changeset_more").remove();
       prevNewList.children().prependTo(oldList);
       prevNewList.remove();
+
+      // restore scroll position only if prepending
+      sidebar.scrollTop = sidebar.scrollHeight - previousScrollHeightMinusTop;
     }
 
     const nextNewList = oldList.nextAll("ol");

--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -1,17 +1,17 @@
-<% if @changesets.present? %>
-  <ol class="changesets list-group list-group-flush">
-    <%= render @changesets %>
-  </ol>
-<% if @changesets.size == 20 -%>
-  <div class="changeset_more mt-3 text-center">
-    <%= link_to t(".load_more"), url_for(@params.merge(:before => @changesets.last.id)), :class => "btn btn-primary" %>
+<% if @newer_changesets_id %>
+  <div class="changeset_more my-3 text-center">
+    <%= link_to t(".load_more"), url_for(@params.merge(:before => nil, :after => @newer_changesets_id)), :class => "btn btn-primary" %>
     <div class="text-center loader">
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
       </div>
     </div>
   </div>
-<% end -%>
+<% end %>
+<% if @changesets.present? %>
+  <ol class="changesets list-group list-group-flush">
+    <%= render @changesets %>
+  </ol>
 <% elsif params[:bbox] %>
   <p class="mx-3"><%= params[:before] ? t(".no_more_area") : t(".empty_area") %></p>
 <% elsif params[:display_name] %>
@@ -19,3 +19,13 @@
 <% else %>
   <p class="mx-3"><%= params[:before] ? t(".no_more") : t(".empty") %></p>
 <% end %>
+<% if @older_changesets_id -%>
+  <div class="changeset_more my-3 text-center">
+    <%= link_to t(".load_more"), url_for(@params.merge(:before => @older_changesets_id, :after => nil)), :class => "btn btn-primary" %>
+    <div class="text-center loader">
+      <div class="spinner-border" role="status">
+        <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
+      </div>
+    </div>
+  </div>
+<% end -%>

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -81,6 +81,34 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
+  test "user history starts after specified changeset" do
+    user = create(:user)
+    changeset0 = create(:changeset)
+    changeset1 = create_visible_changeset(user, "1st-changeset-in-history")
+    changeset2 = create_visible_changeset(user, "2nd-changeset-in-history")
+
+    visit "#{user_path user}/history?after=#{changeset2.id}"
+
+    within_sidebar do
+      assert_no_link "1st-changeset-in-history"
+      assert_no_link "2nd-changeset-in-history"
+    end
+
+    visit "#{user_path user}/history?after=#{changeset1.id}"
+
+    within_sidebar do
+      assert_no_link "1st-changeset-in-history"
+      assert_link "2nd-changeset-in-history"
+    end
+
+    visit "#{user_path user}/history?after=#{changeset0.id}"
+
+    within_sidebar do
+      assert_link "1st-changeset-in-history"
+      assert_link "2nd-changeset-in-history"
+    end
+  end
+
   private
 
   def create_visible_changeset(user, comment)


### PR DESCRIPTION
If you get to the user's history page from the heatmap, it will start on a selected date. You can scroll down, press *Load more* and and load changesets that were created before the initially visible set. But what if you want to see changesets created after the date?

This PR adds a *Load more* button in frond of the changeset list, if there are any changesets that were opened after the ones in the list.

![image](https://github.com/user-attachments/assets/69ce41be-ae9a-4405-8f81-e67638f3dc10) ![image](https://github.com/user-attachments/assets/7e3d054b-42ce-4ebf-8d03-eb0387263c13)

