### PR TITLE
API changeset close resource

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -34,7 +34,7 @@ class ApiAbility
         can :read, :active_user_blocks_list if scopes.include?("read_prefs")
 
         if user.terms_agreed?
-          can [:create, :update, :upload, :close], Changeset if scopes.include?("write_map")
+          can [:create, :update, :upload], Changeset if scopes.include?("write_map")
           can [:create, :destroy], ChangesetSubscription if scopes.include?("write_map")
           can :create, ChangesetComment if scopes.include?("write_changeset_comments")
           can [:create, :update, :destroy], [Node, Way, Relation] if scopes.include?("write_map")

--- a/app/controllers/api/changesets/closes_controller.rb
+++ b/app/controllers/api/changesets/closes_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module Changesets
+    class ClosesController < ApiController
+      before_action :check_api_writable
+      before_action :authorize
+
+      authorize_resource :class => Changeset
+
+      before_action :require_public_data
+
+      # Helper methods for checking consistency
+      include ConsistencyValidations
+
+      ##
+      # marks a changeset as closed. this may be called multiple times
+      # on the same changeset, so is idempotent.
+      def update
+        changeset = Changeset.find(params[:changeset_id])
+        check_changeset_consistency(changeset, current_user)
+
+        # to close the changeset, we'll just set its closed_at time to
+        # now. this might not be enough if there are concurrency issues,
+        # but we'll have to wait and see.
+        changeset.set_closed_time_now
+
+        changeset.save!
+        head :ok
+      end
+    end
+  end
+end

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -6,12 +6,12 @@ module Api
 
     before_action :check_api_writable, :only => [:create, :update, :upload]
     before_action :setup_user_auth, :only => [:show]
-    before_action :authorize, :only => [:create, :update, :upload, :close]
+    before_action :authorize, :only => [:create, :update, :upload]
 
     authorize_resource
 
-    before_action :require_public_data, :only => [:create, :update, :upload, :close]
-    before_action :set_request_formats, :except => [:create, :close, :upload]
+    before_action :require_public_data, :only => [:create, :update, :upload]
+    before_action :set_request_formats, :except => [:create, :upload]
 
     skip_around_action :api_call_timeout, :only => [:upload]
 
@@ -85,22 +85,6 @@ module Api
       cs.subscribers << current_user
 
       render :plain => cs.id.to_s
-    end
-
-    ##
-    # marks a changeset as closed. this may be called multiple times
-    # on the same changeset, so is idempotent.
-    def close
-      changeset = Changeset.find(params[:id])
-      check_changeset_consistency(changeset, current_user)
-
-      # to close the changeset, we'll just set its closed_at time to
-      # now. this might not be enough if there are concurrency issues,
-      # but we'll have to wait and see.
-      changeset.set_closed_time_now
-
-      changeset.save!
-      head :ok
     end
 
     ##

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,12 +18,12 @@ OpenStreetMap::Application.routes.draw do
     get "permissions" => "permissions#show"
 
     post "changeset/:id/upload" => "changesets#upload", :as => :changeset_upload, :id => /\d+/
-    put "changeset/:id/close" => "changesets#close", :as => :changeset_close, :id => /\d+/
   end
 
   namespace :api, :path => "api/0.6" do
     resources :changesets, :only => [:index, :create]
     resources :changesets, :path => "changeset", :id => /\d+/, :only => [:show, :update] do
+      resource :close, :module => :changesets, :only => :update
       resource :download, :module => :changesets, :only => :show
       resource :subscription, :controller => :changeset_subscriptions, :only => [:create, :destroy]
       resources :changeset_comments, :path => "comment", :only => :create

--- a/test/controllers/api/changesets/closes_controller_test.rb
+++ b/test/controllers/api/changesets/closes_controller_test.rb
@@ -32,6 +32,18 @@ module Api
         assert_predicate changeset.reload, :open?
       end
 
+      def test_update_by_changeset_non_creator
+        user = create(:user)
+        changeset = create(:changeset)
+        auth_header = bearer_authorization_header user
+
+        put api_changeset_close_path(changeset), :headers => auth_header
+
+        assert_response :conflict
+        assert_equal "The user doesn't own that changeset", @response.body
+        assert_predicate changeset.reload, :open?
+      end
+
       def test_update_by_changeset_creator
         user = create(:user)
         changeset = create(:changeset, :user => user)
@@ -41,19 +53,6 @@ module Api
 
         assert_response :success
         assert_not_predicate changeset.reload, :open?
-      end
-
-      ##
-      # test that a different user can't close another user's changeset
-      def test_update_invalid
-        user = create(:user)
-        changeset = create(:changeset)
-
-        auth_header = bearer_authorization_header user
-
-        put api_changeset_close_path(changeset), :headers => auth_header
-        assert_response :conflict
-        assert_equal "The user doesn't own that changeset", @response.body
       end
 
       ##

