### PR TITLE
Shorten matching urls in linkify

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -136,6 +136,10 @@ overpass_credentials: false
 graphhopper_url: "https://graphhopper.com/api/1/route"
 fossgis_osrm_url: "https://routing.openstreetmap.de/"
 fossgis_valhalla_url: "https://valhalla1.openstreetmap.de/route"
+# Main website hosts to match in linkify
+linkify_hosts: ["www.openstreetmap.org", "www.osm.org", "www.openstreetmap.com", "openstreetmap.org", "osm.org", "openstreetmap.com"]
+# Shorter host to replace main hosts
+linkify_hosts_replacement: "osm.org"
 # External authentication credentials
 #google_auth_id: ""
 #google_auth_secret: ""

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -76,11 +76,7 @@ module RichText
     end
 
     def linkify(text, mode = :urls)
-      if text.html_safe?
-        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow noopener noreferrer")).html_safe
-      else
-        Rinku.auto_link(text, mode, tag_builder.tag_options(:rel => "nofollow noopener noreferrer"))
-      end
+      Rinku.auto_link(ERB::Util.html_escape(text), mode, tag_builder.tag_options(:rel => "nofollow noopener noreferrer")).html_safe
     end
   end
 

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -76,7 +76,13 @@ module RichText
     end
 
     def linkify(text, mode = :urls)
-      Rinku.auto_link(ERB::Util.html_escape(text), mode, tag_builder.tag_options(:rel => "nofollow noopener noreferrer")).html_safe
+      link_attr = tag_builder.tag_options(:rel => "nofollow noopener noreferrer")
+      Rinku.auto_link(ERB::Util.html_escape(text), mode, link_attr) do |url|
+        %r{^https?://([^/]*)(.*)$}.match(url) do |m|
+          "#{Settings.linkify_hosts_replacement}#{m[2]}" if Settings.linkify_hosts_replacement &&
+                                                            Settings.linkify_hosts&.include?(m[1])
+        end || url
+      end.html_safe
     end
   end
 

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -222,11 +222,50 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify
-    r = RichText.new("text", "foo http://example.com/ bar")
-    assert_html r do
-      assert_select "a", 1
-      assert_select "a[href='http://example.com/']", 1
-      assert_select "a[rel='nofollow noopener noreferrer']", 1
+    with_settings(:linkify_hosts => ["replace-me.example.com"], :linkify_hosts_replacement => "repl.example.com") do
+      r = RichText.new("text", "foo http://example.com/ bar")
+      assert_html r do
+        assert_dom "a", :count => 1, :text => "http://example.com/" do
+          assert_dom "> @href", "http://example.com/"
+          assert_dom "> @rel", "nofollow noopener noreferrer"
+        end
+      end
+    end
+  end
+
+  def test_text_to_html_linkify_replace
+    with_settings(:linkify_hosts => ["replace-me.example.com"], :linkify_hosts_replacement => "repl.example.com") do
+      r = RichText.new("text", "foo https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12 bar")
+      assert_html r do
+        assert_dom "a", :count => 1, :text => "repl.example.com/some/path?query=te<st&limit=20>10#result12" do
+          assert_dom "> @href", "https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12"
+          assert_dom "> @rel", "nofollow noopener noreferrer"
+        end
+      end
+    end
+  end
+
+  def test_text_to_html_linkify_replace_other_scheme
+    with_settings(:linkify_hosts => ["replace-me.example.com"], :linkify_hosts_replacement => "repl.example.com") do
+      r = RichText.new("text", "foo ftp://replace-me.example.com/some/path?query=te<st&limit=20>10#result12 bar")
+      assert_html r do
+        assert_dom "a", :count => 1, :text => "ftp://replace-me.example.com/some/path?query=te<st&limit=20>10#result12" do
+          assert_dom "> @href", "ftp://replace-me.example.com/some/path?query=te<st&limit=20>10#result12"
+          assert_dom "> @rel", "nofollow noopener noreferrer"
+        end
+      end
+    end
+  end
+
+  def test_text_to_html_linkify_replace_undefined
+    with_settings(:linkify_hosts => ["replace-me.example.com"], :linkify_hosts_replacement => nil) do
+      r = RichText.new("text", "foo https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12 bar")
+      assert_html r do
+        assert_dom "a", :count => 1, :text => "https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12" do
+          assert_dom "> @href", "https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12"
+          assert_dom "> @rel", "nofollow noopener noreferrer"
+        end
+      end
     end
   end
 

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -221,19 +221,23 @@ class RichTextTest < ActiveSupport::TestCase
     assert_equal 50, r.spam_score.round
   end
 
-  def test_text_to_html
+  def test_text_to_html_linkify
     r = RichText.new("text", "foo http://example.com/ bar")
     assert_html r do
       assert_select "a", 1
       assert_select "a[href='http://example.com/']", 1
       assert_select "a[rel='nofollow noopener noreferrer']", 1
     end
+  end
 
+  def test_text_to_html_email
     r = RichText.new("text", "foo example@example.com bar")
     assert_html r do
       assert_select "a", 0
     end
+  end
 
+  def test_text_to_html_escape
     r = RichText.new("text", "foo < bar & baz > qux")
     assert_html r do
       assert_select "p", "foo < bar & baz > qux"


### PR DESCRIPTION
After looking at #844 and #5780 I think that first we can do something with full osm urls. Before trying to match patterns like `key=value` or `changeset 12345` or `n12345` we need to check them for false positives/negatives among existing comments. And the first to do with urls that makes sense is to shorten them like [better-osm-org](https://github.com/deevroman/better-osm-org) does: replace `https://www.openstreetmap.org/` (and other osm domains) with `osm.org`. The only possible confusion here could be in comments like "When I tried opening https://www.osm.org/ ... but when I tried https://www.openstreetmap.org/ ..." that talk about different osm domains. Such comments are unlikely in plaintext changeset and note comments, and other editable texts support markdown syntax `[...](...)` where you can directly specify the visible text.

![image](https://github.com/user-attachments/assets/c63980d3-c916-425e-95ff-840c568b311b)
