### PR TITLE
Remove link targets while dragging the map

### DIFF
--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -5,7 +5,8 @@ OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
 
   addChangesetLayer: function (changeset) {
     const style = this._getChangesetStyle(changeset);
-    const anchor = $(L.SVG.create("a")).attr("href", $(`#changeset_${changeset.id} a.changeset_id`).attr("href"));
+    const link = $(`#changeset_${changeset.id} a.changeset_id`).attr("href");
+    const anchor = $(L.SVG.create("a")).attr("href", link);
     const rectangle = L.rectangle(changeset.bounds, {
       ...style,
       contextmenu: true,
@@ -21,6 +22,8 @@ OSM.HistoryChangesetBboxLayer = L.FeatureGroup.extend({
       }]
     });
     rectangle.id = changeset.id;
+    this._map?.on("movestart", () => anchor.removeAttr("href"));
+    this._map?.on("moveend", () => anchor.attr("href", link));
     rectangle.on("add", function () {
       $(this.getElement()).replaceWith(anchor).appendTo(anchor);
     });

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -66,12 +66,16 @@ OSM.Search = function (map) {
   function showSearchResult() {
     const index = processedResults++;
     const listItem = $(this);
+    const data = listItem.find("a.set_position").data();
+    if (!data) return;
     const inverseGoldenAngle = (Math.sqrt(5) - 1) * 180;
     const color = `hwb(${(index * inverseGoldenAngle) % 360}deg 5% 5%)`;
     listItem.css("--marker-color", color);
-    const anchor = $("<a>").attr("href", listItem.find("a.set_position").attr("href"));
-    const data = listItem.find("a.set_position").data();
+    const link = listItem.find("a.set_position").attr("href");
+    const anchor = $("<a>").attr("href", link);
     const marker = L.marker([data.lat, data.lon], { icon: OSM.getMarker({ color, className: "activatable" }) });
+    map.on("movestart", () => anchor.removeAttr("href"));
+    map.on("moveend", () => anchor.attr("href", link));
     marker.on("mouseover", () => listItem.addClass("bg-body-secondary"));
     marker.on("mouseout", () => listItem.removeClass("bg-body-secondary"));
     marker.on("add", function () {


### PR DESCRIPTION
Fixes #6264 by removing the link target when moving the map.
Since the click event happens before moveend, and the click events aren't recognized as drag events, I don't think there's a less bodgy solution.