### PR TITLE
Remove .display_name from user path helper calls

### DIFF
--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -36,9 +36,9 @@
         <li><%= link_to t("users.show.send message"), new_message_path(contact) %></li>
         <li>
           <% if current_user.follows?(contact) %>
-            <%= link_to t("users.show.unfollow"), follow_path(:display_name => contact.display_name, :referer => request.fullpath), :method => :delete %>
+            <%= link_to t("users.show.unfollow"), follow_path(contact, :referer => request.fullpath), :method => :delete %>
           <% else %>
-            <%= link_to t("users.show.follow"), follow_path(:display_name => contact.display_name, :referer => request.fullpath), :method => :post %>
+            <%= link_to t("users.show.follow"), follow_path(contact, :referer => request.fullpath), :method => :post %>
           <% end %>
         </li>
       </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -87,9 +87,9 @@
             <% if current_user %>
               <li>
                 <% if current_user.follows?(@user) %>
-                  <%= link_to t(".unfollow"), follow_path(:display_name => @user.display_name), :method => :delete %>
+                  <%= link_to t(".unfollow"), follow_path(@user), :method => :delete %>
                 <% else %>
-                  <%= link_to t(".follow"), follow_path(:display_name => @user.display_name), :method => :post %>
+                  <%= link_to t(".follow"), follow_path(@user), :method => :post %>
                 <% end %>
               </li>
             <% end %>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -336,7 +336,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     create(:changeset, :user => user, :created_at => 6.months.ago, :num_changes => 10)
     create(:changeset, :user => user, :created_at => 3.months.ago, :num_changes => 20)
 
-    get user_path(user.display_name)
+    get user_path(user)
     assert_response :success
     # The data should not be empty
     heatmap_data = assigns(:heatmap_data)
@@ -359,7 +359,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     create(:changeset, :user => user, :created_at => 6.months.ago, :num_changes => 15)
 
     # First request to populate the cache
-    get user_path(user.display_name)
+    get user_path(user)
     first_response_data = assigns(:heatmap_data)
     assert_not_nil first_response_data, "Expected heatmap data to be assigned on the first request"
     assert_equal 1, first_response_data[:data].values.count { |day| day[:total_changes].positive? }, "Expected one entry in the heatmap data"
@@ -372,7 +372,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     create(:changeset, :user => user, :created_at => 3.months.ago, :num_changes => 20)
 
     # Second request
-    get user_path(user.display_name)
+    get user_path(user)
     second_response_data = assigns(:heatmap_data)
 
     # Confirm that the cache is still being used
@@ -380,7 +380,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     # Clear the cache and make a third request to confirm new data is retrieved
     Rails.cache.clear
-    get user_path(user.display_name)
+    get user_path(user)
     third_response_data = assigns(:heatmap_data)
 
     # Ensure the new entry is now included
@@ -394,7 +394,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   def test_show_heatmap_data_no_changesets
     user = create(:user)
 
-    get user_path(user.display_name)
+    get user_path(user)
     assert_response :success
     assert_empty(assigns(:heatmap_data)[:data].values)
     assert_select ".heatmap", :count => 0

--- a/test/system/report_diary_comment_test.rb
+++ b/test/system/report_diary_comment_test.rb
@@ -8,7 +8,7 @@ class ReportDiaryCommentTest < ApplicationSystemTestCase
   end
 
   def test_no_link_when_not_logged_in
-    visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
+    visit diary_entry_path(@diary_entry.user, @diary_entry)
     assert_content @comment.body
 
     assert_no_content I18n.t("diary_entries.diary_comment.report")
@@ -16,7 +16,7 @@ class ReportDiaryCommentTest < ApplicationSystemTestCase
 
   def test_it_works
     sign_in_as(create(:user))
-    visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
+    visit diary_entry_path(@diary_entry.user, @diary_entry)
     assert_content @diary_entry.title
 
     click_on I18n.t("diary_entries.diary_comment.report")

--- a/test/system/report_diary_entry_test.rb
+++ b/test/system/report_diary_entry_test.rb
@@ -7,7 +7,7 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
   end
 
   def test_no_link_when_not_logged_in
-    visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
+    visit diary_entry_path(@diary_entry.user, @diary_entry)
     assert_content @diary_entry.title
 
     assert_no_content I18n.t("diary_entries.diary_entry.report")
@@ -15,7 +15,7 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
 
   def test_it_works
     sign_in_as(create(:user))
-    visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
+    visit diary_entry_path(@diary_entry.user, @diary_entry)
     assert_content @diary_entry.title
 
     click_on I18n.t("diary_entries.diary_entry.report")
@@ -39,7 +39,7 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
     issue.resolve!
 
     sign_in_as(create(:user))
-    visit diary_entry_path(@diary_entry.user.display_name, @diary_entry)
+    visit diary_entry_path(@diary_entry.user, @diary_entry)
     assert_content @diary_entry.title
 
     click_on I18n.t("diary_entries.diary_entry.report")


### PR DESCRIPTION
Replaces
```
user_path(user.display_name)
```
and likes with
```
user_path(user)
```

They mostly were replaced already but heatmap and friends-follows brought some back.