### PR TITLE
Keep reference to AbortController on AbortError in data layer

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -132,6 +132,8 @@ OSM.initializeDataLayer = function (map) {
         if (map._objectLayer) {
           map._objectLayer.bringToFront();
         }
+
+        dataLoader = null;
       })
       .catch(function (error) {
         if (error.name === "AbortError") return;
@@ -139,9 +141,10 @@ OSM.initializeDataLayer = function (map) {
         displayLoadError(error?.message, () => {
           $("#browse_status").empty();
         });
+
+        dataLoader = null;
       })
       .finally(() => {
-        dataLoader = null;
         spanLoading.remove();
       });
   }


### PR DESCRIPTION
We have this bug in various places where AbortController is used. It happens like this:

1. you enable data layer and `getData()` is called
2. `getData()` checks if `dataLoader` is defined and it's not defined
3. `getData()` initializes `dataLoader` with a new `AbortController` and passes its signal to `fetch`
4. before the loading is finished you move the map and `getData()` is called again
5. `getData()` checks if `dataLoader` is defined, now it is
6. `getData()` calls `dataLoader.abort()` which schedules the abort event
7. `getData()` overwrites `dataLoader` with the second `AbortController` and passes its signal to the second `fetch`; the first `fetch` is still running
8. after the execution returns to the event loop, abort event happens and the first `fetch` is cancelled
9. `.finally` of the first `fetch` is reached and `dataLoader` is cleared, this deletes the reference to *the second `AbortController`*

Now it's impossible to abort the second `fetch`. If you move the map around faster than the fetches finish, you'll notice that only every other of them gets cancelled.

The fix here is not to delete `dataLoader` on `AbortError`.