### PR TITLE
Cache expanded preferred_languages

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -73,6 +73,8 @@ module BrowseHelper
   private
 
   def feature_name(tags)
+    return nil if tags.empty?
+
     locale_keys = preferred_languages.expand.map { |locale| "name:#{locale}" }
 
     (locale_keys + %w[name ref addr:housename]).each do |key|

--- a/lib/locale.rb
+++ b/lib/locale.rb
@@ -15,11 +15,11 @@ class Locale < I18n::Locale::Tag::Rfc4646
     end
 
     def expand
-      List.new(reverse.each_with_object([]) do |locale, expanded|
-                 locale.candidates.uniq.reverse_each do |candidate|
-                   expanded << candidate if candidate == locale || expanded.exclude?(candidate)
-                 end
-               end.reverse.uniq)
+      @expand ||= List.new(reverse.each_with_object([]) do |locale, expanded|
+        locale.candidates.uniq.reverse_each do |candidate|
+          expanded << candidate if candidate == locale || expanded.exclude?(candidate)
+        end
+      end.reverse.uniq)
     end
   end
 


### PR DESCRIPTION
`preferred_languages.expand` in browse_helper.rb is a bit expensive, due to the Locale handling that's being triggered for every single element (see stacktrace below).

However, preferred_languages are not expected to change during a request. They seem like a good candidate for caching. preferred_languages is already cached in the application_controller, but the expanded version is not.

~Caching should work on a request basis. After the request is done, the instance variable should be empty. Unit tests somehow don't have a concept of a request, that's why I had to manually set the value back to nil.~

I've seen about 50% performance improvement on top of #6338 by caching preferred_languages this way.

<img width="1573" height="663" alt="locale_keys" src="https://github.com/user-attachments/assets/795494ab-366b-4dc9-9b59-4a6e9988e72c" />
