### PR TITLE
Add play and stop markers for directions

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -24,8 +24,8 @@ OSM.Directions = function (map) {
   };
 
   const endpoints = [
-    OSM.DirectionsEndpoint(map, $("input[name='route_from']"), { color: "var(--marker-green)" }, endpointDragCallback, endpointChangeCallback),
-    OSM.DirectionsEndpoint(map, $("input[name='route_to']"), { color: "var(--marker-red)" }, endpointDragCallback, endpointChangeCallback)
+    OSM.DirectionsEndpoint(map, $("input[name='route_from']"), { icon: "play", color: "var(--marker-green)" }, endpointDragCallback, endpointChangeCallback),
+    OSM.DirectionsEndpoint(map, $("input[name='route_to']"), { icon: "stop", color: "var(--marker-red)" }, endpointDragCallback, endpointChangeCallback)
   ];
 
   const expiry = new Date();

--- a/app/views/layouts/_markers.html.erb
+++ b/app/views/layouts/_markers.html.erb
@@ -17,6 +17,8 @@
          "plus" => { :"stroke-linecap" => "round", :d => "M5.75 13h13.5m-6.75-6.75v13.5" },
          "tick" => { :"stroke-linecap" => "round", :"stroke-linejoin" => "round", :fill => "none", :d => "M7.157 14.649Q8.9 16 11.22 18.761 14.7 11.7 17.843 8.239" },
          "cross" => { :"stroke-linecap" => "round", :d => "m7.5 8 10 10m0-10-10 10" },
+         "play" => { :"stroke-linejoin" => "round", :fill => "#fff", :d => "M10 17.5v-9l7 4.5z" },
+         "stop" => { :"stroke-linejoin" => "round", :fill => "#fff", :d => "M9 9.5h7v7H9z" },
          "dot" => { :"stroke-linecap" => "round", :fill => "#fff", :d => "M11.5 10a1 1 0 0 0 2 5 1 1 0 0 0-2-5" }
        } %>
 

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -70,7 +70,7 @@
             <div class="routing_marker_column position-absolute">
               <span data-type="from" draggable="true">
                 <svg viewBox="0 0 25 40">
-                  <use href="#pin-dot" color="var(--marker-green)" />
+                  <use href="#pin-play" color="var(--marker-green)" />
                 </svg>
               </span>
             </div>
@@ -80,7 +80,7 @@
             <div class="routing_marker_column position-absolute">
               <span data-type="to" draggable="true">
                 <svg viewBox="0 0 25 40">
-                  <use href="#pin-dot" color="var(--marker-red)" />
+                  <use href="#pin-stop" color="var(--marker-red)" />
                 </svg>
               </span>
             </div>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -51,7 +51,7 @@
   </div>
 
   <svg class="d-none"><%= render :partial => "layouts/control_icons" %></svg>
-  <%= render :partial => "layouts/markers", :locals => { :types => %w[dot cross tick plus] } %>
+  <%= render :partial => "layouts/markers", :locals => { :types => %w[dot cross tick plus play stop] } %>
 
   <noscript>
     <div class="mt-5 p-3">


### PR DESCRIPTION
Closes #2787 by adding media control based marker variants for the directions.
This is inspired by the markers from https://brouter.de/brouter-web/.