### PR TITLE
Changeset num_changed_(element type) methods

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -241,6 +241,10 @@ class Changeset < ApplicationRecord
   def num_modified_elements = num_modified_nodes + num_modified_ways + num_modified_relations
   def num_deleted_elements = num_deleted_nodes + num_deleted_ways + num_deleted_relations
 
+  def num_changed_nodes = num_created_nodes + num_modified_nodes + num_deleted_nodes
+  def num_changed_ways = num_created_ways + num_modified_ways + num_deleted_ways
+  def num_changed_relations = num_created_relations + num_modified_relations + num_deleted_relations
+
   def num_type_changes_in_sync?
     num_changes == num_created_elements + num_modified_elements + num_deleted_elements
   end

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -248,4 +248,8 @@ class Changeset < ApplicationRecord
   def num_type_changes_in_sync?
     num_changes == num_created_elements + num_modified_elements + num_deleted_elements
   end
+
+  def actual_num_changed_nodes = num_type_changes_in_sync? ? num_changed_nodes : old_nodes.count
+  def actual_num_changed_ways = num_type_changes_in_sync? ? num_changed_ways : old_ways.count
+  def actual_num_changed_relations = num_type_changes_in_sync? ? num_changed_relations : old_relations.count
 end

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -237,17 +237,9 @@ class Changeset < ApplicationRecord
     )
   end
 
