### PR TITLE
Add versions label to breadcrumbs

### DIFF
--- a/app/views/elements/show.html.erb
+++ b/app/views/elements/show.html.erb
@@ -7,6 +7,10 @@
 <% if @feature.visible? %>
   <div class='secondary-actions mb-3'>
     <%= link_to(t("browse.download_xml"), :controller => "api/#{@type.pluralize}", :action => :show) %>
+    <% if current_user&.moderator? %>
+      &middot;
+      <%= link_to t("browse.view_unredacted_history"), :controller => "old_#{@type.pluralize}", :params => { :show_redactions => true } %>
+    <% end %>
   </div>
 <% end %>
 
@@ -17,10 +21,6 @@
     </li>
     <li class="breadcrumb-item">
       <%= link_to t("browse.versions_navigation.history"), :controller => "old_#{@type.pluralize}" %>
-      <% if current_user&.moderator? %>
-        &middot;
-        <%= link_to t("browse.versions_navigation.unredacted_history"), :controller => "old_#{@type.pluralize}", :params => { :show_redactions => true } %>
-      <% end %>
     </li>
   </ol>
 

--- a/app/views/elements/show.html.erb
+++ b/app/views/elements/show.html.erb
@@ -22,6 +22,11 @@
     <li class="breadcrumb-item">
       <%= link_to t("browse.versions_navigation.history"), :controller => "old_#{@type.pluralize}" %>
     </li>
+    <li class="breadcrumb-item">
+      <a href="#versions-navigation-active-page-item" class="link-body-emphasis">
+        <%= t "browse.versions_navigation.versions_label" %>
+      </a>
+    </li>
   </ol>
 
   <%= element_versions_pagination(@feature.version, :active_version => @feature.version) do |v|

--- a/app/views/old_elements/index.html.erb
+++ b/app/views/old_elements/index.html.erb
@@ -30,6 +30,14 @@
 
 <div class='secondary-actions mb-3'>
   <%= link_to t("browse.download_xml"), send(:"api_#{@type}_versions_path", @feature.id) %>
+  <% if current_user&.moderator? %>
+    &middot;
+    <% if params["show_redactions"] %>
+      <%= tag.span t("browse.view_unredacted_history"), :class => "py-1 px-2 rounded bg-body-secondary" %>
+    <% else %>
+      <%= link_to t("browse.view_unredacted_history"), params.permit(:before, :after).merge(:show_redactions => true) %>
+    <% end %>
+  <% end %>
 </div>
 
 <nav>
@@ -41,15 +49,7 @@
       <% if !params["show_redactions"] %>
         <%= tag.span t("browse.versions_navigation.history"), :class => "py-1 px-2 rounded bg-body-secondary" %>
       <% else %>
-        <%= link_to t("browse.versions_navigation.history"), params.permit(:before, :after) %>
-      <% end %>
-      <% if current_user&.moderator? %>
-        &middot;
-        <% if params["show_redactions"] %>
-          <%= tag.span t("browse.versions_navigation.unredacted_history"), :class => "py-1 px-2 rounded bg-body-secondary" %>
-        <% else %>
-          <%= link_to t("browse.versions_navigation.unredacted_history"), params.permit(:before, :after).merge(:show_redactions => true) %>
-        <% end %>
+        <%= link_to t("browse.versions_navigation.history"), params.permit(:before, :after), :class => "py-1 px-2 rounded bg-body-secondary" %>
       <% end %>
     </li>
   </ol>

--- a/app/views/old_elements/index.html.erb
+++ b/app/views/old_elements/index.html.erb
@@ -46,10 +46,10 @@
       <%= link_to t(@type, :scope => "browse.versions_navigation"), @current_feature %>
     </li>
     <li class="breadcrumb-item active">
-      <% if !params["show_redactions"] %>
-        <%= tag.span t("browse.versions_navigation.history"), :class => "py-1 px-2 rounded bg-body-secondary" %>
+      <% if params[:show_redactions] || params[:before] || params[:after] %>
+        <%= link_to t("browse.versions_navigation.history"), {}, :class => "py-1 px-2 rounded bg-body-secondary" %>
       <% else %>
-        <%= link_to t("browse.versions_navigation.history"), params.permit(:before, :after), :class => "py-1 px-2 rounded bg-body-secondary" %>
+        <%= tag.span t("browse.versions_navigation.history"), :class => "py-1 px-2 rounded bg-body-secondary" %>
       <% end %>
     </li>
   </ol>

--- a/app/views/old_elements/index.html.erb
+++ b/app/views/old_elements/index.html.erb
@@ -52,6 +52,9 @@
         <%= tag.span t("browse.versions_navigation.history"), :class => "py-1 px-2 rounded bg-body-secondary" %>
       <% end %>
     </li>
+    <li class="breadcrumb-item">
+      <%= t "browse.versions_navigation.versions_label" %>
+    </li>
   </ol>
 
   <%= element_versions_pagination(@current_feature.version) do |v|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,6 +357,7 @@ en:
       one: "%{count} way"
       other: "%{count} ways"
     download_xml: "Download XML"
+    view_unredacted_history: "View Unredacted History"
     location: "Location:"
     common_details:
       coordinates_html: "%{latitude}, %{longitude}"
@@ -425,7 +426,6 @@ en:
       way: "Way"
       relation: "Relation"
       history: "History"
-      unredacted_history: "Unredacted History"
       version: "Version #%{version}"
   feature_queries:
     show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -427,6 +427,7 @@ en:
       relation: "Relation"
       history: "History"
       version: "Version #%{version}"
+      versions_label: "Versions:"
   feature_queries:
     show:
       title: "Query Features"


### PR DESCRIPTION
Adds a *Versions:* label above the versions navigeation list on element pages.

Fixes #6146.

Before for most of the users:
![image](https://github.com/user-attachments/assets/7b30645f-d6b0-45e1-9747-a0fb3dc369df)

After:
![image](https://github.com/user-attachments/assets/6a507162-cb46-4a78-87a6-3eef7d238e38)

Before for moderators:
![image](https://github.com/user-attachments/assets/558c752d-2551-4837-91f5-4dce563d7f1e)

After:
![image](https://github.com/user-attachments/assets/6e5cc064-32e6-43f8-8ff9-a91d0d3a0bdc)
