### PR TITLE
Confirmation popup for Overpass API export

### DIFF
--- a/app/views/site/export.html.erb
+++ b/app/views/site/export.html.erb
@@ -48,3 +48,25 @@
     <dd><%= t ".too_large.other.description" %></dd>
   </dl>
 <% end %>
+
+<div class="modal fade" tabindex="-1" id="export_confirmation" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"><%= t ".confirmation.header" %></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p><%= t ".confirmation.body" %></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+          <%= t ".confirmation.cancel" %>
+        </button>
+        <button type="button" class="btn btn-primary" data-action="download">
+          <%= t ".confirmation.download" %>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2623,6 +2623,11 @@ en:
           description: "Additional sources listed on the OpenStreetMap Wiki"
       export_button: "Export"
       export_download: "Downloading..."
+      confirmation:
+        header: Download XML Data
+        body: Do you want to download map data for this area in XML format? Note that large areas may take some time to download.
+        cancel: Cancel
+        download: Download
     fixthemap:
       title: Report a problem / Fix the map
       how_to_help:


### PR DESCRIPTION
### Description

The list below is a bit confusing from a UX point of view. While 3 out of 4 links would take a user to another page with more details about download options, the Overpass API link immediately starts a potentially huge download. The link is followed by a harmless-looking explanatory text that most users will probably overlook.

<img width="174" height="183" alt="image" src="https://github.com/user-attachments/assets/80f58078-301f-45be-ac90-2aa5df3e2fbe" />

To make things a bit clearer, I'm adding a confirmation pop-up for now.

<img width="602" height="286" alt="image" src="https://github.com/user-attachments/assets/8dfb9eb7-2b20-4f1c-81d6-8d1c81956a2a" />

Some UX redesign might be the better approach in the long run.

### How has this been tested?
Local test
