### PR TITLE
Change colors of changeset bboxes when they enter/exit the viewport

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -64,12 +64,8 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     }
   },
 
-  highlightChangeset: function (id) {
-    this.getLayer(id)?.setStyle({ fillOpacity: 0.3, color: "#FF6600", weight: 3 });
-  },
-
-  unHighlightChangeset: function (id) {
-    this.getLayer(id)?.setStyle({ fillOpacity: 0, color: "#FF9500", weight: 2 });
+  toggleChangesetHighlight: function (id, state) {
+    this.getLayer(id)?.setStyle(state ? { fillOpacity: 0.3, color: "#FF6600", weight: 3 } : { fillOpacity: 0, color: "#FF9500", weight: 2 });
   },
 
   getLayerId: function (layer) {

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -1,9 +1,16 @@
 OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   _changesets: new Map,
 
-  _getChangesetStyle: function ({ isHighlighted }) {
-    let className = "changeset-in-sidebar-viewport";
+  _getChangesetStyle: function ({ isHighlighted, sidebarRelativePosition }) {
+    let className;
 
+    if (sidebarRelativePosition > 0) {
+      className = "changeset-above-sidebar-viewport";
+    } else if (sidebarRelativePosition < 0) {
+      className = "changeset-below-sidebar-viewport";
+    } else {
+      className = "changeset-in-sidebar-viewport";
+    }
     if (isHighlighted) {
       className += " changeset-highlighted";
     }
@@ -96,6 +103,14 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     if (!changeset) return;
 
     changeset.isHighlighted = state;
+    this._updateChangesetStyle(changeset);
+  },
+
+  setChangesetSidebarRelativePosition: function (id, state) {
+    const changeset = this._changesets.get(id);
+    if (!changeset) return;
+
+    changeset.sidebarRelativePosition = state;
     this._updateChangesetStyle(changeset);
   },
 

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -2,16 +2,30 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   _changesets: new Map,
 
   _getChangesetStyle: function ({ isHighlighted }) {
+    let className = "changeset-in-sidebar-viewport";
+
+    if (isHighlighted) {
+      className += " changeset-highlighted";
+    }
+
     return {
       weight: isHighlighted ? 3 : 2,
-      color: isHighlighted ? "#FF6600" : "#FF9500",
-      fillColor: "#FFFFAF",
-      fillOpacity: isHighlighted ? 0.3 : 0
+      color: "var(--changeset-border-color)",
+      fillColor: "var(--changeset-fill-color)",
+      fillOpacity: isHighlighted ? 0.3 : 0,
+      className
     };
   },
 
   _updateChangesetStyle: function (changeset) {
-    this.getLayer(changeset.id)?.setStyle(this._getChangesetStyle(changeset));
+    const rect = this.getLayer(changeset.id);
+    if (!rect) return;
+
+    const style = this._getChangesetStyle(changeset);
+    rect.setStyle(style);
+    // setStyle doesn't update css classes: https://github.com/leaflet/leaflet/issues/2662
+    rect._path.classList.value = style.className;
+    rect._path.classList.add("leaflet-interactive");
   },
 
   updateChangesets: function (map, changesets) {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -68,6 +68,8 @@ OSM.History = function (map) {
         }
       }
 
+      changesetsLayer.reorderChangesets();
+
       if (keepInitialLocation) {
         keepInitialLocation = false;
         return;

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -7,18 +7,18 @@ OSM.History = function (map) {
   $("#sidebar_content")
     .on("click", ".changeset_more a", loadMoreChangesets)
     .on("mouseover", "[data-changeset]", function () {
-      highlightChangeset($(this).data("changeset").id);
+      toggleChangesetHighlight($(this).data("changeset").id, true);
     })
     .on("mouseout", "[data-changeset]", function () {
-      unHighlightChangeset($(this).data("changeset").id);
+      toggleChangesetHighlight($(this).data("changeset").id, false);
     });
 
   const changesetsLayer = new OSM.HistoryChangesetsLayer()
     .on("mouseover", function (e) {
-      highlightChangeset(e.layer.id);
+      toggleChangesetHighlight(e.layer.id, true);
     })
     .on("mouseout", function (e) {
-      unHighlightChangeset(e.layer.id);
+      toggleChangesetHighlight(e.layer.id, false);
     })
     .on("click", function (e) {
       clickChangeset(e.layer.id, e.originalEvent);
@@ -83,14 +83,9 @@ OSM.History = function (map) {
     });
   }
 
-  function highlightChangeset(id) {
-    changesetsLayer.highlightChangeset(id);
-    $("#changeset_" + id).addClass("selected");
-  }
-
-  function unHighlightChangeset(id) {
-    changesetsLayer.unHighlightChangeset(id);
-    $("#changeset_" + id).removeClass("selected");
+  function toggleChangesetHighlight(id, state) {
+    changesetsLayer.toggleChangesetHighlight(id, state);
+    $("#changeset_" + id).toggleClass("selected", state);
   }
 
   function clickChangeset(id, e) {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -105,6 +105,10 @@ OSM.History = function (map) {
   function displayFirstChangesets(html) {
     $("#sidebar_content .changesets").html(html);
 
+    $("#sidebar_content .changesets ol")
+      .before($("<div class='changeset-color-hint-bar opacity-75 sticky-top changeset-above-sidebar-viewport'>"))
+      .after($("<div class='changeset-color-hint-bar opacity-75 sticky-bottom changeset-below-sidebar-viewport'>"));
+
     if (location.pathname === "/history") {
       setPaginationMapHashes();
     }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -601,6 +601,14 @@ tr.turn {
 
 /* Rules for the history sidebar */
 
+.changeset-in-sidebar-viewport {
+  --changeset-border-color: #FF9500;
+  &.changeset-highlighted {
+    --changeset-border-color: #FF6600;
+  }
+  --changeset-fill-color: #FFFFAF;
+}
+
 #sidebar .changesets {
   li {
     &.selected {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -601,12 +601,20 @@ tr.turn {
 
 /* Rules for the history sidebar */
 
+.changeset-above-sidebar-viewport {
+  --changeset-border-color: #CC7755;
+  --changeset-fill-color: #888888;
+}
 .changeset-in-sidebar-viewport {
   --changeset-border-color: #FF9500;
   &.changeset-highlighted {
     --changeset-border-color: #FF6600;
   }
   --changeset-fill-color: #FFFFAF;
+}
+.changeset-below-sidebar-viewport {
+  --changeset-border-color: #8888AA;
+  --changeset-fill-color: #888888;
 }
 
 #sidebar .changesets {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -618,6 +618,11 @@ tr.turn {
 }
 
 #sidebar .changesets {
+  .changeset-color-hint-bar {
+    height: 2px;
+    background: var(--changeset-border-color);
+  }
+
   li {
     &.selected {
       @extend :hover;


### PR DESCRIPTION
On history pages, if you load many changesets and look at the map, it's difficult to find the corresponding changesets in the sidebar. The idea here is to color changesets differently, depending on whether they are above/in/below the sidebar viewport.

- The orange color that was previously used for all changesets is now used only for the ones in the viewport.
- The bluish ("colder") color is for older changesets below the viewport. If you see this color on the map, you know you have to scroll down to find the changeset in the sidebar.
- The reddish ("hotter") is for newer changesets. Actually the color became more brownish as I desaturated it because it has to beless saturated than the usual orange.

https://github.com/user-attachments/assets/0f6eb2d8-3b66-4890-ae23-9f160aadb50b

