### PR TITLE
Drop KaiOS 2.5 support to fix placeholder styling in Firefox

### DIFF
--- a/app/assets/stylesheets/.browserslistrc
+++ b/app/assets/stylesheets/.browserslistrc
@@ -1,0 +1,2 @@
+defaults
+not kaios <= 2.5 # https://github.com/postcss/autoprefixer/issues/1533


### PR DESCRIPTION
While reviewing #6184 I discovered a problem with Firefox causing by autoprefixer adding a `-moz-placeholder` rule alongside the `placeholder-shown` rule.

The details are discussed in https://github.com/postcss/autoprefixer/issues/1533 but basically Firefox has supported `placeholder-shown` since version 50 but before that used `-moz-placeholder` and some other browsers based on old Firefox versions still do. The problem is that newer Firefox versions still recognise `-moz-placeholder` but at some point started treating it as `placeholder` and always matching whether or not the text is shown.

The solution is to drop support for one specific browser (KaiOS 2.5) which is the only thing in the default set actually triggering this. Newer versions (3.0, 3.1) of KaiOS remain supported.
