### PR TITLE
Shorten matching wiki urls in linkify

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -140,6 +140,10 @@ fossgis_valhalla_url: "https://valhalla1.openstreetmap.de/route"
 linkify_hosts: ["www.openstreetmap.org", "www.osm.org", "www.openstreetmap.com", "openstreetmap.org", "osm.org", "openstreetmap.com"]
 # Shorter host to replace main hosts
 linkify_hosts_replacement: "osm.org"
+# Wiki website hosts to match in linkify
+linkify_wiki_hosts: ["wiki.openstreetmap.org", "wiki.osm.org", "wiki.openstreetmap.com", "wiki.openstreetmaps.org", "osm.wiki", "www.osm.wiki", "wiki.osm.wiki"]
+# Shorter host to replace wiki hosts
+linkify_wiki_hosts_replacement: "osm.wiki"
 # External authentication credentials
 #google_auth_id: ""
 #google_auth_secret: ""

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -78,11 +78,17 @@ module RichText
     def linkify(text, mode = :urls)
       link_attr = tag_builder.tag_options(:rel => "nofollow noopener noreferrer")
       Rinku.auto_link(ERB::Util.html_escape(text), mode, link_attr) do |url|
-        %r{^https?://([^/]*)(.*)$}.match(url) do |m|
-          "#{Settings.linkify_hosts_replacement}#{m[2]}" if Settings.linkify_hosts_replacement &&
-                                                            Settings.linkify_hosts&.include?(m[1])
-        end || url
+        url = shorten_host(url, Settings.linkify_hosts, Settings.linkify_hosts_replacement)
+        shorten_host(url, Settings.linkify_wiki_hosts, Settings.linkify_wiki_hosts_replacement)
       end.html_safe
+    end
+
+    private
+
+    def shorten_host(url, hosts, hosts_replacement)
+      %r{^https?://([^/]*)(.*)$}.match(url) do |m|
+        "#{hosts_replacement}#{m[2]}" if hosts_replacement && hosts&.include?(m[1])
+      end || url
     end
   end
 

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -269,6 +269,18 @@ class RichTextTest < ActiveSupport::TestCase
     end
   end
 
+  def test_text_to_html_linkify_wiki_replace
+    with_settings(:linkify_wiki_hosts => ["replace-me-wiki.example.com"], :linkify_wiki_hosts_replacement => "wiki.example.com") do
+      r = RichText.new("text", "foo https://replace-me-wiki.example.com/wiki/Tag:surface%3Dmetal bar")
+      assert_html r do
+        assert_dom "a", :count => 1, :text => "wiki.example.com/wiki/Tag:surface%3Dmetal" do
+          assert_dom "> @href", "https://replace-me-wiki.example.com/wiki/Tag:surface%3Dmetal"
+          assert_dom "> @rel", "nofollow noopener noreferrer"
+        end
+      end
+    end
+  end
+
   def test_text_to_html_email
     r = RichText.new("text", "foo example@example.com bar")
     assert_html r do


### PR DESCRIPTION
Like #5844, but for wiki links that are also common in comments.

Before:
![image](https://github.com/user-attachments/assets/06edebe0-b6e0-4f71-bbfe-cbb945bf0d75)

After:
![image](https://github.com/user-attachments/assets/9d02dad6-5e44-4269-a8eb-0df472ba6bff)
