### PR TITLE
Remove custom position and margin css from .content-inner

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -691,9 +691,7 @@ tr.turn {
 /* Rules for non-map content pages */
 
 .content-inner {
-  position: relative;
   max-width: 960px;
-  margin: auto;
   padding: $lineheight;
 }
 

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -5,13 +5,13 @@
     <%= render :partial => "layouts/flash", :locals => { :flash => flash } %>
     <% if content_for? :heading %>
       <div class="content-heading bg-body-secondary border-bottom border-secondary-subtle">
-        <div class="content-inner <%= yield :heading_class %>">
+        <div class="content-inner position-relative m-auto <%= yield :heading_class %>">
           <%= yield :heading %>
         </div>
       </div>
     <% end %>
     <div class="content-body">
-      <div class="content-inner">
+      <div class="content-inner position-relative m-auto">
         <%= yield %>
       </div>
     </div>


### PR DESCRIPTION
Removes some *Rules for non-map content pages*