### PR TITLE
Fix some language names

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1846,9 +1846,9 @@ en:
         yi: Yiddish
         he: Hebrew
         ar: Arabic
-        skr-arab: Saraiki (Arabic script)
+        skr-arab: Saraiki
         fa: Persian
-        arz: Arabic (Egypt)
+        arz: Egyptian Arabic
         pnb: Western Punjabi
         ps: Pashto
         nqo: N’Ko


### PR DESCRIPTION
I'm a translatewiki administrator, and I noticed that some language names should be fixed.

* arz: The name "Arabic (Egypt)" looks more like a local variant of Standard Arabic for Egypt, but arz is actually a different language and not Standard Arabic.
* skr-arab: Saraiki is always written in the Arabic script. It uses the code "skr-arab" on translatewiki for historical and technical reasons, and some day it may actually move to just "skr". There is no reason to mention "(Arabic)" in parentheses.