### PR TITLE
Lock changeset in api single element changes

### DIFF
--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -79,7 +79,10 @@ module Api
 
       raise OSM::APIBadUserInput, "The id in the url (#{node.id}) is not the same as provided in the xml (#{new_node.id})" unless new_node && new_node.id == node.id
 
-      node.delete_with_history!(new_node, current_user)
+      Changeset.transaction do
+        new_node.changeset&.lock!
+        node.delete_with_history!(new_node, current_user)
+      end
       render :plain => node.version.to_s
     end
   end

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -63,7 +63,10 @@ module Api
 
       raise OSM::APIBadUserInput, "The id in the url (#{node.id}) is not the same as provided in the xml (#{new_node.id})" unless new_node && new_node.id == node.id
 
-      node.update_from(new_node, current_user)
+      Changeset.transaction do
+        new_node.changeset&.lock!
+        node.update_from(new_node, current_user)
+      end
       render :plain => node.version.to_s
     end
 

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -49,8 +49,10 @@ module Api
     def create
       node = Node.from_xml(request.raw_post, :create => true)
 
-      # Assume that Node.from_xml has thrown an exception if there is an error parsing the xml
-      node.create_with_history current_user
+      Changeset.transaction do
+        node.changeset&.lock!
+        node.create_with_history current_user
+      end
       render :plain => node.id.to_s
     end
 

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -121,7 +121,10 @@ module Api
       relation = Relation.find(params[:id])
       new_relation = Relation.from_xml(request.raw_post)
       if new_relation && new_relation.id == relation.id
-        relation.delete_with_history!(new_relation, current_user)
+        Changeset.transaction do
+          new_relation.changeset&.lock!
+          relation.delete_with_history!(new_relation, current_user)
+        end
         render :plain => relation.version.to_s
       else
         head :bad_request

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -110,7 +110,10 @@ module Api
 
       raise OSM::APIBadUserInput, "The id in the url (#{relation.id}) is not the same as provided in the xml (#{new_relation.id})" unless new_relation && new_relation.id == relation.id
 
-      relation.update_from new_relation, current_user
+      Changeset.transaction do
+        new_relation.changeset&.lock!
+        relation.update_from(new_relation, current_user)
+      end
       render :plain => relation.version.to_s
     end
 

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -97,8 +97,10 @@ module Api
     def create
       relation = Relation.from_xml(request.raw_post, :create => true)
 
-      # Assume that Relation.from_xml has thrown an exception if there is an error parsing the xml
-      relation.create_with_history current_user
+      Changeset.transaction do
+        relation.changeset&.lock!
+        relation.create_with_history current_user
+      end
       render :plain => relation.id.to_s
     end
 

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -80,7 +80,10 @@ module Api
       new_way = Way.from_xml(request.raw_post)
 
       if new_way && new_way.id == way.id
-        way.delete_with_history!(new_way, current_user)
+        Changeset.transaction do
+          new_way.changeset&.lock!
+          way.delete_with_history!(new_way, current_user)
+        end
         render :plain => way.version.to_s
       else
         head :bad_request

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -67,7 +67,10 @@ module Api
 
       raise OSM::APIBadUserInput, "The id in the url (#{way.id}) is not the same as provided in the xml (#{new_way.id})" unless new_way && new_way.id == way.id
 
-      way.update_from(new_way, current_user)
+      Changeset.transaction do
+        new_way.changeset&.lock!
+        way.update_from(new_way, current_user)
+      end
       render :plain => way.version.to_s
     end
 

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -54,8 +54,10 @@ module Api
     def create
       way = Way.from_xml(request.raw_post, :create => true)
 
-      # Assume that Way.from_xml has thrown an exception if there is an error parsing the xml
-      way.create_with_history current_user
+      Changeset.transaction do
+        way.changeset&.lock!
+        way.create_with_history current_user
+      end
       render :plain => way.id.to_s
     end
 

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -137,6 +137,16 @@ module Api
       end
     end
 
+    def test_create_in_missing_changeset
+      with_unchanging_request do |headers|
+        osm = "<osm><node lat='0' lon='0' changeset='0'/></osm>"
+
+        post api_nodes_path, :params => osm, :headers => headers
+
+        assert_response :conflict
+      end
+    end
+
     def test_create_with_invalid_osm_structure
       with_unchanging_request do |headers|
         osm = "<create/>"

--- a/test/controllers/api/nodes_controller_test.rb
+++ b/test/controllers/api/nodes_controller_test.rb
@@ -265,6 +265,27 @@ module Api
       end
     end
 
+    def test_create_race_condition
+      user = create(:user)
+      changeset = create(:changeset, :user => user)
+      auth_header = bearer_authorization_header user
+      path = api_nodes_path
+      concurrency_level = 16
+
+      threads = Array.new(concurrency_level) do
+        Thread.new do
+          osm = "<osm><node lat='0' lon='0' changeset='#{changeset.id}'/></osm>"
+          post path, :params => osm, :headers => auth_header
+        end
+      end
+      threads.each(&:join)
+
+      changeset.reload
+      assert_equal concurrency_level, changeset.num_changes
+      assert_predicate changeset, :num_type_changes_in_sync?
+      assert_equal concurrency_level, changeset.num_created_nodes
+    end
+
     def test_show_not_found
       get api_node_path(0)
       assert_response :not_found

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -257,6 +257,26 @@ module Api
       end
     end
 
+    def test_create_in_missing_changeset
+      node1 = create(:node)
+      node2 = create(:node)
+
+      with_unchanging_request do |headers|
+        osm = <<~OSM
+          <osm>
+            <way changeset='0'>
+              <nd ref='#{node1.id}'/>
+              <nd ref='#{node2.id}'/>
+            </way>
+          </osm>
+        OSM
+
+        post api_ways_path, :params => osm, :headers => headers
+
+        assert_response :conflict
+      end
+    end
+
     def test_create_with_missing_node_by_private_user
       with_unchanging_request([:data_public => false]) do |headers, changeset|
         osm = <<~OSM

--- a/test/controllers/api/ways_controller_test.rb
+++ b/test/controllers/api/ways_controller_test.rb
@@ -435,6 +435,34 @@ module Api
       end
     end
 
+    def test_create_race_condition
+      user = create(:user)
+      changeset = create(:changeset, :user => user)
+      node = create(:node)
+      auth_header = bearer_authorization_header user
+      path = api_ways_path
+      concurrency_level = 16
+
+      threads = Array.new(concurrency_level) do
+        Thread.new do
+          osm = <<~OSM
+            <osm>
+              <way changeset='#{changeset.id}'>
+                <nd ref='#{node.id}'/>
+              </way>
+            </osm>
+          OSM
+          post path, :params => osm, :headers => auth_header
+        end
+      end
+      threads.each(&:join)
+
+      changeset.reload
+      assert_equal concurrency_level, changeset.num_changes
+      assert_predicate changeset, :num_type_changes_in_sync?
+      assert_equal concurrency_level, changeset.num_created_ways
+    end
+
     # -------------------------------------
     # Test deleting ways.
     # -------------------------------------


### PR DESCRIPTION
See https://github.com/openstreetmap/openstreetmap-website/pull/6361#issuecomment-3232959610.

I was easily able to trigger race conditions when creating nodes and ways but not when creating relations, modifying nodes and ways. That's why there are race condition tests only for create actions.

I assume we're locking the changeset first and the elements later, that's what cgimap seems to do.