### PR TITLE
Remove OSM.params in favor of URLSearchParams

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -10,7 +10,7 @@ $(function () {
 
   const hash = location.hash.substring(1);
   const hashParams = hash ? OSM.params(hash) : {};
-  const hashArgs = OSM.parseHash(location.hash);
+  const hashArgs = OSM.parseHash();
   const mapParams = OSM.mapParams();
   const params = new URLSearchParams();
   let zoom, lat, lon;

--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -8,8 +8,7 @@ $(function () {
     return;
   }
 
-  const hash = location.hash.substring(1);
-  const hashParams = hash ? OSM.params(hash) : {};
+  const hashParams = new URLSearchParams(location.hash.slice(1));
   const hashArgs = OSM.parseHash();
   const mapParams = OSM.mapParams();
   const params = new URLSearchParams();
@@ -28,7 +27,7 @@ $(function () {
 
   const passThroughKeys = ["background", "comment", "disable_features", "gpx", "hashtags", "locale", "maprules", "notes", "offset", "photo", "photo_dates", "photo_overlay", "photo_username", "presets", "source", "validationDisable", "validationWarning", "validationError", "walkthrough"];
   for (const key of passThroughKeys) {
-    if (hashParams[key]) params.set(key, hashParams[key]);
+    if (hashParams.has(key)) params.set(key, hashParams.get(key));
   }
 
   if (mapParams.layers.includes("N")) params.set("notes", "true");

--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -16,7 +16,7 @@ OSM.i18n.defaultLocale = <%= I18n.default_locale.to_json %>;
 OSM.i18n.enableFallback = true;
 
 window.onload = function () {
-  const args = Object.fromEntries(new URLSearchParams(location.search));
+  const args = new URLSearchParams(location.search);
 
   const options = {
     mapnik: {
@@ -30,15 +30,15 @@ window.onload = function () {
   map.attributionControl.setPrefix("");
   map.removeControl(map.attributionControl);
 
-  const isDarkTheme = args.theme === "dark" || (args.theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+  const isDarkTheme = args.get("theme") === "dark" || (args.get("theme") !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
   const layers = <%= MapLayers::embed_definitions("config/layers.yml").to_json %>;
-  const layerId = (args.layer || "").replaceAll(" ", "");
+  const layerId = (args.get("layer") || "").replaceAll(" ", "");
   const layerConfig = layers[layerId] || layers.mapnik;
   const layer = (isDarkTheme && layerConfig.leafletOsmDarkId) || layerConfig.leafletOsmId;
   new L.OSM[layer]({ apikey: layerConfig.apikey, ...options[layerId] }).addTo(map);
 
-  if (args.marker) {
-    L.marker(args.marker.split(","), { icon: L.icon({
+  if (args.has("marker")) {
+    L.marker(args.get("marker").split(","), { icon: L.icon({
       iconUrl: <%= asset_path('leaflet/dist/images/marker-icon.png').to_json %>,
       iconSize: new L.Point(25, 41),
       iconAnchor: new L.Point(12, 41),
@@ -47,7 +47,7 @@ window.onload = function () {
     }) }).addTo(map);
   }
 
-  const bbox = (args.bbox || "-180,-90,180,90").split(",");
+  const bbox = (args.get("bbox") || "-180,-90,180,90").split(",");
   map.fitBounds([[bbox[1], bbox[0]], [bbox[3], bbox[2]]]);
 
   map.addControl(new L.Control.OSMReportAProblem());

--- a/app/assets/javascripts/fixthemap.js
+++ b/app/assets/javascripts/fixthemap.js
@@ -1,8 +1,8 @@
 $(function () {
-  const params = OSM.params();
+  const params = new URLSearchParams(location.search);
 
   let url = "/note/new";
-  if (!params.zoom) params.zoom = 17;
-  if (params.lat && params.lon) url += OSM.formatHash(params);
+  if (!params.has("zoom")) params.set("zoom", 17);
+  if (params.has("lat") && params.has("lon")) url += OSM.formatHash(params);
   $(".icon.note").attr("href", url);
 });

--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -78,7 +78,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!max_id) continue;
         if (timestamp !== Date.parse(date)) continue;
 
-        const params = new URLSearchParams([["before", max_id + 1]]);
+        const params = new URLSearchParams({ before: max_id + 1 });
         const a = document.createElementNS("http://www.w3.org/2000/svg", "a");
         a.setAttribute("href", `/user/${encodeURIComponent(displayName)}/history?${params}`);
         $(event.target).wrap(a);

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -261,7 +261,7 @@ $(function () {
     e.preventDefault();
   });
 
-  if (OSM.params().edit_help) {
+  if (new URLSearchParams(location.search).get("edit_help")) {
     $("#editanchor")
       .removeAttr("title")
       .tooltip({

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -311,7 +311,7 @@ $(function () {
     };
 
     function addObject(type, id, version, center) {
-      const hashParams = OSM.parseHash(location.hash);
+      const hashParams = OSM.parseHash();
       map.addObject({ type: type, id: parseInt(id, 10), version: version && parseInt(version, 10) }, function (bounds) {
         if (!hashParams.center && bounds.isValid() &&
             (center || !map.getBounds().contains(bounds))) {

--- a/app/assets/javascripts/index/changeset.js
+++ b/app/assets/javascripts/index/changeset.js
@@ -12,7 +12,7 @@ OSM.Changeset = function (map) {
     const changesetData = content.find("[data-changeset]").data("changeset");
     changesetData.type = "changeset";
 
-    const hashParams = OSM.parseHash(location.hash);
+    const hashParams = OSM.parseHash();
     initialize();
     map.addObject(changesetData, function (bounds) {
       if (!hashParams.center && bounds.isValid()) {

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -79,7 +79,7 @@ OSM.Note = function (map) {
     const data = $(".details").data();
 
     if (data) {
-      const hashParams = OSM.parseHash(location.hash);
+      const hashParams = OSM.parseHash();
       map.addObject({
         type: "note",
         id: parseInt(id, 10),

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -54,25 +54,20 @@ OSM = {
     return url;
   },
 
-  params: function (search) {
-    const query = search || location.search;
-    return Object.fromEntries(new URLSearchParams(query));
-  },
-
   mapParams: function (search) {
-    const params = OSM.params(search),
+    const params = new URLSearchParams(search || location.search),
           mapParams = {};
 
-    if (params.mlon && params.mlat) {
+    if (params.has("mlon") && params.has("mlat")) {
       mapParams.marker = true;
-      mapParams.mlon = parseFloat(params.mlon);
-      mapParams.mlat = parseFloat(params.mlat);
+      mapParams.mlon = parseFloat(params.get("mlon"));
+      mapParams.mlat = parseFloat(params.get("mlat"));
     }
 
     // Old-style object parameters; still in use for edit links e.g. /edit?way=1234
     for (const type of ["node", "way", "relation", "note"]) {
-      if (params[type]) {
-        mapParams.object = { type, id: parseInt(params[type], 10) };
+      if (params.has(type)) {
+        mapParams.object = { type, id: parseInt(params.get(type), 10) };
       }
     }
 
@@ -89,15 +84,15 @@ OSM = {
       mapParams.lon = hash.center.lng;
       mapParams.lat = hash.center.lat;
       mapParams.zoom = hash.zoom;
-    } else if (params.bbox) {
-      const [minlon, minlat, maxlon, maxlat] = params.bbox.split(",");
+    } else if (params.has("bbox")) {
+      const [minlon, minlat, maxlon, maxlat] = params.get("bbox").split(",");
       mapParams.bounds = bboxToLatLngBounds({ minlon, minlat, maxlon, maxlat });
-    } else if (params.minlon && params.minlat && params.maxlon && params.maxlat) {
-      mapParams.bounds = bboxToLatLngBounds(params);
-    } else if (params.mlon && params.mlat) {
-      mapParams.lon = params.mlon;
-      mapParams.lat = params.mlat;
-      mapParams.zoom = params.zoom || 12;
+    } else if (params.has("minlon") && params.has("minlat") && params.has("maxlon") && params.has("maxlat")) {
+      mapParams.bounds = bboxToLatLngBounds(Object.fromEntries(params));
+    } else if (params.has("mlon") && params.has("mlat")) {
+      mapParams.lon = params.get("mlon");
+      mapParams.lat = params.get("mlat");
+      mapParams.zoom = params.get("zoom") || 12;
     } else if (loc) {
       [mapParams.lon, mapParams.lat, mapParams.zoom] = loc;
     } else if (OSM.home) {
@@ -109,7 +104,7 @@ OSM = {
     } else {
       mapParams.lon = -0.1;
       mapParams.lat = 51.5;
-      mapParams.zoom = params.zoom || 5;
+      mapParams.zoom = params.get("zoom") || 5;
     }
 
     if (typeof mapParams.lat === "string") mapParams.lat = parseFloat(mapParams.lat);
@@ -118,7 +113,7 @@ OSM = {
 
     mapParams.layers = hash.layers || (loc && loc[3]) || "";
 
-    const scale = parseFloat(params.scale);
+    const scale = parseFloat(params.get("scale"));
     if (scale > 0) {
       mapParams.zoom = Math.log(360.0 / (scale * 512.0)) / Math.log(2.0);
     }
@@ -160,6 +155,10 @@ OSM = {
       center = args.getCenter();
       zoom = args.getZoom();
       layers = args.getLayersCode();
+    } else if (args instanceof URLSearchParams) {
+      center = args.get("center") || L.latLng(args.get("lat"), args.get("lon"));
+      zoom = args.get("zoom");
+      layers = args.get("layers") || "";
     } else {
       center = args.center || L.latLng(args.lat, args.lon);
       zoom = args.zoom;

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -76,7 +76,7 @@ OSM = {
       }
     }
 
-    const hash = OSM.parseHash(location.hash);
+    const hash = OSM.parseHash();
 
     const loc = Cookies.get("_osm_location")?.split("|");
 
@@ -126,7 +126,7 @@ OSM = {
     return mapParams;
   },
 
-  parseHash: function (hash) {
+  parseHash: function (hash = location.hash) {
     const args = {};
 
     const i = hash.indexOf("#");

--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -1,11 +1,11 @@
 $(function () {
-  const params = OSM.params();
+  const params = new URLSearchParams(location.search);
 
-  if (params.lat && params.lon) {
+  if (params.has("lat") && params.has("lon")) {
     let url = "/edit";
 
-    if (params.editor) url += "?editor=" + params.editor;
-    if (!params.zoom) params.zoom = 17;
+    if (params.has("editor")) url += "?editor=" + params.get("editor");
+    if (!params.has("zoom")) params.set("zoom", 17);
     url += OSM.formatHash(params);
 
     $(".start-mapping").attr("href", url);

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -20,14 +20,6 @@ describe("OSM", function () {
     });
   });
 
-  describe(".params", function () {
-    it("parses params", function () {
-      const params = OSM.params("?foo=a&bar=b");
-      expect(params).to.have.property("foo", "a");
-      expect(params).to.have.property("bar", "b");
-    });
-  });
-
   describe(".mapParams", function () {
     beforeEach(function () {
       delete OSM.home;


### PR DESCRIPTION
Removes `OSM.params()` in favor of `new URLSearchParams(location.search)`.
Adds `location.hash` as a default parameter for `OSM.parseHash`.
