### PR TITLE
Add lang attribute to Nominatim results from CJK languages

### DIFF
--- a/app/controllers/concerns/nominatim_methods.rb
+++ b/app/controllers/concerns/nominatim_methods.rb
@@ -18,7 +18,7 @@ module NominatimMethods
     exclude = "&exclude_place_ids=#{params[:exclude]}" if params[:exclude]
 
     # build url
-    "#{Settings.nominatim_url}search?format=#{format}&extratags=1&q=#{CGI.escape(query)}#{viewbox}#{exclude}&accept-language=#{http_accept_language.user_preferred_languages.join(',')}"
+    "#{Settings.nominatim_url}search?format=#{format}&extratags=1&addressdetails=1&q=#{CGI.escape(query)}#{viewbox}#{exclude}&accept-language=#{http_accept_language.user_preferred_languages.join(',')}"
   end
 
   def nominatim_reverse_query_url(format: nil)

--- a/app/controllers/searches/nominatim_queries_controller.rb
+++ b/app/controllers/searches/nominatim_queries_controller.rb
@@ -2,7 +2,7 @@ module Searches
   class NominatimQueriesController < QueriesController
     include NominatimMethods
 
-    LANGUAGE_CODES = { "cn" => "zh-Hans", "hk" => "zh-HK", "jp" => "ja", "tw" => "zh-Hant", "bg" => "bg", "rs" => "rs" }.freeze
+    LANGUAGE_CODES = { "cn" => "zh-Hans", "hk" => "zh-HK", "jp" => "ja", "tw" => "zh-Hant" }.freeze
 
     def create
       # ask nominatim

--- a/app/controllers/searches/nominatim_queries_controller.rb
+++ b/app/controllers/searches/nominatim_queries_controller.rb
@@ -2,6 +2,8 @@ module Searches
   class NominatimQueriesController < QueriesController
     include NominatimMethods
 
+    LANGUAGE_CODES = { "cn" => "zh-Hans", "hk" => "zh-HK", "jp" => "ja", "tw" => "zh-Hant", "bg" => "bg", "rs" => "rs" }.freeze
+
     def create
       # ask nominatim
       response = fetch_xml(nominatim_query_url(:format => "xml"))
@@ -45,11 +47,14 @@ module Searches
         prefix = t "geocoder.search_osm_nominatim.prefix_format", :name => prefix_name
         object_type = place.attributes["osm_type"]
         object_id = place.attributes["osm_id"]
+        # add lang attribute for frontend in certain regions
+        country_code = place.elements["country_code"]&.text
+        lang = country_code ? LANGUAGE_CODES[country_code] : nil
 
         @results.push(:lat => lat, :lon => lon,
                       :min_lat => min_lat, :max_lat => max_lat,
                       :min_lon => min_lon, :max_lon => max_lon,
-                      :prefix => prefix, :name => name,
+                      :prefix => prefix, :name => name, :lang => lang,
                       :type => object_type, :id => object_id)
       end
     rescue StandardError => e

--- a/app/controllers/searches/nominatim_queries_controller.rb
+++ b/app/controllers/searches/nominatim_queries_controller.rb
@@ -48,8 +48,8 @@ module Searches
         object_type = place.attributes["osm_type"]
         object_id = place.attributes["osm_id"]
         # add lang attribute for frontend in certain regions
