### PR TITLE
Show heatmap only to logged in users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,24 +24,26 @@ class UsersController < ApplicationController
     if @user && (@user.visible? || current_user&.administrator?)
       @title = @user.display_name
 
-      @heatmap_data = Rails.cache.fetch("heatmap_data_with_ids_user_#{@user.id}", :expires_in => 1.day) do
-        one_year_ago = 1.year.ago.beginning_of_day
-        today = Time.zone.now.end_of_day
+      if current_user
+        @heatmap_data = Rails.cache.fetch("heatmap_data_with_ids_user_#{@user.id}", :expires_in => 1.day) do
+          one_year_ago = 1.year.ago.beginning_of_day
+          today = Time.zone.now.end_of_day
 
-        Changeset
-          .where(:user_id => @user.id)
-          .where(:created_at => one_year_ago..today)
-          .where(:num_changes => 1..)
-          .group("date_trunc('day', created_at)")
-          .select("date_trunc('day', created_at) AS date, SUM(num_changes) AS total_changes, MAX(id) AS max_id")
-          .order("date")
-          .map do |changeset|
-            {
-              :date => changeset.date.to_date.to_s,
-              :total_changes => changeset.total_changes.to_i,
-              :max_id => changeset.max_id
-            }
-          end
+          Changeset
+            .where(:user_id => @user.id)
+            .where(:created_at => one_year_ago..today)
+            .where(:num_changes => 1..)
+            .group("date_trunc('day', created_at)")
+            .select("date_trunc('day', created_at) AS date, SUM(num_changes) AS total_changes, MAX(id) AS max_id")
+            .order("date")
+            .map do |changeset|
+              {
+                :date => changeset.date.to_date.to_s,
+                :total_changes => changeset.total_changes.to_i,
+                :max_id => changeset.max_id
+              }
+            end
+        end
       end
     else
       render_unknown_user params[:display_name]

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -399,19 +399,23 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_empty assigns(:heatmap_data)
   end
 
-  def test_heatmap_rendering
-    # Test user with no changesets
-    user_without_changesets = create(:user)
-    get user_path(user_without_changesets)
+  def test_show_heatmap_rendering_of_user_with_no_changesets
+    user = create(:user)
+
+    get user_path(user)
+
     assert_response :success
     assert_select "div#cal-heatmap", 0
+  end
 
-    # Test user with changesets
-    user_with_changesets = create(:user)
-    changeset39 = create(:changeset, :user => user_with_changesets, :created_at => 4.months.ago.beginning_of_day, :num_changes => 39)
-    _changeset5 = create(:changeset, :user => user_with_changesets, :created_at => 3.months.ago.beginning_of_day, :num_changes => 5)
-    changeset11 = create(:changeset, :user => user_with_changesets, :created_at => 3.months.ago.beginning_of_day, :num_changes => 11)
-    get user_path(user_with_changesets)
+  def test_show_heatmap_rendering_of_user_with_changesets
+    user = create(:user)
+    changeset39 = create(:changeset, :user => user, :created_at => 4.months.ago.beginning_of_day, :num_changes => 39)
+    _changeset5 = create(:changeset, :user => user, :created_at => 3.months.ago.beginning_of_day, :num_changes => 5)
+    changeset11 = create(:changeset, :user => user, :created_at => 3.months.ago.beginning_of_day, :num_changes => 11)
+
+    get user_path(user)
+
     assert_response :success
     assert_select "div#cal-heatmap[data-heatmap]" do |elements|
       # Check the data-heatmap attribute is present and contains expected JSON

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -343,7 +343,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     heatmap_data = assigns(:heatmap_data)
     # The data should be in the right format
-    assert(heatmap_data.all? { |entry| entry[:date] && entry[:total_changes] }, "Heatmap data should have :date and :total_changes keys")
+    assert(heatmap_data.all? { |entry| entry[:date] && entry[:total_changes] && entry[:max_id] }, "Heatmap data should have :date, :total_changes and :max_id keys")
   end
 
   def test_show_heatmap_data_caching


### PR DESCRIPTION
I'd like to add a year selector to the heatmap and maybe more things. Since that will reveal even more information about users we might want to hide the heatmap for those who didn't log in. A proper check would be the terms of use acceptance, but that's not possible until #5706 is merged.