### PR TITLE
Prefer COPY to ADD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,10 @@ RUN mkdir -p /app
 WORKDIR /app
 
 # Install Ruby packages
-ADD Gemfile Gemfile.lock /app/
+COPY Gemfile Gemfile.lock /app/
 RUN bundle install
 
 # Install NodeJS packages using yarn
-ADD package.json yarn.lock /app/
-ADD bin/yarn /app/bin/
+COPY package.json yarn.lock /app/
+COPY bin/yarn /app/bin/
 RUN bundle exec bin/yarn install


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
Updates the Dockerfile to use `COPY` instead of `ADD`. From [Docker's best practices doc](https://docs.docker.com/build/building/best-practices/#add-or-copy):

> You'll mostly want to use COPY for copying files from one stage to another in a multi-stage build.

and:

> The ADD instruction is best for when you need to download a remote artifact as part of your build.

Since we're just copying files, let's prefer `COPY`.

### How has this been tested?
I rebuilt my docker container with these new changes and was able to successfully navigate the app locally.
