### PR TITLE
Fix tests for Docker on Apple silicon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,8 @@ gem "canonical-rails"
 # Used to generate images for traces
 gem "bzip2-ffi"
 gem "ffi-libarchive"
-gem "gd2-ffij", ">= 0.4.0"
+# Use https://github.com/dark-panda/gd2-ffij/pull/28 for Docker/macOS compatibility
+gem "gd2-ffij", :github => "rkoeze/gd2-ffij", :ref => "a203a8d5ef004a4198950e86329228fe3f331d06"
 gem "marcel"
 
 # Used for S3 object storage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,14 @@ GIT
     active_record_union (1.3.0)
       activerecord (>= 6.0)
 
+GIT
+  remote: https://github.com/rkoeze/gd2-ffij.git
+  revision: a203a8d5ef004a4198950e86329228fe3f331d06
+  ref: a203a8d5ef004a4198950e86329228fe3f331d06
+  specs:
+    gd2-ffij (0.4.1.dev)
+      ffi (>= 1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -296,8 +304,6 @@ GEM
     frozen_record (0.27.4)
       activemodel
     fspath (3.1.2)
-    gd2-ffij (0.4.0)
-      ffi (>= 1.0.0)
     git (2.3.3)
       activesupport (>= 5.0)
       addressable (~> 2.8)
@@ -740,7 +746,7 @@ DEPENDENCIES
   faraday
   ffi-libarchive
   frozen_record
-  gd2-ffij (>= 0.4.0)
+  gd2-ffij!
   htmlentities
   http_accept_language (~> 2.1.1)
   i18n-js (~> 4.2.3)


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/6287
### Context
Currently the test suite fails when run with Docker on Apple post-Intel machines (aka Apple silicon, AArch64, ARM64). The issue is with the gem `gd2-ffij`, which hard-codes possible locations for its underlying C library. Unfortunately it doesn't allow for the path that this library uses in an AArch64 machine, and doesn't offer a configuration option that would serve our use case.
### Description
This PR implements a proposal by @firefishy (https://github.com/openstreetmap/openstreetmap-website/issues/6287#issuecomment-3156583006): it changes the gem dependency to use a fork that implements the required change. Since it's bound to the specific SHA of the commit, it should be safe to use.

This fix is based on an outstanding PR for the `gd2-ffij` repository, awaiting since last June. Given the low level of activity in [the `gd2-ffij` repo](https://github.com/dark-panda/gd2-ffij) (last commit September 2021), it's unlikely that it will be merged.
### How has this been tested?
I have tested this on my MacBook M1 Pro machine.
### Caveat
If the forked repo or the relevant commit are removed from GitHub, that will break our builds. A fix for this would be for OSM to host this fork instead.

 Thoughts?