### PR TITLE
Remove manual edit after 4-second timeout on welcome page

### DIFF
--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -15,10 +15,6 @@ $(function () {
       $(".start-mapping").addClass("loading");
 
       if (navigator.geolocation) {
-        // handle firefox's weird implementation
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=675533
-        window.setTimeout(manualEdit, 4000);
-
         navigator.geolocation.getCurrentPosition(geoSuccess, manualEdit);
       } else {
         manualEdit();


### PR DESCRIPTION
Go to `/welcome` and click *start mapping*:

![image](https://github.com/user-attachments/assets/de3828bf-7417-4567-9491-b7c6d55f72ff)

What's going to happen is that if you didn't give the geolocation permission yet:
1. the permission dialog pops up
2. if you fail to react to it in four seconds, you get redirected to the map view

Four seconds is probably too short. And why do you need any timeout here? Supposedly this was a workaround for [a Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=675533) but it was fixed years ago.

This PR removes the timeout.