### PR TITLE
Use L.OSM.locate control in user.js

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,7 +1,6 @@
 //= require_self
 //= require leaflet.sidebar
 //= require leaflet.sidebar-pane
-//= require leaflet.locatecontrol/dist/L.Control.Locate.umd
 //= require leaflet.locate
 //= require leaflet.layers
 //= require leaflet.key

--- a/app/assets/javascripts/leaflet.locate.js
+++ b/app/assets/javascripts/leaflet.locate.js
@@ -1,3 +1,5 @@
+//= require leaflet.locatecontrol/dist/L.Control.Locate.umd
+
 L.OSM.locate = function (options) {
   const control = L.control.locate({
     icon: "icon geolocate",

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,4 +1,5 @@
 //= require leaflet.locatecontrol/dist/L.Control.Locate.umd
+//= require leaflet.locate
 
 (function () {
   $(document).on("change", "#user_all", function () {
@@ -21,27 +22,7 @@ $(function () {
     L.OSM.zoom({ position: position })
       .addTo(map);
 
-    const locate = L.control.locate({
-      position: position,
-      icon: "icon geolocate",
-      iconLoading: "icon geolocate",
-      strings: {
-        title: OSM.i18n.t("javascripts.map.locate.title"),
-        popup: function (options) {
-          return OSM.i18n.t("javascripts.map.locate." + options.unit + "Popup", { count: options.distance });
-        }
-      }
-    }).addTo(map);
-
-    const locateContainer = locate.getContainer();
-
-    $(locateContainer)
-      .removeClass("leaflet-control-locate leaflet-bar")
-      .addClass("control-locate")
-      .children("a")
-      .attr("href", "#")
-      .removeClass("leaflet-bar-part leaflet-bar-part-single")
-      .addClass("control-button");
+    L.OSM.locate({ position }).addTo(map);
 
     if (OSM.home) {
       map.setView([OSM.home.lat, OSM.home.lon], defaultHomeZoom);

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,4 +1,3 @@
-//= require leaflet.locatecontrol/dist/L.Control.Locate.umd
 //= require leaflet.locate
 
 (function () {


### PR DESCRIPTION
There's a claim in #5752 that "Due to the nature of the leaflet locate plugin, that icon is done with ..." and then various approaches are used such as clip path and polygon in css instead of a regular svg. While true, this is easily fixable inside our `L.OSM.locate` control. But turns out that we don't use our own `L.OSM.locate` in `user.js`. That's because I wasn't paying attention to this file when doing https://github.com/openstreetmap/openstreetmap-website/commit/12a7c9d023bcca01657e357b2ed28cc6bcd20e06.

This PR makes `user.js` use `L.OSM.locate`.