### PR TITLE
Add links to external map legends

### DIFF
--- a/app/assets/javascripts/leaflet.key.js
+++ b/app/assets/javascripts/leaflet.key.js
@@ -40,7 +40,7 @@ L.OSM.key = function (options) {
       const layerId = map.getMapBaseLayerId(),
             zoom = map.getZoom();
 
-      $(".mapkey-table-entry").each(function () {
+      $("#mapkey [data-layer]").each(function () {
         const data = $(this).data();
         $(this).toggle(
           layerId === data.layer &&

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -475,7 +475,7 @@ body.small-nav {
 
 @mixin dark-map-color-scheme {
   .leaflet-tile-container,
-  .mapkey-table-entry td:first-child > * {
+  #mapkey .filtered-image {
     filter: var(--dark-mode-map-filter);
   }
 

--- a/app/controllers/map_keys_controller.rb
+++ b/app/controllers/map_keys_controller.rb
@@ -7,10 +7,10 @@ class MapKeysController < ApplicationController
     expires_in 7.days, :public => true
     @key = YAML.load_file(Rails.root.join("config/key.yml"))
     @key.each_value do |layer_data|
-      layer_data.each do |entry|
+      layer_data["entries"].each do |entry|
         entry["name"] = Array(entry["name"])
       end
-      layer_data.each_cons(2) do |entry, next_entry|
+      layer_data["entries"].each_cons(2) do |entry, next_entry|
         entry["max_zoom"] = next_entry["min_zoom"] - 1 if entry["name"] == next_entry["name"] && !entry["max_zoom"] && next_entry["min_zoom"]
       end
     end

--- a/app/views/map_keys/show.html.erb
+++ b/app/views/map_keys/show.html.erb
@@ -17,4 +17,11 @@
       <% end %>
     <% end %>
   </table>
+  <% @key.each do |layer_name, layer_data| %>
+    <% if layer_data["legend"] %>
+      <%= tag.div :data => { :layer => layer_name }, :class => "mt-3 text-center" do %>
+        <%= link_to t(".see_external_legend"), layer_data["legend"], :target => "_blank", :rel => "noopener" %>
+      <% end %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/map_keys/show.html.erb
+++ b/app/views/map_keys/show.html.erb
@@ -5,9 +5,9 @@
         <%= tag.tr :class => "mapkey-table-entry", :data => { :layer => layer_name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
           <td>
             <% if entry["image"] %>
-              <%= image_tag "key/#{layer_name}/#{entry['image']}", :class => "d-block mx-auto" %>
+              <%= image_tag "key/#{layer_name}/#{entry['image']}", :class => "filtered-image d-block mx-auto" %>
             <% else %>
-              <%= key_svg_tag :class => "d-block mx-auto", **entry %>
+              <%= key_svg_tag :class => "filtered-image d-block mx-auto", **entry %>
             <% end %>
           </td>
           <td>

--- a/app/views/map_keys/show.html.erb
+++ b/app/views/map_keys/show.html.erb
@@ -2,7 +2,7 @@
   <table class="table table-sm table-borderless mb-0 align-middle">
     <% @key.each do |layer_name, layer_data| %>
       <% layer_data.each do |entry| %>
-        <%= tag.tr :class => "mapkey-table-entry", :data => { :layer => layer_name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
+        <%= tag.tr :data => { :layer => layer_name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
           <td>
             <% if entry["image"] %>
               <%= image_tag "key/#{layer_name}/#{entry['image']}", :class => "filtered-image d-block mx-auto" %>

--- a/app/views/map_keys/show.html.erb
+++ b/app/views/map_keys/show.html.erb
@@ -1,7 +1,7 @@
 <div id="mapkey">
   <table class="table table-sm table-borderless mb-0 align-middle">
     <% @key.each do |layer_name, layer_data| %>
-      <% layer_data.each do |entry| %>
+      <% layer_data["entries"].each do |entry| %>
         <%= tag.tr :data => { :layer => layer_name, :zoom_min => entry["min_zoom"], :zoom_max => entry["max_zoom"] } do %>
           <td>
             <% if entry["image"] %>

--- a/config/key.yml
+++ b/config/key.yml
@@ -1,198 +1,201 @@
 mapnik:
-  # transportation: roads.mss
-  - { min_zoom:  6, name: motorway, width: 52, height:  1, line: "#e66e89", line-width: 1 }
-  - { min_zoom:  7, name: motorway, width: 52, height:  3, line: "#e66e89", line-width: 1.5 }
-  - { min_zoom:  9, name: motorway, width: 52, height:  2, line: "#e66e89", line-width: 2 }
-  - { min_zoom: 12, name: motorway, width: 52, height:  5, fill: "#e892a2", casing: "#dc2a67", casing-width: 0.5 }
-  - { min_zoom: 15, name: motorway, width: 52, height: 10, fill: "#e892a2", casing: "#dc2a67" }
-  - { min_zoom:  6, name: main_road, width: 52, height: 3, line: "#f6967a", line-width: 1 }
-  - { min_zoom:  7, name: main_road, width: 52, height: 3, line: "#f6967a", line-width: 1.25 }
-  - { min_zoom:  8, name: main_road, image: mainroad8.svg }
-  - { min_zoom:  9, name: main_road, image: mainroad9.svg }
-  - { min_zoom: 12, name: main_road, image: mainroad12.svg }
-  - { min_zoom: 15, name: main_road, image: mainroad15.svg }
-  - { min_zoom: 13, name: track, width: 52, height: 3, opacity: .8, line: "#996600", line-width: 1.5, line-dasharray: "6 5" }
-  - { min_zoom: 13, name: bridleway, width: 52, height: 3, line: green, line-width: 1.25, line-dasharray: "4 2" }
-  - { min_zoom: 13, name: cycleway, width: 52, height: 1, line: blue, line-dasharray: "3 3.5" }
-  - { min_zoom: 13, name: footway, width: 52, height: 3, line: salmon, line-width: 1.3, line-dasharray: "3 3.5" }
-  - { min_zoom:  8, name: rail, width: 52, height: 1, fill: "#787878" }
-  - { min_zoom: 12, name: rail, width: 52, height: 3, fill: "#707070", line: white, line-dasharray: 8, line-dashoffset: 2 }
-  - { min_zoom: 18, name: rail, width: 52, height: 4, fill: "#707070", line: white, line-dasharray: 8, line-dashoffset: 2, line-width: 2 }
-  - { min_zoom: 12, name: subway, width: 52, height: 2, fill: "#999" }
-  - { min_zoom:  8, name: light_rail, width: 52, height: 1, fill: "#ccc" }
-  - { min_zoom: 10, name: light_rail, width: 52, height: 1, fill: "#aaa" }
-  - { min_zoom: 13, name: light_rail, width: 52, height: 2, fill: "#666" }
-  - { min_zoom: 12, name: tram, width: 52, height: 1, line: "#6e6e6e", line-width: 0.75 }
-  - { min_zoom: 14, name: tram, width: 52, height: 3, line: "#6e6e6e", line-width: 1 }
-  - { min_zoom: 15, name: tram, width: 52, height: 3, line: "#6e6e6e", line-width: 1.5 }
-  - { min_zoom: 17, name: tram, width: 52, height: 2, line: "#6e6e6e", line-width: 2 }
-  - { min_zoom: 12, name: [cable_car, chair_lift], image: cable.png }
-  - { min_zoom: 11, name: [runway, taxiway], image: runway11.svg }
-  - { min_zoom: 12, name: [runway, taxiway], image: runway12.svg }
-  - { min_zoom: 13, name: [runway, taxiway], image: runway13.svg }
-  - { min_zoom: 14, name: [runway, taxiway], image: runway14.svg }
-  - { min_zoom: 11, name: apron, width: 26, height: 10, fill: "#dadae0" } # landcover.mss
-  # administrative boundaries: admin.mss
-  - { name: admin, width: 52, height: 2, fill: "#8d618b88" }
-  # places: placenames.mss
-  - { min_zoom: 4, max_zoom: 6, name: capital, image: capital4.svg }
-  - { min_zoom: 7, max_zoom: 7, name: capital, image: capital7.svg }
-  - { min_zoom: 4, max_zoom: 5, name: city, image: city4.svg }
-  - { min_zoom: 6, max_zoom: 7, name: city, image: city6.svg }
-  # landcover z5: landcover.mss, water.mss
-  - { name: [lake, reservoir], width: 26, height: 10, fill: "#aad3df" }
-  - { name: intermittent_water, image: intermittent_water.svg }
-  - { min_zoom:  5, name: glacier, width: 26, height: 10, fill: "#ddecec", border: "#9cf" }
-  - { min_zoom: 10, name: glacier, width: 26, height: 10, fill: "#ddecec", border: "#9cf", border-dasharray: "4 2" }
-  - { min_zoom: 10, name: reef, image: reef.png }
-  - { min_zoom: 10, name: wetland, image: wetland.png }
-  - { min_zoom:  5, name: [forest, wood], width: 26, height: 10, fill: "#bddab1" }
-  - { min_zoom: 12, name: [forest, wood], width: 26, height: 10, fill: "#add19e" }
-  - { min_zoom:  5, name: [orchard, vineyard], width: 26, height: 10, fill: "#bee5b5" }
-  - { min_zoom: 12, name: [orchard, vineyard], width: 26, height: 10, fill: "#aedfa3" }
-  - { min_zoom:  5, name: [grass, meadow], width: 26, height: 10, fill: "#d7efc0" }
-  - { min_zoom: 12, name: [grass, meadow], width: 26, height: 10, fill: "#cdebb0" }
-  - { min_zoom:  5, name: farmland, width: 26, height: 10, fill: "#f1f3dd" }
-  - { min_zoom: 12, name: farmland, width: 26, height: 10, fill: "#eef0d5" }
-  - { min_zoom:  5, name: heathland, width: 26, height: 10, fill: "#dee1b2" }
-  - { min_zoom: 12, name: heathland, width: 26, height: 10, fill: "#d6d99f" }
-  - { min_zoom:  5, name: scrubland, width: 26, height: 10, fill: "#d3dfbc" }
-  - { min_zoom: 12, name: scrubland, width: 26, height: 10, fill: "#c8d7ab" }
-  - { min_zoom:  5, name: bare_rock, width: 26, height: 10, fill: "#f1eae3" }
-  - { min_zoom: 12, name: bare_rock, width: 26, height: 10, fill: "#eee5dc" }
-  - { min_zoom:  5, name: sand, width: 26, height: 10, fill: "#f7edd1" }
-  - { min_zoom: 12, name: sand, width: 26, height: 10, fill: "#f5e9c6" }
-  # landuse z8, z10: landcover.mss
-  - { min_zoom: 10, name: park, width: 26, height: 10, fill: "#c8facc" }
-  - { min_zoom: 10, name: golf, width: 26, height: 10, fill: "#def6c0" }
-  - { min_zoom:  8, name: built_up, width: 26, height: 10, fill: "#d9d9d9" }
-  - { min_zoom: 12, max_zoom: 12, name: built_up, width: 26, height: 10, fill: "#dddddd" }
-  - { min_zoom: 13, name: resident, width: 26, height: 10, fill: "#e0dfdf" }
-  - { min_zoom: 13, name: retail, width: 26, height: 10, fill: "#ffd6d1" }
-  - { min_zoom: 13, name: commercial, width: 26, height: 10, fill: "#f2dad9" }
-  - { min_zoom: 13, name: industrial, width: 26, height: 10, fill: "#ebdbe8" }
-  - { min_zoom: 10, name: farm, width: 26, height: 10, fill: "#f7e3c8" }
-  - { min_zoom: 12, name: farm, width: 26, height: 10, fill: "#f5dcba" }
-  - { min_zoom: 10, name: brownfield, width: 26, height: 10, fill: "#d2d2c3" }
-  - { min_zoom: 12, name: brownfield, width: 26, height: 10, fill: "#c7c7b4" }
-  - { min_zoom: 10, name: cemetery, width: 26, height: 10, fill: "#bbd5be" }
-  - { min_zoom: 12, name: cemetery, width: 26, height: 10, fill: "#aacbaf" }
-  - { min_zoom: 10, name: allotments, width: 26, height: 10, fill: "#d4e6cc" }
-  - { min_zoom: 12, name: allotments, width: 26, height: 10, fill: "#c9e1bf" }
-  - { min_zoom: 11, name: pitch, width: 26, height: 10, fill: "#88e0be" }
-  - { min_zoom: 11, name: centre, width: 26, height: 10, fill: "#dffce2" }
-  - { min_zoom: 10, name: reserve, image: reserve.svg } # admin.mss
-  - { min_zoom:  8, name: military, image: military.svg }
-  - { min_zoom: 13, name: [school, university, hospital], image: school.svg }
-  # buildings: buildings.mss
-  - { min_zoom: 14, name: building, width: 10, height: 10, fill: "#ab9793" }
-  - { min_zoom: 15, name: building, width: 10, height: 10, fill: "#b9a99c", border: "#a99a8d" }
-  - { min_zoom: 16, name: building, width: 10, height: 10, fill: "#c4b6ab", border: "#a99a8d" }
-  # stations: stations.mss, amenity-points.mss
-  - { min_zoom: 12, max_zoom: 12, name: station, width: 4, height: 4, fill: "#7981b0" }
-  - { min_zoom: 13, max_zoom: 13, name: station, width: 6, height: 6, fill: "#7981b0" }
-  - { min_zoom: 13, max_zoom: 13, name: railway_halt, width: 4, height: 4, fill: "#7981b0" }
-  - { min_zoom: 14, max_zoom: 14, name: [station, subway_station], width: 6, height: 6, fill: "#7981b0" }
-  - { min_zoom: 14, max_zoom: 14, name: [railway_halt, tram_stop], width: 4, height: 4, fill: "#7981b0" }
-  - { min_zoom: 15, name: station, width: 9, height: 9, fill: "#7981b0" }
-  - { min_zoom: 15, name: [railway_halt, subway_station, tram_stop], width: 6, height: 6, fill: "#7981b0" }
-  - { min_zoom: 16, name: bus_stop, width: 6, height: 6, fill: "#0092da" }
-  # other
-  - { min_zoom: 11, name: [summit, peak], image: summit.svg } # amenity-points.mss
-  - { min_zoom: 13, name: tunnel, width: 50, height: 5, casing: grey, casing-dasharray: "4 2", casing-dashoffset: 1 } # roads.mss
-  - { min_zoom: 13, name: bridge, width: 50, height: 5, casing: black } # roads.mss
-  - { min_zoom: 15, name: private, image: private.png }
-  - { min_zoom: 15, name: destination, image: destination.png }
-  - { min_zoom: 12, name: construction, image: construction.png }
+  entries:
+    # transportation: roads.mss
+    - { min_zoom:  6, name: motorway, width: 52, height:  1, line: "#e66e89", line-width: 1 }
+    - { min_zoom:  7, name: motorway, width: 52, height:  3, line: "#e66e89", line-width: 1.5 }
+    - { min_zoom:  9, name: motorway, width: 52, height:  2, line: "#e66e89", line-width: 2 }
+    - { min_zoom: 12, name: motorway, width: 52, height:  5, fill: "#e892a2", casing: "#dc2a67", casing-width: 0.5 }
+    - { min_zoom: 15, name: motorway, width: 52, height: 10, fill: "#e892a2", casing: "#dc2a67" }
+    - { min_zoom:  6, name: main_road, width: 52, height: 3, line: "#f6967a", line-width: 1 }
+    - { min_zoom:  7, name: main_road, width: 52, height: 3, line: "#f6967a", line-width: 1.25 }
+    - { min_zoom:  8, name: main_road, image: mainroad8.svg }
+    - { min_zoom:  9, name: main_road, image: mainroad9.svg }
+    - { min_zoom: 12, name: main_road, image: mainroad12.svg }
+    - { min_zoom: 15, name: main_road, image: mainroad15.svg }
+    - { min_zoom: 13, name: track, width: 52, height: 3, opacity: .8, line: "#996600", line-width: 1.5, line-dasharray: "6 5" }
+    - { min_zoom: 13, name: bridleway, width: 52, height: 3, line: green, line-width: 1.25, line-dasharray: "4 2" }
+    - { min_zoom: 13, name: cycleway, width: 52, height: 1, line: blue, line-dasharray: "3 3.5" }
+    - { min_zoom: 13, name: footway, width: 52, height: 3, line: salmon, line-width: 1.3, line-dasharray: "3 3.5" }
+    - { min_zoom:  8, name: rail, width: 52, height: 1, fill: "#787878" }
+    - { min_zoom: 12, name: rail, width: 52, height: 3, fill: "#707070", line: white, line-dasharray: 8, line-dashoffset: 2 }
+    - { min_zoom: 18, name: rail, width: 52, height: 4, fill: "#707070", line: white, line-dasharray: 8, line-dashoffset: 2, line-width: 2 }
+    - { min_zoom: 12, name: subway, width: 52, height: 2, fill: "#999" }
+    - { min_zoom:  8, name: light_rail, width: 52, height: 1, fill: "#ccc" }
+    - { min_zoom: 10, name: light_rail, width: 52, height: 1, fill: "#aaa" }
+    - { min_zoom: 13, name: light_rail, width: 52, height: 2, fill: "#666" }
+    - { min_zoom: 12, name: tram, width: 52, height: 1, line: "#6e6e6e", line-width: 0.75 }
+    - { min_zoom: 14, name: tram, width: 52, height: 3, line: "#6e6e6e", line-width: 1 }
+    - { min_zoom: 15, name: tram, width: 52, height: 3, line: "#6e6e6e", line-width: 1.5 }
+    - { min_zoom: 17, name: tram, width: 52, height: 2, line: "#6e6e6e", line-width: 2 }
+    - { min_zoom: 12, name: [cable_car, chair_lift], image: cable.png }
+    - { min_zoom: 11, name: [runway, taxiway], image: runway11.svg }
+    - { min_zoom: 12, name: [runway, taxiway], image: runway12.svg }
+    - { min_zoom: 13, name: [runway, taxiway], image: runway13.svg }
+    - { min_zoom: 14, name: [runway, taxiway], image: runway14.svg }
+    - { min_zoom: 11, name: apron, width: 26, height: 10, fill: "#dadae0" } # landcover.mss
+    # administrative boundaries: admin.mss
+    - { name: admin, width: 52, height: 2, fill: "#8d618b88" }
+    # places: placenames.mss
+    - { min_zoom: 4, max_zoom: 6, name: capital, image: capital4.svg }
+    - { min_zoom: 7, max_zoom: 7, name: capital, image: capital7.svg }
+    - { min_zoom: 4, max_zoom: 5, name: city, image: city4.svg }
+    - { min_zoom: 6, max_zoom: 7, name: city, image: city6.svg }
+    # landcover z5: landcover.mss, water.mss
+    - { name: [lake, reservoir], width: 26, height: 10, fill: "#aad3df" }
+    - { name: intermittent_water, image: intermittent_water.svg }
+    - { min_zoom:  5, name: glacier, width: 26, height: 10, fill: "#ddecec", border: "#9cf" }
+    - { min_zoom: 10, name: glacier, width: 26, height: 10, fill: "#ddecec", border: "#9cf", border-dasharray: "4 2" }
+    - { min_zoom: 10, name: reef, image: reef.png }
+    - { min_zoom: 10, name: wetland, image: wetland.png }
+    - { min_zoom:  5, name: [forest, wood], width: 26, height: 10, fill: "#bddab1" }
+    - { min_zoom: 12, name: [forest, wood], width: 26, height: 10, fill: "#add19e" }
+    - { min_zoom:  5, name: [orchard, vineyard], width: 26, height: 10, fill: "#bee5b5" }
+    - { min_zoom: 12, name: [orchard, vineyard], width: 26, height: 10, fill: "#aedfa3" }
+    - { min_zoom:  5, name: [grass, meadow], width: 26, height: 10, fill: "#d7efc0" }
+    - { min_zoom: 12, name: [grass, meadow], width: 26, height: 10, fill: "#cdebb0" }
+    - { min_zoom:  5, name: farmland, width: 26, height: 10, fill: "#f1f3dd" }
+    - { min_zoom: 12, name: farmland, width: 26, height: 10, fill: "#eef0d5" }
+    - { min_zoom:  5, name: heathland, width: 26, height: 10, fill: "#dee1b2" }
+    - { min_zoom: 12, name: heathland, width: 26, height: 10, fill: "#d6d99f" }
+    - { min_zoom:  5, name: scrubland, width: 26, height: 10, fill: "#d3dfbc" }
+    - { min_zoom: 12, name: scrubland, width: 26, height: 10, fill: "#c8d7ab" }
+    - { min_zoom:  5, name: bare_rock, width: 26, height: 10, fill: "#f1eae3" }
+    - { min_zoom: 12, name: bare_rock, width: 26, height: 10, fill: "#eee5dc" }
+    - { min_zoom:  5, name: sand, width: 26, height: 10, fill: "#f7edd1" }
+    - { min_zoom: 12, name: sand, width: 26, height: 10, fill: "#f5e9c6" }
+    # landuse z8, z10: landcover.mss
+    - { min_zoom: 10, name: park, width: 26, height: 10, fill: "#c8facc" }
+    - { min_zoom: 10, name: golf, width: 26, height: 10, fill: "#def6c0" }
+    - { min_zoom:  8, name: built_up, width: 26, height: 10, fill: "#d9d9d9" }
+    - { min_zoom: 12, max_zoom: 12, name: built_up, width: 26, height: 10, fill: "#dddddd" }
+    - { min_zoom: 13, name: resident, width: 26, height: 10, fill: "#e0dfdf" }
+    - { min_zoom: 13, name: retail, width: 26, height: 10, fill: "#ffd6d1" }
+    - { min_zoom: 13, name: commercial, width: 26, height: 10, fill: "#f2dad9" }
+    - { min_zoom: 13, name: industrial, width: 26, height: 10, fill: "#ebdbe8" }
+    - { min_zoom: 10, name: farm, width: 26, height: 10, fill: "#f7e3c8" }
+    - { min_zoom: 12, name: farm, width: 26, height: 10, fill: "#f5dcba" }
+    - { min_zoom: 10, name: brownfield, width: 26, height: 10, fill: "#d2d2c3" }
+    - { min_zoom: 12, name: brownfield, width: 26, height: 10, fill: "#c7c7b4" }
+    - { min_zoom: 10, name: cemetery, width: 26, height: 10, fill: "#bbd5be" }
+    - { min_zoom: 12, name: cemetery, width: 26, height: 10, fill: "#aacbaf" }
+    - { min_zoom: 10, name: allotments, width: 26, height: 10, fill: "#d4e6cc" }
+    - { min_zoom: 12, name: allotments, width: 26, height: 10, fill: "#c9e1bf" }
+    - { min_zoom: 11, name: pitch, width: 26, height: 10, fill: "#88e0be" }
+    - { min_zoom: 11, name: centre, width: 26, height: 10, fill: "#dffce2" }
+    - { min_zoom: 10, name: reserve, image: reserve.svg } # admin.mss
+    - { min_zoom:  8, name: military, image: military.svg }
+    - { min_zoom: 13, name: [school, university, hospital], image: school.svg }
+    # buildings: buildings.mss
+    - { min_zoom: 14, name: building, width: 10, height: 10, fill: "#ab9793" }
+    - { min_zoom: 15, name: building, width: 10, height: 10, fill: "#b9a99c", border: "#a99a8d" }
+    - { min_zoom: 16, name: building, width: 10, height: 10, fill: "#c4b6ab", border: "#a99a8d" }
+    # stations: stations.mss, amenity-points.mss
+    - { min_zoom: 12, max_zoom: 12, name: station, width: 4, height: 4, fill: "#7981b0" }
+    - { min_zoom: 13, max_zoom: 13, name: station, width: 6, height: 6, fill: "#7981b0" }
+    - { min_zoom: 13, max_zoom: 13, name: railway_halt, width: 4, height: 4, fill: "#7981b0" }
+    - { min_zoom: 14, max_zoom: 14, name: [station, subway_station], width: 6, height: 6, fill: "#7981b0" }
+    - { min_zoom: 14, max_zoom: 14, name: [railway_halt, tram_stop], width: 4, height: 4, fill: "#7981b0" }
+    - { min_zoom: 15, name: station, width: 9, height: 9, fill: "#7981b0" }
+    - { min_zoom: 15, name: [railway_halt, subway_station, tram_stop], width: 6, height: 6, fill: "#7981b0" }
+    - { min_zoom: 16, name: bus_stop, width: 6, height: 6, fill: "#0092da" }
+    # other
+    - { min_zoom: 11, name: [summit, peak], image: summit.svg } # amenity-points.mss
+    - { min_zoom: 13, name: tunnel, width: 50, height: 5, casing: grey, casing-dasharray: "4 2", casing-dashoffset: 1 } # roads.mss
+    - { min_zoom: 13, name: bridge, width: 50, height: 5, casing: black } # roads.mss
+    - { min_zoom: 15, name: private, image: private.png }
+    - { min_zoom: 15, name: destination, image: destination.png }
+    - { min_zoom: 12, name: construction, image: construction.png }
 cyclosm:
-  # bicycle routes: roads.mss, road-colors.mss
-  - { min_zoom:  2, name: international_bike_route, width: 50, height:  1, fill: "#ff00ff", opacity: 0.75 }
-  - { min_zoom:  8, name: international_bike_route, width: 50, height:  1, fill: "#ff00ff", opacity: 0.6 }
-  - { min_zoom:  9, name: international_bike_route, width: 50, height:  2, fill: "#ff00ff", opacity: 0.6 }
-  - { min_zoom: 11, name: international_bike_route, width: 50, height:  3, fill: "#ff00ff", opacity: 0.25 }
-  - { min_zoom: 12, name: international_bike_route, width: 50, height:  4, fill: "#ff00ff", opacity: 0.25 }
-  - { min_zoom: 14, name: international_bike_route, width: 50, height:  5, fill: "#ff00ff", opacity: 0.25 }
-  - { min_zoom: 15, name: international_bike_route, width: 50, height:  6, fill: "#ff00ff", opacity: 0.25 }
-  - { min_zoom: 16, name: international_bike_route, width: 50, height:  7, fill: "#ff00ff", opacity: 0.25 }
-  - { min_zoom: 17, name: international_bike_route, width: 50, height: 10, fill: "#ff00ff", opacity: 0.25 }
-  - { min_zoom: 18, name: international_bike_route, width: 50, height: 14, fill: "#ff00ff", opacity: 0.25 }
-  - { min_zoom:  5, name: national_bike_route,      width: 50, height:  1, fill: "#aa00ff", opacity: 0.75 }
-  - { min_zoom:  8, name: national_bike_route,      width: 50, height:  1, fill: "#aa00ff", opacity: 0.6 }
-  - { min_zoom:  9, name: national_bike_route,      width: 50, height:  2, fill: "#aa00ff", opacity: 0.6 }
-  - { min_zoom: 11, name: national_bike_route,      width: 50, height:  3, fill: "#aa00ff", opacity: 0.25 }
-  - { min_zoom: 12, name: national_bike_route,      width: 50, height:  4, fill: "#aa00ff", opacity: 0.25 }
-  - { min_zoom: 14, name: national_bike_route,      width: 50, height:  5, fill: "#aa00ff", opacity: 0.25 }
-  - { min_zoom: 15, name: national_bike_route,      width: 50, height:  6, fill: "#aa00ff", opacity: 0.25 }
-  - { min_zoom: 16, name: national_bike_route,      width: 50, height:  7, fill: "#aa00ff", opacity: 0.25 }
-  - { min_zoom: 17, name: national_bike_route,      width: 50, height: 10, fill: "#aa00ff", opacity: 0.25 }
-  - { min_zoom: 18, name: national_bike_route,      width: 50, height: 14, fill: "#aa00ff", opacity: 0.25 }
-  - { min_zoom:  8, name: regional_bike_route,      width: 50, height:  1, fill: "#5500ff", opacity: 0.6 }
-  - { min_zoom:  9, name: regional_bike_route,      width: 50, height:  2, fill: "#5500ff", opacity: 0.6 }
-  - { min_zoom: 11, name: regional_bike_route,      width: 50, height:  3, fill: "#5500ff", opacity: 0.25 }
-  - { min_zoom: 12, name: regional_bike_route,      width: 50, height:  4, fill: "#5500ff", opacity: 0.25 }
-  - { min_zoom: 14, name: regional_bike_route,      width: 50, height:  5, fill: "#5500ff", opacity: 0.25 }
-  - { min_zoom: 15, name: regional_bike_route,      width: 50, height:  6, fill: "#5500ff", opacity: 0.25 }
-  - { min_zoom: 16, name: regional_bike_route,      width: 50, height:  7, fill: "#5500ff", opacity: 0.25 }
-  - { min_zoom: 17, name: regional_bike_route,      width: 50, height: 10, fill: "#5500ff", opacity: 0.25 }
-  - { min_zoom: 18, name: regional_bike_route,      width: 50, height: 14, fill: "#5500ff", opacity: 0.25 }
-  - { min_zoom: 11, name: local_bike_route,         width: 50, height:  3, fill: "#0000ff", opacity: 0.25 }
-  - { min_zoom: 12, name: local_bike_route,         width: 50, height:  4, fill: "#0000ff", opacity: 0.25 }
-  - { min_zoom: 14, name: local_bike_route,         width: 50, height:  5, fill: "#0000ff", opacity: 0.25 }
-  - { min_zoom: 15, name: local_bike_route,         width: 50, height:  6, fill: "#0000ff", opacity: 0.25 }
-  - { min_zoom: 16, name: local_bike_route,         width: 50, height:  7, fill: "#0000ff", opacity: 0.25 }
-  - { min_zoom: 17, name: local_bike_route,         width: 50, height: 10, fill: "#0000ff", opacity: 0.25 }
-  - { min_zoom: 18, name: local_bike_route,         width: 50, height: 14, fill: "#0000ff", opacity: 0.25 }
+  entries:
+    # bicycle routes: roads.mss, road-colors.mss
+    - { min_zoom:  2, name: international_bike_route, width: 50, height:  1, fill: "#ff00ff", opacity: 0.75 }
+    - { min_zoom:  8, name: international_bike_route, width: 50, height:  1, fill: "#ff00ff", opacity: 0.6 }
+    - { min_zoom:  9, name: international_bike_route, width: 50, height:  2, fill: "#ff00ff", opacity: 0.6 }
+    - { min_zoom: 11, name: international_bike_route, width: 50, height:  3, fill: "#ff00ff", opacity: 0.25 }
+    - { min_zoom: 12, name: international_bike_route, width: 50, height:  4, fill: "#ff00ff", opacity: 0.25 }
+    - { min_zoom: 14, name: international_bike_route, width: 50, height:  5, fill: "#ff00ff", opacity: 0.25 }
+    - { min_zoom: 15, name: international_bike_route, width: 50, height:  6, fill: "#ff00ff", opacity: 0.25 }
+    - { min_zoom: 16, name: international_bike_route, width: 50, height:  7, fill: "#ff00ff", opacity: 0.25 }
+    - { min_zoom: 17, name: international_bike_route, width: 50, height: 10, fill: "#ff00ff", opacity: 0.25 }
+    - { min_zoom: 18, name: international_bike_route, width: 50, height: 14, fill: "#ff00ff", opacity: 0.25 }
+    - { min_zoom:  5, name: national_bike_route,      width: 50, height:  1, fill: "#aa00ff", opacity: 0.75 }
+    - { min_zoom:  8, name: national_bike_route,      width: 50, height:  1, fill: "#aa00ff", opacity: 0.6 }
+    - { min_zoom:  9, name: national_bike_route,      width: 50, height:  2, fill: "#aa00ff", opacity: 0.6 }
+    - { min_zoom: 11, name: national_bike_route,      width: 50, height:  3, fill: "#aa00ff", opacity: 0.25 }
+    - { min_zoom: 12, name: national_bike_route,      width: 50, height:  4, fill: "#aa00ff", opacity: 0.25 }
+    - { min_zoom: 14, name: national_bike_route,      width: 50, height:  5, fill: "#aa00ff", opacity: 0.25 }
+    - { min_zoom: 15, name: national_bike_route,      width: 50, height:  6, fill: "#aa00ff", opacity: 0.25 }
+    - { min_zoom: 16, name: national_bike_route,      width: 50, height:  7, fill: "#aa00ff", opacity: 0.25 }
+    - { min_zoom: 17, name: national_bike_route,      width: 50, height: 10, fill: "#aa00ff", opacity: 0.25 }
+    - { min_zoom: 18, name: national_bike_route,      width: 50, height: 14, fill: "#aa00ff", opacity: 0.25 }
+    - { min_zoom:  8, name: regional_bike_route,      width: 50, height:  1, fill: "#5500ff", opacity: 0.6 }
+    - { min_zoom:  9, name: regional_bike_route,      width: 50, height:  2, fill: "#5500ff", opacity: 0.6 }
+    - { min_zoom: 11, name: regional_bike_route,      width: 50, height:  3, fill: "#5500ff", opacity: 0.25 }
+    - { min_zoom: 12, name: regional_bike_route,      width: 50, height:  4, fill: "#5500ff", opacity: 0.25 }
+    - { min_zoom: 14, name: regional_bike_route,      width: 50, height:  5, fill: "#5500ff", opacity: 0.25 }
+    - { min_zoom: 15, name: regional_bike_route,      width: 50, height:  6, fill: "#5500ff", opacity: 0.25 }
+    - { min_zoom: 16, name: regional_bike_route,      width: 50, height:  7, fill: "#5500ff", opacity: 0.25 }
+    - { min_zoom: 17, name: regional_bike_route,      width: 50, height: 10, fill: "#5500ff", opacity: 0.25 }
+    - { min_zoom: 18, name: regional_bike_route,      width: 50, height: 14, fill: "#5500ff", opacity: 0.25 }
+    - { min_zoom: 11, name: local_bike_route,         width: 50, height:  3, fill: "#0000ff", opacity: 0.25 }
+    - { min_zoom: 12, name: local_bike_route,         width: 50, height:  4, fill: "#0000ff", opacity: 0.25 }
+    - { min_zoom: 14, name: local_bike_route,         width: 50, height:  5, fill: "#0000ff", opacity: 0.25 }
+    - { min_zoom: 15, name: local_bike_route,         width: 50, height:  6, fill: "#0000ff", opacity: 0.25 }
+    - { min_zoom: 16, name: local_bike_route,         width: 50, height:  7, fill: "#0000ff", opacity: 0.25 }
+    - { min_zoom: 17, name: local_bike_route,         width: 50, height: 10, fill: "#0000ff", opacity: 0.25 }
+    - { min_zoom: 18, name: local_bike_route,         width: 50, height: 14, fill: "#0000ff", opacity: 0.25 }
 cyclemap:
-  - { min_zoom:  5, name: motorway, width: 50, height: 2, fill: "#9a9ab1" }
-  - { min_zoom:  9, name: motorway, width: 50, height: 3, fill: "#9a9ab1" }
-  - { min_zoom: 12, name: motorway, width: 50, height: 5, fill: "#bdbece", casing: "#8d95a7" }
-  - { min_zoom: 13, name: motorway, width: 50, height: 9, fill: "#bdbece", casing: "#8d95a7" }
-  - { min_zoom:  6, name: trunk, width: 50, height: 2, fill: "#c8d8c8" }
-  - { min_zoom: 12, name: trunk, width: 50, height: 4, fill: "#c8d8c8", casing: "#abb5a4" }
-  - { min_zoom: 13, name: trunk, width: 50, height: 8, fill: "#c8d8c8", casing: "#abb5a4" }
-  - { min_zoom:  8, name: primary, width: 50, height: 2, fill: "#d8c8c8" }
-  - { min_zoom: 12, name: primary, width: 50, height: 4, fill: "#f0e3e3", casing: "#d4b6b7" }
-  - { min_zoom: 13, name: primary, width: 50, height: 8, fill: "#f0e3e3", casing: "#d4b6b7" }
-  - { min_zoom: 10, name: secondary, width: 50, height: 1, fill: "#dadacc" }
-  - { min_zoom: 12, name: secondary, width: 50, height: 4, fill: "#ededc8", casing: "#c8b48a" }
-  - { min_zoom: 13, name: secondary, width: 50, height: 7, fill: "#ededc8", casing: "#c8b48a" }
-  - { min_zoom: 15, name: pedestrian, width: 50, height: 6, fill: "#e2e3e2", casing: "#9a9a9a" }
-  - { min_zoom: 13, name: track, width: 50, height: 3, fill: white, casing: "#999", casing-dasharray: "5 3", casing-dashoffset: 1 }
-  - { min_zoom: 15, name: track, width: 50, height: 4, fill: white, casing: "#999", casing-dasharray: "5 3", casing-dashoffset: 1 }
-  - { min_zoom: 17, name: track, width: 50, height: 5, fill: white, casing: "#999", casing-dasharray: "5 3", casing-dashoffset: 1 }
-  - { min_zoom: 13, name: bridleway, width: 52, height: 3, line: green, line-width: 1.5, line-dasharray: "4 2" }
-  - { min_zoom:  8, name: cycleway, width: 50, height: 3, line: "#0100fe", line-width: 1.5, line-dasharray: "6 2" }
-  - { min_zoom:  5, name: national_bike_route, width: 50, height:  2, fill: "#fe0000" }
-  - { min_zoom: 12, name: national_bike_route, width: 50, height:  3, fill: "#fe0000" }
-  - { min_zoom: 13, name: national_bike_route, width: 50, height: 12, fill: "#ffb3b3" }
-  - { min_zoom:  7, name: regional_bike_route, width: 50, height:  2, fill: "#b638fb" }
-  - { min_zoom: 12, name: regional_bike_route, width: 50, height:  3, fill: "#b638fb" }
-  - { min_zoom: 13, name: regional_bike_route, width: 50, height: 10, fill: "#ddb5d9" }
-  - { min_zoom:  8, name: local_bike_route, width: 50, height: 2, fill: "#0100fe" }
-  - { min_zoom: 12, name: local_bike_route, width: 50, height: 3, fill: "#0100fe" }
-  - { min_zoom: 13, name: local_bike_route, width: 50, height: 8, fill: "#b2b2ff" }
-  - { min_zoom: 10, name: mountain_bike_route, width: 50, height: 2, fill: "#ff7b1c" }
-  - { min_zoom: 13, name: mountain_bike_route, width: 50, height: 6, fill: "#fbcaa3" }
-  - { min_zoom: 13, name: footway, width: 50, height: 3, line: "#bd6d6e", line-width: 1.5, line-dasharray: "6 2" }
-  - { min_zoom:  7, name: rail, width: 50, height: 3, line: "#999999", line-width: 1.5 }
-  - { min_zoom: 14, name: rail, width: 50, height: 4, fill: "#999999", line: white, line-dasharray: 4, line-width: 2 }
-  - { min_zoom:  1, name: [lake, reservoir], width: 26, height: 10, fill: "#addeff" }
-  - { min_zoom:  9, name: [forest, wood], width: 26, height: 10, fill: "#b3d6a4" }
-  - { min_zoom: 10, name: meadow, width: 26, height: 10, fill: "#c0de9c" }
-  - { min_zoom: 10, name: park, width: 26, height: 10, fill: "#cbe4c4" }
-  - { min_zoom: 10, name: common, width: 26, height: 10, fill: "#d4f0d1" }
-  - { min_zoom: 10, name: heathland, width: 26, height: 10, fill: "#eaf0d6" }
-  - { min_zoom: 11, max_zoom: 13, name: resident, width: 26, height: 10, fill: "#e2e2e2" }
-  - { min_zoom: 11, name: industrial, width: 26, height: 10, fill: "#f1dede" }
-  - { min_zoom: 11, name: allotments, width: 26, height: 10, fill: "#d7d7b1" }
-  - { min_zoom: 12, name: cemetery, width: 26, height: 10, fill: "#abcfb1" }
-  - { min_zoom: 12, name: pitch, width: 26, height: 10, fill: "#ade0c5" }
-  - { min_zoom: 13, name: centre, width: 26, height: 10, fill: "#b4e9cd" }
-  - { min_zoom: 13, name: beach, image: beach.png }
-  - { min_zoom: 13, name: [school, university], width: 26, height: 10, fill: "#f0f0d8" }
-  - { min_zoom: 14, name: bicycle_shop, image: bicycle_shop.png }
-  - { min_zoom: 15, name: bicycle_rental, image: bicycle_rental_small.svg }
-  - { min_zoom: 17, name: bicycle_rental, image: bicycle_rental.png }
-  - { min_zoom: 15, name: bicycle_parking, image: bicycle_parking.png }
-  - { min_zoom: 16, name: bicycle_parking_small, image: bicycle_parking_small.svg }
-  - { min_zoom: 16, name: toilets, image: toilets.png }
+  entries:
+    - { min_zoom:  5, name: motorway, width: 50, height: 2, fill: "#9a9ab1" }
+    - { min_zoom:  9, name: motorway, width: 50, height: 3, fill: "#9a9ab1" }
+    - { min_zoom: 12, name: motorway, width: 50, height: 5, fill: "#bdbece", casing: "#8d95a7" }
+    - { min_zoom: 13, name: motorway, width: 50, height: 9, fill: "#bdbece", casing: "#8d95a7" }
+    - { min_zoom:  6, name: trunk, width: 50, height: 2, fill: "#c8d8c8" }
+    - { min_zoom: 12, name: trunk, width: 50, height: 4, fill: "#c8d8c8", casing: "#abb5a4" }
+    - { min_zoom: 13, name: trunk, width: 50, height: 8, fill: "#c8d8c8", casing: "#abb5a4" }
+    - { min_zoom:  8, name: primary, width: 50, height: 2, fill: "#d8c8c8" }
+    - { min_zoom: 12, name: primary, width: 50, height: 4, fill: "#f0e3e3", casing: "#d4b6b7" }
+    - { min_zoom: 13, name: primary, width: 50, height: 8, fill: "#f0e3e3", casing: "#d4b6b7" }
+    - { min_zoom: 10, name: secondary, width: 50, height: 1, fill: "#dadacc" }
+    - { min_zoom: 12, name: secondary, width: 50, height: 4, fill: "#ededc8", casing: "#c8b48a" }
+    - { min_zoom: 13, name: secondary, width: 50, height: 7, fill: "#ededc8", casing: "#c8b48a" }
+    - { min_zoom: 15, name: pedestrian, width: 50, height: 6, fill: "#e2e3e2", casing: "#9a9a9a" }
+    - { min_zoom: 13, name: track, width: 50, height: 3, fill: white, casing: "#999", casing-dasharray: "5 3", casing-dashoffset: 1 }
+    - { min_zoom: 15, name: track, width: 50, height: 4, fill: white, casing: "#999", casing-dasharray: "5 3", casing-dashoffset: 1 }
+    - { min_zoom: 17, name: track, width: 50, height: 5, fill: white, casing: "#999", casing-dasharray: "5 3", casing-dashoffset: 1 }
+    - { min_zoom: 13, name: bridleway, width: 52, height: 3, line: green, line-width: 1.5, line-dasharray: "4 2" }
+    - { min_zoom:  8, name: cycleway, width: 50, height: 3, line: "#0100fe", line-width: 1.5, line-dasharray: "6 2" }
+    - { min_zoom:  5, name: national_bike_route, width: 50, height:  2, fill: "#fe0000" }
+    - { min_zoom: 12, name: national_bike_route, width: 50, height:  3, fill: "#fe0000" }
+    - { min_zoom: 13, name: national_bike_route, width: 50, height: 12, fill: "#ffb3b3" }
+    - { min_zoom:  7, name: regional_bike_route, width: 50, height:  2, fill: "#b638fb" }
+    - { min_zoom: 12, name: regional_bike_route, width: 50, height:  3, fill: "#b638fb" }
+    - { min_zoom: 13, name: regional_bike_route, width: 50, height: 10, fill: "#ddb5d9" }
+    - { min_zoom:  8, name: local_bike_route, width: 50, height: 2, fill: "#0100fe" }
+    - { min_zoom: 12, name: local_bike_route, width: 50, height: 3, fill: "#0100fe" }
+    - { min_zoom: 13, name: local_bike_route, width: 50, height: 8, fill: "#b2b2ff" }
+    - { min_zoom: 10, name: mountain_bike_route, width: 50, height: 2, fill: "#ff7b1c" }
+    - { min_zoom: 13, name: mountain_bike_route, width: 50, height: 6, fill: "#fbcaa3" }
+    - { min_zoom: 13, name: footway, width: 50, height: 3, line: "#bd6d6e", line-width: 1.5, line-dasharray: "6 2" }
+    - { min_zoom:  7, name: rail, width: 50, height: 3, line: "#999999", line-width: 1.5 }
+    - { min_zoom: 14, name: rail, width: 50, height: 4, fill: "#999999", line: white, line-dasharray: 4, line-width: 2 }
+    - { min_zoom:  1, name: [lake, reservoir], width: 26, height: 10, fill: "#addeff" }
+    - { min_zoom:  9, name: [forest, wood], width: 26, height: 10, fill: "#b3d6a4" }
+    - { min_zoom: 10, name: meadow, width: 26, height: 10, fill: "#c0de9c" }
+    - { min_zoom: 10, name: park, width: 26, height: 10, fill: "#cbe4c4" }
+    - { min_zoom: 10, name: common, width: 26, height: 10, fill: "#d4f0d1" }
+    - { min_zoom: 10, name: heathland, width: 26, height: 10, fill: "#eaf0d6" }
+    - { min_zoom: 11, max_zoom: 13, name: resident, width: 26, height: 10, fill: "#e2e2e2" }
+    - { min_zoom: 11, name: industrial, width: 26, height: 10, fill: "#f1dede" }
+    - { min_zoom: 11, name: allotments, width: 26, height: 10, fill: "#d7d7b1" }
+    - { min_zoom: 12, name: cemetery, width: 26, height: 10, fill: "#abcfb1" }
+    - { min_zoom: 12, name: pitch, width: 26, height: 10, fill: "#ade0c5" }
+    - { min_zoom: 13, name: centre, width: 26, height: 10, fill: "#b4e9cd" }
+    - { min_zoom: 13, name: beach, image: beach.png }
+    - { min_zoom: 13, name: [school, university], width: 26, height: 10, fill: "#f0f0d8" }
+    - { min_zoom: 14, name: bicycle_shop, image: bicycle_shop.png }
+    - { min_zoom: 15, name: bicycle_rental, image: bicycle_rental_small.svg }
+    - { min_zoom: 17, name: bicycle_rental, image: bicycle_rental.png }
+    - { min_zoom: 15, name: bicycle_parking, image: bicycle_parking.png }
+    - { min_zoom: 16, name: bicycle_parking_small, image: bicycle_parking_small.svg }
+    - { min_zoom: 16, name: toilets, image: toilets.png }

--- a/config/key.yml
+++ b/config/key.yml
@@ -1,4 +1,5 @@
 mapnik:
+  legend: https://wiki.openstreetmap.org/wiki/OpenStreetMap_Carto/Symbols
   entries:
     # transportation: roads.mss
     - { min_zoom:  6, name: motorway, width: 52, height:  1, line: "#e66e89", line-width: 1 }
@@ -106,6 +107,7 @@ mapnik:
     - { min_zoom: 15, name: destination, image: destination.png }
     - { min_zoom: 12, name: construction, image: construction.png }
 cyclosm:
+  legend: https://www.cyclosm.org/legend.html
   entries:
     # bicycle routes: roads.mss, road-colors.mss
     - { min_zoom:  2, name: international_bike_route, width: 50, height:  1, fill: "#ff00ff", opacity: 0.75 }
@@ -145,6 +147,7 @@ cyclosm:
     - { min_zoom: 17, name: local_bike_route,         width: 50, height: 10, fill: "#0000ff", opacity: 0.25 }
     - { min_zoom: 18, name: local_bike_route,         width: 50, height: 14, fill: "#0000ff", opacity: 0.25 }
 cyclemap:
+  legend: https://www.opencyclemap.org/docs/
   entries:
     - { min_zoom:  5, name: motorway, width: 50, height: 2, fill: "#9a9ab1" }
     - { min_zoom:  9, name: motorway, width: 50, height: 3, fill: "#9a9ab1" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2642,6 +2642,7 @@ en:
         bicycle_parking: "Bicycle parking"
         bicycle_parking_small: "Small bicycle parking"
         toilets: "Toilets"
+      see_external_legend: "See external map legend"
   traces:
     visibility:
       private: "Private (only shared as anonymous, unordered points)"


### PR DESCRIPTION
Add links to map legends on external sites:
![image](https://github.com/user-attachments/assets/a7536bb1-c196-414f-87c4-61345964754a)

The key on osm.org may not be complete and maybe it doesn't even make sense to complete it, in case there's a lot of icons. This PR adds links to pages like https://www.cyclosm.org/legend.html.

I don't add `noreferrer` etc because we're already linking to these sites without these properties in map attributions, except for `:rel => "noopener"`.