### PR TITLE
Update to rack 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem "rack-uri_sanitizer"
 
 # Omniauth for authentication
 gem "multi_json"
-gem "omniauth", "~> 2.0.2"
+gem "omniauth", "~> 2.1.3"
 gem "omniauth-facebook"
 gem "omniauth-github"
 gem "omniauth-google-oauth2", ">= 0.6.0"
@@ -162,7 +162,7 @@ group :test do
   gem "jwt"
   gem "minitest", "~> 5.1"
   gem "minitest-focus", :require => false
-  gem "puma", "~> 5.6"
+  gem "puma", "~> 6.6"
   gem "rails-controller-testing"
   gem "rubocop"
   gem "rubocop-capybara"
@@ -179,8 +179,10 @@ end
 
 group :development, :test do
   gem "annotaterb"
+  gem "rackup"
   gem "teaspoon"
   gem "teaspoon-mocha", "~> 2.3.3"
+  gem "webrick"
 
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", :require => "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,9 +426,9 @@ GEM
     octokit (9.2.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    omniauth (2.0.4)
+    omniauth (2.1.3)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
+      rack (>= 2.2.3)
       rack-protection
     omniauth-facebook (10.0.0)
       bigdecimal
@@ -484,27 +484,28 @@ GEM
       date
       stringio
     public_suffix (6.0.1)
-    puma (5.6.9)
+    puma (6.6.0)
       nio4r (~> 2.0)
     quad_tile (1.0.1)
     racc (1.8.1)
-    rack (2.2.13)
+    rack (3.1.12)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
-    rack-protection (3.2.0)
+    rack-protection (4.1.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
-    rack-session (1.0.2)
-      rack (< 3)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
     rack-uri_sanitizer (0.0.2)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.2.1)
+      rack (>= 3)
     rails (8.0.2)
       actioncable (= 8.0.2)
       actionmailbox (= 8.0.2)
@@ -749,7 +750,7 @@ DEPENDENCIES
   minitest (~> 5.1)
   minitest-focus
   multi_json
-  omniauth (~> 2.0.2)
+  omniauth (~> 2.1.3)
   omniauth-facebook
   omniauth-github
   omniauth-google-oauth2 (>= 0.6.0)
@@ -760,10 +761,11 @@ DEPENDENCIES
   openstreetmap-deadlock_retry (>= 1.3.1)
   overcommit
   pg
-  puma (~> 5.6)
+  puma (~> 6.6)
   quad_tile (~> 1.0.1)
   rack-cors
   rack-uri_sanitizer
+  rackup
   rails (~> 8.0.0)
   rails-controller-testing
   rails-i18n (~> 8.0.0)
@@ -794,6 +796,7 @@ DEPENDENCIES
   validates_email_format_of (>= 1.5.1)
   vendorer
   webmock
+  webrick
 
 BUNDLED WITH
-   2.5.22
+   2.6.2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from RailsParam::InvalidParameterError, :with => :invalid_parameter
 
-  before_action :fetch_body
+  after_action :close_body
 
   attr_accessor :current_user, :oauth_token
 
@@ -244,10 +244,10 @@ class ApplicationController < ActionController::Base
   #
   #   https://issues.apache.org/bugzilla/show_bug.cgi?id=44782
   #
-  # To work round this we call rewind on the body here, which is added
-  # as a filter, to force it to be fetched from Apache into a file.
-  def fetch_body
-    request.body.rewind
+  # To work round this we call close on the body here, which is added
+  # as a filter, to let Apache know we are done with it.
+  def close_body
+    request.body&.close
   end
 
   def map_layout

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,24 +1,11 @@
 # Be sure to restart your server when you modify this file.
 
-# Mark CORS responses as uncacheable as we don't want a browser to
-# try and reuse a response that had a different origin, even with
-# revalidation, as the origin check will fail.
-module OpenStreetMap
-  class Cors < Rack::Cors
-    def call(env)
-      status, headers, body = super
-      headers["Cache-Control"] = "no-cache" if headers["Access-Control-Allow-Origin"]
-      [status, headers, body]
-    end
-  end
-end
-
 # Allow any and all cross-origin requests to the API. Allow any origin, and
 # any headers. Non-browser requests do not have origin or header restrictions,
 # so browser-requests should be similarly permitted. (Though the API does not
 # require any custom headers, Ajax frameworks may automatically add headers
 # such as X-Requested-By to requests.)
-Rails.application.config.middleware.insert_before 0, OpenStreetMap::Cors do
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "*"
     resource "/oauth/*", :headers => :any, :methods => [:get, :post]

--- a/test/integration/compressed_requests_test.rb
+++ b/test/integration/compressed_requests_test.rb
@@ -38,7 +38,7 @@ class CompressedRequestsTest < ActionDispatch::IntegrationTest
     post "/api/0.6/changeset/#{changeset.id}/upload",
          :params => diff,
          :headers => bearer_authorization_header(user).merge(
-           "HTTP_CONTENT_TYPE" => "application/xml"
+           "Content-Type" => "application/xml"
          )
     assert_response :success,
                     "can't upload an uncompressed diff to changeset: #{@response.body}"
@@ -86,8 +86,8 @@ class CompressedRequestsTest < ActionDispatch::IntegrationTest
     post "/api/0.6/changeset/#{changeset.id}/upload",
          :params => gzip_content(diff),
          :headers => bearer_authorization_header(user).merge(
-           "HTTP_CONTENT_ENCODING" => "gzip",
-           "HTTP_CONTENT_TYPE" => "application/xml"
+           "Content-Encoding" => "gzip",
+           "Content-Type" => "application/xml"
          )
     assert_response :success,
                     "can't upload a gzip compressed diff to changeset: #{@response.body}"
@@ -135,8 +135,8 @@ class CompressedRequestsTest < ActionDispatch::IntegrationTest
     post "/api/0.6/changeset/#{changeset.id}/upload",
          :params => deflate_content(diff),
          :headers => bearer_authorization_header(user).merge(
-           "HTTP_CONTENT_ENCODING" => "deflate",
-           "HTTP_CONTENT_TYPE" => "application/xml"
+           "Content-Encoding" => "deflate",
+           "Content-Type" => "application/xml"
          )
     assert_response :success,
                     "can't upload a deflate compressed diff to changeset: #{@response.body}"
@@ -155,8 +155,8 @@ class CompressedRequestsTest < ActionDispatch::IntegrationTest
     post "/api/0.6/changeset/#{changeset.id}/upload",
          :params => "",
          :headers => bearer_authorization_header(user).merge(
-           "HTTP_CONTENT_ENCODING" => "unknown",
-           "HTTP_CONTENT_TYPE" => "application/xml"
+           "Content-Encoding" => "unknown",
+           "Content-Type" => "application/xml"
          )
     assert_response :unsupported_media_type
   end

--- a/test/integration/cors_test.rb
+++ b/test/integration/cors_test.rb
@@ -2,19 +2,30 @@ require "test_helper"
 
 class CORSTest < ActionDispatch::IntegrationTest
   def test_api_routes_allow_cross_origin_requests
-    process :options, "/api/capabilities", :headers => {
+    options "/api/capabilities", :headers => {
       "Origin" => "http://www.example.com",
       "Access-Control-Request-Method" => "GET"
     }
 
     assert_response :success
     assert_equal "*", response.headers["Access-Control-Allow-Origin"]
+    assert_nil response.headers["Vary"]
     assert_nil response.media_type
     assert_equal "", response.body
+
+    get "/api/capabilities", :headers => {
+      "Origin" => "http://www.example.com",
+      "Access-Control-Request-Method" => "GET"
+    }
+
+    assert_response :success
+    assert_equal "*", response.headers["Access-Control-Allow-Origin"]
+    assert_equal "Origin", response.headers["Vary"]
+    assert_equal "application/xml", response.media_type
   end
 
   def test_non_api_routes_dont_allow_cross_origin_requests
-    process :options, "/", :headers => {
+    options "/", :headers => {
       "Origin" => "http://www.example.com",
       "Access-Control-Request-Method" => "GET"
     }
@@ -23,5 +34,14 @@ class CORSTest < ActionDispatch::IntegrationTest
     assert_nil response.headers["Access-Control-Allow-Origin"]
     assert_nil response.media_type
     assert_equal "", response.body
+
+    get "/", :headers => {
+      "Origin" => "http://www.example.com",
+      "Access-Control-Request-Method" => "GET"
+    }
+
+    assert_response :success
+    assert_nil response.headers["Access-Control-Allow-Origin"]
+    assert_equal "text/html", response.media_type
   end
 end

--- a/test/integration/cors_test.rb
+++ b/test/integration/cors_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 class CORSTest < ActionDispatch::IntegrationTest
   def test_api_routes_allow_cross_origin_requests
     process :options, "/api/capabilities", :headers => {
-      "HTTP_ORIGIN" => "http://www.example.com",
-      "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => "GET"
+      "Origin" => "http://www.example.com",
+      "Access-Control-Request-Method" => "GET"
     }
 
     assert_response :success
@@ -15,8 +15,8 @@ class CORSTest < ActionDispatch::IntegrationTest
 
   def test_non_api_routes_dont_allow_cross_origin_requests
     process :options, "/", :headers => {
-      "HTTP_ORIGIN" => "http://www.example.com",
-      "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => "GET"
+      "Origin" => "http://www.example.com",
+      "Access-Control-Request-Method" => "GET"
     }
 
     assert_response :success

--- a/test/integration/page_locale_test.rb
+++ b/test/integration/page_locale_test.rb
@@ -14,7 +14,7 @@ class PageLocaleTest < ActionDispatch::IntegrationTest
       assert_empty User.find(user.id).languages
       assert_select "html[lang=?]", "en"
 
-      get "/diary/new", :headers => { "HTTP_ACCEPT_LANGUAGE" => "fr, en" }
+      get "/diary/new", :headers => { "Accept-Language" => "fr, en" }
       assert_equal %w[fr en], User.find(user.id).languages
       assert_select "html[lang=?]", "fr"
     end

--- a/test/teaspoon_env.rb
+++ b/test/teaspoon_env.rb
@@ -1,3 +1,7 @@
+# Monkey patch pending new release with
+# https://github.com/jejacks0n/teaspoon/pull/604
+Rack::Server = Rackup::Server
+
 Teaspoon.configure do |config|
   # Determines where the Teaspoon routes will be mounted. Changing this to "/jasmine" would allow you to browse to
   # `http://localhost:3000/jasmine` to run your tests.


### PR DESCRIPTION
This updates to rack 3 which was blocked by omniauth being locked to 2.0 so this updates omniauth to 2.1 which unlocks the rack 3 update which in turn requires a puma update.