### PR TITLE
Fix marking changesets outside of viewport on history pages

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -116,8 +116,10 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     const changeset = this._changesets.get(id);
     if (!changeset) return;
 
-    changeset.sidebarRelativePosition = state;
-    this._updateChangesetStyle(changeset);
+    if (changeset.sidebarRelativePosition !== state) {
+      changeset.sidebarRelativePosition = state;
+      this._updateChangesetStyle(changeset);
+    }
   },
 
   getLayerId: function (layer) {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -38,6 +38,7 @@ OSM.History = function (map) {
     if (!window.IntersectionObserver) return;
 
     let keepInitialLocation = true;
+    let itemsInViewport = $();
 
     changesetIntersectionObserver = new IntersectionObserver((entries) => {
       let closestTargetToTop,
@@ -49,14 +50,15 @@ OSM.History = function (map) {
         const id = $(entry.target).data("changeset")?.id;
 
         if (entry.isIntersecting) {
+          itemsInViewport = itemsInViewport.add(entry.target);
           if (id) changesetsLayer.setChangesetSidebarRelativePosition(id, 0);
           continue;
+        } else {
+          itemsInViewport = itemsInViewport.not(entry.target);
         }
 
         const distanceToTop = entry.rootBounds.top - entry.boundingClientRect.bottom;
         const distanceToBottom = entry.boundingClientRect.top - entry.rootBounds.bottom;
-
-        if (id) changesetsLayer.setChangesetSidebarRelativePosition(id, distanceToTop >= 0 ? 1 : -1);
 
         if (distanceToTop >= 0 && distanceToTop < closestDistanceToTop) {
           closestDistanceToTop = distanceToTop;
@@ -67,6 +69,15 @@ OSM.History = function (map) {
           closestTargetToBottom = entry.target;
         }
       }
+
+      itemsInViewport.first().prevAll().each(function () {
+        const id = $(this).data("changeset")?.id;
+        if (id) changesetsLayer.setChangesetSidebarRelativePosition(id, 1);
+      });
+      itemsInViewport.last().nextAll().each(function () {
+        const id = $(this).data("changeset")?.id;
+        if (id) changesetsLayer.setChangesetSidebarRelativePosition(id, -1);
+      });
 
       changesetsLayer.reorderChangesets();
 


### PR DESCRIPTION
The previous method relied on intersection events for all changeset list items that go from below the viewport to above the viewport or in the opposite direction. But that required the items to enter the viewport in between. This is not guaranteed to happen if the sidebar contents is scrolled fast enough, for example by dragging the scrollbar or pressing Home/End keys. If an item goes from below straight to above without ever being inside the viewport, no intersection event is generated and the changeset is left in an invalid state with wrong color.

This fix updates changesets below/above based on changesets inside the viewport.
