### PR TITLE
Add new diary entry links to user's own diary entry pages

### DIFF
--- a/app/controllers/diary_comments_controller.rb
+++ b/app/controllers/diary_comments_controller.rb
@@ -12,21 +12,21 @@ class DiaryCommentsController < ApplicationController
   allow_thirdparty_images :only => :create
 
   def create
-    @entry = DiaryEntry.find(params[:id])
-    @comments = @entry.visible_comments
-    @diary_comment = @entry.comments.build(comment_params)
+    @diary_entry = DiaryEntry.find(params[:id])
+    @comments = @diary_entry.visible_comments
+    @diary_comment = @diary_entry.comments.build(comment_params)
     @diary_comment.user = current_user
     if @diary_comment.save
 
       # Notify current subscribers of the new comment
-      @entry.subscribers.visible.each do |user|
+      @diary_entry.subscribers.visible.each do |user|
         UserMailer.diary_comment_notification(@diary_comment, user).deliver_later if current_user != user
       end
 
       # Add the commenter to the subscribers if necessary
-      @entry.subscriptions.create(:user => current_user) unless @entry.subscribers.exists?(current_user.id)
+      @diary_entry.subscriptions.create(:user => current_user) unless @diary_entry.subscribers.exists?(current_user.id)
 
-      redirect_to diary_entry_path(@entry.user, @entry, :anchor => "comment#{@diary_comment.id}")
+      redirect_to diary_entry_path(@diary_entry.user, @diary_entry, :anchor => "comment#{@diary_comment.id}")
     else
       render :action => "new"
     end

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -67,17 +67,17 @@ class DiaryEntriesController < ApplicationController
   def show
     entries = @user.diary_entries
     entries = entries.visible unless can? :unhide, DiaryEntry
-    @entry = entries.find_by(:id => params[:id])
-    if @entry
-      @title = t ".title", :user => params[:display_name], :title => @entry.title
+    @diary_entry = entries.find_by(:id => params[:id])
+    if @diary_entry
+      @title = t ".title", :user => params[:display_name], :title => @diary_entry.title
       @opengraph_properties = {
-        "og:title" => @entry.title,
-        "og:image" => @entry.body.image,
-        "og:image:alt" => @entry.body.image_alt,
-        "og:description" => @entry.body.description,
-        "article:published_time" => @entry.created_at.xmlschema
+        "og:title" => @diary_entry.title,
+        "og:image" => @diary_entry.body.image,
+        "og:image:alt" => @diary_entry.body.image_alt,
+        "og:description" => @diary_entry.body.description,
+        "article:published_time" => @diary_entry.created_at.xmlschema
       }
-      @comments = can?(:unhide, DiaryComment) ? @entry.comments : @entry.visible_comments
+      @comments = can?(:unhide, DiaryComment) ? @diary_entry.comments : @diary_entry.visible_comments
     else
       @title = t "diary_entries.no_such_entry.title", :id => params[:id]
       render :action => "no_such_entry", :status => :not_found

--- a/app/views/diary_comments/new.html.erb
+++ b/app/views/diary_comments/new.html.erb
@@ -2,11 +2,11 @@
   <h1><%= t ".heading" %></h1>
 <% end %>
 
-<%= render :partial => "diary_entries/diary_entry_heading", :object => @entry, :as => "diary_entry" %>
+<%= render :partial => "diary_entries/diary_entry_heading", :object => @diary_entry, :as => "diary_entry" %>
 
 <h3><%= t "diary_entries.show.leave_a_comment" %></h3>
 
-<%= bootstrap_form_for @diary_comment, :url => comment_diary_entry_path(@entry.user, @entry) do |f| %>
+<%= bootstrap_form_for @diary_comment, :url => comment_diary_entry_path(@diary_entry.user, @diary_entry) do |f| %>
   <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
   <%= f.primary %>
 <% end %>

