### PR TITLE
Make search show multiple markers

### DIFF
--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -48,12 +48,18 @@ OSM.Search = function (map) {
     $(this).hide();
     div.find(".loader").prop("hidden", false);
 
-    fetch($(this).attr("href"), {
+    fetchReplace(this, div);
+  }
+
+  function fetchReplace({ href }, $target) {
+    return fetch(href, {
       method: "POST",
       body: new URLSearchParams(OSM.csrf)
     })
       .then(response => response.text())
-      .then(data => div.replaceWith(data));
+      .then(html => {
+        $target.replaceWith(html);
+      });
   }
 
   function showSearchResult() {
@@ -113,13 +119,8 @@ OSM.Search = function (map) {
   page.load = function () {
     $(".search_results_entry").each(function (index) {
       const entry = $(this);
-      fetch(entry.data("href"), {
-        method: "POST",
-        body: new URLSearchParams(OSM.csrf)
-      })
-        .then(response => response.text())
-        .then(function (html) {
-          entry.html(html);
+      fetchReplace(this.dataset, entry.children().first())
+        .then(() => {
           // go to first result of first geocoder
           if (index === 0) {
             const firstResult = entry.find("*[data-lat][data-lon]:first").first();

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -564,6 +564,17 @@ header .search_forms,
   } 
 }
 
+/* Rules for search results */
+
+.search_results_entry li.list-group-item {
+  border-right: 1em solid var(--marker-color);
+}
+
+.leaflet-marker-icon:is(.active, :hover) > svg {
+  transform: scale(1.5);
+  transform-origin: bottom;
+}
+
 /* Rules for routing */
 
 td.distance {


### PR DESCRIPTION
This PR improves the visualization and interactivity of search results in the sidebar and map.

- Search result entries now have permanent map markers (instead of hover-only).
- Each marker is assigned a unique color based on the golden angle[^1], improving distinction even with many results.
- List entries visually match their corresponding markers via a colored border (`--marker-color`).
- Hovering over a list entry highlights the marker, and vice versa.
- Clicking a marker forwards that to the associated list entry.
- Refactored fetch logic into a reusable `fetchReplace()` function.

This touches a multitude of issues, see the list at https://github.com/openstreetmap/openstreetmap-website/issues/872#issuecomment-2588598803.

[^1]: Why this way? This approach scales better for arbitrary result counts. The golden angle ensures that hues are distributed evenly and only begin to visually converge after over 20 entries.

https://github.com/user-attachments/assets/b9af00e5-2968-4d0e-8bc7-4f075853edf7
