### PR TITLE
Various API changesets/elements controller test updates

### DIFF
--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -284,14 +284,6 @@ module Api
     # -----------------------
 
     def test_create
-      auth_header = bearer_authorization_header create(:user, :data_public => false)
-      # Create the first user's changeset
-      xml = "<osm><changeset>" \
-            "<tag k='created_by' v='osm test suite checking changesets'/>" \
-            "</changeset></osm>"
-      post api_changesets_path, :params => xml, :headers => auth_header
-      assert_require_public_data
-
       auth_header = bearer_authorization_header
       # Create the first user's changeset
       xml = "<osm><changeset>" \

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -289,9 +289,11 @@ module Api
       xml = "<osm><changeset>" \
             "<tag k='created_by' v='osm test suite checking changesets'/>" \
             "</changeset></osm>"
-      post api_changesets_path, :params => xml, :headers => auth_header
 
-      assert_response :success, "Creation of changeset did not return success status"
+      assert_difference "Changeset.count", 1 do
+        post api_changesets_path, :params => xml, :headers => auth_header
+        assert_response :success, "Creation of changeset did not return success status"
+      end
       newid = @response.body.to_i
 
       # check end time, should be an hour ahead of creation time

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -284,7 +284,8 @@ module Api
     # -----------------------
 
     def test_create
-      auth_header = bearer_authorization_header
+      user = create(:user)
+      auth_header = bearer_authorization_header user
       # Create the first user's changeset
       xml = "<osm><changeset>" \
             "<tag k='created_by' v='osm test suite checking changesets'/>" \
@@ -308,8 +309,7 @@ module Api
         assert_equal 3600, duration.round, "initial idle timeout should be an hour (#{cs.created_at} -> #{cs.closed_at})"
       end
 
-      # checks if uploader was subscribed
-      assert_equal 1, cs.subscribers.length
+      assert_equal [user], cs.subscribers
     end
 
     def test_create_invalid

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -407,12 +407,6 @@ module Api
 
       ## Finally test with the public user
 
-      # try and update a node without authorisation
-      # first try to update node without auth
-      xml = xml_for_node(node)
-      put api_node_path(node), :params => xml.to_s, :headers => auth_header
-      assert_response :forbidden
-
       # setup auth
       auth_header = bearer_authorization_header user
 

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -512,9 +512,13 @@ module Api
 
       # try and put something into a string that the API might
       # use unquoted and therefore allow code injection...
-      xml = "<osm><node lat='0' lon='0' changeset='#{private_changeset.id}'>" \
-            "<tag k='\#{@user.inspect}' v='0'/>" \
-            "</node></osm>"
+      xml = <<~OSM
+        <osm>
+          <node lat='0' lon='0' changeset='#{private_changeset.id}'>
+            <tag k='\#{@user.inspect}' v='0'/>
+          </node>
+        </osm>
+      OSM
       post api_nodes_path, :params => xml, :headers => auth_header
       assert_require_public_data "Shouldn't be able to create with non-public user"
 
@@ -523,9 +527,13 @@ module Api
 
       # try and put something into a string that the API might
       # use unquoted and therefore allow code injection...
-      xml = "<osm><node lat='0' lon='0' changeset='#{changeset.id}'>" \
-            "<tag k='\#{@user.inspect}' v='0'/>" \
-            "</node></osm>"
+      xml = <<~OSM
+        <osm>
+          <node lat='0' lon='0' changeset='#{changeset.id}'>
+            <tag k='\#{@user.inspect}' v='0'/>
+          </node>
+        </osm>
+      OSM
       post api_nodes_path, :params => xml, :headers => auth_header
       assert_response :success
       nodeid = @response.body

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -401,7 +401,7 @@ module Api
 
       # create a relation with non-existing node as member
       xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member type='node' ref='0'/><tag k='test' v='yes' />" \
+            "<member type='node' ref='0'/>" \
             "</relation></osm>"
       post api_relations_path, :params => xml, :headers => auth_header
       # expect failure
@@ -423,7 +423,7 @@ module Api
       # create some xml that should return an error
       xml = "<osm><relation changeset='#{changeset.id}'>" \
             "<member type='type' ref='#{node.id}' role=''/>" \
