### PR TITLE
Fix typo in importer role icon tooltip.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3194,7 +3194,7 @@ en:
       title:
         administrator: "This user is an administrator"
         moderator: "This user is a moderator"
-        importer: "This user is a importer"
+        importer: "This user is an importer"
       grant:
         administrator: "Grant administrator access"
         moderator: "Grant moderator access"


### PR DESCRIPTION
### Description

I noticed that the tooltip for the importer role icon used “a” where it should be “an”, so I made a pull request to fix this.

### How has this been tested?

It hasn’t, but I assume a single-character change to a locale string wouldn’t need to be.