### PR TITLE
Docker: clear out apt repo after installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,30 +6,32 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install system packages then clean up to minimize image size
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
-  build-essential \
-  curl \
-  default-jre-headless \
-  file \
-  git-core \
-  gpg-agent \
-  libarchive-dev \
-  libffi-dev \
-  libgd-dev \
-  libpq-dev \
-  libsasl2-dev \
-  libvips-dev \
-  libxml2-dev \
-  libxslt1-dev \
-  libyaml-dev \
-  locales \
-  postgresql-client \
-  tzdata \
-  unzip \
-  nodejs \
-  npm \
-  osmosis \
-  ca-certificates \
-  firefox-esr
+    build-essential \
+    curl \
+    default-jre-headless \
+    file \
+    git-core \
+    gpg-agent \
+    libarchive-dev \
+    libffi-dev \
+    libgd-dev \
+    libpq-dev \
+    libsasl2-dev \
+    libvips-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libyaml-dev \
+    locales \
+    postgresql-client \
+    tzdata \
+    unzip \
+    nodejs \
+    npm \
+    osmosis \
+    ca-certificates \
+    firefox-esr \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* # Replace with `apt-get dist-clean` after upgrading to Debian 13 (Trixie)
 
 # Install yarn globally
 RUN npm install --global yarn


### PR DESCRIPTION
At https://github.com/openstreetmap/openstreetmap-website/pull/5157, this `apt-get clean` was removed. The man page describes this command as follows:

> clean clears out the local repository of retrieved package files. It removes everything but the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial/.

Normally I wouldn't have thought much about it, but what tickled me was that the comment at the top still says "then clean up to minimize image size". So this left me wondering whether I should update the comment or re-introduce the command. I couldn't see in the PR conversation anything about why it was removed, so I thought I'd start by proposing the re-introduction.

I didn't go as far as adding the `rm -rf /var/lib/apt/lists/*` line as I don't feel comfortable messing up with APT internals.

Thoughts? Perhaps @kcne remembers?