### PR TITLE
Rename "Map Key" to "Legend" in UI and tests for consistency

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3539,9 +3539,9 @@ en:
     embed:
       report_problem: "Report a problem"
     legend:
-      title: "Map Key"
-      tooltip: "Map Key"
-      tooltip_disabled: "Map Key not available for this layer"
+      title: "Legend"
+      tooltip: "Legend"
+      tooltip_disabled: "Legend not available for this layer"
     map:
       zoom:
         in: Zoom In

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -48,7 +48,7 @@ class IndexTest < ApplicationSystemTestCase
 
     within "#map" do
       click_on "Share"
-      click_on "Map Key"
+      click_on "Legend"
     end
 
     assert_no_selector "#content.overlay-right-sidebar"
@@ -60,13 +60,13 @@ class IndexTest < ApplicationSystemTestCase
     assert_no_selector "#content.overlay-right-sidebar"
 
     within "#map" do
-      click_on "Map Key"
+      click_on "Legend"
     end
 
     assert_no_selector "#content.overlay-right-sidebar"
 
     within "#map" do
-      click_on "Map Key"
+      click_on "Legend"
     end
 
     assert_selector "#content.overlay-right-sidebar"

--- a/test/system/site_test.rb
+++ b/test/system/site_test.rb
@@ -18,25 +18,25 @@ class SiteTest < ApplicationSystemTestCase
     assert_selector ".tooltip", :text => "Layers"
   end
 
-  test "tooltip shows for Map Key button on Standard layer" do
+  test "tooltip shows for Legend button on Standard layer" do
     visit "/"
 
     assert_no_selector ".tooltip"
     button = find ".control-legend .control-button"
     button.hover
     tooltip = find ".tooltip"
-    tooltip.assert_text "Map Key"
+    tooltip.assert_text "Legend"
     tooltip.assert_no_text "not available"
   end
 
-  test "tooltip shows for Map Key button on a layer without a key provided" do
-    visit "/#layers=H" # assumes that HOT layer has no map key
+  test "tooltip shows for Legend button on a layer without a legend provided" do
+    visit "/#layers=H" # assumes that HOT layer has no legend
 
     assert_no_selector ".tooltip"
     button = find ".control-legend .control-button"
     button.hover
     tooltip = find ".tooltip"
-    tooltip.assert_text "Map Key"
+    tooltip.assert_text "Legend"
     tooltip.assert_text "not available"
   end
 


### PR DESCRIPTION
Following #6063, this PR aligns the labels with the terminology used everywhere else in this repo.