### PR TITLE
History page links

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -173,7 +173,7 @@ OSM.History = function (map) {
 
     const div = $(this).parents(".changeset_more");
 
-    $(this).closest(".pagination").hide();
+    $(this).closest(".pagination").addClass("invisible");
     div.find(".loader").show();
 
     const data = new URLSearchParams();

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -173,8 +173,8 @@ OSM.History = function (map) {
 
     const div = $(this).parents(".changeset_more");
 
-    $(this).closest(".pagination").addClass("invisible");
-    div.find(".loader").show();
+    div.find(".pagination").addClass("invisible");
+    div.find("[hidden]").prop("hidden", false);
 
     const data = new URLSearchParams();
 

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -104,6 +104,10 @@ OSM.History = function (map) {
 
   function displayFirstChangesets(html) {
     $("#sidebar_content .changesets").html(html);
+
+    if (location.pathname === "/history") {
+      setPaginationMapHashes();
+    }
   }
 
   function displayMoreChangesets(div, html) {
@@ -130,6 +134,19 @@ OSM.History = function (map) {
       nextNewList.children().appendTo(oldList);
       nextNewList.remove();
     }
+
+    if (location.pathname === "/history") {
+      setPaginationMapHashes();
+    }
+  }
+
+  function setPaginationMapHashes() {
+    $("#sidebar .pagination a").each(function () {
+      $(this).prop("hash", OSM.formatHash({
+        center: map.getCenter(),
+        zoom: map.getZoom()
+      }));
+    });
   }
 
   function loadFirstChangesets() {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -182,11 +182,14 @@ OSM.History = function (map) {
     $(this).hide();
     div.find(".loader").show();
 
-    $.get($(this).attr("href"), function (html) {
-      displayMoreChangesets(div, html);
-      enableChangesetIntersectionObserver();
-      updateMap();
-    });
+    fetch($(this).attr("href"))
+      .then(response => response.text())
+      .then(function (html) {
+        displayMoreChangesets(div, html);
+        enableChangesetIntersectionObserver();
+
+        updateMap();
+      });
   }
 
   function reloadChangesetsBecauseOfMapMovement() {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -155,10 +155,12 @@ OSM.History = function (map) {
         if (data.has("before")) {
           const [firstItem] = $("#sidebar_content .changesets ol").children().first();
           firstItem?.scrollIntoView();
-        }
-        if (data.has("after")) {
+        } else if (data.has("after")) {
           const [lastItem] = $("#sidebar_content .changesets ol").children().last();
           lastItem?.scrollIntoView(false);
+        } else {
+          const [sidebar] = $("#sidebar");
+          sidebar.scrollTop = 0;
         }
 
         updateMap();

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -173,7 +173,7 @@ OSM.History = function (map) {
 
     const div = $(this).parents(".changeset_more");
 
-    $(this).hide();
+    $(this).closest(".pagination").hide();
     div.find(".loader").show();
 
     const data = new URLSearchParams();

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -620,11 +620,6 @@ tr.turn {
       z-index: 2; /* needs to be higher than Bootstrap's stretched link ::after z-index */
     }
   }
-
-  .changeset_more .loader {
-    display: none;
-    width: 100%;
-  }
 }
 
 /* Rules for the browse sidebar */

--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -1,6 +1,6 @@
 <% if @newer_changesets_id %>
   <div class="changeset_more my-3 text-center">
-    <%= link_to t(".load_more"), url_for(@params.merge(:before => nil, :after => @newer_changesets_id)), :class => "btn btn-primary" %>
+    <%= link_to t(".load_more"), url_for(:after => @newer_changesets_id), :class => "btn btn-primary" %>
     <div class="text-center loader">
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
@@ -21,7 +21,7 @@
 <% end %>
 <% if @older_changesets_id -%>
   <div class="changeset_more my-3 text-center">
-    <%= link_to t(".load_more"), url_for(@params.merge(:before => @older_changesets_id, :after => nil)), :class => "btn btn-primary" %>
+    <%= link_to t(".load_more"), url_for(:before => @older_changesets_id), :class => "btn btn-primary" %>
     <div class="text-center loader">
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>

--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -1,6 +1,6 @@
 <% if @newer_changesets_id %>
   <div class="changeset_more my-3">
-    <div class="text-center position-absolute loader">
+    <div class="text-center position-absolute start-0 end-0" hidden>
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
       </div>
@@ -25,7 +25,7 @@
 <% end %>
 <% if @older_changesets_id -%>
   <div class="changeset_more my-3">
-    <div class="text-center position-absolute loader">
+    <div class="text-center position-absolute start-0 end-0" hidden>
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
       </div>

--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -1,15 +1,15 @@
 <% if @newer_changesets_id %>
   <div class="changeset_more my-3">
+    <div class="text-center position-absolute loader">
+      <div class="spinner-border" role="status">
+        <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
+      </div>
+    </div>
     <ul class="pagination justify-content-center">
       <li class="page-item">
         <%= link_to t(".newer_changesets"), url_for(:after => @newer_changesets_id), :class => "page-link" %>
       </li>
     </ul>
-    <div class="text-center loader">
-      <div class="spinner-border" role="status">
-        <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
-      </div>
-    </div>
   </div>
 <% end %>
 <% if @changesets.present? %>
@@ -25,15 +25,15 @@
 <% end %>
 <% if @older_changesets_id -%>
   <div class="changeset_more my-3">
+    <div class="text-center position-absolute loader">
+      <div class="spinner-border" role="status">
+        <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
+      </div>
+    </div>
     <ul class="pagination justify-content-center">
       <li class="page-item">
         <%= link_to t(".older_changesets"), url_for(:before => @older_changesets_id), :class => "page-link" %>
       </li>
     </ul>
-    <div class="text-center loader">
-      <div class="spinner-border" role="status">
-        <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
-      </div>
-    </div>
   </div>
 <% end -%>

--- a/app/views/changesets/index.html.erb
+++ b/app/views/changesets/index.html.erb
@@ -1,6 +1,10 @@
 <% if @newer_changesets_id %>
-  <div class="changeset_more my-3 text-center">
-    <%= link_to t(".load_more"), url_for(:after => @newer_changesets_id), :class => "btn btn-primary" %>
+  <div class="changeset_more my-3">
+    <ul class="pagination justify-content-center">
+      <li class="page-item">
+        <%= link_to t(".newer_changesets"), url_for(:after => @newer_changesets_id), :class => "page-link" %>
+      </li>
+    </ul>
     <div class="text-center loader">
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
@@ -20,8 +24,12 @@
   <p class="mx-3"><%= params[:before] ? t(".no_more") : t(".empty") %></p>
 <% end %>
 <% if @older_changesets_id -%>
-  <div class="changeset_more my-3 text-center">
-    <%= link_to t(".load_more"), url_for(:before => @older_changesets_id), :class => "btn btn-primary" %>
+  <div class="changeset_more my-3">
+    <ul class="pagination justify-content-center">
+      <li class="page-item">
+        <%= link_to t(".older_changesets"), url_for(:before => @older_changesets_id), :class => "page-link" %>
+      </li>
+    </ul>
     <div class="text-center loader">
       <div class="spinner-border" role="status">
         <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -494,7 +494,8 @@ en:
       no_more: "No more changesets found."
       no_more_area: "No more changesets in this area."
       no_more_user: "No more changesets by this user."
-      load_more: "Load more"
+      older_changesets: Older Changesets
+      newer_changesets: Newer Changesets
       feed:
         title: "Changeset %{id}"
         title_comment: "Changeset %{id} - %{comment}"

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -35,21 +35,21 @@ class HistoryTest < ApplicationSystemTestCase
       changesets.assert_no_text "bottom-changeset-in-batch-2"
       changesets.assert_no_text "first-changeset-in-history"
       changesets.assert_selector "ol", :count => 1
-      changesets.assert_selector "li", :count => PAGE_SIZE
+      changesets.assert_selector "li[data-changeset]", :count => PAGE_SIZE
 
-      changesets.find(".changeset_more a.btn").click
+      click_on "Older Changesets"
       changesets.assert_text "bottom-changeset-in-batch-1"
       changesets.assert_text "bottom-changeset-in-batch-2"
       changesets.assert_no_text "first-changeset-in-history"
       changesets.assert_selector "ol", :count => 1
-      changesets.assert_selector "li", :count => 2 * PAGE_SIZE
+      changesets.assert_selector "li[data-changeset]", :count => 2 * PAGE_SIZE
 
-      changesets.find(".changeset_more a.btn").click
+      click_on "Older Changesets"
       changesets.assert_text "bottom-changeset-in-batch-1"
       changesets.assert_text "bottom-changeset-in-batch-2"
       changesets.assert_text "first-changeset-in-history"
       changesets.assert_selector "ol", :count => 1
-      changesets.assert_selector "li", :count => (2 * PAGE_SIZE) + 1
+      changesets.assert_selector "li[data-changeset]", :count => (2 * PAGE_SIZE) + 1
     end
   end
 


### PR DESCRIPTION
Changes *Load more* buttons into links similar to those used for pagination.
Changes their text to *Newer/Older Changesets*, see https://github.com/openstreetmap/openstreetmap-website/pull/5812#issuecomment-2735280265.

Now these links can be copied and opened like any other links.

![image](https://github.com/user-attachments/assets/e942d94e-da02-42cc-8500-0a4d01c35623)

For example, you can middle-click a link to open the next page in a new tab.

![image](https://github.com/user-attachments/assets/d8b3b92e-2a84-4aef-a91b-d35978686c85)
