### PR TITLE
Preserve `referer` during oauth JS confirmation

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -14,6 +14,7 @@ class ConfirmationsController < ApplicationController
   before_action :require_cookies, :only => [:confirm]
 
   def confirm
+    # The post happens in confirm.html.erb and user.js
     if request.post?
       user = User.find_by_token_for(:new_user, params[:confirm_string])
 

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -14,7 +14,6 @@ class ConfirmationsController < ApplicationController
   before_action :require_cookies, :only => [:confirm]
 
   def confirm
-    # The post happens in confirm.html.erb and user.js
     if request.post?
       user = User.find_by_token_for(:new_user, params[:confirm_string])
 

--- a/app/views/confirmations/confirm.html.erb
+++ b/app/views/confirmations/confirm.html.erb
@@ -17,6 +17,7 @@
   <%= bootstrap_form_tag :html => { :id => "confirm" } do |f| %>
     <%= f.hidden_field :display_name, :value => params[:display_name] %>
     <%= f.hidden_field :confirm_string, :value => params[:confirm_string] %>
+    <%= f.hidden_field :referer, :value => params[:referer] %>
     <%= f.primary t(".button") %>
   <% end %>
 <% else %>


### PR DESCRIPTION
Closes https://github.com/openstreetmap/openstreetmap-website/issues/6130

Someone helped me debug https://github.com/openstreetmap/openstreetmap-website/issues/6130 and this change fixes the issue.

The OAuth process starts as a GET and becomes a POST by submitting the form below in JS automatically.
We lost the `referer` during this submit which means `confirmation_controller#confirm` never received the referrer to pass it through to the `/welcome` page so the button on that page could never change.

<details><summary>Some debug logging that shows that the referer is there at first and then disapears…</summary>
<p>

