### PR TITLE
Align globe to the end of the container.

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -727,7 +727,7 @@ tr.turn {
 
   &.new-user-main {
     background-image: image-url("sign-up-illustration.svg");
-    background-position-x: 70px;
+    background-position-x: 100%;
   }
 
   &.confirm-main {


### PR DESCRIPTION
This removes the arbitrary pixel-based alignment of the globe, which did not take tab label translations into account. Instead, we give as much space as possible to the tabs, by aligning to the end of the container (right-hand side on LTR, left hand side on RTL).

Refs #4773
