### PR TITLE
Newer/Older Version buttons in element history

### DIFF
--- a/app/controllers/concerns/pagination_methods.rb
+++ b/app/controllers/concerns/pagination_methods.rb
@@ -5,26 +5,30 @@ module PaginationMethods
 
   ##
   # limit selected items to one page, get ids of first item before/after the page
-  def get_page_items(items, includes: [], limit: 20)
+  def get_page_items(items, includes: [], limit: 20, cursor_column: :id)
     param! :before, Integer, :min => 1
     param! :after, Integer, :min => 1
 
-    id_column = "#{items.table_name}.id"
+    qualified_cursor_column = "#{items.table_name}.#{cursor_column}"
     page_items = if params[:before]
-                   items.where("#{id_column} < ?", params[:before]).order(:id => :desc)
+                   items.where("#{qualified_cursor_column} < ?", params[:before]).order(cursor_column => :desc)
                  elsif params[:after]
-                   items.where("#{id_column} > ?", params[:after]).order(:id => :asc)
+                   items.where("#{qualified_cursor_column} > ?", params[:after]).order(cursor_column => :asc)
                  else
-                   items.order(:id => :desc)
+                   items.order(cursor_column => :desc)
                  end
 
     page_items = page_items.limit(limit)
     page_items = page_items.includes(includes)
     page_items = page_items.sort.reverse
 
-    newer_items_id = page_items.first.id if page_items.count.positive? && items.exists?(["#{id_column} > ?", page_items.first.id])
-    older_items_id = page_items.last.id if page_items.count.positive? && items.exists?(["#{id_column} < ?", page_items.last.id])
+    newer_items_cursor = page_items.first&.send cursor_column
+    older_items_cursor = page_items.last&.send cursor_column
 
-    [page_items, newer_items_id, older_items_id]
+    [
+      page_items,
+      (newer_items_cursor if page_items.count.positive? && items.exists?(["#{qualified_cursor_column} > ?", newer_items_cursor])),
+      (older_items_cursor if page_items.count.positive? && items.exists?(["#{qualified_cursor_column} < ?", older_items_cursor]))
+    ]
   end
 end

--- a/app/controllers/old_elements_controller.rb
+++ b/app/controllers/old_elements_controller.rb
@@ -1,4 +1,6 @@
 class OldElementsController < ApplicationController
+  include PaginationMethods
+
   layout :map_layout
 
   before_action :authorize_web

--- a/app/controllers/old_nodes_controller.rb
+++ b/app/controllers/old_nodes_controller.rb
@@ -7,6 +7,11 @@ class OldNodesController < OldElementsController
       :cursor_column => :version,
       :includes => [:old_tags, { :changeset => [:changeset_tags, :user] }]
     )
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html
+    end
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/controllers/old_nodes_controller.rb
+++ b/app/controllers/old_nodes_controller.rb
@@ -1,7 +1,12 @@
 class OldNodesController < OldElementsController
   def index
     @type = "node"
-    @feature = Node.preload(:node_tags, :old_nodes => [:old_tags, { :changeset => [:changeset_tags, :user] }]).find(params[:id])
+    @feature = Node.preload(:node_tags).find(params[:id])
+    @old_features, @newer_features_version, @older_features_version = get_page_items(
+      OldNode.where(:node_id => params[:id]),
+      :cursor_column => :version,
+      :includes => [:old_tags, { :changeset => [:changeset_tags, :user] }]
+    )
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/controllers/old_relations_controller.rb
+++ b/app/controllers/old_relations_controller.rb
@@ -1,7 +1,12 @@
 class OldRelationsController < OldElementsController
   def index
     @type = "relation"
-    @feature = Relation.preload(:relation_tags, :old_relations => [:old_tags, { :changeset => [:changeset_tags, :user], :old_members => :member }]).find(params[:id])
+    @feature = Relation.preload(:relation_tags).find(params[:id])
+    @old_features, @newer_features_version, @older_features_version = get_page_items(
+      OldRelation.where(:relation_id => params[:id]),
+      :cursor_column => :version,
+      :includes => [:old_tags, { :changeset => [:changeset_tags, :user], :old_members => :member }]
+    )
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/controllers/old_ways_controller.rb
+++ b/app/controllers/old_ways_controller.rb
@@ -1,7 +1,12 @@
 class OldWaysController < OldElementsController
   def index
     @type = "way"
