### PR TITLE
API versions, capabilities and permissions resources

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ OpenStreetMap::Application.routes.draw do
   # API
   namespace :api do
     get "capabilities" => "capabilities#show", :as => nil # Deprecated, remove when 0.6 support is removed
-    get "versions" => "versions#show"
+    resource :versions, :only => :show
   end
 
   namespace :api, :path => "api/0.6" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,15 +9,12 @@ OpenStreetMap::Application.routes.draw do
 
   # API
   namespace :api do
-    get "capabilities" => "capabilities#show" # Deprecated, remove when 0.6 support is removed
+    get "capabilities" => "capabilities#show", :as => nil # Deprecated, remove when 0.6 support is removed
     get "versions" => "versions#show"
   end
 
-  scope "api/0.6", :module => :api do
-    get "capabilities" => "capabilities#show"
-  end
-
   namespace :api, :path => "api/0.6" do
+    resource :capabilities, :only => :show
     resource :permissions, :only => :show
 
     resources :changesets, :only => [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,10 +15,11 @@ OpenStreetMap::Application.routes.draw do
 
   scope "api/0.6", :module => :api do
     get "capabilities" => "capabilities#show"
-    get "permissions" => "permissions#show"
   end
 
   namespace :api, :path => "api/0.6" do
+    resource :permissions, :only => :show
+
     resources :changesets, :only => [:index, :create]
     resources :changesets, :path => "changeset", :id => /\d+/, :only => [:show, :update] do
       scope :module => :changesets do

--- a/test/controllers/api/capabilities_controller_test.rb
+++ b/test/controllers/api/capabilities_controller_test.rb
@@ -48,7 +48,7 @@ module Api
     end
 
     def test_capabilities_json
-      get api_capabilities_path, :params => { :format => "json" }
+      get api_capabilities_path(:format => "json")
       assert_response :success
       js = ActiveSupport::JSON.decode(@response.body)
       assert_not_nil js

--- a/test/controllers/api/permissions_controller_test.rb
+++ b/test/controllers/api/permissions_controller_test.rb
@@ -16,14 +16,14 @@ module Api
     end
 
     def test_permissions_anonymous
-      get permissions_path
+      get api_permissions_path
       assert_response :success
       assert_select "osm > permissions", :count => 1 do
         assert_select "permission", :count => 0
       end
 
       # Test json
-      get permissions_path(:format => "json")
+      get api_permissions_path(:format => "json")
       assert_response :success
       assert_equal "application/json", @response.media_type
 
@@ -35,7 +35,7 @@ module Api
     def test_permissions_oauth2
       user = create(:user)
       auth_header = bearer_authorization_header(user, :scopes => %w[read_prefs write_api])
-      get permissions_path, :headers => auth_header
+      get api_permissions_path, :headers => auth_header
       assert_response :success
       assert_select "osm > permissions", :count => 1 do
         assert_select "permission", :count => 2


### PR DESCRIPTION
Converts to resources everything in `routes.rb` that comes before changesets, except for the deprecated `/api/capabilities`.