### PR TITLE
Put changeset and note comments in <article> elements

### DIFF
--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -36,35 +36,31 @@
     <% end %>
   </div>
 
-  <% if @comments.length > 0 %>
-    <ul class="list-unstyled">
-      <% @comments.each do |comment| %>
-        <% next unless comment.visible || current_user&.moderator? %>
-        <li id="c<%= comment.id %>">
-          <small class='text-body-secondary'>
-            <%= comment_by_options = { :time_ago => friendly_date_ago(comment.created_at),
-                                       :user => link_to(comment.author.display_name, comment.author) }
-                comment.visible ? t(".comment_by_html", **comment_by_options) : t(".hidden_comment_by_html", **comment_by_options) %>
-            <% if current_user&.moderator? %>
-              —
-              <%= tag.button t(".#{comment.visible ? 'hide' : 'unhide'}_comment"),
-                             :class => "btn btn-sm small btn-link link-secondary p-0 align-baseline",
-                             :data => { :method => comment.visible ? "DELETE" : "POST",
-                                        :url => api_changeset_comment_visibility_path(comment) } %>
-            <% end %>
-            <a href="#c<%= comment.id %>">
-              <svg width="16" height="16" fill="currentColor">
-                <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z" />
-                <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z" />
-              </svg>
-            </a>
-          </small>
-          <div class="mx-2">
-            <%= comment.body.to_html %>
-          </div>
-        </li>
-      <% end %>
-    </ul>
+  <% @comments.each do |comment| %>
+    <% next unless comment.visible || current_user&.moderator? %>
+    <article id="c<%= comment.id %>">
+      <small class='text-body-secondary'>
+        <%= comment_by_options = { :time_ago => friendly_date_ago(comment.created_at),
+                                   :user => link_to(comment.author.display_name, comment.author) }
+            comment.visible ? t(".comment_by_html", **comment_by_options) : t(".hidden_comment_by_html", **comment_by_options) %>
+        <% if current_user&.moderator? %>
+          —
+          <%= tag.button t(".#{comment.visible ? 'hide' : 'unhide'}_comment"),
+                         :class => "btn btn-sm small btn-link link-secondary p-0 align-baseline",
+                         :data => { :method => comment.visible ? "DELETE" : "POST",
+                                    :url => api_changeset_comment_visibility_path(comment) } %>
+        <% end %>
+        <a href="#c<%= comment.id %>">
+          <svg width="16" height="16" fill="currentColor">
+            <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z" />
+            <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z" />
+          </svg>
+        </a>
+      </small>
+      <div class="mx-2">
+        <%= comment.body.to_html %>
+      </div>
+    </article>
   <% end %>
 
   <% unless current_user %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -52,19 +52,13 @@
     <% end %>
   </div>
 
-  <% if @note_comments.length > 0 %>
-    <div class='note-comments'>
-      <ul class="list-unstyled">
-        <% @note_comments.each do |comment| %>
-          <li id="c<%= comment.id %>">
-            <small class='text-body-secondary'><%= note_event(comment.event, comment.created_at, comment.author) %></small>
-            <div class="mx-2">
-              <%= comment.body.to_html %>
-            </div>
-          </li>
-        <% end %>
-      </ul>
-    </div>
+  <% @note_comments.each do |comment| %>
+    <article id="c<%= comment.id %>">
+      <small class='text-body-secondary'><%= note_event(comment.event, comment.created_at, comment.author) %></small>
+      <div class="mx-2">
+        <%= comment.body.to_html %>
+      </div>
+    </article>
   <% end %>
 
   <% if @note.status == "open" %>

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -279,7 +279,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     sidebar_browse_check :changeset_path, changeset.id, "changesets/show"
     assert_dom "h2", :text => "Changeset: #{changeset.id}"
     assert_dom "p", :text => "tested-changeset-comment"