-            "<tag k='tester' v='yep'/></relation></osm>"
+            "</relation></osm>"
       post api_relations_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :bad_request
@@ -589,7 +589,7 @@ module Api
       xml = "<osm><relation changeset='#{changeset.id}'>" \
             "<member  ref='#{node1.id}' type='node' role='some'/>" \
             "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+            "</relation></osm>"
       post api_relations_path, :params => xml, :headers => auth_header
       assert_response :success, "relation create did not return success status"
 
@@ -600,7 +600,7 @@ module Api
       xml = "<osm><relation id='#{relationid}' version='1' changeset='#{changeset.id}'>" \
             "<member  ref='#{node2.id}' type='node' role='some'/>" \
             "<member  ref='#{node1.id}' type='node' role='some'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+            "</relation></osm>"
       put api_relation_path(relationid), :params => xml, :headers => auth_header
       assert_response :too_many_requests, "relation update did not hit rate limit"
 
@@ -613,7 +613,7 @@ module Api
       xml = "<osm><relation changeset='#{changeset.id}'>" \
             "<member  ref='#{node1.id}' type='node' role='some'/>" \
             "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+            "</relation></osm>"
       post api_relations_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "relation create did not hit rate limit"
     end
@@ -649,7 +649,7 @@ module Api
       xml = "<osm><relation changeset='#{changeset.id}'>" \
             "<member  ref='#{node1.id}' type='node' role='some'/>" \
             "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+            "</relation></osm>"
       post api_relations_path, :params => xml, :headers => auth_header
       assert_response :success, "relation create did not return success status"
 
@@ -660,7 +660,7 @@ module Api
       xml = "<osm><relation id='#{relationid}' version='1' changeset='#{changeset.id}'>" \
             "<member  ref='#{node2.id}' type='node' role='some'/>" \
             "<member  ref='#{node1.id}' type='node' role='some'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+            "</relation></osm>"
       put api_relation_path(relationid), :params => xml, :headers => auth_header
       assert_response :too_many_requests, "relation update did not hit rate limit"
 
@@ -673,7 +673,7 @@ module Api
       xml = "<osm><relation changeset='#{changeset.id}'>" \
             "<member  ref='#{node1.id}' type='node' role='some'/>" \
             "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+            "</relation></osm>"
       post api_relations_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "relation create did not hit rate limit"
     end

--- a/test/controllers/api/relations_controller_test.rb
+++ b/test/controllers/api/relations_controller_test.rb
@@ -218,7 +218,13 @@ module Api
       auth_header = bearer_authorization_header private_user
 
       # create an relation without members
-      xml = "<osm><relation changeset='#{private_changeset.id}'><tag k='test' v='yes' /></relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{private_changeset.id}'>
+            <tag k='test' v='yes' />
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # hope for forbidden, due to user
       assert_response :forbidden,
@@ -227,9 +233,14 @@ module Api
       ###
       # create an relation with a node as member
       # This time try with a role attribute in the relation
-      xml = "<osm><relation changeset='#{private_changeset.id}'>" \
-            "<member  ref='#{node.id}' type='node' role='some'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{private_changeset.id}'>
+            <member ref='#{node.id}' type='node' role='some'/>
+            <tag k='test' v='yes' />
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # hope for forbidden due to user
       assert_response :forbidden,
@@ -238,8 +249,14 @@ module Api
       ###
       # create an relation with a node as member, this time test that we don't
       # need a role attribute to be included
-      xml = "<osm><relation changeset='#{private_changeset.id}'>" \
-            "<member  ref='#{node.id}' type='node'/><tag k='test' v='yes' /></relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{private_changeset.id}'>
+            <member ref='#{node.id}' type='node'/>
+            <tag k='test' v='yes' />
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # hope for forbidden due to user
       assert_response :forbidden,
@@ -247,10 +264,15 @@ module Api
 
       ###
       # create an relation with a way and a node as members
-      xml = "<osm><relation changeset='#{private_changeset.id}'>" \
-            "<member type='node' ref='#{node.id}' role='some'/>" \
-            "<member type='way' ref='#{way.id}' role='other'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{private_changeset.id}'>
+            <member type='node' ref='#{node.id}' role='some'/>
+            <member type='way' ref='#{way.id}' role='other'/>
+            <tag k='test' v='yes' />
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # hope for forbidden, due to user
       assert_response :forbidden,
