### PR TITLE
Add mailer previews for all UserMailer notifications

### DIFF
--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -51,10 +51,35 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.gpx_failure(trace, error)
   end
 
+  def message_notification
+    recipient = create(:user, :languages => [I18n.locale])
+    message = create(:message, :recipient => recipient)
+    UserMailer.message_notification(message)
+  end
+
   def diary_comment_notification
     recipient = create(:user, :languages => [I18n.locale])
     diary_entry = create(:diary_entry)
     diary_comment = create(:diary_comment, :diary_entry => diary_entry)
     UserMailer.diary_comment_notification(diary_comment, recipient)
+  end
+
+  def follow_notification
+    following = create(:user, :languages => [I18n.locale])
+    follow = create(:follow, :following => following)
+    UserMailer.follow_notification(follow)
+  end
+
+  def note_comment_notification
+    recipient = create(:user, :languages => [I18n.locale])
+    commenter = create(:user)
+    comment = create(:note_comment, :author => commenter)
+    UserMailer.note_comment_notification(comment, recipient)
+  end
+
+  def changeset_comment_notification
+    recipient = create(:user, :languages => [I18n.locale])
+    comment = create(:changeset_comment)
+    UserMailer.changeset_comment_notification(comment, recipient)
   end
 end


### PR DESCRIPTION
This continues the work from #6449 by creating previews for all the other notifications. This makes them easier to develop.

As an example, I'd never noticed how much of a mouthful the changeset comment notification can be!

> "__User 30__ left a comment at 2025-10-29 11:55:02 UTC on a changeset you are watching created by User 29 without comment"

<img width="932" height="540" alt="image" src="https://github.com/user-attachments/assets/8ec99da2-da56-4615-bd21-46d821fad8bb" />

Maybe someone can refactor that one! :smile:
