### PR TITLE
Refactor directions output rendering and unit handling

### DIFF
--- a/app/views/directions/show.html.erb
+++ b/app/views/directions/show.html.erb
@@ -103,10 +103,10 @@
     </div>
 
     <div class="btn-group btn-group-sm">
-      <input type="radio" class="btn-check" name="directions_distance_units" id="directions_distance_units_km" autocomplete="off" checked>
+      <input type="radio" class="btn-check" name="directions_distance_units" id="directions_distance_units_km" autocomplete="off" data-unit="km" checked>
       <label class="btn btn-outline-secondary p-0 px-1" for="directions_distance_units_km"><%= t ".button_km" %></label>
 
-      <input type="radio" class="btn-check" name="directions_distance_units" id="directions_distance_units_mi" autocomplete="off">
+      <input type="radio" class="btn-check" name="directions_distance_units" id="directions_distance_units_mi" autocomplete="off" data-unit="mi">
       <label class="btn btn-outline-secondary p-0 px-1" for="directions_distance_units_mi"><%= t ".button_mi" %></label>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3335,10 +3335,12 @@ en:
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
       distance_in_units:
-        m: "%{distance}m"
-        km: "%{distance}km"
-        ft: "%{distance}ft"
-        mi: "%{distance}mi"
+        meters:
+          m: "%{distance}m"
+          km: "%{distance}km"
+        miles:
+          ft: "%{distance}ft"
+          mi: "%{distance}mi"
       errors:
         no_route: "Couldn't find a route between those two places."
         no_place: "Sorry - couldn't locate '%{place}'."


### PR DESCRIPTION
### Description
- Group unit translations by sending the scope with `translateDistanceUnits`
- Regroup `writeSummary` and `writeSteps` into `writeContent` and `writeStep`
- Unify unit toggling into `writeContent` with `data-unit` to simplify event binding.

### How has this been tested?
locally