-    @feature = Way.preload(:way_tags, :old_ways => [:old_tags, { :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:node_tags, :ways] } }]).find(params[:id])
+    @feature = Way.preload(:way_tags).find(params[:id])
+    @old_features, @newer_features_version, @older_features_version = get_page_items(
+      OldWay.where(:way_id => params[:id]),
+      :cursor_column => :version,
+      :includes => [:old_tags, { :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:node_tags, :ways] } }]
+    )
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/views/old_elements/index.html.erb
+++ b/app/views/old_elements/index.html.erb
@@ -2,7 +2,23 @@
 
 <%= render "sidebar_header", :title => t(".#{@type}.title_html", :name => printable_element_name(@feature)) %>
 
-<%= render :partial => "browse/#{@type}", :collection => @feature.send(:"old_#{@type}s").reverse %>
+<% if @newer_features_version %>
+  <ul class="pagination justify-content-center">
+    <li class="page-item">
+      <%= link_to t(".newer_versions"), params.permit(:show_redactions).merge(:after => @newer_features_version), :class => "page-link" %>
+    </li>
+  </ul>
+<% end %>
+
+<%= render :partial => "browse/#{@type}", :collection => @old_features %>
+
+<% if @older_features_version %>
+  <ul class="pagination justify-content-center">
+    <li class="page-item">
+      <%= link_to t(".older_versions"), params.permit(:show_redactions).merge(:before => @older_features_version), :class => "page-link" %>
+    </li>
+  </ul>
+<% end %>
 
 <div class='secondary-actions'>
   <%= link_to t("browse.download_xml"), send(:"api_#{@type}_versions_path", @feature.id) %>

--- a/app/views/old_elements/index.html.erb
+++ b/app/views/old_elements/index.html.erb
@@ -3,19 +3,27 @@
 <%= render "sidebar_header", :title => t(".#{@type}.title_html", :name => printable_element_name(@feature)) %>
 
 <% if @newer_features_version %>
-  <ul class="pagination justify-content-center">
+  <ul id="newer_element_versions_navigation" class="pagination justify-content-center">
     <li class="page-item">
-      <%= link_to t(".newer_versions"), params.permit(:show_redactions).merge(:after => @newer_features_version), :class => "page-link" %>
+      <%= link_to t(".newer_versions"),
+                  params.permit(:show_redactions).merge(:after => @newer_features_version),
+                  :class => "page-link",
+                  :data => { :turbo => true, :turbo_stream => true } %>
     </li>
   </ul>
 <% end %>
 
-<%= render :partial => "browse/#{@type}", :collection => @old_features %>
+<div id="element_versions_list">
+  <%= render :partial => "browse/#{@type}", :collection => @old_features %>
+</div>
 
 <% if @older_features_version %>
-  <ul class="pagination justify-content-center">
+  <ul id="older_element_versions_navigation" class="pagination justify-content-center">
     <li class="page-item">
-      <%= link_to t(".older_versions"), params.permit(:show_redactions).merge(:before => @older_features_version), :class => "page-link" %>
+      <%= link_to t(".older_versions"),
+                  params.permit(:show_redactions).merge(:before => @older_features_version),
+                  :class => "page-link",
+                  :data => { :turbo => true, :turbo_stream => true } %>
     </li>
   </ul>
 <% end %>

--- a/app/views/old_elements/index.html.erb
+++ b/app/views/old_elements/index.html.erb
@@ -26,9 +26,9 @@
   <%= link_to t("browse.view_details"), :controller => @type.pluralize, :action => :show %>
   <% if params[:show_redactions] %>
     &middot;
