### PR TITLE
Don't set Vary response header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -202,7 +202,6 @@ class ApplicationController < ActionController::Base
 
     I18n.locale = Locale.available.preferred(preferred_languages)
 
-    response.headers["Vary"] = "Accept-Language"
     response.headers["Content-Language"] = I18n.locale.to_s
   end
 


### PR DESCRIPTION
Problem:
1. open https://www.openstreetmap.org/traces (or any page with turbo pagination)
2. click *Older Traces* (or older whatever)
3. right-click the tab and select *duplicate* or *duplicate tab*
  ![image](https://github.com/user-attachments/assets/de8e04a0-ee93-43f4-af52-4a60976c47cf)
4. you're going to see something like this
  ![image](https://github.com/user-attachments/assets/79ce95e1-fd3f-422b-9b8a-bad86d537098)

It's the turbo-frame contents, without header, footer and css.

The same is going to happen if you:
1. open the traces page
2. click *Older Traces*
3. close the tab
4. go to history / recently closed tabs and restore the tab

The reason for this is apparently the `Vary` header. It was added long ago in https://github.com/openstreetmap/openstreetmap-website/commit/e48e4ccbd3bb1a61c82bf3a83e1c66217cb0ccac. It was supposed to fix a problem with *map key* https://github.com/openstreetmap/trac-tickets/issues/1995. You open *map key*, then you switch the language and open *map key* again, and it's still in the previous language. Did the header really fix the problem? When I switch the language, I still see *map key* in the old language. That's because we have a rather aggressive caching enabled specifically for https://www.openstreetmap.org/key. `Vary` doesn't really help here.

In addition `Vary` messes things up elsewhere, in turbo requests. `response.headers["Vary"] = "Accept-Language"` tells the browser to pay attention to `Accept-Language` when caching the response, but it also tells to ignore other headers. One of these headers is `turbo-frame`, which tells whether we want to load just the specified frame. If this header is ignored, the browser is going to think that it's fine to restore just the frame at some url instead of requesting the entire page.

Another version of the fix is to change the header like this: `response.headers["Vary"] = "Accept-Language, turbo-frame"`, if `Vary: Accept-Language` actually helps with something.

Can something go wrong if `Vary` is removed, are pages going to be shown in a wrong language (aside from *map key*)? I don't think so because `etag` wouldn't match. Maybe previously `last-modified` was used instead, then it could have been a problem.

---

- In https://github.com/openstreetmap/openstreetmap-website/pull/6106#discussion_r2149515805 I mentioned that there is an issue about *map key* somewhere, and https://github.com/openstreetmap/trac-tickets/issues/1995 happened to be about *map key*. But it's not the issue I was looking for, there's likely another one.
- This is a half of the problem in https://github.com/openstreetmap/openstreetmap-website/pull/5175, another half is that `<head>` has to be sent along with the frame when frame navigation is promoted to page visits. If we fix/remove `Vary`, I can update that pull request.