### PR TITLE
Put map key presence in js layer definitions

### DIFF
--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -27,7 +27,7 @@ L.OSM.key = function (options) {
     }
 
     function updateButton() {
-      const disabled = OSM.LAYERS_WITH_MAP_KEY.indexOf(map.getMapBaseLayerId()) === -1;
+      const disabled = !map.getMapBaseLayer().options.hasLegend;
       button
         .toggleClass("disabled", disabled)
         .attr("data-bs-original-title",

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -27,8 +27,7 @@ OSM = {
 
   DEFAULT_LOCALE: <%= I18n.default_locale.to_json %>,
 
-  LAYER_DEFINITIONS: <%= MapLayers::full_definitions("config/layers.yml").to_json %>,
-  LAYERS_WITH_MAP_KEY: <%= YAML.load_file(Rails.root.join("config/key.yml")).keys.to_json %>,
+  LAYER_DEFINITIONS: <%= MapLayers::full_definitions("config/layers.yml", :legends => "config/key.yml").to_json %>,
 
   MARKER_BLUE: <%= image_path("marker-blue.png").to_json %>,
   MARKER_GREEN: <%= image_path("marker-green.png").to_json %>,

--- a/lib/map_layers.rb
+++ b/lib/map_layers.rb
@@ -1,5 +1,6 @@
 module MapLayers
-  def self.full_definitions(layers_filename)
+  def self.full_definitions(layers_filename, legends: nil)
+    legended_layers = YAML.load_file(Rails.root.join(legends)).keys if legends
     YAML.load_file(Rails.root.join(layers_filename))
         .reject { |layer| layer["apiKeyId"] && !Settings[layer["apiKeyId"]] }
         .map do |layer|
@@ -7,6 +8,7 @@ module MapLayers
             layer["apikey"] = Settings[layer["apiKeyId"]]
             layer.delete "apiKeyId"
           end
+          layer["hasLegend"] = true if legended_layers&.include?(layer["layerId"])
           layer
         end
   end


### PR DESCRIPTION
Links _key.yml_ to _layers.yml_ in the `MapLayers` module by putting a `hasKey` flag into the `LAYER_DEFINITIONS`.
This removes the need for `LAYERS_WITH_MAP_KEY` as the key button can now directly check `layer.options.hasKey`.