### PR TITLE
Adjust colors of out-of-viewport bboxes on history pages

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -605,7 +605,7 @@ tr.turn {
 
 .changeset-above-sidebar-viewport {
   --changeset-border-color: #CC6655;
-  --changeset-fill-color: #888888;
+  --changeset-fill-color: #DDBBBB;
   --changeset-outline-color: #FFFFFF;
 }
 .changeset-in-sidebar-viewport {
@@ -618,7 +618,7 @@ tr.turn {
 }
 .changeset-below-sidebar-viewport {
   --changeset-border-color: #8888AA;
-  --changeset-fill-color: #888888;
+  --changeset-fill-color: #CCCCDD;
   --changeset-outline-color: #FFFFFF;
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -604,7 +604,7 @@ tr.turn {
 /* Rules for the history sidebar */
 
 .changeset-above-sidebar-viewport {
-  --changeset-border-color: #CC7755;
+  --changeset-border-color: #CC6655;
   --changeset-fill-color: #888888;
   --changeset-outline-color: #FFFFFF;
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -606,7 +606,7 @@ tr.turn {
 .changeset-above-sidebar-viewport {
   --changeset-border-color: #CC6655;
   --changeset-fill-color: #DDBBBB;
-  --changeset-outline-color: #FFFFFF;
+  --changeset-outline-color: #FFF4F4;
 }
 .changeset-in-sidebar-viewport {
   --changeset-border-color: #FF9500;
@@ -619,7 +619,7 @@ tr.turn {
 .changeset-below-sidebar-viewport {
   --changeset-border-color: #8888AA;
   --changeset-fill-color: #CCCCDD;
-  --changeset-outline-color: #FFFFFF;
+  --changeset-outline-color: #F4F4FF;
 }
 
 #sidebar .changesets {


### PR DESCRIPTION
- Make newer changeset colors redder. The blue color of older changesets was [more noticeable](https://community.openstreetmap.org/t/blaue-bounding-boxes/128904) than the red of newer. It wasn't very red because I didn't want it to grab too much attention. But looks like it's better to make it slightly more red to increase the distance between it and the in-viewport orange.
- Make fill colors lighter. The highlight fill colors for out-of-viewport changesets are significantly darker than the color for in-viewport changesets. That's because I left there a temporary gray color before I decided on older/newer colors. Now after changing the newer color I can adjust the fill colors to be both lighter and closer to the newer/older colors.

Newer changeset before:
![image](https://github.com/user-attachments/assets/050c05db-0732-47d6-81cb-d3470237f376)

Newer changeset after:
![image](https://github.com/user-attachments/assets/a5d7226a-5571-47f2-a0e8-ad88e54bab9f)

Older changeset before:
![image](https://github.com/user-attachments/assets/ef529efc-00b8-4a7e-bd5b-b916d285f792)

Older changeset after:
![image](https://github.com/user-attachments/assets/2175b97a-f680-4b60-a4e3-578a2393050d)
