### PR TITLE
Changeset highlights in a layer on top of normal bboxes

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -1,6 +1,4 @@
 OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
-  _changesets: new Map,
-
   _getChangesetStyle: function ({ isHighlighted, sidebarRelativePosition }) {
     let className;
 
@@ -125,4 +123,8 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   getLayerId: function (layer) {
     return layer.id;
   }
+});
+
+OSM.HistoryChangesetsLayer.addInitHook(function () {
+  this._changesets = new Map;
 });

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -1,24 +1,21 @@
 OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
-  _getChangesetStyle: function ({ isHighlighted, sidebarRelativePosition }) {
-    let className;
-
+  _getSidebarRelativeClassName: function ({ sidebarRelativePosition }) {
     if (sidebarRelativePosition > 0) {
-      className = "changeset-above-sidebar-viewport";
+      return "changeset-above-sidebar-viewport";
     } else if (sidebarRelativePosition < 0) {
-      className = "changeset-below-sidebar-viewport";
+      return "changeset-below-sidebar-viewport";
     } else {
-      className = "changeset-in-sidebar-viewport";
+      return "changeset-in-sidebar-viewport";
     }
-    if (isHighlighted) {
-      className += " changeset-highlighted";
-    }
+  },
 
+  _getInteractiveStyle: function (changeset) {
     return {
-      weight: isHighlighted ? 4 : 2,
+      weight: changeset.isHighlighted ? 4 : 2,
       color: "var(--changeset-border-color)",
       fillColor: "var(--changeset-fill-color)",
-      fillOpacity: isHighlighted ? 0.3 : 0,
-      className
+      fillOpacity: changeset.isHighlighted ? 0.3 : 0,
+      className: this._getSidebarRelativeClassName(changeset) + (changeset.isHighlighted ? " changeset-highlighted" : "")
     };
   },
 
@@ -26,7 +23,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     const rect = this._interactiveLayer.getLayer(changeset.id);
     if (!rect) return;
 
-    const style = this._getChangesetStyle(changeset);
+    const style = this._getInteractiveStyle(changeset);
     rect.setStyle(style);
     // setStyle doesn't update css classes: https://github.com/leaflet/leaflet/issues/2662
     rect._path.classList.value = style.className;
@@ -96,7 +93,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
 
     for (const changeset of this._changesets.values()) {
       delete changeset.isHighlighted;
-      const rect = L.rectangle(changeset.bounds, this._getChangesetStyle(changeset));
+      const rect = L.rectangle(changeset.bounds, this._getInteractiveStyle(changeset));
       rect.id = changeset.id;
       rect.addTo(this._interactiveLayer);
     }

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -23,7 +23,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   },
 
   _updateChangesetStyle: function (changeset) {
-    const rect = this.getLayer(changeset.id);
+    const rect = this._interactiveLayer.getLayer(changeset.id);
     if (!rect) return;
 
     const style = this._getChangesetStyle(changeset);
@@ -77,7 +77,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
         changesetSouthWest.lng -= shiftInWorldCircumferences * 360;
         changesetNorthEast.lng -= shiftInWorldCircumferences * 360;
 
-        this.getLayer(changeset.id)?.setBounds(changeset.bounds);
+        this._interactiveLayer.getLayer(changeset.id)?.setBounds(changeset.bounds);
       }
     }
   },
@@ -92,13 +92,13 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     });
     this._changesets = new Map(changesetEntries);
 
-    this.clearLayers();
+    this._interactiveLayer.clearLayers();
 
     for (const changeset of this._changesets.values()) {
       delete changeset.isHighlighted;
       const rect = L.rectangle(changeset.bounds, this._getChangesetStyle(changeset));
       rect.id = changeset.id;
-      rect.addTo(this);
+      rect.addTo(this._interactiveLayer);
     }
   },
 
@@ -114,13 +114,13 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     const changeset = this._changesets.get(id);
     if (!changeset) return;
     changeset.sidebarRelativePosition = state;
-  },
-
-  getLayerId: function (layer) {
-    return layer.id;
   }
 });
 
 OSM.HistoryChangesetsLayer.addInitHook(function () {
   this._changesets = new Map;
+
+  this._interactiveLayer = L.featureGroup();
+  this._interactiveLayer.getLayerId = (layer) => layer.id;
+  this.addLayer(this._interactiveLayer);
 });

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -113,11 +113,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   setChangesetSidebarRelativePosition: function (id, state) {
     const changeset = this._changesets.get(id);
     if (!changeset) return;
-
-    if (changeset.sidebarRelativePosition !== state) {
-      changeset.sidebarRelativePosition = state;
-      this._updateChangesetStyle(changeset);
-    }
+    changeset.sidebarRelativePosition = state;
   },
 
   getLayerId: function (layer) {

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -13,11 +13,17 @@ OSM.History = function (map) {
       toggleChangesetHighlight($(this).data("changeset").id, false);
     });
 
+  let inZoom = false;
+  map.on("zoomstart", () => inZoom = true);
+  map.on("zoomend", () => inZoom = false);
+
   const changesetsLayer = new OSM.HistoryChangesetsLayer()
     .on("mouseover", function (e) {
+      if (inZoom) return;
       toggleChangesetHighlight(e.layer.id, true);
     })
     .on("mouseout", function (e) {
+      if (inZoom) return;
       toggleChangesetHighlight(e.layer.id, false);
     })
     .on("click", function (e) {


### PR DESCRIPTION
A fix for ["Also, sometimes the hover fails and the bbox ends up not on top of other bboxes"](https://community.openstreetmap.org/t/better-osm-org-a-script-that-adds-useful-little-things-to-osm-org/121670/105), look at the animation of the lower bbox in the second image.

Sometimes there's a bunch of changesets on the same place. When one of them is highlighted, the orange bbox is visible as intended if it happens to be rendered above others:
![image](https://github.com/user-attachments/assets/020598ae-47b8-4ad7-aa97-d56b42acc939)

If it's below, the highlight is less visible:
![image](https://github.com/user-attachments/assets/b9ca0481-9727-4e59-ad38-10b307d65940)

This PR moves the highlight to another layer rendered on top of normal bboxes. The highlight is non-interactve to avoid interfering with hover events on bboxes below.
![image](https://github.com/user-attachments/assets/b8322191-c2fe-4c0a-bd33-590ee0413891)
![image](https://github.com/user-attachments/assets/cbe845b7-a80f-4ca5-89cf-963e74713b15)

