### PR TITLE
Map XML download with Turbo

### DIFF
--- a/app/assets/javascripts/download_util.js
+++ b/app/assets/javascripts/download_util.js
@@ -1,0 +1,53 @@
+(function () {
+  OSM.downloadBlob = function (blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  class DownloadUtil {
+    static async handleExportSuccess(fetchResponse, filename) {
+      try {
+        const blob = await fetchResponse.response.blob();
+        OSM.downloadBlob(blob, filename);
+      } catch (err) {
+        // eslint-disable-next-line no-alert
+        alert(OSM.i18n.t("javascripts.share.export_failed", { reason: "(blob error)" }));
+      }
+    }
+
+    static async handleExportError(event) {
+      let detailMessage;
+      try {
+        detailMessage = event?.detail?.error?.message;
+        if (!detailMessage) {
+          const responseText = await event.detail.fetchResponse.responseText;
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(responseText, "text/html");
+          detailMessage = doc.body ? doc.body.textContent.trim() : "(unknown)";
+        }
+      } catch (err) {
+        detailMessage = "(unknown)";
+      }
+      // eslint-disable-next-line no-alert
+      alert(OSM.i18n.t("javascripts.share.export_failed", { reason: detailMessage }));
+    }
+
+    static getTurboBlobHandler(filename) {
+      return function (event) {
+        if (event.detail.success) {
+          DownloadUtil.handleExportSuccess(event.detail.fetchResponse, filename);
+        } else {
+          DownloadUtil.handleExportError(event);
+        }
+      };
+    }
+  }
+
+  OSM.getTurboBlobHandler = DownloadUtil.getTurboBlobHandler;
+}());

--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -70,6 +70,56 @@ OSM.Export = function (map) {
     $("#drag_box").click(enableFilter);
     $(".export_form").on("submit", checkSubmit);
 
+    function downloadBlob(blob, filename) {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    async function handleExportSuccess(fetchResponse) {
+      try {
+        const blob = await fetchResponse.response.blob();
+        downloadBlob(blob, "map.osm");
+      } catch (err) {
+        // eslint-disable-next-line no-alert
+        alert(OSM.i18n.t("javascripts.share.export_failed", { reason: "(blob error)" }));
+      }
+    }
+
+    async function handleExportError(event) {
+      let detailMessage;
+      try {
+        detailMessage = event?.detail?.error?.message;
+        if (!detailMessage) {
+          const responseText = await event.detail.fetchResponse.responseText;
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(responseText, "text/html");
+          detailMessage = doc.body ? doc.body.textContent.trim() : "(unknown)";
+        }
+      } catch (err) {
+        detailMessage = "(unknown)";
+      }
+      // eslint-disable-next-line no-alert
+      alert(OSM.i18n.t("javascripts.share.export_failed", { reason: detailMessage }));
+    }
+
+    document.querySelector(".export_form").addEventListener("turbo:submit-end", function (event) {
+      if (event.detail.success) {
+        handleExportSuccess(event.detail.fetchResponse);
+      } else {
+        handleExportError(event);
+      }
+    });
+
+    document.querySelector(".export_form").addEventListener("turbo:before-fetch-request", function (event) {
+      event.detail.fetchOptions.headers.Accept = "application/xml";
+    });
+
     update();
     return map.getState();
   };

--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -1,3 +1,5 @@
+//= require download_util
+
 OSM.Export = function (map) {
   const page = {};
 
@@ -70,55 +72,13 @@ OSM.Export = function (map) {
     $("#drag_box").click(enableFilter);
     $(".export_form").on("submit", checkSubmit);
 
-    function downloadBlob(blob, filename) {
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    }
+    document.querySelector(".export_form")
+      .addEventListener("turbo:submit-end", OSM.getTurboBlobHandler("map.osm"));
 
-    async function handleExportSuccess(fetchResponse) {
-      try {
-        const blob = await fetchResponse.response.blob();
-        downloadBlob(blob, "map.osm");
-      } catch (err) {
-        // eslint-disable-next-line no-alert
-        alert(OSM.i18n.t("javascripts.share.export_failed", { reason: "(blob error)" }));
-      }
-    }
-
-    async function handleExportError(event) {
-      let detailMessage;
-      try {
-        detailMessage = event?.detail?.error?.message;
-        if (!detailMessage) {
-          const responseText = await event.detail.fetchResponse.responseText;
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(responseText, "text/html");
-          detailMessage = doc.body ? doc.body.textContent.trim() : "(unknown)";
-        }
-      } catch (err) {
-        detailMessage = "(unknown)";
-      }
-      // eslint-disable-next-line no-alert
-      alert(OSM.i18n.t("javascripts.share.export_failed", { reason: detailMessage }));
-    }
-
-    document.querySelector(".export_form").addEventListener("turbo:submit-end", function (event) {
-      if (event.detail.success) {
-        handleExportSuccess(event.detail.fetchResponse);
-      } else {
-        handleExportError(event);
-      }
-    });
-
-    document.querySelector(".export_form").addEventListener("turbo:before-fetch-request", function (event) {
-      event.detail.fetchOptions.headers.Accept = "application/xml";
-    });
+    document.querySelector(".export_form")
+      .addEventListener("turbo:before-fetch-request", function (event) {
+        event.detail.fetchOptions.headers.Accept = "application/xml";
+      });
 
     update();
     return map.getState();

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -1,3 +1,5 @@
+//= require download_util
+
 L.OSM.share = function (options) {
   const control = L.OSM.sidebarPane(options, "share", "javascripts.share.title", "javascripts.share.title"),
         marker = L.marker([0, 0], { draggable: true, icon: OSM.getMarker({ color: "var(--marker-blue)" }) }),
@@ -28,52 +30,10 @@ L.OSM.share = function (options) {
     const csrfInput = $ui.find("#csrf_export")[0];
     [[csrfInput.name, csrfInput.value]] = Object.entries(OSM.csrf);
 
-    function downloadBlob(blob, filename) {
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    }
 
-    async function handleExportSuccess(fetchResponse) {
-      try {
-        const blob = await fetchResponse.response.blob();
-        const filename = OSM.i18n.t("javascripts.share.filename");
-        downloadBlob(blob, filename);
-      } catch (err) {
-        // eslint-disable-next-line no-alert
-        alert(OSM.i18n.t("javascripts.share.export_failed", { reason: "(blob error)" }));
-      }
-    }
-
-    async function handleExportError(event) {
-      let detailMessage;
-      try {
-        detailMessage = event?.detail?.error?.message;
-        if (!detailMessage) {
-          const responseText = await event.detail.fetchResponse.responseText;
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(responseText, "text/html");
-          detailMessage = doc.body ? doc.body.textContent.trim() : "(unknown)";
-        }
-      } catch (err) {
-        detailMessage = "(unknown)";
-      }
-      // eslint-disable-next-line no-alert
-      alert(OSM.i18n.t("javascripts.share.export_failed", { reason: detailMessage }));
-    }
-
-    document.getElementById("export-image").addEventListener("turbo:submit-end", function (event) {
-      if (event.detail.success) {
-        handleExportSuccess(event.detail.fetchResponse);
-      } else {
-        handleExportError(event);
-      }
-    });
+    document.getElementById("export-image")
+      .addEventListener("turbo:submit-end",
+                        OSM.getTurboBlobHandler(OSM.i18n.t("javascripts.share.filename")));
 
     document.getElementById("export-image").addEventListener("turbo:before-fetch-response", function (event) {
       const response = event.detail.fetchResponse.response;

--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "sidebar_header", :title => t(".title") %>
 
-<%= form_tag({ :controller => "export", :action => "finish" }, { :class => "export_form" }) do %>
+<%= form_tag({ :controller => "export", :action => "finish" }, :class => "export_form", :data => { "turbo" => true }) do %>
   <%= hidden_field_tag "format", "osm", :autocomplete => "off" %>
 
   <div class='export_area_inputs text-center mb-3'>
@@ -28,7 +28,7 @@
 
   <div id="export_commit">
     <div class="mb-3 d-flex">
-      <%= submit_tag t(".export_button"), :class => "btn btn-primary mx-auto" %>
+      <%= submit_tag t(".export_button"), :class => "btn btn-primary mx-auto", :data => { "turbo-submits-with" => t(".export_download") } %>
     </div>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2498,6 +2498,7 @@ en:
           title: "Other Sources"
           description: "Additional sources listed on the OpenStreetMap Wiki"
       export_button: "Export"
+      export_download: "Downloading..."
     fixthemap:
       title: Report a problem / Fix the map
       how_to_help:


### PR DESCRIPTION
Map XML download currently has a few issues, such as a button staying in disabled state after a download, or error messages that are shown on a blank page.

Applying the same concepts as in #6192, this PR aims at making the download a bit more robust and user friendly.

We have a bit of code duplication here, and it would probably make sense to move downloadBlob, handleExportError and  turbo:submit-end handler to a common file. Any ideas?