### PR TITLE
add dir="auto" to paragraphs in rich_text.rb

### DIFF
--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -68,7 +68,7 @@ module RichText
     protected
 
     def simple_format(text)
-      SimpleFormat.new.simple_format(text)
+      SimpleFormat.new.simple_format(text, :dir => "auto")
     end
 
     def sanitize(text)


### PR DESCRIPTION
(the edit history of this comment contains some questions that are no longer relevant)

### Description
This PR adds `dir="auto"` to user-generated content that uses the classes in `lib/rich_text.rb`, such as changeset comments, map notes, and the discussions under them. It also applies a necessary CSS rule for text alignment on those discussions.

This would solve a significant portion of #3428. It *might* have some overlap with #3429, ~~but at a glance it doesn't seem like it~~. It seems some of the changes in that PR would have affected the same content, however they would have done so with less finesse.

I never used Ruby before (and technically, I still haven't... see "How has this been tested?"), so this change is entirely based on the documentation found [here](https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-simple_format). I hope I've understood it correctly. Further changes were made as a response to the discussion below.

### How has this been tested?
**This has not been tested at all. For all I know, it might even contain syntax errors.** I don't currently have the means to clone and run this repository. I know this is bad form to put it mildly, but with a change this small and focused I am hoping you can forgive and review it nonetheless, and run any tests in your already-set-up environment.

If this is totally unacceptable, let me know.

### Things a reviewer should check or know the answer to
- Which parts of the website would be affected by this change?
- Does it actually work? (As said, I can't test it)
- Does this exclusively affect user-generated content, or is it sometimes applied to other kinds of content? If so, does it ever cause undesirable results? (I believe it wouldn't)
- Are there any other places where text alignment doesn't change based on text direction? (This was only an issue on discussion comments because they are contained in `<li>` elements, see discussion below)