### PR TITLE
Disabling asynchronous Map data layer rendering

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -43,7 +43,7 @@ L.OSM.Map = L.Map.extend({
     this.noteLayer = new L.FeatureGroup();
     this.noteLayer.options = { code: "N" };
 
-    this.dataLayer = new L.OSM.DataLayer(null, { asynchronous: true });
+    this.dataLayer = new L.OSM.DataLayer(null);
     this.dataLayer.options.code = "D";
 
     this.gpsLayer = new L.OSM.GPS({


### PR DESCRIPTION
Full discussion here: https://github.com/openstreetmap/openstreetmap-website/pull/5009#issuecomment-2722980833 But I'll duplicate the comment here.

https://github.com/openstreetmap/openstreetmap-website/pull/5009 brought two problems:

1. When moving the map, a white flash occurs and all objects on the map are redrawn:

https://github.com/user-attachments/assets/3c87c769-174c-4513-a5be-115eb9517bb8

2. Rendering slowed down. What used to occupy ~400ms now occupies ~1.3s. Hiding a data layer was previously performed on ~100ms, now ~1.5s (!)

Both problems arise due to the fact that before that the redrawing of the map was performed only once, after the completion of the removal/adding of objects to the SVG-element of the map.

--

This PR only removes asynchronous rendering. The loader that shows downloading data near the checkbox remains.
