### PR TITLE
Add outlines for in-viewport changeset bboxes

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -5,16 +5,8 @@ OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
 
   updateChangesetLayerBounds: function (changeset) {
     this.getLayer(changeset.id)?.setBounds(changeset.bounds);
-  }
-});
+  },
 
-OSM.HistoryChangesetBboxAreaLayer = OSM.HistoryChangesetBboxLayer.extend({});
-
-OSM.HistoryChangesetBboxBorderLayer = OSM.HistoryChangesetBboxLayer.extend({});
-
-OSM.HistoryChangesetBboxHighlightLayer = OSM.HistoryChangesetBboxLayer.extend({});
-
-OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   _getSidebarRelativeClassName: function ({ sidebarRelativePosition }) {
     if (sidebarRelativePosition > 0) {
       return "changeset-above-sidebar-viewport";
@@ -23,26 +15,32 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     } else {
       return "changeset-in-sidebar-viewport";
     }
-  },
+  }
+});
 
-  _getAreaStyle: function (changeset) {
+OSM.HistoryChangesetBboxAreaLayer = OSM.HistoryChangesetBboxLayer.extend({
+  _getChangesetStyle: function (changeset) {
     return {
       weight: 0,
       fillOpacity: 0,
       className: this._getSidebarRelativeClassName(changeset)
     };
-  },
+  }
+});
 
-  _getBorderStyle: function (changeset) {
+OSM.HistoryChangesetBboxBorderLayer = OSM.HistoryChangesetBboxLayer.extend({
+  _getChangesetStyle: function (changeset) {
     return {
       weight: 2,
       color: "var(--changeset-border-color)",
       fill: false,
       className: this._getSidebarRelativeClassName(changeset)
     };
-  },
+  }
+});
 
-  _getHighlightStyle: function (changeset) {
+OSM.HistoryChangesetBboxHighlightLayer = OSM.HistoryChangesetBboxLayer.extend({
+  _getChangesetStyle: function (changeset) {
     return {
       interactive: false,
       weight: 4,
@@ -51,8 +49,10 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
       fillOpacity: 0.3,
       className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"
     };
-  },
+  }
+});
 
+OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   updateChangesets: function (map, changesets) {
     this._changesets = new Map(changesets.map(changeset => [changeset.id, changeset]));
     this.updateChangesetShapes(map);
@@ -119,13 +119,13 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     }
 
     for (const changeset of this._changesets.values()) {
-      const rect = L.rectangle(changeset.bounds, this._getAreaStyle(changeset));
+      const rect = L.rectangle(changeset.bounds, this._areaLayer._getChangesetStyle(changeset));
       rect.id = changeset.id;
       rect.addTo(this._areaLayer);
     }
 
     for (const changeset of this._changesets.values()) {
-      const rect = L.rectangle(changeset.bounds, this._getBorderStyle(changeset));
+      const rect = L.rectangle(changeset.bounds, this._borderLayer._getChangesetStyle(changeset));
       rect.id = changeset.id;
       rect.addTo(this._borderLayer);
     }