-    assert_dom "li#c#{changeset_comment.id}" do
+    assert_dom "article#c#{changeset_comment.id}" do
       assert_dom "> small", :text => /^Comment from #{commenting_user.display_name}/
       assert_dom "a[href='#{user_path(commenting_user)}']"
     end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -129,12 +129,12 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     end
 
     sidebar_browse_check :note_path, note_with_hidden_comment.id, "notes/show"
-    assert_select "div.note-comments ul li", :count => 1
+    assert_dom "article:match('id', ?)", /^c\d+$/, :count => 1
 
     session_for(create(:moderator_user))
 
     sidebar_browse_check :note_path, note_with_hidden_comment.id, "notes/show"
-    assert_select "div.note-comments ul li", :count => 2
+    assert_dom "article:match('id', ?)", /^c\d+$/, :count => 2
   end
 
   def test_read_note_hidden_user_comment
@@ -144,12 +144,12 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     end
 
     sidebar_browse_check :note_path, note_with_hidden_user_comment.id, "notes/show"
-    assert_select "div.note-comments ul li", :count => 1
+    assert_dom "article:match('id', ?)", /^c\d+$/, :count => 1
 
     session_for(create(:moderator_user))
 
     sidebar_browse_check :note_path, note_with_hidden_user_comment.id, "notes/show"
-    assert_select "div.note-comments ul li", :count => 1
+    assert_dom "article:match('id', ?)", /^c\d+$/, :count => 1
   end
 
   def test_read_note_hidden_opener
@@ -158,7 +158,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     create(:note_comment, :author => hidden_user, :note => note_with_hidden_opener)
 
     sidebar_browse_check :note_path, note_with_hidden_opener.id, "notes/show"
-    assert_select "div.note-comments ul li", :count => 0
+    assert_dom "article:match('id', ?)", /^c\d+$/, :count => 0
   end
 
   def test_read_note_suspended_opener_and_comment
@@ -167,7 +167,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     create(:note_comment, :note => note, :event => "commented")
 
     sidebar_browse_check :note_path, note.id, "notes/show"
-    assert_select "div.note-comments ul li", :count => 1
+    assert_dom "article:match('id', ?)", /^c\d+$/, :count => 1
   end
 
   def test_read_closed_note
@@ -175,16 +175,16 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     closed_note = create(:note_with_comments, :closed, :closed_by => user, :comments_count => 2)
 
     sidebar_browse_check :note_path, closed_note.id, "notes/show"
-    assert_select "div.note-comments ul li", :count => 2
-    assert_select "div.details", /Resolved by #{user.display_name}/
+    assert_dom "article:match('id', ?)", /^c\d+$/, :count => 2
+    assert_dom "div.details", /Resolved by #{user.display_name}/
 
     user.soft_destroy!
 
     reset!
 
     sidebar_browse_check :note_path, closed_note.id, "notes/show"
-    assert_select "div.note-comments ul li", :count => 1
-    assert_select "div.details", /Resolved by deleted/
+    assert_dom "article:match('id', ?)", /^c\d+$/, :count => 1
+    assert_dom "div.details", /Resolved by deleted/
   end
 
   def test_new_note_anonymous


### PR DESCRIPTION
Our `/changeset/:id` and `/note/:id` pages have comments in the sidebar. Those comments are marked up as list items: 
```html
<ul>
  <li id="c1">...</li>
  <li id="c2">...</li>
  ...
</ul>
```

Turn out there's a drawback to that: list items redefine text alignment inside them. Normally you wouldn't notice that everything is either left-aligned or right-aligned in case of rtl. But if you want mixed ltr and rtl text inside, you'll have to override `text-align`. See https://github.com/openstreetmap/openstreetmap-website/pull/5835#issuecomment-2745310604, see "Add text-align: start; to the mx-2 class CSS." in #5785.

Another way to mark up comments is to use `<article>` elements. There are examples of that on [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article) and in the [html spec](https://html.spec.whatwg.org/multipage/sections.html#the-article-element). If we use `<article>`, #5835 will just need to add `dir="auto"` to paragraphs without modifying css.

```html
<article id="c1">
<article id="c2">
...
```
