### PR TITLE
Improve dates in heatmap tooltips

### DIFF
--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -65,7 +65,7 @@ $(function () {
   }
 
   function getTooltipText(date, value) {
-    const localizedDate = OSM.i18n.l("date.formats.long", date);
+    const localizedDate = OSM.i18n.l("date.formats.heatmap", date);
 
     if (value > 0) {
       return OSM.i18n.t("javascripts.heatmap.tooltip.contributions", { count: value, date: localizedDate });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,9 @@
 en:
   html:
     dir: ltr
+  date:
+    formats:
+      heatmap: "%B %-d"
   time:
     formats:
       friendly: "%e %B %Y at %H:%M"


### PR DESCRIPTION
This uses a custom date format to drop the year from the heatmap tooltips, which doesn't really seem necessary when it only covers a single year - certainly GitHub doesn't show a year.

It also suppresses the leading zero from the day number, so overall "04 January, 2025" becomes "January 4" which seems nicer to me.