### PR TITLE
Social link icon filter

### DIFF
--- a/app/assets/images/social_link_icons/ogf.svg
+++ b/app/assets/images/social_link_icons/ogf.svg
@@ -1,20 +1,12 @@
 <!-- https://en.namu.wiki/w/%EC%98%A4%ED%94%88%EC%A7%80%EC%98%A4%ED%94%BD%EC%85%98 -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 107.43229 100.52796"  filter="url(#grayscale)">
-  <defs>
-    <filter id="grayscale">
-      <feColorMatrix type="matrix" values="0.13 0.13 0.13 0 0
-                                           0.15 0.15 0.15 0 0
-                                           0.16 0.16 0.16 0 0
-                                           0 0 0 1 0"/>
-    </filter>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 107.43229 100.52796">
   <g transform="translate(-41.59 -94.407)">
-    <ellipse cx="-121.74805" cy="94.363007" rx="39.6875" ry="33.639881" style="fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3" transform="scale(-1 1) rotate(-20)"/>
-    <ellipse cx="-121.37007" cy="94.174011" fill="none" rx="20.410715" ry="33.072914" style="fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1" transform="scale(-1 1) rotate(-20)"/>
-    <path fill="none" d="M-81.859 93.448a69.359 27.592 0 0 1-79.448.197M-89.001 75.617a69.359 46.869 0 0 1-64.497-.2M-89.687 112.996a95.628 71.626 0 0 1-65.347-.54" style="fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1" transform="scale(-1 1) rotate(-20)"/>
-    <path fill="none" d="M-121.243 60.781a47.814 132.103 0 0 1-1.285 67.373" style="fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1" transform="scale(-1 1) rotate(-20)"/>
-    <circle cx="-114.63764" cy="171.88988" r="6.8035707" style="fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3" transform="scale(-1 1)"/>
-    <circle cx="-130.51263" cy="182.47322" r="4.9136896" style="fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3" transform="scale(-1 1)"/>
-    <circle cx="-144.11978" cy="190.03275" r="3.4017854" style="fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3" transform="scale(-1 1)"/>
+    <ellipse cx="-121.74805" cy="94.363007" rx="39.6875" ry="33.639881" fill-opacity=".13" stroke="#000" stroke-width="3" transform="scale(-1 1) rotate(-20)"/>
+    <ellipse cx="-121.37007" cy="94.174011" rx="20.410715" ry="33.072914" fill="none" stroke="#000" transform="scale(-1 1) rotate(-20)"/>
+    <path d="M-81.859 93.448a69.359 27.592 0 0 1-79.448.197M-89.001 75.617a69.359 46.869 0 0 1-64.497-.2M-89.687 112.996a95.628 71.626 0 0 1-65.347-.54" fill="none" stroke="#000" transform="scale(-1 1) rotate(-20)"/>
+    <path d="M-121.243 60.781a47.814 132.103 0 0 1-1.285 67.373" fill="none" stroke="#000" transform="scale(-1 1) rotate(-20)"/>
+    <circle cx="-114.63764" cy="171.88988" r="6.8035707" fill-opacity=".13" stroke="#000" stroke-width="3" transform="scale(-1 1)"/>
+    <circle cx="-130.51263" cy="182.47322" r="4.9136896" fill-opacity=".13" stroke="#000" stroke-width="3" transform="scale(-1 1)"/>
+    <circle cx="-144.11978" cy="190.03275" r="3.4017854" fill-opacity=".13" stroke="#000" stroke-width="3" transform="scale(-1 1)"/>
   </g>
 </svg>

--- a/app/assets/images/social_link_icons/ogf.svg
+++ b/app/assets/images/social_link_icons/ogf.svg
@@ -9,12 +9,12 @@
     </filter>
   </defs>
   <g transform="translate(-41.59 -94.407)">
-    <ellipse cx="-121.74805" cy="94.363007" rx="39.6875" ry="33.639881" style="opacity:1;fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" transform="scale(-1 1) rotate(-20)"/>
-    <ellipse cx="-121.37007" cy="94.174011" fill="none" rx="20.410715" ry="33.072914" style="opacity:1;fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" transform="scale(-1 1) rotate(-20)"/>
-    <path fill="none" d="M-81.859 93.448a69.359 27.592 0 0 1-79.448.197M-89.001 75.617a69.359 46.869 0 0 1-64.497-.2M-89.687 112.996a95.628 71.626 0 0 1-65.347-.54" style="opacity:1;fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" transform="scale(-1 1) rotate(-20)"/>
-    <path fill="none" d="M-121.243 60.781a47.814 132.103 0 0 1-1.285 67.373" style="opacity:1;fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" transform="scale(-1 1) rotate(-20)"/>
-    <circle cx="-114.63764" cy="171.88988" r="6.8035707" style="opacity:1;fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" transform="scale(-1 1)"/>
-    <circle cx="-130.51263" cy="182.47322" r="4.9136896" style="opacity:1;fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" transform="scale(-1 1)"/>
-    <circle cx="-144.11978" cy="190.03275" r="3.4017854" style="opacity:1;fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" transform="scale(-1 1)"/>
+    <ellipse cx="-121.74805" cy="94.363007" rx="39.6875" ry="33.639881" style="fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3" transform="scale(-1 1) rotate(-20)"/>
+    <ellipse cx="-121.37007" cy="94.174011" fill="none" rx="20.410715" ry="33.072914" style="fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1" transform="scale(-1 1) rotate(-20)"/>
+    <path fill="none" d="M-81.859 93.448a69.359 27.592 0 0 1-79.448.197M-89.001 75.617a69.359 46.869 0 0 1-64.497-.2M-89.687 112.996a95.628 71.626 0 0 1-65.347-.54" style="fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1" transform="scale(-1 1) rotate(-20)"/>
+    <path fill="none" d="M-121.243 60.781a47.814 132.103 0 0 1-1.285 67.373" style="fill:#000;fill-opacity:0;stroke:#ae3134;stroke-width:1" transform="scale(-1 1) rotate(-20)"/>
+    <circle cx="-114.63764" cy="171.88988" r="6.8035707" style="fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3" transform="scale(-1 1)"/>
+    <circle cx="-130.51263" cy="182.47322" r="4.9136896" style="fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3" transform="scale(-1 1)"/>
+    <circle cx="-144.11978" cy="190.03275" r="3.4017854" style="fill:#ae3134;fill-opacity:.13333333;stroke:#ae3134;stroke-width:3" transform="scale(-1 1)"/>
   </g>
 </svg>

