### PR TITLE
Reuse mirrored turn icons

### DIFF
--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -23,17 +23,17 @@
   <symbol id="routing-sprite-u-turn-right" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M4 17 v-7 a4.5 4.5 0 0 1 9 0 v5 m2.5 -2 l-2.5 2.5 -2.5 -2.5 z" />
   </symbol>
-  <symbol id="routing-sprite-slight-left" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M13 17 v-3 q0 -2 -2 -4 l-5 -5 m0 0 h3 l-3 3 z" />
+  <symbol id="routing-sprite-slight-left">
+    <use href="#routing-sprite-slight-right" transform="matrix(-1 0 0 1 20 0)" />
   </symbol>
-  <symbol id="routing-sprite-left" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M13 17 v-5 q0 -3 -3 -3 h-4 m2 2.5 l-2.5 -2.5 2.5 -2.5 z" />
+  <symbol id="routing-sprite-left">
+    <use href="#routing-sprite-right" transform="matrix(-1 0 0 1 21 0)" />
   </symbol>
-  <symbol id="routing-sprite-sharp-left" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M13 17 v-7 q0 -6 -6 0 l-2 2 m0 0 v-3 l3 3 z" />
+  <symbol id="routing-sprite-sharp-left">
+    <use href="#routing-sprite-sharp-right" transform="matrix(-1 0 0 1 21 0)" />
   </symbol>
-  <symbol id="routing-sprite-u-turn-left" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M16 17 v-7 a4.5 4.5 0 0 0 -9 0 v5 m-2.5 -2 l2.5 2.5 2.5 -2.5 z" />
+  <symbol id="routing-sprite-u-turn-left">
+    <use href="#routing-sprite-u-turn-right" transform="matrix(-1 0 0 1 20 0)" />
   </symbol>
 
   <symbol id="routing-sprite-roundabout" fill="none" stroke="currentColor" stroke-width="2">
@@ -44,33 +44,29 @@
     <path d="M9 14 q0 -2 -2 -4 l-3 -3" opacity=".5" />
     <path d="M9 17 v-3 q0 -2 2 -4 l5 -5 m0 0 h-3 l3 3 z" />
   </symbol>
-  <symbol id="routing-sprite-fork-left" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M11 14 q0 -2 2 -4 l3 -3" opacity=".5" />
-    <path d="M11 17 v-3 q0 -2 -2 -4 l-5 -5 m0 0 h3 l-3 3 z" />
+  <symbol id="routing-sprite-fork-left">
+    <use href="#routing-sprite-fork-right" transform="matrix(-1 0 0 1 20 0)" />
   </symbol>
   <symbol id="routing-sprite-merge-left" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M8 7 q0 2 -2 4 l-3 3" opacity=".5" />
     <path d="M8 4 v3 q0 2 2 4 l5 5 m-5 -5 h3 l-3 3 z" />
   </symbol>
-  <symbol id="routing-sprite-merge-right" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M12 7 q0 2 2 4 l3 3" opacity=".5" />
-    <path d="M12 4 v3 q0 2 -2 4 l-5 5 m5 -5 h-3 l3 3 z" />
+  <symbol id="routing-sprite-merge-right">
+    <use href="#routing-sprite-merge-left" transform="matrix(-1 0 0 1 20 0)" />
   </symbol>
   <symbol id="routing-sprite-end-of-road-right" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M2 9 h10" opacity=".5" />
     <path d="M9 17 v-5 q0 -3 3 -3 h4 m-2 2.5 l2.5 -2.5 -2.5 -2.5 z" />
   </symbol>
-  <symbol id="routing-sprite-end-of-road-left" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M18 9 h-10" opacity=".5" />
-    <path d="M11 17 v-5 q0 -3 -3 -3 h-4 m2 2.5 l-2.5 -2.5 2.5 -2.5 z" />
+  <symbol id="routing-sprite-end-of-road-left">
+    <use href="#routing-sprite-end-of-road-right" transform="matrix(-1 0 0 1 20 0)" />
   </symbol>
   <symbol id="routing-sprite-exit-right" fill="none" stroke="currentColor" stroke-width="2">
     <path d="M9 14 v-8" opacity=".5" />
     <path d="M9 17 v-3 q0 -2 2 -4 l5 -5 m0 0 h-3 l3 3 z" />
   </symbol>
-  <symbol id="routing-sprite-exit-left" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M11 14 v-8" opacity=".5" />
-    <path d="M11 17 v-3 q0 -2 -2 -4 l-5 -5 m0 0 h3 l-3 3 z" />
+  <symbol id="routing-sprite-exit-left">
+    <use href="#routing-sprite-exit-right" transform="matrix(-1 0 0 1 20 0)" />
   </symbol>
 
   <symbol id="routing-sprite-ferry" fill="none" stroke="currentColor" stroke-width="1">


### PR DESCRIPTION
There's a pull request #5776 that claims to *reuse mirrored turn icons*, however most of the changes there are not related to mirroring.

This pull request keeps only the mirroring changes from #5776.

You can see all of the directions icons by adding the following test to `test/system/directions_test.rb` and running it:

```ruby
  test "show all routing icons" do
    visit directions_path

    extra_steps = %w[
      straight
      slight-right right sharp-right u-turn-right
      slight-left left sharp-left u-turn-left
      roundabout
      fork-right fork-left
      merge-left merge-right
      end-of-road-right end-of-road-left
      exit-right exit-left
      ferry
    ].map { |name| "[points[1], '#{name}', '#{name}', 0, [points[1]]]" }.join(",")

    stub_routing <<~CALLBACK
      const distance = points[0].distanceTo(points[1]);
      const time = distance * 30;
      return Promise.resolve({
        line: points,
        steps: [
          [points[0], "start", "start", distance, points],
          [points[1], "destination", "destination", 0, [points[1]]],
          #{extra_steps}
        ],
        distance,
        time
      });
    CALLBACK

    fill_in "route_from", :with => "60 30"
    fill_in "route_to", :with => "61 31"
    click_on "Go"

    sleep 1000
  end
```

![image](https://github.com/user-attachments/assets/1e7f5177-13e2-4f8b-a0fc-a56e6699511b)
