### PR TITLE
Make handler able to handle SVG links

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -334,13 +334,14 @@ $(function () {
     }
 
     // Ignore cross-protocol and cross-origin links.
-    if (location.protocol !== this.protocol || location.host !== this.host) {
+    const url = new URL($(this).attr("href"), location);
+    if (location.protocol !== url.protocol || location.host !== url.host) {
       return;
     }
 
-    if (OSM.router.route(this.pathname + this.search + this.hash)) {
+    if (OSM.router.route(url.pathname + url.search + url.hash)) {
       e.preventDefault();
-      if (this.pathname !== "/directions") {
+      if (url.pathname !== "/directions") {
         $("header").addClass("closed");
       }
     }


### PR DESCRIPTION
SVG anchors don't have the URL properties, which forces a page reload. This can be avoided by getting the properties from the href.