### PR TITLE
Add reload on iframe redirect

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -36,4 +36,10 @@ $(function () {
   if (idData.gpx) params.set("gpx", idData.gpx);
 
   id.attr("src", idData.url + "#" + params);
+
+  id.ready(function () {
+    if (!this.contentWindow.location.href.startsWith(idData.url)) {
+      location.reload();
+    }
+  });
 });


### PR DESCRIPTION
In some cases, an expired session only causes the window in the iframe to reload on the `/edit` page.
This fixes #5807 (the issue for that bug)