### PR TITLE
Remove cookies_serializer initializer

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
### Description
In recent years [Rails has cut down on the number of initializers](https://github.com/rails/rails/pull/42538) it ships with. Some  because they are disabled initializers users may never need. Others because they specify values that are already set by default. This PR, like https://github.com/openstreetmap/openstreetmap-website/pull/6456, simplifies our initializers folder by removing an initializer[ that specifies already defined default behavior](https://github.com/rails/rails/blob/f73b7f173b3004ec9e920b99dafaaf029887847a/railties/lib/rails/application/configuration.rb#L231) and no longer ships with new Rails projects.

### How has this been tested?
The tests pass and I was able to navigate the app. Running `Rails.application.config.action_dispatch.cookies_serializer` returned `:json` before and after this change.