--- a/test/controllers/api/changesets/closes_controller_test.rb
+++ b/test/controllers/api/changesets/closes_controller_test.rb
@@ -1,0 +1,99 @@
+require "test_helper"
+
+module Api
+  module Changesets
+    class ClosesControllerTest < ActionDispatch::IntegrationTest
+      ##
+      # test all routes which lead to this controller
+      def test_routes
+        assert_routing(
+          { :path => "/api/0.6/changeset/1/close", :method => :put },
+          { :controller => "api/changesets/closes", :action => "update", :changeset_id => "1" }
+        )
+      end
+
+      ##
+      # test that the user who opened a change can close it
+      def test_update
+        private_user = create(:user, :data_public => false)
+        private_changeset = create(:changeset, :user => private_user)
+        user = create(:user)
+        changeset = create(:changeset, :user => user)
+
+        ## Try without authentication
+        put api_changeset_close_path(changeset)
+        assert_response :unauthorized
+
+        ## Try using the non-public user
+        auth_header = bearer_authorization_header private_user
+        put api_changeset_close_path(private_changeset), :headers => auth_header
+        assert_require_public_data
+
+        ## The try with the public user
+        auth_header = bearer_authorization_header user
+
+        cs_id = changeset.id
+        put api_changeset_close_path(cs_id), :headers => auth_header
+        assert_response :success
+
+        # test that it really is closed now
+        cs = Changeset.find(changeset.id)
+        assert_not(cs.open?,
+                   "changeset should be closed now (#{cs.closed_at} > #{Time.now.utc}.")
+      end
+
+      ##
+      # test that a different user can't close another user's changeset
+      def test_update_invalid
+        user = create(:user)
+        changeset = create(:changeset)
+
+        auth_header = bearer_authorization_header user
+
+        put api_changeset_close_path(changeset), :headers => auth_header
+        assert_response :conflict
+        assert_equal "The user doesn't own that changeset", @response.body
+      end
+
+      ##
+      # test that you can't close using another method
+      def test_update_method_invalid
+        user = create(:user)
+        changeset = create(:changeset, :user => user)
+
+        auth_header = bearer_authorization_header user
+
+        get api_changeset_close_path(changeset), :headers => auth_header
+        assert_response :not_found
+        assert_template "rescues/routing_error"
+
+        post api_changeset_close_path(changeset), :headers => auth_header
+        assert_response :not_found
+        assert_template "rescues/routing_error"
+      end
+
+      ##
+      # check that you can't close a changeset that isn't found
+      def test_update_not_found
+        cs_ids = [0, -132, "123"]
+
+        # First try to do it with no auth
+        cs_ids.each do |id|
+          put api_changeset_close_path(id)
+          assert_response :unauthorized, "Shouldn't be able close the non-existant changeset #{id}, when not authorized"
+        rescue ActionController::UrlGenerationError => e
+          assert_match(/No route matches/, e.to_s)
+        end
+
+        # Now try with auth
+        auth_header = bearer_authorization_header
+        cs_ids.each do |id|
+          put api_changeset_close_path(id), :headers => auth_header
+          assert_response :not_found, "The changeset #{id} doesn't exist, so can't be closed"
+        rescue ActionController::UrlGenerationError => e
+          assert_match(/No route matches/, e.to_s)
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/api/changesets/closes_controller_test.rb
+++ b/test/controllers/api/changesets/closes_controller_test.rb
@@ -62,10 +62,21 @@ module Api
         assert_predicate changeset.reload, :open?
       end
 
-      def test_update_by_changeset_creator
+      def test_update_without_required_scope
         user = create(:user)
         changeset = create(:changeset, :user => user)
-        auth_header = bearer_authorization_header user
+        auth_header = bearer_authorization_header user, :scopes => %w[read_prefs]
+
+        put api_changeset_close_path(changeset), :headers => auth_header
+
+        assert_response :forbidden
+        assert_predicate changeset.reload, :open?
+      end
+
+      def test_update_by_changeset_creator_with_required_scope
+        user = create(:user)
+        changeset = create(:changeset, :user => user)
+        auth_header = bearer_authorization_header user, :scopes => %w[write_api]
 
         put api_changeset_close_path(changeset), :headers => auth_header
 

--- a/test/controllers/api/changesets/closes_controller_test.rb
+++ b/test/controllers/api/changesets/closes_controller_test.rb
@@ -16,6 +16,20 @@ module Api
         end
       end
 
