### PR TITLE
Update history.js - Correct function name for updating changeset loca…

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -237,7 +237,7 @@ OSM.History = function (map) {
       OSM.router.replace("/history" + window.location.hash);
       loadFirstChangesets();
     } else {
-      changesetsLayer.updateChangesetsPositions(map);
+      changesetsLayer.updateChangesetLocations(map);
     }
   }
 


### PR DESCRIPTION
Fixes regression from https://github.com/openstreetmap/openstreetmap-website/commit/f11b38709b6cdf6b837d822f4c1e04f06d65ca71 where changeset highlights for `/user/history` disappear after automatically zooming in, do not load at all or are incorrectly scaled when manually zooming.

Corrects invalid function name (`Uncaught TypeError: changesetsLayer.updateChangesetsPositions is not a function`)

cc: @AntonKhorev 