### PR TITLE
Limit number of directions endpoint geocoding results to 1

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -97,7 +97,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, marker, dragCallback, cha
 
   function getGeocode() {
     const viewbox = map.getBounds().toBBoxString(), // <sw lon>,<sw lat>,<ne lon>,<ne lat>
-          geocodeUrl = OSM.NOMINATIM_URL + "search?" + new URLSearchParams({ q: endpoint.value, format: "json", viewbox });
+          geocodeUrl = OSM.NOMINATIM_URL + "search?" + new URLSearchParams({ q: endpoint.value, format: "json", viewbox, limit: 1 });
 
     endpoint.geocodeRequest = new AbortController();
     fetch(geocodeUrl, { signal: endpoint.geocodeRequest.signal })


### PR DESCRIPTION
Geocoding for route endpoints requests the default number of results, which is 10, but only uses the first one.