### PR TITLE
Remove ruby-dev and ruby-bundler dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ RUN apt-get update \
   libyaml-dev \
   locales \
   postgresql-client \
-  ruby-dev \
-  ruby-bundler \
   tzdata \
   unzip \
   nodejs \


### PR DESCRIPTION
### Description
This PR makes 2 changes to the Dockerfile:
1. Removes `ruby-bundler` as bundler has been installed as a default gem since [ruby 2.6.0](https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/).
2. Removes `ruby-dev` because header files for compiling extensions are already present in `ruby:3.2-bookworm`.

### How has this been tested?
 The tests pass. I also ran `docker run --rm ruby:3.2-bookworm bundler -v` as a quick sanity check for change 1. I ran `docker run --rm ruby:3.2-bookworm ruby -rrbconfig -e 'puts RbConfig::CONFIG["rubyhdrdir"]'` as a sanity check for change 2.




