### PR TITLE
Move more map layer logic to MapLayers lib to simplify JS

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -20,9 +20,7 @@ L.OSM.Map = L.Map.extend({
       const layerOptions = {};
 
       for (const [property, value] of Object.entries(layerDefinition)) {
-        if (property === "credit") {
-          layerOptions.attribution = makeAttribution(value);
-        } else if (property === "leafletOsmId") {
+        if (property === "leafletOsmId") {
           layerConstructor = L.OSM[value];
         } else if (property === "leafletOsmDarkId" && OSM.isDarkMap() && L.OSM[value]) {
           layerConstructor = L.OSM[value];
@@ -60,49 +58,6 @@ L.OSM.Map = L.Map.extend({
         this.setMaxZoom(event.layer.options.maxZoom);
       }
     });
-
-    function makeAttribution(credit) {
-      let attribution = "";
-
-      attribution += OSM.i18n.t("javascripts.map.copyright_text", {
-        copyright_link: $("<a>", {
-          href: "/copyright",
-          text: OSM.i18n.t("javascripts.map.openstreetmap_contributors")
-        }).prop("outerHTML")
-      });
-
-      attribution += credit.donate ? " &hearts; " : ". ";
-      attribution += makeCredit(credit);
-      attribution += ". ";
-
-      attribution += $("<a>", {
-        href: "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
-        text: OSM.i18n.t("javascripts.map.website_and_api_terms")
-      }).prop("outerHTML");
-
-      return attribution;
-    }
-
-    function makeCredit(credit) {
-      const children = {};
-      for (const childId in credit.children) {
-        children[childId] = makeCredit(credit.children[childId]);
-      }
-      const text = OSM.i18n.t(`javascripts.map.${credit.id}`, children);
-      if (credit.href) {
-        const link = $("<a>", {
-          href: credit.href,
-          text: text
-        });
-        if (credit.donate) {
-          link.addClass("donate-attr");
-        } else {
-          link.attr("target", "_blank");
-        }
-        return link.prop("outerHTML");
-      }
-      return text;
-    }
   },
 
   updateLayers: function (layerParam) {

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -15,7 +15,7 @@ L.OSM.Map = L.Map.extend({
 
     this.baseLayers = [];
 
-    for (const layerDefinition of OSM.LAYER_DEFINITIONS) {
+    for (const layerDefinition of JSON.parse(document.getElementById(id).dataset.layers)) {
       let layerConstructor = L.OSM.TileLayer;
       const layerOptions = {};
 

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -13,28 +13,16 @@ L.OSM.Map = L.Map.extend({
   initialize: function (id, options) {
     L.Map.prototype.initialize.call(this, id, options);
 
-    this.baseLayers = [];
-
-    for (const layerDefinition of JSON.parse(document.getElementById(id).dataset.layers)) {
-      let layerConstructor = L.OSM.TileLayer;
-      const layerOptions = {};
-
-      for (const [property, value] of Object.entries(layerDefinition)) {
-        if (property === "leafletOsmId") {
-          layerConstructor = L.OSM[value];
-        } else if (property === "leafletOsmDarkId" && OSM.isDarkMap() && L.OSM[value]) {
-          layerConstructor = L.OSM[value];
-        } else {
-          layerOptions[property] = value;
-        }
-      }
+    this.baseLayers = JSON.parse(document.getElementById(id).dataset.layers).map(layerDefinition => {
+      const { leafletOsmId, leafletOsmDarkId, ...layerOptions } = layerDefinition;
+      const layerConstructor = (OSM.isDarkMap() && L.OSM[leafletOsmDarkId]) || L.OSM[leafletOsmId] || L.OSM.TileLayer;
 
       const layer = new layerConstructor(layerOptions);
       layer.on("add", () => {
         this.fire("baselayerchange", { layer: layer });
       });
-      this.baseLayers.push(layer);
-    }
+      return layer;
+    });
 
     this.noteLayer = new L.FeatureGroup();
     this.noteLayer.options = { code: "N" };

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -22,8 +22,6 @@ L.OSM.Map = L.Map.extend({
       for (const [property, value] of Object.entries(layerDefinition)) {
         if (property === "credit") {
           layerOptions.attribution = makeAttribution(value);
-        } else if (property === "nameId") {
-          layerOptions.name = OSM.i18n.t(`javascripts.map.base.${value}`);
         } else if (property === "leafletOsmId") {
           layerConstructor = L.OSM[value];
         } else if (property === "leafletOsmDarkId" && OSM.isDarkMap() && L.OSM[value]) {

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -27,7 +27,6 @@ OSM = {
 
   DEFAULT_LOCALE: <%= I18n.default_locale.to_json %>,
 
-  LAYER_DEFINITIONS: <%= MapLayers::full_definitions("config/layers.yml").to_json %>,
   LAYERS_WITH_MAP_KEY: <%= YAML.load_file(Rails.root.join("config/key.yml")).keys.to_json %>,
 
   MARKER_GREEN: <%= image_path("marker-green.png").to_json %>,

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -61,7 +61,7 @@
     <%= render :partial => "layouts/sidebar_close" %>
   </div>
 
-  <div id="map" tabindex="2" class="bg-body-secondary z-0">
+  <div id="map" tabindex="2" class="bg-body-secondary z-0" data-layers='<%= MapLayers.full_definitions("config/layers.yml").to_json %>'>
   </div>
 
   <div id="attribution" class="d-none">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2312,6 +2312,19 @@ en:
         project_url: "https://openstreetmap.org"
       remote_failed: "Editing failed - make sure JOSM or Merkaartor is loaded and the remote control option is enabled"
       map:
+        copyright_text: "© %{copyright_link}"
+        openstreetmap_contributors: "OpenStreetMap contributors"
+        website_and_api_terms: Website and API terms
+        make_a_donation: Make a Donation
+        cyclosm_credit: "Tiles style by %{cyclosm_link} hosted by %{osm_france_link}"
+        cyclosm_name: CyclOSM
+        osm_france: OpenStreetMap France
+        thunderforest_credit: "Tiles courtesy of %{thunderforest_link}"
+        andy_allan: Andy Allan
+        tracestrack_credit: "Tiles courtesy of %{tracestrack_link}"
+        tracestrack: Tracestrack
+        hotosm_credit: "Tiles style by %{hotosm_link} hosted by %{osm_france_link}"
+        hotosm_name: Humanitarian OpenStreetMap Team
         base:
           standard: Standard
           cyclosm: CyclOSM
@@ -3262,19 +3275,6 @@ en:
         gps: Public GPS Traces
         overlays: Enable overlays for troubleshooting the map
         title: "Layers"
-      copyright_text: "© %{copyright_link}"
-      openstreetmap_contributors: "OpenStreetMap contributors"
-      make_a_donation: Make a Donation
-      website_and_api_terms: Website and API terms
-      cyclosm_credit: "Tiles style by %{cyclosm_link} hosted by %{osm_france_link}"
-      cyclosm_name: CyclOSM
-      osm_france: OpenStreetMap France
-      thunderforest_credit: "Tiles courtesy of %{thunderforest_link}"
-      andy_allan: Andy Allan
-      tracestrack_credit: "Tiles courtesy of %{tracestrack_link}"
-      tracestrack: Tracestrack
-      hotosm_credit: "Tiles style by %{hotosm_link} hosted by %{osm_france_link}"
-      hotosm_name: Humanitarian OpenStreetMap Team
     site:
       edit_tooltip: Edit the map
       edit_disabled_tooltip: Zoom in to edit the map

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2311,6 +2311,14 @@ en:
         license_url: "https://openstreetmap.org/copyright"
         project_url: "https://openstreetmap.org"
       remote_failed: "Editing failed - make sure JOSM or Merkaartor is loaded and the remote control option is enabled"
+      map:
+        base:
+          standard: Standard
+          cyclosm: CyclOSM
+          cycle_map: Cycle Map
+          transport_map: Transport Map
+          tracestracktop_topo: Tracestrack Topo
+          hot: Humanitarian
     not_public_flash:
       not_public: "You have not set your edits to be public."
       not_public_description_html: "You can no longer edit the map unless you do so. You can set your edits as public from your %{user_page}."
@@ -3247,13 +3255,6 @@ en:
         feetPopup:
           one: You are within %{count} foot of this point
           other: You are within %{count} feet of this point
-      base:
-        standard: Standard
-        cyclosm: CyclOSM
-        cycle_map: Cycle Map
-        transport_map: Transport Map
-        tracestracktop_topo: Tracestrack Topo
-        hot: Humanitarian
       layers:
         header: Map Layers
         notes: Map Notes

--- a/lib/map_layers.rb
+++ b/lib/map_layers.rb
@@ -3,6 +3,8 @@ module MapLayers
     YAML.load_file(Rails.root.join(layers_filename))
         .reject { |layer| layer["apiKeyId"] && !Settings[layer["apiKeyId"]] }
         .map do |layer|
+          layer["name"] = I18n.t("site.index.map.base.#{layer['nameId']}")
+          layer.delete "nameId"
           if layer["apiKeyId"]
             layer["apikey"] = Settings[layer["apiKeyId"]]
             layer.delete "apiKeyId"

--- a/lib/map_layers.rb
+++ b/lib/map_layers.rb
@@ -5,6 +5,8 @@ module MapLayers
         .map do |layer|
           layer["name"] = I18n.t("site.index.map.base.#{layer['nameId']}")
           layer.delete "nameId"
+          layer["attribution"] = make_attribution(layer["credit"])
+          layer.delete "credit"
           if layer["apiKeyId"]
             layer["apikey"] = Settings[layer["apiKeyId"]]
             layer.delete "apiKeyId"
@@ -17,5 +19,33 @@ module MapLayers
     full_definitions(layers_filename)
       .select { |entry| entry["canEmbed"] }
       .to_h { |entry| [entry["layerId"], entry.slice("leafletOsmId", "leafletOsmDarkId", "apikey").compact] }
+  end
+
+  extend ActionView::Helpers::UrlHelper
+
+  def self.make_attribution(credit)
+    attribution = ""
+
+    attribution += I18n.t("site.index.map.copyright_text",
+                          :copyright_link => link_to(I18n.t("site.index.map.openstreetmap_contributors"), "/copyright"))
+
+    attribution += credit["donate"] ? " &hearts; " : ". "
+    attribution += make_credit(credit)
+    attribution += ". "
+
+    attribution += link_to(I18n.t("site.index.map.website_and_api_terms"),
+                           "https://wiki.osmfoundation.org/wiki/Terms_of_Use")
+
+    attribution
+  end
+
+  def self.make_credit(credit)
+    children = credit["children"]&.transform_values { |child| make_credit(child) } || {}
+
+    text = I18n.t("site.index.map.#{credit['id']}", **children.transform_keys(&:to_sym))
+
+    return text unless credit["href"]
+
+    link_to(text, credit["href"], :class => ("donate-attr" if credit["donate"]), :target => ("_blank" unless credit["donate"]))
   end
 end


### PR DESCRIPTION
This PR moves name and attribution i18n from `L.OSM.Map.initialize` to the new `MapLayers` lib from #5809.
So I could remove `layerConstructor` redefinitions and simplify the generation of the map's `baseLayers` by using `OSM.LAYER_DEFINITIONS.map()`.
There might be a better place for the translations I moved from `javascripts.map` to `site.index.map` but I couldn't find one.