### PR TITLE
Get current locale without function

### DIFF
--- a/app/assets/javascripts/index/directions/fossgis_valhalla.js
+++ b/app/assets/javascripts/index/directions/fossgis_valhalla.js
@@ -97,7 +97,7 @@
             costing: costing,
             directions_options: {
               units: "km",
-              language: OSM.i18n.currentLocale()
+              language: OSM.i18n.locale
             }
           })
         });

--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -57,7 +57,7 @@
         // https://graphhopper.com/api/1/docs/routing/
         const query = new URLSearchParams({
           vehicle: vehicleType,
-          locale: OSM.i18n.currentLocale(),
+          locale: OSM.i18n.locale,
           key: "LijBPDQGfu7Iiq80w3HzwB4RUDJbMbhs6BU0dEnn",
           elevation: false,
           instructions: true,


### PR DESCRIPTION
Removes the usage of the `currentLocale` function since the update to I18n v4 in #5811 which fixes #5821