### PR TITLE
Add latest diaries partial to profile page

### DIFF
--- a/app/views/diary_entries/_profile_diaries.html.erb
+++ b/app/views/diary_entries/_profile_diaries.html.erb
@@ -1,0 +1,31 @@
+<% if diary_entries.present? %>
+  <h2 class="text-body-secondary fs-5 mt-4"><%= t(".latest_diaries") %></h2>
+  <div class="row row-cols-1 row-cols-md-2 g-4">
+    <% diary_entries.each do |entry| %>
+      <div class="col profile-diary-card">
+        <div class="card h-100">
+          <div class="card-body d-flex flex-column">
+            <p class="card-title">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Diary Entry"><path d="M2 6h4" /><path d="M2 10h4" /><path d="M2 14h4" /><path d="M2 18h4" /><rect width="16" height="20" x="4" y="2" rx="2" /><path d="M9.5 8h5" /><path d="M9.5 12H16" /><path d="M9.5 16H14" /></svg>
+              <%= link_to entry.title, diary_entry_path(@user, entry) %>
+            </p>
+            <p class="card-text flex-grow-1"><%= truncate(strip_tags(entry.body.to_html), :length => 150) %></p>
+
+            <div class="card-text d-flex justify-content-between align-items-center mt-auto">
+              <small class="text-body-secondary d-flex align-items-center">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="me-1" aria-label="Comments"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" /></svg>
+                <%= link_to diary_entry_path(@user, entry, :anchor => "comments"), :class => "text-body-secondary" do %>
+                  <span><%= t(".comments", :count => entry.comments.size) %></span>
+                <% end %>
+              </small>
+              <small class="text-body-secondary d-flex align-items-center">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="me-1" aria-label="Date"><path d="M8 2v4" /><path d="M16 2v4" /><rect width="18" height="18" x="3" y="4" rx="2" /><path d="M3 10h18" /></svg>
+                <span><%= l(entry.created_at.to_date, :format => :long) %></span>
+              </small>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -251,6 +251,8 @@
   <%= render :partial => "heatmap", :locals => @heatmap_data %>
 <% end %>
 
+<%= render :partial => "diary_entries/profile_diaries", :locals => { :diary_entries => @user.diary_entries.visible.order(:created_at => :desc).limit(4) } %>
+
 <% if current_user and @user.id == current_user.id %>
   <div class="my-3">
     <%= link_to t(".edit_profile"), edit_profile_path, :class => "btn btn-outline-primary" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -650,6 +650,11 @@ en:
       my_diary: My Diary
       new: New Diary Entry
       new_title: Compose a new entry in my user diary
+    profile_diaries:
+      latest_diaries: "Latest Diaries"
+      comments:
+        one: "%{count} comment"
+        other: "%{count} comments"
   diary_comments:
     new:
       heading: Add a comment to the following diary entry discussion?


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->
Closes #6009.
Adds recent diary entries partial and displays it on the user profiles pages by implementing a responsive card layout. It takes 4 most recent diary entries by default. Each diary entry is now shown in a Bootstrap card that displays the title, truncated content, comment count, and creation date. The layout is responsive - showing as a single column on mobile and two columns on larger screens

### How has this been tested?
Both testing manually to make sure it works along different screen sizes and adding tests to `users_controller_test.rb`.
<!--Explain the steps you took to test your code.-->
### Screenshots
<img width="1035" alt="Screenshot 2025-05-13 at 09 02 26" src="https://github.com/user-attachments/assets/969e5bf9-0f72-48da-b06b-d6ac8528c6d0" />
