### PR TITLE
Simplify changeset icon definitions

### DIFF
--- a/app/assets/images/icons/comment.svg
+++ b/app/assets/images/icons/comment.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 16 16" stroke="currentColor">
+  <path stroke-linejoin="round" d="M5.6 14.16c-.82.4-1.54.77-3.78 1.2.37-1 .57-1.88.67-2.95A7.5 6.5 0 0 1 .5 8 7.5 6.5 0 1 1 8 14.5a7.5 6.5 0 0 1-2.4-.34Z" />
+</svg>

--- a/app/assets/images/icons/pencil.svg
+++ b/app/assets/images/icons/pencil.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor">
+  <path stroke-linejoin="round" d="m2.5 10.5-2 5 5-2 10-10-3-3zm1-1v1h1v1h1v1h1m7-7-3-3" />
+</svg>

--- a/app/views/changesets/_changeset_line.html.erb
+++ b/app/views/changesets/_changeset_line.html.erb
@@ -7,9 +7,7 @@
     <%= tag.span :class => ["d-flex align-items-baseline gap-1", { "opacity-50" => num_changes.zero? }],
                  :title => t(".changes", :count => num_changes) do %>
       <%= num_changes %>
-      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-        <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325" />
-      </svg>
+      <%= inline_svg_tag "icons/pencil.svg" %>
     <% end %>
   <% end %>
 
@@ -17,13 +15,7 @@
     <%= tag.span :class => ["changeset_num_comments d-flex align-items-baseline gap-1 justify-content-end", { "opacity-50" => num_comments.zero? }],
                  :title => t(".comments", :count => num_comments) do %>
       <%= num_comments %>
-      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-        <% if num_comments.zero? %>
-          <path d="M2.678 11.894a1 1 0 0 1 .287.801 11 11 0 0 1-.398 2c1.395-.323 2.247-.697 2.634-.893a1 1 0 0 1 .71-.074A8 8 0 0 0 8 14c3.996 0 7-2.807 7-6s-3.004-6-7-6-7 2.808-7 6c0 1.468.617 2.83 1.678 3.894m-.493 3.905a22 22 0 0 1-.713.129c-.2.032-.352-.176-.273-.362a10 10 0 0 0 .244-.637l.003-.01c.248-.72.45-1.548.524-2.319C.743 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7-3.582 7-8 7a9 9 0 0 1-2.347-.306c-.52.263-1.639.742-3.468 1.105" />
-        <% else %>
-          <path d="M8 15c4.418 0 8-3.134 8-7s-3.582-7-8-7-8 3.134-8 7c0 1.76.743 3.37 1.97 4.6-.097 1.016-.417 2.13-.771 2.966-.079.186.074.394.273.362 2.256-.37 3.597-.938 4.18-1.234A9 9 0 0 0 8 15" />
-        <% end %>
-      </svg>
+      <%= inline_svg_tag "icons/comment.svg", :fill => num_comments.zero? ? "none" : "currentColor" %>
     <% end %>
   <% end %>
 </div>

--- a/config/initializers/inline_svg.rb
+++ b/config/initializers/inline_svg.rb
@@ -6,8 +6,17 @@ module OpenStreetMap
       end
     end
   end
+
+  class SvgFillOverrideTransform < InlineSvg::CustomTransformation
+    def transform(doc)
+      with_svg(doc) do |svg|
+        svg.set_attribute("fill", value)
+      end
+    end
+  end
 end
 
 InlineSvg.configure do |config|
   config.add_custom_transformation(:attribute => :to_symbol, :transform => OpenStreetMap::SvgToSymbolTransform)
+  config.add_custom_transformation(:attribute => :fill, :transform => OpenStreetMap::SvgFillOverrideTransform)
 end


### PR DESCRIPTION
Makes the changeset icon definitions a bit more compact and doesn't redefine them in every single history entry.