+      def test_update_missing_changeset_when_unauthorized
+        put api_changeset_close_path(999111)
+
+        assert_response :unauthorized
+      end
+
+      def test_update_missing_changeset_by_regular_user
+        auth_header = bearer_authorization_header
+
+        put api_changeset_close_path(999111), :headers => auth_header
+
+        assert_response :not_found
+      end
+
       def test_update_when_unauthorized
         changeset = create(:changeset)
 
@@ -74,25 +88,6 @@ module Api
         post api_changeset_close_path(changeset), :headers => auth_header
         assert_response :not_found
         assert_template "rescues/routing_error"
-      end
-
-      ##
-      # check that you can't close a changeset that isn't found
-      def test_update_not_found
-        cs_ids = [0, "123"]
-
-        # First try to do it with no auth
-        cs_ids.each do |id|
-          put api_changeset_close_path(id)
-          assert_response :unauthorized, "Shouldn't be able close the non-existant changeset #{id}, when not authorized"
-        end
-
-        # Now try with auth
-        auth_header = bearer_authorization_header
-        cs_ids.each do |id|
-          put api_changeset_close_path(id), :headers => auth_header
-          assert_response :not_found, "The changeset #{id} doesn't exist, so can't be closed"
-        end
       end
     end
   end

--- a/test/controllers/api/changesets/closes_controller_test.rb
+++ b/test/controllers/api/changesets/closes_controller_test.rb
@@ -10,6 +10,10 @@ module Api
           { :path => "/api/0.6/changeset/1/close", :method => :put },
           { :controller => "api/changesets/closes", :action => "update", :changeset_id => "1" }
         )
+
+        assert_raises(ActionController::UrlGenerationError) do
+          put api_changeset_close_path(-132)
+        end
       end
 
       def test_update_when_unauthorized
@@ -75,14 +79,12 @@ module Api
       ##
       # check that you can't close a changeset that isn't found
       def test_update_not_found
-        cs_ids = [0, -132, "123"]
+        cs_ids = [0, "123"]
 
         # First try to do it with no auth
         cs_ids.each do |id|
           put api_changeset_close_path(id)
           assert_response :unauthorized, "Shouldn't be able close the non-existant changeset #{id}, when not authorized"
-        rescue ActionController::UrlGenerationError => e
-          assert_match(/No route matches/, e.to_s)
         end
 
         # Now try with auth
@@ -90,8 +92,6 @@ module Api
         cs_ids.each do |id|
           put api_changeset_close_path(id), :headers => auth_header
           assert_response :not_found, "The changeset #{id} doesn't exist, so can't be closed"
-        rescue ActionController::UrlGenerationError => e
-          assert_match(/No route matches/, e.to_s)
         end
       end
     end

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -33,10 +33,6 @@ module Api
         { :path => "/api/0.6/changeset/1/upload", :method => :post },
         { :controller => "api/changesets", :action => "upload", :id => "1" }
       )
