### PR TITLE
Shorten options of map controls

### DIFF
--- a/app/assets/javascripts/diary_entry.js
+++ b/app/assets/javascripts/diary_entry.js
@@ -30,8 +30,7 @@ $(function () {
       zoomControl: false
     }).addLayer(new L.OSM.Mapnik());
 
-    L.OSM.zoom({ position: position })
-      .addTo(map);
+    L.OSM.zoom({ position }).addTo(map);
 
     map.setView(centre, params.zoom);
 

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -111,39 +111,30 @@ $(function () {
   }
 
   addControlGroup([
-    L.OSM.zoom({ position: position }),
-    L.OSM.locate({ position: position })
+    L.OSM.zoom({ position }),
+    L.OSM.locate({ position })
   ]);
 
   addControlGroup([
     L.OSM.layers({
-      position: position,
-      layers: map.baseLayers,
-      sidebar: sidebar
+      position,
+      sidebar,
+      layers: map.baseLayers
     }),
-    L.OSM.key({
-      position: position,
-      sidebar: sidebar
-    }),
+    L.OSM.key({ position, sidebar }),
     L.OSM.share({
-      "position": position,
-      "sidebar": sidebar,
+      position,
+      sidebar,
       "short": true
     })
   ]);
 
   addControlGroup([
-    L.OSM.note({
-      position: position,
-      sidebar: sidebar
-    })
+    L.OSM.note({ position, sidebar })
   ]);
 
   addControlGroup([
-    L.OSM.query({
-      position: position,
-      sidebar: sidebar
-    })
+    L.OSM.query({ position, sidebar })
   ]);
 
   L.control.scale()

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -18,8 +18,7 @@ $(function () {
 
     const position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
 
-    L.OSM.zoom({ position: position })
-      .addTo(map);
+    L.OSM.zoom({ position }).addTo(map);
 
     const locate = L.control.locate({
       position: position,


### PR DESCRIPTION
This is in addition to #5872 where I wrote `{ position }` instead of a longer `{ position: position }`.