### PR TITLE
update-wiki-pages: process ChangesetKey template

### DIFF
--- a/config/wiki_pages.yml
+++ b/config/wiki_pages.yml
@@ -6498,6 +6498,7 @@ en:
     centralkey: Key:centralkey
     change: Key:change
     change:lanes: Key:change:lanes
+    changesets_count: ChangesetKey:changesets count
     changing_table: Key:changing table
     changing_table:adult: Key:changing table:adult
     changing_table:count: Key:changing table:count
@@ -7483,6 +7484,7 @@ en:
     horse_scale: Key:horse scale
     hospital:level:CN: Key:hospital:level:CN
     hospital:level:DE: Key:hospital:level:DE
+    host: Key:host
     hot_water: Key:hot water
     house: Key:house
     hov: Key:hov
@@ -7866,6 +7868,7 @@ en:
     memorial:subject:wikidata: Key:memorial:subject:wikidata
     memorial:subject:wikipedia: Key:memorial:subject:wikipedia
     memorial:type: Key:memorial:type
+    merge_conflict_resolved: ChangesetKey:merge conflict resolved
     message: Key:message
     mhs:inscription_date: Key:mhs:inscription date
     microbrewery: Key:microbrewery

--- a/script/misc/update-wiki-pages
+++ b/script/misc/update-wiki-pages
@@ -71,9 +71,15 @@ for my $lang ('', map { "${_}:" } qw[ Pt Fi De It HU Cz Fr RU Pl ]) {
     $cnt = stick_content_in_hash("tag", "Template:${lang}ValueDescription", \%feature);
     ok(1, "    Got $cnt value pages");
     $count{value} += $cnt;
+
+    # ChangesetKey pages
+    ok(1, "    Getting changeset key pages");
+    $cnt = stick_content_in_hash("key", "Template:${lang}ChangesetKeyDescription", \%feature, "ChangesetKey");
+    ok(1, "    Got $cnt changeset key pages");
+    $count{changesetkey} += $cnt;
 }
 
-ok(1, "Got a total of $count{$_} ${_}s") for qw[ key keyprefix value ];
+ok(1, "Got a total of $count{$_} ${_}s") for qw[ key keyprefix changesetkey value ];
 
 # Dump to .yml file
 open my $out, ">", $out_file or die "Can't open file '$out_file' supplied on the command line";
@@ -87,8 +93,9 @@ exit 0;
 
 sub stick_content_in_hash
 {
-    my ($key, $title, $hash) = @_;
+    my ($key, $title, $hash, $namespace) = @_;
     my $ukey = ucfirst $key;
+    $namespace ||= $ukey;
 
     my $space_to_underscore = sub {
         my $txt = shift;
@@ -105,7 +112,7 @@ sub stick_content_in_hash
         my $title = $link->{title};
         my $lang;
         my $key_name;
-        if ($title =~ /^$ukey:(?<key_name>.*?)$/) {
+        if ($title =~ /^($namespace|$ukey):(?<key_name>.*?)$/) {
             # English by default
             $lang = "en";
             $key_name = $space_to_underscore->($+{key_name});


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
This perl script was last run in #5668, which caused the links for some keys like [`host=*`](https://osm.wiki/Key:host) to disappear, because these pages were migrated from [`Template:KeyDescription`](https://osm.wiki/Template:KeyDescription) to [`Template:ChangesetKeyDescription`](https://osm.wiki/Template:ChangesetKeyDescription)[^1][^2].

This PR updates the script to support [`Template:ChangesetKeyDescription`](https://osm.wiki/Template:ChangesetKeyDescription), which is used by pages under the `Key:` namespace, and/or the `ChangesetKey:` namespace.

### How has this been tested?
Ran the perl script and commited the relevant changes.

[^1]: [`Key:changesets_count` diff#2685844](https://osm.wiki/w/index.php?title=Key:changesets_count&diff=2685844&oldid=2685832)
[^2]: [`Key:host` diff#2612462](https://osm.wiki/w/index.php?title=Key:host&diff=2612462&oldid=2612460)