### PR TITLE
Remove reddish color and add shadows to history changeset highlights

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -76,7 +76,7 @@ OSM.HistoryChangesetBboxHighlightOutlineLayer = OSM.HistoryChangesetBboxLayer.ex
       weight: changeset.sidebarRelativePosition === 0 ? 8 : 6,
       color: "var(--changeset-outline-color)",
       fill: false,
-      className: this._getSidebarRelativeClassName(changeset)
+      className: this._getSidebarRelativeClassName(changeset) + " changeset-highlight-outline"
     };
   }
 });

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -57,14 +57,25 @@ OSM.HistoryChangesetBboxBorderLayer = OSM.HistoryChangesetBboxLayer.extend({
   }
 });
 
-OSM.HistoryChangesetBboxHighlightBackLayer = OSM.HistoryChangesetBboxLayer.extend({
+OSM.HistoryChangesetBboxHighlightAreaLayer = OSM.HistoryChangesetBboxLayer.extend({
+  _getChangesetStyle: function (changeset) {
+    return {
+      interactive: false,
+      stroke: false,
+      fillColor: "var(--changeset-fill-color)",
+      fillOpacity: 0.3,
+      className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"
+    };
+  }
+});
+
+OSM.HistoryChangesetBboxHighlightOutlineLayer = OSM.HistoryChangesetBboxLayer.extend({
   _getChangesetStyle: function (changeset) {
     return {
       interactive: false,
       weight: 6,
       color: "var(--changeset-outline-color)",
-      fillColor: "var(--changeset-fill-color)",
-      fillOpacity: 0.3,
+      fill: false,
       className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"
     };
   }
@@ -183,10 +194,12 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     if (!changeset) return;
 
     if (state) {
-      this._highlightBackLayer.addChangesetLayer(changeset);
+      this._highlightAreaLayer.addChangesetLayer(changeset);
+      this._highlightOutlineLayer.addChangesetLayer(changeset);
       this._highlightBorderLayer.addChangesetLayer(changeset);
     } else {
-      this._highlightBackLayer.removeLayer(id);
+      this._highlightAreaLayer.removeLayer(id);
+      this._highlightOutlineLayer.removeLayer(id);
       this._highlightBorderLayer.removeLayer(id);
     }
   },
@@ -205,7 +218,8 @@ OSM.HistoryChangesetsLayer.addInitHook(function () {
     this._areaLayer = new OSM.HistoryChangesetBboxAreaLayer().addTo(this),
     this._outlineLayer = new OSM.HistoryChangesetBboxOutlineLayer().addTo(this),
     this._borderLayer = new OSM.HistoryChangesetBboxBorderLayer().addTo(this),
-    this._highlightBackLayer = new OSM.HistoryChangesetBboxHighlightBackLayer().addTo(this),
+    this._highlightAreaLayer = new OSM.HistoryChangesetBboxHighlightAreaLayer().addTo(this),
+    this._highlightOutlineLayer = new OSM.HistoryChangesetBboxHighlightOutlineLayer().addTo(this),
     this._highlightBorderLayer = new OSM.HistoryChangesetBboxHighlightBorderLayer().addTo(this)
   ];
 });

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -73,7 +73,7 @@ OSM.HistoryChangesetBboxHighlightOutlineLayer = OSM.HistoryChangesetBboxLayer.ex
   _getChangesetStyle: function (changeset) {
     return {
       interactive: false,
-      weight: 6,
+      weight: changeset.sidebarRelativePosition === 0 ? 8 : 6,
       color: "var(--changeset-outline-color)",
       fill: false,
       className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -64,7 +64,7 @@ OSM.HistoryChangesetBboxHighlightAreaLayer = OSM.HistoryChangesetBboxLayer.exten
       stroke: false,
       fillColor: "var(--changeset-fill-color)",
       fillOpacity: 0.3,
-      className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"
+      className: this._getSidebarRelativeClassName(changeset)
     };
   }
 });
