### PR TITLE
Use MediaWiki languagefallback

### DIFF
--- a/app/assets/javascripts/index/element.js
+++ b/app/assets/javascripts/index/element.js
@@ -1,7 +1,7 @@
 (function () {
   let abortController = null;
-  const languagesToRequest = [...new Set([...OSM.preferred_languages.map(l => l.toLowerCase()), "mul", "en"])];
-  const wikisToRequest = [...new Set(languagesToRequest.filter(l => l !== "mul").map(l => l.split("-")[0] + "wiki"))];
+  const languagesToRequest = [...new Set(OSM.preferred_languages.map(l => l.toLowerCase()))];
+  const wikisToRequest = [...new Set([...OSM.preferred_languages, "en"].map(l => l.split("-")[0] + "wiki"))];
   const isOfExpectedLanguage = ({ language }) => languagesToRequest[0].startsWith(language) || language === "mul";
 
   $(document).on("click", "a[href='#versions-navigation-active-page-item']", function (e) {
@@ -124,6 +124,7 @@
       ids: items.join("|"),
       props: "labels|sitelinks/urls|claims|descriptions",
       languages: languagesToRequest.join("|"),
+      languagefallback: 1,
       sitefilter: wikisToRequest.join("|")
     }), {
       headers: { "Api-User-Agent": "OSM-TagPreview (https://github.com/openstreetmap/openstreetmap-website)" },

--- a/app/assets/javascripts/index/element.js
+++ b/app/assets/javascripts/index/element.js
@@ -149,17 +149,17 @@
   function getLocalizedResponse(entity) {
     const rank = ({ rank }) => ({ preferred: 1, normal: 0, deprecated: -1 })[rank] ?? 0;
     const toBestClaim = (out, claim) => (rank(claim) > rank(out)) ? claim : out;
-    const toFirstOf = (property) => (out, localization) => out ?? entity[property][localization];
+    const toFirstOf = (property) => (out, localization) => out ?? property[localization];
     const data = {
       qid: entity.id,
-      label: languagesToRequest.reduce(toFirstOf("labels"), null),
+      label: languagesToRequest.reduce(toFirstOf(entity.labels), null),
       icon: [
         "P8972", // small logo or icon
         "P154", // logo image
         "P14" // traffic sign
       ].reduce((out, prop) => out ?? entity.claims[prop]?.reduce(toBestClaim)?.mainsnak?.datavalue?.value, null),
-      description: languagesToRequest.reduce(toFirstOf("descriptions"), null),
-      article: wikisToRequest.reduce(toFirstOf("sitelinks"), null)
+      description: languagesToRequest.reduce(toFirstOf(entity.descriptions), null),
+      article: wikisToRequest.reduce(toFirstOf(entity.sitelinks), null)
     };
     if (data.article) data.article.language = data.article.site.replace("wiki", "");
     return data;


### PR DESCRIPTION
Following the [suggestion](https://wikis.world/@LucasWerkmeister/114876146945706671) from @lucaswerkmeister to use the `languagefallback` parameter, requesting `OSM.preferred_languages` is still required to receive language variant-specific labels and descriptions.
e.g., OSM has `pt-PT`, MediaWiki doesn't.
Thanks @1ec5 for forwarding in https://github.com/openstreetmap/openstreetmap-website/pull/6127#discussion_r2220068035!