### PR TITLE
Use a bootstrap dropdown for language selection

### DIFF
--- a/app/assets/javascripts/language_selector.js
+++ b/app/assets/javascripts/language_selector.js
@@ -1,4 +1,4 @@
-$(document).on("change", ".language-change-trigger", function () {
-  Cookies.set("_osm_locale", this.value, { secure: true, path: "/", samesite: "lax" });
+$(document).on("click", "#language-selector .dropdown-menu button", function () {
+  Cookies.set("_osm_locale", $(this).data("language"), { secure: true, path: "/", samesite: "lax" });
   document.location.reload();
 });

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -22,13 +22,6 @@ time[title] {
   color: $blue;
 }
 
-/* Utility for transparent color */
-
-.text-transparent {
-  color: transparent !important;
-  user-select: none;
-}
-
 /* Bootstrap contextual table classes overrides in dark mode */
 
 @include color-mode(dark) {
@@ -150,6 +143,11 @@ nav.secondary {
 
   > ul {
     height: 1.5em;
+  }
+
+  .dropdown-menu {
+    max-height: calc(100vh - 300px);
+    overflow-y: auto;
   }
 }
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -66,16 +66,14 @@
         <ul class="dropdown-menu">
         </ul>
       </li>
-      <li class="nav-item ps-1 not-collapsible">
-        <% if current_user && current_user.id %>
-          <%= link_to(basic_preferences_path, :class => "nav-link text-secondary") do %>
-            <%= render "shared/language_selector", :classes => "", :disabled => true %>
-          <% end %>
-        <% else %>
-          <%= render "shared/language_selector", :classes => "nav-link text-secondary", :disabled => false %>
-        <% end %>
-      </li>
     </ul>
+    <% if current_user && current_user.id %>
+      <%= link_to(basic_preferences_path, :class => "nav-link text-secondary") do %>
+        <%= render "shared/language_selector", :classes => "", :disabled => true %>
+      <% end %>
+    <% else %>
+      <%= render "shared/language_selector", :classes => "nav-link text-secondary", :disabled => false %>
+    <% end %>
     <% if current_user && current_user.id %>
       <div class='d-inline-flex dropdown user-menu logged-in'>
         <button class='d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1 mw-100' type='button' data-bs-toggle='dropdown'>

--- a/app/views/shared/_language_selector.html.erb
+++ b/app/views/shared/_language_selector.html.erb
@@ -1,11 +1,12 @@
-<label class="position-relative d-flex <%= classes %>" role="button">
-  <svg width="20" height="20" fill="currentColor">
-    <path d="M20 18h-1.44a.61.61 0 0 1-.4-.12.81.81 0 0 1-.23-.31L17 15h-5l-1 2.54a.77.77 0 0 1-.22.3.59.59 0 0 1-.4.14H9l4.55-11.47h1.89zm-3.53-4.31L14.89 9.5a11.62 11.62 0 0 1-.39-1.24q-.09.37-.19.69l-.19.56-1.58 4.19zm-6.3-1.58a13.43 13.43 0 0 1-2.91-1.41 11.46 11.46 0 0 0 2.81-5.37H12V4H7.31a4 4 0 0 0-.2-.56C6.87 2.79 6.6 2 6.6 2l-1.47.5s.4.89.6 1.5H0v1.33h2.15A11.23 11.23 0 0 0 5 10.7a17.19 17.19 0 0 1-5 2.1q.56.82.87 1.38a23.28 23.28 0 0 0 5.22-2.51 15.64 15.64 0 0 0 3.56 1.77zM3.63 5.33h4.91a8.11 8.11 0 0 1-2.45 4.45 9.11 9.11 0 0 1-2.46-4.45z" />
-  </svg>
-  <% unless disabled %>
-    <%= select_tag "language",
-                   options_for_select(AVAILABLE_LANGUAGES.map { |e| [e[:native_name], e[:code], { :class => "form-select" }] }, I18n.locale),
-                   :role => "button",
-                   :class => "p-0 position-absolute top-0 start-0 w-100 h-100 language-change-trigger text-transparent bg-transparent #{classes}" %>
-  <% end %>
+<label id="language-selector" class="position-relative d-flex <%= classes %>" role="button">
+  <button class="btn btn-secondary-outline dropdown-toggle" type="button"<% unless disabled -%> data-bs-toggle="dropdown"<% end -%> aria-label="<%= t(".label") %>" aria-expanded="false">
+    <svg width="20" height="20" fill="currentColor">
+      <path d="M20 18h-1.44a.61.61 0 0 1-.4-.12.81.81 0 0 1-.23-.31L17 15h-5l-1 2.54a.77.77 0 0 1-.22.3.59.59 0 0 1-.4.14H9l4.55-11.47h1.89zm-3.53-4.31L14.89 9.5a11.62 11.62 0 0 1-.39-1.24q-.09.37-.19.69l-.19.56-1.58 4.19zm-6.3-1.58a13.43 13.43 0 0 1-2.91-1.41 11.46 11.46 0 0 0 2.81-5.37H12V4H7.31a4 4 0 0 0-.2-.56C6.87 2.79 6.6 2 6.6 2l-1.47.5s.4.89.6 1.5H0v1.33h2.15A11.23 11.23 0 0 0 5 10.7a17.19 17.19 0 0 1-5 2.1q.56.82.87 1.38a23.28 23.28 0 0 0 5.22-2.51 15.64 15.64 0 0 0 3.56 1.77zM3.63 5.33h4.91a8.11 8.11 0 0 1-2.45 4.45 9.11 9.11 0 0 1-2.46-4.45z" />
+    </svg>
+  </button>
+  <ul class="dropdown-menu">
+    <% AVAILABLE_LANGUAGES.each do |language| -%>
+      <li><button class="dropdown-item" type="button" data-language="<%= language[:code] %>"><%= language[:native_name] %></button></li>
+    <% end -%>
+  </ul>
 </label>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2031,6 +2031,8 @@ en:
       contact_support_html: Please contact %{support_link} if you wish to discuss this.
       support: support
   shared:
+    language_selector:
+      label: Language Selector
     markdown_help:
       heading_html: Parsed with %{kramdown_link}
       kramdown_url: https://kramdown.gettalong.org/quickref.html

--- a/test/system/site_test.rb
+++ b/test/system/site_test.rb
@@ -91,19 +91,35 @@ class SiteTest < ApplicationSystemTestCase
     assert_selector ".tooltip", :text => "Zoom in to see"
   end
 
-  test "language selector should exist when logged out" do
+  test "language selector should be active when logged out" do
     visit "/"
-    assert_selector ".language-change-trigger", :visible => "all"
-    AVAILABLE_LANGUAGES.each do |locale|
-      assert_selector "option[value='#{locale[:code]}']", :visible => "all"
+
+    within "#language-selector" do
+      assert_selector ".dropdown-toggle[data-bs-toggle='dropdown']", :visible => "all"
+
+      AVAILABLE_LANGUAGES.each do |locale|
+        assert_selector ".dropdown-item[data-language='#{locale[:code]}']", :visible => "all"
+      end
+
+      click_on "Language Selector"
+      click_on "français"
     end
+
+    assert_selector "html[lang='fr']"
   end
 
-  test "language selector should not exist when logged in" do
+  test "language selector should not be active when logged in" do
     sign_in_as(create(:user))
 
     visit "/"
-    assert_no_selector ".language-change-trigger", :visible => "all"
+
+    within "#language-selector" do
+      assert_no_selector ".dropdown-toggle[data-bs-toggle='dropdown']", :visible => "all"
+
+      click_on "Language Selector"
+    end
+
+    assert_current_path basic_preferences_path
   end
 
   private


### PR DESCRIPTION
This updates the new locale menu to use a bootstrap dropdown instead of a simple HTML select so that it's appearance better matches the rest of the site.

To do this I had to move the selector out of the secondary nav bar which probably isn't ideal but without that something in bootstrap was grabbing all the list items for the dropdown and moving them to the outer list for the nav bar... That move also causes the icon to move to the right which I think is probably fine but could likely be changed if I knew what I was doing.

I'm not sure the effect in small screen mode is ideal either... I did consider moving the language selector to the top to always be visible in that case which I think is fine but possibly a bit weird?

Other changes are improving the tests a bit and adding an aria label to the selector button to explain what it is for screen readers (and make it easy to click in tests).

New design, large screen, with menu open:

![image](https://github.com/user-attachments/assets/08484d6c-27cd-4a95-b73f-b2bdbb283a62)

and small screen:

![image](https://github.com/user-attachments/assets/dc3d17a9-e827-412d-b333-bbd11417f156)
