### PR TITLE
Fix fixthemap note link

### DIFF
--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -158,11 +158,11 @@ OSM = {
       layers = args.getLayersCode();
     } else if (args instanceof URLSearchParams) {
       center = args.get("center") || L.latLng(args.get("lat"), args.get("lon"));
-      zoom = args.get("zoom");
+      zoom = Number(args.get("zoom"));
       layers = args.get("layers") || "";
     } else {
       center = args.center || L.latLng(args.lat, args.lon);
-      zoom = args.zoom;
+      zoom = Number(args.zoom);
       layers = args.layers || "";
     }
 

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -22,7 +22,8 @@
   <div class='col-sm'>
     <h3 class='fs-5'><%= t "site.welcome.add_a_note.title" %></h3>
     <p><%= t "site.welcome.add_a_note.para_1" %></p>
-    <p><%= t ".how_to_help.add_a_note.instructions_1_html", :note_icon => tag.a(:class => "icon note bg-dark rounded-1") %></p>
+    <p><%= t ".how_to_help.add_a_note.instructions_1_html", :note_icon => tag.a(:class => "icon note bg-dark rounded-1",
+                                                                                :title => t("javascripts.site.createnote_tooltip")) %></p>
   </div>
 </div>
 

--- a/test/system/fixthemap_test.rb
+++ b/test/system/fixthemap_test.rb
@@ -1,0 +1,11 @@
+require "application_system_test_case"
+
+class FixthemapTest < ApplicationSystemTestCase
+  test "should have 'create a note' link with correct map hash" do
+    visit fixthemap_path(:lat => 60, :lon => 30, :zoom => 10)
+
+    within_content_body do
+      assert_link "Add a note to the map", :href => %r{/note/new#map=10/60(\.\d+)?/30(\.\d+)?}
+    end
+  end
+end


### PR DESCRIPTION
Embed pages have links to the *fixthemap* page that have lat/lon/zoom params:
![image](https://github.com/user-attachments/assets/32f4ac9c-0dc8-4311-a48b-ac5dab3ebbcf)

[Example link](https://www.openstreetmap.org/fixthemap?lat=53.25688279713156&lon=-1.4329004287719729&zoom=13)

*fixthemap* has an *Add a Note* section with a new note icon that is supposed to be a link:
![image](https://github.com/user-attachments/assets/e6286464-d694-4864-9e12-0ddb21c23c8d)

But it's not a link because javascript writing it is broken. `zoom` is used as a string with `+` operator, concatenation happens instead of addition, and link generation fails.

This PR forces zoom to be a number inside `OSM.formatHash` which is used to generate a link.
![image](https://github.com/user-attachments/assets/f23548aa-257d-4201-8305-99d6c5bfdd29)

Actually we don't need javascript to write new note links because lat/lon/zoom are available server-side, but I'm not changing that yet.