### PR TITLE
Include changeset with node instead of loading it while rendering

### DIFF
--- a/app/controllers/api/maps_controller.rb
+++ b/app/controllers/api/maps_controller.rb
@@ -44,7 +44,7 @@ module Api
       else
         way_nodes = WayNode.where(:node_id => node_ids)
         way_ids = way_nodes.collect { |way_node| way_node.id[0] }
-        ways = Way.preload(:way_nodes, :way_tags).find(way_ids)
+        ways = Way.preload(:way_nodes, :way_tags, :changeset).find(way_ids)
 
         list_of_way_nodes = ways.flat_map { |way| way.way_nodes.map(&:node_id) }
       end
@@ -58,8 +58,12 @@ module Api
 
       @ways = ways.filter(&:visible?)
 
-      @relations = Relation.nodes(@nodes).visible +
-                   Relation.ways(@ways).visible
+      @relations = Relation.nodes(@nodes)
+                           .visible
+                           .includes(:changeset, :relation_members, :relation_tags) +
+                   Relation.ways(@ways)
+                           .visible
+                           .includes(:changeset, :relation_members, :relation_tags)
 
       # we do not normally return the "other" partners referenced by an relation,
       # e.g. if we return a way A that is referenced by relation X, and there's

--- a/app/controllers/api/maps_controller.rb
+++ b/app/controllers/api/maps_controller.rb
@@ -28,7 +28,7 @@ module Api
         return
       end
 
-      nodes = Node.bbox(@bounds).where(:visible => true).includes(:node_tags).limit(Settings.max_number_of_nodes + 1)
+      nodes = Node.bbox(@bounds).where(:visible => true).includes(:node_tags, :changeset).limit(Settings.max_number_of_nodes + 1)
 
       node_ids = nodes.collect(&:id)
       if node_ids.length > Settings.max_number_of_nodes
@@ -52,7 +52,7 @@ module Api
       # - [0] in case some thing links to node 0 which doesn't exist. Shouldn't actually ever happen but it does. FIXME: file a ticket for this
       nodes_to_fetch = (list_of_way_nodes.uniq - node_ids) - [0]
 
-      nodes += Node.includes(:node_tags).find(nodes_to_fetch) unless nodes_to_fetch.empty?
+      nodes += Node.includes(:node_tags, :changeset).find(nodes_to_fetch) unless nodes_to_fetch.empty?
 
       @nodes = nodes.filter(&:visible?)
 


### PR DESCRIPTION
Related to this issue: https://github.com/openstreetmap/openstreetmap-website/issues/6057

The exact details in the issue above. 

As changeset is required while rendering [here](https://github.com/openstreetmap/openstreetmap-website/blob/812557147870c02d5dadc22e42b1cf805006292f/app/views/api/nodes/_node.xml.builder#L7)