### PR TITLE
Make element version scrollbar appear only when necessary

### DIFF
--- a/app/helpers/numbered_pagination_helper.rb
+++ b/app/helpers/numbered_pagination_helper.rb
@@ -41,7 +41,7 @@ module NumberedPaginationHelper
       lists << tag.ul(:id => "versions-navigation-list-middle",
                       :class => [
                         "pagination pagination-sm",
-                        "overflow-x-scroll pb-3", # horizontal scrollbar with reserved space below
+                        "overflow-x-auto pb-3", # horizontal scrollbar with reserved space below
                         "pt-1 px-1 mx-n1", # space reserved for focus outlines
                         "position-relative" # required for centering when clicking "Version #n"
                       ]) do


### PR DESCRIPTION
Mentioned in #6142, "Non-functional scrollbar".

This is for browsers that display scrollbars not only during scrolling. On Linux this is currently Chrome, but not Firefox.

If the version list is long enough to have the potentially scrollable part (currently >= 5 versions) but it fits in the sidebar entirely without scrolling, the scrollbar may still be visible.

![image](https://github.com/user-attachments/assets/527f117c-dbe6-4c8d-b615-10af6bb79e67)

This PR sets the horizontal overflow to `auto` instead of `scroll`, which hides the scrollbar when there's nothing to scroll.

![image](https://github.com/user-attachments/assets/e784e46c-5013-4fce-a8fd-8101a2678bb6)
