### PR TITLE
Move dashboard-specific javascript to dashboard.js

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,0 +1,33 @@
+//= require leaflet.locate
+
+$(function () {
+  const defaultHomeZoom = 12;
+  let map;
+
+  if ($("#map").length) {
+    map = L.map("map", {
+      attributionControl: false,
+      zoomControl: false
+    }).addLayer(new L.OSM.Mapnik());
+
+    const position = $("html").attr("dir") === "rtl" ? "topleft" : "topright";
+
+    L.OSM.zoom({ position }).addTo(map);
+
+    L.OSM.locate({ position }).addTo(map);
+
+    if (OSM.home) {
+      map.setView([OSM.home.lat, OSM.home.lon], defaultHomeZoom);
+    } else {
+      map.setView([0, 0], 0);
+    }
+
+    $("[data-user]").each(function () {
+      const user = $(this).data("user");
+      if (user.lon && user.lat) {
+        L.marker([user.lat, user.lon], { icon: OSM.getMarker({ icon: user.icon }) }).addTo(map)
+          .bindPopup(user.description, { minWidth: 200 });
+      }
+    });
+  }
+});

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -10,7 +10,7 @@
       </div>
     <% else %>
       <% content_for :head do %>
-        <%= javascript_include_tag "user" %>
+        <%= javascript_include_tag "dashboard" %>
       <% end %>
       <% user_data = {
            :lon => current_user.home_lon,

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -57,7 +57,7 @@
       <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.home_location? %> checked <% end %> id="updatehome" />
       <label class="form-check-label" for="updatehome"><%= t ".update home location on click" %></label>
     </div>
-    <%= tag.div "", :id => "map", :class => "content_map set_location border border-secondary-subtle rounded z-0" %>
+    <%= tag.div "", :id => "map", :class => "content_map border border-secondary-subtle rounded z-0" %>
   </fieldset>
 
   <%= f.primary t(".save") %>

--- a/test/system/dashboard_test.rb
+++ b/test/system/dashboard_test.rb
@@ -49,4 +49,25 @@ class DashboardSystemTest < ApplicationSystemTestCase
       assert_link "Unfollow", :below => followings_heading, :above => others_nearby_heading
     end
   end
+
+  test "show map with home marker if home location is set" do
+    user = create(:user, :display_name => "Fred Tester", :home_lon => 1.1, :home_lat => 1.1)
+    sign_in_as(user)
+
+    visit dashboard_path
+
+    within "#map" do
+      assert_no_text "Your location"
+      assert_no_link "Fred Tester"
+
+      find("img.leaflet-marker-icon").click
+
+      assert_text "Your location"
+      assert_link "Fred Tester"
+
+      click_on "Fred Tester"
+    end
+
+    assert_current_path user_path(user)
+  end
 end


### PR DESCRIPTION
Fixes #5971.

`user.js` does too many different things. It's better to take it apart and have smaller scripts included from all of the pages that currently include it.

This PR takes out dashboard-specific code from `user.js` and puth it into `dashboard.js`. This code doesn't include `OSM.HomeLocationNameGeocoder` which would fail on dashboard pages breaking the map:

![image](https://github.com/user-attachments/assets/025776f8-2015-485e-adc3-01f5e415b7f4)

