### PR TITLE
Always use button elements for Remove social link buttons

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -12,8 +12,7 @@ $(function () {
   let map, marker, deleted_lat, deleted_lon, deleted_home_name, homeLocationNameGeocoder, savedLat, savedLon;
 
   if ($("#social_links").length) {
-    $("#add-social-link").click(function (event) {
-      event.preventDefault();
+    $("#add-social-link").click(function () {
       const newIndex = -Date.now();
       const socialLinkForm = $(`
         <div class="social-link-added-fields row mb-3">

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -19,15 +19,34 @@ $(function () {
         .find("input").attr("name", `user[social_links_attributes][${newIndex}][url]`).trigger("focus")
         .end().find("button").on("click", function () {
           $(this).parent().remove();
+          renumberSocialLinks();
         });
+
+      renumberSocialLinks();
     });
 
     $(".social_link_destroy input[type='checkbox']").change(function () {
       $(this).parent().parent().addClass("d-none");
+      renumberSocialLinks();
     });
 
     $(".social_link_destroy input[type='checkbox']:checked").each(function () {
       $(this).parent().parent().addClass("d-none");
+    });
+
+    renumberSocialLinks();
+  }
+
+  function renumberSocialLinks() {
+    $("#social_links .row:not(.d-none)").each(function (i) {
+      const inputLabel = OSM.i18n.t("javascripts.profile.social_link_n", { n: i + 1 });
+      const removeButtonLabel = OSM.i18n.t("javascripts.profile.remove_social_link_n", { n: i + 1 });
+
+      $(this).find("input[type='text']")
+        .attr("placeholder", inputLabel)
+        .attr("aria-label", inputLabel);
+      $(this).find("label, button")
+        .attr("title", removeButtonLabel);
     });
   }
 

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -17,7 +17,7 @@ $(function () {
       const socialLinkForm = $(`
         <div class="social-link-added-fields row mb-3">
           <div class="col-sm-8">
-            <input class="form-control" type="text" name="user[social_links_attributes][${newIndex}][url]" id="user_social_links_attributes_${newIndex}_url">
+            <input class="form-control" type="text" name="user[social_links_attributes][${newIndex}][url]">
           </div>
           <button type="button" class="btn btn-outline-primary col-sm-2 align-self-start">${OSM.i18n.t("javascripts.social_links.remove")}</button>
         </div>

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -14,22 +14,12 @@ $(function () {
   if ($("#social_links").length) {
     $("#add-social-link").click(function () {
       const newIndex = -Date.now();
-      const socialLinkForm = $(`
-        <div class="social-link-added-fields row mb-3">
-          <div class="col-sm-8">
-            <input class="form-control" type="text" name="user[social_links_attributes][${newIndex}][url]">
-          </div>
-          <button type="button" class="btn btn-outline-primary col-sm-2 align-self-start">${OSM.i18n.t("javascripts.social_links.remove")}</button>
-        </div>
-      `);
 
-      socialLinkForm.find("button").click(function () {
-        $(this).parent().remove();
-      });
-
-      $("#social_links").append(socialLinkForm);
-
-      socialLinkForm.find("input").trigger("focus");
+      $("#social_links template").contents().clone().appendTo("#social_links")
+        .find("input").attr("name", `user[social_links_attributes][${newIndex}][url]`).trigger("focus")
+        .end().find("button").on("click", function () {
+          $(this).parent().remove();
+        });
     });
 
     $(".social_link_destroy input[type='checkbox']").change(function () {

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -12,26 +12,31 @@ $(function () {
   let map, marker, deleted_lat, deleted_lon, deleted_home_name, homeLocationNameGeocoder, savedLat, savedLon;
 
   if ($("#social_links").length) {
-    $("#add-social-link").click(function () {
+    $("#add-social-link").on("click", function () {
       const newIndex = -Date.now();
 
       $("#social_links template").contents().clone().appendTo("#social_links")
-        .find("input").attr("name", `user[social_links_attributes][${newIndex}][url]`).trigger("focus")
-        .end().find("button").on("click", function () {
-          $(this).parent().remove();
-          renumberSocialLinks();
-        });
+        .find("input").attr("name", `user[social_links_attributes][${newIndex}][url]`).trigger("focus");
 
       renumberSocialLinks();
     });
 
-    $(".social_link_destroy input[type='checkbox']").change(function () {
-      $(this).parent().parent().addClass("d-none");
+    $("#social_links").on("click", "button", function () {
+      const row = $(this).closest(".row");
+      const [destroyCheckbox] = row.find(".social_link_destroy input[type='checkbox']");
+
+      if (destroyCheckbox) {
+        destroyCheckbox.checked = true;
+        row.addClass("d-none");
+      } else {
+        row.remove();
+      }
+
       renumberSocialLinks();
     });
 
     $(".social_link_destroy input[type='checkbox']:checked").each(function () {
-      $(this).parent().parent().addClass("d-none");
+      $(this).closest(".row").addClass("d-none");
     });
 
     renumberSocialLinks();
@@ -45,7 +50,7 @@ $(function () {
       $(this).find("input[type='text']")
         .attr("placeholder", inputLabel)
         .attr("aria-label", inputLabel);
-      $(this).find("label, button")
+      $(this).find("button")
         .attr("title", removeButtonLabel);
     });
   }

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -15,6 +15,14 @@
 
     <%= f.label t(".social_links.title"), :class => "form-label" %>
     <div id="social_links">
+      <template>
+        <div class="social-link-added-fields row mb-3">
+          <div class="col-sm-8">
+            <input class="form-control" type="text" autocomplete="off">
+          </div>
+          <button type="button" class="btn btn-outline-primary col-sm-2 align-self-start"><%= t(".social_links.remove") %></button>
+        </div>
+      </template>
       <%= f.fields_for :social_links do |social_link_form| %>
         <div class="social-link-fields row mb-3">
           <%= social_link_form.text_field :url, :hide_label => true, :wrapper_class => "col-sm-8" %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,7 +27,7 @@
         <div class="social-link-fields row mb-3">
           <%= social_link_form.text_field :url, :skip_label => true, :wrapper_class => "col-sm-8" %>
           <%= social_link_form.check_box :_destroy, :wrapper_class => "d-none social_link_destroy" %>
-          <%= social_link_form.label :_destroy, t(".social_links.remove"), :class => "btn btn-outline-primary col-sm-2 align-self-start" %>
+          <button type="button" class="btn btn-outline-primary col-sm-2 align-self-start"><%= t(".social_links.remove") %></button>
         </div>
       <% end %>
     </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -25,7 +25,7 @@
       </template>
       <%= f.fields_for :social_links do |social_link_form| %>
         <div class="social-link-fields row mb-3">
-          <%= social_link_form.text_field :url, :hide_label => true, :wrapper_class => "col-sm-8" %>
+          <%= social_link_form.text_field :url, :skip_label => true, :wrapper_class => "col-sm-8" %>
           <%= social_link_form.check_box :_destroy, :wrapper_class => "d-none social_link_destroy" %>
           <%= social_link_form.label :_destroy, t(".social_links.remove"), :class => "btn btn-outline-primary col-sm-2 align-self-start" %>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3343,6 +3343,9 @@ en:
       queryfeature_tooltip: Query features
       queryfeature_disabled_tooltip: Zoom in to query features
       embed_html_disabled: HTML embedding is not available for this map layer
+    profile:
+      social_link_n: "Social Profile Link %{n}"
+      remove_social_link_n: "Remove Social Profile Link %{n}"
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
       distance_in_units:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3343,8 +3343,6 @@ en:
       queryfeature_tooltip: Query features
       queryfeature_disabled_tooltip: Zoom in to query features
       embed_html_disabled: HTML embedding is not available for this map layer
-    social_links:
-      remove: Remove
     edit_help: Move the map and zoom in on a location you want to edit, then click here.
     directions:
       distance_in_units:

--- a/test/system/user_social_links_test.rb
+++ b/test/system/user_social_links_test.rb
@@ -1,0 +1,25 @@
+require "application_system_test_case"
+
+class UserSocialLinksTest < ApplicationSystemTestCase
+  def setup
+    stub_request(:get, /.*gravatar.com.*d=404/).to_return(:status => 404)
+
+    @user = create(:user)
+    sign_in_as(@user)
+    visit user_path(@user)
+  end
+
+  test "can add social links" do
+    within_content_body do
+      click_on "Edit Profile"
+
+      assert_no_field "Social Profile Link 1"
+
+      click_on "Add Social Link"
+      fill_in "Social Profile Link 1", :with => "https://example.com/user/fred"
+      click_on "Update Profile"
+
+      assert_link "example.com/user/fred"
+    end
+  end
+end

--- a/test/system/user_social_links_test.rb
+++ b/test/system/user_social_links_test.rb
@@ -9,7 +9,23 @@ class UserSocialLinksTest < ApplicationSystemTestCase
     visit user_path(@user)
   end
 
-  test "can add social links" do
+  test "can add and remove social link without submitting" do
+    within_content_body do
+      click_on "Edit Profile"
+
+      assert_no_field "Social Profile Link 1"
+
+      click_on "Add Social Link"
+
+      assert_field "Social Profile Link 1"
+
+      click_on "Remove Social Profile Link 1"
+
+      assert_no_field "Social Profile Link 1"
+    end
+  end
+
+  test "can add and remove social links" do
     within_content_body do
       click_on "Edit Profile"
 
@@ -20,6 +36,86 @@ class UserSocialLinksTest < ApplicationSystemTestCase
       click_on "Update Profile"
 
       assert_link "example.com/user/fred"
+
+      click_on "Edit Profile"
+      click_on "Remove Social Profile Link 1"
+
+      assert_no_field "Social Profile Link 1"
+
+      click_on "Update Profile"
+
+      assert_no_link "example.com/user/fred"
+    end
+  end
+
+  test "can control social links using keyboard without submitting" do
+    within_content_body do
+      click_on "Edit Profile"
+      click_on "Add Social Link"
+
+      assert_field "Social Profile Link 1"
+
+      send_keys :tab, :enter
+
+      assert_no_field "Social Profile Link 1"
+    end
+  end
+
+  test "can control social links using keyboard" do
+    within_content_body do
+      click_on "Edit Profile"
+      click_on "Add Social Link"
+      send_keys "https://example.com/user/typed"
+      click_on "Update Profile"
+
+      assert_link "example.com/user/typed"
+
+      click_on "Edit Profile"
+      find_field("Social Profile Link 1").click
+      send_keys :tab, :enter
+
+      assert_no_field "Social Profile Link 1"
+
+      click_on "Update Profile"
+
+      assert_no_link "example.com/user/typed"
+    end
+  end
+
+  test "can add and remove multiple links" do
+    within_content_body do
+      click_on "Edit Profile"
+      click_on "Add Social Link"
+      fill_in "Social Profile Link 1", :with => "https://example.com/a"
+      click_on "Add Social Link"
+      fill_in "Social Profile Link 2", :with => "https://example.com/b"
+      click_on "Add Social Link"
+      fill_in "Social Profile Link 3", :with => "https://example.com/c"
+      click_on "Update Profile"
+
+      assert_link "example.com/a"
+      assert_link "example.com/b"
+      assert_link "example.com/c"
+
+      click_on "Edit Profile"
+
+      assert_field "Social Profile Link 1", :with => "https://example.com/a"
+      assert_field "Social Profile Link 2", :with => "https://example.com/b"
+      assert_field "Social Profile Link 3", :with => "https://example.com/c"
+
+      click_on "Remove Social Profile Link 2"
+
+      assert_field "Social Profile Link 1", :with => "https://example.com/a"
+      assert_field "Social Profile Link 2", :with => "https://example.com/c"
+
+      click_on "Add Social Link"
+      fill_in "Social Profile Link 3", :with => "https://example.com/d"
+      click_on "Update Profile"
+
+      assert_link "example.com/a"
+      assert_no_link "example.com/b"
+      assert_link "example.com/c"
+      assert_link "example.com/d"
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/pull/5439#issuecomment-2904227124

Here's how tabbing through social link inputs looks like:

https://github.com/user-attachments/assets/0bb01428-9b4c-4a27-9093-6d563c912d45

Notice that only the newly added *Remove* buttons are reachable. That's because *Remove* buttons for already existing links are not actually buttons. They are labels for hidden checkboxes styled as buttons.

This PR makes *Remove* buttons actual `<button>` elements. It also adds placeholders for link inputs, mainly because it's easier to test:
![image](https://github.com/user-attachments/assets/2cb6ec12-8a56-450c-bdf1-4c419b1fdc80)

Also removes interpolation of strings from Translatewiki into html like this:
```html
<button type="button" class="btn btn-outline-primary col-sm-2 align-self-start">${OSM.i18n.t("javascripts.social_links.remove")}</button>
```
by writing html in the erb template.