### PR TITLE
Bundle vector layer maxZoom definitions in layers.yml

### DIFF
--- a/app/assets/javascripts/leaflet.maptiler.js
+++ b/app/assets/javascripts/leaflet.maptiler.js
@@ -4,7 +4,6 @@
 L.OSM.OpenMapTiles = L.MaplibreGL.extend({
   initialize: function (options) {
     L.MaplibreGL.prototype.initialize.call(this, {
-      maxZoom: 23,
       style:
         "https://api.maptiler.com/maps/openstreetmap/style.json?key=" +
         options.apikey,

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -84,6 +84,7 @@
   code: "S"
   layerId: "shortbread"
   nameId: "shortbread"
+  maxZoom: 23
   credit:
     id: "make_a_donation"
     href: "https://supporting.openstreetmap.org"
@@ -94,6 +95,7 @@
   layerId: "openmaptiles_osm"
   nameId: "openmaptiles_osm"
   apiKeyId: "maptiler_key"
+  maxZoom: 23
   credit:
     id: "openmaptiles_credit"
     children:


### PR DESCRIPTION
In contrast to raster tile layers, the maxZoom for vector tile layers isn't determined by the served tiles (up to zoom level 14).
Hence, the maxZoom for vector tile layers is more of an integration decision than an inherent property of the tile layer itself.
Therefore, I argue, the maxZoom for vector tile layers should be set in the layers.yml instead.

Also resolves #6222.
