### PR TITLE
Remove kgio gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,6 @@ gem "rotp"
 # Load memcache client in case we are using it
 gem "connection_pool"
 gem "dalli"
-gem "kgio"
 
 # Load canonical-rails to generate canonical URLs
 gem "canonical-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,7 +371,6 @@ GEM
       faraday-follow_redirects
     jwt (2.10.2)
       base64
-    kgio (2.11.4)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -757,7 +756,6 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   jquery-rails
   jwt
-  kgio
   kramdown
   libxml-ruby (>= 2.0.5)
   listen


### PR DESCRIPTION
### Description
The kgio gem was added [in this commit](https://github.com/openstreetmap/openstreetmap-website/commit/255b0b94252b48a9fe4326bb9d9fc4f184308460) as a dependency of dalli. However, [dalli no longer needs it](https://github.com/petergoldstein/dalli/blob/c6d85e4e4b440b22bf4a784eca77b234798553e5/3.0-Upgrade.md?plain=1#L17). See [this PR](https://github.com/petergoldstein/dalli/pull/721) for removal.

### How has this been tested?
I was able to build and run the app locally.  The tests pass.
