### PR TITLE
Company Name on Profile Page

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -29,6 +29,8 @@ class ProfilesController < ApplicationController
       current_user.image_use_gravatar = true
     end
 
+    current_user.company = params[:user][:company]
+
     current_user.home_lat = params[:user][:home_lat]
     current_user.home_lon = params[:user][:home_lon]
     current_user.home_location_name = params[:user][:home_location_name]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@
 #  diary_comments_count :integer          default(0)
 #  note_comments_count  :integer          default(0)
 #  creation_address     :inet
+#  company              :string
 #
 # Indexes
 #

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -40,6 +40,10 @@
     </div>
   </fieldset>
 
+  <fieldset class="mb-3">
+    <%= f.text_field :company, :wrapper_class => "col-sm-8", :id => "company" %>
+  </fieldset>
+
   <fieldset>
     <legend><%= t ".home location" -%></legend>
     <p id="home_message" class="text-body-secondary m-0<% if current_user.home_location? %> invisible<% end %>"><%= t ".no home location" %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -153,6 +153,14 @@
               </dt>
               <dd class="list-inline-item"><%= @user.home_location_name %></dd>
             <% end %>
+            <% if @user.company&.strip.present? %>
+              <dt class="list-inline-item m-0 align-text-bottom">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-suitcase-lg-fill" viewBox="0 0 16 16">
+                  <path d="M7 0a2 2 0 0 0-2 2H1.5A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14H2a.5.5 0 0 0 1 0h10a.5.5 0 0 0 1 0h.5a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2H11a2 2 0 0 0-2-2zM6 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1zM3 13V3h1v10zm9 0V3h1v10z" />
+                </svg>
+              </dt>
+              <dd class="list-inline-item"><%= @user.company %></dd>
+            <% end %>
             <dt class="list-inline-item m-0"><%= t ".mapper since" %></dt>
             <dd class="list-inline-item"><%= l @user.created_at.to_date, :format => :long %></dd>
             <dt class="list-inline-item m-0"><%= t ".last map edit" %></dt>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
         active: "Active"
         display_name: "Display Name"
         description: Profile Description
+        company: Company
         home_lat: Latitude
         home_lon: Longitude
         languages: Preferred Languages
@@ -2904,6 +2905,7 @@ en:
       mapper since: "Mapper since:"
       last map edit: "Last map edit:"
       home location: "Home location"
+      company: "Company"
       no activity yet: "No activity yet"
       uid: "User id:"
       ct status: "Contributor terms:"

--- a/db/migrate/20250506052030_add_company_to_users.rb
+++ b/db/migrate/20250506052030_add_company_to_users.rb
@@ -1,0 +1,5 @@
+class AddCompanyToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :company, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1520,7 +1520,8 @@ CREATE TABLE public.users (
     diary_comments_count integer DEFAULT 0,
     note_comments_count integer DEFAULT 0,
     creation_address inet,
-    home_location_name character varying
+    home_location_name character varying,
+    company character varying
 );
 
 
@@ -3451,6 +3452,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('23'),
 ('22'),
 ('21'),
+('20250506052030'),
 ('20250304172798'),
 ('20250304172758'),
 ('20250212160355'),

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -59,5 +59,14 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     get edit_profile_path
     assert_select "form > fieldset > div > div.col-sm-10 > div > input[name=avatar_action][checked]", false
     assert_select "form > fieldset > div > div.col-sm-10 > div > div.form-check > input[name=avatar_action][checked]", false
+
+    # Updating the company name should work
+    put profile_path, :params => { :user => { :company => "new company", :description => user.description } }
+    assert_redirected_to user_path(user)
+    follow_redirect!
+    assert_response :success
+    assert_template :show
+    assert_select ".alert-success", /^Profile updated./
+    assert_select "dd", "new company"
   end
 end

--- a/test/system/user_company_test.rb
+++ b/test/system/user_company_test.rb
@@ -1,0 +1,27 @@
+require "application_system_test_case"
+
+class UserCompanyTest < ApplicationSystemTestCase
+  test "User can change company" do
+    user = create(:user)
+    sign_in_as(user)
+    company = "Test Company"
+
+    visit user_path(user)
+
+    within_content_heading do
+      assert_no_selector ".bi.bi-suitcase-lg-fill"
+    end
+
+    visit edit_profile_path
+
+    assert_text I18n.t("activerecord.attributes.user.company")
+
+    fill_in "Company", :with => company
+    click_on I18n.t("profiles.edit.save")
+
+    assert_text I18n.t("profiles.update.success")
+    within_content_heading do
+      assert_text company
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses "Company Name on Profile Page" issue mentioned in #5986

PR adds Company Name functionality on Profile page. If user modifies company field, value will be shown on the profile page. It can be changed from `Edit Profile`. `company` field can be empty, in which case, company information will be hidden on the profile page.
Ruby - `ProfilesController` has one more field to save
DB - nullable `company` column added to the user table
JS - no change

Tested: manually, controller tests (checking controller saving functionality), system tests (checking translations and flow)

Fixes #5986

Screenshots:
![image](https://github.com/user-attachments/assets/1ae32cc1-7674-4023-9cb6-8d1863a5dc54)
![image](https://github.com/user-attachments/assets/a6b07041-cd85-44c3-8434-108e0a7d57a2)