### PR TITLE
Add kilometers/miles switch to directions

### DIFF
--- a/app/assets/javascripts/index/directions-route-output.js
+++ b/app/assets/javascripts/index/directions-route-output.js
@@ -13,10 +13,15 @@ OSM.DirectionsRouteOutput = function (map) {
     weight: 12
   });
 
+  let distanceUnits = "km";
   let downloadURL = null;
 
   function translateDistanceUnits(m) {
-    return [m, "m", m / 1000, "km"];
+    if (distanceUnits === "km") {
+      return [m, "m", m / 1000, "km"];
+    } else {
+      return [m / 0.3048, "ft", m / 1609.344, "mi"];
+    }
   }
 
   function formatTotalDistance(minorValue, minorName, majorValue, majorName) {
@@ -117,6 +122,17 @@ OSM.DirectionsRouteOutput = function (map) {
     writeSummary(route);
     writeSteps(route);
 
+    $("#directions_distance_units_km").off().on("change", () => {
+      distanceUnits = "km";
+      writeSummary(route);
+      writeSteps(route);
+    });
+    $("#directions_distance_units_mi").off().on("change", () => {
+      distanceUnits = "mi";
+      writeSummary(route);
+      writeSteps(route);
+    });
+
     const blob = new Blob([JSON.stringify(polyline.toGeoJSON())], { type: "application/json" });
     URL.revokeObjectURL(downloadURL);
     downloadURL = URL.createObjectURL(blob);
@@ -139,6 +155,9 @@ OSM.DirectionsRouteOutput = function (map) {
     map
       .removeLayer(popup)
       .removeLayer(polyline);
+
+    $("#directions_distance_units_km").off();
+    $("#directions_distance_units_mi").off();
 
     $("#directions_route_steps").empty();
 

--- a/app/assets/javascripts/index/directions-route-output.js
+++ b/app/assets/javascripts/index/directions-route-output.js
@@ -16,31 +16,37 @@ OSM.DirectionsRouteOutput = function (map) {
   let downloadURL = null;
 
   function formatTotalDistance(m) {
+    const scope = "javascripts.directions.distance_in_units";
+
     if (m < 1000) {
-      return OSM.i18n.t("javascripts.directions.distance_m", { distance: Math.round(m) });
+      return OSM.i18n.t("m", { scope, distance: Math.round(m) });
     } else if (m < 10000) {
-      return OSM.i18n.t("javascripts.directions.distance_km", { distance: (m / 1000.0).toFixed(1) });
+      return OSM.i18n.t("km", { scope, distance: (m / 1000.0).toFixed(1) });
     } else {
-      return OSM.i18n.t("javascripts.directions.distance_km", { distance: Math.round(m / 1000) });
+      return OSM.i18n.t("km", { scope, distance: Math.round(m / 1000) });
     }
   }
 
   function formatStepDistance(m) {
+    const scope = "javascripts.directions.distance_in_units";
+
     if (m < 5) {
       return "";
     } else if (m < 200) {
-      return OSM.i18n.t("javascripts.directions.distance_m", { distance: String(Math.round(m / 10) * 10) });
+      return OSM.i18n.t("m", { scope, distance: String(Math.round(m / 10) * 10) });
     } else if (m < 1500) {
-      return OSM.i18n.t("javascripts.directions.distance_m", { distance: String(Math.round(m / 100) * 100) });
+      return OSM.i18n.t("m", { scope, distance: String(Math.round(m / 100) * 100) });
     } else if (m < 5000) {
-      return OSM.i18n.t("javascripts.directions.distance_km", { distance: String(Math.round(m / 100) / 10) });
+      return OSM.i18n.t("km", { scope, distance: String(Math.round(m / 100) / 10) });
     } else {
-      return OSM.i18n.t("javascripts.directions.distance_km", { distance: String(Math.round(m / 1000)) });
+      return OSM.i18n.t("km", { scope, distance: String(Math.round(m / 1000)) });
     }
   }
 
   function formatHeight(m) {
-    return OSM.i18n.t("javascripts.directions.distance_m", { distance: Math.round(m) });
+    const scope = "javascripts.directions.distance_in_units";
+
+    return OSM.i18n.t("m", { scope, distance: Math.round(m) });
   }
 
   function formatTime(s) {

--- a/app/assets/javascripts/index/directions-route-output.js
+++ b/app/assets/javascripts/index/directions-route-output.js
@@ -33,13 +33,13 @@ OSM.DirectionsRouteOutput = function (map) {
     if (m < 5) {
       return "";
     } else if (m < 200) {
-      return OSM.i18n.t("m", { scope, distance: String(Math.round(m / 10) * 10) });
+      return OSM.i18n.t("m", { scope, distance: Math.round(m / 10) * 10 });
     } else if (m < 1500) {
-      return OSM.i18n.t("m", { scope, distance: String(Math.round(m / 100) * 100) });
+      return OSM.i18n.t("m", { scope, distance: Math.round(m / 100) * 100 });
     } else if (m < 5000) {
-      return OSM.i18n.t("km", { scope, distance: String(Math.round(m / 100) / 10) });
+      return OSM.i18n.t("km", { scope, distance: Math.round(m / 100) / 10 });
     } else {
-      return OSM.i18n.t("km", { scope, distance: String(Math.round(m / 1000)) });
+      return OSM.i18n.t("km", { scope, distance: Math.round(m / 1000) });
     }
   }
 

--- a/app/assets/javascripts/index/directions-route-output.js
+++ b/app/assets/javascripts/index/directions-route-output.js
@@ -15,38 +15,42 @@ OSM.DirectionsRouteOutput = function (map) {
 
   let downloadURL = null;
 
-  function formatTotalDistance(m) {
+  function translateDistanceUnits(m) {
+    return [m, "m", m / 1000, "km"];
+  }
+
+  function formatTotalDistance(minorValue, minorName, majorValue, majorName) {
     const scope = "javascripts.directions.distance_in_units";
 
-    if (m < 1000) {
-      return OSM.i18n.t("m", { scope, distance: Math.round(m) });
-    } else if (m < 10000) {
-      return OSM.i18n.t("km", { scope, distance: (m / 1000.0).toFixed(1) });
+    if (minorValue < 1000 || majorValue < 0.25) {
+      return OSM.i18n.t(minorName, { scope, distance: Math.round(minorValue) });
+    } else if (majorValue < 10) {
+      return OSM.i18n.t(majorName, { scope, distance: majorValue.toFixed(1) });
     } else {
-      return OSM.i18n.t("km", { scope, distance: Math.round(m / 1000) });
+      return OSM.i18n.t(majorName, { scope, distance: Math.round(majorValue) });
     }
   }
 
-  function formatStepDistance(m) {
+  function formatStepDistance(minorValue, minorName, majorValue, majorName) {
     const scope = "javascripts.directions.distance_in_units";
 
-    if (m < 5) {
+    if (minorValue < 5) {
       return "";
-    } else if (m < 200) {
-      return OSM.i18n.t("m", { scope, distance: Math.round(m / 10) * 10 });
-    } else if (m < 1500) {
-      return OSM.i18n.t("m", { scope, distance: Math.round(m / 100) * 100 });
-    } else if (m < 5000) {
-      return OSM.i18n.t("km", { scope, distance: Math.round(m / 100) / 10 });
+    } else if (minorValue < 200) {
+      return OSM.i18n.t(minorName, { scope, distance: Math.round(minorValue / 10) * 10 });
+    } else if (minorValue < 1500 || majorValue < 0.25) {
+      return OSM.i18n.t(minorName, { scope, distance: Math.round(minorValue / 100) * 100 });
+    } else if (majorValue < 5) {
+      return OSM.i18n.t(majorName, { scope, distance: majorValue.toFixed(1) });
     } else {
-      return OSM.i18n.t("km", { scope, distance: Math.round(m / 1000) });
+      return OSM.i18n.t(majorName, { scope, distance: Math.round(majorValue) });
     }
   }
 
-  function formatHeight(m) {
+  function formatHeight(minorValue, minorName) {
     const scope = "javascripts.directions.distance_in_units";
 
-    return OSM.i18n.t("m", { scope, distance: Math.round(m) });
+    return OSM.i18n.t(minorName, { scope, distance: Math.round(minorValue) });
   }
 
   function formatTime(s) {
@@ -57,12 +61,12 @@ OSM.DirectionsRouteOutput = function (map) {
   }
 
   function writeSummary(route) {
-    $("#directions_route_distance").val(formatTotalDistance(route.distance));
+    $("#directions_route_distance").val(formatTotalDistance(...translateDistanceUnits(route.distance)));
     $("#directions_route_time").val(formatTime(route.time));
     if (typeof route.ascend !== "undefined" && typeof route.descend !== "undefined") {
       $("#directions_route_ascend_descend").prop("hidden", false);
-      $("#directions_route_ascend").val(formatHeight(route.ascend));
-      $("#directions_route_descend").val(formatHeight(route.descend));
+      $("#directions_route_ascend").val(formatHeight(...translateDistanceUnits(route.ascend)));
+      $("#directions_route_descend").val(formatHeight(...translateDistanceUnits(route.descend)));
     } else {
       $("#directions_route_ascend_descend").prop("hidden", true);
       $("#directions_route_ascend").val("");
@@ -82,7 +86,7 @@ OSM.DirectionsRouteOutput = function (map) {
         row.append("<td class='border-0'>");
       }
       row.append(`<td><b>${i + 1}.</b> ${instruction}`);
-      row.append("<td class='distance text-body-secondary text-end'>" + formatStepDistance(dist));
+      row.append("<td class='distance text-body-secondary text-end'>" + formatStepDistance(...translateDistanceUnits(dist)));
 
       row.on("click", function () {
         popup

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -100,10 +100,8 @@ OSM.Directions = function (map) {
       route: points.map(p => `${p.lat},${p.lng}`).join(";")
     }));
 
-    // copy loading item to sidebar and display it. we copy it, rather than
-    // just using it in-place and replacing it in case it has to be used
-    // again.
-    $("#directions_content").html($(".directions_form .loader_copy").html());
+    $("#directions_loader").prop("hidden", false);
+    $("#directions_content").prop("hidden", true);
     map.setSidebarOverlaid(false);
     controller = new AbortController();
     chosenEngine.getRoute(points, controller.signal).then(function (route) {
@@ -117,6 +115,8 @@ OSM.Directions = function (map) {
         $("#directions_content").html("<div class=\"alert alert-danger\">" + OSM.i18n.t("javascripts.directions.errors.no_route") + "</div>");
       }
     }).finally(function () {
+      $("#directions_loader").prop("hidden", true);
+      $("#directions_content").prop("hidden", false);
       controller = null;
     });
   }

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -101,29 +101,32 @@ OSM.Directions = function (map) {
     }));
 
     $("#directions_loader").prop("hidden", false);
-    $("#directions_content").prop("hidden", true);
+    $("#directions_error").prop("hidden", true).empty();
+    $("#directions_route").prop("hidden", true);
     map.setSidebarOverlaid(false);
     controller = new AbortController();
     chosenEngine.getRoute(points, controller.signal).then(function (route) {
-      routeOutput.write($("#directions_content"), route);
+      $("#directions_route").prop("hidden", false);
+      routeOutput.write($("#directions_route"), route);
       if (fitRoute) {
         routeOutput.fit();
       }
     }).catch(function () {
-      routeOutput.remove($("#directions_content"));
+      routeOutput.remove($("#directions_route"));
       if (reportErrors) {
-        $("#directions_content").html("<div class=\"alert alert-danger\">" + OSM.i18n.t("javascripts.directions.errors.no_route") + "</div>");
+        $("#directions_error")
+          .prop("hidden", false)
+          .html("<div class=\"alert alert-danger\">" + OSM.i18n.t("javascripts.directions.errors.no_route") + "</div>");
       }
     }).finally(function () {
       $("#directions_loader").prop("hidden", true);
-      $("#directions_content").prop("hidden", false);
       controller = null;
     });
   }
 
   function closeButtonListener(e) {
     e.stopPropagation();
-    routeOutput.remove($("#directions_content"));
+    routeOutput.remove($("#directions_route"));
     map.setSidebarOverlaid(true);
     // TODO: collapse width of sidebar back to previous
   }
@@ -212,7 +215,7 @@ OSM.Directions = function (map) {
   const page = {};
 
   page.pushstate = page.popstate = function () {
-    if ($("#directions_content").length) {
+    if ($("#directions_route").length) {
       page.load();
     } else {
       initializeFromParams();
@@ -251,7 +254,7 @@ OSM.Directions = function (map) {
     endpoints[0].clearValue();
     endpoints[1].clearValue();
 
-    routeOutput.remove($("#directions_content"));
+    routeOutput.remove($("#directions_route"));
   };
 
   return page;

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -107,12 +107,12 @@ OSM.Directions = function (map) {
     controller = new AbortController();
     chosenEngine.getRoute(points, controller.signal).then(function (route) {
       $("#directions_route").prop("hidden", false);
-      routeOutput.write($("#directions_route"), route);
+      routeOutput.write(route);
       if (fitRoute) {
         routeOutput.fit();
       }
     }).catch(function () {
-      routeOutput.remove($("#directions_route"));
+      routeOutput.remove();
       if (reportErrors) {
         $("#directions_error")
           .prop("hidden", false)
@@ -126,7 +126,7 @@ OSM.Directions = function (map) {
 
   function closeButtonListener(e) {
     e.stopPropagation();
-    routeOutput.remove($("#directions_route"));
+    routeOutput.remove();
     map.setSidebarOverlaid(true);
     // TODO: collapse width of sidebar back to previous
   }
@@ -254,7 +254,7 @@ OSM.Directions = function (map) {
     endpoints[0].clearValue();
     endpoints[1].clearValue();
 
-    routeOutput.remove($("#directions_route"));
+    routeOutput.remove();
   };
 
   return page;

--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -86,4 +86,6 @@
   </div>
 </div>
 
-<div id="directions_content"></div>
+<div id="directions_error" hidden></div>
+
+<div id="directions_route" hidden></div>

--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -91,13 +91,13 @@
 <div id="directions_route" hidden>
   <p>
     <span>
-      <%= t "javascripts.directions.distance" %>: <output id="directions_route_distance"></output>.
-      <%= t "javascripts.directions.time" %>: <output id="directions_route_time"></output>.
+      <%= t ".distance" %>: <output id="directions_route_distance"></output>.
+      <%= t ".time" %>: <output id="directions_route_time"></output>.
     </span>
     <br>
     <span id="directions_route_ascend_descend">
-      <%= t "javascripts.directions.ascend" %>: <output id="directions_route_ascend"></output>.
-      <%= t "javascripts.directions.descend" %>: <output id="directions_route_descend"></output>.
+      <%= t ".ascend" %>: <output id="directions_route_ascend"></output>.
+      <%= t ".descend" %>: <output id="directions_route_descend"></output>.
     </span>
   </p>
 
@@ -106,10 +106,10 @@
   </table>
 
   <p class="text-center">
-    <%= tag.a t("javascripts.directions.download"), :id => "directions_route_download", :download => t("javascripts.directions.filename") %>
+    <%= tag.a t(".download"), :id => "directions_route_download", :download => t(".filename") %>
   </p>
 
   <p class="text-center">
-    <%= t "javascripts.directions.instructions.courtesy_html", :link => tag.a("", :id => "directions_route_credit", :target => "_blank") %>
+    <%= t ".directions_courtesy_html", :link => tag.a("", :id => "directions_route_credit", :target => "_blank") %>
   </p>
 </div>

--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -88,4 +88,28 @@
 
 <div id="directions_error" hidden></div>
 
-<div id="directions_route" hidden></div>
+<div id="directions_route" hidden>
+  <p>
+    <span>
+      <%= t "javascripts.directions.distance" %>: <output id="directions_route_distance"></output>.
+      <%= t "javascripts.directions.time" %>: <output id="directions_route_time"></output>.
+    </span>
+    <br>
+    <span id="directions_route_ascend_descend">
+      <%= t "javascripts.directions.ascend" %>: <output id="directions_route_ascend"></output>.
+      <%= t "javascripts.directions.descend" %>: <output id="directions_route_descend"></output>.
+    </span>
+  </p>
+
+  <table class='table table-hover table-sm mb-3'>
+    <tbody id="directions_route_steps"></tbody>
+  </table>
+
+  <p class="text-center">
+    <%= tag.a t("javascripts.directions.download"), :id => "directions_route_download", :download => t("javascripts.directions.filename") %>
+  </p>
+
+  <p class="text-center">
+    <%= t "javascripts.directions.instructions.courtesy_html", :link => tag.a("", :id => "directions_route_credit", :target => "_blank") %>
+  </p>
+</div>

--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -89,17 +89,27 @@
 <div id="directions_error" hidden></div>
 
 <div id="directions_route" hidden>
-  <p>
-    <span>
-      <%= t ".distance" %>: <output id="directions_route_distance"></output>.
-      <%= t ".time" %>: <output id="directions_route_time"></output>.
-    </span>
-    <br>
-    <span id="directions_route_ascend_descend">
-      <%= t ".ascend" %>: <output id="directions_route_ascend"></output>.
-      <%= t ".descend" %>: <output id="directions_route_descend"></output>.
-    </span>
-  </p>
+  <div class="d-flex align-items-end mb-3">
+    <div class="flex-grow-1 text-truncate">
+      <span>
+        <%= t ".distance" %>: <output id="directions_route_distance"></output>.
+        <%= t ".time" %>: <output id="directions_route_time"></output>.
+      </span>
+      <br>
+      <span id="directions_route_ascend_descend">
+        <%= t ".ascend" %>: <output id="directions_route_ascend"></output>.
+        <%= t ".descend" %>: <output id="directions_route_descend"></output>.
+      </span>
+    </div>
+
+    <div class="btn-group btn-group-sm">
+      <input type="radio" class="btn-check" name="directions_distance_units" id="directions_distance_units_km" autocomplete="off" checked>
+      <label class="btn btn-outline-secondary p-0 px-1" for="directions_distance_units_km"><%= t ".button_km" %></label>
+
+      <input type="radio" class="btn-check" name="directions_distance_units" id="directions_distance_units_mi" autocomplete="off">
+      <label class="btn btn-outline-secondary p-0 px-1" for="directions_distance_units_mi"><%= t ".button_mi" %></label>
+    </div>
+  </div>
 
   <table class='table table-hover table-sm mb-3'>
     <tbody id="directions_route_steps"></tbody>

--- a/app/views/directions/search.html.erb
+++ b/app/views/directions/search.html.erb
@@ -78,4 +78,12 @@
 
 <%= render "sidebar_header", :title => t(".title") %>
 
+<div id="directions_loader" hidden>
+  <div class="text-center loader">
+    <div class="spinner-border" role="status">
+      <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
+    </div>
+  </div>
+</div>
+
 <div id="directions_content"></div>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -89,13 +89,5 @@
         <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-primary py-1 px-2", :data => { :disable_with => false } %>
       </div>
     </div>
-
-    <div class="loader_copy d-none">
-      <div class="text-center loader">
-        <div class="spinner-border" role="status">
-          <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
-        </div>
-      </div>
-    </div>
   </form>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1545,6 +1545,8 @@ en:
       time: "Time"
       ascend: "Ascend"
       descend: "Descend"
+      button_km: "km"
+      button_mi: "mi"
       download: "Download route as GeoJSON"
       filename: "route"
       directions_courtesy_html: "Directions courtesy of %{link}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3296,8 +3296,9 @@ en:
       embed_html_disabled: HTML embedding is not available for this map layer
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
-      distance_m: "%{distance}m"
-      distance_km: "%{distance}km"
+      distance_in_units:
+        m: "%{distance}m"
+        km: "%{distance}km"
       errors:
         no_route: "Couldn't find a route between those two places."
         no_place: "Sorry - couldn't locate '%{place}'."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3349,7 +3349,7 @@ en:
         roundabout_with_exit_ordinal: At the roundabout take the %{exit} exit onto %{name}
         exit_roundabout: Exit the roundabout onto %{name}
         unnamed: "unnamed road"
-        courtesy: "Directions courtesy of %{link}"
+        courtesy_html: "Directions courtesy of %{link}"
         exit_counts:
           first: "1st"
           second: "2nd"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1541,6 +1541,13 @@ en:
   directions:
     search:
       title: Directions
+      distance: "Distance"
+      time: "Time"
+      ascend: "Ascend"
+      descend: "Descend"
+      download: "Download route as GeoJSON"
+      filename: "route"
+      directions_courtesy_html: "Directions courtesy of %{link}"
   issues:
     index:
       title: Issues
@@ -3287,9 +3294,6 @@ en:
       embed_html_disabled: HTML embedding is not available for this map layer
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
-      ascend: "Ascend"
-      descend: "Descend"
-      distance: "Distance"
       distance_m: "%{distance}m"
       distance_km: "%{distance}km"
       errors:
@@ -3349,7 +3353,6 @@ en:
         roundabout_with_exit_ordinal: At the roundabout take the %{exit} exit onto %{name}
         exit_roundabout: Exit the roundabout onto %{name}
         unnamed: "unnamed road"
-        courtesy_html: "Directions courtesy of %{link}"
         exit_counts:
           first: "1st"
           second: "2nd"
@@ -3361,9 +3364,6 @@ en:
           eighth: "8th"
           ninth: "9th"
           tenth: "10th"
-      time: "Time"
-      download: "Download route as GeoJSON"
-      filename: "route"
     query:
       node: Node
       way: Way

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3299,6 +3299,8 @@ en:
       distance_in_units:
         m: "%{distance}m"
         km: "%{distance}km"
+        ft: "%{distance}ft"
+        mi: "%{distance}mi"
       errors:
         no_route: "Couldn't find a route between those two places."
         no_place: "Sorry - couldn't locate '%{place}'."


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7dd84bcc-8ae1-46d2-890d-ee62e1277dcd)

Previous attempt was in #1747. This PR is a complete rewrite.

The main difference is that #1747 tried to store in locale strings what kind of "imperial" units are in use, along with conversion factors. I don't think that was a good idea and I don't do that in this PR.

I also moved most of html writing from javascript to the erb template because it's easier to deal with flex containers and button groups this way. This is probably what @gravitystorm wants for all javascript page controllers.