### PR TITLE
Lock GitHub Actions dependencies to SHAs for security and predictability

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -14,11 +14,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
         with:
           ruby-version: 3.2
           rubygems: 3.4.10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Checkout source
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Poke config
       run: |
         cp config/example.storage.yml config/storage.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,9 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Setup ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
       with:
         ruby-version: ${{ env.ruby }}
         rubygems: 3.4.10
@@ -29,9 +29,9 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Setup ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
       with:
         ruby-version: ${{ env.ruby }}
         rubygems: 3.4.10
@@ -44,15 +44,15 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Setup ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
       with:
         ruby-version: ${{ env.ruby }}
         rubygems: 3.4.10
         bundler-cache: true
     - name: Cache node modules
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         cache: yarn
     - name: Install node modules
@@ -67,9 +67,9 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Setup ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
       with:
         ruby-version: ${{ env.ruby }}
         rubygems: 3.4.10
@@ -84,9 +84,9 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Setup ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
       with:
         ruby-version: ${{ env.ruby }}
         rubygems: 3.4.10
@@ -96,7 +96,7 @@ jobs:
         cp config/github.database.yml config/database.yml
         cp config/example.storage.yml config/storage.yml
     - name: Cache node modules
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         cache: yarn
     - name: Install node modules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,15 +18,15 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Checkout source
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Setup ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
       with:
         ruby-version: ${{ matrix.ruby }}
         rubygems: 3.4.10
         bundler-cache: true
     - name: Cache node modules
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         cache: yarn
     - name: Install packages
@@ -64,14 +64,14 @@ jobs:
     - name: Run javascript tests
       run: bundle exec teaspoon
     - name: Upload screenshots
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: failure()
       with:
         name: screenshots
         path: tmp/screenshots
         if-no-files-found: ignore
     - name: Report completion to Coveralls
-      uses: coverallsapp/github-action@v2.3.6
+      uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
       with:
         github-token: ${{ secrets.github_token }}
         flag-name: ruby-${{ matrix.ruby }}
@@ -84,7 +84,7 @@ jobs:
     timeout-minutes: 1
     steps:
     - name: Report completion to Coveralls
-      uses: coverallsapp/github-action@v2.3.6
+      uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true


### PR DESCRIPTION
### Description

Lock GitHub Actions dependencies to specific version SHAs for security and predictability. Doing so is a best practice as we then know exactly which version of a given dependency is being used. Without locking to SHAs, Actions will simply use whatever latest version is available for the given specified version, usually a major such as "v4", leading to "silent bumps" at the GitHub Action runtime level.

Locking to SHAs will also allow us to receive patch and minor level dependency upgrade PRs as opposed to, in most cases, just bumps for major versions.

### How has this been tested?

CI and Danger runs will prove if these changes are proper or not as they only affect GitHub Actions.

For reference here are the GitHub Actions dependencies releases so we can check the SHAs.

- https://github.com/actions/checkout/releases/tag/v5.0.0 (https://github.com/actions/checkout/commit/08c6903cd8c0fde910a37f88322edcfb5dd907a8)
- https://github.com/ruby/setup-ruby/releases/tag/v1.255.0 (https://github.com/ruby/setup-ruby/commit/829114fc20da43a41d27359103ec7a63020954d4)
- https://github.com/actions/setup-node/releases/tag/v4.4.0 (https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020)
- https://github.com/actions/upload-artifact/releases/tag/v4.6.2 (https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02)
- https://github.com/coverallsapp/github-action/releases/tag/v2.3.6 (https://github.com/coverallsapp/github-action/commit/648a8eb78e6d50909eff900e4ec85cab4524a45b)