### PR TITLE
Remove leftover Travis references

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 /Dockerfile*
 /docker-compose*
 /.dockerignore
-/.travis.yml
 /.git
 /.gitignore
 /.github

--- a/config/travis.database.yml
+++ b/config/travis.database.yml
@@ -1,5 +1,0 @@
-test:
-  adapter: postgresql
-  database: openstreetmap
-  username: postgres
-  encoding: utf8


### PR DESCRIPTION
As it says on the tin. Travis was removed in 2020 (https://github.com/openstreetmap/openstreetmap-website/pull/3002).