### PR TITLE
Don't do partial renders for turbo page visits

### DIFF
--- a/app/controllers/accounts/deletions_controller.rb
+++ b/app/controllers/accounts/deletions_controller.rb
@@ -1,6 +1,6 @@
 module Accounts
   class DeletionsController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/accounts/pd_declarations_controller.rb
+++ b/app/controllers/accounts/pd_declarations_controller.rb
@@ -1,6 +1,6 @@
 module Accounts
   class PdDeclarationsController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/accounts/terms_controller.rb
+++ b/app/controllers/accounts/terms_controller.rb
@@ -2,7 +2,7 @@ module Accounts
   class TermsController < ApplicationController
     include SessionMethods
 
-    layout "site"
+    layout :site_layout
 
     before_action -> { authorize_web(:skip_terms => true) }
     before_action :set_locale

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -2,7 +2,7 @@ class AccountsController < ApplicationController
   include SessionMethods
   include UserMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,6 +39,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def site_layout
+    turbo_frame_request? ? "turbo_frame" : "site"
+  end
+
   def authorize_web(skip_terms: false)
     if session[:user]
       self.current_user = User.find_by(:id => session[:user], :status => %w[active confirmed suspended])

--- a/app/controllers/changeset_subscriptions_controller.rb
+++ b/app/controllers/changeset_subscriptions_controller.rb
@@ -1,5 +1,5 @@
 class ChangesetSubscriptionsController < ApplicationController
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -4,7 +4,7 @@ class ChangesetsController < ApplicationController
   include UserMethods
   include PaginationMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -2,7 +2,7 @@ class ConfirmationsController < ApplicationController
   include SessionMethods
   include UserMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,5 +1,5 @@
 class DashboardsController < ApplicationController
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/diary_comments_controller.rb
+++ b/app/controllers/diary_comments_controller.rb
@@ -1,5 +1,5 @@
 class DiaryCommentsController < ApplicationController
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -2,7 +2,7 @@ class DiaryEntriesController < ApplicationController
   include UserMethods
   include PaginationMethods
 
-  layout "site", :except => :rss
+  layout :site_layout, :except => :rss
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -52,8 +52,6 @@ class DiaryEntriesController < ApplicationController
     @params = params.permit(:display_name, :friends, :nearby, :language)
 
     @entries, @newer_entries_id, @older_entries_id = get_page_items(entries, :includes => [:user, :language])
-
-    render :partial => "page" if turbo_frame_request_id == "pagination"
   end
 
   def show

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,7 +1,7 @@
 class FollowsController < ApplicationController
   include UserMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -1,5 +1,5 @@
 class IssueCommentsController < ApplicationController
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/issues/reporters_controller.rb
+++ b/app/controllers/issues/reporters_controller.rb
@@ -1,6 +1,6 @@
 module Issues
   class ReportersController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -53,8 +53,6 @@ class IssuesController < ApplicationController
         :users => User.in_order_of(:id, user_ids.first(@unique_reporters_limit))
       }
     end
-
-    render :partial => "page" if turbo_frame_request_id == "pagination"
   end
 
   def show

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,7 +1,7 @@
 class IssuesController < ApplicationController
   include PaginationMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/messages/mailboxes_controller.rb
+++ b/app/controllers/messages/mailboxes_controller.rb
@@ -1,6 +1,6 @@
 module Messages
   class MailboxesController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/messages/mutes_controller.rb
+++ b/app/controllers/messages/mutes_controller.rb
@@ -1,6 +1,6 @@
 module Messages
   class MutesController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/messages/read_marks_controller.rb
+++ b/app/controllers/messages/read_marks_controller.rb
@@ -1,6 +1,6 @@
 module Messages
   class ReadMarksController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/messages/replies_controller.rb
+++ b/app/controllers/messages/replies_controller.rb
@@ -1,6 +1,6 @@
 module Messages
   class RepliesController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,7 @@
 class MessagesController < ApplicationController
   include UserMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/oauth2_applications_controller.rb
+++ b/app/controllers/oauth2_applications_controller.rb
@@ -1,5 +1,5 @@
 class Oauth2ApplicationsController < Doorkeeper::ApplicationsController
-  layout "site"
+  layout :site_layout
 
   prepend_before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/oauth2_authorizations_controller.rb
+++ b/app/controllers/oauth2_authorizations_controller.rb
@@ -1,5 +1,5 @@
 class Oauth2AuthorizationsController < Doorkeeper::AuthorizationsController
-  layout "site"
+  layout :site_layout
 
   prepend_before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/oauth2_authorized_applications_controller.rb
+++ b/app/controllers/oauth2_authorized_applications_controller.rb
@@ -1,5 +1,5 @@
 class Oauth2AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicationsController
-  layout "site"
+  layout :site_layout
 
   prepend_before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,7 +1,7 @@
 class PasswordsController < ApplicationController
   include SessionMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/preferences/preferences_controller.rb
+++ b/app/controllers/preferences/preferences_controller.rb
@@ -1,6 +1,6 @@
 module Preferences
   class PreferencesController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/profiles/profile_sections_controller.rb
+++ b/app/controllers/profiles/profile_sections_controller.rb
@@ -1,6 +1,6 @@
 module Profiles
   class ProfileSectionsController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/redactions_controller.rb
