### PR TITLE
Clean OSM.formatHash calls

### DIFF
--- a/app/assets/javascripts/fixthemap.js
+++ b/app/assets/javascripts/fixthemap.js
@@ -1,8 +1,0 @@
-$(function () {
-  const params = new URLSearchParams(location.search);
-
-  let url = "/note/new";
-  if (!params.has("zoom")) params.set("zoom", 17);
-  if (params.has("lat") && params.has("lon")) url += OSM.formatHash(params);
-  $(".icon.note").attr("href", url);
-});

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -163,10 +163,7 @@ OSM.History = function (map) {
 
   function setPaginationMapHashes() {
     $("#sidebar .pagination a").each(function () {
-      $(this).prop("hash", OSM.formatHash({
-        center: map.getCenter(),
-        zoom: map.getZoom()
-      }));
+      $(this).prop("hash", OSM.formatHash(map));
     });
   }
 

--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -1,18 +1,9 @@
 $(function () {
-  const params = new URLSearchParams(location.search);
-
-  if (params.has("lat") && params.has("lon")) {
-    let url = "/edit";
-
-    if (params.has("editor")) url += "?editor=" + params.get("editor");
-    if (!params.has("zoom")) params.set("zoom", 17);
-    url += OSM.formatHash(params);
-
-    $(".start-mapping").attr("href", url);
-  } else {
-    $(".start-mapping").on("click", function (e) {
+  const mappingBtn = $(".start-mapping");
+  if (!mappingBtn.prop("hash")) {
+    mappingBtn.on("click", function (e) {
       e.preventDefault();
-      $(".start-mapping").addClass("loading");
+      mappingBtn.addClass("loading");
 
       if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(geoSuccess, manualEdit);

--- a/app/helpers/geocoder_helper.rb
+++ b/app/helpers/geocoder_helper.rb
@@ -7,7 +7,7 @@ module GeocoderHelper
           elsif result[:min_lon] && result[:min_lat] && result[:max_lon] && result[:max_lat]
             "/?bbox=#{result[:min_lon]},#{result[:min_lat]},#{result[:max_lon]},#{result[:max_lat]}"
           else
-            "/#map=#{result[:zoom]}/#{result[:lat]}/#{result[:lon]}"
+            "/##{map_hash(result)}"
           end
 
     result.each do |key, value|
@@ -21,6 +21,12 @@ module GeocoderHelper
     html << " " if result[:suffix] && result[:name]
     html << result[:suffix] if result[:suffix]
     safe_join(html)
+  end
+
+  def map_hash(params)
+    return nil unless params[:lat].present? && params[:lon].present?
+
+    "map=#{params[:zoom] || 17}/#{params[:lat]}/#{params[:lon]}"
   end
 
   def describe_location(lat, lon, zoom = nil, language = nil)

--- a/app/views/site/fixthemap.html.erb
+++ b/app/views/site/fixthemap.html.erb
@@ -1,7 +1,3 @@
-<% content_for :head do %>
- <%= javascript_include_tag "fixthemap" %>
-<% end %>
-
 <% content_for :heading do %>
   <h1><%= t ".title" %></h1>
 <% end %>
@@ -23,6 +19,7 @@
     <h3 class='fs-5'><%= t "site.welcome.add_a_note.title" %></h3>
     <p><%= t "site.welcome.add_a_note.para_1" %></p>
     <p><%= t ".how_to_help.add_a_note.instructions_1_html", :note_icon => tag.a(:class => "icon note bg-dark rounded-1",
+                                                                                :href => new_note_path(:anchor => map_hash(params)),
                                                                                 :title => t("javascripts.site.createnote_tooltip")) %></p>
   </div>
 </div>

--- a/app/views/site/welcome.html.erb
+++ b/app/views/site/welcome.html.erb
@@ -81,7 +81,7 @@
 <% if params[:oauth_return_url] %>
   <a class="btn btn-primary" href="<%= params[:oauth_return_url] %>"><%= t ".continue_authorization" %></a>
 <% else %>
-  <a class="btn btn-primary start-mapping" href="<%= edit_path %>"><%= t ".start_mapping" %></a>
+  <%= link_to t(".start_mapping"), edit_path(:editor => params[:editor], :anchor => map_hash(params)), :class => "btn btn-primary start-mapping" %>
 <% end %>
 </div>
 


### PR DESCRIPTION
There is not just a `formatHash` call in `fixthemap` but also one in `welcome` that can be written in the template.
Looked through all `formatHash` calls and cleaned up another call.
Builds on the commit from #5752 that fixes gravitystorm#257.
See also #5869.