### PR TITLE
Fix template rendered on profile update failure

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -43,7 +43,7 @@ class ProfilesController < ApplicationController
       redirect_to user_path(current_user)
     else
       flash.now[:error] = t ".failure"
-      render :edit
+      render :show
     end
   end
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -80,4 +80,15 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_select ".alert-success", /^Profile updated./
     assert_select "dd", "new company"
   end
+
+  def test_update_empty_social_link
+    user = create(:user)
+    session_for(user)
+
+    put profile_path, :params => { :user => { :description => user.description, :social_links_attributes => [{ :url => "" }] } }
+
+    assert_response :success
+    assert_template :show
+    assert_dom ".alert-danger", :text => "Couldn't update profile."
+  end
 end


### PR DESCRIPTION
Go to `/profile`, add an empty social link, click *Update Profile*. You should see this:

![image](https://github.com/user-attachments/assets/569a2190-9c1b-4acb-8fa0-58b4dde16e8a)

But actually you'll get error 500.

When doing #6060 I forgot to update the template that's rendered when `current_user.save` fails from `:edit` to `:show`. Turned out we didn't have a test for profile update failures.