### PR TITLE
Restore about section partial

### DIFF
--- a/app/assets/images/about/community.svg
+++ b/app/assets/images/about/community.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30">
+  <circle fill="none" stroke="#c0c0c0" stroke-width="4" cx="15" cy="15" r="13" />
+  <path fill="#c0c0c0" d="m15 7-6 6v7h4v-4h4v4h4v-7z" />
+</svg>

--- a/app/assets/images/about/legal.svg
+++ b/app/assets/images/about/legal.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="none" stroke="#c0c0c0" stroke-width="1.125" stroke-linecap="round">
+  <circle fill="none" stroke="#c0c0c0" stroke-width="4" cx="15" cy="15" r="13" />
+  <path transform="translate(15 15) scale(2.2 1.75) rotate(45)" d="M.5 1a1 1 0 0 0 0-2h-2.5a1 1 0 0 1 0-2h.5" />
+  <path transform="translate(15 15) scale(-2.2 -1.75) rotate(45)" d="M.5 1a1 1 0 0 0 0-2h-2.5a1 1 0 0 1 0-2h.5" />
+</svg>

--- a/app/assets/images/about/local.svg
+++ b/app/assets/images/about/local.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30">
+  <circle fill="none" stroke="#c0c0c0" stroke-width="4" cx="15" cy="15" r="13" />
+  <path fill="#c0c0c0" d="m15 22s5-4.52 5-8c0-3-2-5-5-5s-5 2-5 5c0 3.48 5 8 5 8z" />
+</svg>

--- a/app/assets/images/about/open.svg
+++ b/app/assets/images/about/open.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="none" stroke="#c0c0c0">
+  <circle stroke-width="4" cx="15" cy="15" r="13" />
+  <path stroke-width="3" d="M20.196 18a6 6 0 1 1 0-6" />
+</svg>

--- a/app/assets/images/about/partners.svg
+++ b/app/assets/images/about/partners.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="none" stroke="#c0c0c0" stroke-width="4" stroke-linecap="round">
+  <circle cx="15" cy="15" r="13" />
+  <line x1="11" y1="15" x2="19" y2="15" />
+  <line x1="15" y1="11" x2="15" y2="19" />
+</svg>

--- a/app/views/site/_about_section.html.erb
+++ b/app/views/site/_about_section.html.erb
@@ -1,0 +1,7 @@
+<%= tag.section :id => local_assigns[:id] do %>
+  <div class="d-flex align-items-center gap-2 mb-2">
+    <%= inline_svg_tag "about/#{icon}.svg", :class => "flex-shrink-0" %>
+    <h2 class="flex-grow-1 mb-0"><%= t ".#{title}_title" %></h2>
+  </div>
+  <%= yield %>
+<% end %>

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -23,10 +23,7 @@
 
       <section>
         <div class="d-flex align-items-center gap-2 mb-2">
-          <svg width="30" height="30" class="flex-shrink-0">
-            <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
-            <path d="m 15,22 c 0,0 5,-4.5199 5,-8 0,-3 -2,-5 -5,-5 -3,0 -5,2 -5,5 0,3.4801 5,8 5,8 z" fill="#c0c0c0" />
-          </svg>
+          <%= inline_svg_tag "about/local.svg", :class => "flex-shrink-0" %>
           <h2 class="flex-grow-1 mb-0"><%= t ".local_knowledge_title" %></h2>
         </div>
         <p><%= t ".local_knowledge_html" %></p>
@@ -34,10 +31,7 @@
 
       <section>
         <div class="d-flex align-items-center gap-2 mb-2">
-          <svg width="30" height="30" class="flex-shrink-0">
-            <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
-            <path d="m 15,7 -6,6 0,7 4,0 0,-4 4,0 0,4 4,0 0,-7 z" fill="#c0c0c0" />
-          </svg>
+          <%= inline_svg_tag "about/community.svg", :class => "flex-shrink-0" %>
           <h2 class="flex-grow-1 mb-0"><%= t ".community_driven_title" %></h2>
         </div>
         <p>
@@ -54,10 +48,7 @@
 
       <section id="open-data">
         <div class="d-flex align-items-center gap-2 mb-2">
-          <svg width="30" height="30" class="flex-shrink-0">
-            <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
-            <path d="M20.196 18 a6 6 0 1 1 0 -6" fill="none" stroke="#c0c0c0" stroke-width="3" />
-          </svg>
+          <%= inline_svg_tag "about/open.svg", :class => "flex-shrink-0" %>
           <h2 class="flex-grow-1 mb-0"><%= t ".open_data_title" %></h2>
         </div>
         <p>
@@ -68,15 +59,7 @@
 
       <section id="legal">
         <div class="d-flex align-items-center gap-2 mb-2">
-          <svg width="30" height="30" class="flex-shrink-0">
-            <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
-            <g fill="none" stroke="#c0c0c0" stroke-width="1.125" stroke-linecap="round">
-              <path transform="translate(15 15) scale(2.2 1.75) rotate(45)"
-                    d="M.5 1 a1 1 0 0 0 0 -2 h-2.5 a1 1 0 0 1 0 -2 h.5" />
-              <path transform="translate(15 15) scale(-2.2 -1.75) rotate(45)"
-                    d="M.5 1 a1 1 0 0 0 0 -2 h-2.5 a1 1 0 0 1 0 -2 h.5" />
-            </g>
-          </svg>
+          <%= inline_svg_tag "about/legal.svg", :class => "flex-shrink-0" %>
           <h2 class="flex-grow-1 mb-0"><%= t ".legal_title" %></h2>
         </div>
         <p>
