### PR TITLE
Add Arpitan to ui languages list

### DIFF
--- a/config/ui_languages.yml
+++ b/config/ui_languages.yml
@@ -3,6 +3,8 @@
   :native_name: Afrikaans
 - :code: gsw
   :native_name: Alemannisch
+- :code: frp
+  :native_name: arpetan
 - :code: ast
   :native_name: asturianu
 - :code: az


### PR DESCRIPTION
This language arrived from Translatewiki in https://github.com/openstreetmap/openstreetmap-website/commit/bae910cf844ede7c23d20c6b51e2f844be9b10dc and broke tests.

<img width="817" height="751" alt="image" src="https://github.com/user-attachments/assets/14c4850f-0740-4e58-9991-70b62a646da1" />
