### PR TITLE
Add native links to HistoryChangesetsLayer

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -5,6 +5,7 @@ OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
 
   addChangesetLayer: function (changeset) {
     const style = this._getChangesetStyle(changeset);
+    const anchor = $(L.SVG.create("a")).attr("href", $(`#changeset_${changeset.id} a.changeset_id`).attr("href"));
     const rectangle = L.rectangle(changeset.bounds, {
       ...style,
       contextmenu: true,
@@ -20,6 +21,12 @@ OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
       }]
     });
     rectangle.id = changeset.id;
+    rectangle.on("add", function () {
+      $(this.getElement()).replaceWith(anchor).appendTo(anchor);
+    });
+    rectangle.on("remove", function () {
+      anchor.remove();
+    });
     return this.addLayer(rectangle);
   },
 

--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -1,4 +1,3 @@
-//= require jquery-simulate/jquery.simulate
 //= require ./history-changesets-layer
 
 OSM.History = function (map) {
@@ -25,9 +24,6 @@ OSM.History = function (map) {
     .on("mouseout", function (e) {
       if (inZoom) return;
       toggleChangesetHighlight(e.layer.id, false);
-    })
-    .on("click", function (e) {
-      clickChangeset(e.layer.id, e.originalEvent);
     })
     .on("requestscrolltochangeset", function (e) {
       const [item] = $(`#changeset_${e.id}`);
@@ -120,10 +116,6 @@ OSM.History = function (map) {
     if (state) {
       $("#changeset_" + id).addClass("selected");
     }
-  }
-
-  function clickChangeset(id, e) {
-    $("#changeset_" + id).find("a.changeset_id").simulate("click", e);
   }
 
   function displayFirstChangesets(html) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@maplibre/maplibre-gl-leaflet": "^0.1.1",
     "@maptiler/maplibre-gl-omt-language": "^0.0.3",
     "i18n-js": "^4.5.1",
-    "jquery-simulate": "^1.0.2",
     "js-cookie": "^3.0.0",
     "leaflet": "^1.8.0",
     "leaflet.locatecontrol": "^0.84.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,11 +612,6 @@ isexe@^3.1.1:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
   integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
 
-jquery-simulate@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/jquery-simulate/-/jquery-simulate-1.0.2.tgz#2174b859b75123a0ac6d8ab3a9a6fb4ad7e82898"
-  integrity sha512-Bq610fSrwTwvH5d06z5oskYaX/79s0BNrKiJZjZOiXRib3iL4ZkSn/wvLwzhf3P9KeXCEpk9wlIaGui/1arOpQ==
-
 js-cookie@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"


### PR DESCRIPTION
Alternative to #6252 that closes #6252.
UX difference is that this makes the URL show in the browser's status bar when hovering over a changeset bbox:
<img width="199" height="31" alt="image" src="https://github.com/user-attachments/assets/eec47929-bd51-49cd-b9a1-22491e6c6f82" />