### PR TITLE
Fix HDYC social link

### DIFF
--- a/app/models/social_link.rb
+++ b/app/models/social_link.rb
@@ -29,7 +29,7 @@ class SocialLink < ApplicationRecord
     :flickr => %r{\Ahttps?://(?:www\.)?flickr\.com/people/([a-zA-Z0-9@._-]+)},
     :github => %r{\Ahttps?://(?:www\.)?github\.com/([a-zA-Z0-9_-]+)},
     :gitlab => %r{\Ahttps?://(?:www\.)?gitlab\.com/([a-zA-Z0-9_-]+)},
-    :hdyc => %r{\Ahttps?://(?:www\.)?hdyc\.neis-one\.org/?([a-zA-Z0-9_-]+)},
+    :hdyc => %r{\Ahttps?://(?:www\.)?hdyc\.neis-one\.org/\?([a-zA-Z0-9_-]+)},
     :hot => %r{\Ahttps?://tasks\.hotosm\.org/users/([a-zA-Z0-9_-]+)},
     :instagram => %r{\Ahttps?://(?:www\.)?instagram\.com/([a-zA-Z0-9._]+)},
     :linkedin => %r{\Ahttps?://(?:www\.)?linkedin\.com/in/([a-zA-Z0-9_-]+)},


### PR DESCRIPTION
`?` character needs to be escaped.

Before: 

<img width="437" height="135" alt="image" src="https://github.com/user-attachments/assets/ee9d0f8a-5876-442c-9720-142aa4c1eb89" />

After:

<img width="463" height="178" alt="image" src="https://github.com/user-attachments/assets/3601e07a-8d4f-471f-bdee-9f7e6d905209" />