### PR TITLE
Remove background-color rgba fallback from Leaflet controls

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -255,7 +255,6 @@ body.small-nav {
   width: 40px;
   color: white;
   padding: 10px;
-  background-color: #333;
   background-color: rgba(0,0,0,.6);
   outline: none;
 
@@ -266,7 +265,6 @@ body.small-nav {
 
   &.disabled,
   &.leaflet-disabled {
-    background-color: #333;
     background-color: rgba(0,0,0,.5);
     cursor: default;
   }


### PR DESCRIPTION
Two `background-color` rules one after another is a [fallback for browsers not supporting rgba](https://css-tricks.com/rgba-browser-support/#aa-declaring-a-fallback-color) which you might want to use 15 years ago. It was added in https://github.com/openstreetmap/openstreetmap-website/commit/b9a19ab23a8dc63bc7c7f867e2ece6924319f0f2 and https://github.com/openstreetmap/openstreetmap-website/commit/dcbc42b1a485fdf39f5f11e37a628b383843e69b.