### PR TITLE
Change 'search more' spinner hiding css to hidden attribute

### DIFF
--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -54,7 +54,7 @@ OSM.Search = function (map) {
     const div = $(this).parents(".search_more");
 
     $(this).hide();
-    div.find(".loader").show();
+    div.find(".loader").prop("hidden", false);
 
     fetch($(this).attr("href"), {
       method: "POST",

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -580,14 +580,6 @@ header .search_forms,
   }
 }
 
-/* Rules for search sidebar */
-
-#sidebar .search_results_entry {
-  .search_more .loader {
-    display: none;
-  }
-}
-
 /* Rules for routing */
 
 td.distance {

--- a/app/views/geocoder/results.html.erb
+++ b/app/views/geocoder/results.html.erb
@@ -13,7 +13,7 @@
   <% if @more_params %>
     <div class="search_more text-center my-3">
       <%= link_to t(".more_results"), url_for(@more_params), :class => "btn btn-primary" %>
-      <div class="text-center loader">
+      <div class="text-center loader" hidden>
         <div class="spinner-border" role="status">
           <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>
         </div>


### PR DESCRIPTION
For spinners that appear after clicking this button in search results:
![image](https://github.com/user-attachments/assets/a481b1f6-0318-449e-bba7-91e629c58687)

Removes a little bit of custom css.