### PR TITLE
Add display:block to the editor iframe

### DIFF
--- a/app/views/site/_id.html.erb
+++ b/app/views/site/_id.html.erb
@@ -1,11 +1,11 @@
 <%= javascript_include_tag "edit/id" %>
 
-<div id="map" class="h-100 overflow-hidden">
+<div id="map" class="h-100">
   <% data = { :configured => Settings.key?(:id_application) }
      data[:lat] = @lat if @lat
      data[:lon] = @lon if @lon
      data[:zoom] = @zoom if @zoom
      data[:gpx] = trace_data_url(params[:gpx], :format => :xml) if params[:gpx]
      data[:url] = id_url(:locale => params[:locale]) %>
-  <%= tag.iframe "", :frameBorder => 0, :id => "id-embed", :class => "w-100 h-100", :allowfullscreen => true, :autofocus => true, :data => data %>
+  <%= tag.iframe "", :frameBorder => 0, :id => "id-embed", :class => "w-100 h-100 d-block", :allowfullscreen => true, :autofocus => true, :data => data %>
 </div>


### PR DESCRIPTION
### Description

Pressing the down arrow key will sometimes scroll the parent element of the iframe, since it generates an inline box with some whitespace below. This parent element having overflow: hidden meant that it was impossible to scroll deliberately and I would be stuck with a white gutter on the bottom of the viewport for the remainder of my editing session.

Instead of overflow: hidden, give the iframe display: block to avoid generating an inline block.

### How has this been tested?

Manually in Firefox and Chrome.