+++ b/app/controllers/redactions_controller.rb
@@ -1,5 +1,5 @@
 class RedactionsController < ApplicationController
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,5 @@
 class ReportsController < ApplicationController
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < ApplicationController
   include SessionMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web, :except => [:destroy]
   before_action -> { authorize_web(:skip_terms => true) }, :only => [:destroy]

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,5 +1,5 @@
 class SiteController < ApplicationController
-  layout "site"
+  layout :site_layout
   layout :map_layout, :only => [:index, :export]
 
   before_action :authorize_web

--- a/app/controllers/traces/data_controller.rb
+++ b/app/controllers/traces/data_controller.rb
@@ -1,6 +1,6 @@
 module Traces
   class DataController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -2,7 +2,7 @@ class TracesController < ApplicationController
   include UserMethods
   include PaginationMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -65,8 +65,6 @@ class TracesController < ApplicationController
 
     # final helper vars for view
     @target_user = target_user
-
-    render :partial => "page" if turbo_frame_request_id == "pagination"
   end
 
   def show

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -2,7 +2,7 @@ class UserBlocksController < ApplicationController
   include UserMethods
   include PaginationMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -24,8 +24,6 @@ class UserBlocksController < ApplicationController
 
     @show_user_name = true
     @show_creator_name = true
-
-    render :partial => "page" if turbo_frame_request_id == "pagination"
   end
 
   def show

--- a/app/controllers/user_mutes_controller.rb
+++ b/app/controllers/user_mutes_controller.rb
@@ -1,7 +1,7 @@
 class UserMutesController < ApplicationController
   include UserMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
   before_action :set_locale

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,7 +1,7 @@
 class UserRolesController < ApplicationController
   include UserMethods
 
-  layout "site"
+  layout :site_layout
 
   before_action :authorize_web
 

--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -3,7 +3,7 @@ module Users
     include UserMethods
     include PaginationMethods
 
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/users/diary_comments_controller.rb
+++ b/app/controllers/users/diary_comments_controller.rb
@@ -9,8 +9,6 @@ module Users
       @params = params.permit(:display_name, :before, :after)
 
       @comments, @newer_comments_id, @older_comments_id = get_page_items(comments, :includes => [:user, :diary_entry])
-
-      render :partial => "page" if turbo_frame_request_id == "pagination"
     end
   end
 end

--- a/app/controllers/users/issued_blocks_controller.rb
+++ b/app/controllers/users/issued_blocks_controller.rb
@@ -3,7 +3,7 @@ module Users
     include UserMethods
     include PaginationMethods
 
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/users/issued_blocks_controller.rb
+++ b/app/controllers/users/issued_blocks_controller.rb
@@ -24,8 +24,6 @@ module Users
 
       @show_user_name = true
       @show_creator_name = false
-
-      render :partial => "user_blocks/page" if turbo_frame_request_id == "pagination"
     end
   end
 end

--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -2,7 +2,7 @@ module Users
   class ListsController < ApplicationController
     include PaginationMethods
 
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -26,8 +26,6 @@ module Users
       @users_count = I18n.t("count.at_least_pattern", :count => 500) if @users_count > 500
 
       @users, @newer_users_id, @older_users_id = get_page_items(users, :limit => 50)
-
-      render :partial => "page" if turbo_frame_request_id == "pagination"
     end
 
     ##

--- a/app/controllers/users/received_blocks_controller.rb
+++ b/app/controllers/users/received_blocks_controller.rb
@@ -25,8 +25,6 @@ module Users
 
       @show_user_name = false
       @show_creator_name = true
-
-      render :partial => "user_blocks/page" if turbo_frame_request_id == "pagination"
     end
 
     ##

--- a/app/controllers/users/received_blocks_controller.rb
+++ b/app/controllers/users/received_blocks_controller.rb
@@ -3,7 +3,7 @@ module Users
     include UserMethods
     include PaginationMethods
 
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/users/statuses_controller.rb
+++ b/app/controllers/users/statuses_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class StatusesController < ApplicationController
-    layout "site"
+    layout :site_layout
 
     before_action :authorize_web
     before_action :set_locale

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   include SessionMethods
   include UserMethods
 
-  layout "site"
+  layout :site_layout
 
   skip_before_action :verify_authenticity_token, :only => [:auth_success]
   before_action :authorize_web

--- a/app/views/layouts/turbo_frame.html.erb
+++ b/app/views/layouts/turbo_frame.html.erb
@@ -1,0 +1,6 @@
+<html>
+  <%= render :partial => "layouts/head" %>
+  <body>
+    <%= yield %>
+  </body>
+</html>


### PR DESCRIPTION
Setting `turbo-action=advance` as our pagination helper does causes a frame navigation to be [promoted to a page visit](https://turbo.hotwired.dev/handbook/frames#promoting-a-frame-navigation-to-a-page-visit) which means turbo will try and [merge the head elements](https://turbo.hotwired.dev/handbook/drive#page-navigation-basics) and remove meta and link elements which are missing from the turbo response.

In order to avoid breaking things we need to ensure we send the full head element in such cases or things like the CSRF token will be lost.

Fixes #6172