### PR TITLE
Reorganize parseHash to avoid needing to destructure parseHash.center

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -21,7 +21,7 @@ $(function () {
   }
   if (mapParams.object) {
     params.set("id", mapParams.object.type + "/" + mapParams.object.id);
-    if (hashArgs.center) ({ zoom, center: { lat, lng: lon } } = hashArgs);
+    if (hashArgs.center) ({ zoom, lat, lon } = hashArgs);
   }
   if (lat && lon) params.set("map", [zoom || 17, lat, lon].join("/"));
 

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -89,9 +89,7 @@ OSM = {
 
     // Decide on a map starting position. Various ways of doing this.
     if (hash.center) {
-      mapParams.lon = hash.center.lng;
-      mapParams.lat = hash.center.lat;
-      mapParams.zoom = hash.zoom;
+      Object.assign(mapParams, hash);
     } else if (params.has("bbox")) {
       const [minlon, minlat, maxlon, maxlat] = params.get("bbox").split(",");
       mapParams.bounds = bboxToLatLngBounds({ minlon, minlat, maxlon, maxlat });
@@ -159,22 +157,20 @@ OSM = {
   },
 
   parseHash: function (hash = location.hash) {
-    const args = {};
-
     const i = hash.indexOf("#");
-    if (i < 0) {
-      return args;
-    }
+    if (i < 0) return {};
 
-    const hashParams = new URLSearchParams(hash.slice(i + 1));
-
-    const map = (hashParams.get("map") || "").split("/"),
+    const hashParams = new URLSearchParams(hash.slice(i + 1)),
+          map = (hashParams.get("map") || "").split("/"),
           zoom = parseInt(map[0], 10),
           lat = parseFloat(map[1]),
-          lon = parseFloat(map[2]);
+          lon = parseFloat(map[2]),
+          args = {};
 
     if (!isNaN(zoom) && !isNaN(lat) && !isNaN(lon)) {
       args.center = new L.LatLng(lat, lon);
+      args.lat = lat;
+      args.lon = lon;
       args.zoom = zoom;
     }
 


### PR DESCRIPTION
The destructuring of parseHash.center makes using parseHash more unwieldy. Adding these parameters separately allows for easier integration elsewhere.