### PR TITLE
Fix naming in abstract adapter initializer

### DIFF
--- a/config/initializers/abstract_adapter.rb
+++ b/config/initializers/abstract_adapter.rb
@@ -4,7 +4,7 @@ if defined?(ActiveRecord::ConnectionAdapters::AbstractAdapter)
   module OpenStreetMap
     module AbstractAdapter
       module PropagateTimeouts
-        def translate_exception_class(e, sql)
+        def translate_exception_class(e, sql, binds)
           if e.is_a?(Timeout::Error) || e.is_a?(OSM::APITimeoutError)
             e
           else


### PR DESCRIPTION
### Description
Fix module name referenced in AbstractAdapter.  Changes `ConnectionAdaptors` to `ConnectionAdapters`. 

### How has this been tested?
TBD