-        country_code = place.elements["country_code"]&.text
-        lang = country_code ? LANGUAGE_CODES[country_code] : nil
+        region_code = place.elements["ISO3166-2-lvl3"]&.text == "CN-HK" ? "hk" : place.elements["country_code"]&.text
+        lang = region_code ? LANGUAGE_CODES[region_code] : nil
 
         @results.push(:lat => lat, :lon => lon,
                       :min_lat => min_lat, :max_lat => max_lat,

--- a/app/helpers/geocoder_helper.rb
+++ b/app/helpers/geocoder_helper.rb
@@ -2,6 +2,8 @@ module GeocoderHelper
   def result_to_html(result)
     html_options = { :class => "set_position stretched-link", :data => {} }
 
+    html_options[:lang] = result[:lang] if result[:lang]
+
     url = if result[:type] && result[:id]
             url_for(:controller => "/#{result[:type].pluralize}", :action => :show, :id => result[:id])
           elsif result[:min_lon] && result[:min_lat] && result[:max_lon] && result[:max_lat]

--- a/test/http/nominatim.yml
+++ b/test/http/nominatim.yml
@@ -1,4 +1,4 @@
-/search?accept-language=&extratags=1&format=xml&q=Hoddesdon&viewbox=-0.559,51.766,0.836,51.217:
+/search?accept-language=&addressdetails=1&extratags=1&format=xml&q=Hoddesdon&viewbox=-0.559,51.766,0.836,51.217:
   code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8" ?>
@@ -6,7 +6,7 @@
       <place place_id='110741' osm_type='node' osm_id='18007599' place_rank='18' boundingbox="51.7216709,51.8016709,-0.0512898,0.0287102" lat='51.7616709' lon='-0.0112898' display_name='Hoddesdon, Hertfordshire, East of England, England, United Kingdom' class='place' type='town' importance='0.50547792382382' icon='http://nominatim.openstreetmap.org/images/mapicons/poi_place_town.p.20.png'/>
     </searchresults>
 
-/search?accept-language=&extratags=1&format=xml&q=Broxbourne&viewbox=-0.559,51.766,0.836,51.217:
+/search?accept-language=&addressdetails=1&extratags=1&format=xml&q=Broxbourne&viewbox=-0.559,51.766,0.836,51.217:
   code: 200
   body: |
     <?xml version="1.0" encoding="UTF-8" ?>


### PR DESCRIPTION
### Description

In Unicode, some CJK characters such as 化 have one codepoint but will appear differently in Simplified Chinese (<span lang="zh-Hans">化</span>), Traditional Chinese (<span lang="zh-Hant">化</span>), and Japanese (<span lang="ja">化</span>). On the frontend, we can display names correctly using an HTML attribute such as `lang="zh-Hant"` This issue is known as [Han unification](https://en.wikipedia.org/wiki/Han_unification) and it has appeared over the years [in many software projects](https://issues.chromium.org/issues/41315603)

This was addressed in iD https://github.com/openstreetmap/iD/pull/10716 and is a long-running discussion in openstreetmap-carto.

If we add `&addressdetails=1` to Nominatim queries, we can read the country_code and display the best label for mainland China, Hong Kong, Japan, or Taiwan.

### How has this been tested?

This can be tricky to test, as **many names do not change**, and the display_name will be in your browser's language if it's available

- Search results will have a lang tag, such as `lang="zh-HK"` or `lang="ja"`, regardless of language of display_name
- In Taiwan, a search result for <span lang="zh-Hant">彰化</span> should show a horizontal bar in <span lang="zh-Hant">化</span>
- In mainland China, a search result for <span lang="zh-Hans">玉门 expressway</span> should return a split frame <span lang="zh-Hans">门</span>  in the second character, not the 门 with a +

### Notes

As an alternative to adding `&addressdetails=1` to queries, we could possibly parse display_name (varies with the browser language) or use geo bounding boxes?

This matching of languages is imperfect, but without a language tag we are always using your browser's default for any CJK character. It would be difficult to make exceptions (for example, Japanese restaurants in these countries) without a name regex, a language tag, or access to other tags

This does not affect CJK search results from other countries

I have heard that there are some variations for Cyrillic in [Bulgaria](https://en.wikipedia.org/wiki/Bulgarian_alphabet) and [Serbia](https://en.wikipedia.org/wiki/Serbian_Cyrillic_alphabet#Differences_from_other_Cyrillic_alphabets), particularly in italics? But I don't know how universal it is. [Additional info](https://commons.wikimedia.org/wiki/File:Special_Cyrillics_BGDPT.svg)