### PR TITLE
Make Valhalla use fork icons

### DIFF
--- a/app/assets/javascripts/index/directions/fossgis_valhalla.js
+++ b/app/assets/javascripts/index/directions/fossgis_valhalla.js
@@ -24,8 +24,8 @@
       "exit-right", // kExitRight = 20;
       "exit-left", // kExitLeft = 21;
       "straight", // kStayStraight = 22;
-      "slight-right", // kStayRight = 23;
-      "slight-left", // kStayLeft = 24;
+      "fork-right", // kStayRight = 23;
+      "fork-left", // kStayLeft = 24;
       "merge-left", // kMerge = 25;
       "roundabout", // kRoundaboutEnter = 26;
       "roundabout", // kRoundaboutExit = 27;


### PR DESCRIPTION
Valhalla seems to use "stay" for forks, and "slight" icons are already separate.
I was unable to find more concrete documentation, though.