### PR TITLE
Remove unused Leaflet popup paragraph margins css

### DIFF
--- a/app/assets/stylesheets/leaflet-all.scss
+++ b/app/assets/stylesheets/leaflet-all.scss
@@ -19,7 +19,3 @@ div.leaflet-marker-icon.location-filter.move-marker {
 .user_popup p {
   margin: 0 !important;
 }
-
-.site .leaflet-popup p {
-  margin: 0 0 20px 0;
-}


### PR DESCRIPTION
Was added in https://github.com/openstreetmap/openstreetmap-website/commit/0d35a10a503f466f5cb7fe41fcb9e0c5167d9ee1, the commit message doesn't say why. There's a number of other Leaflet popup paragraph margin overrides. This one doesn't seem to be active in dashboard/directions/diary popups.