### PR TITLE
Remove area layers for changesets completely covering map view

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -90,24 +90,24 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
 
   updateChangesetsGeometry: function (map) {
     for (const changeset of this._changesets.values()) {
-      const topLeft = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.minlon)),
-            bottomRight = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.maxlon)),
-            width = bottomRight.x - topLeft.x,
-            height = bottomRight.y - topLeft.y,
-            minSize = 20; // Min width/height of changeset in pixels
+      const changesetMinCorner = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.minlon)),
+            changesetMaxCorner = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.maxlon)),
+            changesetSizeX = changesetMaxCorner.x - changesetMinCorner.x,
+            changesetSizeY = changesetMaxCorner.y - changesetMinCorner.y,
+            changesetSizeLowerBound = 20; // Min width/height of changeset in pixels
 
-      if (width < minSize) {
-        topLeft.x -= ((minSize - width) / 2);
-        bottomRight.x += ((minSize - width) / 2);
+      if (changesetSizeX < changesetSizeLowerBound) {
+        changesetMinCorner.x -= (changesetSizeLowerBound - changesetSizeX) / 2;
+        changesetMaxCorner.x += (changesetSizeLowerBound - changesetSizeX) / 2;
       }
 
-      if (height < minSize) {
-        topLeft.y -= ((minSize - height) / 2);
-        bottomRight.y += ((minSize - height) / 2);
+      if (changesetSizeY < changesetSizeLowerBound) {
+        changesetMinCorner.y -= (changesetSizeLowerBound - changesetSizeY) / 2;
+        changesetMaxCorner.y += (changesetSizeLowerBound - changesetSizeY) / 2;
       }
 
-      changeset.bounds = L.latLngBounds(map.unproject(topLeft),
-                                        map.unproject(bottomRight));
+      changeset.bounds = L.latLngBounds(map.unproject(changesetMinCorner),
+                                        map.unproject(changesetMaxCorner));
     }
 
     this._updateChangesetLocations(map);

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -115,18 +115,18 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   },
 
   _updateChangesetLocations: function (map) {
-    const mapCenterLng = map.getCenter().lng;
+    const mapViewCenterLng = map.getCenter().lng;
 
     for (const changeset of this._changesets.values()) {
-      const changesetNorthWest = changeset.bounds.getNorthWest();
-      const changesetSouthEast = changeset.bounds.getSouthEast();
-      const changesetCenterLng = (changesetNorthWest.lng + changesetSouthEast.lng) / 2;
-      const shiftInWorldCircumferences = Math.round((changesetCenterLng - mapCenterLng) / 360);
+      const changesetNorthWestLatLng = changeset.bounds.getNorthWest();
+      const changesetSouthEastLatLng = changeset.bounds.getSouthEast();
+      const changesetCenterLng = (changesetNorthWestLatLng.lng + changesetSouthEastLatLng.lng) / 2;
+      const shiftInWorldCircumferences = Math.round((changesetCenterLng - mapViewCenterLng) / 360);
 
       if (shiftInWorldCircumferences) {
-        changesetNorthWest.lng -= shiftInWorldCircumferences * 360;
-        changesetSouthEast.lng -= shiftInWorldCircumferences * 360;
-        changeset.bounds = L.latLngBounds(changesetNorthWest, changesetSouthEast);
+        changesetNorthWestLatLng.lng -= shiftInWorldCircumferences * 360;
+        changesetSouthEastLatLng.lng -= shiftInWorldCircumferences * 360;
+        changeset.bounds = L.latLngBounds(changesetNorthWestLatLng, changesetSouthEastLatLng);
 
         for (const layer of this._bboxLayers) {
           layer.updateChangesetLayerBounds(changeset);

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -118,14 +118,15 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     const mapCenterLng = map.getCenter().lng;
 
     for (const changeset of this._changesets.values()) {
-      const changesetSouthWest = changeset.bounds.getSouthWest();
-      const changesetNorthEast = changeset.bounds.getNorthEast();
-      const changesetCenterLng = (changesetSouthWest.lng + changesetNorthEast.lng) / 2;
+      const changesetNorthWest = changeset.bounds.getNorthWest();
+      const changesetSouthEast = changeset.bounds.getSouthEast();
+      const changesetCenterLng = (changesetNorthWest.lng + changesetSouthEast.lng) / 2;
       const shiftInWorldCircumferences = Math.round((changesetCenterLng - mapCenterLng) / 360);
 
       if (shiftInWorldCircumferences) {
-        changesetSouthWest.lng -= shiftInWorldCircumferences * 360;
-        changesetNorthEast.lng -= shiftInWorldCircumferences * 360;
+        changesetNorthWest.lng -= shiftInWorldCircumferences * 360;
+        changesetSouthEast.lng -= shiftInWorldCircumferences * 360;
+        changeset.bounds = L.latLngBounds(changesetNorthWest, changesetSouthEast);
 
         for (const layer of this._bboxLayers) {
           layer.updateChangesetLayerBounds(changeset);

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -90,24 +90,24 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
 
   updateChangesetShapes: function (map) {
     for (const changeset of this._changesets.values()) {
-      const bottomLeft = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.minlon)),
-            topRight = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.maxlon)),
-            width = topRight.x - bottomLeft.x,
-            height = bottomLeft.y - topRight.y,
+      const topLeft = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.minlon)),
+            bottomRight = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.maxlon)),
+            width = bottomRight.x - topLeft.x,
+            height = bottomRight.y - topLeft.y,
             minSize = 20; // Min width/height of changeset in pixels
 
       if (width < minSize) {
-        bottomLeft.x -= ((minSize - width) / 2);
-        topRight.x += ((minSize - width) / 2);
+        topLeft.x -= ((minSize - width) / 2);
+        bottomRight.x += ((minSize - width) / 2);
       }
 
       if (height < minSize) {
-        bottomLeft.y += ((minSize - height) / 2);
-        topRight.y -= ((minSize - height) / 2);
+        topLeft.y -= ((minSize - height) / 2);
+        bottomRight.y += ((minSize - height) / 2);
       }
 
-      changeset.bounds = L.latLngBounds(map.unproject(bottomLeft),
-                                        map.unproject(topRight));
+      changeset.bounds = L.latLngBounds(map.unproject(topLeft),
+                                        map.unproject(bottomRight));
     }
 
     this.updateChangesetLocations(map);

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -85,10 +85,10 @@ OSM.HistoryChangesetBboxHighlightBorderLayer = OSM.HistoryChangesetBboxLayer.ext
 OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
   updateChangesets: function (map, changesets) {
     this._changesets = new Map(changesets.map(changeset => [changeset.id, changeset]));
-    this.updateChangesetShapes(map);
+    this.updateChangesetsGeometry(map);
   },
 
