### PR TITLE
Remove search input autofocus workaround for old browsers

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -278,9 +278,6 @@ $(function () {
       if (params.has("query")) {
         $("#sidebar .search_form input[name=query]").value(params.get("query"));
       }
-      if (!("autofocus" in document.createElement("input"))) {
-        $("#sidebar .search_form input[name=query]").focus();
-      }
       return map.getState();
     };
 


### PR DESCRIPTION
The workaround was added in https://github.com/openstreetmap/openstreetmap-website/commit/9cc9a0098840363b6497337951b53aa583f4aa44. It uses [deprecated .focus() jQuery function](https://api.jquery.com/focus-shorthand/).

It's also not necessary because [browsers supported autofocus on input for a long time](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus#browser_compatibility). Except maybe on iOS but we may not want anything to happen on mobile devices. In fact I'm going to do another pull request that prevents virtual keyboard from popping up on certain focus operations.