### PR TITLE
Focus on newly added social link fields

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -29,6 +29,8 @@ $(function () {
       });
 
       $("#social_links").append(socialLinkForm);
+
+      socialLinkForm.find("input").trigger("focus");
     });
 
     $(".social_link_destroy input[type='checkbox']").change(function () {


### PR DESCRIPTION
When a new social link is added presumably the user is about to fill it in, so focus on it.