### PR TITLE
Added error handling for object display on map

### DIFF
--- a/app/assets/javascripts/download_util.js
+++ b/app/assets/javascripts/download_util.js
@@ -54,3 +54,17 @@ OSM.turboHtmlResponseHandler = function (event) {
     event.stopPropagation();
   }
 };
+
+OSM.displayLoadError = function (message, close) {
+  $("#browse_status").html(
+    $("<div class='p-3'>").append(
+      $("<div class='d-flex'>").append(
+        $("<h2 class='flex-grow-1 text-break'>")
+          .text(OSM.i18n.t("browse.start_rjs.load_data")),
+        $("<div>").append(
+          $("<button type='button' class='btn-close'>")
+            .attr("aria-label", OSM.i18n.t("javascripts.close"))
+            .on("click", close))),
+      $("<p class='alert alert-warning'>")
+        .text(OSM.i18n.t("browse.start_rjs.feature_error", { message: message }))));
+};

--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -1,3 +1,4 @@
+//= require download_util
 OSM.initializeDataLayer = function (map) {
   let dataLoader, loadedBounds;
   const dataLayer = map.dataLayer;
@@ -47,20 +48,6 @@ OSM.initializeDataLayer = function (map) {
         $("<input type='submit' class='btn btn-primary d-block mx-auto'>")
           .val(OSM.i18n.t("browse.start_rjs.load_data"))
           .click(add)));
-  }
-
-  function displayLoadError(message, close) {
-    $("#browse_status").html(
-      $("<div class='p-3'>").append(
-        $("<div class='d-flex'>").append(
-          $("<h2 class='flex-grow-1 text-break'>")
-            .text(OSM.i18n.t("browse.start_rjs.load_data")),
-          $("<div>").append(
-            $("<button type='button' class='btn-close'>")
-              .attr("aria-label", OSM.i18n.t("javascripts.close"))
-              .click(close))),
-        $("<p class='alert alert-warning'>")
-          .text(OSM.i18n.t("browse.start_rjs.feature_error", { message: message }))));
   }
 
   function getData() {
@@ -166,7 +153,7 @@ OSM.initializeDataLayer = function (map) {
       .catch(function (error) {
         if (error.name === "AbortError") return;
 
-        displayLoadError(error?.message, () => {
+        OSM.displayLoadError(error?.message, () => {
           $("#browse_status").empty();
         });
       })


### PR DESCRIPTION
Now that we're able to display large relations without hitting gateway timeout errors, users will try this out on fairly large objects. At some point they're likely to encounter rate limiting. Previously, any error messages were silently discarded, and an empty map is shown instead, which is a bit confusing.

I'm reusing the good old error handling code from app/assets/javascripts/index/layers/data.js in this PR to display a proper error message instead:

<img width="552" height="381" alt="error1" src="https://github.com/user-attachments/assets/4b8c460d-b954-4c9a-a61c-a643d02f3564" />


