### PR TITLE
Fix erroneously collapsed CSS rule

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -187,7 +187,7 @@ body.small-nav {
   .overlay-sidebar #sidebar {
     .welcome,
     #banner {
-      display: block;
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Closes #6301 by restoring the behaviour prior to #6271.