### PR TITLE
Stop GitHub from cancelling related workflows early

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2', '3.3', '3.4']
+      fail-fast: false
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test


### PR DESCRIPTION
Most workflow cancellations occur just seconds before they would finish anyway, so failing fast doesn't safe many resources, it just makes workflow reattempts consume more.