### PR TITLE
Fix typo in comment about Gravatar setting

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -118,7 +118,7 @@ class ConfirmationsController < ApplicationController
   end
 
   ##
-  # display a message about th current status of the gravatar setting
+  # display a message about the current status of the Gravatar setting
   def gravatar_status_message(user)
     if user.image_use_gravatar
       t "profiles.edit.gravatar.enabled"


### PR DESCRIPTION
### Description
Fixed a minor typo in a comment to reflect correct spelling and proper noun usage. No functional changes to the codebase.

### How has this been tested?
No tests were necessary, as this change only affects a code comment and does not alter runtime behavior.
