### PR TITLE
Maximum field length for Home Location

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -82,7 +82,7 @@
         <button type="button" id="home_undelete" class="btn btn-outline-primary" hidden><%= t ".undelete" %></button>
       </div>
     </div>
-    <%= f.text_field :home_location_name, :wrapper_class => "my-2 col-sm-4 pe-3", :class => "mt-auto", :id => "home_location_name" %>
+    <%= f.text_field :home_location_name, :wrapper_class => "my-2", :id => "home_location_name" %>
     <div class="form-check">
       <input class="form-check-input" type="checkbox" name="updatehome" value="1" <% unless current_user.home_location? %> checked <% end %> id="updatehome" />
       <label class="form-check-label" for="updatehome"><%= t ".update home location on click" %></label>


### PR DESCRIPTION
### Problem
According to https://github.com/openstreetmap/openstreetmap-website/pull/5987#issuecomment-2858925494, as @mmd-osm mentioned, it will be good if `Home Location Name` has maximum field length.

### Description
Changes length of the `Home Location Name` field to be stretched to the maximum length.

### How has this been tested?
Manually. Tests are not affected.

### Screenshots
![image](https://github.com/user-attachments/assets/1a2c34e8-6e74-475a-9a8e-afd1072564b3)