@@ -101,13 +84,7 @@
 
       <section id="partners">
         <div class="d-flex align-items-center gap-2 mb-2">
-          <svg width="30" height="30" class="flex-shrink-0">
-            <circle cx="15" cy="15" r="13" fill="none" stroke="#c0c0c0" stroke-width="4" />
-            <g stroke="#c0c0c0" stroke-width="4" stroke-linecap="round">
-              <line x1="11" y1="15" x2="19" y2="15" />
-              <line x1="15" y1="11" x2="15" y2="19" />
-            </g>
-          </svg>
+          <%= inline_svg_tag "about/partners.svg", :class => "flex-shrink-0" %>
           <h2 class="flex-grow-1 mb-0"><%= t ".partners_title" %></h2>
         </div>
         <p><%= t "layouts.hosting_partners_2024_html", :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),

--- a/app/views/site/about.html.erb
+++ b/app/views/site/about.html.erb
@@ -21,19 +21,11 @@
     <div class='bg-body px-5 py-4'>
       <p class="lead"><%= t ".lede_text" %></p>
 
-      <section>
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <%= inline_svg_tag "about/local.svg", :class => "flex-shrink-0" %>
-          <h2 class="flex-grow-1 mb-0"><%= t ".local_knowledge_title" %></h2>
-        </div>
+      <%= render :layout => "about_section", :locals => { :icon => "local", :title => "local_knowledge" } do %>
         <p><%= t ".local_knowledge_html" %></p>
-      </section>
+      <% end %>
 
-      <section>
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <%= inline_svg_tag "about/community.svg", :class => "flex-shrink-0" %>
-          <h2 class="flex-grow-1 mb-0"><%= t ".community_driven_title" %></h2>
-        </div>
+      <%= render :layout => "about_section", :locals => { :icon => "community", :title => "community_driven" } do %>
         <p>
           <%= t ".community_driven_1_html", :osm_blog_link => link_to(t(".community_driven_osm_blog"),
                                                                       t(".community_driven_osm_blog_url")),
@@ -44,24 +36,16 @@
                                             :osm_foundation_link => link_to(t(".community_driven_osm_foundation"),
                                                                             t(".community_driven_osm_foundation_url")) %>
         </p>
-      </section>
+      <% end %>
 
-      <section id="open-data">
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <%= inline_svg_tag "about/open.svg", :class => "flex-shrink-0" %>
-          <h2 class="flex-grow-1 mb-0"><%= t ".open_data_title" %></h2>
-        </div>
+      <%= render :layout => "about_section", :locals => { :id => "open-data", :icon => "open", :title => "open_data" } do %>
         <p>
           <%= t ".open_data_1_html", :open_data => tag.i(t(".open_data_open_data")),
                                      :copyright_license_link => link_to(t(".open_data_copyright_license"),
                                                                         copyright_path) %></p>
-      </section>
+      <% end %>
 
-      <section id="legal">
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <%= inline_svg_tag "about/legal.svg", :class => "flex-shrink-0" %>
-          <h2 class="flex-grow-1 mb-0"><%= t ".legal_title" %></h2>
-        </div>
+      <%= render :layout => "about_section", :locals => { :id => "legal", :icon => "legal", :title => "legal" } do %>
         <p>
           <%= t ".legal_1_1_html", :openstreetmap_foundation_link => link_to(t(".legal_1_1_openstreetmap_foundation"),
                                                                              t(".legal_1_1_openstreetmap_foundation_url")),
@@ -80,18 +64,14 @@
           <%= t ".legal_2_2_html", :registered_trademarks_link => link_to(t(".legal_2_2_registered_trademarks"),
                                                                           t(".legal_2_2_registered_trademarks_url")) %>
         </p>
-      </section>
+      <% end %>
 
-      <section id="partners">
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <%= inline_svg_tag "about/partners.svg", :class => "flex-shrink-0" %>
-          <h2 class="flex-grow-1 mb-0"><%= t ".partners_title" %></h2>
-        </div>
+      <%= render :layout => "about_section", :locals => { :id => "partners", :icon => "partners", :title => "partners" } do %>
         <p><%= t "layouts.hosting_partners_2024_html", :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
                                                        :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
                                                        :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
         </p>
-      </section>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2167,6 +2167,7 @@ en:
       lede_text: |
         OpenStreetMap is built by a community of mappers that contribute and maintain data
         about roads, trails, cafés, railway stations, and much more, all over the world.
+    about_section:
       local_knowledge_title: Local Knowledge
       local_knowledge_html: |
         OpenStreetMap emphasizes local knowledge. Contributors use


### PR DESCRIPTION
`_about_section.html.erb` was removed in #4868 due to the incompatibility with manually inlined icons.
With the icons inlined with the new gem, we can re-add the layout partial.
This slims #5938. See also the changed files in [this diff](https://github.com/openstreetmap/openstreetmap-website/compare/c36f09b28db7244066df53b9e52c7ab32a1693da..4f163a434f5b15c3ce4d602d87ed6119e3b3b221#diff-20b1b4068a14bbb692bf60b143f2cd17d495893dbd397e41eadeb732056341d7).