### PR TITLE
Add Bootstrap .d-none class to print styles to hide svg defs

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -52,6 +52,7 @@ header,
 /* Rules for attribution text under the main map shown on printouts */
 
 #attribution {
+  display: block;
   page-break-inside: avoid;
   height: 40px;
   font-size: 12px;
@@ -63,4 +64,10 @@ header,
 
 .attribution_notice {
   text-align: center;
+}
+
+/* Bootstrap classes */
+
+.d-none {
+  display: none;
 }


### PR DESCRIPTION
I merged #5752 which started to use svg `<defs>` more widely. They are in `<svg>` elements that still take space on the page unless hidden. We hide these images with `d-none` class. The problem is this is a Bootstrap class and we don't load Bootstrap for print styles. This is how the map looks in print view:

![image](https://github.com/user-attachments/assets/cb7f4534-7af3-405f-9487-bd782d250c8f)

Notice the empty space above the map. I also did that hiding before with routing icons but it wasn't as noticeable because I set width/height on the svg defs image to small enought values.

This PR adds `d-none` class to the print stylesheet:

![image](https://github.com/user-attachments/assets/7cd33c6e-aba1-4c70-92c9-ec7ed8d9206f)

Another option could have been using `hidden` attribute, but it works slightly differently (looks like it prevents margin folding, so the svg still takes some space, even if used together with width=0 + height=0). And I'm not sure if it's standardized yet (https://github.com/w3c/svgwg/issues/508).