### PR TITLE
Reorder paginated items

### DIFF
--- a/app/controllers/concerns/pagination_methods.rb
+++ b/app/controllers/concerns/pagination_methods.rb
@@ -11,11 +11,11 @@ module PaginationMethods
 
     qualified_cursor_column = "#{items.table_name}.#{cursor_column}"
     page_items = if params[:before]
-                   items.where("#{qualified_cursor_column} < ?", params[:before]).order(cursor_column => :desc)
+                   items.where("#{qualified_cursor_column} < ?", params[:before]).reorder(cursor_column => :desc)
                  elsif params[:after]
-                   items.where("#{qualified_cursor_column} > ?", params[:after]).order(cursor_column => :asc)
+                   items.where("#{qualified_cursor_column} > ?", params[:after]).reorder(cursor_column => :asc)
                  else
-                   items.order(cursor_column => :desc)
+                   items.reorder(cursor_column => :desc)
                  end
 
     page_items = page_items.limit(limit)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,7 +274,7 @@ OpenStreetMap::Application.routes.draw do
   get "/user/:display_name/diary/rss" => "diary_entries#rss", :defaults => { :format => :rss }
   get "/diary/:language/rss" => "diary_entries#rss", :defaults => { :format => :rss }
   get "/diary/rss" => "diary_entries#rss", :defaults => { :format => :rss }
-  get "/user/:display_name/diary" => "diary_entries#index"
+  get "/user/:display_name/diary" => "diary_entries#index", :as => :user_diary_entries
   get "/diary/:language" => "diary_entries#index"
   scope "/user/:display_name" do
     resources :diary_entries, :path => "diary", :only => [:edit, :update, :show], :id => /\d+/ do

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -468,44 +468,15 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_index_paged
-    # Create several pages worth of diary entries
     create_list(:diary_entry, 50)
-    next_path = diary_entries_path
+    check_pagination_of_50_entries diary_entries_path
+  end
 
-    # Try and get the index
-    get next_path
-    assert_response :success
-    assert_select "article.diary_post", :count => 20
-    check_no_page_link "Newer Entries"
-    next_path = check_page_link "Older Entries"
-
-    # Try and get the second page
-    get next_path
-    assert_response :success
-    assert_select "article.diary_post", :count => 20
-    check_page_link "Newer Entries"
-    next_path = check_page_link "Older Entries"
-
-    # Try and get the third page
-    get next_path
-    assert_response :success
-    assert_select "article.diary_post", :count => 10
-    next_path = check_page_link "Newer Entries"
-    check_no_page_link "Older Entries"
-
-    # Go back to the second page
-    get next_path
-    assert_response :success
-    assert_select "article.diary_post", :count => 20
-    next_path = check_page_link "Newer Entries"
-    check_page_link "Older Entries"
-
-    # Go back to the first page
-    get next_path
-    assert_response :success
-    assert_select "article.diary_post", :count => 20
-    check_no_page_link "Newer Entries"
-    check_page_link "Older Entries"
+  def test_index_user_paged
+    user = create(:user)
+    create_list(:diary_entry, 50, :user => user)
+    user.confirm!
+    check_pagination_of_50_entries user_diary_entries_path(user)
   end
 
   def test_index_invalid_paged
@@ -994,6 +965,43 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     entries.each do |entry|
       assert_select "a[href=?]", "/user/#{ERB::Util.u(entry.user.display_name)}/diary/#{entry.id}"
     end
+  end
+
+  def check_pagination_of_50_entries(path)
+    # Try and get the index
+    get path
+    assert_response :success
+    assert_select "article.diary_post", :count => 20
+    check_no_page_link "Newer Entries"
+    path = check_page_link "Older Entries"
+
+    # Try and get the second page
+    get path
+    assert_response :success
+    assert_select "article.diary_post", :count => 20
+    check_page_link "Newer Entries"
+    path = check_page_link "Older Entries"
+
+    # Try and get the third page
+    get path
+    assert_response :success
+    assert_select "article.diary_post", :count => 10
+    path = check_page_link "Newer Entries"
+    check_no_page_link "Older Entries"
+
+    # Go back to the second page
+    get path
+    assert_response :success
+    assert_select "article.diary_post", :count => 20
+    path = check_page_link "Newer Entries"
+    check_page_link "Older Entries"
+
+    # Go back to the first page
+    get path
+    assert_response :success
+    assert_select "article.diary_post", :count => 20
+    check_no_page_link "Newer Entries"
+    check_page_link "Older Entries"
   end
 
   def check_no_page_link(name)


### PR DESCRIPTION
1. Go to the diary of someone who has a lot of entries written, for example https://www.openstreetmap.org/user/SomeoneElse/diary
2. Press the [*>>* button](https://www.openstreetmap.org/user/SomeoneElse/diary?after=0) to get to the earliest entries
3. Notice that it doesn't work

The actual bug existed before *>>* was added. *>>* here is just the easiest way to notice it.

The reason is that the `diary_entries` association of the user model has an order defined as `order(:created_at => :desc)`. When the pagination method sorts user diary entries by id, that order gets added after the existing order. The entries are still going to be sorted by `:created_at => :desc` first and by id next. The added order by id doesn't do anything, therefore ascending order by id doesn't work, therefore pages using the `after` parameter don't work correctly.