### PR TITLE
Render changesets on both sides of the antimeridian

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -34,11 +34,31 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
       return b.bounds.getSize() - a.bounds.getSize();
     });
 
+    this.updateChangesetLocations(map);
+
     for (const changeset of this._changesets) {
       const rect = L.rectangle(changeset.bounds,
                                { weight: 2, color: "#FF9500", opacity: 1, fillColor: "#FFFFAF", fillOpacity: 0 });
       rect.id = changeset.id;
       rect.addTo(this);
+    }
+  },
+
+  updateChangesetLocations: function (map) {
+    const mapCenterLng = map.getCenter().lng;
+
+    for (const changeset of this._changesets) {
+      const changesetSouthWest = changeset.bounds.getSouthWest();
+      const changesetNorthEast = changeset.bounds.getNorthEast();
+      const changesetCenterLng = (changesetSouthWest.lng + changesetNorthEast.lng) / 2;
+      const shiftInWorldCircumferences = Math.round((changesetCenterLng - mapCenterLng) / 360);
+
+      if (shiftInWorldCircumferences) {
+        changesetSouthWest.lng -= shiftInWorldCircumferences * 360;
+        changesetNorthEast.lng -= shiftInWorldCircumferences * 360;
+
+        this.getLayer(changeset.id)?.setBounds(changeset.bounds);
+      }
     }
   },
 

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -1,0 +1,56 @@
+OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
+  _changesets: [],
+
+  updateChangesets: function (map, changesets) {
+    this._changesets = changesets;
+    this.updateChangesetShapes(map);
+  },
+
+  updateChangesetShapes: function (map) {
+    this.clearLayers();
+
+    for (const changeset of this._changesets) {
+      const bottomLeft = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.minlon)),
+            topRight = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.maxlon)),
+            width = topRight.x - bottomLeft.x,
+            height = bottomLeft.y - topRight.y,
+            minSize = 20; // Min width/height of changeset in pixels
+
+      if (width < minSize) {
+        bottomLeft.x -= ((minSize - width) / 2);
+        topRight.x += ((minSize - width) / 2);
+      }
+
+      if (height < minSize) {
+        bottomLeft.y += ((minSize - height) / 2);
+        topRight.y -= ((minSize - height) / 2);
+      }
+
+      changeset.bounds = L.latLngBounds(map.unproject(bottomLeft),
+                                        map.unproject(topRight));
+    }
+
+    this._changesets.sort(function (a, b) {
+      return b.bounds.getSize() - a.bounds.getSize();
+    });
+
+    for (const changeset of this._changesets) {
+      const rect = L.rectangle(changeset.bounds,
+                               { weight: 2, color: "#FF9500", opacity: 1, fillColor: "#FFFFAF", fillOpacity: 0 });
+      rect.id = changeset.id;
+      rect.addTo(this);
+    }
+  },
+
+  highlightChangeset: function (id) {
+    this.getLayer(id)?.setStyle({ fillOpacity: 0.3, color: "#FF6600", weight: 3 });
+  },
+
+  unHighlightChangeset: function (id) {
+    this.getLayer(id)?.setStyle({ fillOpacity: 0, color: "#FF9500", weight: 2 });
+  },
+
+  getLayerId: function (layer) {
+    return layer.id;
+  }
+});

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -13,7 +13,7 @@ OSM.History = function (map) {
       unHighlightChangeset($(this).data("changeset").id);
     });
 
-  const group = new OSM.HistoryChangesetsLayer()
+  const changesetsLayer = new OSM.HistoryChangesetsLayer()
     .on("mouseover", function (e) {
       highlightChangeset(e.layer.id);
     })
@@ -84,12 +84,12 @@ OSM.History = function (map) {
   }
 
   function highlightChangeset(id) {
-    group.highlightChangeset(id);
+    changesetsLayer.highlightChangeset(id);
     $("#changeset_" + id).addClass("selected");
   }
 
   function unHighlightChangeset(id) {
-    group.unHighlightChangeset(id);
+    changesetsLayer.unHighlightChangeset(id);
     $("#changeset_" + id).removeClass("selected");
   }
 
@@ -238,7 +238,7 @@ OSM.History = function (map) {
   }
 
   function updateBounds() {
-    group.updateChangesetShapes(map);
+    changesetsLayer.updateChangesetShapes(map);
   }
 
   function updateMap() {
@@ -248,10 +248,10 @@ OSM.History = function (map) {
       return changeset.bbox;
     });
 
-    group.updateChangesets(map, changesets);
+    changesetsLayer.updateChangesets(map, changesets);
 
     if (location.pathname !== "/history") {
-      const bounds = group.getBounds();
+      const bounds = changesetsLayer.getBounds();
       if (bounds.isValid()) map.fitBounds(bounds);
     }
   }
