### PR TITLE
Lock describe_location button to query placeholder

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -54,7 +54,6 @@ OSM.Directions = function (map) {
 
   $(".directions_form .btn-close").on("click", function (e) {
     e.preventDefault();
-    $(".describe_location").toggle(!endpoints[1].value);
     $(".search_form input[name='query']").val(endpoints[1].value);
     OSM.router.route("/" + OSM.formatHash(map));
   });

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -1,12 +1,4 @@
 OSM.Search = function (map) {
-  $(".search_form input[name=query]").on("input", function (e) {
-    if ($(e.target).val() === "") {
-      $(".describe_location").fadeIn(100);
-    } else {
-      $(".describe_location").fadeOut(100);
-    }
-  });
-
   $(".search_form a.btn.switch_link").on("click", function (e) {
     e.preventDefault();
     const query = $(this).closest("form").find("input[name=query]").val();
@@ -112,10 +104,8 @@ OSM.Search = function (map) {
     const params = new URLSearchParams(path.substring(path.indexOf("?")));
     if (params.has("query")) {
       $(".search_form input[name=query]").val(params.get("query"));
-      $(".describe_location").hide();
     } else if (params.has("lat") && params.has("lon")) {
       $(".search_form input[name=query]").val(params.get("lat") + ", " + params.get("lon"));
-      $(".describe_location").hide();
     }
     OSM.loadSidebarContent(path, page.load);
   };
@@ -146,7 +136,6 @@ OSM.Search = function (map) {
   page.unload = function () {
     markers.clearLayers();
     $(".search_form input[name=query]").val("");
-    $(".describe_location").fadeIn(100);
   };
 
   return page;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -556,6 +556,10 @@ header .search_forms,
 .search_form {
   .describe_location {
     font-size: 10px;
+
+    input:not(:placeholder-shown) + .input-group-text & {
+      display: none;
+    }
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -556,11 +556,11 @@ header .search_forms,
 .search_form {
   .describe_location {
     font-size: 10px;
-
-    input:not(:placeholder-shown) + .input-group-text & {
-      display: none;
-    }
   }
+
+  input:not(:placeholder-shown) + .input-group-text .describe_location {
+    display: none;
+  } 
 }
 
 /* Rules for routing */


### PR DESCRIPTION
Use the input state to toggle the describe_location button's visibility with CSS instead of manually updating.