### PR TITLE
Change incomplete report flash style from success to warning

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -33,7 +33,7 @@ class ReportsController < ApplicationController
 
       redirect_to helpers.reportable_url(@report.issue.reportable), :notice => t(".successful_report")
     else
-      flash.now[:notice] = t(".provide_details")
+      flash.now[:warning] = t(".provide_details")
       render :action => "new"
     end
   end

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -65,7 +65,7 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
     assert_template :new
-    assert_match(/Please provide the required details/, flash[:notice])
+    assert_match(/Please provide the required details/, flash[:warning])
 
     assert_equal 1, issue.reports.count
   end


### PR DESCRIPTION
If you're reporting something and you managed to submit the form without filling out the required fields[^1], there's a message "Please provide the required details". The problem is that it's styled as a *success* message, as if the report was created, while actually it wasn't.

Before:
![image](https://github.com/user-attachments/assets/ef8b3a30-d223-455a-bc4d-305f8eff4d15)

After:
![image](https://github.com/user-attachments/assets/5ae667af-8606-4a11-8e9c-944791d90f64)

[^1]: This shouldn't normally happen, you'll get a javascript error, as long as `required` html attributes are there.