### PR TITLE
Follow redirects to suspended page in spammy tests

### DIFF
--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -118,8 +118,7 @@ class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal spammy_text, comment.body
     assert_equal "suspended", User.find(other_user.id).status
 
-    # Follow the redirect
-    get diary_entries_path(:display_name => user.display_name)
+    follow_redirect!
     assert_redirected_to :controller => :users, :action => :suspended
 
     # Now show the diary entry, and check the new comment is not present

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -247,8 +247,7 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "en", entry.language_code
     assert_equal "suspended", User.find(user.id).status
 
-    # Follow the redirect
-    get diary_entries_path(:display_name => user.display_name)
+    follow_redirect!
     assert_redirected_to :controller => :users, :action => :suspended
   end
 


### PR DESCRIPTION
You don't need to write comments about following the redirect if you actually `follow_redirect!`.