### PR TITLE
Make flash alerts dismissable

### DIFF
--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,13 +1,16 @@
 <% [[:error, :danger], [:warning, :warning], [:notice, :success]].each do |flash_type, bootstrap_type| %>
   <% if flash[flash_type] %>
-    <%= tag.div :class => "alert alert-#{bootstrap_type} row mx-0 mb-0 p-3 rounded-0 align-items-center",
+    <%= tag.div :class => "alert alert-dismissible alert-#{bootstrap_type} mb-0 rounded-0",
                 :data => { :turbo_temporary => true } do %>
-      <div class="col-auto">
-        <%= notice_svg_tag %>
+      <div class="d-flex gap-3 align-items-center">
+        <div class="d-flex">
+          <%= notice_svg_tag %>
+        </div>
+        <div>
+          <%= render_flash flash[flash_type] %>
+        </div>
       </div>
-      <div class="col">
-        <%= render_flash flash[flash_type] %>
-      </div>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="<%= t("javascripts.close") %>"></button>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4ab8971d-fd08-4649-bd59-7b47f79e145f)

## Why

I was redoing the language selector. I made it always update the language, even when the user is logged in, which means updating the preferences when a new language is picked. But updating the preferences generates a flash message which may overlap with map controls on small screens.

![image](https://github.com/user-attachments/assets/568ece28-3e70-4709-ba10-067571e876c8)

If the alert can be closed, the overlap is not a big problem.