--- a/app/assets/images/social_link_icons/ohm.svg
+++ b/app/assets/images/social_link_icons/ohm.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generator: Adobe Illustrator 25.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="svg4247" filter="url(#grayscale)" width="16" height="16" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 117.9 118.5" style="enable-background:new 0 0 117.9 118.5;" xml:space="preserve">
+<svg version="1.1" id="svg4247" filter="grayscale(100%) brightness(65%)" width="16" height="16" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 117.9 118.5" style="enable-background:new 0 0 117.9 118.5;" xml:space="preserve">
 <style type="text/css">
 	.st0{opacity:0.7;fill:#2D3335;enable-background:new    ;}
 	.st1{opacity:0.5;enable-background:new    ;}
@@ -46,14 +46,6 @@
 	.st41{opacity:0.6043;fill:url(#path6587_1_);enable-background:new    ;}
 	.st42{opacity:0.7652;fill:url(#path6587-7_1_);enable-background:new    ;}
 </style>
-<defs>
-	<filter id="grayscale">
-		<feColorMatrix type="matrix" values="0.13 0.13 0.13 0 0
-																				 0.15 0.15 0.15 0 0
-																				 0.16 0.16 0.16 0 0
-																				 0 0 0 1 0"/>
-	</filter>
-</defs>
 <sodipodi:namedview bordercolor="#666666" borderopacity="1" gridtolerance="10" guidetolerance="10" id="namedview4249" inkscape:current-layer="g4255" inkscape:cx="239.91391" inkscape:cy="46.706091" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-height="704" inkscape:window-maximized="0" inkscape:window-width="1366" inkscape:window-x="0" inkscape:window-y="27" inkscape:zoom="1.246935" objecttolerance="10" pagecolor="#ffffff" showgrid="false">
 	</sodipodi:namedview>
 <g id="layer8">

--- a/app/assets/images/social_link_icons/osm_forum.svg
+++ b/app/assets/images/social_link_icons/osm_forum.svg
@@ -13,7 +13,7 @@
    viewBox="0 0 256 256"
    id="svg3038"
    version="1.1"
-   filter="url(#grayscale)"
+   filter="grayscale(100%) brightness(65%)"
    inkscape:version="0.48.2 r9819"
    sodipodi:docname="Public-images-osm_logo.svg"
    inkscape:export-filename="/home/fred/bla.png"
@@ -25,12 +25,6 @@
      id="title3594">OpenStreetMap logo 2011</title>
   <defs
      id="defs3040">
-     <filter id="grayscale">
-      <feColorMatrix type="matrix" values="0.13 0.13 0.13 0 0
-                                           0.15 0.15 0.15 0 0
-                                           0.16 0.16 0.16 0 0
-                                           0 0 0 1 0"/>
-    </filter>
     <linearGradient
        inkscape:collect="always"
        id="linearGradient8729">

--- a/app/assets/images/social_link_icons/osm_wiki.svg
+++ b/app/assets/images/social_link_icons/osm_wiki.svg
@@ -1,12 +1,6 @@
 <!-- https://wiki.openstreetmap.org/wiki/File:Osm_logo_wiki_2019.svg -->
-<svg width="16" height="16" viewBox="0 0 256 256" filter="url(#grayscale)" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="16" height="16" viewBox="0 0 256 256" filter="grayscale(100%) brightness(65%)" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs>
-  <filter id="grayscale">
-    <feColorMatrix type="matrix" values="0.13 0.13 0.13 0 0
-                                         0.15 0.15 0.15 0 0
-                                         0.16 0.16 0.16 0 0
-                                         0 0 0 1 0"/>
-  </filter>
   <linearGradient id="linearGradient4680">
    <stop offset="0"/>
    <stop stop-opacity="0" offset="1"/>


### PR DESCRIPTION
This is how some social link icons look on profile pages in Firefox:
![image](https://github.com/user-attachments/assets/36189b9f-b3f3-4b50-9e59-b6d589c5b928)

For comparison in Chrome they look like this:
![image](https://github.com/user-attachments/assets/d87eff1c-f72f-4f96-9dad-97b77fc9b7d0)

The icons are supposed to be grayscale, which is achieved by applying `<feColorMatrix>` filter to the entire `<svg>`. Firefox doesn't like that, maybe because `filter="url(#grayscale)"` references something inside the svg. Anyway there's a simpler way to define this filter without using `url`.

If icons are kept with colors, the dark mode filter would have to be changed because currently the icons look like this:
![image](https://github.com/user-attachments/assets/c82aef17-5481-4142-8c04-e2c4faf307fd)

This PR replaces filter attributes with `filter="grayscale(100%) brightness(65%)"` and removes `<feColorMatrix>`. For OpenGeoFiction icon it sets colors directly.

After in Firefox:
![image](https://github.com/user-attachments/assets/50aab560-2da2-4077-b622-f425bc19fdf4) ![image](https://github.com/user-attachments/assets/9c13082f-c18e-4198-bdd0-b5dc73a27b67)
