### PR TITLE
Use Date().toLocaleString() to construct month titles

### DIFF
--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -16,7 +16,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const colorScheme = document.documentElement.getAttribute("data-bs-theme") ?? "auto";
   const rangeColors = ["#14432a", "#166b34", "#37a446", "#4dd05a"];
   const startDate = new Date(Date.now() - (365 * 24 * 60 * 60 * 1000));
-  const monthNames = OSM.i18n.t("date.abbr_month_names");
 
   const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
@@ -34,7 +33,7 @@ document.addEventListener("DOMContentLoaded", () => {
         type: "month",
         gutter: 4,
         label: {
-          text: (timestamp) => monthNames[new Date(timestamp).getUTCMonth() + 1],
+          text: (timestamp) => new Date(timestamp).toLocaleString(OSM.i18n.locale, { timeZone: "UTC", month: "short" }),
           position: "top",
           textAlign: "middle"
         },


### PR DESCRIPTION
In some languages month names when used inside dates may differ from month names when used alone as titles. `OSM.i18n.t("date.abbr_month_names")` gives you month names for dates. That doesn't work with calendar month titles.

Example in Russian:
"May" = "май"
"21 May, 2024" = "21 мая 2024"
You don't want "мая" as a title, you want "май".

Before:
![image](https://github.com/user-attachments/assets/3eaf28c1-c5f6-4a11-b518-a6deb5028a52)

After:
![image](https://github.com/user-attachments/assets/1a56e23f-a837-4d8c-a216-5fd1281086cc)
