### PR TITLE
Bump minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,7 +159,7 @@ group :test do
   gem "erb_lint", :require => false
   gem "factory_bot_rails"
   gem "jwt"
-  gem "minitest", "~> 5.1"
+  gem "minitest"
   gem "minitest-focus", :require => false
   gem "puma", "~> 6.6"
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -935,7 +935,7 @@ DEPENDENCIES
   marcel
   maxminddb
   mini_racer (~> 0.9.0)
-  minitest (~> 5.1)
+  minitest
   minitest-focus
   omniauth (~> 2.1.3)
   omniauth-apple


### PR DESCRIPTION
### Description

This PR removes the version constraint for the minitest gem. A version constraint [was first added back in 2013](https://github.com/openstreetmap/openstreetmap-website/commit/61dd2af0a0d952c9aabea92426e961cfc09b838b), but I don't see a reason to keep it around at this point. If the gem receives a breaking update, we'll find out when the tests stop passing and can decide to ship a fix or pin a version as needed.

### How has this been tested?
The tests pass.
