### PR TITLE
Switch to dynamic allocation for the Firefox bidi port

### DIFF
--- a/config/initializers/selenium.rb
+++ b/config/initializers/selenium.rb
@@ -4,28 +4,10 @@ if Rails.env.test?
   module OpenStreetMap
     module Selenium
       module BidiPort
-        module ClassMethods
-          attr_accessor :websocket_port
-        end
-
-        def self.prepended(base)
-          class << base
-            prepend ClassMethods
-          end
-
-          base.websocket_port = 10000
-
-          ActiveSupport::Testing::Parallelization.after_fork_hook do |worker|
-            base.websocket_port = 10000 + worker
-          end
-        end
-
         def initialize(config)
           super
 
-          @extra_args = Array(@extra_args) << "--websocket-port=#{self.class.websocket_port}"
-
-          self.class.websocket_port += 256
+          @extra_args = Array(@extra_args) << "--websocket-port=0"
         end
       end
     end


### PR DESCRIPTION
As pointed out in https://github.com/mozilla/geckodriver/issues/2218#issuecomment-2735625538 you can use port zero to ask Firefox to dynamically allocate a port which should make this more robust as well as much simpler.