### PR TITLE
Data layer: display text for http 509 rate limiting errors

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -88,7 +88,7 @@ OSM.initializeDataLayer = function (map) {
       .then(response => {
         if (response.ok) return response.json();
         const status = response.statusText || response.status;
-        if (response.status !== 400) throw new Error(status);
+        if (response.status !== 400 && response.status !== 509) throw new Error(status);
         return response.text().then(text => {
           throw new Error(text || status);
         });


### PR DESCRIPTION
This pull request adds human readable HTTP 509 rate limiting error messages.

Before:
![b2](https://github.com/user-attachments/assets/a068668c-1218-463f-aec6-3635a10347b9)

After:
![b3](https://github.com/user-attachments/assets/6abee1b7-24c7-4649-8280-480e3c7a0f07)
