### PR TITLE
Use webp tile format for tracestrack topo

### DIFF
--- a/vendor/assets/leaflet/leaflet.osm.js
+++ b/vendor/assets/leaflet/leaflet.osm.js
@@ -71,7 +71,7 @@ L.OSM.HOT = L.OSM.TileLayer.extend({
 
 L.OSM.TracestrackTopo = L.OSM.TileLayer.extend({
   options: {
-    url: 'https://tile.tracestrack.com/topo__/{z}/{x}/{y}.png?key={apikey}',
+    url: 'https://tile.tracestrack.com/topo__/{z}/{x}/{y}.webp?key={apikey}',
     maxZoom: 19,
     attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors. Tiles courtesy of <a href="https://www.tracestrack.com/" target="_blank">Tracestrack Maps</a>'
   }


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->

Tracestrack Maps recently started providing webp tiles. webp is widely supported and has better compression. It loads faster without noticeable quality degradation.

### How has this been tested?
<!--Explain the steps you took to test your code.-->

The new tiles can be tested in Map Explorer: https://console.tracestrack.com/explorer#basemap=topo