### PR TITLE
Enable ActionMailer Previews

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -189,6 +189,10 @@ Rails has its own log. To inspect the log during development:
 tail -f log/development.log
 ```
 
+### Email Previews
+
+We use [ActionMailer Previews](https://guides.rubyonrails.org/action_mailer_basics.html#previewing-and-testing-mailers) to generate previews of the emails sent by the application. Visit [http://localhost:3000/rails/mailers](http://localhost:3000/rails/mailers) to see the list of available previews.
+
 ### Maintaining Your Installation
 
 > [!TIP]

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "factory_bot_rails"
+
+class UserMailerPreview < ActionMailer::Preview
+  include FactoryBot::Syntax::Methods
+
+  # Wraps the preview in a transaction, so that no changes
+  # are persisted to the development db
+  def self.call(...)
+    preview = nil
+    ActiveRecord::Base.transaction do
+      preview = super(...)
+      raise ActiveRecord::Rollback
+    end
+    preview
+  end
+
+  def diary_comment_notification
+    recipient = create(:user, :languages => [I18n.locale])
+    diary_entry = create(:diary_entry)
+    diary_comment = create(:diary_comment, :diary_entry => diary_entry)
+    UserMailer.diary_comment_notification(diary_comment, recipient)
+  end
+end


### PR DESCRIPTION
Previewing email notifications during development is hard. Previously I've set up the [mailcatcher](https://mailcatcher.me/) gem and configured the app to send emails to the right place. But nowadays rails has a built-in option - [ActionMailer::Preview](https://guides.rubyonrails.org/action_mailer_basics.html#previewing-and-testing-mailers), so let's use that.

The previews run using the development database, which may or may not already contain sufficient records (e.g. diary comments). So to avoid failures, we generate content using factory bot, and to avoid filling your development database with duplicate data, we run the previews inside a transaction.

If you manually create records in the database that collide with factory bot (e.g. users with the same email pattern as the factory) then you'll need to update your manual records to avoid collisions.

My hope is that this will make it much easier for new contributors to work on the email notifications. If this PR is merged, then I intend to add an example of each outbound email to the previews.