### PR TITLE
Use require_relative in scripts

### DIFF
--- a/script/deliver-message
+++ b/script/deliver-message
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.join(File.dirname(__FILE__), "..", "config", "environment")
+require_relative File.join("..", "config", "environment")
 
 if recipient = ARGV[0].match(/^c-(\d+)-(\d+)-(.*)$/)
   comment = DiaryComment.find(recipient[1])

--- a/script/statistics
+++ b/script/statistics
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.join(File.dirname(__FILE__), "..", "config", "environment")
+require_relative File.join("..", "config", "environment")
 
 start_time = Time.now.utc
 

--- a/script/update-spam-blocks
+++ b/script/update-spam-blocks
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.join(File.dirname(__FILE__), "..", "config", "environment")
+require_relative File.join("..", "config", "environment")
 require "generator"
 
 addresses = User.count(


### PR DESCRIPTION
I tried running the statistics script because of #5994:

```
ruby script/statistics
```

and it didn't work until I made this change. `config/environment.rb` already uses `require_relative`.