```log
2025-06-27 17:03:33 Started GET "/user/test23/confirm?confirm_string=eyJfcmFpbHMiOnsiZGF0YSI6WzMsIjA2MWU3YWNjZjIxYjI3MzVlYmY0MDUwMjk3ZmE1YzJmNjJiZWY4YTc3ZGEyNmMwYTYwMjlkNzkyYjkxNDY3NWIiXSwiZXhwIjoiMjAyNS0wNy0wNFQxNTowMTo1OS41MjJaIiwicHVyIjoiVXNlclxubmV3X3VzZXJcbjYwNDgwMCJ9fQ%3D%3D--2359edd41975d1e561bf22666f32d5c457507380&referer=%2Fwelcome%3Foauth_return_url%3D%252Foauth2%252Fauthorize%253Fclient_id%253DuglV_cJniuc96GQT0-rO6sXsgJPZfat8PLCfv91qRC4%2526scope%253Dopenid%252520read_prefs%252520write_prefs%252520write_notes%2526response_type%253Dcode%2526redirect_uri%253Dhttps%25253A%25252F%25252Fstaging.tilda-geo.de%25252Fapi%25252Fauth%25252Fosm%25252Fcallback%2526nextauth%253Dosm%25252Clogin%2526state%253DsHLAM8Pu8h6vLJHBmPOwDTR4N786cdOi74QMN9Ld8es%2526code_challenge%253DZGz_cGc0z5SWRGRImxp2SVplCQkLmeeZn0n7iI6yUz0%2526code_challenge_method%253DS256" for 192.168.65.1 at 2025-06-27 15:03:33 +0000

// ^--- still has the `referer`

2025-06-27 17:03:35 Processing by ConfirmationsController#confirm as HTML
2025-06-27 17:03:35   Parameters: {"confirm_string"=>"eyJfcmFpbHMiOnsiZGF0YSI6WzMsIjA2MWU3YWNjZjIxYjI3MzVlYmY0MDUwMjk3ZmE1YzJmNjJiZWY4YTc3ZGEyNmMwYTYwMjlkNzkyYjkxNDY3NWIiXSwiZXhwIjoiMjAyNS0wNy0wNFQxNTowMTo1OS41MjJaIiwicHVyIjoiVXNlclxubmV3X3VzZXJcbjYwNDgwMCJ9fQ==--2359edd41975d1e561bf22666f32d5c457507380", "referer"=>"/welcome?oauth_return_url=%2Foauth2%2Fauthorize%3Fclient_id%3DuglV_cJniuc96GQT0-rO6sXsgJPZfat8PLCfv91qRC4%26scope%3Dopenid%2520read_prefs%2520write_prefs%2520write_notes%26response_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Fstaging.tilda-geo.de%252Fapi%252Fauth%252Fosm%252Fcallback%26nextauth%3Dosm%252Clogin%26state%3DsHLAM8Pu8h6vLJHBmPOwDTR4N786cdOi74QMN9Ld8es%26code_challenge%3DZGz_cGc0z5SWRGRImxp2SVplCQkLmeeZn0n7iI6yUz0%26code_challenge_method%3DS256", "display_name"=>"test23"}
2025-06-27 17:03:36 xxxxxxx1: #<ActionDispatch::Request GET "http://127.0.0.1:3001/user/test23/confirm?confirm_string=eyJfcmFpbHMiOnsiZGF0YSI6WzMsIjA2MWU3YWNjZjIxYjI3MzVlYmY0MDUwMjk3ZmE1YzJmNjJiZWY4YTc3ZGEyNmMwYTYwMjlkNzkyYjkxNDY3NWIiXSwiZXhwIjoiMjAyNS0wNy0wNFQxNTowMTo1OS41MjJaIiwicHVyIjoiVXNlclxubmV3X3VzZXJcbjYwNDgwMCJ9fQ%3D%3D--2359edd41975d1e561bf22666f32d5c457507380&referer=%2Fwelcome%3Foauth_return_url%3D%252Foauth2%252Fauthorize%253Fclient_id%253DuglV_cJniuc96GQT0-rO6sXsgJPZfat8PLCfv91qRC4%2526scope%253Dopenid%252520read_prefs%252520write_prefs%252520write_notes%2526response_type%253Dcode%2526redirect_uri%253Dhttps%25253A%25252F%25252Fstaging.tilda-geo.de%25252Fapi%25252Fauth%25252Fosm%25252Fcallback%2526nextauth%253Dosm%25252Clogin%2526state%253DsHLAM8Pu8h6vLJHBmPOwDTR4N786cdOi74QMN9Ld8es%2526code_challenge%253DZGz_cGc0z5SWRGRImxp2SVplCQkLmeeZn0n7iI6yUz0%2526code_challenge_method%253DS256" for 192.168.65.1>
2025-06-27 17:03:36   User Load (1.2ms)  SELECT "users".* FROM "users" WHERE "users"."status" IN ('pending', 'active', 'confirmed') AND "users"."display_name" = 'test23' LIMIT 1 /*action='confirm',application='OpenStreetMap',controller='confirmations'*/
2025-06-27 17:03:36   ↳ app/controllers/confirmations_controller.rb:56:in `confirm'
2025-06-27 17:03:36   Rendering layout layouts/site.html.erb
2025-06-27 17:03:36   Rendering confirmations/confirm.html.erb within layouts/site
2025-06-27 17:03:36   Rendered confirmations/confirm.html.erb within layouts/site (Duration: 53.4ms | GC: 15.4ms)
2025-06-27 17:03:36   Rendered layouts/_meta.html.erb (Duration: 42.8ms | GC: 8.1ms)
2025-06-27 17:03:36   Rendered layouts/_head.html.erb (Duration: 217.4ms | GC: 38.7ms)
2025-06-27 17:03:36   Rendered layouts/_select_language_button.html.erb (Duration: 0.7ms | GC: 0.0ms)
2025-06-27 17:03:36   Rendered layouts/_select_language_button.html.erb (Duration: 0.2ms | GC: 0.0ms)
2025-06-27 17:03:36   Rendered layouts/_select_language_list.html.erb (Duration: 87.6ms | GC: 22.1ms)
2025-06-27 17:03:36   Rendered layouts/_header.html.erb (Duration: 118.4ms | GC: 32.2ms)
2025-06-27 17:03:36   Rendered layouts/_flash.html.erb (Duration: 4.3ms | GC: 0.0ms)
2025-06-27 17:03:36   Rendered layouts/_content.html.erb (Duration: 16.2ms | GC: 2.2ms)
2025-06-27 17:03:36   Rendered layout layouts/site.html.erb (Duration: 423.9ms | GC: 88.6ms)
2025-06-27 17:03:36 Completed 200 OK in 808ms (Views: 429.0ms | ActiveRecord: 30.9ms (1 query, 0 cached) | GC: 185.0ms)
2025-06-27 17:03:36 
2025-06-27 17:03:36 
2025-06-27 17:03:37 Started POST "/user/test23/confirm" for 192.168.65.1 at 2025-06-27 15:03:37 +0000
2025-06-27 17:03:37 Processing by ConfirmationsController#confirm as HTML
2025-06-27 17:03:37   Parameters: {"authenticity_token"=>"MhnDTkRQDADXsAxObtacIwSCH5ZvF5hSOWaMxvPjEQ0-cjOcT3czC8Ul_EHhVU8kgkPjzt9xGQgDH5AftbQMKA", "display_name"=>"test23", "confirm_string"=>"eyJfcmFpbHMiOnsiZGF0YSI6WzMsIjA2MWU3YWNjZjIxYjI3MzVlYmY0MDUwMjk3ZmE1YzJmNjJiZWY4YTc3ZGEyNmMwYTYwMjlkNzkyYjkxNDY3NWIiXSwiZXhwIjoiMjAyNS0wNy0wNFQxNTowMTo1OS41MjJaIiwicHVyIjoiVXNlclxubmV3X3VzZXJcbjYwNDgwMCJ9fQ==--2359edd41975d1e561bf22666f32d5c457507380"}
2025-06-27 17:03:37 xxxxxxx1: #<ActionDispatch::Request POST "http://127.0.0.1:3001/user/test23/confirm" for 192.168.65.1>

// ^--- but now, that we are in the part of the code that will show the welcome page, the `referer` is missing.
// As a result the /welcome route never receives the referer and the button will never change…

```

</p>
</details> 

I assume this issue is present since https://github.com/openstreetmap/openstreetmap-website/pull/4758 and was not caught in https://github.com/openstreetmap/openstreetmap-website/pull/4846. A different thing might be that the whole JS-Redirect part was changed later (did not check this).

---

I want to `+1` https://github.com/openstreetmap/openstreetmap-website/issues/6131 but unfortunately I cannot help with this; I don't know enough Rails for that. As a side note, I also did not manage to get an OAuth setup going locally for proper debugging (I don't have https://www.openstreetmap.org/.well-known/openid-configuration locally for some reason).