-    <%= link_to t("browse.view_history") %>
+    <%= link_to t("browse.view_history"), params.permit(:before, :after) %>
   <% elsif current_user&.moderator? %>
     &middot;
-    <%= link_to t("browse.view_unredacted_history"), :params => { :show_redactions => true } %>
+    <%= link_to t("browse.view_unredacted_history"), params.permit(:before, :after).merge(:show_redactions => true) %>
   <% end %>
 </div>

--- a/app/views/old_elements/index.turbo_stream.erb
+++ b/app/views/old_elements/index.turbo_stream.erb
@@ -1,0 +1,33 @@
+<% if params[:after] %>
+  <% if @newer_features_version %>
+    <%= turbo_stream.update "newer_element_versions_navigation" do %>
+      <li class="page-item">
+        <%= link_to t(".newer_versions"),
+                    params.permit(:show_redactions).merge(:after => @newer_features_version),
+                    :class => "page-link",
+                    :data => { :turbo => true, :turbo_stream => true } %>
+      </li>
+    <% end %>
+  <% else %>
+    <%= turbo_stream.remove "newer_element_versions_navigation" %>
+  <% end %>
+  <%= turbo_stream.prepend "element_versions_list" do %>
+    <%= render :partial => "browse/#{@type}", :formats => [:html], :collection => @old_features %>
+  <% end %>
+<% elsif params[:before] %>
+  <%= turbo_stream.append "element_versions_list" do %>
+    <%= render :partial => "browse/#{@type}", :formats => [:html], :collection => @old_features %>
+  <% end %>
+  <% if @older_features_version %>
+    <%= turbo_stream.update "older_element_versions_navigation" do %>
+      <li class="page-item">
+        <%= link_to t(".older_versions"),
+                    params.permit(:show_redactions).merge(:before => @older_features_version),
+                    :class => "page-link",
+                    :data => { :turbo => true, :turbo_stream => true } %>
+      </li>
+    <% end %>
+  <% else %>
+    <%= turbo_stream.remove "older_element_versions_navigation" %>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,6 +437,8 @@ en:
         title_html: "Way History: %{name}"
       relation:
         title_html: "Relation History: %{name}"
+      older_versions: Older Versions
+      newer_versions: Newer Versions
     actions:
       view_redacted_data: "View Redacted Data"
       view_redaction_message: "View Redaction Message"

--- a/test/system/element_history_test.rb
+++ b/test/system/element_history_test.rb
@@ -1,0 +1,53 @@
+require "application_system_test_case"
+
+class ElementHistoryTest < ApplicationSystemTestCase
+  test "can view node history" do
+    node = create(:node, :with_history, :version => 41)
+
+    visit node_path(node)
+
+    check_element_history(->(v) { old_node_path(node, v) })
+  end
+
+  test "can view way history" do
+    way = create(:way, :with_history, :version => 41)
+
+    visit way_path(way)
+
+    check_element_history(->(v) { old_way_path(way, v) })
+  end
+
+  test "can view relation history" do
+    relation = create(:relation, :with_history, :version => 41)
+
+    visit relation_path(relation)
+
+    check_element_history(->(v) { old_relation_path(relation, v) })
+  end
+
+  private
+
+  def check_element_history(get_path)
+    within_sidebar do
+      click_on "View History"
+
+      41.downto(22) do |v|
+        assert_link v.to_s, :href => get_path.call(v)
+      end
+
+      click_on "Older Versions"
+
+      41.downto(2) do |v|
+        assert_link v.to_s, :href => get_path.call(v)
+      end
+
+      click_on "Older Versions"
+
+      41.downto(1) do |v|
+        assert_link v.to_s, :href => get_path.call(v)
+      end
+
+      assert_no_link "Older Versions"
+    end
+  end
+end


### PR DESCRIPTION
Paginates element history like changesets history, with *Older/Newer* buttons and 20 versions per page. Should help with history pages of elements with hundreds of versions.

Uses Turbo streams, no javascript required.

![image](https://github.com/user-attachments/assets/24a039f9-e2f3-41d9-8e26-5b7c25ffbc3c)
