### PR TITLE
Show warning when visiting login page while already logged in

### DIFF
--- a/app/assets/javascripts/login.js
+++ b/app/assets/javascripts/login.js
@@ -2,5 +2,6 @@ $(function () {
   // Preserve location hash in referer
   if (location.hash) {
     $("#referer").val($("#referer").val() + location.hash);
+    $("#referer_link").prop("hash", location.hash);
   }
 });

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,6 +16,9 @@ class SessionsController < ApplicationController
   def new
     referer = safe_referer(params[:referer]) if params[:referer]
 
+    @safe_referer = referer
+    @safe_referer = nil if referer != params[:referer]
+
     parse_oauth_referer referer
   end
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -37,7 +37,7 @@
         <%= t ".access_another_page" %>
       </p>
       <p class="text-center">
-        <%= link_to t(".visit_referring_page"), @safe_referer, :class => "btn btn-warning" %>
+        <%= link_to t(".visit_referring_page"), @safe_referer, :id => "referer_link", :class => "btn btn-warning" %>
       </p>
     <% end %>
   </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -28,8 +28,18 @@
 <% end %>
 
 <% if current_user %>
-  <div class="alert alert-warning">
-    <%= t ".already_logged_in_html", :user => tag.strong(current_user.display_name) %>
+  <div class="alert alert-warning pb-0">
+    <p>
+      <%= t ".already_logged_in_html", :user => tag.strong(current_user.display_name) %>
+    </p>
+    <% if @safe_referer %>
+      <p>
+        <%= t ".access_another_page" %>
+      </p>
+      <p class="text-center">
+        <%= link_to t(".visit_referring_page"), @safe_referer, :class => "btn btn-warning" %>
+      </p>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -27,6 +27,12 @@
   <%= render :partial => "shared/section_divider", :locals => { :text => t(".or") } %>
 <% end %>
 
+<% if current_user %>
+  <div class="alert alert-warning">
+    <%= t ".already_logged_in_html", :user => tag.strong(current_user.display_name) %>
+  </div>
+<% end %>
+
 <%= bootstrap_form_tag(:action => "login", :html => { :id => "login_form" }) do |f| %>
   <%= hidden_field_tag("referer", h(params[:referer]), :autocomplete => "off") %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1975,6 +1975,7 @@ en:
     new:
       tab_title: "Log In"
       login_to_authorize_html: "Log in to OpenStreetMap to access %{client_app_name}."
+      already_logged_in_html: "You are already logged in as %{user}. Logging in again will change your current account."
       email or username: "Email Address or Username"
       password: "Password"
       remember: "Remember me"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1976,6 +1976,8 @@ en:
       tab_title: "Log In"
       login_to_authorize_html: "Log in to OpenStreetMap to access %{client_app_name}."
       already_logged_in_html: "You are already logged in as %{user}. Logging in again will change your current account."
+      access_another_page: "You arrived here while trying to access another page. If you want to access that page using your current account, click the button below:"
+      visit_referring_page: "Visit referring page"
       email or username: "Email Address or Username"
       password: "Password"
       remember: "Remember me"

--- a/test/integration/login_test.rb
+++ b/test/integration/login_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class UserLoginTest < ActionDispatch::IntegrationTest
+class LoginTest < ActionDispatch::IntegrationTest
   def setup
     OmniAuth.config.test_mode = true
   end

--- a/test/system/user_login_test.rb
+++ b/test/system/user_login_test.rb
@@ -1,0 +1,17 @@
+require "application_system_test_case"
+
+class UserLoginTest < ApplicationSystemTestCase
+  test "Show OpenID form when OpenID provider button is clicked" do
+    visit login_path
+
+    within_content_body do
+      assert_no_field "OpenID URL"
+      assert_no_button "Continue"
+
+      click_on "Log in with OpenID"
+
+      assert_field "OpenID URL"
+      assert_button "Continue"
+    end
+  end
+end

--- a/test/system/user_login_test.rb
+++ b/test/system/user_login_test.rb
@@ -1,6 +1,25 @@
 require "application_system_test_case"
 
 class UserLoginTest < ApplicationSystemTestCase
