### PR TITLE
Use same logic for feature names

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -109,23 +109,14 @@ OSM.Query = function (map) {
 
   function featureName(feature) {
     const tags = feature.tags,
-          locales = OSM.preferred_languages;
+          localeKeys = OSM.preferred_languages.map(locale => `name:${locale}`);
 
-    for (const locale of locales) {
-      if (tags["name:" + locale]) {
-        return tags["name:" + locale];
-      }
+    for (const key of [...localeKeys, "name", "ref", "addr:housename"]) {
+      if (tags[key]) return tags[key];
     }
+    // TODO: Localize format to country of address
+    if (tags["addr:housenumber"] && tags["addr:street"]) return `${tags["addr:housenumber"]} ${tags["addr:street"]}`;
 
-    for (const key of ["name", "ref", "addr:housename"]) {
-      if (tags[key]) {
-        return tags[key];
-      }
-    }
-
-    if (tags["addr:housenumber"] && tags["addr:street"]) {
-      return tags["addr:housenumber"] + " " + tags["addr:street"];
-    }
     return "#" + feature.id;
   }
 


### PR DESCRIPTION
JS and Ruby side feature naming has been a bit different. Using a similar structure and logic, these parts can become nearly identical to read.
I also moved the standard address to i18n as some languages have it the other way round.
Closes #3447