### PR TITLE
Remove /wiki prefix from wiki urls in linkify

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -144,6 +144,8 @@ linkify_hosts_replacement: "osm.org"
 linkify_wiki_hosts: ["wiki.openstreetmap.org", "wiki.osm.org", "wiki.openstreetmap.com", "wiki.openstreetmaps.org", "osm.wiki", "www.osm.wiki", "wiki.osm.wiki"]
 # Shorter host to replace wiki hosts
 linkify_wiki_hosts_replacement: "osm.wiki"
+# Regexp for wiki prefix that can be removed
+linkify_wiki_optional_path_prefix: "^/wiki(?=/[A-Z])"
 # External authentication credentials
 #google_auth_id: ""
 #google_auth_secret: ""


### PR DESCRIPTION
#5855 replaces `wiki.openstreetmap.org` with `osm.wiki`, and now wiki link text has `... wiki/wiki ...` which looks redundant. Osm wiki is set up so that prefix is optional in most of the cases, that's why there's a proposal to remove the prefix: https://github.com/openstreetmap/openstreetmap-website/pull/5855#issuecomment-2758382889. When the prefix is actually optional is determined by mod_rewrite rules as I commented in https://github.com/openstreetmap/openstreetmap-website/pull/5855#issuecomment-2759174982. I don't want to reproduce those rules to check when it's safe to remove `/wiki`. Instead I'm using a simpler rule: `/wiki` can be removed if it's followed by `/` and an uppercase Latin letter, which is going to be true for most of the articles. Special pages skipped using `RewriteCond` all start with lowercase letters, therefore stripping `wiki` won't cause a collision with them and `RewriteRule` will execute and put `wiki` back. There are also rules for filenames, but I don't expect any collisions with them either.

https://github.com/openstreetmap/chef/blob/0cad06b01638b433858a5be37f87c236084cb743/cookbooks/mediawiki/templates/default/apache.erb#L72-L92

Technically I don't need to check all those rules because I'm not changing the `href`, I'm just changing the link text. But I still want that text to be something that can be pasted into the location bar and work as the original link.

![image](https://github.com/user-attachments/assets/5c3e43a4-bd4e-49e2-aaaa-0b62e36a66fa)
