### PR TITLE
Retire jquery-simulate

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -1,4 +1,3 @@
-//= require jquery-simulate/jquery.simulate
 //= require ./history-changesets-layer
 
 OSM.History = function (map) {
@@ -27,7 +26,7 @@ OSM.History = function (map) {
       toggleChangesetHighlight(e.layer.id, false);
     })
     .on("click", function (e) {
-      clickChangeset(e.layer.id, e.originalEvent);
+      clickChangeset(e.layer.id);
     })
     .on("requestscrolltochangeset", function (e) {
       const [item] = $(`#changeset_${e.id}`);
@@ -122,8 +121,14 @@ OSM.History = function (map) {
     }
   }
 
-  function clickChangeset(id, e) {
-    $("#changeset_" + id).find("a.changeset_id").simulate("click", e);
+  function clickChangeset(id) {
+    const changesetElem = document.getElementById("changeset_" + id);
+    if (changesetElem) {
+      const link = changesetElem.querySelector("a.changeset_id");
+      if (link) {
+        link.click();
+      }
+    }
   }
 
   function displayFirstChangesets(html) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@maplibre/maplibre-gl-leaflet": "^0.1.1",
     "@maptiler/maplibre-gl-omt-language": "^0.0.3",
     "i18n-js": "^4.5.1",
-    "jquery-simulate": "^1.0.2",
     "js-cookie": "^3.0.0",
     "leaflet": "^1.8.0",
     "leaflet.locatecontrol": "^0.84.1",


### PR DESCRIPTION
Remove jquery-simulate, replace it by https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click

Follow up for https://github.com/openstreetmap/openstreetmap-website/pull/6192#discussion_r2230801035