### PR TITLE
Add explicit requirement for Node.js 22.2+

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,7 @@ Many of the dependencies are managed through the standard Ruby on Rails mechanis
 
 **Minimum requirements:**
 * Ruby 3.2+
+* Node.js 22.2+
 * PostgreSQL 13+
 * Bundler (see note below about [developer Ruby setup](#ruby-version-manager-optional))
 * JavaScript Runtime

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "eslint": "^9.0.0",
     "eslint-formatter-compact": "^9.0.1",
     "eslint-plugin-erb": "^2.1.0"
+  },
+  "engines": {
+    "node": ">=22.2"
   }
 }


### PR DESCRIPTION
As noted by @tomhughes at https://github.com/openstreetmap/openstreetmap-website/pull/6462#issuecomment-3435496014, this is the minimum required by osm-community-index, which is one of our dependencies. The change was introduced at https://github.com/osmlab/osm-community-index/commit/c3738945eeda5c43d6130d0139dc21d36352d39f
