### PR TITLE
Focus first endpoint when routing is activated

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -168,5 +168,9 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, marker, dragCallback, cha
     input.val(latlng.lat + ", " + latlng.lng);
   }
 
+  endpoint.focusInput = function () {
+    input.trigger("focus");
+  };
+
   return endpoint;
 };

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -216,6 +216,8 @@ OSM.Directions = function (map) {
 
     endpoints[0].enableListeners();
     endpoints[1].enableListeners();
+
+    endpoints[0].focusInput();
   }
 
   const page = {};


### PR DESCRIPTION
When routing is activated we are presumably about to look for a route, and anything already in the search box will have been transferred to the route end field, so focus on the route start field ready to accept input.