@@ -260,7 +282,13 @@ module Api
       auth_header = bearer_authorization_header user
 
       # create an relation without members
-      xml = "<osm><relation changeset='#{changeset.id}'><tag k='test' v='yes' /></relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <tag k='test' v='yes' />
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # hope for success
       assert_response :success,
@@ -286,9 +314,14 @@ module Api
       ###
       # create an relation with a node as member
       # This time try with a role attribute in the relation
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member  ref='#{node.id}' type='node' role='some'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member ref='#{node.id}' type='node' role='some'/>
+            <tag k='test' v='yes' />
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # hope for success
       assert_response :success,
@@ -315,8 +348,14 @@ module Api
       ###
       # create an relation with a node as member, this time test that we don't
       # need a role attribute to be included
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member  ref='#{node.id}' type='node'/><tag k='test' v='yes' /></relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member ref='#{node.id}' type='node'/>
+            <tag k='test' v='yes' />
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # hope for success
       assert_response :success,
@@ -342,10 +381,15 @@ module Api
 
       ###
       # create an relation with a way and a node as members
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member type='node' ref='#{node.id}' role='some'/>" \
-            "<member type='way' ref='#{way.id}' role='other'/>" \
-            "<tag k='test' v='yes' /></relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member type='node' ref='#{node.id}' role='some'/>
+            <member type='way' ref='#{way.id}' role='other'/>
+            <tag k='test' v='yes' />
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # hope for success
       assert_response :success,
@@ -400,9 +444,13 @@ module Api
       auth_header = bearer_authorization_header user
 
       # create a relation with non-existing node as member
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member type='node' ref='0'/>" \
-            "</relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member type='node' ref='0'/>
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :precondition_failed,
@@ -421,9 +469,13 @@ module Api
       auth_header = bearer_authorization_header user
 
       # create some xml that should return an error
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member type='type' ref='#{node.id}' role=''/>" \
-            "</relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member type='type' ref='#{node.id}' role=''/>
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :bad_request
@@ -586,10 +638,14 @@ module Api
       auth_header = bearer_authorization_header user
 
       # try creating a relation
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member  ref='#{node1.id}' type='node' role='some'/>" \
-            "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "</relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member ref='#{node1.id}' type='node' role='some'/>
+            <member ref='#{node2.id}' type='node' role='some'/>
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       assert_response :success, "relation create did not return success status"
 
@@ -597,10 +653,14 @@ module Api
       relationid = @response.body
 
       # try updating the relation, which should be rate limited
-      xml = "<osm><relation id='#{relationid}' version='1' changeset='#{changeset.id}'>" \
-            "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "<member  ref='#{node1.id}' type='node' role='some'/>" \
-            "</relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation id='#{relationid}' version='1' changeset='#{changeset.id}'>
+            <member ref='#{node2.id}' type='node' role='some'/>
+            <member ref='#{node1.id}' type='node' role='some'/>
+          </relation>
+        </osm>
+      OSM
       put api_relation_path(relationid), :params => xml, :headers => auth_header
       assert_response :too_many_requests, "relation update did not hit rate limit"
 
@@ -610,10 +670,14 @@ module Api
       assert_response :too_many_requests, "relation delete did not hit rate limit"
 
       # try creating a relation, which should be rate limited
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member  ref='#{node1.id}' type='node' role='some'/>" \
-            "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "</relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member ref='#{node1.id}' type='node' role='some'/>
+            <member ref='#{node2.id}' type='node' role='some'/>
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "relation create did not hit rate limit"
     end
@@ -646,10 +710,14 @@ module Api
       auth_header = bearer_authorization_header user
 
       # try creating a relation
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member  ref='#{node1.id}' type='node' role='some'/>" \
-            "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "</relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member ref='#{node1.id}' type='node' role='some'/>
+            <member ref='#{node2.id}' type='node' role='some'/>
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       assert_response :success, "relation create did not return success status"
 
@@ -657,10 +725,14 @@ module Api
       relationid = @response.body
 
       # try updating the relation, which should be rate limited
