### PR TITLE
Don't visit profile page after tested profile location update

### DIFF
--- a/test/system/user_location_change_test.rb
+++ b/test/system/user_location_change_test.rb
@@ -10,13 +10,19 @@ class UserLocationChangeTest < ApplicationSystemTestCase
     sign_in_as(user)
 
     visit user_path(user)
-    assert_no_selector ".bi.bi-geo-alt-fill"
+
+    within_content_heading do
+      assert_no_selector ".bi.bi-geo-alt-fill"
+    end
 
     visit edit_profile_path
+
     fill_in "Home location name", :with => "Test Location"
     click_on "Update Profile"
 
-    visit user_path(user)
-    assert_text "Test Location"
+    assert_text "Profile updated"
+    within_content_heading do
+      assert_text "Test Location"
+    end
   end
 end


### PR DESCRIPTION
The system test from #5302 sometimes fails:
```
Failure:
UserLocationChangeTest#test_User_can_change_their_location [test/system/user_location_change_test.rb:20]:
expected to find text "Test Location" in "OpenStreetMap\nEdit\nHistory\nExport\nGPS Traces\nUser Diaries\nCommunities\nCopyright\nHelp\nAbout\nUser 597\nUser 597\nMy Edits 0\nMy Notes 0\nMy Traces 0\nMy Diary 0\nMy Comments 0\nMy Account\nMapper since: April 26, 2025 Last map edit: No activity yet\nEdit Profile"

bin/rails test test/system/user_location_change_test.rb:8
```

It could be because it leaves the edit profile page before sending the update request, or because arriving at the view profile page before the changes propagate. But `visit user_path(user)` is unnecessary because clicking *Update Profile* redirects you to that page.