### PR TITLE
Allow `user/preferences` values up to 10_000

### DIFF
--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -17,7 +17,8 @@ class UserPreference < ApplicationRecord
   belongs_to :user
 
   validates :user, :associated => true
-  validates :k, :v, :length => 1..255, :characters => true, :presence => true
+  validates :k, :length => 1..255, :characters => true, :presence => true
+  validates :v, :length => 1..1_000_000, :characters => true, :presence => true
 
   scope :color_schemes, -> { where("k LIKE '%.color_scheme'") }
 end

--- a/app/views/api/capabilities/show.builder
+++ b/app/views/api/capabilities/show.builder
@@ -14,6 +14,8 @@ xml.osm(OSM::API.new.xml_root_attributes) do |osm|
                    :maximum_query_limit => Settings.max_changeset_query_limit)
     api.notes(:default_query_limit => Settings.default_note_query_limit,
               :maximum_query_limit => Settings.max_note_query_limit)
+    api.user_preferences(:key_maximum_length => 255,
+                         :value_maximum_length => 1_000_000)
     api.timeout(:seconds => Settings.api_timeout)
     api.status(:database => @database_status,
                :api => @api_status,

--- a/app/views/api/capabilities/show.json.jbuilder
+++ b/app/views/api/capabilities/show.json.jbuilder
@@ -31,6 +31,10 @@ json.api do
     json.default_query_limit Settings.default_note_query_limit
     json.maximum_query_limit Settings.max_note_query_limit
   end
+  json.user_preferences do
+    json.key_maximum_length 255
+    json.value_maximum_length 1_000_000
+  end
   json.timeout do
     json.seconds Settings.api_timeout
   end

--- a/test/controllers/api/capabilities_controller_test.rb
+++ b/test/controllers/api/capabilities_controller_test.rb
@@ -42,6 +42,7 @@ module Api
           assert_select "notes" \
                         "[default_query_limit='#{Settings.default_note_query_limit}']" \
                         "[maximum_query_limit='#{Settings.max_note_query_limit}']", :count => 1
+          assert_select "user_preferences[key_maximum_length='255'][value_maximum_length='1000000']", :count => 1
           assert_select "status[database='online']", :count => 1
           assert_select "status[api='online']", :count => 1
           assert_select "status[gpx='online']", :count => 1
@@ -68,6 +69,8 @@ module Api
       assert_equal Settings.max_number_of_relation_members, js["api"]["relationmembers"]["maximum"]
       assert_equal Settings.default_note_query_limit, js["api"]["notes"]["default_query_limit"]
       assert_equal Settings.max_note_query_limit, js["api"]["notes"]["maximum_query_limit"]
+      assert_equal 255, js["api"]["user_preferences"]["key_maximum_length"]
+      assert_equal 1_000_000, js["api"]["user_preferences"]["value_maximum_length"]
       assert_equal "online", js["api"]["status"]["database"]
       assert_equal "online", js["api"]["status"]["api"]
       assert_equal "online", js["api"]["status"]["gpx"]


### PR DESCRIPTION
### Description

Fixes https://github.com/openstreetmap/openstreetmap-website/issues/6297

The goal is to increase the limit of the `user/preferences` API values.
~I picket 10k which is what we use for user blocks and should be enough to add more complex data.~
_Update:_ [After more discussion](https://github.com/osmlab/osm-api-js/issues/32#issuecomment-3660625648), I change the limit to 1_000_000. A lower limit would still mean that many of the use cases we have in mind would require workarounds to split the data into chunks which would make this unreasonable hard to work with.

<details><summary>Other limits</summary>
<p>

User descriptions can be up to 65,536 characters
Diary comments can be up to 65,536 characters
User block reasons can be up to 10,000 characters
Note comments can be up to 2,000 characters

</p>
</details> 


### How has this been tested?

I tested it with the demo page from https://gist.github.com/tordans/94481e6336e8c34f258c677350fc2e77 which uses https://github.com/osmlab/osm-api-js to authenticate against localhost 3001 (hard coded) with a local oAuth App (hardcoded) and then runs two test cases against the preferences endpoint.