-      xml = "<osm><relation id='#{relationid}' version='1' changeset='#{changeset.id}'>" \
-            "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "<member  ref='#{node1.id}' type='node' role='some'/>" \
-            "</relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation id='#{relationid}' version='1' changeset='#{changeset.id}'>
+            <member ref='#{node2.id}' type='node' role='some'/>
+            <member ref='#{node1.id}' type='node' role='some'/>
+          </relation>
+        </osm>
+      OSM
       put api_relation_path(relationid), :params => xml, :headers => auth_header
       assert_response :too_many_requests, "relation update did not hit rate limit"
 
@@ -670,10 +742,14 @@ module Api
       assert_response :too_many_requests, "relation delete did not hit rate limit"
 
       # try creating a relation, which should be rate limited
-      xml = "<osm><relation changeset='#{changeset.id}'>" \
-            "<member  ref='#{node1.id}' type='node' role='some'/>" \
-            "<member  ref='#{node2.id}' type='node' role='some'/>" \
-            "</relation></osm>"
+      xml = <<~OSM
+        <osm>
+          <relation changeset='#{changeset.id}'>
+            <member ref='#{node1.id}' type='node' role='some'/>
+            <member ref='#{node2.id}' type='node' role='some'/>
+          </relation>
+        </osm>
+      OSM
       post api_relations_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "relation create did not hit rate limit"
     end

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -213,9 +213,15 @@ module Api
       changeset_id = private_changeset.id
 
       # create a way with pre-existing nodes
-      xml = "<osm><way changeset='#{changeset_id}'>" \
-            "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "<tag k='test' v='yes' /></way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{changeset_id}'>
+            <nd ref='#{node1.id}'/>
+            <nd ref='#{node2.id}'/>
+            <tag k='test' v='yes' />
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # hope for failure
       assert_response :forbidden,
@@ -228,9 +234,15 @@ module Api
       changeset_id = changeset.id
 
       # create a way with pre-existing nodes
-      xml = "<osm><way changeset='#{changeset_id}'>" \
-            "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "<tag k='test' v='yes' /></way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{changeset_id}'>
+            <nd ref='#{node1.id}'/>
+            <nd ref='#{node2.id}'/>
+            <tag k='test' v='yes' />
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # hope for success
       assert_response :success,
@@ -272,24 +284,38 @@ module Api
 
       # use the first user's open changeset
       # create a way with non-existing node
-      xml = "<osm><way changeset='#{private_open_changeset.id}'>" \
-            "<nd ref='0'/></way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{private_open_changeset.id}'>
+            <nd ref='0'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :forbidden,
                       "way upload with invalid node using a private user did not return 'forbidden'"
 
       # create a way with no nodes
-      xml = "<osm><way changeset='#{private_open_changeset.id}'>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{private_open_changeset.id}'>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :forbidden,
                       "way upload with no node using a private userdid not return 'forbidden'"
 
       # create a way inside a closed changeset
-      xml = "<osm><way changeset='#{private_closed_changeset.id}'>" \
-            "<nd ref='#{node.id}'/></way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{private_closed_changeset.id}'>
+            <nd ref='#{node.id}'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :forbidden,
@@ -300,8 +326,13 @@ module Api
 
       # use the first user's open changeset
       # create a way with non-existing node
-      xml = "<osm><way changeset='#{open_changeset.id}'>" \
-            "<nd ref='0'/></way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{open_changeset.id}'>
+            <nd ref='0'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :precondition_failed,
@@ -309,8 +340,12 @@ module Api
       assert_equal "Precondition failed: Way  requires the nodes with id in (0), which either do not exist, or are not visible.", @response.body
 
       # create a way with no nodes
-      xml = "<osm><way changeset='#{open_changeset.id}'>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{open_changeset.id}'>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :precondition_failed,
@@ -318,18 +353,27 @@ module Api
       assert_equal "Precondition failed: Cannot create way: data is invalid.", @response.body
 
       # create a way inside a closed changeset
-      xml = "<osm><way changeset='#{closed_changeset.id}'>" \
-            "<nd ref='#{node.id}'/></way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{closed_changeset.id}'>
+            <nd ref='#{node.id}'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :conflict,
                       "way upload to closed changeset did not return 'conflict'"
 
       # create a way with a tag which is too long
