### PR TITLE
Deduplicate note adding instructions

### DIFF
--- a/app/views/site/_add_a_note.html.erb
+++ b/app/views/site/_add_a_note.html.erb
@@ -1,0 +1,6 @@
+<p><%= t ".para_1" %></p>
+<p><%= t ".para_2_html",
+         :note_icon => tag.a(:href => new_note_path,
+                             :class => "icon note bg-dark rounded-1",
+                             :title => t("javascripts.site.createnote_tooltip")),
+         :map_link => link_to(t(".the_map"), root_path) %></p>

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -20,10 +20,8 @@
     </p>
   </div>
   <div class='col-sm'>
-    <h3 class='fs-5'><%= t "site.welcome.add_a_note.title" %></h3>
-    <p><%= t "site.welcome.add_a_note.para_1" %></p>
-    <p><%= t ".how_to_help.add_a_note.instructions_1_html", :note_icon => tag.a(:class => "icon note bg-dark rounded-1",
-                                                                                :title => t("javascripts.site.createnote_tooltip")) %></p>
+    <h3 class='fs-5'><%= t "site.add_a_note.title" %></h3>
+    <%= render "add_a_note" %>
   </div>
 </div>
 

--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -86,8 +86,6 @@
 </div>
 
 <div class='alert alert-secondary'>
-  <h2><%= t ".add_a_note.title" %></h2>
-  <p><%= t ".add_a_note.para_1" %></p>
-  <p><%= t ".add_a_note.para_2_html", :map_link => link_to(t(".add_a_note.the_map"), root_path),
-                                      :note_icon => tag.span(:class => "icon note bg-dark rounded-1") %></p>
+  <h2><%= t "site.add_a_note.title" %></h2>
+  <%= render "add_a_note" %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2368,11 +2368,6 @@ en:
           explanation_html: |
             If you have noticed a problem with our map data, for example a road is missing or your address, the best way to
             proceed is to join the OpenStreetMap community and add or repair the data yourself.
-        add_a_note:
-          instructions_1_html: |
-            Just click %{note_icon} or the same icon on the map display.
-            This will add a marker to the map, which you can move
-            by dragging. Add your message, then click save, and other mappers will investigate.
       other_concerns:
         title: Other concerns
         concerns_html: |
@@ -2496,16 +2491,16 @@ en:
         automated_edits_url: https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct
       start_mapping: Start Mapping
       continue_authorization: Continue Authorization
-      add_a_note:
-        title: No Time To Edit? Add a Note!
-        para_1: |
-          If you just want something small fixed and don't have the time to sign up and learn how to edit, it's
-          easy to add a note.
-        para_2_html: |
-          Just go to %{map_link} and click the note icon: %{note_icon}.
-          This will add a marker to the map, which you can move by dragging.
-          Add your message, then click save, and other mappers will investigate.
-        the_map: the map
+    add_a_note:
+      title: No Time To Edit? Add a Note!
+      para_1: |
+        If you just want something small fixed and don't have the time to sign up and learn how to edit, it's
+        easy to add a note.
+      para_2_html: |
+        Just click %{note_icon} or the same icon on %{map_link}.
+        This will add a marker to the map, which you can move by dragging.
+        Add your message, then click save, and other mappers will investigate.
+      the_map: the map
     communities:
       title: Communities
       lede_text: |


### PR DESCRIPTION
We have two versions of the guide to notes: one with the link as an icon and one with the link as plaintext in a barely different color. I dropped the second version.