### PR TITLE
Attach routing credit to route

### DIFF
--- a/app/assets/javascripts/index/directions-route-output.js
+++ b/app/assets/javascripts/index/directions-route-output.js
@@ -52,7 +52,7 @@ OSM.DirectionsRouteOutput = function (map) {
 
   const routeOutput = {};
 
-  routeOutput.write = function (content, engine, route) {
+  routeOutput.write = function (content, route) {
     polyline
       .setLatLngs(route.line)
       .addTo(map);
@@ -117,7 +117,9 @@ OSM.DirectionsRouteOutput = function (map) {
     }</a></p>`);
 
     content.append("<p class=\"text-center\">" +
-      OSM.i18n.t("javascripts.directions.instructions.courtesy", { link: engine.creditline }) +
+      OSM.i18n.t("javascripts.directions.instructions.courtesy", {
+        link: `<a href="${route.creditlink}" target="_blank">${route.credit}</a>`
+      }) +
       "</p>");
   };
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -107,7 +107,7 @@ OSM.Directions = function (map) {
     map.setSidebarOverlaid(false);
     controller = new AbortController();
     chosenEngine.getRoute(points, controller.signal).then(function (route) {
-      routeOutput.write($("#directions_content"), chosenEngine, route);
+      routeOutput.write($("#directions_content"), route);
       if (fitRoute) {
         routeOutput.fit();
       }

--- a/app/assets/javascripts/index/directions/fossgis_osrm.js
+++ b/app/assets/javascripts/index/directions/fossgis_osrm.js
@@ -146,14 +146,15 @@
         line: steps.flatMap(step => step[3]),
         steps,
         distance: leg.distance,
-        time: leg.duration
+        time: leg.duration,
+        credit: "OSRM (FOSSGIS)",
+        creditlink: "https://routing.openstreetmap.de/about.html"
       };
     }
 
     return {
       mode: modeId,
       provider: "fossgis_osrm",
-      creditline: "<a href=\"https://routing.openstreetmap.de/about.html\" target=\"_blank\">OSRM (FOSSGIS)</a>",
       draggable: true,
 
       getRoute: function (points, signal) {

--- a/app/assets/javascripts/index/directions/fossgis_valhalla.js
+++ b/app/assets/javascripts/index/directions/fossgis_valhalla.js
@@ -56,15 +56,15 @@
         line,
         steps,
         distance: leg.summary.length * 1000,
-        time: leg.summary.time
+        time: leg.summary.time,
+        credit: "Valhalla (FOSSGIS)",
+        creditlink: "https://gis-ops.com/global-open-valhalla-server-online/"
       };
     }
 
     return {
       mode: modeId,
       provider: "fossgis_valhalla",
-      creditline:
-      "<a href='https://gis-ops.com/global-open-valhalla-server-online/' target='_blank'>Valhalla (FOSSGIS)</a>",
       draggable: false,
 
       getRoute: function (points, signal) {

--- a/app/assets/javascripts/index/directions/graphhopper.js
+++ b/app/assets/javascripts/index/directions/graphhopper.js
@@ -35,14 +35,15 @@
         distance: path.distance,
         time: path.time / 1000,
         ascend: path.ascend,
-        descend: path.descend
+        descend: path.descend,
+        credit: "GraphHopper",
+        creditlink: "https://www.graphhopper.com/"
       };
     }
 
     return {
       mode: modeId,
       provider: "graphhopper",
-      creditline: "<a href=\"https://www.graphhopper.com/\" target=\"_blank\">GraphHopper</a>",
       draggable: false,
 
       getRoute: function (points, signal) {


### PR DESCRIPTION
Much like in the API responses from GraphHopper or Overpass Turbo, this PR adds the credit information to the returned routes, removing the need to pass the `chosenEngine` to the `DirectionsRouteOutput`.