### PR TITLE
Prefer new style hash syntax in config files

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { :host => "localhost", :port => 3000 }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { :host => "example.com" }
+  config.action_mailer.default_url_options = { host: "example.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { :host => Settings.server_url }
+  config.action_mailer.default_url_options = { host: Settings.server_url }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
Ran `bin/rails app:update` to get an idea of what our configuration files looked like relative to the 8.0 defaults. There were a couple places where the diff boiled down to the old versus new hash syntax. Figured I'd update those so the next time anyone runs `bin/rails app:update` they don't get picked up in the diff. Or in the case of `test.rb`, the `Settings.server_url` value is the only difference.
