### PR TITLE
Update fix for close button inside themed elements

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -84,12 +84,14 @@ time[title] {
 
 /* Bootstrap close button overrides for nested light/dark themes */
 
-[data-bs-theme="dark"] .btn-close {
-  filter: var(--bs-btn-close-white-filter);
+[data-bs-theme="dark"],
+[data-bs-theme] [data-bs-theme="dark"] {
+  --bs-btn-close-filter: invert(1) grayscale(100%) brightness(200%);
 }
 
-[data-bs-theme="light"] .btn-close {
-  filter: none;
+[data-bs-theme="light"],
+[data-bs-theme] [data-bs-theme="light"] {
+  --bs-btn-close-filter: none;
 }
 
 /* Rules for the header */

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -82,6 +82,16 @@ time[title] {
   100% { opacity: 1 }
 }
 
+/* Bootstrap close button overrides for nested light/dark themes */
+
+[data-bs-theme="dark"] .btn-close {
+  filter: var(--bs-btn-close-white-filter);
+}
+
+[data-bs-theme="light"] .btn-close {
+  filter: none;
+}
+
 /* Rules for the header */
 
 #menu-icon {


### PR DESCRIPTION
Update the close button light/dark theme fix from #4761 after Bootstrap v5.3.4 broke it. #5951 removed the fix as "unneeded".

Currently the fix is needed for *auto site theme in osm preferences* + *no system dark theme preference* + *dark banner theme*.

Black close button that should be white without the fix:
![image](https://github.com/user-attachments/assets/339dd075-9a0c-4cd7-937c-248b3c591467)

White close button with the fix:
![image](https://github.com/user-attachments/assets/6d91463d-68b6-4f82-9814-728755a13917)

Possible Bootstrap issue: https://github.com/twbs/bootstrap/issues/39481