### PR TITLE
Use secure cookies only when HTTPS is expected

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -171,16 +171,16 @@ $(function () {
       map.getLayersCode(),
       map._object);
 
-    Cookies.set("_osm_location", OSM.locationCookie(map), { secure: true, expires: expiry, path: "/", samesite: "lax" });
+    OSM.cookies.set("_osm_location", OSM.locationCookie(map), { expires: expiry });
   });
 
-  if (Cookies.get("_osm_welcome") !== "hide") {
+  if (OSM.cookies.get("_osm_welcome") !== "hide") {
     $(".welcome").removeAttr("hidden");
   }
 
   $(".welcome .btn-close").on("click", function () {
     $(".welcome").hide();
-    Cookies.set("_osm_welcome", "hide", { secure: true, expires: expiry, path: "/", samesite: "lax" });
+    OSM.cookies.set("_osm_welcome", "hide", { expires: expiry });
   });
 
   const bannerExpiry = new Date();
@@ -191,7 +191,7 @@ $(function () {
     $("#banner").hide();
     e.preventDefault();
     if (cookieId) {
-      Cookies.set(cookieId, "hide", { secure: true, expires: bannerExpiry, path: "/", samesite: "lax" });
+      OSM.cookies.set(cookieId, "hide", { expires: bannerExpiry });
     }
   });
 

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -137,17 +137,17 @@ OSM.Directions = function (map) {
   }
 
   setEngine("fossgis_osrm_car");
-  setEngine(Cookies.get("_osm_directions_engine"));
+  setEngine(OSM.cookies.get("_osm_directions_engine"));
 
   modeGroup.on("change", "input[name='modes']", function (e) {
     setEngine(chosenEngine.provider + "_" + e.target.value);
-    Cookies.set("_osm_directions_engine", chosenEngine.id, { secure: true, expires: expiry, path: "/", samesite: "lax" });
+    OSM.cookies.set("_osm_directions_engine", chosenEngine.id, { expires: expiry });
     getRoute(true, true);
   });
 
   select.on("change", function (e) {
     setEngine(e.target.value + "_" + chosenEngine.mode);
-    Cookies.set("_osm_directions_engine", chosenEngine.id, { secure: true, expires: expiry, path: "/", samesite: "lax" });
+    OSM.cookies.set("_osm_directions_engine", chosenEngine.id, { expires: expiry });
     getRoute(true, true);
   });
 

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -146,8 +146,8 @@ OSM.NewNote = function (map) {
 
       createNote(location, text, (feature) => {
         if (typeof OSM.user === "undefined") {
-          const anonymousNotesCount = Number(Cookies.get("_osm_anonymous_notes_count")) || 0;
-          Cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { secure: true, expires: 30, path: "/", samesite: "lax" });
+          const anonymousNotesCount = Number(OSM.cookies.get("_osm_anonymous_notes_count")) || 0;
+          OSM.cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { expires: 30 });
         }
         content.find("textarea").val("");
         addCreatedNoteMarker(feature);

--- a/app/assets/javascripts/language_selector.js
+++ b/app/assets/javascripts/language_selector.js
@@ -8,7 +8,7 @@ $(document).on("click", "#select_language_dialog [data-language-code]", function
     form.elements.language.value = code;
     form.submit();
   } else {
-    Cookies.set("_osm_locale", code, { secure: true, path: "/", samesite: "lax" });
+    OSM.cookies.set("_osm_locale", code);
     location.reload();
   }
 });

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -27,7 +27,7 @@ OSM = {
       end.to_json
   %>,
 
-  cookies: Cookies.withAttributes({ path: "/", samesite: "lax", secure: true }),
+  cookies: Cookies.withAttributes({ path: "/", samesite: "lax", secure: <%= (Settings.server_protocol == "https").to_json %> }),
 
   DEFAULT_LOCALE: <%= I18n.default_locale.to_json %>,
 

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -27,6 +27,8 @@ OSM = {
       end.to_json
   %>,
 
+  cookies: Cookies.withAttributes({ path: "/", samesite: "lax", secure: true }),
+
   DEFAULT_LOCALE: <%= I18n.default_locale.to_json %>,
 
   LAYER_DEFINITIONS: <%= MapLayers::full_definitions("config/layers.yml", :legends => "config/legend.yml").to_json %>,
@@ -73,7 +75,7 @@ OSM = {
 
     const hash = OSM.parseHash();
 
-    const loc = Cookies.get("_osm_location")?.split("|");
+    const loc = OSM.cookies.get("_osm_location")?.split("|");
 
     function bboxToLatLngBounds({ minlon, minlat, maxlon, maxlat }) {
       return L.latLngBounds([minlat, minlon], [maxlat, maxlon]);


### PR DESCRIPTION
Two changes:
- DRY up the code handling JS cookies.
	- It's very repetitive as every single instance repeats the arguments `{ secure: true, path: "/", samesite: "lax" }`.
	- We can avoid this using `Cookies.withAttributes`, creating a preset that I have placed at `OSM.cookies`.
	- Argument `expires` left in place as it does change in each instance.
- Change `secure: true` to only apply when HTTPS is expected. This is, when `Settings.server_protocol == "https"`.

This change is extracted from https://github.com/openstreetmap/openstreetmap-website/pull/6424. Over there it was done so that system tests work with remote Selenium.