### PR TITLE
Use SVG marker in embed

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -17,8 +17,6 @@
 
 //= link_tree ../../../vendor/assets/leaflet .png
 
-//= link leaflet/dist/images/marker-icon.png
-//= link leaflet/dist/images/marker-icon-2x.png
 //= link leaflet/dist/images/marker-shadow.png
 
 //= link @mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js

--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -38,12 +38,10 @@ window.onload = function () {
   new L.OSM[layer]({ apikey: layerConfig.apikey, ...options[layerId] }).addTo(map);
 
   if (args.has("marker")) {
-    L.marker(args.get("marker").split(","), { icon: L.icon({
-      iconUrl: <%= asset_path('leaflet/dist/images/marker-icon.png').to_json %>,
-      iconSize: new L.Point(25, 41),
-      iconAnchor: new L.Point(12.5, 41),
-      shadowUrl: <%= asset_path('leaflet/dist/images/marker-shadow.png').to_json %>,
-      shadowSize: new L.Point(41, 41)
+    L.marker(args.get("marker").split(","), { icon: L.divIcon({
+      html: "<svg viewBox='0 0 25 40' overflow='visible'><use href='#pin-shadow' /><use href='#pin-dot' color='#0b8ef1' /></svg>",
+      iconSize: [25, 40],
+      iconAnchor: [12.5, 40]
     }) }).addTo(map);
   }
 

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -17,3 +17,13 @@ body {
   width: 100%;
   height: 100%;
 }
+
+.leaflet-marker-icon.leaflet-div-icon {
+  background: none;
+  border: none;
+  pointer-events: none;
+
+  use[color] {
+    pointer-events: auto;
+  }
+}

--- a/app/views/export/embed.html.erb
+++ b/app/views/export/embed.html.erb
@@ -7,6 +7,10 @@
     <%= javascript_include_tag "embed" %>
   </head>
   <body>
-    <div id="map"></div>
+    <div id="map">
+      <% if params[:marker].present? %>
+        <%= render :partial => "layouts/markers", :locals => { :types => %w[dot] } %>
+      <% end %>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Since #6249 mentioned retina displays on the embed page, I changed my decision on whether to put the SVG marker there too.
This also already overwrites the interactivity for the marker, which is tackled by #6250 for the main page.