### PR TITLE
Replace javascript alerts with bootstrap modals

### DIFF
--- a/app/assets/javascripts/download_util.js
+++ b/app/assets/javascripts/download_util.js
@@ -10,13 +10,6 @@
     URL.revokeObjectURL(url);
   };
 
-  OSM.showAlert = function (message) {
-    const modalBody = document.getElementById("osm_alert_message");
-    modalBody.textContent = message;
-    const alertModal = new bootstrap.Modal(document.getElementById("osm_alert_modal"));
-    alertModal.show();
-  };
-
   class DownloadUtil {
     static async handleExportSuccess(fetchResponse, filename) {
       try {

--- a/app/assets/javascripts/download_util.js
+++ b/app/assets/javascripts/download_util.js
@@ -16,7 +16,7 @@
         const blob = await fetchResponse.response.blob();
         OSM.downloadBlob(blob, filename);
       } catch (err) {
-        OSM.showAlert(OSM.i18n.t("javascripts.share.export_failed", { reason: "(blob error)" }));
+        OSM.showAlert(OSM.i18n.t("javascripts.share.export_failed_title"), "(blob error)");
       }
     }
 
@@ -33,7 +33,7 @@
       } catch (err) {
         detailMessage = "(unknown)";
       }
-      OSM.showAlert(OSM.i18n.t("javascripts.share.export_failed", { reason: detailMessage }));
+      OSM.showAlert(OSM.i18n.t("javascripts.share.export_failed_title"), detailMessage);
     }
 
     static getTurboBlobHandler(filename) {

--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -3,8 +3,8 @@ $(function () {
         idData = id.data();
 
   if (!idData.configured) {
-    // eslint-disable-next-line no-alert
-    alert(OSM.i18n.t("site.edit.id_not_configured"));
+    OSM.showAlert(OSM.i18n.t("javascripts.edit.id_not_configured.title"),
+                  OSM.i18n.t("javascripts.edit.id_not_configured.body"));
     return;
   }
 

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -237,8 +237,8 @@ $(function () {
         }
       })
       .catch(() => {
-        // eslint-disable-next-line no-alert
-        alert(OSM.i18n.t("site.index.remote_failed"));
+        OSM.showAlert(OSM.i18n.t("javascripts.remote_edit.failed.title"),
+                      OSM.i18n.t("javascripts.remote_edit.failed.body"));
       });
 
     function sendRemoteEditCommand(url) {

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -109,8 +109,8 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, marker, dragCallback, cha
       delete endpoint.geocodeRequest;
       if (json.length === 0) {
         input.addClass("is-invalid");
-        // eslint-disable-next-line no-alert
-        alert(OSM.i18n.t("javascripts.directions.errors.no_place", { place: endpoint.value }));
+        OSM.showAlert(OSM.i18n.t("javascripts.directions.errors.no_place.title"),
+                      OSM.i18n.t("javascripts.directions.errors.no_place.body", { place: endpoint.value }));
         return;
       }
 

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -219,7 +219,9 @@ OSM = {
     return [...center, zoom, map.getLayersCode()].join("|");
   },
 
-  showAlert: function (message) {
+  showAlert: function (title, message) {
+    const modalTitle = document.getElementById("osm_alert_title");
+    modalTitle.textContent = title;
     const modalBody = document.getElementById("osm_alert_message");
     modalBody.textContent = message;
     const alertModal = new bootstrap.Modal(document.getElementById("osm_alert_modal"));

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -217,5 +217,12 @@ OSM = {
     const zoom = map.getZoom(),
           center = OSM.cropLocation(map.getCenter(), zoom).reverse();
     return [...center, zoom, map.getLayersCode()].join("|");
+  },
+
+  showAlert: function (message) {
+    const modalBody = document.getElementById("osm_alert_message");
+    modalBody.textContent = message;
+    const alertModal = new bootstrap.Modal(document.getElementById("osm_alert_modal"));
+    alertModal.show();
   }
 };

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -134,7 +134,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="osm_alert_title"><%= t "javascripts.alert" %></h5>
+        <h5 class="modal-title" id="osm_alert_title"></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t "javascripts.close" %>"></button>
       </div>
       <div class="modal-body" id="osm_alert_message">

--- a/config/i18n.yml
+++ b/config/i18n.yml
@@ -13,7 +13,6 @@ translations:
     - "*.browse.start_rjs.*"
     - "*.javascripts.*"
     - "*.site.edit.*"
-    - "*.site.index.remote_failed"
     - "*.site.sidebar.search_results"
     - "*.diary_entries.edit.marker_text"
     - "*.layouts.project_name.title"

--- a/config/i18n.yml
+++ b/config/i18n.yml
@@ -12,7 +12,6 @@ translations:
     - "*.time.*"
     - "*.browse.start_rjs.*"
     - "*.javascripts.*"
-    - "*.site.edit.*"
     - "*.site.sidebar.search_results"
     - "*.diary_entries.edit.marker_text"
     - "*.layouts.project_name.title"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3472,7 +3472,9 @@ en:
         mi: "%{distance}mi"
       errors:
         no_route: "Couldn't find a route between those two places."
-        no_place: "Sorry - couldn't locate '%{place}'."
+        no_place:
+          title: "Search failed"
+          body: "Couldn't locate '%{place}'."
       instructions:
         continue_without_exit: Continue on %{name}
         slight_right_without_exit: Slight right onto %{name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3399,12 +3399,11 @@ en:
       sorry: "Sorry, note #%{id} could not be found."
   javascripts:
     close: Close
-    alert: Alert
     ok: OK
     share:
       title: "Share"
       view_larger_map: "View Larger Map"
-      export_failed: "Map export failed: %{reason}"
+      export_failed_title: "Map export failed"
       filename: "map"
     embed:
       report_problem: "Report a problem"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2472,8 +2472,6 @@ en:
       anon_edits_html: "(%{link})"
       anon_edits_link: "https://wiki.openstreetmap.org/wiki/Anonymous_edits"
       anon_edits_link_text: "Find out why this is the case."
-    edit:
-      id_not_configured: "iD has not been configured"
     export:
       title: "Export"
       manually_select: "Manually select a different area"
@@ -3571,6 +3569,10 @@ en:
       failed:
         title: "Editing failed"
         body: "Make sure JOSM or Merkaartor is loaded and the remote control option is enabled"
+    edit:
+      id_not_configured:
+        title: "iD has not been configured"
+        body: "Please see CONFIGURE.md for more information"
   redactions:
     edit:
       heading: "Edit Redaction"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2465,7 +2465,6 @@ en:
         copyright: "Copyright OpenStreetMap and contributors, under an open license"
         license_url: "https://openstreetmap.org/copyright"
         project_url: "https://openstreetmap.org"
-      remote_failed: "Editing failed - make sure JOSM or Merkaartor is loaded and the remote control option is enabled"
     not_public_flash:
       not_public: "You have not set your edits to be public."
       not_public_description_html: "You can no longer edit the map unless you do so. You can set your edits as public from your %{user_page}."
@@ -3568,6 +3567,10 @@ en:
         contributions:
           one: "%{count} contribution on %{date}"
           other: "%{count} contributions on %{date}"
+    remote_edit:
+      failed:
+        title: "Editing failed"
+        body: "Make sure JOSM or Merkaartor is loaded and the remote control option is enabled"
   redactions:
     edit:
       heading: "Edit Redaction"


### PR DESCRIPTION
This builds on the work from #6263 by replacing all other uses of `alert` with bootstrap modals.