### PR TITLE
Move Bootstrap modal ok string out of javascripts

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -140,7 +140,7 @@
       <div class="modal-body" id="osm_alert_message">
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"><%= t "javascripts.ok" %></button>
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"><%= t ".ok" %></button>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1747,6 +1747,7 @@ en:
     learn_more: "Learn More"
     more: More
     header:
+      ok: OK
       select_language: Select Language
     select_language_button:
       title: Select Language
@@ -3398,7 +3399,6 @@ en:
       sorry: "Sorry, note #%{id} could not be found."
   javascripts:
     close: Close
-    ok: OK
     share:
       title: "Share"
       view_larger_map: "View Larger Map"


### PR DESCRIPTION
This string doesn't need to be in javascripts because we're not placing it in javascript. We don't need to send it again along with other js i18n strings.