### PR TITLE
Order tracepoints before asking for the first one

### DIFF
--- a/test/controllers/api/traces_controller_test.rb
+++ b/test/controllers/api/traces_controller_test.rb
@@ -142,7 +142,7 @@ module Api
 
       # Validate tracepoints
       assert_equal 1, trace.points.size
-      tp = trace.points.first
+      tp = trace.points.order(:timestamp).first
       assert_equal 10000000, tp.latitude
       assert_equal 10000000, tp.longitude
       assert_equal 3221331576, tp.tile


### PR DESCRIPTION
This fixes a new warning in rails 8.1.0 about calling first on a query that does not have a defined order.

We've been getting away with because the trace only has one point.