### PR TITLE
Move English language names to en.yml

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -195,7 +195,7 @@ body.small-nav {
 /* Rules for language selector */
 
 .select_language_list {
-  column-width: 160px;
+  column-width: 165px;
 
   a {
     .native_name small {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -202,7 +202,7 @@ body.small-nav {
       font-size: 10px;
     }
 
-    &:hover .english_name {
+    &:hover .current_locale_name {
       text-decoration: underline;
     }
   }

--- a/app/views/layouts/_select_language_list.html.erb
+++ b/app/views/layouts/_select_language_list.html.erb
@@ -16,8 +16,8 @@
             <%= language[:native_name] %>
           <% end %>
         </span>
-        <small lang="en" class="english_name d-block text-secondary">
-          <%= language[:english_name] %>
+        <small class="current_locale_name d-block text-secondary">
+          <%= t ".languages.#{language[:code]}" %>
         </small>
       <% end %>
     </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1762,6 +1762,116 @@ en:
       select_language: Select Language
     select_language_button:
       title: Select Language
+    select_language_list:
+      languages:
+        af: Afrikaans
+        gsw: Alemannic
+        frp: Arpitan
+        ast: Asturian
+        az: Azerbaijani
+        id: Indonesian
+        ms: Malay
+        bs: Bosnian
+        br: Breton
+        ca: Catalan
+        cs: Czech
+        cy: Welsh
+        da: Danish
+        de: German
+        dsb: Lower Sorbian
+        et: Estonian
+        en: English
+        en-GB: English (UK)
+        es: Spanish
+        eo: Esperanto
+        eu: Basque
+        fr: French
+        fy: Western Frisian
+        fur: Friulian
+        ga: Irish
+        gd: Scottish Gaelic
+        gl: Galician
+        aln: Gheg Albanian
+        hsb: Upper Sorbian
+        hr: Croatian
+        ia: Interlingua
+        is: Icelandic
+        it: Italian
+        gcf: Guadeloupean Creole
+        ku-Latn: Kurdish (Latin)
+        lv: Latvian
+        lb: Luxembourgish
+        lt: Lithuanian
+        hu: Hungarian
+        fit: Tornedalen Finnish
+        nl: Dutch
+        nb: Norwegian Bokmål
+        nn: Norwegian Nynorsk
+        oc: Occitan
+        nds: Low German
+        pl: Polish
+        pt-PT: Portuguese
+        pt: Portuguese (Brazil)
+        ksh: Colognian
+        ro: Romanian
+        sc: Sardinian
+        sco: Scots
+        sq: Albanian
+        scn: Sicilian
+        sk: Slovak
+        sl: Slovenian
+        sr-Latn: Serbian (Latin)
+        sh: Serbo-Croatian (Latin)
+        fi: Finnish
+        sv: Swedish
+        tl: Tagalog
+        kab: Kabyle
+        vi: Vietnamese
+        tr: Turkish
+        yo: Yoruba
+        diq: Dimli
+        el: Greek
+        ba: Bashkir
+        be: Belarusian
+        be-Tarask: Belarusian (Tarašk.)
+        bg: Bulgarian
+        mk: Macedonian
+        mo: Moldovan
+        ce: Chechen
+        ru: Russian
+        sr: Serbian (Cyrillic)
+        tt: Tatar (Cyrillic)
+        uk: Ukrainian
+        kk-cyrl: Kazakh (Cyrillic)
+        yi: Yiddish
+        he: Hebrew
+        ar: Arabic
+        skr-arab: Saraiki (Arabic script)
+        fa: Persian
+        arz: Arabic (Egypt)
+        pnb: Western Punjabi
+        ps: Pashto
+        nqo: N’Ko
+        ne: Nepali
+        mr: Marathi
+        hi: Hindi
+        bn: Bangla
+        pa: Punjabi
+        gu: Gujarati
+        ta: Tamil
+        te: Telugu
+        kn: Kannada
+        th: Thai
+        my: Burmese
+        xmf: Mingrelian
+        ka: Georgian
+        km: Khmer
+        sat: Santali
+        zh-CN: Chinese (Simplified)
+        zh-TW: Chinese (Traditional)
+        zh-HK: Chinese (Hong Kong)
+        ja: Japanese
+        ko: Korean
     offline_flash:
       osm_offline: "The OpenStreetMap database is currently offline while essential maintenance work is carried out."
       osm_read_only: "The OpenStreetMap database is currently in read-only mode while essential maintenance work is carried out."

--- a/config/ui_languages.yml
+++ b/config/ui_languages.yml
@@ -1,339 +1,231 @@
 ---
 - :code: af
   :native_name: Afrikaans
-  :english_name: Afrikaans
 - :code: gsw
   :native_name: Alemannisch
-  :english_name: Alemannic
 - :code: frp
   :native_name: arpetan
-  :english_name: Arpitan
 - :code: ast
   :native_name: asturianu
-  :english_name: Asturian
 - :code: az
   :native_name: azərbaycanca
-  :english_name: Azerbaijani
 - :code: id
   :native_name: Bahasa Indonesia
-  :english_name: Indonesian
 - :code: ms
   :native_name: Bahasa Melayu
-  :english_name: Malay
 - :code: bs
   :native_name: bosanski
-  :english_name: Bosnian
 - :code: br
   :native_name: brezhoneg
-  :english_name: Breton
 - :code: ca
   :native_name: català
-  :english_name: Catalan
 - :code: cs
   :native_name: čeština
-  :english_name: Czech
 - :code: cy
   :native_name: Cymraeg
-  :english_name: Welsh
 - :code: da
   :native_name: dansk
-  :english_name: Danish
 - :code: de
   :native_name: Deutsch
-  :english_name: German
 - :code: dsb
   :native_name: dolnoserbski
-  :english_name: Lower Sorbian
 - :code: et
   :native_name: eesti
-  :english_name: Estonian
 - :code: en
   :native_name: English
-  :english_name: English
 - :code: en-GB
   :native_name: English (United Kingdom)
   :short_native_name: English (UK)
-  :english_name: English (UK)
 - :code: es
   :native_name: español
-  :english_name: Spanish
 - :code: eo
   :native_name: Esperanto
-  :english_name: Esperanto
 - :code: eu
   :native_name: euskara
-  :english_name: Basque
 - :code: fr
   :native_name: français
-  :english_name: French
 - :code: fy
   :native_name: Frysk
-  :english_name: Western Frisian
 - :code: fur
   :native_name: furlan
-  :english_name: Friulian
 - :code: ga
   :native_name: Gaeilge
-  :english_name: Irish
 - :code: gd
   :native_name: Gàidhlig
-  :english_name: Scottish Gaelic
 - :code: gl
   :native_name: galego
-  :english_name: Galician
 - :code: aln
   :native_name: Gegë
-  :english_name: Gheg Albanian
 - :code: hsb
   :native_name: hornjoserbsce
-  :english_name: Upper Sorbian
 - :code: hr
   :native_name: hrvatski
-  :english_name: Croatian
 - :code: ia
   :native_name: interlingua
-  :english_name: Interlingua
 - :code: is
   :native_name: íslenska
-  :english_name: Icelandic
 - :code: it
   :native_name: italiano
-  :english_name: Italian
 - :code: gcf
   :native_name: kréyòl Gwadloup
-  :english_name: Guadeloupean Creole
 - :code: ku-Latn
   :native_name: kurdî (latînî)
   :short_native_name: kurdî
   :short_native_note: latînî
-  :english_name: Kurdish (Latin)
 - :code: lv
   :native_name: latviešu
-  :english_name: Latvian
 - :code: lb
   :native_name: Lëtzebuergesch
-  :english_name: Luxembourgish
 - :code: lt
   :native_name: lietuvių
-  :english_name: Lithuanian
 - :code: hu
   :native_name: magyar
-  :english_name: Hungarian
 - :code: fit
   :native_name: meänkieli
-  :english_name: Tornedalen Finnish
 - :code: nl
   :native_name: Nederlands
-  :english_name: Dutch
 - :code: nb
   :native_name: norsk bokmål
-  :english_name: Norwegian Bokmål
 - :code: nn
   :native_name: norsk nynorsk
-  :english_name: Norwegian Nynorsk
 - :code: oc
   :native_name: occitan
-  :english_name: Occitan
 - :code: nds
   :native_name: Plattdüütsch
-  :english_name: Low German
 - :code: pl
   :native_name: polski
-  :english_name: Polish
 - :code: pt-PT
   :native_name: português
-  :english_name: Portuguese
 - :code: pt
   :native_name: português do Brasil
   :short_native_name: português (Brasil)
-  :english_name: Portuguese (Brazil)
 - :code: ksh
   :native_name: Ripoarisch
-  :english_name: Colognian
 - :code: ro
   :native_name: română
-  :english_name: Romanian
 - :code: sc
   :native_name: sardu
-  :english_name: Sardinian
 - :code: sco
   :native_name: Scots
-  :english_name: Scots
 - :code: sq
   :native_name: shqip
-  :english_name: Albanian
 - :code: scn
   :native_name: sicilianu
-  :english_name: Sicilian
 - :code: sk
   :native_name: slovenčina
-  :english_name: Slovak
 - :code: sl
   :native_name: slovenščina
-  :english_name: Slovenian
 - :code: sr-Latn
   :native_name: srpski (latinica)
   :short_native_name: srpski
   :short_native_note: latinica
-  :english_name: Serbian (Latin)
 - :code: sh
   :native_name: srpskohrvatski (latinica)
   :short_native_name: srpskohrvatski
   :short_native_note: lat.
-  :english_name: Serbo-Croatian (Latin)
 - :code: fi
   :native_name: suomi
-  :english_name: Finnish
 - :code: sv
   :native_name: svenska
-  :english_name: Swedish
 - :code: tl
   :native_name: Tagalog
-  :english_name: Tagalog
 - :code: kab
   :native_name: Taqbaylit
-  :english_name: Kabyle
 - :code: vi
   :native_name: Tiếng Việt
-  :english_name: Vietnamese
 - :code: tr
   :native_name: Türkçe
-  :english_name: Turkish
 - :code: yo
   :native_name: Yorùbá
-  :english_name: Yoruba
 - :code: diq
   :native_name: Zazaki
-  :english_name: Dimli
 - :code: el
   :native_name: Ελληνικά
-  :english_name: Greek
 - :code: ba
   :native_name: башҡортса
-  :english_name: Bashkir
 - :code: be
   :native_name: беларуская
-  :english_name: Belarusian
 - :code: be-Tarask
   :native_name: беларуская (тарашкевіца)
   :short_native_name: беларуская
   :short_native_note: тарашк.
-  :english_name: Belarusian (Tarašk.)
 - :code: bg
   :native_name: български
-  :english_name: Bulgarian
 - :code: mk
   :native_name: македонски
-  :english_name: Macedonian
 - :code: mo
   :native_name: молдовеняскэ
-  :english_name: Moldovan
 - :code: ce
   :native_name: нохчийн
-  :english_name: Chechen
 - :code: ru
   :native_name: русский
-  :english_name: Russian
 - :code: sr
   :native_name: српски (ћирилица)
   :short_native_name: српски
   :short_native_note: ћирилица
-  :english_name: Serbian (Cyrillic)
 - :code: tt
   :native_name: татарча
-  :english_name: Tatar (Cyrillic)
 - :code: uk
   :native_name: українська
-  :english_name: Ukrainian
 - :code: kk-cyrl
   :native_name: қазақша (кирил)
   :short_native_name: қазақша
   :short_native_note: кирил
-  :english_name: Kazakh (Cyrillic)
 - :code: yi
   :native_name: ייִדיש
-  :english_name: Yiddish
 - :code: he
   :native_name: עברית
-  :english_name: Hebrew
 - :code: ar
   :native_name: العربية
-  :english_name: Arabic
 - :code: skr-arab
   :native_name: سرائیکی
-  :english_name: Saraiki (Arabic script)
 - :code: fa
   :native_name: فارسی
-  :english_name: Persian
 - :code: arz
   :native_name: مصرى
-  :english_name: Arabic (Egypt)
 - :code: pnb
   :native_name: پنجابی
-  :english_name: Western Punjabi
 - :code: ps
   :native_name: پښتو
-  :english_name: Pashto
 - :code: nqo
   :native_name: ߒߞߏ
-  :english_name: N’Ko
 - :code: ne
   :native_name: नेपाली
-  :english_name: Nepali
 - :code: mr
   :native_name: मराठी
-  :english_name: Marathi
 - :code: hi
   :native_name: हिन्दी
-  :english_name: Hindi
 - :code: bn
   :native_name: বাংলা
-  :english_name: Bangla
 - :code: pa
   :native_name: ਪੰਜਾਬੀ
-  :english_name: Punjabi
 - :code: gu
   :native_name: ગુજરાતી
-  :english_name: Gujarati
 - :code: ta
   :native_name: தமிழ்
-  :english_name: Tamil
 - :code: te
   :native_name: తెలుగు
-  :english_name: Telugu
 - :code: kn
   :native_name: ಕನ್ನಡ
-  :english_name: Kannada
 - :code: th
   :native_name: ไทย
-  :english_name: Thai
 - :code: my
   :native_name: မြန်မာဘာသာ
-  :english_name: Burmese
 - :code: xmf
   :native_name: მარგალური
-  :english_name: Mingrelian
 - :code: ka
   :native_name: ქართული
-  :english_name: Georgian
 - :code: km
   :native_name: ភាសាខ្មែរ
-  :english_name: Khmer
 - :code: sat
   :native_name: ᱥᱟᱱᱛᱟᱲᱤ
-  :english_name: Santali
 - :code: zh-CN
   :native_name: 中文（简体）
-  :english_name: Chinese (Simplified)
 - :code: zh-TW
   :native_name: 中文（繁體）
-  :english_name: Chinese (Traditional)
 - :code: zh-HK
   :native_name: 中文（香港）
-  :english_name: Chinese (Hong Kong)
 - :code: ja
   :native_name: 日本語
-  :english_name: Japanese
 - :code: ko
   :native_name: 한국어
-  :english_name: Korean

--- a/test/lib/i18n_test.rb
+++ b/test/lib/i18n_test.rb
@@ -84,7 +84,7 @@ class I18nTest < ActiveSupport::TestCase
 
   def test_ui_languages_have_required_fields
     AVAILABLE_LANGUAGES.each do |language|
-      assert_pattern { language => { code: String, native_name: String, english_name: String } }
+      assert_pattern { language => { code: String, native_name: String } }
     end
   end
 


### PR DESCRIPTION
With this PR the language names in *Select Language* dialog can be translated, that would fix #6319.

Using CLDR or anything derived from it is not going to work because it's not complete enough. If you try, you'll have to "fall back to ... the raw language code" as #6319 says and why would you want that when we already have English names.

The problem this PR may introduce is that we won't be able to control how wide the names are. Some of them will likely won't fit on one line which will make the list look worse.