### PR TITLE
Avoid virtual keyboard when visiting new note page

### DIFF
--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -130,7 +130,9 @@ OSM.NewNote = function (map) {
 
     content.find("textarea")
       .on("input", updateControls)
-      .trigger("focus");
+      .attr("readonly", "readonly") // avoid virtual keyboard popping up on focus
+      .trigger("focus")
+      .removeAttr("readonly");
 
     content.find("input[type=submit]").on("click", function (e) {
       const location = newNoteMarker.getLatLng().wrap();

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -87,7 +87,7 @@ OSM.NewNote = function (map) {
     newNoteMarker = null;
   }
 
-  function moveNewNotMarkerToClick(e) {
+  function moveNewNoteMarkerToClick(e) {
     if (newNoteMarker) newNoteMarker.setLatLng(e.latlng);
     if (halo) halo.setLatLng(e.latlng);
     content.find("textarea").focus();
@@ -152,7 +152,7 @@ OSM.NewNote = function (map) {
       });
     });
 
-    map.on("click", moveNewNotMarkerToClick);
+    map.on("click", moveNewNoteMarkerToClick);
     addNoteButton.on("disabled enabled", updateControls);
     updateControls();
 
@@ -160,7 +160,7 @@ OSM.NewNote = function (map) {
   };
 
   page.unload = function () {
-    map.off("click", moveNewNotMarkerToClick);
+    map.off("click", moveNewNoteMarkerToClick);
     addNoteButton.off("disabled enabled", updateControls);
     removeNewNoteMarker();
     addNoteButton.removeClass("active");

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -77,7 +77,7 @@ OSM.NewNote = function (map) {
     addHalo(newNoteMarker.getLatLng());
 
     newNoteMarker.on("dragend", function () {
-      content.find("textarea").focus();
+      content.find("textarea").trigger("focus");
     });
   }
 
@@ -90,7 +90,7 @@ OSM.NewNote = function (map) {
   function moveNewNoteMarkerToClick(e) {
     if (newNoteMarker) newNoteMarker.setLatLng(e.latlng);
     if (halo) halo.setLatLng(e.latlng);
-    content.find("textarea").focus();
+    content.find("textarea").trigger("focus");
   }
 
   function updateControls() {
@@ -130,7 +130,7 @@ OSM.NewNote = function (map) {
 
     content.find("textarea")
       .on("input", updateControls)
-      .focus();
+      .trigger("focus");
 
     content.find("input[type=submit]").on("click", function (e) {
       const location = newNoteMarker.getLatLng().wrap();


### PR DESCRIPTION
Another autofocus-related change in addition to #5899.

Normally on map view pages we have the search input autofocused. But on the *Add a note* page it makes sense to focus on the note description input. Since it may be loaded in the sidebar after the regular page load, we're focusing with javascript instead of a html attribute.

Now try adding a note on a phone with a small screen. What's normally a sidebar now takes up the upper half of the screen. You get the lower half to see the map and to place the note marker. Except not really because the virtual keyboard shows up as soon as the description input gains focus, that is right away:

![Screenshot_20250406-144921](https://github.com/user-attachments/assets/1c313e5c-516f-46fc-8174-b98614c33389)

This PR adds [a workaround](https://gist.github.com/supertanuki/1f73f9aa33d5010bf07205804596e042) to suppress the initial focus from triggering the virtual keyboard. The proper API for that [is still experimental](https://developer.mozilla.org/en-US/docs/Web/API/VirtualKeyboard_API).