### PR TITLE
Include preferred_username claim in OIDC ID token

### DIFF
--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -27,7 +27,7 @@ Doorkeeper::OpenidConnect.configure do
   end
 
   claims do
-    claim :preferred_username, :scope => :openid do |resource_owner, _scopes, _access_token|
+    claim :preferred_username, :scope => :openid, :response => [:id_token, :user_info] do |resource_owner, _scopes, _access_token|
       resource_owner.display_name
     end
 

--- a/test/integration/oauth2_test.rb
+++ b/test/integration/oauth2_test.rb
@@ -110,7 +110,7 @@ class OAuth2Test < ActionDispatch::IntegrationTest
     end
 
     assert_equal user.id.to_s, data["sub"]
-    assert_not data.key?("preferred_username")
+    assert_equal user.display_name, data["preferred_username"]
 
     get oauth_userinfo_path
     assert_response :unauthorized


### PR DESCRIPTION
The id_token that is issued when the `openid` scope is set does not contain the `preferred_username` claim which would require external applications using OIDC to make another request to the API to be able to get the (current) user name to address users more personally.
I did not found any information if the decision to not include this claim in the token was deliberate? Otherwise this pull request would change the Doorkeeper configuration so the `preferred_username` is also included in the id_token