### PR TITLE
Suppress strokes on bbox area layers using stroke: false

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -28,7 +28,7 @@ OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
 OSM.HistoryChangesetBboxAreaLayer = OSM.HistoryChangesetBboxLayer.extend({
   _getChangesetStyle: function (changeset) {
     return {
-      weight: 0,
+      stroke: false,
       fillOpacity: 0,
       className: this._getSidebarRelativeClassName(changeset)
     };


### PR DESCRIPTION
Previously strokes were suppressed using weight: 0 which made them have zero width. That produced some unnecessary svg attributes for strokes.