### PR TITLE
Overwrite marker shadow interactability

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -361,11 +361,11 @@ OSM.isDarkMap = function () {
 };
 
 OSM.getMarker = function ({ icon = "dot", color = "var(--marker-red)", shadow = true }) {
-  const html = `<svg viewBox="0 0 25 40"${
+  const html = `<svg viewBox="0 0 25 40" class="pe-none"${
     shadow ? " overflow='visible'" : ""
   }>${
     shadow ? "<use href='#pin-shadow' />" : ""
-  }<use href="#pin-${icon}" color="${color}" /></svg>`;
+  }<use href="#pin-${icon}" color="${color}" class="pe-auto" /></svg>`;
   return L.divIcon({
     html,
     iconSize: [25, 40],


### PR DESCRIPTION
Since Leaflet's divIcon doesn't support putting elements in the shadow pane, all `OSM.getMarker` shadows are currently interactive.
This PR overwrites this behaviour.