### PR TITLE
Show valid username in header when renaming

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -75,7 +75,7 @@
             <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
           <% end %>
           <span class='username align-middle text-truncate' dir='auto'>
-            <%= current_user.display_name %>
+            <%= current_user.display_name_was %>
           </span>
         </button>
         <div class='dropdown-menu dropdown-menu-end'>

--- a/test/system/account_rename_test.rb
+++ b/test/system/account_rename_test.rb
@@ -1,0 +1,19 @@
+require "application_system_test_case"
+
+class AccountRenameTest < ApplicationSystemTestCase
+  test "renaming to invalid name shouldn't alter user button" do
+    user = create(:user, :display_name => "Valid User")
+    sign_in_as(user)
+
+    visit account_path
+
+    assert_button "Valid User"
+    assert_field "Display Name", :with => "Valid User"
+
+    fill_in "Display Name", :with => "x"
+    click_on "Save Changes"
+
+    assert_button "Valid User"
+    assert_field "Display Name", :with => "x"
+  end
+end


### PR DESCRIPTION
When trying to rename a user account to an invalid name, the invalid name is shown in the upper right corner as if the rename already happened:
![image](https://github.com/user-attachments/assets/319ac66a-6f2b-4c41-b1e5-67dc9410ce21)

This PR shows the name before the invalid change:
![image](https://github.com/user-attachments/assets/1e502034-88a3-4e24-b5af-d37837b6bff6)
