### PR TITLE
Use I18n.exists? to filter available locales

### DIFF
--- a/lib/locale.rb
+++ b/lib/locale.rb
@@ -36,9 +36,7 @@ class Locale < I18n::Locale::Tag::Rfc4646
   end
 
   def invalid?
-    I18n.t("activerecord.models.acl", :locale => self, :fallback => false, :raise => true).nil?
-  rescue I18n::MissingTranslationData
-    true
+    !I18n.exists? "activerecord.models.acl", :locale => self, :fallback => false
   end
 
   def candidates


### PR DESCRIPTION
The method that checks if a locale exists currently does it by accessing the translation and checking if exception is (not) thrown. It could use `I18n.exists?` instead.