### PR TITLE
Combine dashboard user popup custom css

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -744,8 +744,7 @@ tr.turn {
 
 .user_popup {
   p {
-    padding: 0 0 5px 0;
-    margin: 0 0 0 60px;
+    margin: 0 0 5px 0 !important;
     font-size: 12px;
   }
 }

--- a/app/assets/stylesheets/leaflet-all.scss
+++ b/app/assets/stylesheets/leaflet-all.scss
@@ -12,10 +12,3 @@ div.leaflet-marker-icon.location-filter.resize-marker {
 div.leaflet-marker-icon.location-filter.move-marker {
   background-image: image-url("img/move-handle.png");
 }
-
-/* Override some conflicting styles.
-   https://github.com/openstreetmap/openstreetmap-website/pull/121#issuecomment-10206946 */
-
-.user_popup p {
-  margin: 0 !important;
-}


### PR DESCRIPTION
Part of the css is in `leaflet-all.scss` where it partially overrides another part of the css from `common.scss`. This PR puts everything into `common.scss`.

The comment in `leaflet-all.scss` with https://github.com/openstreetmap/openstreetmap-website/pull/121#issuecomment-10206946 was about rules for images. It was added in https://github.com/openstreetmap/openstreetmap-website/commit/ed84516db2ccf634c8639d15fc39b1896f66cd18 where paragraphs had large left margins to make space for avatar images. That css was removed in https://github.com/openstreetmap/openstreetmap-website/commit/dc67e54958c50301cd0b8b0ada72936a4ae0b0f2 which switched to Bootstrap grid.