### PR TITLE
Show marker for hidden notes

### DIFF
--- a/app/views/layouts/_markers.html.erb
+++ b/app/views/layouts/_markers.html.erb
@@ -17,6 +17,7 @@
          "plus" => { :"stroke-linecap" => "round", :d => "M5.75 13h13.5m-6.75-6.75v13.5" },
          "tick" => { :"stroke-linecap" => "round", :"stroke-linejoin" => "round", :fill => "none", :d => "M7.157 14.649Q8.9 16 11.22 18.761 14.7 11.7 17.843 8.239" },
          "cross" => { :"stroke-linecap" => "round", :d => "m7.5 8 10 10m0-10-10 10" },
+         "minus" => { :"stroke-linecap" => "round", :d => "M5.75 13h13.5" },
          "play" => { :"stroke-linejoin" => "round", :fill => "#fff", :d => "M10 17.5v-9l7 4.5z" },
          "stop" => { :"stroke-linejoin" => "round", :fill => "#fff", :d => "M9 9.5h7v7H9z" },
          "dot" => { :"stroke-linecap" => "round", :fill => "#fff", :d => "M11.5 10a1 1 0 0 0 2 5 1 1 0 0 0-2-5" }

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -26,7 +26,7 @@
 <% else %>
   <%= render :partial => "notes_paging_nav" %>
 
-  <%= render :partial => "layouts/markers", :locals => { :types => %w[cross tick] } %>
+  <%= render :partial => "layouts/markers", :locals => { :types => %w[cross tick minus] } %>
 
   <table class="table table-sm note_list">
     <thead>
@@ -42,8 +42,18 @@
   <% @notes.each do |note| -%>
     <tr<% if note.author == @user %> class="table-primary"<% end %>>
       <td>
-        <svg width="25" height="40" alt="<%= t(note.closed? ? ".closed" : ".open") %>">
-          <%= tag.use :href => note.closed? ? "#pin-tick" : "#pin-cross", :color => "var(--marker-#{note.closed? ? 'green' : 'red'})" %>
+        <% if !note.visible?
+             alt_text_key = ".hidden"
+             pin_marker = tag.use :href => "#pin-minus", :color => "gray"
+           elsif note.closed?
+             alt_text_key = ".closed"
+             pin_marker = tag.use :href => "#pin-tick", :color => "var(--marker-green)"
+           else
+             alt_text_key = ".open"
+             pin_marker = tag.use :href => "#pin-cross", :color => "var(--marker-red)"
+           end %>
+        <svg width="25" height="40" alt="<%= t alt_text_key %>">
+          <%= pin_marker %>
         </svg>
       </td>
       <td><%= link_to note.id, note %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3331,8 +3331,9 @@ en:
       last_changed: "Last changed"
       apply: "Apply"
       all: "All"
-      open: "Open"
-      closed: "Closed"
+      open: "Unresolved"
+      closed: "Resolved"
+      hidden: "Hidden"
       status: "Status"
     show:
       title: "Note: %{id}"


### PR DESCRIPTION
Fixes #507 by adding a special marker for hidden notes.

<img width="74" height="177" alt="image" src="https://github.com/user-attachments/assets/395510f4-966b-4447-ad0d-bba8c658c712" />