### PR TITLE
Update straight routing in tests to use named directions icons

### DIFF
--- a/test/system/directions_test.rb
+++ b/test/system/directions_test.rb
@@ -38,8 +38,8 @@ class DirectionsSystemTest < ApplicationSystemTestCase
       return Promise.resolve({
         line: points,
         steps: [
-          [points[0],  8, "<b>1.</b> #{start_instruction}", distance, points],
-          [points[1], 14, "<b>2.</b> #{finish_instruction}", 0, [points[1]]]
+          [points[0], "start", "<b>1.</b> #{start_instruction}", distance, points],
+          [points[1], "destination", "<b>2.</b> #{finish_instruction}", 0, [points[1]]]
         ],
         distance,
         time


### PR DESCRIPTION
Routing icons were updated to be referenced by names instead of numbers, but there was test code that still used numbers. This didn't affect the functioning of the tests because the icons weren't checked.

This PR updates the *straight routing stub* to use named icons:

![image](https://github.com/user-attachments/assets/a044260a-a0f6-4da7-97a1-f4d297aa00c7)