-      assert_routing(
-        { :path => "/api/0.6/changeset/1/close", :method => :put },
-        { :controller => "api/changesets/closes", :action => "update", :changeset_id => "1" }
-      )
 
       assert_recognizes(
         { :controller => "api/changesets", :action => "create" },
@@ -646,89 +642,6 @@ module Api
       [0, -32, 233455644, "afg", "213"].each do |id|
         get api_changeset_path(id)
         assert_response :not_found, "should get a not found"
-      rescue ActionController::UrlGenerationError => e
-        assert_match(/No route matches/, e.to_s)
-      end
-    end
-
-    ##
-    # test that the user who opened a change can close it
-    def test_close
-      private_user = create(:user, :data_public => false)
-      private_changeset = create(:changeset, :user => private_user)
-      user = create(:user)
-      changeset = create(:changeset, :user => user)
-
-      ## Try without authentication
-      put api_changeset_close_path(changeset)
-      assert_response :unauthorized
-
-      ## Try using the non-public user
-      auth_header = bearer_authorization_header private_user
-      put api_changeset_close_path(private_changeset), :headers => auth_header
-      assert_require_public_data
-
-      ## The try with the public user
-      auth_header = bearer_authorization_header user
-
-      cs_id = changeset.id
-      put api_changeset_close_path(cs_id), :headers => auth_header
-      assert_response :success
-
-      # test that it really is closed now
-      cs = Changeset.find(changeset.id)
-      assert_not(cs.open?,
-                 "changeset should be closed now (#{cs.closed_at} > #{Time.now.utc}.")
-    end
-
-    ##
-    # test that a different user can't close another user's changeset
-    def test_close_invalid
-      user = create(:user)
-      changeset = create(:changeset)
-
-      auth_header = bearer_authorization_header user
-
-      put api_changeset_close_path(changeset), :headers => auth_header
-      assert_response :conflict
-      assert_equal "The user doesn't own that changeset", @response.body
-    end
-
-    ##
-    # test that you can't close using another method
-    def test_close_method_invalid
-      user = create(:user)
-      changeset = create(:changeset, :user => user)
-
-      auth_header = bearer_authorization_header user
-
-      get api_changeset_close_path(changeset), :headers => auth_header
-      assert_response :not_found
-      assert_template "rescues/routing_error"
-
-      post api_changeset_close_path(changeset), :headers => auth_header
-      assert_response :not_found
-      assert_template "rescues/routing_error"
-    end
-
-    ##
-    # check that you can't close a changeset that isn't found
-    def test_close_not_found
-      cs_ids = [0, -132, "123"]
-
-      # First try to do it with no auth
-      cs_ids.each do |id|
-        put api_changeset_close_path(id)
-        assert_response :unauthorized, "Shouldn't be able close the non-existant changeset #{id}, when not authorized"
-      rescue ActionController::UrlGenerationError => e
-        assert_match(/No route matches/, e.to_s)
-      end
-
-      # Now try with auth
-      auth_header = bearer_authorization_header
-      cs_ids.each do |id|
-        put api_changeset_close_path(id), :headers => auth_header
-        assert_response :not_found, "The changeset #{id} doesn't exist, so can't be closed"
       rescue ActionController::UrlGenerationError => e
         assert_match(/No route matches/, e.to_s)
       end

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -35,7 +35,7 @@ module Api
       )
       assert_routing(
         { :path => "/api/0.6/changeset/1/close", :method => :put },
-        { :controller => "api/changesets", :action => "close", :id => "1" }
+        { :controller => "api/changesets/closes", :action => "update", :changeset_id => "1" }
       )
 
       assert_recognizes(
@@ -660,19 +660,19 @@ module Api
       changeset = create(:changeset, :user => user)
 
       ## Try without authentication
-      put changeset_close_path(changeset)
+      put api_changeset_close_path(changeset)
       assert_response :unauthorized
 
       ## Try using the non-public user
       auth_header = bearer_authorization_header private_user
-      put changeset_close_path(private_changeset), :headers => auth_header
+      put api_changeset_close_path(private_changeset), :headers => auth_header
       assert_require_public_data
 
       ## The try with the public user
       auth_header = bearer_authorization_header user
 
       cs_id = changeset.id
-      put changeset_close_path(cs_id), :headers => auth_header
+      put api_changeset_close_path(cs_id), :headers => auth_header
       assert_response :success
 
       # test that it really is closed now
@@ -689,7 +689,7 @@ module Api
 
       auth_header = bearer_authorization_header user
 
-      put changeset_close_path(changeset), :headers => auth_header
+      put api_changeset_close_path(changeset), :headers => auth_header
       assert_response :conflict
       assert_equal "The user doesn't own that changeset", @response.body
     end
@@ -702,11 +702,11 @@ module Api
 
       auth_header = bearer_authorization_header user
 
-      get changeset_close_path(changeset), :headers => auth_header
+      get api_changeset_close_path(changeset), :headers => auth_header
       assert_response :not_found
       assert_template "rescues/routing_error"
 
-      post changeset_close_path(changeset), :headers => auth_header
+      post api_changeset_close_path(changeset), :headers => auth_header
       assert_response :not_found
       assert_template "rescues/routing_error"
     end
@@ -718,7 +718,7 @@ module Api
 
       # First try to do it with no auth
       cs_ids.each do |id|
-        put changeset_close_path(id)
+        put api_changeset_close_path(id)
         assert_response :unauthorized, "Shouldn't be able close the non-existant changeset #{id}, when not authorized"
       rescue ActionController::UrlGenerationError => e
         assert_match(/No route matches/, e.to_s)
@@ -727,7 +727,7 @@ module Api
       # Now try with auth
       auth_header = bearer_authorization_header
       cs_ids.each do |id|
-        put changeset_close_path(id), :headers => auth_header
+        put api_changeset_close_path(id), :headers => auth_header
         assert_response :not_found, "The changeset #{id} doesn't exist, so can't be closed"
       rescue ActionController::UrlGenerationError => e
         assert_match(/No route matches/, e.to_s)


### PR DESCRIPTION
Continues #5801.

Creates changeset close resource that responds to `PUT /api/0.6/changeset/:changeset_id/close`, which doesn't change the API.

I think `PUT` is wrong here because it should be idempotent. If executed twice, the result should be the same. And it's the same, changeset is closed, except for the response status. The second response is `Conflict`, but shouldn't it be `OK`? I'm not changing this yet, if this needs fixing, the backwards-compatible fix is to make the route respond to `POST`.