### PR TITLE
Allow new diary entry language to be specified in params

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -89,7 +89,7 @@ class DiaryEntriesController < ApplicationController
 
     default_lang = current_user.preferences.find_by(:k => "diary.default_language")
     lang_code = default_lang ? default_lang.v : current_user.preferred_language
-    @diary_entry = DiaryEntry.new(entry_params.merge(:language_code => lang_code))
+    @diary_entry = DiaryEntry.new(entry_params.reverse_merge(:language_code => lang_code))
     set_map_location
     render :action => "new"
   end

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -133,14 +133,36 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_new_get_with_params
+    create(:language, :code => "fr")
     # Now try creating a diary entry using get
-    session_for(create(:user))
+    session_for(create(:user, :languages => ["en"]))
+
     assert_difference "DiaryEntry.count", 0 do
       get new_diary_entry_path(:diary_entry => { :title => "New Title", :body => "This is a new body for the diary entry", :latitude => "1.1",
-                                                 :longitude => "2.2", :language_code => "en" })
+                                                 :longitude => "2.2", :language_code => "fr" })
     end
+
     assert_response :success
     assert_template :new
+    assert_dom "div#content", :count => 1 do
+      assert_dom "form[action='/diary'][method=post]", :count => 1 do
+        assert_dom "input#diary_entry_title[name='diary_entry[title]']", :count => 1 do
+          assert_dom "> @value", "New Title"
+        end
+        assert_dom "textarea#diary_entry_body[name='diary_entry[body]']", :count => 1, :text => "This is a new body for the diary entry"
+        assert_dom "select#diary_entry_language_code", :count => 1 do
+          assert_dom "option[selected]", :count => 1 do
+            assert_dom "> @value", "fr"
+          end
+        end
+        assert_dom "input#latitude[name='diary_entry[latitude]']", :count => 1 do
+          assert_dom "> @value", "1.1"
+        end
+        assert_dom "input#longitude[name='diary_entry[longitude]']", :count => 1 do
+          assert_dom "> @value", "2.2"
+        end
+      end
+    end
   end
 
   def test_create_no_body

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -104,24 +104,30 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
 
   def test_new_form
     # Now try again when logged in
-    session_for(create(:user))
+    session_for(create(:user, :languages => ["en"]))
+
     get new_diary_entry_path
+
     assert_response :success
-    assert_select "title", :text => /New Diary Entry/, :count => 1
-    assert_select "div.content-heading", :count => 1 do
-      assert_select "h1", :text => /New Diary Entry/, :count => 1
+    assert_dom "title", :text => /New Diary Entry/, :count => 1
+    assert_dom "div.content-heading", :count => 1 do
+      assert_dom "h1", :text => /New Diary Entry/, :count => 1
     end
-    assert_select "div#content", :count => 1 do
-      assert_select "form[action='/diary'][method=post]", :count => 1 do
-        assert_select "input#diary_entry_title[name='diary_entry[title]']", :count => 1
-        assert_select "textarea#diary_entry_body[name='diary_entry[body]']", :text => "", :count => 1
-        assert_select "select#diary_entry_language_code", :count => 1
-        assert_select "input#latitude[name='diary_entry[latitude]']", :count => 1
-        assert_select "input#longitude[name='diary_entry[longitude]']", :count => 1
-        assert_select "input[name=commit][type=submit][value=Publish]", :count => 1
-        assert_select "button[type=button]", :text => "Edit", :count => 1
-        assert_select "button[type=button]", :text => "Preview", :count => 1
-        assert_select "input", :count => 4
+    assert_dom "div#content", :count => 1 do
+      assert_dom "form[action='/diary'][method=post]", :count => 1 do
+        assert_dom "input#diary_entry_title[name='diary_entry[title]']", :count => 1
+        assert_dom "textarea#diary_entry_body[name='diary_entry[body]']", :text => "", :count => 1
+        assert_dom "select#diary_entry_language_code", :count => 1 do
+          assert_dom "option[selected]", :count => 1 do
+            assert_dom "> @value", "en"
+          end
+        end
+        assert_dom "input#latitude[name='diary_entry[latitude]']", :count => 1
+        assert_dom "input#longitude[name='diary_entry[longitude]']", :count => 1
+        assert_dom "input[name=commit][type=submit][value=Publish]", :count => 1
+        assert_dom "button[type=button]", :text => "Edit", :count => 1
+        assert_dom "button[type=button]", :text => "Preview", :count => 1
+        assert_dom "input", :count => 4
       end
     end
   end


### PR DESCRIPTION
It's possible to open the new diary entry link with parameters to initialize the form values like this:  
https://www.openstreetmap.org/diary/new?diary_entry[title]=Subject&diary_entry[body]=texttexttext

The only value that is not supported is entry language because it's overwritten by user preferences. But the prefences are supposed to set only the default language value judging by `diary.default_language` name, not to override explicitly specified values.

This PR allows to use the `diary_entry[language_code]` parameter to specify the language of a new diary entry.