### PR TITLE
Fix missing raster marker

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -215,7 +215,7 @@ $(function () {
   if (params.marker && params.mrad) {
     L.circle([params.mlat, params.mlon], { radius: params.mrad }).addTo(map);
   } else if (params.marker) {
-    L.marker([params.mlat, params.mlon]).addTo(map);
+    L.marker([params.mlat, params.mlon], { icon: OSM.getMarker({ color: "var(--marker-blue)" }) }).addTo(map);
   }
 
   function remoteEditHandler(bbox, object) {

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -1,6 +1,6 @@
 L.OSM.share = function (options) {
   const control = L.OSM.sidebarPane(options, "share", "javascripts.share.title", "javascripts.share.title"),
-        marker = L.marker([0, 0], { draggable: true }),
+        marker = L.marker([0, 0], { draggable: true, icon: OSM.getMarker({ color: "var(--marker-blue)" }) }),
         locationFilter = new L.LocationFilter({
           enableButton: false,
           adjustButton: false


### PR DESCRIPTION
Fixes #6225 by passing the SVG marker for the `L.marker` that didn't have one already.