### PR TITLE
feat: add social links and company to user api endpoint

### DIFF
--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -5,6 +5,14 @@ json.user do
   json.display_name user.display_name
   json.account_created user.created_at.xmlschema
   json.description user.description if user.description
+  json.company user.company if user.company
+  json.social_links do
+    json.array! user.social_links do |link|
+      details = link.parsed
+      json.url details[:url]
+      json.platform details[:platform]
+    end
+  end
 
   if current_user && current_user == user && can?(:details, User)
     json.contributor_terms do

--- a/app/views/api/users/_user.xml.builder
+++ b/app/views/api/users/_user.xml.builder
@@ -4,6 +4,15 @@ xml.tag! "user", :id => user.id,
                  :display_name => user.display_name,
                  :account_created => user.created_at.xmlschema do
   xml.tag! "description", user.description if user.description
+  xml.tag! "company", user.company if user.company
+
+  xml.tag! "social-links" do
+    user.social_links.each do |link|
+      details = link.parsed
+      xml.tag! "link", details[:url], :platform => details[:platform]
+    end
+  end
+
   if current_user && current_user == user && can?(:details, User)
     xml.tag! "contributor-terms", :agreed => user.terms_agreed.present?,
                                   :pd => user.consider_pd


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
- add missing `company` property to api user endpoint
- add missing `social_links` property to api user endpoint

closes #6451 

### How has this been tested?
Manual, local testing. Could not find any automated tests for API endpoint properties.
