### PR TITLE
Protect I18n.locale around tests which may change it

### DIFF
--- a/test/controllers/preferences/advanced_preferences_controller_test.rb
+++ b/test/controllers/preferences/advanced_preferences_controller_test.rb
@@ -16,17 +16,19 @@ module Preferences
     end
 
     def test_update_languages
-      user = create(:user, :languages => [])
-      session_for(user)
+      I18n.with_locale "en" do
+        user = create(:user, :languages => [])
+        session_for(user)
 
-      put advanced_preferences_path, :params => { :user => { :preferred_editor => "id", :languages => "fr es en" } }
+        put advanced_preferences_path, :params => { :user => { :preferred_editor => "id", :languages => "fr es en" } }
 
-      assert_redirected_to advanced_preferences_path
-      follow_redirect!
-      assert_template :show
-      assert_select ".alert-success", /^Préférences mises à jour/
-      user.reload
-      assert_equal %w[fr es en], user.languages
+        assert_redirected_to advanced_preferences_path
+        follow_redirect!
+        assert_template :show
+        assert_select ".alert-success", /^Préférences mises à jour/
+        user.reload
+        assert_equal %w[fr es en], user.languages
+      end
     end
   end
 end

--- a/test/controllers/preferences/basic_preferences_controller_test.rb
+++ b/test/controllers/preferences/basic_preferences_controller_test.rb
@@ -144,17 +144,19 @@ module Preferences
     private
 
     def check_language_change(from_languages, selecting_language, to_languages)
-      user = create(:user, :languages => from_languages)
-      another_user = create(:user, :languages => %w[not going to change])
-      session_for(user)
+      I18n.with_locale "en" do
+        user = create(:user, :languages => from_languages)
+        another_user = create(:user, :languages => %w[not going to change])
+        session_for(user)
 
-      put basic_preferences_path, :params => { :user => { :preferred_editor => "default" }, :language => selecting_language }
+        put basic_preferences_path, :params => { :user => { :preferred_editor => "default" }, :language => selecting_language }
 
-      assert_redirected_to basic_preferences_path
-      user.reload
-      assert_equal to_languages, user.languages
-      another_user.reload
-      assert_equal %w[not going to change], another_user.languages
+        assert_redirected_to basic_preferences_path
+        user.reload
+        assert_equal to_languages, user.languages
+        another_user.reload
+        assert_equal %w[not going to change], another_user.languages
+      end
     end
   end
 end


### PR DESCRIPTION
Avoid accidental changes to `I18n.locale` when a request is made as a logged in user with a different language preference.

Fixes #6075.
