### PR TITLE
Map API requests with Bearer token

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -97,6 +97,7 @@ OSM.initializeDataLayer = function (map) {
 
     function fetchDataForBounds(bounds) {
       return fetch(`/api/${OSM.API_VERSION}/map.json?bbox=${bounds.toBBoxString()}`, {
+        headers: { ...OSM.oauth },
         signal: dataLoader.signal
       });
     }

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -282,7 +282,7 @@ L.OSM.Map = L.Map.extend({
       const map = this;
       this._objectLoader = new AbortController();
       fetch(OSM.apiUrl(object), {
-        headers: { accept: "application/json" },
+        headers: { accept: "application/json", ...OSM.oauth },
         signal: this._objectLoader.signal
       })
         .then(async response => {


### PR DESCRIPTION
In this PR, we're adding a Bearer token for Map API requests, if available.

Benefits:
- Users behind a shared IP address are less likely to hit rate limiting.
- Higher rate limits for moderators are taken into account.

Tested with anonymous / known user for "Map Data" and single object map display. Map requests were  served by a cgimap backend.