### PR TITLE
Integrate human-readable wikidata browser plugin

### DIFF
--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -19,6 +19,8 @@ OSM = {
       graphhopper_url
       fossgis_osrm_url
       fossgis_valhalla_url
+      wikidata_api_url
+      wikimedia_commons_url
     ]
       .each_with_object({}) do |key, hash|
         hash[key.to_s.upcase] = Settings.send(key) if Settings.respond_to?(key)

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -633,11 +633,14 @@ tr.turn {
 #sidebar_content {
   .browse-tag-list {
     table-layout: fixed;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    word-break: break-word;
 
-    tr:last-child th, tr:last-child td {
+    tr > *:not([colspan]) {
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      word-break: break-word;
+    }
+
+    tr:last-child > * {
       border-bottom: 0;
     }
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -246,8 +246,9 @@ class ApplicationController < ActionController::Base
   def map_layout
     policy = request.content_security_policy.clone
 
-    policy.connect_src(*policy.connect_src, "http://127.0.0.1:8111", Settings.nominatim_url, Settings.overpass_url, Settings.fossgis_osrm_url, Settings.graphhopper_url, Settings.fossgis_valhalla_url)
+    policy.connect_src(*policy.connect_src, "http://127.0.0.1:8111", Settings.nominatim_url, Settings.overpass_url, Settings.fossgis_osrm_url, Settings.graphhopper_url, Settings.fossgis_valhalla_url, Settings.wikidata_api_url)
     policy.form_action(*policy.form_action, "render.openstreetmap.org")
+    policy.img_src(*policy.img_src, Settings.wikimedia_commons_url, "upload.wikimedia.org")
     policy.style_src(*policy.style_src, :unsafe_inline)
 
     request.content_security_policy = policy

--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -17,10 +17,16 @@ module BrowseTagsHelper
     elsif wdt = wikidata_links(key, value)
       # IMPORTANT: Note that wikidata_links() returns an array of hashes, unlike for example wikipedia_link(),
       # which just returns one such hash.
+      svg = button_tag :type => "button", :role => "button", :class => "btn btn-link float-end d-flex m-1 mt-0 me-n1 border-0 p-0 wdt-preview", :data => { :qids => wdt.map { |w| w[:title] } } do
+        tag.svg :width => 27, :height => 16 do
+          concat tag.title t("browse.tag_details.wikidata_preview", :count => wdt.length)
+          concat tag.path :fill => "currentColor", :d => "M0 16h1V0h-1Zm2 0h3V0h-3Zm4 0h3V0h-3Zm4 0h1V0h-1Zm2 0h1V0h-1Zm2 0h3V0h-3Zm4 0h1V0h-1Zm2 0h3V0h-3Zm4 0h1V0h-1Zm2 0h1V0h-1Z"
+        end
+      end
       wdt = wdt.map do |w|
         link_to(w[:title], w[:url], :title => t("browse.tag_details.wikidata_link", :page => w[:title].strip))
       end
-      safe_join(wdt, ";")
+      svg + safe_join(wdt, ";")
     elsif wmc = wikimedia_commons_link(key, value)
       link_to h(wmc[:title]), wmc[:url], :title => t("browse.tag_details.wikimedia_commons_link", :page => wmc[:title])
     elsif url = wiki_link("tag", "#{key}=#{value}")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -421,6 +421,9 @@ en:
         key: "The wiki description page for the %{key} tag"
         tag: "The wiki description page for the %{key}=%{value} tag"
       wikidata_link: "The %{page} item on Wikidata"
+      wikidata_preview:
+        one: "Wikidata item preview"
+        other: "Wikidata items preview"
       wikipedia_link: "The %{page} article on Wikipedia"
       wikimedia_commons_link: "The %{page} item on Wikimedia Commons"
       telephone_link: "Call %{phone_number}"
@@ -3526,6 +3529,8 @@ en:
       nothing_found: No features found
       error: "Error contacting %{server}: %{error}"
       timeout: "Timeout contacting %{server}"
+    element:
+      wikipedia: "Wikipedia"
     context:
       directions_from: Directions from here
       directions_to: Directions to here

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -136,6 +136,9 @@ overpass_credentials: false
 graphhopper_url: "https://graphhopper.com/api/1/route"
 fossgis_osrm_url: "https://routing.openstreetmap.de/"
 fossgis_valhalla_url: "https://valhalla1.openstreetmap.de/route"
+# Endpoints for Wikimedia integration
+wikidata_api_url: "https://www.wikidata.org/w/api.php"
+wikimedia_commons_url: "https://commons.wikimedia.org/wiki/"
 # Main website hosts to match in linkify
 linkify_hosts: ["www.openstreetmap.org", "www.osm.org", "www.openstreetmap.com", "openstreetmap.org", "osm.org", "openstreetmap.com"]
 # Shorter host to replace main hosts

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -41,14 +41,20 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_dom_equal "<a title=\"The Test article on Wikipedia\" href=\"https://en.wikipedia.org/wiki/Test?uselang=en\">Test</a>", html
 
     html = format_value("wikidata", "Q42")
-    assert_dom_equal "<a title=\"The Q42 item on Wikidata\" href=\"//www.wikidata.org/entity/Q42?uselang=en\">Q42</a>", html
+    dom = Rails::Dom::Testing.html_document_fragment.parse html
+    assert_select dom, "a[title='The Q42 item on Wikidata'][href$='www.wikidata.org/entity/Q42?uselang=en']", :text => "Q42"
+    assert_select dom, "button.wdt-preview>svg>path[fill]", 1
 
     html = format_value("operator:wikidata", "Q12;Q98")
-    assert_dom_equal "<a title=\"The Q12 item on Wikidata\" href=\"//www.wikidata.org/entity/Q12?uselang=en\">Q12</a>;" \
-                     "<a title=\"The Q98 item on Wikidata\" href=\"//www.wikidata.org/entity/Q98?uselang=en\">Q98</a>", html
+    dom = Rails::Dom::Testing.html_document_fragment.parse html
+    assert_select dom, "a[title='The Q12 item on Wikidata'][href$='www.wikidata.org/entity/Q12?uselang=en']", :text => "Q12"
+    assert_select dom, "a[title='The Q98 item on Wikidata'][href$='www.wikidata.org/entity/Q98?uselang=en']", :text => "Q98"
+    assert_select dom, "button.wdt-preview>svg>path[fill]", 1
 
     html = format_value("name:etymology:wikidata", "Q123")
-    assert_dom_equal "<a title=\"The Q123 item on Wikidata\" href=\"//www.wikidata.org/entity/Q123?uselang=en\">Q123</a>", html
+    dom = Rails::Dom::Testing.html_document_fragment.parse html
+    assert_select dom, "a[title='The Q123 item on Wikidata'][href$='www.wikidata.org/entity/Q123?uselang=en']", :text => "Q123"
+    assert_select dom, "button.wdt-preview>svg>path[fill]", 1
 
     html = format_value("wikimedia_commons", "File:Test.jpg")
     assert_dom_equal "<a title=\"The File:Test.jpg item on Wikimedia Commons\" href=\"//commons.wikimedia.org/wiki/File:Test.jpg?uselang=en\">File:Test.jpg</a>", html


### PR DESCRIPTION
### Description
See original plugin [announcement](https://community.openstreetmap.org/t/announcing-human-readable-wikidata-browser-plugins-for-openstreetmap-org/108180/9) and [codebase](https://github.com/ZeLonewolf/osm-wikidata-greasemonkey) from @ZeLonewolf.
Updates the CSP and sets the requested paths from the settings.
Changes to the plugin are requesting more of the user's languages, getting the images more directly and replacing flexbox with float to accommodate longer descriptions better.

### How has this been tested?
DevTools to test on real data.