### PR TITLE
Remove min height from dashboard map popups

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -744,7 +744,6 @@ tr.turn {
 
 .content_map .leaflet-popup-content {
   margin: $spacer;
-  min-height: 50px;
 }
 
 /* Rules for user popups on maps */


### PR DESCRIPTION
This min-height only affects dashboard popups of users with small avatars.

Before:
![image](https://github.com/user-attachments/assets/f48c176f-5401-4204-baad-84e071fd1910)

After:
![image](https://github.com/user-attachments/assets/5c6633b0-c34b-4bf0-895e-9a5333194afd)

It doesn't seem to make look anything better. It could have been useful in the past if floated images were used, but I don't thinnk they were when this css rule was introduced. It was first added in https://github.com/openstreetmap/openstreetmap-website/commit/a36f3558dd43dd5a598e36dd21fd5f7d2b4a94f5 and then changed to 50px in https://github.com/openstreetmap/openstreetmap-website/commit/40012189cb311510e545202d688294b9a8490ab1.