### PR TITLE
drop obsolete IE related code

### DIFF
--- a/app/views/site/id.html.erb
+++ b/app/views/site/id.html.erb
@@ -3,9 +3,7 @@
 <head>
   <meta charset='utf-8'>
   <%= stylesheet_link_tag "id" %>
-  <!--[if !IE || gte IE 9]><!-->
   <%= javascript_include_tag "id" %>
-  <!-- <![endif]-->
   <title></title>
 </head>
 <body>


### PR DESCRIPTION
iD fully dropped support for IE [a while ago](https://github.com/openstreetmap/iD/blob/develop/CHANGELOG.md#2210). This comments were triggered only by the very oldest IE versions and prevented it from loading. As those old versions of IE are not able to parse the js of the modern versions of iD, it had no effect. And of course no mapper will want to use that ancient browser anyway.