### PR TITLE
Keep search input until sidebar close

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -347,6 +347,7 @@ $(function () {
   });
 
   $(document).on("click", "#sidebar .sidebar-close-controls button", function () {
+    $(".search_form input[name=query]").val("");
     OSM.router.route("/" + OSM.formatHash(map));
   });
 });

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -135,7 +135,6 @@ OSM.Search = function (map) {
 
   page.unload = function () {
     markers.clearLayers();
-    $(".search_form input[name=query]").val("");
   };
 
   return page;


### PR DESCRIPTION
Addressing a part of #3123 to keep the search input longer, now that #6184 simplified the state management.