-      xml = "<osm><way changeset='#{open_changeset.id}'>" \
-            "<nd ref='#{node.id}'/>" \
-            "<tag k='foo' v='#{'x' * 256}'/>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{open_changeset.id}'>
+            <nd ref='#{node.id}'/>
+            <tag k='foo' v='#{'x' * 256}'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :bad_request,
@@ -751,10 +795,14 @@ module Api
       auth_header = bearer_authorization_header private_user
 
       # add the tag into the existing xml
-      way_str = "<osm><way changeset='#{private_changeset.id}'>"
-      way_str << "<tag k='addr:housenumber' v='1'/>"
-      way_str << "<tag k='addr:housenumber' v='2'/>"
-      way_str << "</way></osm>"
+      way_str = <<~OSM
+        <osm>
+          <way changeset='#{private_changeset.id}'>
+            <tag k='addr:housenumber' v='1'/>
+            <tag k='addr:housenumber' v='2'/>
+          </way>
+        </osm>
+      OSM
 
       # try and upload it
       post api_ways_path, :params => way_str, :headers => auth_header
@@ -766,10 +814,14 @@ module Api
       auth_header = bearer_authorization_header user
 
       # add the tag into the existing xml
-      way_str = "<osm><way changeset='#{changeset.id}'>"
-      way_str << "<tag k='addr:housenumber' v='1'/>"
-      way_str << "<tag k='addr:housenumber' v='2'/>"
-      way_str << "</way></osm>"
+      way_str = <<~OSM
+        <osm>
+          <way changeset='#{changeset.id}'>
+            <tag k='addr:housenumber' v='1'/>
+            <tag k='addr:housenumber' v='2'/>
+          </way>
+        </osm>
+      OSM
 
       # try and upload it
       post api_ways_path, :params => way_str, :headers => auth_header
@@ -797,9 +849,14 @@ module Api
       auth_header = bearer_authorization_header user
 
       # try creating a way
-      xml = "<osm><way changeset='#{changeset.id}'>" \
-            "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{changeset.id}'>
+            <nd ref='#{node1.id}'/>
+            <nd ref='#{node2.id}'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       assert_response :success, "way create did not return success status"
 
@@ -807,9 +864,14 @@ module Api
       wayid = @response.body
 
       # try updating the way, which should be rate limited
-      xml = "<osm><way id='#{wayid}' version='1' changeset='#{changeset.id}'>" \
-            "<nd ref='#{node2.id}'/><nd ref='#{node1.id}'/>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way id='#{wayid}' version='1' changeset='#{changeset.id}'>
+            <nd ref='#{node2.id}'/>
+            <nd ref='#{node1.id}'/>
+          </way>
+        </osm>
+      OSM
       put api_way_path(wayid), :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way update did not hit rate limit"
 
@@ -819,9 +881,14 @@ module Api
       assert_response :too_many_requests, "way delete did not hit rate limit"
 
       # try creating a way, which should be rate limited
-      xml = "<osm><way changeset='#{changeset.id}'>" \
-            "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{changeset.id}'>
+            <nd ref='#{node1.id}'/>
+            <nd ref='#{node2.id}'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way create did not hit rate limit"
     end
@@ -854,9 +921,14 @@ module Api
       auth_header = bearer_authorization_header user
 
       # try creating a way
-      xml = "<osm><way changeset='#{changeset.id}'>" \
-            "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{changeset.id}'>
+            <nd ref='#{node1.id}'/>
+            <nd ref='#{node2.id}'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       assert_response :success, "way create did not return success status"
 
@@ -864,9 +936,14 @@ module Api
       wayid = @response.body
 
       # try updating the way, which should be rate limited
-      xml = "<osm><way id='#{wayid}' version='1' changeset='#{changeset.id}'>" \
-            "<nd ref='#{node2.id}'/><nd ref='#{node1.id}'/>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way id='#{wayid}' version='1' changeset='#{changeset.id}'>
+            <nd ref='#{node2.id}'/>
+            <nd ref='#{node1.id}'/>
+          </way>
+        </osm>
+      OSM
       put api_way_path(wayid), :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way update did not hit rate limit"
 
@@ -876,9 +953,14 @@ module Api
       assert_response :too_many_requests, "way delete did not hit rate limit"
 
       # try creating a way, which should be rate limited
