### PR TITLE
Redraw OpenGeofiction social icon

### DIFF
--- a/app/assets/images/social_link_icons/ogf.svg
+++ b/app/assets/images/social_link_icons/ogf.svg
@@ -1,12 +1,13 @@
 <!-- https://en.namu.wiki/w/%EC%98%A4%ED%94%88%EC%A7%80%EC%98%A4%ED%94%BD%EC%85%98 -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 107.43229 100.52796">
-  <g transform="translate(-41.59 -94.407)">
-    <ellipse cx="-121.74805" cy="94.363007" rx="39.6875" ry="33.639881" fill-opacity=".13" stroke="#000" stroke-width="3" transform="scale(-1 1) rotate(-20)"/>
-    <ellipse cx="-121.37007" cy="94.174011" rx="20.410715" ry="33.072914" fill="none" stroke="#000" transform="scale(-1 1) rotate(-20)"/>
-    <path d="M-81.859 93.448a69.359 27.592 0 0 1-79.448.197M-89.001 75.617a69.359 46.869 0 0 1-64.497-.2M-89.687 112.996a95.628 71.626 0 0 1-65.347-.54" fill="none" stroke="#000" transform="scale(-1 1) rotate(-20)"/>
-    <path d="M-121.243 60.781a47.814 132.103 0 0 1-1.285 67.373" fill="none" stroke="#000" transform="scale(-1 1) rotate(-20)"/>
-    <circle cx="-114.63764" cy="171.88988" r="6.8035707" fill-opacity=".13" stroke="#000" stroke-width="3" transform="scale(-1 1)"/>
-    <circle cx="-130.51263" cy="182.47322" r="4.9136896" fill-opacity=".13" stroke="#000" stroke-width="3" transform="scale(-1 1)"/>
-    <circle cx="-144.11978" cy="190.03275" r="3.4017854" fill-opacity=".13" stroke="#000" stroke-width="3" transform="scale(-1 1)"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="#212529">
+  <g transform="translate(6.5 5.75) rotate(20)">
+    <ellipse rx="6" ry="5" />
+    <g stroke-width=".5">
+      <ellipse rx="2.75" ry="5" />
+      <path d="M-6 0 A10 4 0 0 0 6 0 M-5.2 -2.5 A10 5 0 0 0 5.2 -2.5 M-5.2 2.5 A10 5 0 0 0 5.2 2.5 M0 -5 V5" stroke-width=".5" />
+    </g>
   </g>
+  <circle cx="10.5" cy="12.5" r="1" stroke-width="0.75" />
+  <circle cx="13" cy="14" r="0.75" stroke-width="0.375" />
+  <circle cx="15.375" cy="15.125" r="0.5" stroke-width="0.25" />
 </svg>


### PR DESCRIPTION
#6072 tried to change the color of the ogf icon to match the colors of other social icons. Except that wouldn't work as intended because the lines in the ogf icon are narrower than 1px. It already looks bleak, and with that color change it's going to be bleaker. There's not much to be done about it other than redrawing the entire icon. That's what this PR does.

Here's the ogf icon changes compared to the generic website icon.

Before (100% / 200%):
![image](https://github.com/user-attachments/assets/a133fb7b-8ec9-4a68-8416-edbfbd905e07) ![image](https://github.com/user-attachments/assets/ff47e4b2-c26b-4bac-9ef6-92db43b920a0)

After (100% / 200%):
![image](https://github.com/user-attachments/assets/15e1eadc-5bbd-425c-9550-c081628eba36) ![image](https://github.com/user-attachments/assets/0cb0d101-31a5-4a6e-946d-1d8111bdbfbe)