-  def num_created_elements
-    num_created_nodes + num_created_ways + num_created_relations
-  end
-
-  def num_modified_elements
-    num_modified_nodes + num_modified_ways + num_modified_relations
-  end
-
-  def num_deleted_elements
-    num_deleted_nodes + num_deleted_ways + num_deleted_relations
-  end
+  def num_created_elements = num_created_nodes + num_created_ways + num_created_relations
+  def num_modified_elements = num_modified_nodes + num_modified_ways + num_modified_relations
+  def num_deleted_elements = num_deleted_nodes + num_deleted_ways + num_deleted_relations
 
   def num_type_changes_in_sync?
     num_changes == num_created_elements + num_modified_elements + num_deleted_elements

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -33,41 +33,71 @@ class ChangesetTest < ActiveSupport::TestCase
 
   def test_num_type_changes_in_sync_for_new_changeset
     changeset = create(:changeset)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_not_in_sync_for_changeset_without_type_changes
     changeset = create(:changeset, :num_changes => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_not_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_created_nodes
     changeset = create(:changeset, :num_changes => 1, :num_created_nodes => 1)
+
     assert_equal 1, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 1, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_modified_nodes
     changeset = create(:changeset, :num_changes => 1, :num_modified_nodes => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 1, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 1, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_deleted_nodes
     changeset = create(:changeset, :num_changes => 1, :num_deleted_nodes => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 1, changeset.num_deleted_elements
+
+    assert_equal 1, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
@@ -76,33 +106,57 @@ class ChangesetTest < ActiveSupport::TestCase
                                    :num_created_nodes => 3,
                                    :num_modified_nodes => 2,
                                    :num_deleted_nodes => 1)
+
     assert_equal 3, changeset.num_created_elements
     assert_equal 2, changeset.num_modified_elements
     assert_equal 1, changeset.num_deleted_elements
+
+    assert_equal 3 + 2 + 1, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_created_ways
     changeset = create(:changeset, :num_changes => 1, :num_created_ways => 1)
+
     assert_equal 1, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 1, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_modified_ways
     changeset = create(:changeset, :num_changes => 1, :num_modified_ways => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 1, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 1, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_deleted_ways
     changeset = create(:changeset, :num_changes => 1, :num_deleted_ways => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 1, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 1, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
@@ -111,33 +165,57 @@ class ChangesetTest < ActiveSupport::TestCase
                                    :num_created_ways => 3,
                                    :num_modified_ways => 2,
                                    :num_deleted_ways => 1)
+
     assert_equal 3, changeset.num_created_elements
     assert_equal 2, changeset.num_modified_elements
     assert_equal 1, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 3 + 2 + 1, changeset.num_changed_ways
+    assert_equal 0, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_created_relations
     changeset = create(:changeset, :num_changes => 1, :num_created_relations => 1)
+
     assert_equal 1, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 1, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_modified_relations
     changeset = create(:changeset, :num_changes => 1, :num_modified_relations => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 1, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 1, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
   def test_num_type_changes_in_sync_for_changeset_with_deleted_relations
     changeset = create(:changeset, :num_changes => 1, :num_deleted_relations => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 1, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 1, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
@@ -146,9 +224,15 @@ class ChangesetTest < ActiveSupport::TestCase
                                    :num_created_relations => 3,
                                    :num_modified_relations => 2,
                                    :num_deleted_relations => 1)
+
     assert_equal 3, changeset.num_created_elements
     assert_equal 2, changeset.num_modified_elements
     assert_equal 1, changeset.num_deleted_elements
+
+    assert_equal 0, changeset.num_changed_nodes
+    assert_equal 0, changeset.num_changed_ways
+    assert_equal 3 + 2 + 1, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
@@ -157,9 +241,15 @@ class ChangesetTest < ActiveSupport::TestCase
                                    :num_created_nodes => 3,
                                    :num_created_ways => 2,
                                    :num_created_relations => 1)
+
     assert_equal 3 + 2 + 1, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 3, changeset.num_changed_nodes
+    assert_equal 2, changeset.num_changed_ways
+    assert_equal 1, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
@@ -168,9 +258,15 @@ class ChangesetTest < ActiveSupport::TestCase
                                    :num_modified_nodes => 3,
                                    :num_modified_ways => 2,
                                    :num_modified_relations => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 3 + 2 + 1, changeset.num_modified_elements
     assert_equal 0, changeset.num_deleted_elements
+
+    assert_equal 3, changeset.num_changed_nodes
+    assert_equal 2, changeset.num_changed_ways
+    assert_equal 1, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
@@ -179,9 +275,15 @@ class ChangesetTest < ActiveSupport::TestCase
                                    :num_deleted_nodes => 3,
                                    :num_deleted_ways => 2,
                                    :num_deleted_relations => 1)
+
     assert_equal 0, changeset.num_created_elements
     assert_equal 0, changeset.num_modified_elements
     assert_equal 3 + 2 + 1, changeset.num_deleted_elements
+
+    assert_equal 3, changeset.num_changed_nodes
+    assert_equal 2, changeset.num_changed_ways
+    assert_equal 1, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
@@ -196,9 +298,15 @@ class ChangesetTest < ActiveSupport::TestCase
                                    :num_deleted_nodes => 13,
                                    :num_deleted_ways => 12,
                                    :num_deleted_relations => 11)
+
     assert_equal 33 + 32 + 31, changeset.num_created_elements
     assert_equal 23 + 22 + 21, changeset.num_modified_elements
     assert_equal 13 + 12 + 11, changeset.num_deleted_elements
+
+    assert_equal 33 + 23 + 13, changeset.num_changed_nodes
+    assert_equal 32 + 22 + 12, changeset.num_changed_ways
+    assert_equal 31 + 21 + 11, changeset.num_changed_relations
+
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -310,6 +310,35 @@ class ChangesetTest < ActiveSupport::TestCase
     assert_predicate changeset, :num_type_changes_in_sync?
   end
 
+  def test_actual_num_changed_elements_in_sync
+    changeset = create(:changeset, :num_changes => 5 + 4 + 3,
+                                   :num_created_nodes => 5,
+                                   :num_created_ways => 4,
+                                   :num_created_relations => 3)
+    create_list(:old_node, 5, :changeset => changeset)
+    create_list(:old_way, 4, :changeset => changeset)
+    create_list(:old_relation, 3, :changeset => changeset)
+
+    assert_predicate changeset, :num_type_changes_in_sync?
+
+    assert_equal 5, changeset.actual_num_changed_nodes
+    assert_equal 4, changeset.actual_num_changed_ways
+    assert_equal 3, changeset.actual_num_changed_relations
+  end
+
+  def test_actual_num_changed_elements_out_of_sync
+    changeset = create(:changeset, :num_changes => 5 + 4 + 3)
+    create_list(:old_node, 5, :changeset => changeset)
+    create_list(:old_way, 4, :changeset => changeset)
+    create_list(:old_relation, 3, :changeset => changeset)
+
+    assert_not_predicate changeset, :num_type_changes_in_sync?
+
+    assert_equal 5, changeset.actual_num_changed_nodes
+    assert_equal 4, changeset.actual_num_changed_ways
+    assert_equal 3, changeset.actual_num_changed_relations
+  end
+
   def test_from_xml_no_text
     no_text = ""
     message_create = assert_raise(OSM::APIBadXMLError) do


### PR DESCRIPTION
Optional part of https://github.com/openstreetmap/openstreetmap-website/pull/6299.

That PR deals with pages of elements changed in a given changeset. We need to know the total number of elements and derive the total number of pages. Currently we're just counting them all with sql `COUNT(*)`. But we don't need to do it for new changesets because we have per element statistics. See https://github.com/openstreetmap/openstreetmap-website/issues/5758#issuecomment-2781054236.

This PR adds some changeset model methods for easier access to number of changed nodes/ways/relations.