### PR TITLE
Remove no-warning-comments eslint rule

### DIFF
--- a/config/eslint.config.mjs
+++ b/config/eslint.config.mjs
@@ -146,7 +146,6 @@ export default [
       "no-useless-return": "error",
       "no-var": "error",
       "no-void": "error",
-      "no-warning-comments": "warn",
       "operator-assignment": "error",
       "prefer-const": "error",
       "prefer-object-spread": "error",


### PR DESCRIPTION
Fixes #6434

This is the fast fix which removes the warning, but does not fix the TODOs.