### PR TITLE
Truncate rich text description on word boundaries if possible

### DIFF
--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -239,7 +239,7 @@ module RichText
 
       return nil if text.blank?
 
-      text_truncated_to_word_break = text.truncate(DESCRIPTION_MAX_LENGTH, :separator => " ")
+      text_truncated_to_word_break = text.truncate(DESCRIPTION_MAX_LENGTH, :separator => /(?<!\s)\s+/)
 
       if text_truncated_to_word_break.length >= DESCRIPTION_WORD_BREAK_THRESHOLD_LENGTH
         text_truncated_to_word_break

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -5,7 +5,7 @@ module RichText
     "Business Description:", "Additional Keywords:"
   ].freeze
 
-  MAX_DESCRIPTION_LENGTH = 500
+  DESCRIPTION_MAX_LENGTH = 500
 
   def self.new(format, text)
     case format
@@ -230,7 +230,7 @@ module RichText
         else
           child.children.each do |c|
             append_text.call(c)
-            break if text.length > MAX_DESCRIPTION_LENGTH
+            break if text.length > DESCRIPTION_MAX_LENGTH
           end
         end
       end
@@ -238,7 +238,7 @@ module RichText
 
       return nil if text.blank?
 
-      text.truncate(MAX_DESCRIPTION_LENGTH)
+      text.truncate(DESCRIPTION_MAX_LENGTH)
     end
 
     def image?(element)

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -6,6 +6,7 @@ module RichText
   ].freeze
 
   DESCRIPTION_MAX_LENGTH = 500
+  DESCRIPTION_WORD_BREAK_THRESHOLD_LENGTH = 450
 
   def self.new(format, text)
     case format
@@ -238,7 +239,13 @@ module RichText
 
       return nil if text.blank?
 
-      text.truncate(DESCRIPTION_MAX_LENGTH)
+      text_truncated_to_word_break = text.truncate(DESCRIPTION_MAX_LENGTH, :separator => " ")
+
+      if text_truncated_to_word_break.length >= DESCRIPTION_WORD_BREAK_THRESHOLD_LENGTH
+        text_truncated_to_word_break
+      else
+        text.truncate(DESCRIPTION_MAX_LENGTH)
+      end
     end
 
     def image?(element)

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -461,14 +461,14 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_markdown_description_max_length
-    r = RichText.new("markdown", "x" * RichText::MAX_DESCRIPTION_LENGTH)
-    assert_equal "x" * RichText::MAX_DESCRIPTION_LENGTH, r.description
+    r = RichText.new("markdown", "x" * RichText::DESCRIPTION_MAX_LENGTH)
+    assert_equal "x" * RichText::DESCRIPTION_MAX_LENGTH, r.description
 
-    r = RichText.new("markdown", "y" * (RichText::MAX_DESCRIPTION_LENGTH + 1))
-    assert_equal "#{'y' * (RichText::MAX_DESCRIPTION_LENGTH - 3)}...", r.description
+    r = RichText.new("markdown", "y" * (RichText::DESCRIPTION_MAX_LENGTH + 1))
+    assert_equal "#{'y' * (RichText::DESCRIPTION_MAX_LENGTH - 3)}...", r.description
 
-    r = RichText.new("markdown", "*zzzzzzzzz*z" * ((RichText::MAX_DESCRIPTION_LENGTH + 1) / 10.0).ceil)
-    assert_equal "#{'z' * (RichText::MAX_DESCRIPTION_LENGTH - 3)}...", r.description
+    r = RichText.new("markdown", "*zzzzzzzzz*z" * ((RichText::DESCRIPTION_MAX_LENGTH + 1) / 10.0).ceil)
+    assert_equal "#{'z' * (RichText::DESCRIPTION_MAX_LENGTH - 3)}...", r.description
   end
 
   private

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -462,15 +462,34 @@ class RichTextTest < ActiveSupport::TestCase
 
   def test_markdown_description_max_length
     m = RichText::DESCRIPTION_MAX_LENGTH
+    o = 3 # "...".length
 
     r = RichText.new("markdown", "x" * m)
     assert_equal "x" * m, r.description
 
     r = RichText.new("markdown", "y" * (m + 1))
