### PR TITLE
Rewrite history page url when scrolling

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -4,7 +4,7 @@ OSM.History = function (map) {
   const page = {};
 
   $("#sidebar_content")
-    .on("click", ".changeset_more a", loadMore)
+    .on("click", ".changeset_more a", loadMoreChangesets)
     .on("mouseover", "[data-changeset]", function () {
       highlightChangeset($(this).data("changeset").id);
     })
@@ -132,7 +132,7 @@ OSM.History = function (map) {
     }
   }
 
-  function update() {
+  function loadFirstChangesets() {
     const data = new URLSearchParams();
     const params = new URLSearchParams(location.search);
 
@@ -173,7 +173,7 @@ OSM.History = function (map) {
       });
   }
 
-  function loadMore(e) {
+  function loadMoreChangesets(e) {
     e.preventDefault();
     e.stopPropagation();
 
@@ -250,17 +250,17 @@ OSM.History = function (map) {
     map.addLayer(group);
 
     if (location.pathname === "/history") {
-      map.on("moveend", update);
+      map.on("moveend", loadFirstChangesets);
     }
 
     map.on("zoomend", updateBounds);
 
-    update();
+    loadFirstChangesets();
   };
 
   page.unload = function () {
     map.removeLayer(group);
-    map.off("moveend", update);
+    map.off("moveend", loadFirstChangesets);
     map.off("zoomend", updateBounds);
     disableChangesetIntersectionObserver();
   };

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -159,6 +159,16 @@ OSM.History = function (map) {
       .then(function (html) {
         displayFirstChangesets(html);
         enableChangesetIntersectionObserver();
+
+        if (params.has("before")) {
+          const [firstItem] = $("#sidebar_content .changesets ol").children().first();
+          firstItem?.scrollIntoView();
+        }
+        if (params.has("after")) {
+          const [lastItem] = $("#sidebar_content .changesets ol").children().last();
+          lastItem?.scrollIntoView(false);
+        }
+
         updateMap();
       });
   }

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -189,6 +189,11 @@ OSM.History = function (map) {
     });
   }
 
+  function reloadChangesetsBecauseOfMapMovement() {
+    OSM.router.replace("/history" + window.location.hash);
+    loadFirstChangesets();
+  }
+
   let changesets = [];
 
   function updateBounds() {
@@ -250,7 +255,7 @@ OSM.History = function (map) {
     map.addLayer(group);
 
     if (location.pathname === "/history") {
-      map.on("moveend", loadFirstChangesets);
+      map.on("moveend", reloadChangesetsBecauseOfMapMovement);
     }
 
     map.on("zoomend", updateBounds);
@@ -260,7 +265,7 @@ OSM.History = function (map) {
 
   page.unload = function () {
     map.removeLayer(group);
-    map.off("moveend", loadFirstChangesets);
+    map.off("moveend", reloadChangesetsBecauseOfMapMovement);
     map.off("zoomend", updateBounds);
     disableChangesetIntersectionObserver();
   };

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -109,6 +109,30 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
+  test "update sidebar when before param is included and map is moved" do
+    changeset1 = create(:changeset, :num_changes => 1, :min_lat => 50000000, :max_lat => 50000001, :min_lon => 50000000, :max_lon => 50000001)
+    create(:changeset_tag, :changeset => changeset1, :k => "comment", :v => "changeset-at-fives")
+    changeset2 = create(:changeset, :num_changes => 1, :min_lat => 50100000, :max_lat => 50100001, :min_lon => 50100000, :max_lon => 50100001)
+    create(:changeset_tag, :changeset => changeset2, :k => "comment", :v => "changeset-close-to-fives")
+    changeset3 = create(:changeset)
+
+    visit "/history?before=#{changeset3.id}#map=17/5/5"
+
+    within_sidebar do
+      assert_link "changeset-at-fives"
+      assert_no_link "changeset-close-to-fives"
+    end
+
+    find("#map [aria-label='Zoom Out']").click(:shift)
+
+    within_sidebar do
+      assert_link "changeset-at-fives"
+      assert_link "changeset-close-to-fives"
+    end
+
+    assert_current_path history_path
+  end
+
   private
 
   def create_visible_changeset(user, comment)


### PR DESCRIPTION
The goal here is when viewing history to be able to go back to roughly the same place after visiting a changeset page. It works like this:
- when the changeset list is scrolled down and some item leaves the viewport, the current page location gets changed to include a `before=:changeset_id` parameter, `:changeset_id` being the id of the changeset that left the viewport
- when the changeset list is scrolled up, same thing happens with `after=:changeset_id`
- when the history page is visited and its url includes a `before` parameter, the sidebar is scrolled so the first item is at the top of the viewport
- when the history page is visited and its url includes an `after` parameter, the sidebar is scrolled so the last item is at the bottom of the viewport

With these changes you can open a history page, scroll and load more if necessary, click on a changeset, then click back and arrive at a view that includes roughly the same changesets.

https://github.com/user-attachments/assets/5b745d80-748e-4c4a-a724-c874e15943f5

Fixes #647. Also fixes the main issue from #1089 which is the same as #647.

Kind of fixes #933. Clicking *Load more* won't rewrite the url, but scrolling will. *Load more* is actually a link but it doesn't do the expected thing when used as a link, that's to be fixed later.