@@ -261,7 +261,7 @@ OSM.History = function (map) {
   };
 
   page.load = function () {
-    map.addLayer(group);
+    map.addLayer(changesetsLayer);
 
     if (location.pathname === "/history") {
       map.on("moveend", reloadChangesetsBecauseOfMapMovement);
@@ -273,7 +273,7 @@ OSM.History = function (map) {
   };
 
   page.unload = function () {
-    map.removeLayer(group);
+    map.removeLayer(changesetsLayer);
     map.off("moveend", reloadChangesetsBecauseOfMapMovement);
     map.off("zoomend", updateBounds);
     disableChangesetIntersectionObserver();

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -236,6 +236,8 @@ OSM.History = function (map) {
     if (location.pathname === "/history") {
       OSM.router.replace("/history" + window.location.hash);
       loadFirstChangesets();
+    } else {
+      changesetsLayer.updateChangesetsPositions(map);
     }
   }
 

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -1,4 +1,5 @@
 //= require jquery-simulate/jquery.simulate
+//= require ./history-changesets-layer
 
 OSM.History = function (map) {
   const page = {};
@@ -12,7 +13,7 @@ OSM.History = function (map) {
       unHighlightChangeset($(this).data("changeset").id);
     });
 
-  const group = L.featureGroup()
+  const group = new OSM.HistoryChangesetsLayer()
     .on("mouseover", function (e) {
       highlightChangeset(e.layer.id);
     })
@@ -22,10 +23,6 @@ OSM.History = function (map) {
     .on("click", function (e) {
       clickChangeset(e.layer.id, e.originalEvent);
     });
-
-  group.getLayerId = function (layer) {
-    return layer.id;
-  };
 
   let changesetIntersectionObserver;
 
@@ -87,14 +84,12 @@ OSM.History = function (map) {
   }
 
   function highlightChangeset(id) {
-    const layer = group.getLayer(id);
-    if (layer) layer.setStyle({ fillOpacity: 0.3, color: "#FF6600", weight: 3 });
+    group.highlightChangeset(id);
     $("#changeset_" + id).addClass("selected");
   }
 
   function unHighlightChangeset(id) {
-    const layer = group.getLayer(id);
-    if (layer) layer.setStyle({ fillOpacity: 0, color: "#FF9500", weight: 2 });
+    group.unHighlightChangeset(id);
     $("#changeset_" + id).removeClass("selected");
   }
 
@@ -242,52 +237,18 @@ OSM.History = function (map) {
     loadFirstChangesets();
   }
 
-  let changesets = [];
-
   function updateBounds() {
-    group.clearLayers();
-
-    for (const changeset of changesets) {
-      const bottomLeft = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.minlon)),
-            topRight = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.maxlon)),
-            width = topRight.x - bottomLeft.x,
-            height = bottomLeft.y - topRight.y,
-            minSize = 20; // Min width/height of changeset in pixels
-
-      if (width < minSize) {
-        bottomLeft.x -= ((minSize - width) / 2);
-        topRight.x += ((minSize - width) / 2);
-      }
-
-      if (height < minSize) {
-        bottomLeft.y += ((minSize - height) / 2);
-        topRight.y -= ((minSize - height) / 2);
-      }
-
-      changeset.bounds = L.latLngBounds(map.unproject(bottomLeft),
-                                        map.unproject(topRight));
-    }
-
-    changesets.sort(function (a, b) {
-      return b.bounds.getSize() - a.bounds.getSize();
-    });
-
-    for (const changeset of changesets) {
-      const rect = L.rectangle(changeset.bounds,
-                               { weight: 2, color: "#FF9500", opacity: 1, fillColor: "#FFFFAF", fillOpacity: 0 });
-      rect.id = changeset.id;
-      rect.addTo(group);
-    }
+    group.updateChangesetShapes(map);
   }
 
   function updateMap() {
-    changesets = $("[data-changeset]").map(function (index, element) {
+    const changesets = $("[data-changeset]").map(function (index, element) {
       return $(element).data("changeset");
     }).get().filter(function (changeset) {
       return changeset.bbox;
     });
 
-    updateBounds();
+    group.updateChangesets(map, changesets);
 
     if (location.pathname !== "/history") {
       const bounds = group.getBounds();

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -232,12 +232,14 @@ OSM.History = function (map) {
     }
   }
 
-  function reloadChangesetsBecauseOfMapMovement() {
-    OSM.router.replace("/history" + window.location.hash);
-    loadFirstChangesets();
+  function moveEndListener() {
+    if (location.pathname === "/history") {
+      OSM.router.replace("/history" + window.location.hash);
+      loadFirstChangesets();
+    }
   }
 
-  function updateBounds() {
+  function zoomEndListener() {
     changesetsLayer.updateChangesetShapes(map);
   }
 
@@ -262,20 +264,15 @@ OSM.History = function (map) {
 
   page.load = function () {
     map.addLayer(changesetsLayer);
-
-    if (location.pathname === "/history") {
-      map.on("moveend", reloadChangesetsBecauseOfMapMovement);
-    }
-
-    map.on("zoomend", updateBounds);
-
+    map.on("moveend", moveEndListener);
+    map.on("zoomend", zoomEndListener);
     loadFirstChangesets();
   };
 
   page.unload = function () {
     map.removeLayer(changesetsLayer);
-    map.off("moveend", reloadChangesetsBecauseOfMapMovement);
-    map.off("zoomend", updateBounds);
+    map.off("moveend", moveEndListener);
+    map.off("zoomend", zoomEndListener);
     disableChangesetIntersectionObserver();
   };
 


### PR DESCRIPTION
Continues #5473 by fixing the rendering.

When anything is added to the map, its longitude could be as well (the original longitude) + n * 360. n is an integer and usually it's 0 but that doesn't work when looking at the map near the antimeridian. Here I'm picking such n for each changeset bbox that it's going to be at the closest location to the map view center.

![image](https://github.com/user-attachments/assets/6607ac59-e348-4ae8-a817-aebf07465639)
