### PR TITLE
Send the user's preferred languages to Nominatim

### DIFF
--- a/app/controllers/concerns/nominatim_methods.rb
+++ b/app/controllers/concerns/nominatim_methods.rb
@@ -7,7 +7,7 @@ module NominatimMethods
 
   def nominatim_url(method, parameters)
     url = URI.join(Settings.nominatim_url, method)
-    url.query = parameters.merge("accept-language" => http_accept_language.user_preferred_languages.join(",")).to_query
+    url.query = parameters.merge("accept-language" => preferred_languages.join(",")).to_query
     url
   end
 


### PR DESCRIPTION
This sends the user's preferred languages to Nominatim instead of sending the browser languages - it will still fallback to the browser languages that were being sent before if we have no other source for preferred languages.

I also did (in a separate commit) some refactoring to improve how we build the URL for nominatim.

Fixes #6420.
