### PR TITLE
Remove unused dropdown caret css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -118,10 +118,6 @@ nav.primary {
       color: $grey;
       cursor: default;
 
-      .caret {
-        border-top-color: $grey;
-      }
-
       &:hover {
         background-color: lighten($green, 30%);
       }


### PR DESCRIPTION
Works fine without this css rule:
![image](https://github.com/user-attachments/assets/743177c7-04ed-4d5d-90ee-81a15b7bfc7e)

because `.caret` is not used anymore. It was used explicitly before #2524, after that maybe it was in Bootstrap, but currently it isn't.