### PR TITLE
Fix message reuse on account terms page

### DIFF
--- a/app/views/accounts/terms/show.html.erb
+++ b/app/views/accounts/terms/show.html.erb
@@ -55,7 +55,7 @@
   <h4>
     <%= t "layouts.tou" %>
   </h4>
-  <p class="text-body-secondary"><%= t ".tou_explain_html", :tou_link => link_to(t("layouts.tou"), "https://wiki.osmfoundation.org/wiki/Terms_of_Use", :target => :new) %></p>
+  <p class="text-body-secondary"><%= t ".tou_explain.html", :tou_link => link_to(t(".tou_explain.tou"), "https://wiki.osmfoundation.org/wiki/Terms_of_Use", :target => :new) %></p>
 
   <div class="mb-3">
     <div class="form-check">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,7 +316,9 @@ en:
         read and accept with tou: "Please read the contributor agreement and the terms of use, check both checkboxes when done and then press the continue button."
         contributor_terms_explain: "This agreement governs the terms for your existing and future contributions."
         read_ct: "I have read and agree to the above contributor terms"
-        tou_explain_html: "These %{tou_link} govern the use of the website and other infrastructure provided by the OSMF. Please click on the link, read and agree to the text."
+        tou_explain:
+          html: "These %{tou_link} govern the use of the website and other infrastructure provided by the OSMF. Please click on the link, read and agree to the text."
+          tou: "Terms of Use"
         read_tou: "I have read and agree to the Terms of Use"
         guidance_info_html: "Information to help understand these terms: a %{readable_summary_link} and some %{informal_translations_link}"
         readable_summary: human readable summary


### PR DESCRIPTION
After having replaced another use of `layouts.tou` earlier (#6166) I now notice it still has two distinct uses. It is used as a standalone header and as a link text in subsequent sentence. Some languages need different capitalization  and/or declension for these uses.

Here new message is added for use in the subsequent sentence. In English it's identical to previous `layouts.tou` message.