### PR TITLE
Fix sorting of enclosing features with bounds including antimeridian

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -224,15 +224,12 @@ OSM.Query = function (map) {
       });
   }
 
-  function compareSize(feature1, feature2) {
-    const width1 = feature1.bounds.maxlon - feature1.bounds.minlon,
-          height1 = feature1.bounds.maxlat - feature1.bounds.minlat,
-          area1 = width1 * height1,
-          width2 = feature2.bounds.maxlat - feature2.bounds.minlat,
-          height2 = feature2.bounds.maxlat - feature2.bounds.minlat,
-          area2 = width2 * height2;
+  function featureArea({ bounds }) {
+    const height = bounds.maxlat - bounds.minlat;
+    let width = bounds.maxlon - bounds.minlon;
 
-    return area1 - area2;
+    if (width < 0) width += 360;
+    return width * height;
   }
 
   /*
@@ -282,7 +279,7 @@ OSM.Query = function (map) {
     }).addTo(map);
 
     runQuery(latlng, radius, nearby, $("#query-nearby"), false);
-    runQuery(latlng, radius, isin, $("#query-isin"), true, compareSize);
+    runQuery(latlng, radius, isin, $("#query-isin"), true, (feature1, feature2) => featureArea(feature1) - featureArea(feature2));
   }
 
   function clickHandler(e) {

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -1,7 +1,5 @@
 OSM.Query = function (map) {
-  const url = OSM.OVERPASS_URL,
-        credentials = OSM.OVERPASS_CREDENTIALS,
-        control = $(".control-query"),
+  const control = $(".control-query"),
         queryButton = control.find(".control-button"),
         uninterestingTags = ["source", "source_ref", "source:ref", "history", "attribution", "created_by", "tiger:county", "tiger:tlid", "tiger:upload_uuid", "KSJ2:curve_id", "KSJ2:lat", "KSJ2:lon", "KSJ2:coordinate", "KSJ2:filename", "note:ja"];
   let marker;
@@ -151,12 +149,12 @@ OSM.Query = function (map) {
     }
 
     $section.data("ajax", new AbortController());
-    fetch(url, {
+    fetch(OSM.OVERPASS_URL, {
       method: "POST",
       body: new URLSearchParams({
         data: "[timeout:10][out:json];" + query
       }),
-      credentials: credentials ? "include" : "same-origin",
+      credentials: OSM.OVERPASS_CREDENTIALS ? "include" : "same-origin",
       signal: $section.data("ajax").signal
     })
       .then(response => response.json())
@@ -201,7 +199,7 @@ OSM.Query = function (map) {
         if (results.remark) {
           $("<li>")
             .addClass("list-group-item")
-            .text(OSM.i18n.t("javascripts.query.error", { server: url, error: results.remark }))
+            .text(OSM.i18n.t("javascripts.query.error", { server: OSM.OVERPASS_URL, error: results.remark }))
             .appendTo($ul);
         }
 
@@ -219,7 +217,7 @@ OSM.Query = function (map) {
 
         $("<li>")
           .addClass("list-group-item")
-          .text(OSM.i18n.t("javascripts.query.error", { server: url, error: error.message }))
+          .text(OSM.i18n.t("javascripts.query.error", { server: OSM.OVERPASS_URL, error: error.message }))
           .appendTo($ul);
       });
   }

--- a/test/system/query_features_test.rb
+++ b/test/system/query_features_test.rb
@@ -1,0 +1,152 @@
+require "application_system_test_case"
+
+class QueryFeaturesSystemTest < ApplicationSystemTestCase
+  test "sorts enclosing features correctly" do
+    visit "/#map=15/54.18315/7.88473"
+
+    within "#map" do
+      click_on "Query features"
+
+      stub_overpass :enclosing_elements => [
+        {
+          "type" => "relation",
+          "id" => 51477,
+          "bounds" => {
+            "minlat" => 47.2701114,
+            "minlon" => 5.8663153,
+            "maxlat" => 55.0991610,
+            "maxlon" => 15.0419309
+          },
+          "tags" => {
+            "admin_level" => "2",
+            "border_type" => "country",
+            "boundary" => "administrative",
+            "name" => "Deutschland",
+            "name:de" => "Deutschland",
+            "name:en" => "Germany",
+            "type" => "boundary"
+          }
+        },
+        {
+          "type" => "relation",
+          "id" => 51529,
+          "bounds" => {
+            "minlat" => 53.3598160,
+            "minlon" => 7.5211615,
+            "maxlat" => 55.0991610,
+            "maxlon" => 11.6723860
+          },
+          "tags" => {
+            "admin_level" => "4",
+            "border_type" => "state",
+            "boundary" => "administrative",
+            "name" => "Schleswig-Holstein",
+            "name:de" => "Schleswig-Holstein",
+            "name:en" => "Schleswig-Holstein",
+            "type" => "boundary"
+          }
+        },
+        {
+          "type" => "relation",
+          "id" => 3787052,
+          "bounds" => {
+            "minlat" => 54.1693099,
+            "minlon" => 7.8648436,
+            "maxlat" => 54.1907839,
+            "maxlon" => 7.9001626
+          },
+          "tags" => {
+            "name" => "Helgoland",
+            "name:de" => "Helgoland",
+            "name:en" => "Heligoland",
+            "place" => "island"
+          }
+        }
+      ]
+
+      click
+    end
+
+    within_sidebar do
+      assert_link "Heligoland"
+      assert_link "Schleswig-Holstein", :below => find_link("Heligoland")
+      assert_link "Germany", :below => find_link("Schleswig-Holstein")
+    end
+  end
+
+  test "sorts enclosing features correctly across antimeridian" do
+    visit "/#map=15/60/30"
+
+    within "#map" do
+      click_on "Query features"
+
+      stub_overpass :enclosing_elements => [
+        {
+          "type" => "relation",
+          "id" => 60189,
+          "bounds" => {
+            "minlat" => 41.1850968,
+            "minlon" => 19.4041722,
+            "maxlat" => 82.0586232,
+            "maxlon" => -168.9769440
+          },
+          "tags" => {
+            "admin_level" => "2",
+            "border_type" => "nation",
+            "boundary" => "administrative",
+            "name" => "Россия",
+            "name:en" => "Russia",
+            "name:ru" => "Россия",
+            "type" => "boundary"
+          }
+        },
+        {
+          "type" => "relation",
+          "id" => 1114253,
+          "bounds" => {
+            "minlat" => 59.8587853,
+            "minlon" => 29.6720697,
+            "maxlat" => 60.0370554,
+            "maxlon" => 30.2307057
+          },
+          "tags" => {
+            "name" => "Невская губа",
+            "name:en" => "Neva Bay",
+            "name:ru" => "Невская губа",
+            "natural" => "bay",
+            "type" => "multipolygon"
+          }
+        }
+      ]
+
+      click
+    end
+
+    within_sidebar do
+      assert_link "Neva Bay"
+      assert_link "Russia", :below => find_link("Neva Bay")
+    end
+  end
+
+  private
+
+  def stub_overpass(nearby_elements: [], enclosing_elements: [])
+    execute_script <<~SCRIPT
+      {
+        const originalFetch = fetch;
+        window.fetch = (...args) => {
+          const [resource, options] = args;
+
+          if (resource != OSM.OVERPASS_URL) return originalFetch(...args);
+
+          const data = options.body.get("data"),
+                elements = data.includes("is_in") ? #{enclosing_elements.to_json} : #{nearby_elements.to_json};
+
+          return Promise.resolve({
+            json: () => Promise.resolve({ elements })
+          });
+        }
+      }
+    SCRIPT
+  end
+end


### PR DESCRIPTION
When using *Query features*, enclosing features are sorted by their bounding box size. But the sorting is broken if the bounding boxes cross the antimeridian. This is noticeable in Russia. The entire Russia should be larger than some place inside Russia, therefore Russia should be at the end of the list. Instead Russia is at the start, because the bbox area is calculated as negative.

This is what Overpass returns as bounds for Russia. `maxlon` is smaller than `minlon`, going up to [this place](https://www.openstreetmap.org/#map=10/65.7679/-168.9787) and wrapping to a negative value:
```json
  "bounds": {
    "minlat": 41.1850968,
    "minlon": 19.4041722,
    "maxlat": 82.0586232,
    "maxlon": -168.9769440
  },
```

Before / after:
![image](https://github.com/user-attachments/assets/4e1c8e4b-3c7c-4528-8024-7fc7c12b26c1) ![image](https://github.com/user-attachments/assets/a9cd7137-3230-4bbd-b133-407f08e374a4)

Same for Fiji:

Before:
![image](https://github.com/user-attachments/assets/5b821198-989a-460a-99c5-4f9b83ea6b08)

After:
![image](https://github.com/user-attachments/assets/cc641eee-d976-4551-b37b-a4c38f2f0a92)
