### PR TITLE
Add headline to heatmap

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,6 +43,8 @@ class UsersController < ApplicationController
             }
           end
       end
+
+      @changes_count = @heatmap_data.sum { |entry| entry[:total_changes] }
     else
       render_unknown_user params[:display_name]
     end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -248,6 +248,9 @@
 <div class="richtext text-break"><%= @user.description.to_html %></div>
 
 <% if @heatmap_data.present? %>
+  <h2 class="text-body-secondary fs-5">
+    <%= t(".contributions", :count => @changes_count) %>
+  </h2>
   <div class="row">
     <div class="col overflow-auto">
       <div class="heatmap-wrapper d-flex align-items-start">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2939,6 +2939,9 @@ en:
       delete_user: "Delete this User"
       confirm: "Confirm"
       report: Report this User
+      contributions:
+        one: "%{count} contribution in the last year"
+        other: "%{count} contributions in the last year"
     go_public:
       flash success: "All your edits are now public, and you are now allowed to edit."
     issued_blocks:

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -423,4 +423,33 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       assert_equal expected_data, heatmap_data
     end
   end
+
+  def test_heatmap_headline_changset_zero
+    user = create(:user)
+
+    get user_path(user)
+
+    assert_response :success
+    assert_select "h2.text-body-secondary.fs-5", :count => 0
+  end
+
+  def test_heatmap_headline_changeset_singular
+    user = create(:user)
+    create(:changeset, :user => user, :created_at => 4.months.ago.beginning_of_day, :num_changes => 1)
+
+    get user_path(user)
+
+    assert_response :success
+    assert_select "h2.text-body-secondary.fs-5", :text => "1 contribution in the last year"
+  end
+
+  def test_heatmap_headline_changeset_plural
+    user = create(:user)
+    create(:changeset, :user => user, :created_at => 4.months.ago.beginning_of_day, :num_changes => 12)
+
+    get user_path(user)
+
+    assert_response :success
+    assert_select "h2.text-body-secondary.fs-5", :text => "12 contributions in the last year"
+  end
 end


### PR DESCRIPTION
### Description
Adds dynamic headline to heatmap. Addresses https://github.com/openstreetmap/openstreetmap-website/issues/5810.
<img width="952" alt="Screenshot 2025-05-04 at 6 33 05 AM" src="https://github.com/user-attachments/assets/b5613300-5e89-4369-b270-ca3f88e2484a" />


### How has this been tested?
On my local machine I've verified that the header works as expected in the case that a user has 0, 1, and >1 contributions.

