### PR TITLE
Remove invalid setStyle from data layer

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -2,21 +2,6 @@ OSM.initializeDataLayer = function (map) {
   let dataLoader, loadedBounds;
   const dataLayer = map.dataLayer;
 
-  dataLayer.setStyle({
-    way: {
-      weight: 3,
-      color: "#000000",
-      opacity: 0.4
-    },
-    area: {
-      weight: 3,
-      color: "#ff0000"
-    },
-    node: {
-      color: "#00ff00"
-    }
-  });
-
   dataLayer.isWayArea = function () {
     return false;
   };


### PR DESCRIPTION
Look at data layer. Notice that everything is blue:
![image](https://github.com/user-attachments/assets/219698eb-5124-44a7-b133-c12bf8c3e8f0)

Now look at the `setStyle` call that I remove in this PR. Notice that the colors are supposed to be black, red, green. It's broken since https://github.com/openstreetmap/openstreetmap-website/commit/5e9ab5bc5edb63b7ab7719fa989a18f52e3637a2, but I'm not fixing it because those colors don't look very well over the tiles and everyone probably got used to blue.

The argument to `setStyle` is invalid; and when used on feature group layer, `setStyle` should be called after adding the geometry.
https://leafletjs.com/reference.html#featuregroup-setstyle