### PR TITLE
Use @elements instead of @elems in api element history

### DIFF
--- a/app/controllers/api/old_elements_controller.rb
+++ b/app/controllers/api/old_elements_controller.rb
@@ -19,11 +19,7 @@ module Api
       raise OSM::APINotFoundError if @elements.empty?
 
       # determine visible elements
-      @elems = if show_redactions?
-                 @elements
-               else
-                 @elements.unredacted
-               end
+      @elements = @elements.unredacted unless show_redactions?
 
       # Render the result
       respond_to do |format|

--- a/app/views/api/old_nodes/index.json.jbuilder
+++ b/app/views/api/old_nodes/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.partial! "api/root_attributes"
 
 json.elements do
-  json.array! @elems, :partial => "old_node", :as => :old_node
+  json.array! @elements, :partial => "old_node", :as => :old_node
 end

--- a/app/views/api/old_nodes/index.xml.builder
+++ b/app/views/api/old_nodes/index.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@elems) || "")
+  osm << (render(@elements) || "")
 end

--- a/app/views/api/old_relations/index.json.jbuilder
+++ b/app/views/api/old_relations/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.partial! "api/root_attributes"
 
 json.elements do
-  json.array! @elems, :partial => "old_relation", :as => :old_relation
+  json.array! @elements, :partial => "old_relation", :as => :old_relation
 end

--- a/app/views/api/old_relations/index.xml.builder
+++ b/app/views/api/old_relations/index.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@elems) || "")
+  osm << (render(@elements) || "")
 end

--- a/app/views/api/old_ways/index.json.jbuilder
+++ b/app/views/api/old_ways/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.partial! "api/root_attributes"
 
 json.elements do
-  json.array! @elems, :partial => "old_way", :as => :old_way
+  json.array! @elements, :partial => "old_way", :as => :old_way
 end

--- a/app/views/api/old_ways/index.xml.builder
+++ b/app/views/api/old_ways/index.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
 
 xml.osm(OSM::API.new.xml_root_attributes) do |osm|
-  osm << (render(@elems) || "")
+  osm << (render(@elements) || "")
 end


### PR DESCRIPTION
Eliminates `@elems` instance variable. Otherwise there are both `@elements` and `@elems` and the difference is that one is filtered by redactions and the other is not, which you can't guess from their names.