### PR TITLE
Add shn to UI languages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1863,6 +1863,7 @@ en:
         kn: Kannada
         th: Thai
         my: Burmese
+        shn: Shan
         xmf: Mingrelian
         ka: Georgian
         km: Khmer

--- a/config/ui_languages.yml
+++ b/config/ui_languages.yml
@@ -211,6 +211,8 @@
   :native_name: ไทย
 - :code: my
   :native_name: မြန်မာဘာသာ
+- :code: shn
+  :native_name: လိၵ်ႈတႆး
 - :code: xmf
   :native_name: მარგალური
 - :code: ka


### PR DESCRIPTION
Fixes #6390.

Name is taken from https://en.wikipedia.org/wiki/Shan_language#Names.