### PR TITLE
Remove unused options argument from user_image_url

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -40,9 +40,9 @@ module UserHelper
     end
   end
 
-  def user_image_url(user, options = {})
+  def user_image_url(user)
     if user.image_use_gravatar
-      user_gravatar_url(user, options)
+      user_gravatar_url(user)
     elsif user.avatar.attached?
       polymorphic_url(user_avatar_variant(user, :resize_to_limit => [100, 100]), :host => Settings.server_url)
     else


### PR DESCRIPTION
Not in use since https://github.com/openstreetmap/openstreetmap-website/commit/f70edc02f086d97727453e738e9f0083c68ec706. Whatever it did would only apply to Gravatar images and not to other kind of images.