### PR TITLE
Fix message reuse for Terms of Use link in signup form

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -68,7 +68,7 @@
   <% end %>
 
   <p class="mb-3 text-body-secondary fs-6"><%= t(".by_signing_up.html",
-                                                 :tou_link => link_to(t("layouts.tou"),
+                                                 :tou_link => link_to(t(".by_signing_up.tou"),
                                                                       "https://wiki.osmfoundation.org/wiki/Terms_of_Use",
                                                                       :target => :new),
                                                  :privacy_policy_link => link_to(t(".by_signing_up.privacy_policy"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2997,6 +2997,7 @@ en:
       display name description: "Your publicly displayed username. You can change this later in the preferences."
       by_signing_up:
         html: "By signing up, you agree to our %{tou_link}, %{privacy_policy_link} and %{contributor_terms_link}."
+        tou: "Terms of Use"
         privacy_policy: privacy policy
         privacy_policy_url: https://osmfoundation.org/wiki/Privacy_Policy
         privacy_policy_title: OSMF privacy policy including section on email addresses


### PR DESCRIPTION
Currently `layouts.tou` message (link label) is reused in two different sentences, i.e. in messages `accounts.terms.show.tou explain html` and `users.new.by_signing_up.html`. In some languages however the link label needs different declension in these sentences.

Here `users.new.by_signing_up.tou` message is added for use in the latter sentence in signup form. In English it's identical to previous `layouts.tou` message.

Similarly in #4936 two other link labels in the same sentence were already adjusted like this.

It also appears that at some point the terms of use link label already existed for this particular sentence, as still documented in translatewiki, but no one remembered to actually use it, and then it got removed as an unused message in b0ad96e.