### PR TITLE
Bootstrap modal instead of alert()

### DIFF
--- a/app/assets/javascripts/download_util.js
+++ b/app/assets/javascripts/download_util.js
@@ -10,14 +10,20 @@
     URL.revokeObjectURL(url);
   };
 
+  OSM.showAlert = function (message) {
+    const modalBody = document.getElementById("osm_alert_message");
+    modalBody.textContent = message;
+    const alertModal = new bootstrap.Modal(document.getElementById("osm_alert_modal"));
+    alertModal.show();
+  };
+
   class DownloadUtil {
     static async handleExportSuccess(fetchResponse, filename) {
       try {
         const blob = await fetchResponse.response.blob();
         OSM.downloadBlob(blob, filename);
       } catch (err) {
-        // eslint-disable-next-line no-alert
-        alert(OSM.i18n.t("javascripts.share.export_failed", { reason: "(blob error)" }));
+        OSM.showAlert(OSM.i18n.t("javascripts.share.export_failed", { reason: "(blob error)" }));
       }
     }
 
@@ -34,8 +40,7 @@
       } catch (err) {
         detailMessage = "(unknown)";
       }
-      // eslint-disable-next-line no-alert
-      alert(OSM.i18n.t("javascripts.share.export_failed", { reason: detailMessage }));
+      OSM.showAlert(OSM.i18n.t("javascripts.share.export_failed", { reason: detailMessage }));
     }
 
     static getTurboBlobHandler(filename) {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -127,3 +127,19 @@
     </div>
   </div>
 </div>
+
+<div class="modal fade" id="osm_alert_modal" tabindex="-1" aria-labelledby="osm_alert_title" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="osm_alert_title"><%= t "javascripts.alert" %></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t "javascripts.close" %>"></button>
+      </div>
+      <div class="modal-body" id="osm_alert_message">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"><%= t "javascripts.ok" %></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3399,6 +3399,8 @@ en:
       sorry: "Sorry, note #%{id} could not be found."
   javascripts:
     close: Close
+    alert: Alert
+    ok: OK
     share:
       title: "Share"
       view_larger_map: "View Larger Map"


### PR DESCRIPTION
For better UX consistency, this PR replaces alert() by a centered Bootstrap modal window. It's currently used for map export messages only.

Before:

<img width="744" height="399" alt="image" src="https://github.com/user-attachments/assets/4537694d-fb22-4ce5-8eff-a7d996ba22cd" />


After:

<img width="744" height="399" alt="image" src="https://github.com/user-attachments/assets/d2bc7553-8efd-4c3a-bda7-9a753bec51f2" />
