### PR TITLE
Support interactive debugger with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       /tmp/pids/
     ports:
       - "3000:3000"
+    stdin_open: true
+    tty: true
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     depends_on:
       - db


### PR DESCRIPTION
### Description

Configures the `web` service in `docker-compose.yml` file to allow for interactive debugging. `tty` allocates a pseudo terminal while `stdin_open` runs the container with stdin. Running `docker attach WEB_CONTAINER_ID` connects to the running container where the debugger can be interacted with.

One alternative is to run `docker-compose run --rm --service-ports -it web bash` and then `bundle exec rails s -p 3000 -b '0.0.0.0'` inside the container. However, I think leaning into `docker-compose.yml` makes sense here — we get consistent terminal behavior as a default when running `docker compose up` and `docker attach`. 

### How has this been tested?
I ran `docker-compose up` and then in a separate terminal ran `docker attach WEB_CONTAINER_ID`.  When I hit a `debugger` I can then step through the code.


