### PR TITLE
Change highlighted bbox border width to 4px on history pages

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -16,7 +16,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     }
 
     return {
-      weight: isHighlighted ? 3 : 2,
+      weight: isHighlighted ? 4 : 2,
       color: "var(--changeset-border-color)",
       fillColor: "var(--changeset-fill-color)",
       fillOpacity: isHighlighted ? 0.3 : 0,


### PR DESCRIPTION
This is https://github.com/openstreetmap/openstreetmap-website/pull/5866#issuecomment-2764695781 for borders. You want horizontal/vertical line boundaries to coincide with pixel boundaries. If the line is drawn at integer coordinates, it means that its width has to be an even number. The line shape boundaries are width/2 to one side and width/2 to another and you want the original coords +- width/2 to still be integers.

Before, notice the blurry changeset bbox:
![image](https://github.com/user-attachments/assets/b6dddfdd-898a-4031-94bd-b225d90897db)

This will be noticeable on 1x pixel density devices, and technically on 3x or other odd-numbered density, although physical pixels probably get too small to notice.

After:
![image](https://github.com/user-attachments/assets/90f2a812-eb54-45fb-ba22-a91c7a97d900)
