### PR TITLE
Move directions step numbering out of engine-specific code

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -184,7 +184,7 @@ OSM.Directions = function (map) {
         );
 
       // Add each row
-      route.steps.forEach(function (step) {
+      for (const [i, step] of route.steps.entries()) {
         const [ll, direction, instruction, dist, lineseg] = step;
 
         const row = $("<tr class='turn'/>");
@@ -193,7 +193,7 @@ OSM.Directions = function (map) {
         } else {
           row.append("<td class='border-0'>");
         }
-        row.append("<td>" + instruction);
+        row.append(`<td><b>${i + 1}.</b> ${instruction}`);
         row.append("<td class='distance text-body-secondary text-end'>" + formatStepDistance(dist));
 
         row.on("click", function () {
@@ -212,7 +212,7 @@ OSM.Directions = function (map) {
         });
 
         turnByTurnTable.append(row);
-      });
+      }
 
       const blob = new Blob([JSON.stringify(polyline.toGeoJSON())], { type: "application/json" });
       URL.revokeObjectURL(downloadURL);

--- a/app/assets/javascripts/index/directions/fossgis_osrm.js
+++ b/app/assets/javascripts/index/directions/fossgis_osrm.js
@@ -89,7 +89,7 @@
       }
 
       const steps = route.legs.flatMap(
-        leg => leg.steps.map(function (step, idx) {
+        leg => leg.steps.map(function (step) {
           const maneuver_id = getManeuverId(step.maneuver);
 
           const instrPrefix = "javascripts.directions.instructions.";
@@ -97,7 +97,7 @@
 
           const step_geometry = L.PolylineUtil.decode(step.geometry, { precision: 5 }).map(L.latLng);
 
-          let instText = "<b>" + (idx + 1) + ".</b> ";
+          let instText;
           const destinations = "<b>" + step.destinations + "</b>";
           let namedRoad = true;
           let name;
@@ -114,16 +114,16 @@
           }
 
           if (step.maneuver.type.match(/^exit (rotary|roundabout)$/)) {
-            instText += OSM.i18n.t(template, { name: name });
+            instText = OSM.i18n.t(template, { name: name });
           } else if (step.maneuver.type.match(/^(rotary|roundabout)$/)) {
             if (step.maneuver.exit) {
               if (step.maneuver.exit <= 10) {
-                instText += OSM.i18n.t(template + "_with_exit_ordinal", { exit: OSM.i18n.t(instrPrefix + "exit_counts." + numToWord(step.maneuver.exit)), name: name });
+                instText = OSM.i18n.t(template + "_with_exit_ordinal", { exit: OSM.i18n.t(instrPrefix + "exit_counts." + numToWord(step.maneuver.exit)), name: name });
               } else {
-                instText += OSM.i18n.t(template + "_with_exit", { exit: step.maneuver.exit, name: name });
+                instText = OSM.i18n.t(template + "_with_exit", { exit: step.maneuver.exit, name: name });
               }
             } else {
-              instText += OSM.i18n.t(template + "_without_exit", { name: name });
+              instText = OSM.i18n.t(template + "_without_exit", { name: name });
             }
           } else if (step.maneuver.type.match(/^(on ramp|off ramp)$/)) {
             const params = {};
@@ -133,9 +133,9 @@
             if (Object.keys(params).length > 0) {
               template = template + "_with_" + Object.keys(params).join("_");
             }
-            instText += OSM.i18n.t(template, params);
+            instText = OSM.i18n.t(template, params);
           } else {
-            instText += OSM.i18n.t(template + "_without_exit", { name: name });
+            instText = OSM.i18n.t(template + "_without_exit", { name: name });
           }
           return [[step.maneuver.location[1], step.maneuver.location[0]], ICON_MAP[maneuver_id], instText, step.distance, step_geometry];
         })

--- a/app/assets/javascripts/index/directions/fossgis_valhalla.js
+++ b/app/assets/javascripts/index/directions/fossgis_valhalla.js
@@ -53,15 +53,14 @@
           precision: 6
         });
 
-        const legSteps = leg.maneuvers.map(function (manoeuvre, idx) {
-          const num = `<b>${idx + 1}.</b> `;
+        const legSteps = leg.maneuvers.map(function (manoeuvre) {
           const lineseg = legLine
             .slice(manoeuvre.begin_shape_index, manoeuvre.end_shape_index + 1)
             .map(([lat, lng]) => ({ lat, lng }));
           return [
             lineseg[0],
             INSTR_MAP[manoeuvre.type],
-            num + manoeuvre.instruction,
+            manoeuvre.instruction,
             manoeuvre.length * 1000,
             lineseg
           ];

--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -21,15 +21,14 @@
     function _processDirections(path) {
       const line = L.PolylineUtil.decode(path.points);
 
-      const steps = path.instructions.map(function (instr, i) {
-        const num = `<b>${i + 1}.</b> `;
+      const steps = path.instructions.map(function (instr) {
         const lineseg = line
           .slice(instr.interval[0], instr.interval[1] + 1)
           .map(([lat, lng]) => ({ lat, lng }));
         return [
           lineseg[0],
           GH_INSTR_MAP[instr.sign],
-          num + instr.text,
+          instr.text,
           instr.distance,
           lineseg
         ]; // TODO does graphhopper map instructions onto line indices?


### PR DESCRIPTION
Writing step numbers is currently the responsibility of each routing engine:

![image](https://github.com/user-attachments/assets/17a2fe98-158f-4446-873d-653ac875f74b)

But that shouldn't be the case. Writing the numbers outside would later help to stop constructing html by concatenation.