@@ -136,7 +136,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     if (!changeset) return;
 
     if (state) {
-      const highlightRect = L.rectangle(changeset.bounds, this._getHighlightStyle(changeset));
+      const highlightRect = L.rectangle(changeset.bounds, this._highlightLayer._getChangesetStyle(changeset));
       highlightRect.id = id;
       this._highlightLayer.addLayer(highlightRect);
     } else {

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -113,12 +113,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
 
   reorderChangesets: function () {
     const changesetEntries = [...this._changesets];
-    changesetEntries.sort(([, a], [, b]) => {
-      const aInViewport = !a.sidebarRelativePosition;
-      const bInViewport = !b.sidebarRelativePosition;
-      if (aInViewport !== bInViewport) return aInViewport - bInViewport;
-      return b.bounds.getSize() - a.bounds.getSize();
-    });
+    changesetEntries.sort(([, a], [, b]) => b.bounds.getSize() - a.bounds.getSize());
     this._changesets = new Map(changesetEntries);
 
     for (const layer of this._bboxLayers) {
@@ -126,11 +121,27 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     }
 
     for (const changeset of this._changesets.values()) {
-      this._areaLayer.addChangesetLayer(changeset);
+      if (changeset.sidebarRelativePosition !== 0) {
+        this._areaLayer.addChangesetLayer(changeset);
+      }
     }
 
     for (const changeset of this._changesets.values()) {
-      this._borderLayer.addChangesetLayer(changeset);
+      if (changeset.sidebarRelativePosition === 0) {
+        this._areaLayer.addChangesetLayer(changeset);
+      }
+    }
+
+    for (const changeset of this._changesets.values()) {
+      if (changeset.sidebarRelativePosition !== 0) {
+        this._borderLayer.addChangesetLayer(changeset);
+      }
+    }
+
+    for (const changeset of this._changesets.values()) {
+      if (changeset.sidebarRelativePosition === 0) {
+        this._borderLayer.addChangesetLayer(changeset);
+      }
     }
   },
 

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -35,6 +35,17 @@ OSM.HistoryChangesetBboxAreaLayer = OSM.HistoryChangesetBboxLayer.extend({
   }
 });
 
