### PR TITLE
Remove .clearfix from places without floats

### DIFF
--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -4,7 +4,7 @@
      :icon => type == "following" ? "MARKER_BLUE" : "MARKER_GREEN",
      :description => render(:partial => "popup", :object => contact, :locals => { :type => type })
    } %>
-<%= tag.div :class => "clearfix row", :data => { :user => user_data } do %>
+<%= tag.div :class => "row", :data => { :user => user_data } do %>
   <div class="col-auto">
     <%= user_thumbnail contact %>
   </div>
@@ -32,7 +32,7 @@
     </p>
 
     <nav class='secondary-actions'>
-      <ul class='clearfix text-body-secondary'>
+      <ul class='text-body-secondary'>
         <li><%= link_to t("users.show.send message"), new_message_path(contact) %></li>
         <li>
           <% if current_user.follows?(contact) %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -29,7 +29,7 @@
       <%= t ".no followings" %>
     <% else %>
       <nav class='secondary-actions mb-3'>
-        <ul class='clearfix'>
+        <ul>
           <li><%= link_to t(".followed_changesets"), friend_changesets_path %></li>
           <li><%= link_to t(".followed_diaries"), friends_diary_entries_path %></li>
         </ul>
@@ -47,7 +47,7 @@
       <%= t ".no nearby users" %>
     <% else %>
       <nav class='secondary-actions mb-3'>
-        <ul class='clearfix'>
+        <ul>
           <li><%= link_to t(".nearby_changesets"), nearby_changesets_path %></li>
           <li><%= link_to t(".nearby_diaries"), nearby_diary_entries_path %></li>
         </ul>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 
   <nav class='secondary-actions'>
-    <ul class='clearfix'>
+    <ul>
       <% if params[:action] == 'index' %>
         <li><%= link_to t(".comment_link"), diary_entry_path(diary_entry.user, diary_entry, :anchor => "newcomment") %></li>
         <li><%= link_to t(".reply_link"), new_message_path(diary_entry.user, :message => { :title => "Re: #{diary_entry.title}" }) %></li>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -11,7 +11,7 @@
       <h1><%= @title %></h1>
 
       <nav class="secondary-actions">
-        <ul class="clearfix">
+        <ul>
           <% unless params[:friends] or params[:nearby] -%>
             <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>
           <% end -%>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -26,7 +26,7 @@
   </small>
 </p>
 <nav class="secondary-actions">
-  <ul class="clearfix">
+  <ul>
     <% if @issue.may_resolve? %>
       <li><%= link_to t(".resolve"), resolve_issue_url(@issue), :method => :post %></li>
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,7 +12,7 @@
       <% if current_user and @user.id == current_user.id %>
         <!-- Displaying user's own profile page -->
         <nav class='secondary-actions'>
-          <ul class='clearfix'>
+          <ul>
             <li>
               <%= link_to t(".my edits"), :controller => "changesets", :action => "index", :display_name => current_user.display_name %>
               <span class='badge count-number'><%= number_with_delimiter(current_user.changesets.size) %></span>
@@ -57,7 +57,7 @@
         <% else %>
         <!-- Displaying user profile page to the public -->
         <nav class='secondary-actions'>
-          <ul class='clearfix'>
+          <ul>
 
             <li>
               <%= link_to t(".edits"), :controller => "changesets", :action => "index", :display_name => @user.display_name %>
@@ -167,7 +167,7 @@
 
       <% if can?(:update, :user_status) %>
         <nav class='secondary-actions'>
-          <ul class='clearfix'>
+          <ul>
             <% if @user.may_activate? %>
               <li>
                 <%= link_to t(".activate_user"), user_status_path(@user, :event => "activate"), :method => :put, :data => { :confirm => t(".confirm") } %>
@@ -235,7 +235,7 @@
   </div>
 <% end %>
 
-<div class="richtext text-break clearfix"><%= @user.description.to_html %></div>
+<div class="richtext text-break"><%= @user.description.to_html %></div>
 
 <% if @heatmap_data.present? %>
   <div class="row">


### PR DESCRIPTION
We don't need [Bootstrap's clearfix class](https://getbootstrap.com/docs/5.3/helpers/clearfix/) because we're not using css floats anywhere.[^1] That includes user-provided richtext because we're removing `style` and `class` attributes.

[^1]: except on the *Export* page, see the next PR.