### PR TITLE
Remove TagHelper include from RichText module

### DIFF
--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -25,8 +25,6 @@ module RichText
   end
 
   class Base < String
-    include ActionView::Helpers::TagHelper
-
     def spam_score
       link_count = 0
       link_size = 0
@@ -76,7 +74,7 @@ module RichText
     end
 
     def linkify(text, mode = :urls)
-      link_attr = tag_builder.tag_options(:rel => "nofollow noopener noreferrer")
+      link_attr = 'rel="nofollow noopener noreferrer"'
       Rinku.auto_link(ERB::Util.html_escape(text), mode, link_attr) do |url|
         %r{^https?://([^/]*)(.*)$}.match(url) do |m|
           "#{Settings.linkify_hosts_replacement}#{m[2]}" if Settings.linkify_hosts_replacement &&


### PR DESCRIPTION
We use TagHelper module to convert `:rel => "nofollow noopener noreferrer"` into `'rel="nofollow noopener noreferrer"'`, probably because [Rinku](https://github.com/vmg/rinku)'s readme says thet we can generate an attribute string from a hash. And to do that we have to call what is now a private method of TagHelper; maybe it wasn't private when the readme was last updated.

Or we could just write a string.