### PR TITLE
Don't set bbox history param when the entire world is visible

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -213,7 +213,15 @@ OSM.History = function (map) {
   }
 
   function setBboxFetchData(data) {
-    data.set("bbox", map.getBounds().wrap().toBBoxString());
+    const crs = map.options.crs;
+    const sw = map.getBounds().getSouthWest();
+    const ne = map.getBounds().getNorthEast();
+    const swClamped = crs.unproject(crs.project(sw));
+    const neClamped = crs.unproject(crs.project(ne));
+
+    if (sw.lat >= swClamped.lat || ne.lat <= neClamped.lat || ne.lng - sw.lng < 360) {
+      data.set("bbox", map.getBounds().wrap().toBBoxString());
+    }
   }
 
   function setListFetchData(data, url) {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -155,7 +155,7 @@ OSM.History = function (map) {
     disableChangesetIntersectionObserver();
 
     if (location.pathname === "/history") {
-      data.set("bbox", map.getBounds().wrap().toBBoxString());
+      setBboxFetchData(data);
       const feedLink = $("link[type=\"application/atom+xml\"]"),
             feedHref = feedLink.attr("href").split("?")[0];
       feedLink.attr("href", feedHref + "?" + data);
@@ -196,7 +196,7 @@ OSM.History = function (map) {
     const data = new URLSearchParams();
 
     if (location.pathname === "/history") {
-      data.set("bbox", map.getBounds().wrap().toBBoxString());
+      setBboxFetchData(data);
     }
 
     const url = new URL($(this).attr("href"), location);
@@ -210,6 +210,10 @@ OSM.History = function (map) {
 
         updateMap();
       });
+  }
+
+  function setBboxFetchData(data) {
+    data.set("bbox", map.getBounds().wrap().toBBoxString());
   }
 
   function setListFetchData(data, url) {

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -133,6 +133,27 @@ class HistoryTest < ApplicationSystemTestCase
     assert_current_path history_path
   end
 
+  test "all changesets are listed when fully zoomed out" do
+    user = create(:user)
+    [-177, -90, 0, 90, 177].each do |lon|
+      create(:changeset, :user => user, :num_changes => 1,
+                         :min_lat => 0 * GeoRecord::SCALE, :min_lon => (lon - 1) * GeoRecord::SCALE,
+                         :max_lat => 1 * GeoRecord::SCALE, :max_lon => (lon + 1) * GeoRecord::SCALE) do |changeset|
+        create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "changeset-at-lon(#{lon})")
+      end
+    end
+
+    visit history_path(:anchor => "map=0/0/0")
+
+    within_sidebar do
+      assert_link "changeset-at-lon(-177)", :count => 1
+      assert_link "changeset-at-lon(-90)", :count => 1
+      assert_link "changeset-at-lon(0)", :count => 1
+      assert_link "changeset-at-lon(90)", :count => 1
+      assert_link "changeset-at-lon(177)", :count => 1
+    end
+  end
+
   private
 
   def create_visible_changeset(user, comment)


### PR DESCRIPTION
The regular `/history` page shows changesets intersecting with the map view. To get them, the current map view bounds are sent as the `bbox` parameter. But the bound can be outside of [-180..180] longitude range, therefore also a `.wrap()` fix is applied. The fix itself is broken, see #5473 which removes it and implements support for longitudes outside of [-180..180].

Still, we don't need to send the `bbox` parameter with huge longitude values when the entire planet is visible.[^1] If there's no `bbox`, no filtering by `bbox` happens and all changesets are visible. This is what this PR does.

This is a partial fix for #3423 when the entire planet is visible. #5473 is still required for map views with the antimeridian that don't include the entire planet. But even without #5473 you'll be able to fully zoom out, click *History* and see all the latest changesets.

![image](https://github.com/user-attachments/assets/fe43fe64-c893-4425-9290-fb8c2a14cce4)

[^1]: Strictly speaking, that never happens because poles are infinitely away, but we can consider them visible if ~[-85..85] latitude range is visible.