### PR TITLE
Fix "undefined" comment when hiding resolved notes

### DIFF
--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -41,8 +41,11 @@ OSM.Note = function (map) {
             data = new URLSearchParams();
       content.find("button[name]").prop("disabled", true);
 
-      if (name !== "subscribe" && name !== "unsubscribe" && name !== "reopen") {
-        data.set("text", content.find("textarea").val());
+      if (name !== "subscribe" && name !== "unsubscribe") {
+        const textarea = content.find("textarea");
+        if (textarea.length) {
+          data.set("text", textarea.val());
+        }
       }
 
       fetch(url, {

--- a/test/system/resolve_note_test.rb
+++ b/test/system/resolve_note_test.rb
@@ -86,6 +86,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
 
       assert_content "Hidden note ##{note.id}"
       assert_no_content "<iframe" # leak from share textarea
+      assert_no_content "undefined" # value from missing comment textarea
     end
   end
 


### PR DESCRIPTION
There's no comment textarea on resolved note pages, but pressing *Hide* if you're a moderator still tries to read a value and submit it as a comment.

![image](https://github.com/user-attachments/assets/5d91489d-977e-4e58-a6e5-dd889cb4a6d5)

With this PR the value is read only if the textarea is present.