### PR TITLE
Simpliy linkify normalisation to use a single array of rules

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -136,16 +136,13 @@ overpass_credentials: false
 graphhopper_url: "https://graphhopper.com/api/1/route"
 fossgis_osrm_url: "https://routing.openstreetmap.de/"
 fossgis_valhalla_url: "https://valhalla1.openstreetmap.de/route"
-# Main website hosts to match in linkify
-linkify_hosts: ["www.openstreetmap.org", "www.osm.org", "www.openstreetmap.com", "openstreetmap.org", "osm.org", "openstreetmap.com"]
-# Shorter host to replace main hosts
-linkify_hosts_replacement: "osm.org"
-# Wiki website hosts to match in linkify
-linkify_wiki_hosts: ["wiki.openstreetmap.org", "wiki.osm.org", "wiki.openstreetmap.com", "wiki.openstreetmaps.org", "osm.wiki", "www.osm.wiki", "wiki.osm.wiki"]
-# Shorter host to replace wiki hosts
-linkify_wiki_hosts_replacement: "osm.wiki"
-# Regexp for wiki prefix that can be removed
-linkify_wiki_optional_path_prefix: "^/wiki(?=/[A-Z])"
+# Normalisation rules for linkify
+linkify_rules:
+  - hosts: ["www.openstreetmap.org", "www.osm.org", "www.openstreetmap.com", "openstreetmap.org", "osm.org", "openstreetmap.com"]
+    host_replacement: "osm.org"
+  - hosts : ["wiki.openstreetmap.org", "wiki.osm.org", "wiki.openstreetmap.com", "wiki.openstreetmaps.org", "osm.wiki", "www.osm.wiki", "wiki.osm.wiki"]
+    host_replacement: "osm.wiki"
+    path_prefix: "^/wiki(?=/[A-Z])"
 # External authentication credentials
 #google_auth_id: ""
 #google_auth_secret: ""

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -76,9 +76,10 @@ module RichText
     def linkify(text, mode = :urls)
       link_attr = 'rel="nofollow noopener noreferrer"'
       Rinku.auto_link(ERB::Util.html_escape(text), mode, link_attr) do |url|
-        url = shorten_host(url, Settings.linkify_hosts, Settings.linkify_hosts_replacement)
-        shorten_host(url, Settings.linkify_wiki_hosts, Settings.linkify_wiki_hosts_replacement) do |path|
-          path.sub(Regexp.new(Settings.linkify_wiki_optional_path_prefix || ""), "")
+        Array(Settings.linkify_rules).reduce(url) do |normalised_url, rule|
+          shorten_host(normalised_url, rule[:hosts], rule[:host_replacement]) do |path|
+            path.sub(Regexp.new(rule[:path_prefix] || ""), "")
+          end
         end
       end.html_safe
     end

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -222,7 +222,7 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify
-    with_settings(:linkify_hosts => ["replace-me.example.com"], :linkify_hosts_replacement => "repl.example.com") do
+    with_settings(:linkify_rules => [{ :hosts => ["replace-me.example.com"], :host_replacement => "repl.example.com" }]) do
       r = RichText.new("text", "foo http://example.com/ bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "http://example.com/" do
@@ -234,7 +234,7 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify_replace
-    with_settings(:linkify_hosts => ["replace-me.example.com"], :linkify_hosts_replacement => "repl.example.com") do
+    with_settings(:linkify_rules => [{ :hosts => ["replace-me.example.com"], :host_replacement => "repl.example.com" }]) do
       r = RichText.new("text", "foo https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12 bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "repl.example.com/some/path?query=te<st&limit=20>10#result12" do
@@ -246,7 +246,7 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify_replace_other_scheme
-    with_settings(:linkify_hosts => ["replace-me.example.com"], :linkify_hosts_replacement => "repl.example.com") do
+    with_settings(:linkify_rules => [{ :hosts => ["replace-me.example.com"], :host_replacement => "repl.example.com" }]) do
       r = RichText.new("text", "foo ftp://replace-me.example.com/some/path?query=te<st&limit=20>10#result12 bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "ftp://replace-me.example.com/some/path?query=te<st&limit=20>10#result12" do
@@ -258,7 +258,7 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify_replace_undefined
-    with_settings(:linkify_hosts => ["replace-me.example.com"], :linkify_hosts_replacement => nil) do
+    with_settings(:linkify_rules => [{ :hosts => ["replace-me.example.com"] }]) do
       r = RichText.new("text", "foo https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12 bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "https://replace-me.example.com/some/path?query=te<st&limit=20>10#result12" do
@@ -270,8 +270,7 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify_wiki_replace_prefix
-    with_settings(:linkify_wiki_hosts => ["replace-me-wiki.example.com"], :linkify_wiki_hosts_replacement => "wiki.example.com",
-                  :linkify_wiki_optional_path_prefix => "^/wiki(?=/[A-Z])") do
+    with_settings(:linkify_rules => [{ :hosts => ["replace-me-wiki.example.com"], :host_replacement => "wiki.example.com", :path_prefix => "^/wiki(?=/[A-Z])" }]) do
       r = RichText.new("text", "foo https://replace-me-wiki.example.com/wiki/Tag:surface%3Dmetal bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "wiki.example.com/Tag:surface%3Dmetal" do
@@ -283,8 +282,7 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify_wiki_replace_prefix_undefined
-    with_settings(:linkify_wiki_hosts => ["replace-me-wiki.example.com"], :linkify_wiki_hosts_replacement => "wiki.example.com",
-                  :linkify_wiki_optional_path_prefix => nil) do
+    with_settings(:linkify_rules => [{ :hosts => ["replace-me-wiki.example.com"], :host_replacement => "wiki.example.com" }]) do
       r = RichText.new("text", "foo https://replace-me-wiki.example.com/wiki/Tag:surface%3Dmetal bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "wiki.example.com/wiki/Tag:surface%3Dmetal" do
@@ -296,8 +294,7 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify_wiki_replace_undefined_prefix
-    with_settings(:linkify_wiki_hosts => ["replace-me-wiki.example.com"], :linkify_wiki_hosts_replacement => nil,
-                  :linkify_wiki_optional_path_prefix => "^/wiki(?=/[A-Z])") do
+    with_settings(:linkify_rules => [{ :hosts => ["replace-me-wiki.example.com"], :path_prefix => "^/wiki(?=/[A-Z])" }]) do
       r = RichText.new("text", "foo https://replace-me-wiki.example.com/wiki/Tag:surface%3Dmetal bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "https://replace-me-wiki.example.com/Tag:surface%3Dmetal" do
@@ -309,8 +306,7 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_text_to_html_linkify_wiki_replace_prefix_no_match
-    with_settings(:linkify_wiki_hosts => ["replace-me-wiki.example.com"], :linkify_wiki_hosts_replacement => "wiki.example.com",
-                  :linkify_wiki_optional_path_prefix => "^/wiki(?=/[A-Z])") do
+    with_settings(:linkify_rules => [{ :hosts => ["replace-me-wiki.example.com"], :host_replacement => "wiki.example.com", :path_prefix => "^/wiki(?=/[A-Z])" }]) do
       r = RichText.new("text", "foo https://replace-me-wiki.example.com/wiki/w bar")
       assert_html r do
         assert_dom "a", :count => 1, :text => "wiki.example.com/wiki/w" do


### PR DESCRIPTION
Rather than adding an ever larger list of configuration options for link normalisation this uses a single option that provides an array of rules to apply.