### PR TITLE
Use flex+justify instead of floats on export page

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -674,12 +674,6 @@ tr.turn {
     > * {
         margin: -1px;
     }
-    #minlon {
-      /*rtl:ignore*/ float: left;
-    }
-    #maxlon {
-      /*rtl:ignore*/ float: right;
-    }
   }
 }
 

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -8,7 +8,7 @@
   <div class='export_area_inputs text-center mb-3'>
     <div class='export_boxy border border-secondary-subtle rounded bg-body-secondary' dir='ltr'>
       <%= text_field_tag("maxlat", nil, :size => 10, :autocomplete => "off", :class => "form-control text-center mx-auto") %>
-      <div class="clearfix">
+      <div class="d-flex justify-content-between">
         <%= text_field_tag("minlon", nil, :size => 10, :autocomplete => "off", :class => "form-control text-center my-2") %>
         <%= text_field_tag("maxlon", nil, :size => 10, :autocomplete => "off", :class => "form-control text-center my-2") %>
       </div>


### PR DESCRIPTION
In the export box on the `/export` page we're positioning inputs using floats. Then we have to guard them with `/*rtl:ignore*/` in css. But actually we don't need any custom css here because we set `dir='ltr'` on the entire box. If we don't use any styles that mention left/right/start/end, `dir` will work as expected. Instead of left/right floats, I'm using flex with justify-content-between to push the inputs to the edges of the box.

![image](https://github.com/user-attachments/assets/ca6951c7-829a-4a89-8360-eb51234298f3)
