### PR TITLE
Remove json dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,6 @@ source "https://rubygems.org"
 gem "rails", "~> 8.0.0"
 gem "turbo-rails"
 
-# Require json for multi_json
-gem "json"
-
 # Use postgres as the database
 gem "pg"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -757,7 +757,6 @@ DEPENDENCIES
   inline_svg
   jbuilder (~> 2.7)
   jquery-rails
-  json
   jwt
   kgio
   kramdown


### PR DESCRIPTION
### Description
Ruby has shipped with the default JSON gem since 1.9, so there's no need to require this in the Gemfile unless we want to pin a version (which I don't think we do). 

I don't think `multi_json` requires us to explicitly require the gem either. They mention in their docs [the JSON gem that ships with Ruby is supported](https://github.com/sferik/multi_json?tab=readme-ov-file#supported-json-engines). I also don't see anything concerning in the `multi_json` [adapter](https://github.com/sferik/multi_json/blob/main/lib/multi_json/adapters/json_gem.rb#L7).  

### How has this been tested?
The tests pass and I was able to navigate the app locally.