### PR TITLE
Remove `multi_json` library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,8 +70,6 @@ gem "quad_tile", "~> 1.0.1"
 gem "addressable", "~> 2.8"
 gem "rack-uri_sanitizer"
 
-# Omniauth for authentication
-gem "multi_json"
 gem "omniauth", "~> 2.1.3"
 gem "omniauth-apple"
 gem "omniauth-facebook"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,7 +408,6 @@ GEM
     minitest-focus (1.4.0)
       minitest (>= 4, < 6)
     msgpack (1.8.0)
-    multi_json (1.17.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     nap (1.1.0)
@@ -768,7 +767,6 @@ DEPENDENCIES
   mini_racer (~> 0.9.0)
   minitest (~> 5.1)
   minitest-focus
-  multi_json
   omniauth (~> 2.1.3)
   omniauth-apple
   omniauth-facebook

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,3 @@
-require "multi_json"
-
 OmniAuth.config.logger = Rails.logger
 OmniAuth.config.failure_raise_out_environments = []
 OmniAuth.config.allowed_request_methods = [:post, :patch]


### PR DESCRIPTION
### Description
Removes the `multi_json` gem. `multi_json` was originally [added as a dependency for the omniauth-windowslive plugin](https://github.com/openstreetmap/openstreetmap-website/commit/5a28ff2901fd0387805240732a31194d198d1071). However, that plugin was replaced with `omniauth-microsoft_graph` in https://github.com/openstreetmap/openstreetmap-website/pull/4169. Since `omniauth-microsoft_graph` does not need `multi_json` we can remove it from the Gemfile.

### How has this been tested?
The tests pass and I was able to run the app locally. I've also looked through the other omniauth plugins and confirmed they do not rely on `multi_json` gem either:

- [omniauth](https://github.com/search?q=repo%3Aomniauth%2Fomniauth+MultiJson&type=code)
- [omniauth-apple](https://github.com/search?q=repo%3Anhosoya%2Fomniauth-apple%20MultiJson&type=code)
- [omniauth-facebook](https://github.com/search?q=repo%3Asimi%2Fomniauth-facebook%20MultiJson&type=code)
- [omniauth-github](https://github.com/search?q=repo%3Aomniauth%2Fomniauth-github%20MultiJson&type=code)
- [omniauth-google-oauth2](https://github.com/search?q=repo%3Azquestz%2Fomniauth-google-oauth2%20MultiJson&type=code)
- [omniauth-mediawiki](https://github.com/search?q=repo%3Atimwaters%2Fomniauth-mediawiki%20MultiJson&type=code)
- [omniauth-microsoft_graph](https://github.com/search?q=repo%3Asynth%2Fomniauth-microsoft_graph+MultiJson&type=code)
- [omniauth-rails_csrf_protection](https://github.com/search?q=repo%3Acookpad%2Fomniauth-rails_csrf_protection%20MultiJson&type=code)