### PR TITLE
Move markers out of the map div for the embed view

### DIFF
--- a/app/views/export/embed.html.erb
+++ b/app/views/export/embed.html.erb
@@ -7,10 +7,10 @@
     <%= javascript_include_tag "embed" %>
   </head>
   <body>
+    <% if params[:marker].present? %>
+      <%= render :partial => "layouts/markers", :locals => { :types => %w[dot] } %>
+    <% end %>
     <div id="map">
-      <% if params[:marker].present? %>
-        <%= render :partial => "layouts/markers", :locals => { :types => %w[dot] } %>
-      <% end %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Having the markers inside the map div means they get destroyed when the map is created.

Fixes #6045.