-      xml = "<osm><way changeset='#{changeset.id}'>" \
-            "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "</way></osm>"
+      xml = <<~OSM
+        <osm>
+          <way changeset='#{changeset.id}'>
+            <nd ref='#{node1.id}'/>
+            <nd ref='#{node2.id}'/>
+          </way>
+        </osm>
+      OSM
       post api_ways_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way create did not hit rate limit"
     end

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -273,7 +273,7 @@ module Api
       # use the first user's open changeset
       # create a way with non-existing node
       xml = "<osm><way changeset='#{private_open_changeset.id}'>" \
-            "<nd ref='0'/><tag k='test' v='yes' /></way></osm>"
+            "<nd ref='0'/></way></osm>"
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :forbidden,
@@ -281,7 +281,7 @@ module Api
 
       # create a way with no nodes
       xml = "<osm><way changeset='#{private_open_changeset.id}'>" \
-            "<tag k='test' v='yes' /></way></osm>"
+            "</way></osm>"
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :forbidden,
@@ -301,7 +301,7 @@ module Api
       # use the first user's open changeset
       # create a way with non-existing node
       xml = "<osm><way changeset='#{open_changeset.id}'>" \
-            "<nd ref='0'/><tag k='test' v='yes' /></way></osm>"
+            "<nd ref='0'/></way></osm>"
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :precondition_failed,
@@ -310,7 +310,7 @@ module Api
 
       # create a way with no nodes
       xml = "<osm><way changeset='#{open_changeset.id}'>" \
-            "<tag k='test' v='yes' /></way></osm>"
+            "</way></osm>"
       post api_ways_path, :params => xml, :headers => auth_header
       # expect failure
       assert_response :precondition_failed,
@@ -799,7 +799,7 @@ module Api
       # try creating a way
       xml = "<osm><way changeset='#{changeset.id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "<tag k='test' v='yes' /></way></osm>"
+            "</way></osm>"
       post api_ways_path, :params => xml, :headers => auth_header
       assert_response :success, "way create did not return success status"
 
@@ -809,7 +809,7 @@ module Api
       # try updating the way, which should be rate limited
       xml = "<osm><way id='#{wayid}' version='1' changeset='#{changeset.id}'>" \
             "<nd ref='#{node2.id}'/><nd ref='#{node1.id}'/>" \
-            "<tag k='test' v='yes' /></way></osm>"
+            "</way></osm>"
       put api_way_path(wayid), :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way update did not hit rate limit"
 
@@ -821,7 +821,7 @@ module Api
       # try creating a way, which should be rate limited
       xml = "<osm><way changeset='#{changeset.id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "<tag k='test' v='yes' /></way></osm>"
+            "</way></osm>"
       post api_ways_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way create did not hit rate limit"
     end
@@ -856,7 +856,7 @@ module Api
       # try creating a way
       xml = "<osm><way changeset='#{changeset.id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "<tag k='test' v='yes' /></way></osm>"
+            "</way></osm>"
       post api_ways_path, :params => xml, :headers => auth_header
       assert_response :success, "way create did not return success status"
 
@@ -866,7 +866,7 @@ module Api
       # try updating the way, which should be rate limited
       xml = "<osm><way id='#{wayid}' version='1' changeset='#{changeset.id}'>" \
             "<nd ref='#{node2.id}'/><nd ref='#{node1.id}'/>" \
-            "<tag k='test' v='yes' /></way></osm>"
+            "</way></osm>"
       put api_way_path(wayid), :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way update did not hit rate limit"
 
@@ -878,7 +878,7 @@ module Api
       # try creating a way, which should be rate limited
       xml = "<osm><way changeset='#{changeset.id}'>" \
             "<nd ref='#{node1.id}'/><nd ref='#{node2.id}'/>" \
-            "<tag k='test' v='yes' /></way></osm>"
+            "</way></osm>"
       post api_ways_path, :params => xml, :headers => auth_header
       assert_response :too_many_requests, "way create did not hit rate limit"
     end


### PR DESCRIPTION
A number of changes to api changesets, nodes, ways and relations controllers going towards #6170. I split the existing tests there to make them independent. This PR contains changes prior to the splits.