### PR TITLE
Lower max allowed blank line count

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -42,7 +42,6 @@ L.OSM.Map = L.Map.extend({
       this.fire("overlayremove", { layer: this.gpsLayer });
     });
 
-
     this.on("baselayerchange", function (event) {
       if (this.baseLayers.indexOf(event.layer) >= 0) {
         this.setMaxZoom(event.layer.options.maxZoom);

--- a/app/assets/javascripts/leaflet.share.js
+++ b/app/assets/javascripts/leaflet.share.js
@@ -30,7 +30,6 @@ L.OSM.share = function (options) {
     const csrfInput = $ui.find("#csrf_export")[0];
     [[csrfInput.name, csrfInput.value]] = Object.entries(OSM.csrf);
 
-
     document.getElementById("export-image")
       .addEventListener("turbo:submit-end",
                         OSM.getTurboBlobHandler(OSM.i18n.t("javascripts.share.filename")));

--- a/config/eslint.config.mjs
+++ b/config/eslint.config.mjs
@@ -71,7 +71,7 @@ export default [
       "@stylistic/no-floating-decimal": "error",
       "@stylistic/no-mixed-operators": "error",
       "@stylistic/no-multi-spaces": "error",
-      "@stylistic/no-multiple-empty-lines": "error",
+      "@stylistic/no-multiple-empty-lines": ["error", { max: 1 }],
       "@stylistic/no-trailing-spaces": "error",
       "@stylistic/no-whitespace-before-property": "error",
       "@stylistic/object-curly-newline": ["error", { consistent: true }],

--- a/test/javascripts/osm_test.js
+++ b/test/javascripts/osm_test.js
@@ -273,10 +273,8 @@ describe("OSM", function () {
       let args = { center: L.latLng(57.6247, -3.6845), zoom: 5 };
       expect(OSM.formatHash(args)).to.eq("#map=5/57.62/-3.68");
 
-
       args = { center: L.latLng(57.6247, -3.6845), zoom: 9 };
       expect(OSM.formatHash(args)).to.eq("#map=9/57.625/-3.685");
-
 
       args = { center: L.latLng(57.6247, -3.6845), zoom: 12 };
       expect(OSM.formatHash(args)).to.eq("#map=12/57.6247/-3.6845");
@@ -292,7 +290,6 @@ describe("OSM", function () {
       expect(OSM.formatHash(args)).to.eq("#map=9/57.625/-3.685");
     });
   });
-
 
   describe(".zoomPrecision", function () {
     it("suggests 1 digit for z0-2", function () {


### PR DESCRIPTION
Only very few affected gaps, none of which looked like it was needed for contextual separation.