### PR TITLE
Change "add a note" background to secondary on welcome page

### DIFF
--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -85,7 +85,7 @@
 <% end %>
 </div>
 
-<div class='alert alert-primary'>
+<div class='alert alert-secondary'>
   <h2><%= t ".add_a_note.title" %></h2>
   <p><%= t ".add_a_note.para_1" %></p>
   <p><%= t ".add_a_note.para_2_html", :map_link => link_to(t(".add_a_note.the_map"), root_path),


### PR DESCRIPTION
`/welcome` page has this section at the bottom:
![image](https://github.com/user-attachments/assets/ded704cb-009e-4ce7-b7c6-560284bcdae5)

Notice *the map* link. Now look at it in dark mode:
![image](https://github.com/user-attachments/assets/475f169d-f1b0-4266-8a67-824dfb9582fc)

You can't see the link because this is a *primary alert*, the primary color is blue and the links are also blue.

Why is it primary-blue? It was made blue during a Bootstrap refactor in https://github.com/openstreetmap/openstreetmap-website/commit/f0ee117cffb37d36cc2fc0be198832358a451025. Previously it was *offwhite*. Dark mode didn't exist during that time.

This PR changes the color to secondary:

![image](https://github.com/user-attachments/assets/f1307cfa-b376-4ebd-93a8-cdec0963d07c)

![image](https://github.com/user-attachments/assets/49571b2f-673a-456b-ac8a-4ad5b92d5d36)
