### PR TITLE
User profile page: number delimiter if large number of contributions

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -247,7 +247,7 @@
 <div class="richtext text-break"><%= @user.description.to_html %></div>
 
 <% if @heatmap_data[:count].positive? %>
-  <h2 class="text-body-secondary fs-5 mt-4"><%= t("users.show.contributions", :count => @heatmap_data[:count]) %></h2>
+  <h2 class="text-body-secondary fs-5 mt-4"><%= t("users.show.contributions", :count => number_with_delimiter(@heatmap_data[:count])) %></h2>
   <%= render :partial => "heatmap", :locals => @heatmap_data %>
 <% end %>
 


### PR DESCRIPTION
I noticed large numbers on the user profile page are formatted (thousand separator) but not the number of contributions yet.

### Description
![image](https://github.com/user-attachments/assets/f33b5821-8e34-4c2b-8889-7eaf5ade3cca)

### How has this been tested?
Github CI. The `test/controllers/users_controller_test.rb` currently doesn't check large numbers.


