### PR TITLE
Clear floats in diary entries

### DIFF
--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -1,7 +1,7 @@
 <article class='diary_post border-top border-secondary-subtle py-3<%= " text-body-secondary px-3 bg-danger bg-opacity-10" unless diary_entry.visible %> user_<%= diary_entry.user.id %>'>
   <%= render :partial => "diary_entry_heading", :object => diary_entry, :as => "diary_entry" %>
 
-  <div class="richtext text-break" xml:lang="<%= diary_entry.language_code %>" lang="<%= diary_entry.language_code %>">
+  <div class="richtext text-break clearfix" xml:lang="<%= diary_entry.language_code %>" lang="<%= diary_entry.language_code %>">
     <% if truncated %>
       <% truncated_entry = diary_entry.body.truncate_html(2000) %>
       <%= truncated_entry[:html] %>

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -148,4 +148,15 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     assert_content body
     assert_no_content I18n.t("diary_entries.diary_entry.full_entry")
   end
+
+  test "contents after diary entry should be below floated images" do
+    user = create(:user)
+    diary_entry = create(:diary_entry, :user => user, :body => "<img width=100 height=1000 align=left alt='Floated Image'>")
+
+    sign_in_as(user)
+    visit diary_entry_path(user, diary_entry)
+
+    img = find "img[alt='Floated Image']"
+    assert_link "Edit this entry", :below => img
+  end
 end


### PR DESCRIPTION
If a diary entry has floated contents, its controls and discussion may be displayed to the side of floated elements.

This PR clears floats in diary entry texts.

Example entry text to trigger the bug:
```
<img width="100" height="1000" align="left">
```

Before:
<img width="355" height="225" alt="image" src="https://github.com/user-attachments/assets/4e6e2970-794f-4478-8bba-393635c915e9" />

After:
<img width="264" height="314" alt="image" src="https://github.com/user-attachments/assets/866f7feb-4310-4e15-8411-b7073b76f9e3" />

Fixes #6186.