### PR TITLE
Set getRoute default function parameters

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -19,13 +19,10 @@ OSM.Directions = function (map) {
 
     getRoute(false, !dragging);
   };
-  const endpointChangeCallback = function () {
-    getRoute(true, true);
-  };
 
   const endpoints = [
-    OSM.DirectionsEndpoint(map, $("input[name='route_from']"), { icon: "start", color: "var(--marker-green)" }, endpointDragCallback, endpointChangeCallback),
-    OSM.DirectionsEndpoint(map, $("input[name='route_to']"), { icon: "destination", color: "var(--marker-red)" }, endpointDragCallback, endpointChangeCallback)
+    OSM.DirectionsEndpoint(map, $("input[name='route_from']"), { icon: "start", color: "var(--marker-green)" }, endpointDragCallback, getRoute),
+    OSM.DirectionsEndpoint(map, $("input[name='route_to']"), { icon: "destination", color: "var(--marker-red)" }, endpointDragCallback, getRoute)
   ];
 
   const expires = new Date();
@@ -95,7 +92,7 @@ OSM.Directions = function (map) {
     select.val(chosenEngine.provider);
   }
 
-  function getRoute(fitRoute, reportErrors) {
+  function getRoute(fitRoute = true, reportErrors = true) {
     // Cancel any route that is already in progress
     if (controller) controller.abort();
 
@@ -153,18 +150,18 @@ OSM.Directions = function (map) {
   modeGroup.on("change", "input[name='modes']", function (e) {
     setEngine(chosenEngine.provider + "_" + e.target.value);
     OSM.cookies.set("_osm_directions_engine", chosenEngine.id, { expires });
-    getRoute(true, true);
+    getRoute();
   });
 
   select.on("change", function (e) {
     setEngine(e.target.value + "_" + chosenEngine.mode);
     OSM.cookies.set("_osm_directions_engine", chosenEngine.id, { expires });
-    getRoute(true, true);
+    getRoute();
   });
 
   $(".directions_form").on("submit", function (e) {
     e.preventDefault();
-    getRoute(true, true);
+    getRoute();
   });
 
   $(".routing_marker_column span").on("dragstart", function (e) {


### PR DESCRIPTION
An idea for closing #6442:
Use the selected mode of the mode group to trigger showing the route again after hiding the sidebar.
This does NOT request the route again.

Tested locally.