### PR TITLE
Fix Postgres.app PATH on macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,7 +98,7 @@ nano ~/.profile
 and adding:
 
 ```bash
-export PATH=/Applications/Postgres.app/Contents/MacOS/bin:$PATH
+export PATH=/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH
 ```
 
 After this, you may need to start a new shell window, or source the profile again by running `. ~/.profile`.


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
In INSTALL.md, within the Manual Installation Guide section:
```
- export PATH=/Applications/Postgres.app/Contents/MacOS/bin:$PATH
+ export PATH=/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH
```
…/Contents/MacOS/bin was the path before Postgres.app 9.2. The CLI tools now live under Contents/Versions/[version]/bin with a stable Versions/latest/bin symlink. The current path in INSTALL.md can lead to psql not being found.

### How has this been tested?
Docs change only. I verified locally on macOS by trying both paths and confirming psql only resolves from …/Versions/latest/bin. 
