### PR TITLE
Use Close as the button label to close modal alerts

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -140,7 +140,7 @@
       <div class="modal-body" id="osm_alert_message">
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"><%= t ".ok" %></button>
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"><%= t "javascripts.close" %></button>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1758,7 +1758,6 @@ en:
     learn_more: "Learn More"
     more: More
     header:
-      ok: OK
       select_language: Select Language
     select_language_button:
       title: Select Language


### PR DESCRIPTION
The avoids using "OK" as a button label, and aligns with the labelling of the cross in the corner of the modal.

I considered alternative labels (like "dismiss") but since we have two ways to close the dialog, the cross is already labelled as "Close", so let's use "Close" for the button too.

Before:

<img width="893" height="379" alt="Screenshot from 2025-09-24 14-22-16" src="https://github.com/user-attachments/assets/f572dd87-4ec9-4049-9a99-93a96db197c9" />

After:
<img width="893" height="379" alt="Screenshot from 2025-09-24 14-24-31" src="https://github.com/user-attachments/assets/d171c568-a631-405a-9e15-2b86b361f9b7" />
