### PR TITLE
Remove unneeded and broken bootstrap close button theme overrides

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -82,16 +82,6 @@ time[title] {
   100% { opacity: 1 }
 }
 
-/* Bootstrap close button overrides for nested light/dark themes */
-
-[data-bs-theme="dark"] .btn-close {
-  filter: var(--bs-btn-close-white-filter);
-}
-
-[data-bs-theme="light"] .btn-close {
-  filter: none;
-}
-
 /* Rules for the header */
 
 #menu-icon {


### PR DESCRIPTION
### Description
Fixes #5947 by removing the broken reference to `--bs-btn-close-white-filter` and also the `filter: none` because both are already taken care of by Bootstrap's definition of `--bs-btn-close-filter`.

### How has this been tested?
dev tools