### PR TITLE
Add routing provider tips

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -57,6 +57,8 @@ OSM.Directions = function (map) {
     OSM.router.route("/" + OSM.formatHash(map));
   });
 
+  $(".directions_form select + .input-group-text > span").tooltip();
+
   function setEngine(id) {
     const engines = OSM.Directions.engines;
     const desired = engines.find(engine => engine.id === id);

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -570,6 +570,16 @@ header .search_forms,
   }
 }
 
+.directions_form {
+  select + .input-group-text > span {
+    border: solid;
+    width: 3ch;
+    height: 3ch;
+    font-size: x-small;
+    margin: 0 7ch;
+  }
+}
+
 /* Rules for routing */
 
 td.distance {

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -81,11 +81,18 @@
             </svg>
           </label>
         </div>
-        <select class="routing_engines form-select py-1 px-2" name="routing_engines">
-          <option value="graphhopper" disabled><%= t("site.search.providers.graphhopper") %></option>
-          <option value="fossgis_osrm" disabled><%= t("site.search.providers.fossgis_osrm") %></option>
-          <option value="fossgis_valhalla" disabled><%= t("site.search.providers.fossgis_valhalla") %></option>
-        </select>
+        <div class="d-flex flex-grow-1">
+          <select class="routing_engines form-select py-1 px-2" name="routing_engines" title="<%= t("site.search.providers.description") %>">
+            <optgroup label="<%= t("site.search.providers.description") %>">
+              <option value="graphhopper" disabled><%= t("site.search.providers.graphhopper") %></option>
+              <option value="fossgis_osrm" disabled><%= t("site.search.providers.fossgis_osrm") %></option>
+              <option value="fossgis_valhalla" disabled><%= t("site.search.providers.fossgis_valhalla") %></option>
+            </optgroup>
+          </select>
+          <div class="border-0 input-group-text p-0 position-relative">
+            <span class="border-1 end-0 position-absolute rounded-circle text-body-secondary" data-bs-original-title="<%= t("site.search.providers.tooltip") %>">i</span>
+          </div>
+        </div>
         <%= submit_tag t("site.search.submit_text"), :class => "routing_go btn btn-primary py-1 px-2", :data => { :disable_with => false } %>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2438,6 +2438,8 @@ en:
         car: "Car"
         foot: "Foot"
       providers:
+        description: "Routing service"
+        tooltip: "Routing services allow checking that each point is connected to the rest of the map."
         fossgis_osrm: "OSRM"
         graphhopper: "GraphHopper"
         fossgis_valhalla: "Valhalla"


### PR DESCRIPTION
Addresses a concern from #3123 about the routing engine providers not being labeled.
| ![image](https://github.com/user-attachments/assets/2c5cdbdd-bb7e-4443-b2eb-d0931d50c458) | ![image](https://github.com/user-attachments/assets/549a1963-d80a-46eb-b864-16fd28131a52) | ![image](https://github.com/user-attachments/assets/7ac76175-62de-464c-8c0d-078cb4e32943) |
|-|-|-|