### PR TITLE
Use <bdi> for comments in changeset history lists

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -598,7 +598,7 @@ tr.turn {
       @extend :hover;
     }
 
-    a.stretched-link > span, a:not(.stretched-link), [title] {
+    a.stretched-link > bdi, a:not(.stretched-link), [title] {
       position: relative;
       z-index: 2; /* needs to be higher than Bootstrap's stretched link ::after z-index */
     }

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -7,7 +7,7 @@
   #<%= link_to_unless_current common_details.version, :controller => "old_#{@type.pluralize}", :action => :show, :version => common_details.version %>
 </h4>
 
-<p class="fs-6 overflow-x-auto">
+<p class="fs-6 overflow-x-auto" dir="auto">
   <% if common_details.changeset.tags["comment"].present? %>
     <%= linkify(common_details.changeset.tags["comment"]) %>
   <% else %>

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -1,7 +1,7 @@
 <%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data(changeset) }, :class => "list-group-item list-group-item-action" do %>
   <p class="fs-6 text-truncate text-wrap mb-0">
     <a class="changeset_id link-body-emphasis stretched-link" href="<%= changeset_path(changeset) %>">
-      <span><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></span>
+      <bdi><%= changeset.tags["comment"].to_s.presence || t("browse.no_comment") %></bdi>
     </a>
   </p>
   <div class="d-flex flex-nowrap gap-3 justify-content-between align-items-end">


### PR DESCRIPTION
Not part of #3429.

Fixes bidi bugs illustrated by images in https://github.com/openstreetmap/openstreetmap-website/pull/3429#issuecomment-2828944354.

Before:
![image](https://github.com/user-attachments/assets/f6732d9e-f205-47a5-b6b9-076cc12e3710) ![image](https://github.com/user-attachments/assets/29d082b9-45b1-4a66-a4b4-f31f662310d1)

After:
![image](https://github.com/user-attachments/assets/6d97a6cc-1650-4945-a2a1-2447770d3971) ![image](https://github.com/user-attachments/assets/53e68c83-4544-4325-acb1-bc74059bf55f)
