### PR TITLE
Add Bootstrap .modal class to print styles to hide language select dialog

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -68,6 +68,6 @@ header,
 
 /* Bootstrap classes */
 
-.d-none {
+.d-none, .modal {
   display: none;
 }


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/pull/6119#issuecomment-3059447787 by making Bootstrap modals hidden by default.

Similar to #5999.