### PR TITLE
Remove `file_exists` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,9 +45,6 @@ gem "argon2"
 # Support brotli compression for assets
 gem "sprockets-exporters_pack"
 
-# Restore File.exists? for oauth gem
-gem "file_exists"
-
 # Load rails plugins
 gem "actionpack-page_caching", ">= 1.2.0"
 gem "activerecord-import"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,7 +293,6 @@ GEM
       rake
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
-    file_exists (0.2.0)
     frozen_record (0.27.4)
       activemodel
     fspath (3.1.2)
@@ -747,7 +746,6 @@ DEPENDENCIES
   factory_bot_rails
   faraday
   ffi-libarchive
-  file_exists
   frozen_record
   gd2-ffij (>= 0.4.0)
   htmlentities


### PR DESCRIPTION
### Description
The file_exists gem [was originally added](https://github.com/til/openstreetmap-website/commit/c68fa8f8f5a89213aa22920edc72170093c5abbe) to support `File.exists?`, which was deprecated in Ruby 3.2 but still used by version 0.4.7 of the oauth gem. Since `File.exists?` was removed in version [0.5.0](https://github.com/oauth-xx/oauth-ruby/releases/tag/v0.5.0) of the oauth gem (see commit [here](https://github.com/ruby-oauth/oauth/pull/106/files)) and we are on 1.1.0, the dependency is no longer needed and can now be removed.

### How has this been tested?
The tests pass. I was also able to navigate the app after this change.