--- a/app/views/diary_entries/_navigation.html.erb
+++ b/app/views/diary_entries/_navigation.html.erb
@@ -1,0 +1,26 @@
+<nav class="secondary-actions">
+  <ul>
+    <% unless params[:friends] or params[:nearby] -%>
+      <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>
+    <% end -%>
+
+    <% @languages&.each do |language| %>
+      <li><%= link_to t(".in_language", :language => language.name), :action => "index", :language => language.code %></li>
+    <% end %>
+
+    <% if !@user && current_user %>
+      <li><%= link_to t(".my_diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %></li>
+    <% end %>
+
+    <% if @user && @user == current_user || !@user && current_user %>
+      <li>
+        <%= link_to new_diary_entry_path, :class => "icon-link", :title => t(".new_title") do %>
+          <svg width="16" height="16">
+            <path d="M2 0 a2 2 0 0 0 -2 2 v12 a2 2 0 0 0 2 2 h12 a2 2 0 0 0 2 -2 v-12 a2 2 0 0 0 -2 -2 z M4 7 h3 v-3 h2 v3 h3 v2 h-3 v3 h-2 v-3 h-3 z" fill="currentColor" />
+          </svg>
+          <%= t(".new") %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/diary_entries/index.html.erb
+++ b/app/views/diary_entries/index.html.erb
@@ -9,33 +9,7 @@
 
     <div class="col">
       <h1><%= @title %></h1>
-
-      <nav class="secondary-actions">
-        <ul>
-          <% unless params[:friends] or params[:nearby] -%>
-            <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>
-          <% end -%>
-
-          <% @languages&.each do |language| %>
-            <li><%= link_to t(".in_language_title", :language => language.name), :action => "index", :language => language.code %></li>
-          <% end %>
-
-          <% if !@user && current_user %>
-            <li><%= link_to t(".my_diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %></li>
-          <% end %>
-
-          <% if @user && @user == current_user || !@user && current_user %>
-            <li>
-              <%= link_to new_diary_entry_path, :class => "icon-link", :title => t(".new_title") do %>
-                <svg width="16" height="16">
-                  <path d="M2 0 a2 2 0 0 0 -2 2 v12 a2 2 0 0 0 2 2 h12 a2 2 0 0 0 2 -2 v-12 a2 2 0 0 0 -2 -2 z M4 7 h3 v-3 h2 v3 h3 v2 h-3 v3 h-2 v-3 h-3 z" fill="currentColor" />
-                </svg>
-                <%= t(".new") %>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
+      <%= render :partial => "navigation" %>
     </div>
   </div>
 <% end %>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="col">
       <h1><%= link_to t(".user_title", :user => @diary_entry.user.display_name), :action => :index %></h1>
-      <p><%= rss_link_to :action => :rss, :display_name => @diary_entry.user.display_name %></p>
+      <%= render :partial => "navigation" %>
     </div>
   </div>
 <% end %>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -5,17 +5,17 @@
 <% content_for :heading do %>
   <div class="row">
     <div class="col-sm-auto">
-      <%= user_image @entry.user %>
+      <%= user_image @diary_entry.user %>
     </div>
     <div class="col">
-      <h1><%= link_to t(".user_title", :user => @entry.user.display_name), :action => :index %></h1>
-      <p><%= rss_link_to :action => :rss, :display_name => @entry.user.display_name %></p>
+      <h1><%= link_to t(".user_title", :user => @diary_entry.user.display_name), :action => :index %></h1>
+      <p><%= rss_link_to :action => :rss, :display_name => @diary_entry.user.display_name %></p>
     </div>
   </div>
 <% end %>
 
-<%= render @entry, :truncated => false %>
-<%= social_share_buttons(:title => @entry.title, :url => diary_entry_url(@entry.user, @entry)) %>
+<%= render @diary_entry, :truncated => false %>
+<%= social_share_buttons(:title => @diary_entry.title, :url => diary_entry_url(@diary_entry.user, @diary_entry)) %>
 
 <div id="comments" class="comments mb-3 overflow-hidden">
   <div class="row border-bottom border-secondary-subtle">
@@ -23,10 +23,10 @@
 
     <% if current_user %>
       <div class="col-auto">
-        <% if @entry.subscribers.exists?(current_user.id) %>
-          <%= link_to t(".unsubscribe"), diary_entry_unsubscribe_path(@entry.user, @entry), :method => :post, :class => "btn btn-sm btn-primary" %>
+        <% if @diary_entry.subscribers.exists?(current_user.id) %>
+          <%= link_to t(".unsubscribe"), diary_entry_unsubscribe_path(@diary_entry.user, @diary_entry), :method => :post, :class => "btn btn-sm btn-primary" %>
         <% else %>
-          <%= link_to t(".subscribe"), diary_entry_subscribe_path(@entry.user, @entry), :method => :post, :class => "btn btn-sm btn-primary" %>
+          <%= link_to t(".subscribe"), diary_entry_subscribe_path(@diary_entry.user, @diary_entry), :method => :post, :class => "btn btn-sm btn-primary" %>
         <% end %>
       </div>
     <% end %>
@@ -39,7 +39,7 @@
   <% if current_user %>
     <h3 id="newcomment"><%= t ".leave_a_comment" %></h3>
 
-    <%= bootstrap_form_for @entry.comments.new, :url => comment_diary_entry_path(@entry.user, @entry) do |f| %>
+    <%= bootstrap_form_for @diary_entry.comments.new, :url => comment_diary_entry_path(@diary_entry.user, @diary_entry) do |f| %>
       <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
       <%= f.primary %>
     <% end %>
@@ -49,5 +49,5 @@
 </div>
 
 <% content_for :auto_discovery_link_tag do -%>
-<%= auto_discovery_link_tag :rss, :action => :rss, :display_name => @entry.user.display_name %>
+<%= auto_discovery_link_tag :rss, :action => :rss, :display_name => @diary_entry.user.display_name %>
 <% end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -583,9 +583,6 @@ en:
       title_nearby: "Nearby Users' Diaries"
       user_title: "%{user}'s Diary"
       in_language_title: "Diary Entries in %{language}"
-      new: New Diary Entry
-      new_title: Compose a new entry in my user diary
-      my_diary: My Diary
       no_entries: No diary entries
     page:
       recent_entries: "Recent diary entries"
@@ -645,6 +642,11 @@ en:
     unsubscribe:
       heading: Unsubscribe from the following diary entry discussion?
       button: Unsubscribe from discussion
+    navigation:
+      in_language: "Diary Entries in %{language}"
+      my_diary: My Diary
+      new: New Diary Entry
+      new_title: Compose a new entry in my user diary
   diary_comments:
     new:
       heading: Add a comment to the following diary entry discussion?

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -75,6 +75,30 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     assert_no_link "Diary Entries in Russian"
   end
 
+  test "should have new diary entry link on own diary entry page" do
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user)
+
+    sign_in_as(user)
+    visit diary_entry_path(diary_entry.user, diary_entry)
+
+    within_content_heading do
+      assert_link "New Diary Entry"
+    end
+  end
+
+  test "should not have new diary entry link on other user's diary entry page" do
+    user = create(:user)
+    diary_entry = create(:diary_entry)
+
+    sign_in_as(user)
+    visit diary_entry_path(diary_entry.user, diary_entry)
+
+    within_content_heading do
+      assert_no_link "New Diary Entry"
+    end
+  end
+
   test "should not be hidden on the list page" do
     body = SecureRandom.alphanumeric(1998)
     create(:diary_entry, :body => body)


### PR DESCRIPTION
You open your diary, look at the top of the page and see something like this:
![image](https://github.com/user-attachments/assets/8b2254c7-7c0b-480e-83c0-e4b301f3fd76)

You click *New Diary Entry*, write an entry and publish it. Now you look at the top of the page again and see:
![image](https://github.com/user-attachments/assets/6a1cb65d-1215-4356-b598-7917380cd13a)

Where's the *New Diary Entry* link? The answer is, you're on a different page. Previously you were on your *index* page with several entries, but right after publishing you ended up on the *show* page of your new entry. And for whatever reason we don't show *New Diary Entry* on *show* pages. But I don't think there's a good reason, after all the RSS link for your entire diary is still there.

This PR adds *New Diary Entry* links on *show* pages of your own diary entries.
- includes *Rename entry to diary_entry* commit which turned out to be unnecessary for implementing this, but I think is a good idea anyway
