### PR TITLE
Fix svg icon path in manifest.json

### DIFF
--- a/app/assets/favicons/manifest.json.erb
+++ b/app/assets/favicons/manifest.json.erb
@@ -7,7 +7,7 @@
 			type: "image/png",
 			density: res.to_f / 48
 		} }.push({
-			src: image_path("../images/osm_logo.svg"),
+			src: image_path("osm_logo.svg"),
 			sizes: "any",
 			type: "image/svg+xml"
 		}).to_json %>,


### PR DESCRIPTION
I don't think the svg icon added in #5735 ever worked.

Before:
![image](https://github.com/user-attachments/assets/e1a320f0-b31e-4bf3-b01d-032bb6ca49e8)
See that the path is wrong.

After:
![image](https://github.com/user-attachments/assets/9e323b66-0812-4d5d-b2a3-45abed4c5571)
![image](https://github.com/user-attachments/assets/fe73b12f-77e9-464e-8fc9-356d5f000d5c)
