### PR TITLE
Remove a few exclusions from RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,12 +23,6 @@ Rails:
 Layout/ExtraSpacing:
   AllowForAlignment: true
 
-Lint/PercentStringArray:
-  Exclude:
-    - 'config/initializers/secure_headers.rb'
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/site_controller.rb'
-
 Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'
@@ -78,10 +72,6 @@ Rails/SkipsModelValidations:
 Style/Documentation:
   Enabled: false
 
-Style/FormatStringToken:
-  Exclude:
-    - 'config/routes.rb'
-
 Style/IfInsideElse:
   Enabled: false
 
@@ -93,9 +83,6 @@ Style/HashEachMethods:
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
-  Exclude:
-    - 'lib/tasks/testing.rake'
-    - 'config/initializers/wrap_parameters.rb'
 
 Style/HashTransformKeys:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -166,7 +166,6 @@ Rails/ThreeStateBooleanColumn:
 # This cop supports safe autocorrection (--autocorrect).
 Rake/Desc:
   Exclude:
-    - 'lib/tasks/auto_annotate_models.rake'
     - 'lib/tasks/eslint.rake'
     - 'lib/tasks/subscribe_diary_authors.rake'
     - 'lib/tasks/subscribe_old_changesets.rake'

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -5,7 +5,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
+  wrap_parameters :format => [:json]
 end
 
 # To enable root element in JSON for ActiveRecord objects.


### PR DESCRIPTION
Going through the Rubocop config, I found a few exclusions that weren't necessary anymore.