### PR TITLE
Fix alignment issues on the profile page

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -288,8 +288,8 @@
     <div class="col-sm-9">
       <div class="richtext text-break"><%= @user.description.to_html %></div>
       <% if owned %>
-        <div class="mb-3">
-          <%= link_to t(".edit_description"), profile_description_path, :class => "btn btn-outline-primary" %>
+        <div class="mt-2 mb-3 col-sm-4">
+          <%= link_to t(".edit_description"), profile_description_path, :class => "btn btn-sm w-100 btn-outline-primary" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
about #6493
fix the problem that "Edit Profile Details" and "Edit Description" different size and are not aligned.
old version
<img width="1708" height="492" alt="image" src="https://github.com/user-attachments/assets/a10d72bf-b91c-4c96-ae23-f8a75e8d8786" />
new version
<img width="1678" height="458" alt="image" src="https://github.com/user-attachments/assets/fab71866-98cd-4bc0-94a6-d6d15b9a43c5" />
