### PR TITLE
Fix outputting route before directions sidebar is loaded

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -222,25 +222,18 @@ OSM.Directions = function (map) {
   const page = {};
 
   page.pushstate = page.popstate = function () {
-    if ($("#directions_content").length) {
-      page.load();
-    } else {
-      initializeFromParams();
+    page.load();
 
-      $(".search_form").hide();
-      $(".directions_form").show();
+    if ($("#directions_content").length) return;
 
-      OSM.loadSidebarContent("/directions", () => {
-        enableListeners();
+    OSM.loadSidebarContent("/directions", () => {
+      if (scheduledRouteArguments) {
+        getScheduledRoute(...scheduledRouteArguments);
+        scheduledRouteArguments = null;
+      }
+    });
 
-        if (scheduledRouteArguments) {
-          getScheduledRoute(...scheduledRouteArguments);
-          scheduledRouteArguments = null;
-        }
-      });
-
-      map.setSidebarOverlaid(!endpoints[0].latlng || !endpoints[1].latlng);
-    }
+    map.setSidebarOverlaid(!endpoints[0].latlng || !endpoints[1].latlng);
   };
 
   page.load = function () {


### PR DESCRIPTION
Fixes #5959.

To reproduce the bug:
1. Add `sleep 5` or something similar to directions search action: https://github.com/openstreetmap/openstreetmap-website/blob/d54310c0dbf0c69ddbaeabfc93e415129dad6f66/app/controllers/directions_controller.rb#L7-L9 The goal is to make it take longer than the route request.
2. Do steps from #5959.

The fix here delays the route request to be performed after the sidebar finishes loading.