@@ -76,7 +76,7 @@ OSM.HistoryChangesetBboxHighlightOutlineLayer = OSM.HistoryChangesetBboxLayer.ex
       weight: changeset.sidebarRelativePosition === 0 ? 8 : 6,
       color: "var(--changeset-outline-color)",
       fill: false,
-      className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"
+      className: this._getSidebarRelativeClassName(changeset)
     };
   }
 });
@@ -88,7 +88,7 @@ OSM.HistoryChangesetBboxHighlightBorderLayer = OSM.HistoryChangesetBboxLayer.ext
       weight: 4,
       color: "var(--changeset-border-color)",
       fill: false,
-      className: this._getSidebarRelativeClassName(changeset) + " changeset-highlighted"
+      className: this._getSidebarRelativeClassName(changeset)
     };
   }
 });

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -610,9 +610,6 @@ tr.turn {
 }
 .changeset-in-sidebar-viewport {
   --changeset-border-color: #FF9500;
-  &.changeset-highlighted {
-    --changeset-border-color: #FF6600;
-  }
   --changeset-fill-color: #FFFFAF;
   --changeset-outline-color: #FFFFFF;
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -612,11 +612,17 @@ tr.turn {
   --changeset-border-color: #FF9500;
   --changeset-fill-color: #FFFFAF;
   --changeset-outline-color: #FFFFFF;
+  &.changeset-highlight-outline {
+    filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, .75));
+  }
 }
 .changeset-below-sidebar-viewport {
   --changeset-border-color: #8888AA;
   --changeset-fill-color: #CCCCDD;
   --changeset-outline-color: #F4F4FF;
+}
+.changeset-highlight-outline {
+  filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, .25));
 }
 
 #sidebar .changesets {


### PR DESCRIPTION
Currently highlighted in-viewport bboxes change their color to more reddish. Changing their color made sense previously when only one orange color was in use. However now we have different colors, with red being for newer changesets. The problem is that if the highlighted changeset is located on a pile of newer changesets, it's made less noticeable by this color change. I think it's better to do highlights by other means without color changes. In this PR I'm making highlighted outlines bolder fo in-viewport changesets.

Before / after:
![image](https://github.com/user-attachments/assets/27fbdc0e-43ee-4749-82de-f2d7c9f4a653) ![image](https://github.com/user-attachments/assets/5f88cfe9-4a69-4ec2-855a-356c8d7bce94)

This should especially helpful for valious cases of color blindness.

Before / after for completely colorblind users:
![image](https://github.com/user-attachments/assets/a0e9784d-a721-4d19-a897-598cef5aa628) ![image](https://github.com/user-attachments/assets/58c4e9d8-16c9-40b5-8c27-2ca79f8f24c5)

But I had to do one more thing. Changing the color still made highlighted changesets stand out more among other in-viewport changesets, compared with same color + bolder outline. To compensate for keeping the same color I added shadows to highlighted changesets. This should make sense because they are displayed "above" the rest. Initially I wanted a light shadow, like I do for sticky close buttons, and that's what the PR still has for out-of-viewport changesets. However for in-viewport changesets that wasn't enough and I gave them heavier shadows.

Before / after:
![image](https://github.com/user-attachments/assets/f6a7545e-d30c-405a-9602-49930f73c744) ![image](https://github.com/user-attachments/assets/caf64f86-8b90-42ee-b5e4-2918cef791ea)

The reason why light shadows are not enough for in-viewport highlights is because they can be highlighted without direcly hovering over them on the map. You need to be able to notice highlights while also looking at the sidebar and hovering there:
![image](https://github.com/user-attachments/assets/aac1e16e-c2db-49f6-b810-9d90f1f1cf0b)

That all makes borders + outlines quite thick, but I think that it can only be a noticeable problem on small screens, such as phones. And on phones you'll rarely see hover highlights.