### PR TITLE
Fix the build by adding Arpitan as UI language

### DIFF
--- a/config/ui_languages.yml
+++ b/config/ui_languages.yml
@@ -42,6 +42,8 @@
   :native_name: euskara
 - :code: fr
   :native_name: français
+- :code: frp
+  :native_name: arpetan
 - :code: fy
   :native_name: Frysk
 - :code: fur


### PR DESCRIPTION
The recent merge of https://github.com/openstreetmap/openstreetmap-website/commit/bae910cf844ede7c23d20c6b51e2f844be9b10dc broke the build. It added a new language: Franco-Provençal aka Arpitan (code `frp`), but didn't add it to the list at `config/ui_languages.yml`.

I know nothing about Franco-Provençal, and I'm new to this codebase. Judging from the current list of UI languages, I gather these rules apply:
1. Languages are listed with their native name: Eg: _español_, _italiano_.
2. Where Latin script applies, languages names are capitalised only if the rules of the language require it. Eg: _español_, _italiano_ vs _English_, _Deutsch_.

Therefore, and looking at [the relevant Wikipedia page](https://en.wikipedia.org/wiki/Franco-Proven%C3%A7al), I'm going with the name _arpetan_ as it appears to follow the rules above.

I'm aware that I might be completely wrong at several levels! Happy to learn if someone will correct me.