### PR TITLE
Add dir="auto" to Markdown content for bidi

### DIFF
--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -3,7 +3,7 @@
 <%= render "sidebar_header", :title => t(".title", :id => @changeset.id) %>
 
 <div class="browse-section">
-  <p class="fs-6 overflow-x-auto">
+  <p class="fs-6 overflow-x-auto" dir="auto">
     <%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %>
   </p>
   <%= tag.p :class => "details", :data => { :changeset => changeset_data(@changeset) } do %>


### PR DESCRIPTION
### Description
1. Derive a kramdown converter subclass that adds `dir="auto"` to HTML elements where appropriate.
2. Call this new converter instead of the default HTML converter
3. Add `dir="auto"` to changeset comment tag (unrelated, should have been part of #5835)

This solves the last (to my knowledge) of the most prominent user-generated content bidi issues of #3428, that being user diaries. Other less prominent issues are handled in #3429, which best I can tell does not overlap with this PR.

### How has this been tested?
The kramdown subclass was tested here: https://codeberg.org/NeatNit/kramdown-bidi/src/branch/main/code.rb

Its integration into the OpenStreetMap website **has not been tested.**

I don't expect you'd like the amount of comments in that converter, or that github issue comment link in the source code. In my opinion it's needed to understand the choices I've made. If you prefer, I can remove some of the comments, just tell me which ones.