### PR TITLE
Update num_changes when backfilling changesets

### DIFF
--- a/lib/tasks/backfill_changeset_stats.rake
+++ b/lib/tasks/backfill_changeset_stats.rake
@@ -91,7 +91,16 @@ namespace :db do
             num_deleted_ways       = total.num_deleted_ways,
             num_created_relations  = total.num_created_relations,
             num_modified_relations = total.num_modified_relations,
-            num_deleted_relations  = total.num_deleted_relations
+            num_deleted_relations  = total.num_deleted_relations,
+            num_changes            = total.num_created_nodes +
+                                     total.num_modified_nodes +
+                                     total.num_deleted_nodes +
+                                     total.num_created_ways +
+                                     total.num_modified_ways +
+                                     total.num_deleted_ways +
+                                     total.num_created_relations +
+                                     total.num_modified_relations +
+                                     total.num_deleted_relations
         FROM total
         WHERE changesets.id = total.changeset_id
       SQL


### PR DESCRIPTION
It seems that at least among the early changesets there are a number where `num_changes` is not correct so they still appear to have out of date statistics after running the backfill.

So far I see about 25000 such changesets in the first 3 million.

This PR adjusts the backfill to update `num_changes` as well as the individual components.