+  test "Warn on login page when already logged in" do
+    user1 = create(:user, :display_name => "First User")
+    user2 = create(:user, :display_name => "Second User")
+    sign_in_as(user1)
+
+    visit login_path
+
+    assert_button "First User"
+    within_content_body do
+      assert_text "logged in as First User"
+    end
+
+    fill_in "username", :with => user2.email
+    fill_in "password", :with => "test"
+    click_on "Log in"
+
+    assert_button "Second User"
+  end
+
   test "Show OpenID form when OpenID provider button is clicked" do
     visit login_path
 

--- a/test/system/user_login_test.rb
+++ b/test/system/user_login_test.rb
@@ -25,7 +25,7 @@ class UserLoginTest < ApplicationSystemTestCase
     user1 = create(:user, :display_name => "First User")
     sign_in_as(user1)
 
-    visit login_path(:referer => about_path)
+    visit login_path(:referer => copyright_path, :anchor => "trademarks")
 
     assert_button "First User"
     within_content_body do
@@ -35,7 +35,8 @@ class UserLoginTest < ApplicationSystemTestCase
       click_on "Visit referring page"
     end
 
-    assert_current_path about_path
+    assert_current_path copyright_path
+    assert_equal "#trademarks", execute_script("return location.hash")
   end
 
   test "Only show safe referer links inside warnings" do

--- a/test/system/user_login_test.rb
+++ b/test/system/user_login_test.rb
@@ -11,6 +11,7 @@ class UserLoginTest < ApplicationSystemTestCase
     assert_button "First User"
     within_content_body do
       assert_text "logged in as First User"
+      assert_no_link "Visit referring page"
     end
 
     fill_in "username", :with => user2.email
@@ -18,6 +19,36 @@ class UserLoginTest < ApplicationSystemTestCase
     click_on "Log in"
 
     assert_button "Second User"
+  end
+
+  test "Warn on login page when already logged in with referer link" do
+    user1 = create(:user, :display_name => "First User")
+    sign_in_as(user1)
+
+    visit login_path(:referer => about_path)
+
+    assert_button "First User"
+    within_content_body do
+      assert_text "logged in as First User"
+      assert_link "Visit referring page"
+
+      click_on "Visit referring page"
+    end
+
+    assert_current_path about_path
+  end
+
+  test "Only show safe referer links inside warnings" do
+    user1 = create(:user, :display_name => "First User")
+    sign_in_as(user1)
+
+    visit login_path(:referer => "https://example.com/")
+
+    assert_button "First User"
+    within_content_body do
+      assert_text "logged in as First User"
+      assert_no_link "Visit referring page"
+    end
   end
 
   test "Show OpenID form when OpenID provider button is clicked" do

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -87,18 +87,4 @@ class UserSignupTest < ApplicationSystemTestCase
       assert_content "Confirm Password"
     end
   end
-
-  test "Show OpenID form when OpenID provider button is clicked" do
-    visit login_path
-
-    within_content_body do
-      assert_no_field "OpenID URL"
-      assert_no_button "Continue"
-
-      click_on "Log in with OpenID"
-
-      assert_field "OpenID URL"
-      assert_button "Continue"
-    end
-  end
 end


### PR DESCRIPTION
Fixes #5441 by showing a warning as described in https://github.com/openstreetmap/openstreetmap-website/issues/5441#issuecomment-2563121432.

This is what you'll see if you visit the login page while already logged in:
![image](https://github.com/user-attachments/assets/ea3e9b12-f294-467d-8aca-e0b9a3c40569)

Additionally there's going to be a link (styled as button) if there's a referer parameter and it's a "safe" referer (according to the `safe_referer` method of `ApplicationController`; the check looks a bit silly because it has to satisfy both RuboCop and Brakeman):
![image](https://github.com/user-attachments/assets/753f2ac3-9b7a-474d-b96c-ae9e6ed1c41e)

In the scenario described in https://github.com/openstreetmap/openstreetmap-website/issues/5441#issue-2758188137 that link should open the editor.
