### PR TITLE
Use entire width of sidebar for directions table

### DIFF
--- a/app/assets/javascripts/index/directions-route-output.js
+++ b/app/assets/javascripts/index/directions-route-output.js
@@ -86,12 +86,12 @@ OSM.DirectionsRouteOutput = function (map) {
       const row = $("<tr class='turn'/>").appendTo($("#directions_route_steps"));
 
       if (direction) {
-        row.append("<td class='border-0'><svg width='20' height='20' class='d-block'><use href='#routing-sprite-" + direction + "' /></svg></td>");
+        row.append("<td class='ps-3'><svg width='20' height='20' class='d-block'><use href='#routing-sprite-" + direction + "' /></svg></td>");
       } else {
-        row.append("<td class='border-0'>");
+        row.append("<td class='ps-3'>");
       }
       row.append(`<td><b>${i + 1}.</b> ${instruction}`);
-      row.append("<td class='distance text-body-secondary text-end'>" + formatStepDistance(...translateDistanceUnits(dist)));
+      row.append("<td class='pe-3 distance text-body-secondary text-end'>" + formatStepDistance(...translateDistanceUnits(dist)));
 
       row.on("click", function () {
         popup

--- a/app/views/directions/show.html.erb
+++ b/app/views/directions/show.html.erb
@@ -111,9 +111,11 @@
     </div>
   </div>
 
-  <table class='table table-hover table-sm mb-3'>
-    <tbody id="directions_route_steps"></tbody>
-  </table>
+  <div class="mx-n3">
+    <table class='table table-hover table-sm mb-3'>
+      <tbody id="directions_route_steps"></tbody>
+    </table>
+  </div>
 
   <p class="text-center">
     <%= tag.a t(".download"), :id => "directions_route_download", :download => t(".filename") %>


### PR DESCRIPTION
Our search results and changeset lists in the sidebar look like this:
![image](https://github.com/user-attachments/assets/f48e8aa0-43ec-41b0-9f9f-57bc9c8f4419)

They take full width with borders between entries going from one side to another.

However out routing directions look a little different:
![image](https://github.com/user-attachments/assets/0cfe9e26-d28e-41dc-9c4d-97556df4108e)

They have margins which are especially noticeable when enties are highlighted. Margins don't get highlighted. This PR removes the margins:
![image](https://github.com/user-attachments/assets/47b97caa-41e0-4918-8f13-c81b808900b7)
