### PR TITLE
Replace auth_button helper with template

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,6 +1,4 @@
 module UserHelper
-  include InlineSvg::ActionView::Helpers
-
   # User images
 
   def user_image(user, options = {})
@@ -50,22 +48,6 @@ module UserHelper
     else
       image_url("avatar.svg")
     end
-  end
-
-  # External authentication support
-
-  def auth_button(provider, preferred: false)
-    body = inline_svg_tag("auth_providers/#{provider}.svg",
-                          :class => "rounded-1 text-body-emphasis",
-                          :size => "36")
-    body += t("application.auth_providers.#{provider}.title") if preferred
-    link_to(
-      body,
-      auth_path(:provider => provider),
-      :method => :post,
-      :class => ["auth_button btn btn-outline-secondary border p-2", { "px-4 d-flex gap-3 justify-content-center align-items-center" => preferred }],
-      :title => t("application.auth_providers.#{provider}.title")
-    )
   end
 
   private

--- a/app/views/application/_auth_button.html.erb
+++ b/app/views/application/_auth_button.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (provider:, preferred: false) %>
+<%= link_to auth_path(:provider => provider),
+            :method => :post,
+            :class => ["auth_button btn btn-outline-secondary border p-2", { "px-4 d-flex gap-3 justify-content-center align-items-center" => preferred }],
+            :title => t("application.auth_providers.#{provider}.title") do %>
+  <%= inline_svg_tag "auth_providers/#{provider}.svg",
+                     :class => "rounded-1 text-body-emphasis",
+                     :size => "36" %>
+  <% if preferred %>
+    <%= t "application.auth_providers.#{provider}.title" %>
+  <% end %>
+<% end %>

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -6,14 +6,14 @@
 
     <% if prefered_auth_button_available %>
       <div class="col justify-content-center d-flex align-items-center flex-wrap">
-        <%= auth_button @preferred_auth_provider, :preferred => true %>
+        <%= render "auth_button", :provider => @preferred_auth_provider, :preferred => true %>
       </div>
     <% end %>
 
     <div class="col justify-content-center d-flex align-items-center flex-wrap gap-2">
       <% Auth.providers.each do |provider| %>
         <% if provider != @preferred_auth_provider %>
-          <%= auth_button provider %>
+          <%= render "auth_button", :provider => provider %>
         <% end %>
       <% end -%>
     </div>

--- a/test/helpers/user_helper_test.rb
+++ b/test/helpers/user_helper_test.rb
@@ -109,11 +109,6 @@ class UserHelperTest < ActionView::TestCase
     assert_match %r{^<img .* width="50" height="50" .* />$}, thumbnail
   end
 
-  def test_auth_button
-    button = auth_button("google")
-    assert_match %r{^<a class="auth_button btn btn-outline-secondary border p-2" title="Log in with Google" rel="nofollow" data-method="post" href="/auth/google"><svg .*>.*</svg></a>$}, button
-  end
-
   private
 
   def request


### PR DESCRIPTION
After #6351 and #6352 I don't think we need a helper for auth buttons.

I think a template is easier to read. Unlike the helper, it doesn't have html string concatenation.