### PR TITLE
Move `gravatar_enable` method to User model

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -66,7 +66,7 @@ Metrics/BlockNesting:
 # Offense count: 26
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 309
+  Max: 321
 
 # Offense count: 58
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -28,7 +28,7 @@ class ConfirmationsController < ApplicationController
       else
         user.activate
         user.email_valid = true
-        flash[:notice] = gravatar_status_message(user) if gravatar_enable(user)
+        flash[:notice] = gravatar_status_message(user) if user.gravatar_enable
         user.save!
         cookies.delete :_osm_anonymous_notes_count
         referer = safe_referer(params[:referer]) if params[:referer]
@@ -73,7 +73,7 @@ class ConfirmationsController < ApplicationController
         current_user.email = current_user.new_email
         current_user.new_email = nil
         current_user.email_valid = true
-        gravatar_enabled = gravatar_enable(current_user)
+        gravatar_enabled = current_user.gravatar_enable
         if current_user.save
           flash[:notice] = if gravatar_enabled
                              "#{t('.success')} #{gravatar_status_message(current_user)}"
@@ -96,26 +96,6 @@ class ConfirmationsController < ApplicationController
   end
 
   private
-
-  ##
-  # check if this user has a gravatar and set the user pref is true
-  def gravatar_enable(user)
-    # code from example https://en.gravatar.com/site/implement/images/ruby/
-    return false if user.avatar.attached?
-
-    begin
-      hash = Digest::MD5.hexdigest(user.email.downcase)
-      url = "https://www.gravatar.com/avatar/#{hash}?d=404" # without d=404 we will always get an image back
-      response = OSM.http_client.get(URI.parse(url))
-      available = response.success?
-    rescue StandardError
-      available = false
-    end
-
-    oldsetting = user.image_use_gravatar
-    user.image_use_gravatar = available
-    oldsetting != user.image_use_gravatar
-  end
 
   ##
   # display a message about the current status of the Gravatar setting

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -446,6 +446,26 @@ class User < ApplicationRecord
     deletion_allowed_at <= Time.now.utc
   end
 
+  ##
+  # check if this user has a gravatar and set the user pref is true
+  def gravatar_enable
+    # code from example https://en.gravatar.com/site/implement/images/ruby/
+    return false if avatar.attached?
+
+    begin
+      hash = Digest::MD5.hexdigest(email.downcase)
+      url = "https://www.gravatar.com/avatar/#{hash}?d=404" # without d=404 we will always get an image back
+      response = OSM.http_client.get(URI.parse(url))
+      available = response.success?
+    rescue StandardError
+      available = false
+    end
+
+    oldsetting = image_use_gravatar
+    self.image_use_gravatar = available
+    oldsetting != image_use_gravatar
+  end
+
   private
 
   def encrypt_password


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
The `gravatar_enable` method configures a gravatar for the user. Since this is business logic let's put it on the model instead of in the controller. This also opens the door to testing this method outside of the request/response lifecycle.

### How has this been tested?
The existing test coverage in `ConfirmationsController` continues to pass.