-  updateChangesetShapes: function (map) {
+  updateChangesetsGeometry: function (map) {
     for (const changeset of this._changesets.values()) {
       const topLeft = map.project(L.latLng(changeset.bbox.maxlat, changeset.bbox.minlon)),
             bottomRight = map.project(L.latLng(changeset.bbox.minlat, changeset.bbox.maxlon)),
@@ -110,11 +110,11 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
                                         map.unproject(bottomRight));
     }
 
-    this.updateChangesetLocations(map);
-    this.reorderChangesets();
+    this._updateChangesetLocations(map);
+    this.updateChangesetsOrder();
   },
 
-  updateChangesetLocations: function (map) {
+  _updateChangesetLocations: function (map) {
     const mapCenterLng = map.getCenter().lng;
 
     for (const changeset of this._changesets.values()) {
@@ -135,7 +135,7 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     }
   },
 
-  reorderChangesets: function () {
+  updateChangesetsOrder: function () {
     const changesetEntries = [...this._changesets];
     changesetEntries.sort(([, a], [, b]) => b.bounds.getSize() - a.bounds.getSize());
     this._changesets = new Map(changesetEntries);

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -263,11 +263,13 @@ OSM.History = function (map) {
       OSM.router.replace("/history" + window.location.hash);
       loadFirstChangesets();
     } else {
+      $("#sidebar_content .changesets ol li").removeClass("selected");
       changesetsLayer.updateChangesetsGeometry(map);
     }
   }
 
   function zoomEndListener() {
+    $("#sidebar_content .changesets ol li").removeClass("selected");
     changesetsLayer.updateChangesetsGeometry(map);
   }
 

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -85,7 +85,7 @@ OSM.History = function (map) {
         if (id) changesetsLayer.setChangesetSidebarRelativePosition(id, -1);
       });
 
-      changesetsLayer.reorderChangesets();
+      changesetsLayer.updateChangesetsOrder();
 
       if (keepInitialLocation) {
         keepInitialLocation = false;
@@ -263,12 +263,12 @@ OSM.History = function (map) {
       OSM.router.replace("/history" + window.location.hash);
       loadFirstChangesets();
     } else {
-      changesetsLayer.updateChangesetLocations(map);
+      changesetsLayer.updateChangesetsGeometry(map);
     }
   }
 
   function zoomEndListener() {
-    changesetsLayer.updateChangesetShapes(map);
+    changesetsLayer.updateChangesetsGeometry(map);
   }
 
   function updateMap() {


### PR DESCRIPTION
Let's suppose there's a large enough changeset:
![image](https://github.com/user-attachments/assets/9421a626-f521-49da-8716-1b04e2499cde)

You can zoom in and this changeset is going to cover the view completely:
![image](https://github.com/user-attachments/assets/da1bc5b1-cf08-4c06-8fde-53604a26eaea)

If you click anywhere on the map you'll open this changeset, unless you click some other changeset. But that's not a good way to pick this changeset because you can even see it. Seeing it requires some part of its border to be in view and there isn't any. It also fills the entire view with its hover color, which even though transparent makes things more difficult to see.

This PR checks whether any part of a changeset border is visible and if none is, removes the area layer of the changeset. This disables hover on area for this changeset, making it easier to see and select other changesets that fit on the screen:
![image](https://github.com/user-attachments/assets/6f3c90a7-dbbc-496c-a74b-8b897cc38415)

If you look at the edit history of some place and do *load more* a few times, often you encounter planetary scale changesets. You'll be at a wrong zoom level to see them properly, so it's better not to see them at all when zoomed in to the place. See https://github.com/openstreetmap/openstreetmap-website/pull/5924#issuecomment-2817089708. These huge changesets are still selectable in the sidebar with hover effects.