### PR TITLE
Use <h1> as Bootstrap modal title

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -134,7 +134,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="osm_alert_title"></h5>
+        <h1 class="modal-title fs-5" id="osm_alert_title"></h1>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t "javascripts.close" %>"></button>
       </div>
       <div class="modal-body" id="osm_alert_message">


### PR DESCRIPTION
As recommended in https://getbootstrap.com/docs/5.3/components/modal/#modal-components

*Select Language* modal uses `<h1 class="modal-title fs-5" ...>`. Why should the alert modal be different?