### PR TITLE
Remove extra sanitize after simple_format RichText::HTML

### DIFF
--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -88,7 +88,7 @@ module RichText
 
   class HTML < Base
     def to_html
-      linkify(sanitize(simple_format(self)))
+      linkify(simple_format(self))
     end
 
     def to_text


### PR DESCRIPTION
`simple_format` already calls `sanitize` internally. We don't call `sanitize` again from a similar place of `RichText::Text`.