+OSM.HistoryChangesetBboxOutlineLayer = OSM.HistoryChangesetBboxLayer.extend({
+  _getChangesetStyle: function (changeset) {
+    return {
+      weight: 4,
+      color: "var(--changeset-outline-color)",
+      fill: false,
+      className: this._getSidebarRelativeClassName(changeset)
+    };
+  }
+});
+
 OSM.HistoryChangesetBboxBorderLayer = OSM.HistoryChangesetBboxLayer.extend({
   _getChangesetStyle: function (changeset) {
     return {
@@ -140,6 +151,12 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
 
     for (const changeset of this._changesets.values()) {
       if (changeset.sidebarRelativePosition === 0) {
+        this._outlineLayer.addChangesetLayer(changeset);
+      }
+    }
+
+    for (const changeset of this._changesets.values()) {
+      if (changeset.sidebarRelativePosition === 0) {
         this._borderLayer.addChangesetLayer(changeset);
       }
     }
@@ -168,6 +185,7 @@ OSM.HistoryChangesetsLayer.addInitHook(function () {
 
   this._bboxLayers = [
     this._areaLayer = new OSM.HistoryChangesetBboxAreaLayer().addTo(this),
+    this._outlineLayer = new OSM.HistoryChangesetBboxOutlineLayer().addTo(this),
     this._borderLayer = new OSM.HistoryChangesetBboxBorderLayer().addTo(this),
     this._highlightLayer = new OSM.HistoryChangesetBboxHighlightLayer().addTo(this)
   ];

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -57,14 +57,26 @@ OSM.HistoryChangesetBboxBorderLayer = OSM.HistoryChangesetBboxLayer.extend({
   }
 });
 
-OSM.HistoryChangesetBboxHighlightLayer = OSM.HistoryChangesetBboxLayer.extend({
+OSM.HistoryChangesetBboxHighlightBackLayer = OSM.HistoryChangesetBboxLayer.extend({
+  _getChangesetStyle: function (changeset) {
+    return {
+      interactive: false,
+      weight: 6,
+      color: "var(--changeset-outline-color)",
+      fillColor: "var(--changeset-fill-color)",
+      fillOpacity: 0.3,
+      className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"
+    };
+  }
+});
+
+OSM.HistoryChangesetBboxHighlightBorderLayer = OSM.HistoryChangesetBboxLayer.extend({
   _getChangesetStyle: function (changeset) {
     return {
       interactive: false,
       weight: 4,
       color: "var(--changeset-border-color)",
-      fillColor: "var(--changeset-fill-color)",
-      fillOpacity: 0.3,
+      fill: false,
       className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"
     };
   }
@@ -167,9 +179,11 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     if (!changeset) return;
 
     if (state) {
-      this._highlightLayer.addChangesetLayer(changeset);
+      this._highlightBackLayer.addChangesetLayer(changeset);
+      this._highlightBorderLayer.addChangesetLayer(changeset);
     } else {
-      this._highlightLayer.removeLayer(id);
+      this._highlightBackLayer.removeLayer(id);
+      this._highlightBorderLayer.removeLayer(id);
     }
   },
 
@@ -187,6 +201,7 @@ OSM.HistoryChangesetsLayer.addInitHook(function () {
     this._areaLayer = new OSM.HistoryChangesetBboxAreaLayer().addTo(this),
     this._outlineLayer = new OSM.HistoryChangesetBboxOutlineLayer().addTo(this),
     this._borderLayer = new OSM.HistoryChangesetBboxBorderLayer().addTo(this),
-    this._highlightLayer = new OSM.HistoryChangesetBboxHighlightLayer().addTo(this)
+    this._highlightBackLayer = new OSM.HistoryChangesetBboxHighlightBackLayer().addTo(this),
+    this._highlightBorderLayer = new OSM.HistoryChangesetBboxHighlightBorderLayer().addTo(this)
   ];
 });

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -81,9 +81,9 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
         changesetSouthWest.lng -= shiftInWorldCircumferences * 360;
         changesetNorthEast.lng -= shiftInWorldCircumferences * 360;
 
-        this._areaLayer.getLayer(changeset.id)?.setBounds(changeset.bounds);
-        this._borderLayer.getLayer(changeset.id)?.setBounds(changeset.bounds);
-        this._highlightLayer.getLayer(changeset.id)?.setBounds(changeset.bounds);
+        for (const layer of this._bboxLayers) {
+          layer.getLayer(changeset.id)?.setBounds(changeset.bounds);
+        }
       }
     }
   },
@@ -98,9 +98,9 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     });
     this._changesets = new Map(changesetEntries);
 
-    this._areaLayer.clearLayers();
-    this._borderLayer.clearLayers();
-    this._highlightLayer.clearLayers();
+    for (const layer of this._bboxLayers) {
+      layer.clearLayers();
+    }
 
     for (const changeset of this._changesets.values()) {
       const rect = L.rectangle(changeset.bounds, this._getAreaStyle(changeset));
@@ -138,11 +138,13 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
 OSM.HistoryChangesetsLayer.addInitHook(function () {
   this._changesets = new Map;
 
-  this._areaLayer = L.featureGroup().addTo(this);
-  this._borderLayer = L.featureGroup().addTo(this);
-  this._highlightLayer = L.featureGroup().addTo(this);
+  this._bboxLayers = [
+    this._areaLayer = L.featureGroup().addTo(this),
+    this._borderLayer = L.featureGroup().addTo(this),
+    this._highlightLayer = L.featureGroup().addTo(this)
+  ];
 
-  this._areaLayer.getLayerId = (layer) => layer.id;
-  this._borderLayer.getLayerId = (layer) => layer.id;
-  this._highlightLayer.getLayerId = (layer) => layer.id;
+  for (const layer of this._bboxLayers) {
+    layer.getLayerId = (layer) => layer.id;
+  }
 });

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -1,3 +1,5 @@
+OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({});
+
 OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   _getSidebarRelativeClassName: function ({ sidebarRelativePosition }) {
     if (sidebarRelativePosition > 0) {
@@ -139,9 +141,9 @@ OSM.HistoryChangesetsLayer.addInitHook(function () {
   this._changesets = new Map;
 
   this._bboxLayers = [
-    this._areaLayer = L.featureGroup().addTo(this),
-    this._borderLayer = L.featureGroup().addTo(this),
-    this._highlightLayer = L.featureGroup().addTo(this)
+    this._areaLayer = new OSM.HistoryChangesetBboxLayer().addTo(this),
+    this._borderLayer = new OSM.HistoryChangesetBboxLayer().addTo(this),
+    this._highlightLayer = new OSM.HistoryChangesetBboxLayer().addTo(this)
   ];
 
   for (const layer of this._bboxLayers) {

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -119,14 +119,12 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     const changeset = this._changesets.get(id);
     if (!changeset) return;
 
-    let highlightRect = this._highlightLayer.getLayer(id);
-    if (!state && highlightRect) {
-      this._highlightLayer.removeLayer(highlightRect);
-    }
-    if (state && !highlightRect) {
-      highlightRect = L.rectangle(changeset.bounds, this._getHighlightStyle(changeset));
+    if (state) {
+      const highlightRect = L.rectangle(changeset.bounds, this._getHighlightStyle(changeset));
       highlightRect.id = id;
       this._highlightLayer.addLayer(highlightRect);
+    } else {
+      this._highlightLayer.removeLayer(id);
     }
   },
 

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -3,6 +3,13 @@ OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
     return layer.id;
   },
 
+  addChangesetLayer: function (changeset) {
+    const style = this._getChangesetStyle(changeset);
+    const rectangle = L.rectangle(changeset.bounds, style);
+    rectangle.id = changeset.id;
+    return this.addLayer(rectangle);
+  },
+
   updateChangesetLayerBounds: function (changeset) {
     this.getLayer(changeset.id)?.setBounds(changeset.bounds);
   },
@@ -119,15 +126,11 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     }
 
     for (const changeset of this._changesets.values()) {
-      const rect = L.rectangle(changeset.bounds, this._areaLayer._getChangesetStyle(changeset));
-      rect.id = changeset.id;
-      rect.addTo(this._areaLayer);
+      this._areaLayer.addChangesetLayer(changeset);
     }
 
     for (const changeset of this._changesets.values()) {
-      const rect = L.rectangle(changeset.bounds, this._borderLayer._getChangesetStyle(changeset));
-      rect.id = changeset.id;
-      rect.addTo(this._borderLayer);
+      this._borderLayer.addChangesetLayer(changeset);
     }
   },
 
@@ -136,9 +139,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     if (!changeset) return;
 
     if (state) {
-      const highlightRect = L.rectangle(changeset.bounds, this._highlightLayer._getChangesetStyle(changeset));
-      highlightRect.id = id;
-      this._highlightLayer.addLayer(highlightRect);
+      this._highlightLayer.addChangesetLayer(changeset);
     } else {
       this._highlightLayer.removeLayer(id);
     }

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -1,6 +1,10 @@
 OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
   getLayerId: function (layer) {
     return layer.id;
+  },
+
+  updateChangesetLayerBounds: function (changeset) {
+    this.getLayer(changeset.id)?.setBounds(changeset.bounds);
   }
 });
 
@@ -88,7 +92,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
         changesetNorthEast.lng -= shiftInWorldCircumferences * 360;
 
         for (const layer of this._bboxLayers) {
-          layer.getLayer(changeset.id)?.setBounds(changeset.bounds);
+          layer.updateChangesetLayerBounds(changeset);
         }
       }
     }

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -1,4 +1,8 @@
-OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({});
+OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
+  getLayerId: function (layer) {
+    return layer.id;
+  }
+});
 
 OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   _getSidebarRelativeClassName: function ({ sidebarRelativePosition }) {
@@ -145,8 +149,4 @@ OSM.HistoryChangesetsLayer.addInitHook(function () {
     this._borderLayer = new OSM.HistoryChangesetBboxLayer().addTo(this),
     this._highlightLayer = new OSM.HistoryChangesetBboxLayer().addTo(this)
   ];
-
-  for (const layer of this._bboxLayers) {
-    layer.getLayerId = (layer) => layer.id;
-  }
 });

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -8,6 +8,12 @@ OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
   }
 });
 
