### PR TITLE
Replace redirect with bad request error for new report with missing params

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,7 +14,7 @@ class ReportsController < ApplicationController
       @report = Report.new
       @report.issue = Issue.find_or_initialize_by(create_new_report_params)
     else
-      redirect_to root_path, :notice => t(".missing_params")
+      head :bad_request
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1656,7 +1656,6 @@ en:
   reports:
     new:
       title_html: "Report %{link}"
-      missing_params: "Cannot create a new report"
       disclaimer:
         intro: "Before sending your report to the site moderators, please ensure that:"
         not_just_mistake: You are certain that the problem is not just a mistake

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -1,6 +1,13 @@
 require "test_helper"
 
 class ReportsControllerTest < ActionDispatch::IntegrationTest
+  def test_new_missing_parameters
+    session_for(create(:user))
+    get new_report_path
+
+    assert_response :bad_request
+  end
+
   def test_new_report_without_login
     target_user = create(:user)
     get new_report_path(:reportable_id => target_user.id, :reportable_type => "User")

--- a/test/system/report_diary_entry_test.rb
+++ b/test/system/report_diary_entry_test.rb
@@ -56,10 +56,4 @@ class ReportDiaryEntryTest < ApplicationSystemTestCase
     assert_not_predicate issue, :resolved?
     assert_predicate issue, :open?
   end
-
-  def test_missing_report_params
-    sign_in_as(create(:user))
-    visit new_report_path
-    assert_content I18n.t("reports.new.missing_params")
-  end
 end


### PR DESCRIPTION
If the user somehow manages to open `/reports/new` page without `reportable_id` and `reportable_type` parameters, send a bad request error instead of redirection. 

The error happens when you try to open https://www.openstreetmap.org/reports/new. This page shouldn't be accessible without `reportable_id` / `reportable_type`. Links without these parameters shouldn't exist. The redirect also displays a message "Cannot create a new report", but the `new` action is not creating anything, it just displays a form; creating is done by the `create` action which you can't access by opening a broken url.

The redirect with a message was added in https://github.com/openstreetmap/openstreetmap-website/commit/2fc70be734fb6439b1eef340d396af62965817df.

---

The test that I delete in pull request started to fail for unknown reasons when trying to merge #6119. But that pull request doesn't change anything about the redirec and the displayed flash message. What did change recently is that flash messages were made dismissable in #6115, but the tests didn't start to fail because of that.

![image](https://github.com/user-attachments/assets/cb39fb9a-ed84-4103-b3d7-ac06b910b562)

Screenshots of failed tests show that there's no message. Whatever is the cause of that, it doesn't make sense to fix this message because I don't think it should be displayed.