### PR TITLE
Update strong_migrations to be compatible with rails 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem "rack-cors"
 gem "rails-i18n", "~> 8.0.0"
 gem "rails_param"
 gem "rinku", ">= 2.0.6", :require => "rails_rinku"
-gem "strong_migrations", "< 2.0.0"
+gem "strong_migrations"
 gem "validates_email_format_of", ">= 1.5.1"
 
 # Native OSM extensions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -645,8 +645,8 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     stringio (3.1.6)
-    strong_migrations (1.8.0)
-      activerecord (>= 5.2)
+    strong_migrations (2.2.1)
+      activerecord (>= 7)
     teaspoon (1.4.0)
       railties (>= 5.0)
     teaspoon-mocha (2.3.3)
@@ -784,7 +784,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   sprockets-exporters_pack
-  strong_migrations (< 2.0.0)
+  strong_migrations
   teaspoon
   teaspoon-mocha (~> 2.3.3)
   terser


### PR DESCRIPTION
We previously pinned to an old version for ruby 3.1 support, but that's no longer required since rails needs 3.2 anyway.

Fixes #5845

I'll follow up with the issue about why CI didn't catch this.