### PR TITLE
Change edit link to profile location in dashboard

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -8,7 +8,7 @@
   <div class="col-md order-md-last">
     <% if !current_user.home_location? %>
       <div id="map" class="content_map border border-secondary-subtle">
-        <p class="m-3"><%= t(".no_home_location_html", :edit_profile_link => link_to(t(".edit_your_profile"), profile_description_path)) %></p>
+        <p class="m-3"><%= t(".no_home_location_html", :edit_profile_link => link_to(t(".edit_your_profile"), profile_location_path)) %></p>
       </div>
     <% else %>
       <% content_for :head do %>


### PR DESCRIPTION
When you don't have your home location set, this link in your dashboard leads to *Profile Description*:

<img width="941" height="292" alt="image" src="https://github.com/user-attachments/assets/3c46495f-5fe7-4eb6-842a-52fb85ad46f7" />

It makes more sense to link to *Profile Location* instead.