+OSM.HistoryChangesetBboxAreaLayer = OSM.HistoryChangesetBboxLayer.extend({});
+
+OSM.HistoryChangesetBboxBorderLayer = OSM.HistoryChangesetBboxLayer.extend({});
+
+OSM.HistoryChangesetBboxHighlightLayer = OSM.HistoryChangesetBboxLayer.extend({});
+
 OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   _getSidebarRelativeClassName: function ({ sidebarRelativePosition }) {
     if (sidebarRelativePosition > 0) {
@@ -149,8 +155,8 @@ OSM.HistoryChangesetsLayer.addInitHook(function () {
   this._changesets = new Map;
 
   this._bboxLayers = [
-    this._areaLayer = new OSM.HistoryChangesetBboxLayer().addTo(this),
-    this._borderLayer = new OSM.HistoryChangesetBboxLayer().addTo(this),
-    this._highlightLayer = new OSM.HistoryChangesetBboxLayer().addTo(this)
+    this._areaLayer = new OSM.HistoryChangesetBboxAreaLayer().addTo(this),
+    this._borderLayer = new OSM.HistoryChangesetBboxBorderLayer().addTo(this),
+    this._highlightLayer = new OSM.HistoryChangesetBboxHighlightLayer().addTo(this)
   ];
 });

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -606,6 +606,7 @@ tr.turn {
 .changeset-above-sidebar-viewport {
   --changeset-border-color: #CC7755;
   --changeset-fill-color: #888888;
+  --changeset-outline-color: #FFFFFF;
 }
 .changeset-in-sidebar-viewport {
   --changeset-border-color: #FF9500;
@@ -618,6 +619,7 @@ tr.turn {
 .changeset-below-sidebar-viewport {
   --changeset-border-color: #8888AA;
   --changeset-fill-color: #888888;
+  --changeset-outline-color: #FFFFFF;
 }
 
 #sidebar .changesets {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -613,6 +613,7 @@ tr.turn {
     --changeset-border-color: #FF6600;
   }
   --changeset-fill-color: #FFFFAF;
+  --changeset-outline-color: #FFFFFF;
 }
 .changeset-below-sidebar-viewport {
   --changeset-border-color: #8888AA;


### PR DESCRIPTION
This PR adds outlines on history pages for:
- bboxes of changesets inside the sidebar viewport
- highlighted bboxes

This attempts to address [the *hard to find the edit* / *color noise* problem](https://community.openstreetmap.org/t/better-osm-org-a-script-that-adds-useful-little-things-to-osm-org/121670/106).

I tried different colors for outlines. For example, I tried [black](https://community.openstreetmap.org/t/better-osm-org-a-script-that-adds-useful-little-things-to-osm-org/121670/108) for hover highlights. That makes them more noticeable, but the color itself looks too out of place. So temporarily I'm keeping all of them white.

## In-viewport bboxes

When there's a lot of bboxes shown on the map, the in-viewport bboxes don't stand out enough from the rest:
![image](https://github.com/user-attachments/assets/9ed1b2ca-b2c9-469b-8074-5a0e757f9015)

With outlines they are more visible:
![image](https://github.com/user-attachments/assets/fef00a4b-cdaf-4c95-9e5f-d52e5419b574)

## Highlighted bboxes

This is how a group of out-of-viewport bboxes look without any of them highlighted:
![image](https://github.com/user-attachments/assets/62253847-5357-4d48-b14d-3216dab6cbaf)

They don't look much different when one of them is highlighted, and you can't easily say see which bbox it is:
![image](https://github.com/user-attachments/assets/dc38767d-3989-42a4-aefc-1a840b07ce2e)

But with an outline it's easier to see the highlighted bbox:
![image](https://github.com/user-attachments/assets/721acaf9-30df-482d-a775-6395ded5d948)

