### PR TITLE
Invert social link icons in dark mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -960,6 +960,14 @@ img.trace_image {
   }
 }
 
+/* Rules for the social links */
+
+@include color-mode(dark) {
+  .social_links img {
+    filter: invert(1);
+  }
+}
+
 /* Rules for the heatmap */
 
 .heatmap {

--- a/app/views/social_links/_show.html.erb
+++ b/app/views/social_links/_show.html.erb
@@ -1,4 +1,4 @@
-<ul class="list-unstyled">
+<ul class="list-unstyled social_links">
   <% social_links.each do |social_link| %>
     <li>
       <%= link_to social_link.parsed[:url], :class => "icon-link mw-100 text-body-secondary mb-3", :rel => "nofollow me" do %>


### PR DESCRIPTION
Fixes #6043.

![image](https://github.com/user-attachments/assets/d4b81a35-1061-423d-80f6-8822ce60ce37)
