### PR TITLE
More precise marker position

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -41,7 +41,7 @@ window.onload = function () {
     L.marker(args.get("marker").split(","), { icon: L.icon({
       iconUrl: <%= asset_path('leaflet/dist/images/marker-icon.png').to_json %>,
       iconSize: new L.Point(25, 41),
-      iconAnchor: new L.Point(12, 41),
+      iconAnchor: new L.Point(12.5, 41),
       shadowUrl: <%= asset_path('leaflet/dist/images/marker-shadow.png').to_json %>,
       shadowSize: new L.Point(41, 41)
     }) }).addTo(map);

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -369,7 +369,7 @@ OSM.getMarker = function ({ icon = "dot", color = "var(--marker-red)", shadow = 
   return L.divIcon({
     html,
     iconSize: [25, 40],
-    iconAnchor: [12, 40],
+    iconAnchor: [12.5, 40],
     popupAnchor: [1, -34]
   });
 };


### PR DESCRIPTION
### Description

The marker is currently described as follows:
https://github.com/openstreetmap/openstreetmap-website/blob/9c8467e7ed9d38260077eaf64bb270b2acf18679/app/assets/javascripts/leaflet.map.js#L369-L373

Instead of 12 in `iconAnchor` it should be 12.5 because the marker is symmetrical. This is, of course, a small thing, but on Retina displays it can be noticed if, for example, the marker is set at the end node of the way.

The following screenshots can be reproduced using the following snippet for the browser console (more precisely, in the place of the code where the object of the current map is available):

```javascript
L.marker(([42, 42]), ({ draggable: false, icon: OSM.getMarker({ color: "var(--marker-blue)" }) })).addTo(map);
L.circleMarker(L.latLng(42, 42), { weight: 2.5, radius: 3, fillOpacity: 0, color: "red" }).addTo(map);
```

<table>

<td>

Before
<td>

After

<tr>

<td>
<img width="50" height="60" src="https://github.com/user-attachments/assets/23afbded-0234-4586-9f76-483b1b538fba" />

<td>

<img width="50" height="60" src="https://github.com/user-attachments/assets/a19f08e3-b509-46c5-8682-223bdd715f2c" />

</table>
