### PR TITLE
Restore the original heatmap cell colors

### DIFF
--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -48,7 +48,7 @@ $(function () {
         customClass: "wide",
         delay: { show: 0, hide: 0 }
       })
-      .find("div")
+      .find("span")
       .css("opacity", Math.sqrt(count / maxPerDay));
   }
   heatmap.find(`[data-month="${previousMonth}"] ~ [data-month]`).remove();

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -977,12 +977,29 @@ img.trace_image {
   }
 
   [data-date] {
-    @extend .bg-body-secondary, .bg-opacity-75;
+    background-color: #ededed;
     span {
-      background-color: $green;
+      background-color: #14432a;
+    }
+    &[data-count] {
+      background-color: #4dd05a;
     }
     &:hover {
       border: solid 1px #8884;
+    }
+  }
+}
+
+@include color-mode(dark) {
+  .heatmap {
+    [data-date] {
+      background-color: #2d333b;
+      span {
+        background-color: #4dd05a;
+      }
+      &[data-count] {
+        background-color: #14432a;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -985,7 +985,7 @@ img.trace_image {
       background-color: #4dd05a;
     }
     &:hover {
-      border: solid 1px #8884;
+      box-shadow: 0px 0px 0px 1px #8884;
     }
   }
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -970,7 +970,7 @@ img.trace_image {
   font-size: x-small;
   gap: 0.3em;
 
-  [data-date], [data-date] div {
+  [data-date], [data-date] span {
     display: block;
     aspect-ratio: 1;
     border-radius: 25%;
@@ -978,7 +978,7 @@ img.trace_image {
 
   [data-date] {
     @extend .bg-body-secondary, .bg-opacity-75;
-    div {
+    span {
       background-color: $green;
     }
     &:hover {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -969,13 +969,17 @@ img.trace_image {
   grid-auto-rows: minmax(1em, 1fr);
   font-size: x-small;
   gap: 0.3em;
-  [data-date] {
+
+  [data-date], [data-date] div {
+    display: block;
     aspect-ratio: 1;
-    @extend .bg-body-secondary, .bg-opacity-75, .h-100, .overflow-hidden;
     border-radius: 25%;
+  }
+
+  [data-date] {
+    @extend .bg-body-secondary, .bg-opacity-75;
     div {
       background-color: $green;
-      @extend .h-100;
     }
     &:hover {
       border: solid 1px #8884;

--- a/app/views/users/_heatmap.html.erb
+++ b/app/views/users/_heatmap.html.erb
@@ -15,7 +15,7 @@
         <% if day[:total_changes] == 0 %>
           <span data-date="<%= day[:date] %>"></span>
         <% else %>
-          <a href="<%= user_history_path @user, :before => day[:max_id] + 1 %>" data-date="<%= day[:date] %>" data-count="<%= day[:total_changes] %>"><div></div></a>
+          <a href="<%= user_history_path @user, :before => day[:max_id] + 1 %>" data-date="<%= day[:date] %>" data-count="<%= day[:total_changes] %>"><span></span></a>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
I don't think that the goal of #5998 was changing colors. Color changes led to issues like https://github.com/openstreetmap/openstreetmap-website/pull/5998#issuecomment-2888521983 that make it impossible to see the days with edits for some editing patterns.

Before:
![image](https://github.com/user-attachments/assets/5e9ad934-f75d-422c-b649-2a259713c4aa) ![image](https://github.com/user-attachments/assets/d3add426-a672-45d9-a421-d5d7a19fc76b)

After:
![image](https://github.com/user-attachments/assets/600baaed-996a-46c1-a15c-644365293179) ![image](https://github.com/user-attachments/assets/998ebe3c-d2fc-4d9c-a394-d0c13cce86b7)

---

To address this comment https://github.com/openstreetmap/openstreetmap-website/pull/5998#issuecomment-2887816546:

> And anything involving different light and dark color palletes requires watching the color scheme media query again, which I really want to avoid.

Most of watching was made necessary by cal-heatmap controlling the colors. Now that cal-heatmap is gone, `@include color-mode(dark) { ... }` css is enough to redefine colors for dark mode.