### PR TITLE
Remove .browse-section and other css classes previously used for testing

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -644,6 +644,24 @@ tr.turn {
     }
   }
 
+  .browse-element-list {
+    line-height: 1.25rem;
+
+    .browse-icon {
+      height: 1.25rem;
+    }
+
+    .d-flex > .browse-icon {
+      height: max(20px, 1.25rem);
+    }
+
+    @include color-mode(dark) {
+      .browse-icon-invertible {
+        filter: invert(.8) hue-rotate(180deg);
+      }
+    }
+  }
+
   .query-results {
     display: none;
   }
@@ -948,26 +966,6 @@ img.trace_image {
   img.trace_image {
     filter: invert(1);
     mix-blend-mode: lighten;
-  }
-}
-
-/* Rules for map sidebar icons */
-
-.browse-section .browse-element-list {
-  line-height: 1.25rem;
-
-  .browse-icon {
-    height: 1.25rem;
-  }
-
-  .d-flex > .browse-icon {
-    height: max(20px, 1.25rem);
-  }
-
-  @include color-mode(dark) {
-    .browse-icon-invertible {
-      filter: invert(.8) hue-rotate(180deg);
-    }
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -623,12 +623,6 @@ tr.turn {
 /* Rules for the browse sidebar */
 
 #sidebar_content {
-  .browse-section {
-    padding-bottom: $spacer;
-    margin-bottom: $spacer;
-    border-bottom: 1px solid $grey;
-  }
-
   .browse-tag-list {
     table-layout: fixed;
     white-space: pre-wrap;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -644,16 +644,16 @@ tr.turn {
     .d-flex > .browse-icon {
       height: max(20px, 1.25rem);
     }
-
-    @include color-mode(dark) {
-      .browse-icon-invertible {
-        filter: invert(.8) hue-rotate(180deg);
-      }
-    }
   }
 
   .query-results {
     display: none;
+  }
+}
+
+@include color-mode(dark) {
+  #sidebar_content .browse-element-list .browse-icon-invertible {
+    filter: invert(.8) hue-rotate(180deg);
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -629,10 +629,6 @@ tr.turn {
     border-bottom: 1px solid $grey;
   }
 
-  .browse-section:last-of-type {
-    border-bottom: none;
-  }
-
   .browse-tag-list {
     table-layout: fixed;
     white-space: pre-wrap;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -627,10 +627,6 @@ tr.turn {
     padding-bottom: $spacer;
     margin-bottom: $spacer;
     border-bottom: 1px solid $grey;
-
-    h4:first-child {
-      word-wrap: break-word;
-    }
   }
 
   .browse-section:last-of-type {

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -1,13 +1,11 @@
-<% if node.redacted? && !params[:show_redactions] %>
-  <div class="browse-section">
+<%= tag.div :class => ["browse-section", { "text-body-secondary" => node.redacted? && params[:show_redactions] }] do %>
+  <% if node.redacted? && !params[:show_redactions] %>
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.node"),
           :version => node.version,
           :redaction_link => link_to(t("browse.redacted.redaction",
                                        :id => node.redaction.id), node.redaction) %>
-  </div>
-<% else %>
-  <%= tag.div :class => ["browse-section", { "text-body-secondary" => node.redacted? }] do %>
+  <% else %>
     <%= render :partial => "browse/common_details", :object => node %>
 
     <% unless node.ways.empty? and node.containing_relation_members.empty? %>

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -1,4 +1,5 @@
-<%= tag.div :class => ["browse-section", { "text-body-secondary" => node.redacted? && params[:show_redactions] }] do %>
+<%= tag.div :class => ["mb-3 border-bottom border-secondary-subtle pb-3",
+                       { "text-body-secondary" => node.redacted? && params[:show_redactions] }] do %>
   <% if node.redacted? && !params[:show_redactions] %>
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.node"),

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -7,7 +7,7 @@
                                        :id => node.redaction.id), node.redaction) %>
   </div>
 <% else %>
-  <%= tag.div :class => ["browse-section", "browse-node", { "text-body-secondary" => node.redacted? }] do %>
+  <%= tag.div :class => ["browse-section", { "text-body-secondary" => node.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => node %>
 
     <% unless node.ways.empty? and node.containing_relation_members.empty? %>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -1,4 +1,5 @@
-<%= tag.div :class => ["browse-section", { "text-body-secondary" => relation.redacted? && params[:show_redactions] }] do %>
+<%= tag.div :class => ["mb-3 border-bottom border-secondary-subtle pb-3",
+                       { "text-body-secondary" => relation.redacted? && params[:show_redactions] }] do %>
   <% if relation.redacted? && !params[:show_redactions] %>
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.relation"),

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -1,13 +1,11 @@
-<% if relation.redacted? && !params[:show_redactions] %>
-  <div class="browse-section">
+<%= tag.div :class => ["browse-section", { "text-body-secondary" => relation.redacted? && params[:show_redactions] }] do %>
+  <% if relation.redacted? && !params[:show_redactions] %>
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.relation"),
           :version => relation.version,
           :redaction_link => link_to(t("browse.redacted.redaction",
                                        :id => relation.redaction.id), relation.redaction) %>
-  </div>
-<% else %>
-  <%= tag.div :class => ["browse-section", { "text-body-secondary" => relation.redacted? }] do %>
+  <% else %>
     <%= render :partial => "browse/common_details", :object => relation %>
 
     <% unless relation.containing_relation_members.empty? %>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -7,7 +7,7 @@
                                        :id => relation.redaction.id), relation.redaction) %>
   </div>
 <% else %>
-  <%= tag.div :class => ["browse-section", "browse-relation", { "text-body-secondary" => relation.redacted? }] do %>
+  <%= tag.div :class => ["browse-section", { "text-body-secondary" => relation.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => relation %>
 
     <% unless relation.containing_relation_members.empty? %>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -1,13 +1,11 @@
-<% if way.redacted? && !params[:show_redactions] %>
-  <div class="browse-section">
+<%= tag.div :class => ["browse-section", { "text-body-secondary" => way.redacted? && params[:show_redactions] }] do %>
+  <% if way.redacted? && !params[:show_redactions] %>
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.way"),
           :version => way.version,
           :redaction_link => link_to(t("browse.redacted.redaction",
                                        :id => way.redaction.id), way.redaction) %>
-  </div>
-<% else %>
-  <%= tag.div :class => ["browse-section", { "text-body-secondary" => way.redacted? }] do %>
+  <% else %>
     <%= render :partial => "browse/common_details", :object => way %>
 
     <% unless way.containing_relation_members.empty? %>

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -1,4 +1,5 @@
-<%= tag.div :class => ["browse-section", { "text-body-secondary" => way.redacted? && params[:show_redactions] }] do %>
+<%= tag.div :class => ["mb-3 border-bottom border-secondary-subtle pb-3",
+                       { "text-body-secondary" => way.redacted? && params[:show_redactions] }] do %>
   <% if way.redacted? && !params[:show_redactions] %>
     <%= t "browse.redacted.message_html",
           :type => t("browse.redacted.type.way"),

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -7,7 +7,7 @@
                                        :id => way.redaction.id), way.redaction) %>
   </div>
 <% else %>
-  <%= tag.div :class => ["browse-section", "browse-way", { "text-body-secondary" => way.redacted? }] do %>
+  <%= tag.div :class => ["browse-section", { "text-body-secondary" => way.redacted? }] do %>
     <%= render :partial => "browse/common_details", :object => way %>
 
     <% unless way.containing_relation_members.empty? %>

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "sidebar_header", :title => t(".title", :id => @changeset.id) %>
 
-<div class="browse-section">
+<div class="mb-3 border-bottom border-secondary-subtle pb-3">
   <p class="fs-6 overflow-x-auto" dir="auto">
     <%= linkify(@changeset.tags["comment"].to_s.presence || t("browse.no_comment")) %>
   </p>


### PR DESCRIPTION
`.browse-section` has some custom css associated with it but it's now outdated, including one issue mentioned in #6142, "the footer divider".

`.browse-node`, `.browse-way` and `.browse-relation` are not necessary after #6129 because they were only used in tests. `.browse-redacted` is already removed in #6129.