-    assert_equal "#{'y' * (m - 3)}...", r.description
+    assert_equal "#{'y' * (m - o)}...", r.description
 
     r = RichText.new("markdown", "*zzzzzzzzz*z" * ((m + 1) / 10.0).ceil)
-    assert_equal "#{'z' * (m - 3)}...", r.description
+    assert_equal "#{'z' * (m - o)}...", r.description
+  end
+
+  def test_markdown_description_word_break_threshold_length
+    m = RichText::DESCRIPTION_MAX_LENGTH
+    t = RichText::DESCRIPTION_WORD_BREAK_THRESHOLD_LENGTH
+    o = 3 # "...".length
+
+    r = RichText.new("markdown", "#{'x' * (t - o - 1)} #{'y' * (m - (t - o - 1) - 1)}")
+    assert_equal "#{'x' * (t - o - 1)} #{'y' * (m - (t - o - 1) - 1)}", r.description
+
+    r = RichText.new("markdown", "#{'x' * (t - o - 1)} #{'y' * (m - (t - o - 1))}")
+    assert_equal "#{'x' * (t - o - 1)} #{'y' * (m - (t - o - 1) - 4)}...", r.description
+
+    r = RichText.new("markdown", "#{'x' * (t - o)} #{'y' * (m - (t - o) - 1)}")
+    assert_equal "#{'x' * (t - o)} #{'y' * (m - (t - o) - 1)}", r.description
+
+    r = RichText.new("markdown", "#{'x' * (t - o)} #{'y' * (m - (t - o))}")
+    assert_equal "#{'x' * (t - o)}...", r.description
   end
 
   private

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -492,6 +492,15 @@ class RichTextTest < ActiveSupport::TestCase
     assert_equal "#{'x' * (t - o)}...", r.description
   end
 
+  def test_markdown_description_word_break_multiple_spaces
+    m = RichText::DESCRIPTION_MAX_LENGTH
+    t = RichText::DESCRIPTION_WORD_BREAK_THRESHOLD_LENGTH
+    o = 3 # "...".length
+
+    r = RichText.new("markdown", "#{'x' * (t - o)}  #{'y' * (m - (t - o - 1))}")
+    assert_equal "#{'x' * (t - o)}...", r.description
+  end
+
   private
 
   def assert_html(richtext, &block)

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -461,14 +461,16 @@ class RichTextTest < ActiveSupport::TestCase
   end
 
   def test_markdown_description_max_length
-    r = RichText.new("markdown", "x" * RichText::DESCRIPTION_MAX_LENGTH)
-    assert_equal "x" * RichText::DESCRIPTION_MAX_LENGTH, r.description
+    m = RichText::DESCRIPTION_MAX_LENGTH
 
-    r = RichText.new("markdown", "y" * (RichText::DESCRIPTION_MAX_LENGTH + 1))
-    assert_equal "#{'y' * (RichText::DESCRIPTION_MAX_LENGTH - 3)}...", r.description
+    r = RichText.new("markdown", "x" * m)
+    assert_equal "x" * m, r.description
 
-    r = RichText.new("markdown", "*zzzzzzzzz*z" * ((RichText::DESCRIPTION_MAX_LENGTH + 1) / 10.0).ceil)
-    assert_equal "#{'z' * (RichText::DESCRIPTION_MAX_LENGTH - 3)}...", r.description
+    r = RichText.new("markdown", "y" * (m + 1))
+    assert_equal "#{'y' * (m - 3)}...", r.description
+
+    r = RichText.new("markdown", "*zzzzzzzzz*z" * ((m + 1) / 10.0).ceil)
+    assert_equal "#{'z' * (m - 3)}...", r.description
   end
 
   private


### PR DESCRIPTION
#6010 added truncated diary entries to profile pages. The truncation procedure is different from from others already in use. It gets html, strips tags and does the standard rails truncation to 150 chars:

```ruby
truncate(strip_tags(entry.body.to_html), :length => 150)
```

So it's truncate to plaintext. This is similar to richtext `.description` for `og:description` from #5056. I experimented using `entry.body.description` instead of `truncate(...)`. One thing that I wanted to change in `.description` is a truncation separator. This is what this PR does.

Before:
![image](https://github.com/user-attachments/assets/5746fb99-6df5-4f85-ad59-7cf38aec28c7)

After:
![image](https://github.com/user-attachments/assets/e90a20a6-009f-42be-9cd7-1def036ab35b)
