### PR TITLE
WIP: Reduce use of Selenium in favour of rack-test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Enable virtual display
       run: Xvfb :99 -screen 0 1024x768x24 &
     - name: Run tests
-      run: bundle exec rails test:all
+      run: "bundle exec rails test test/system/[abcds]*"
       env:
         DISPLAY: ":99"
     - name: Run javascript tests

--- a/Gemfile
+++ b/Gemfile
@@ -173,7 +173,6 @@ end
 
 # Gems needed for running tests
 group :test do
-  gem "rack-test"
   gem "brakeman"
   gem "capybara", ">= 2.15"
   gem "erb_lint", :require => false
@@ -182,6 +181,7 @@ group :test do
   gem "minitest-focus", :require => false
   gem "minitest-mock"
   gem "puma", "~> 8.0"
+  gem "rack-test"
   gem "rails-controller-testing"
   gem "rubocop"
   gem "rubocop-capybara"

--- a/Gemfile
+++ b/Gemfile
@@ -173,6 +173,7 @@ end
 
 # Gems needed for running tests
 group :test do
+  gem "rack-test"
   gem "brakeman"
   gem "capybara", ">= 2.15"
   gem "erb_lint", :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -998,6 +998,7 @@ DEPENDENCIES
   puma (~> 8.0)
   quad_tile (~> 1.0.1)
   rack-cors
+  rack-test
   rack-uri_sanitizer
   rackup
   rails (~> 8.1.0)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -48,7 +48,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     end
   end
 
-  driven_by_selenium
+  driven_by :rack_test
 
   def before_setup
     super

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -48,6 +48,15 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     end
   end
 
+  def self.js_test(name, &)
+    js_test_class = subclasses.detect { |c| c.name.demodulize == "JsTest" }
+    js_test_class ||=
+      Class.new(self)
+           .tap { |klass| superclass.const_set("#{superclass.name.sub(/Test$/, '')}JsTest", klass) }
+           .tap(&:driven_by_selenium)
+    js_test_class.test(name, &)
+  end
+
   driven_by :rack_test
 
   def before_setup

--- a/test/system/account_deletion_test.rb
+++ b/test/system/account_deletion_test.rb
@@ -8,93 +8,99 @@ class AccountDeletionTest < ApplicationSystemTestCase
     sign_in_as(@user)
   end
 
-  test "the status is deleted and the personal data removed" do
-    visit account_path
+  class JsTest < AccountDeletionTest
+    driven_by_selenium
 
-    click_on "Delete Account..."
-    accept_confirm do
-      click_on "Delete Account"
+    test "the status is deleted and the personal data removed" do
+      visit account_path
+
+      click_on "Delete Account..."
+      accept_confirm do
+        click_on "Delete Account"
+      end
+
+      assert_current_path root_path
+      @user.reload
+      assert_equal "deleted", @user.status
+      assert_equal "user_#{@user.id}", @user.display_name
     end
 
-    assert_current_path root_path
-    @user.reload
-    assert_equal "deleted", @user.status
-    assert_equal "user_#{@user.id}", @user.display_name
-  end
+    test "the user is signed out after deletion" do
+      visit account_path
 
-  test "the user is signed out after deletion" do
-    visit account_path
+      click_on "Delete Account..."
+      accept_confirm do
+        click_on "Delete Account"
+      end
 
-    click_on "Delete Account..."
-    accept_confirm do
-      click_on "Delete Account"
+      assert_content "Log In"
     end
 
-    assert_content "Log In"
-  end
+    test "the user is shown a confirmation flash message" do
+      visit account_path
 
-  test "the user is shown a confirmation flash message" do
-    visit account_path
+      click_on "Delete Account..."
+      accept_confirm do
+        click_on "Delete Account"
+      end
 
-    click_on "Delete Account..."
-    accept_confirm do
-      click_on "Delete Account"
+      assert_content "Account Deleted"
     end
-
-    assert_content "Account Deleted"
   end
 
-  test "can delete with any delay setting value if the user has no changesets" do
-    with_user_account_deletion_delay(10000) do
-      travel 1.hour do
-        visit account_path
+  class HtmlTest < AccountDeletionTest
+    test "can delete with any delay setting value if the user has no changesets" do
+      with_user_account_deletion_delay(10000) do
+        travel 1.hour do
+          visit account_path
 
-        click_on "Delete Account..."
+          click_on "Delete Account..."
 
-        assert_no_content "cannot currently be deleted"
+          assert_no_content "cannot currently be deleted"
+        end
       end
     end
-  end
 
-  test "can delete with delay disabled" do
-    with_user_account_deletion_delay(nil) do
-      create(:changeset, :user => @user)
+    test "can delete with delay disabled" do
+      with_user_account_deletion_delay(nil) do
+        create(:changeset, :user => @user)
 
-      travel 1.hour do
-        visit account_path
+        travel 1.hour do
+          visit account_path
 
-        click_on "Delete Account..."
+          click_on "Delete Account..."
 
-        assert_no_content "cannot currently be deleted"
+          assert_no_content "cannot currently be deleted"
+        end
       end
     end
-  end
 
-  test "can delete when last changeset is old enough" do
-    with_user_account_deletion_delay(10) do
-      create(:changeset, :user => @user, :created_at => Time.now.utc, :closed_at => Time.now.utc + 1.hour)
+    test "can delete when last changeset is old enough" do
+      with_user_account_deletion_delay(10) do
+        create(:changeset, :user => @user, :created_at => Time.now.utc, :closed_at => Time.now.utc + 1.hour)
 
-      travel 12.hours do
-        visit account_path
+        travel 12.hours do
+          visit account_path
 
-        click_on "Delete Account..."
+          click_on "Delete Account..."
 
-        assert_no_content "cannot currently be deleted"
+          assert_no_content "cannot currently be deleted"
+        end
       end
     end
-  end
 
-  test "can't delete when last changeset isn't old enough" do
-    with_user_account_deletion_delay(10) do
-      create(:changeset, :user => @user, :created_at => Time.now.utc, :closed_at => Time.now.utc + 1.hour)
+    test "can't delete when last changeset isn't old enough" do
+      with_user_account_deletion_delay(10) do
+        create(:changeset, :user => @user, :created_at => Time.now.utc, :closed_at => Time.now.utc + 1.hour)
 
-      travel 10.hours do
-        visit account_path
+        travel 10.hours do
+          visit account_path
 
-        click_on "Delete Account..."
+          click_on "Delete Account..."
 
-        assert_content "cannot currently be deleted"
-        assert_content "in about 1 hour"
+          assert_content "cannot currently be deleted"
+          assert_content "in about 1 hour"
+        end
       end
     end
   end

--- a/test/system/account_deletion_test.rb
+++ b/test/system/account_deletion_test.rb
@@ -8,99 +8,93 @@ class AccountDeletionTest < ApplicationSystemTestCase
     sign_in_as(@user)
   end
 
-  class JsTest < AccountDeletionTest
-    driven_by_selenium
+  js_test "the status is deleted and the personal data removed" do
+    visit account_path
 
-    test "the status is deleted and the personal data removed" do
-      visit account_path
-
-      click_on "Delete Account..."
-      accept_confirm do
-        click_on "Delete Account"
-      end
-
-      assert_current_path root_path
-      @user.reload
-      assert_equal "deleted", @user.status
-      assert_equal "user_#{@user.id}", @user.display_name
+    click_on "Delete Account..."
+    accept_confirm do
+      click_on "Delete Account"
     end
 
-    test "the user is signed out after deletion" do
-      visit account_path
+    assert_current_path root_path
+    @user.reload
+    assert_equal "deleted", @user.status
+    assert_equal "user_#{@user.id}", @user.display_name
+  end
 
-      click_on "Delete Account..."
-      accept_confirm do
-        click_on "Delete Account"
-      end
+  js_test "the user is signed out after deletion" do
+    visit account_path
 
-      assert_content "Log In"
+    click_on "Delete Account..."
+    accept_confirm do
+      click_on "Delete Account"
     end
 
-    test "the user is shown a confirmation flash message" do
-      visit account_path
+    assert_content "Log In"
+  end
 
-      click_on "Delete Account..."
-      accept_confirm do
-        click_on "Delete Account"
+  js_test "the user is shown a confirmation flash message" do
+    visit account_path
+
+    click_on "Delete Account..."
+    accept_confirm do
+      click_on "Delete Account"
+    end
+
+    assert_content "Account Deleted"
+  end
+
+  test "can delete with any delay setting value if the user has no changesets" do
+    with_user_account_deletion_delay(10000) do
+      travel 1.hour do
+        visit account_path
+
+        click_on "Delete Account..."
+
+        assert_no_content "cannot currently be deleted"
       end
-
-      assert_content "Account Deleted"
     end
   end
 
-  class HtmlTest < AccountDeletionTest
-    test "can delete with any delay setting value if the user has no changesets" do
-      with_user_account_deletion_delay(10000) do
-        travel 1.hour do
-          visit account_path
+  test "can delete with delay disabled" do
+    with_user_account_deletion_delay(nil) do
+      create(:changeset, :user => @user)
 
-          click_on "Delete Account..."
+      travel 1.hour do
+        visit account_path
 
-          assert_no_content "cannot currently be deleted"
-        end
+        click_on "Delete Account..."
+
+        assert_no_content "cannot currently be deleted"
       end
     end
+  end
 
-    test "can delete with delay disabled" do
-      with_user_account_deletion_delay(nil) do
-        create(:changeset, :user => @user)
+  test "can delete when last changeset is old enough" do
+    with_user_account_deletion_delay(10) do
+      create(:changeset, :user => @user, :created_at => Time.now.utc, :closed_at => Time.now.utc + 1.hour)
 
-        travel 1.hour do
-          visit account_path
+      travel 12.hours do
+        visit account_path
 
-          click_on "Delete Account..."
+        click_on "Delete Account..."
 
-          assert_no_content "cannot currently be deleted"
-        end
+        assert_no_content "cannot currently be deleted"
       end
     end
+  end
 
-    test "can delete when last changeset is old enough" do
-      with_user_account_deletion_delay(10) do
-        create(:changeset, :user => @user, :created_at => Time.now.utc, :closed_at => Time.now.utc + 1.hour)
+  test "can't delete when last changeset isn't old enough" do
+    with_user_account_deletion_delay(10) do
+      create(:changeset, :user => @user, :created_at => Time.now.utc, :closed_at => Time.now.utc + 1.hour)
 
-        travel 12.hours do
-          visit account_path
+      travel 10.hours do
+        visit account_path
 
-          click_on "Delete Account..."
+        click_on "Delete Account..."
 
-          assert_no_content "cannot currently be deleted"
-        end
-      end
-    end
-
-    test "can't delete when last changeset isn't old enough" do
-      with_user_account_deletion_delay(10) do
-        create(:changeset, :user => @user, :created_at => Time.now.utc, :closed_at => Time.now.utc + 1.hour)
-
-        travel 10.hours do
-          visit account_path
-
-          click_on "Delete Account..."
-
-          assert_content "cannot currently be deleted"
-          assert_content "in about 1 hour"
-        end
+        assert_content "cannot currently be deleted"
+        assert_content "in about 1 hour"
       end
     end
   end

--- a/test/system/account_home_test.rb
+++ b/test/system/account_home_test.rb
@@ -3,57 +3,63 @@
 require "application_system_test_case"
 
 class AccountHomeTest < ApplicationSystemTestCase
-  test "Go to Home Location works on map layout pages" do
-    user = create(:user, :display_name => "test user", :home_lat => 60, :home_lon => 30)
-    sign_in_as(user)
+  class HtmlTest < AccountHomeTest
+    test "Go to Home Location is not available for users without home location" do
+      user = create(:user, :display_name => "test user")
+      sign_in_as(user)
 
-    visit root_path
-    assert_no_selector ".leaflet-marker-icon"
+      visit root_path
+      assert_no_selector ".leaflet-marker-icon"
 
-    click_on "test user"
-    click_on "Go to Home Location"
-    all ".leaflet-marker-icon", :count => 1 do |marker|
-      assert_equal "My home location", marker["title"]
+      click_on "test user"
+      assert_no_link "Go to Home Location"
+    end
+  end
+
+  class JsTest < AccountHomeTest
+    driven_by_selenium
+
+    test "Go to Home Location works on map layout pages" do
+      user = create(:user, :display_name => "test user", :home_lat => 60, :home_lon => 30)
+      sign_in_as(user)
+
+      visit root_path
+      assert_no_selector ".leaflet-marker-icon"
+
+      click_on "test user"
+      click_on "Go to Home Location"
+      all ".leaflet-marker-icon", :count => 1 do |marker|
+        assert_equal "My home location", marker["title"]
+      end
+
+      click_on "OpenStreetMap logo"
+      assert_no_selector ".leaflet-marker-icon"
     end
 
-    click_on "OpenStreetMap logo"
-    assert_no_selector ".leaflet-marker-icon"
-  end
+    test "Go to Home Location works on non-map layout pages" do
+      user = create(:user, :display_name => "test user", :home_lat => 60, :home_lon => 30)
+      sign_in_as(user)
 
-  test "Go to Home Location works on non-map layout pages" do
-    user = create(:user, :display_name => "test user", :home_lat => 60, :home_lon => 30)
-    sign_in_as(user)
+      visit about_path
+      assert_no_selector ".leaflet-marker-icon"
 
-    visit about_path
-    assert_no_selector ".leaflet-marker-icon"
+      click_on "test user"
+      click_on "Go to Home Location"
+      all ".leaflet-marker-icon", :count => 1 do |marker|
+        assert_equal "My home location", marker["title"]
+      end
 
-    click_on "test user"
-    click_on "Go to Home Location"
-    all ".leaflet-marker-icon", :count => 1 do |marker|
-      assert_equal "My home location", marker["title"]
+      click_on "OpenStreetMap logo"
+      assert_no_selector ".leaflet-marker-icon"
     end
 
-    click_on "OpenStreetMap logo"
-    assert_no_selector ".leaflet-marker-icon"
-  end
+    test "account home page shows a warning when visited by users without home location" do
+      user = create(:user, :display_name => "test user")
+      sign_in_as(user)
 
-  test "Go to Home Location is not available for users without home location" do
-    user = create(:user, :display_name => "test user")
-    sign_in_as(user)
-
-    visit root_path
-    assert_no_selector ".leaflet-marker-icon"
-
-    click_on "test user"
-    assert_no_link "Go to Home Location"
-  end
-
-  test "account home page shows a warning when visited by users without home location" do
-    user = create(:user, :display_name => "test user")
-    sign_in_as(user)
-
-    visit account_home_path
-    assert_no_selector ".leaflet-marker-icon"
-    assert_text "Home location is not set"
+      visit account_home_path
+      assert_no_selector ".leaflet-marker-icon"
+      assert_text "Home location is not set"
+    end
   end
 end

--- a/test/system/browse_comment_links_test.rb
+++ b/test/system/browse_comment_links_test.rb
@@ -3,6 +3,8 @@
 require "application_system_test_case"
 
 class BrowseCommentLinksTest < ApplicationSystemTestCase
+  driven_by_selenium
+
   test "visiting changeset comment link should pan to changeset" do
     changeset = create(:changeset, :bbox => [30, 60, 30, 60])
     comment = create(:changeset_comment, :changeset => changeset, :body => "Linked changeset comment")

--- a/test/system/changeset_comments_test.rb
+++ b/test/system/changeset_comments_test.rb
@@ -3,162 +3,168 @@
 require "application_system_test_case"
 
 class ChangesetCommentsTest < ApplicationSystemTestCase
-  test "open changeset has a still open notice" do
-    changeset = create(:changeset)
-    sign_in_as(create(:user))
-    visit changeset_path(changeset)
+  class HtmlTest < ChangesetCommentsTest
+    test "open changeset has a still open notice" do
+      changeset = create(:changeset)
+      sign_in_as(create(:user))
+      visit changeset_path(changeset)
 
-    within_sidebar do
-      assert_no_button "Comment"
-      assert_text "Changeset still open"
+      within_sidebar do
+        assert_no_button "Comment"
+        assert_text "Changeset still open"
+      end
+    end
+
+    test "changeset has a login notice" do
+      changeset = create(:changeset, :closed)
+      visit changeset_path(changeset)
+
+      within_sidebar do
+        assert_no_button "Subscribe"
+        assert_no_button "Comment"
+        assert_link "Log in to join the discussion", :href => login_path(:referer => changeset_path(changeset))
+      end
+    end
+
+    test "regular users can't hide comments" do
+      changeset = create(:changeset, :closed)
+      create(:changeset_comment, :changeset => changeset, :body => "Unwanted comment")
+      sign_in_as(create(:user))
+      visit changeset_path(changeset)
+
+      within_sidebar do
+        assert_text "Unwanted comment"
+        assert_no_button "hide"
+      end
     end
   end
 
-  test "changeset has a login notice" do
-    changeset = create(:changeset, :closed)
-    visit changeset_path(changeset)
+  class JsTest < ChangesetCommentsTest
+    driven_by_selenium
 
-    within_sidebar do
-      assert_no_button "Subscribe"
-      assert_no_button "Comment"
-      assert_link "Log in to join the discussion", :href => login_path(:referer => changeset_path(changeset))
-    end
-  end
+    test "can add a comment to a changeset" do
+      changeset = create(:changeset, :closed)
+      user = create(:user)
+      sign_in_as(user)
+      visit changeset_path(changeset)
 
-  test "can add a comment to a changeset" do
-    changeset = create(:changeset, :closed)
-    user = create(:user)
-    sign_in_as(user)
-    visit changeset_path(changeset)
+      within_sidebar do
+        assert_no_content "Comment from #{user.display_name}"
+        assert_no_content "Some newly added changeset comment"
+        assert_button "Comment", :disabled => true
 
-    within_sidebar do
-      assert_no_content "Comment from #{user.display_name}"
-      assert_no_content "Some newly added changeset comment"
-      assert_button "Comment", :disabled => true
+        fill_in "text", :with => "Some newly added changeset comment"
 
-      fill_in "text", :with => "Some newly added changeset comment"
+        assert_button "Comment", :disabled => false
 
-      assert_button "Comment", :disabled => false
+        click_on "Comment"
 
-      click_on "Comment"
-
-      assert_content "Comment from #{user.display_name}"
-      assert_content "Some newly added changeset comment"
-    end
-  end
-
-  test "regular users can't hide comments" do
-    changeset = create(:changeset, :closed)
-    create(:changeset_comment, :changeset => changeset, :body => "Unwanted comment")
-    sign_in_as(create(:user))
-    visit changeset_path(changeset)
-
-    within_sidebar do
-      assert_text "Unwanted comment"
-      assert_no_button "hide"
-    end
-  end
-
-  test "moderators can hide comments" do
-    changeset = create(:changeset, :closed)
-    create(:changeset_comment, :changeset => changeset, :body => "Unwanted comment")
-
-    visit changeset_path(changeset)
-
-    within_sidebar do
-      assert_text "Unwanted comment"
+        assert_content "Comment from #{user.display_name}"
+        assert_content "Some newly added changeset comment"
+      end
     end
 
-    sign_in_as(create(:moderator_user))
-    visit changeset_path(changeset)
+    test "moderators can hide comments" do
+      changeset = create(:changeset, :closed)
+      create(:changeset_comment, :changeset => changeset, :body => "Unwanted comment")
 
-    within_sidebar do
-      assert_text "Unwanted comment"
-      assert_button "hide", :exact => true
-      assert_no_button "unhide", :exact => true
+      visit changeset_path(changeset)
 
-      click_on "hide", :exact => true
+      within_sidebar do
+        assert_text "Unwanted comment"
+      end
 
-      assert_text "Unwanted comment"
-      assert_no_button "hide", :exact => true
-      assert_button "unhide", :exact => true
+      sign_in_as(create(:moderator_user))
+      visit changeset_path(changeset)
+
+      within_sidebar do
+        assert_text "Unwanted comment"
+        assert_button "hide", :exact => true
+        assert_no_button "unhide", :exact => true
+
+        click_on "hide", :exact => true
+
+        assert_text "Unwanted comment"
+        assert_no_button "hide", :exact => true
+        assert_button "unhide", :exact => true
+      end
+
+      sign_out
+      visit changeset_path(changeset)
+
+      within_sidebar do
+        assert_no_text "Unwanted comment"
+      end
     end
 
-    sign_out
-    visit changeset_path(changeset)
+    test "moderators can unhide comments" do
+      changeset = create(:changeset, :closed)
+      create(:changeset_comment, :changeset => changeset, :body => "Wanted comment", :visible => false)
 
-    within_sidebar do
-      assert_no_text "Unwanted comment"
+      visit changeset_path(changeset)
+
+      within_sidebar do
+        assert_no_text "Wanted comment"
+      end
+
+      sign_in_as(create(:moderator_user))
+      visit changeset_path(changeset)
+
+      within_sidebar do
+        assert_text "Wanted comment"
+        assert_no_button "hide", :exact => true
+        assert_button "unhide", :exact => true
+
+        click_on "unhide", :exact => true
+
+        assert_text "Wanted comment"
+        assert_button "hide", :exact => true
+        assert_no_button "unhide", :exact => true
+      end
+
+      sign_out
+      visit changeset_path(changeset)
+
+      within_sidebar do
+        assert_text "Wanted comment"
+      end
     end
-  end
 
-  test "moderators can unhide comments" do
-    changeset = create(:changeset, :closed)
-    create(:changeset_comment, :changeset => changeset, :body => "Wanted comment", :visible => false)
+    test "can subscribe" do
+      changeset = create(:changeset, :closed)
+      user = create(:user)
+      sign_in_as(user)
+      visit changeset_path(changeset)
 
-    visit changeset_path(changeset)
+      within_sidebar do
+        assert_button "Subscribe"
+        assert_no_button "Unsubscribe"
 
-    within_sidebar do
-      assert_no_text "Wanted comment"
+        click_on "Subscribe"
+
+        assert_no_button "Subscribe"
+        assert_button "Unsubscribe"
+      end
     end
 
-    sign_in_as(create(:moderator_user))
-    visit changeset_path(changeset)
+    test "can't subscribe when blocked" do
+      changeset = create(:changeset, :closed)
+      user = create(:user)
+      sign_in_as(user)
+      visit changeset_path(changeset)
+      create(:user_block, :user => user)
 
-    within_sidebar do
-      assert_text "Wanted comment"
-      assert_no_button "hide", :exact => true
-      assert_button "unhide", :exact => true
+      within_sidebar do
+        assert_no_text "Your access to the API has been blocked"
+        assert_button "Subscribe"
+        assert_no_button "Unsubscribe"
 
-      click_on "unhide", :exact => true
+        click_on "Subscribe"
 
-      assert_text "Wanted comment"
-      assert_button "hide", :exact => true
-      assert_no_button "unhide", :exact => true
-    end
-
-    sign_out
-    visit changeset_path(changeset)
-
-    within_sidebar do
-      assert_text "Wanted comment"
-    end
-  end
-
-  test "can subscribe" do
-    changeset = create(:changeset, :closed)
-    user = create(:user)
-    sign_in_as(user)
-    visit changeset_path(changeset)
-
-    within_sidebar do
-      assert_button "Subscribe"
-      assert_no_button "Unsubscribe"
-
-      click_on "Subscribe"
-
-      assert_no_button "Subscribe"
-      assert_button "Unsubscribe"
-    end
-  end
-
-  test "can't subscribe when blocked" do
-    changeset = create(:changeset, :closed)
-    user = create(:user)
-    sign_in_as(user)
-    visit changeset_path(changeset)
-    create(:user_block, :user => user)
-
-    within_sidebar do
-      assert_no_text "Your access to the API has been blocked"
-      assert_button "Subscribe"
-      assert_no_button "Unsubscribe"
-
-      click_on "Subscribe"
-
-      assert_text "Your access to the API has been blocked"
-      assert_button "Subscribe"
-      assert_no_button "Unsubscribe"
+        assert_text "Your access to the API has been blocked"
+        assert_button "Subscribe"
+        assert_no_button "Unsubscribe"
+      end
     end
   end
 end

--- a/test/system/changeset_elements_test.rb
+++ b/test/system/changeset_elements_test.rb
@@ -3,6 +3,8 @@
 require "application_system_test_case"
 
 class ChangesetElementsTest < ApplicationSystemTestCase
+  driven_by_selenium
+
   test "can navigate between element subpages without losing comment input" do
     element_page_size = 20
     changeset = create(:changeset, :closed, :num_changes => 2 * (element_page_size + 1))

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -16,221 +16,227 @@ class CreateNoteTest < ApplicationSystemTestCase
     OmniAuth.config.test_mode = false
   end
 
-  test "can create note" do
-    visit new_note_path(:anchor => "map=18/0/0")
+  class HtmlTest < CreateNoteTest
+    test "cannot create note when api is readonly" do
+      with_settings(:status => "api_readonly") do
+        visit new_note_path(:anchor => "map=18/0/0")
 
-    within_sidebar do
-      assert_button "Add Note", :disabled => true
-
-      fill_in "text", :with => "Some newly added note description"
-      click_on "Add Note"
-
-      assert_content "Unresolved note #"
-      assert_content "Some newly added note description"
+        within_sidebar do
+          assert_no_button "Add Note", :disabled => true
+        end
+      end
     end
   end
 
-  test "cannot create new note when zoomed out" do
-    visit new_note_path(:anchor => "map=12/0/0")
+  class JsTest < CreateNoteTest
+    driven_by_selenium
 
-    within_sidebar do
-      assert_no_content "Zoom in to add a note"
-      assert_button "Add Note", :disabled => true
-
-      fill_in "text", :with => "Some newly added note description"
-
-      assert_no_content "Zoom in to add a note"
-      assert_button "Add Note", :disabled => false
-    end
-
-    within "#map" do
-      click_on "Zoom Out"
-    end
-
-    within_sidebar do
-      assert_content "Zoom in to add a note"
-      assert_button "Add Note", :disabled => true
-    end
-
-    within "#map" do
-      click_on "Zoom In"
-    end
-
-    within_sidebar do
-      assert_no_content "Zoom in to add a note"
-      assert_button "Add Note", :disabled => false
-
-      click_on "Add Note"
-
-      assert_content "Unresolved note #"
-      assert_content "Some newly added note description"
-    end
-  end
-
-  test "can open new note page when zoomed out" do
-    visit new_note_path(:anchor => "map=11/0/0")
-
-    within_sidebar do
-      assert_content "Zoom in to add a note"
-      assert_button "Add Note", :disabled => true
-
-      fill_in "text", :with => "Some newly added note description"
-
-      assert_content "Zoom in to add a note"
-      assert_button "Add Note", :disabled => true
-    end
-
-    within "#map" do
-      click_on "Zoom In"
-    end
-
-    within_sidebar do
-      assert_no_content "Zoom in to add a note"
-      assert_button "Add Note", :disabled => false
-    end
-  end
-
-  test "cannot create note when api is readonly" do
-    with_settings(:status => "api_readonly") do
+    test "can create note" do
       visit new_note_path(:anchor => "map=18/0/0")
 
       within_sidebar do
-        assert_no_button "Add Note", :disabled => true
+        assert_button "Add Note", :disabled => true
+
+        fill_in "text", :with => "Some newly added note description"
+        click_on "Add Note"
+
+        assert_content "Unresolved note #"
+        assert_content "Some newly added note description"
       end
     end
-  end
 
-  test "encouragement to contribute appears after 5 created notes and disappears after login" do
-    check_encouragement_while_creating_notes(5)
+    test "cannot create new note when zoomed out" do
+      visit new_note_path(:anchor => "map=12/0/0")
 
-    sign_in_as(create(:user))
+      within_sidebar do
+        assert_no_content "Zoom in to add a note"
+        assert_button "Add Note", :disabled => true
 
-    check_no_encouragement_while_logging_out
-  end
+        fill_in "text", :with => "Some newly added note description"
 
-  test "encouragement to contribute appears after 5 created notes and disappears after email signup" do
-    check_encouragement_while_creating_notes(5)
+        assert_no_content "Zoom in to add a note"
+        assert_button "Add Note", :disabled => false
+      end
 
-    sign_up_with_email
+      within "#map" do
+        click_on "Zoom Out"
+      end
 
-    check_no_encouragement_while_logging_out
-  end
+      within_sidebar do
+        assert_content "Zoom in to add a note"
+        assert_button "Add Note", :disabled => true
+      end
 
-  test "encouragement to contribute appears after 5 created notes and disappears after google signup" do
-    check_encouragement_while_creating_notes(5)
+      within "#map" do
+        click_on "Zoom In"
+      end
 
-    sign_up_with_google
+      within_sidebar do
+        assert_no_content "Zoom in to add a note"
+        assert_button "Add Note", :disabled => false
 
-    check_no_encouragement_while_logging_out
-  end
+        click_on "Add Note"
 
-  test "strict encouragement to contribute appears after 10 created notes and disappears after login" do
-    check_strict_encouragement_while_creating_notes(5, 10)
+        assert_content "Unresolved note #"
+        assert_content "Some newly added note description"
+      end
+    end
 
-    sign_in_as(create(:user))
+    test "can open new note page when zoomed out" do
+      visit new_note_path(:anchor => "map=11/0/0")
 
-    check_no_encouragement_while_logging_out
-  end
+      within_sidebar do
+        assert_content "Zoom in to add a note"
+        assert_button "Add Note", :disabled => true
 
-  private
+        fill_in "text", :with => "Some newly added note description"
 
-  def check_encouragement_while_creating_notes(encouragement_threshold)
-    encouragement_threshold.times do |n|
-      visit new_note_path(:anchor => "map=16/0/#{0.001 * n}")
+        assert_content "Zoom in to add a note"
+        assert_button "Add Note", :disabled => true
+      end
+
+      within "#map" do
+        click_on "Zoom In"
+      end
+
+      within_sidebar do
+        assert_no_content "Zoom in to add a note"
+        assert_button "Add Note", :disabled => false
+      end
+    end
+
+    test "encouragement to contribute appears after 5 created notes and disappears after login" do
+      check_encouragement_while_creating_notes(5)
+
+      sign_in_as(create(:user))
+
+      check_no_encouragement_while_logging_out
+    end
+
+    test "encouragement to contribute appears after 5 created notes and disappears after email signup" do
+      check_encouragement_while_creating_notes(5)
+
+      sign_up_with_email
+
+      check_no_encouragement_while_logging_out
+    end
+
+    test "encouragement to contribute appears after 5 created notes and disappears after google signup" do
+      check_encouragement_while_creating_notes(5)
+
+      sign_up_with_google
+
+      check_no_encouragement_while_logging_out
+    end
+
+    test "strict encouragement to contribute appears after 10 created notes and disappears after login" do
+      check_strict_encouragement_while_creating_notes(5, 10)
+
+      sign_in_as(create(:user))
+
+      check_no_encouragement_while_logging_out
+    end
+
+    private
+
+    def check_encouragement_while_creating_notes(encouragement_threshold)
+      encouragement_threshold.times do |n|
+        visit new_note_path(:anchor => "map=16/0/#{0.001 * n}")
+
+        within_sidebar do
+          assert_no_content(/already posted at least \d+ anonymous note/)
+
+          fill_in "text", :with => "new note ##{n + 1}"
+          click_on "Add Note"
+
+          assert_content "new note ##{n + 1}"
+        end
+      end
+
+      visit new_note_path(:anchor => "map=16/0/#{0.001 * encouragement_threshold}")
+
+      within_sidebar do
+        assert_content(/already posted at least #{encouragement_threshold} anonymous note/)
+      end
+    end
+
+    def check_strict_encouragement_while_creating_notes(encouragement_threshold, strict_encouragement_threshold)
+      strict_encouragement_threshold.times do |n|
+        visit new_note_path(:anchor => "map=16/0/#{0.001 * n}")
+
+        within_sidebar do
+          if n < encouragement_threshold
+            assert_no_content(/already posted at least \d+ anonymous note/)
+          else
+            assert_content(/already posted at least \d+ anonymous note/)
+          end
+
+          fill_in "text", :with => "new note ##{n + 1}"
+          click_on "Add Note"
+
+          assert_content "new note ##{n + 1}"
+        end
+      end
+
+      visit new_note_path(:anchor => "map=16/0/#{0.001 * strict_encouragement_threshold}")
+
+      within_sidebar do
+        assert_content(/already posted at least #{strict_encouragement_threshold} anonymous note/)
+        assert_no_button "Add Note"
+      end
+    end
+
+    def check_no_encouragement_while_logging_out
+      visit new_note_path(:anchor => "map=16/0/0")
 
       within_sidebar do
         assert_no_content(/already posted at least \d+ anonymous note/)
-
-        fill_in "text", :with => "new note ##{n + 1}"
-        click_on "Add Note"
-
-        assert_content "new note ##{n + 1}"
       end
-    end
 
-    visit new_note_path(:anchor => "map=16/0/#{0.001 * encouragement_threshold}")
-
-    within_sidebar do
-      assert_content(/already posted at least #{encouragement_threshold} anonymous note/)
-    end
-  end
-
-  def check_strict_encouragement_while_creating_notes(encouragement_threshold, strict_encouragement_threshold)
-    strict_encouragement_threshold.times do |n|
-      visit new_note_path(:anchor => "map=16/0/#{0.001 * n}")
+      sign_out
+      visit new_note_path(:anchor => "map=16/0/0")
 
       within_sidebar do
-        if n < encouragement_threshold
-          assert_no_content(/already posted at least \d+ anonymous note/)
-        else
-          assert_content(/already posted at least \d+ anonymous note/)
-        end
-
-        fill_in "text", :with => "new note ##{n + 1}"
-        click_on "Add Note"
-
-        assert_content "new note ##{n + 1}"
+        assert_no_content(/already posted at least \d+ anonymous note/)
       end
     end
 
-    visit new_note_path(:anchor => "map=16/0/#{0.001 * strict_encouragement_threshold}")
+    def sign_up_with_email
+      click_on "Sign Up"
 
-    within_sidebar do
-      assert_content(/already posted at least #{strict_encouragement_threshold} anonymous note/)
-      assert_no_button "Add Note"
+      within_content_body do
+        fill_in "Email", :with => "new_user_account@example.com"
+        fill_in "Display Name", :with => "new_user_account"
+        fill_in "Password", :with => "new_user_password"
+        fill_in "Confirm Password", :with => "new_user_password"
+
+        assert_emails 1 do
+          click_on "Sign Up"
+        end
+      end
+
+      email = ActionMailer::Base.deliveries.first
+      email_text = email.parts[0].parts[0].decoded
+      match = %r{/user/new_user_account/confirm\?confirm_string=\S+}.match(email_text)
+      assert_not_nil match
+
+      visit match[0]
+
+      assert_content "Welcome!"
     end
-  end
 
-  def check_no_encouragement_while_logging_out
-    visit new_note_path(:anchor => "map=16/0/0")
+    def sign_up_with_google
+      OmniAuth.config.add_mock(:google,
+                               :uid => "123454321",
+                               :extra => { :id_info => { :openid_id => "http://localhost:1123/new.tester" } },
+                               :info => { :email => "google_user_account@example.com", :name => "google_user_account" })
 
-    within_sidebar do
-      assert_no_content(/already posted at least \d+ anonymous note/)
-    end
+      click_on "Sign Up"
 
-    sign_out
-    visit new_note_path(:anchor => "map=16/0/0")
-
-    within_sidebar do
-      assert_no_content(/already posted at least \d+ anonymous note/)
-    end
-  end
-
-  def sign_up_with_email
-    click_on "Sign Up"
-
-    within_content_body do
-      fill_in "Email", :with => "new_user_account@example.com"
-      fill_in "Display Name", :with => "new_user_account"
-      fill_in "Password", :with => "new_user_password"
-      fill_in "Confirm Password", :with => "new_user_password"
-
-      assert_emails 1 do
+      within_content_body do
+        click_on "Log in with Google"
         click_on "Sign Up"
       end
-    end
-
-    email = ActionMailer::Base.deliveries.first
-    email_text = email.parts[0].parts[0].decoded
-    match = %r{/user/new_user_account/confirm\?confirm_string=\S+}.match(email_text)
-    assert_not_nil match
-
-    visit match[0]
-
-    assert_content "Welcome!"
-  end
-
-  def sign_up_with_google
-    OmniAuth.config.add_mock(:google,
-                             :uid => "123454321",
-                             :extra => { :id_info => { :openid_id => "http://localhost:1123/new.tester" } },
-                             :info => { :email => "google_user_account@example.com", :name => "google_user_account" })
-
-    click_on "Sign Up"
-
-    within_content_body do
-      click_on "Log in with Google"
-      click_on "Sign Up"
     end
   end
 end

--- a/test/system/dashboard_test.rb
+++ b/test/system/dashboard_test.rb
@@ -3,73 +3,79 @@
 require "application_system_test_case"
 
 class DashboardSystemTest < ApplicationSystemTestCase
-  test "show no users if have no followings" do
-    user = create(:user)
-    sign_in_as(user)
+  class HtmlTest < DashboardSystemTest
+    test "show no users if have no followings" do
+      user = create(:user)
+      sign_in_as(user)
 
-    visit dashboard_path
-    assert_text "You have not followed any user yet."
-  end
-
-  test "show users if have friends" do
-    user = create(:user, :home_lon => 1.1, :home_lat => 1.1)
-    friend_user = create(:user, :home_lon => 1.2, :home_lat => 1.2)
-    create(:follow, :follower => user, :following => friend_user)
-    create(:changeset, :user => friend_user)
-    sign_in_as(user)
-
-    visit dashboard_path
-    assert_no_text "You have not followed any user yet."
-
-    friends_heading = find :element, "h2", :text => "Users you follow"
-    others_heading = find :element, "h2", :text => "Other nearby users"
-
-    assert_link friend_user.display_name, :below => friends_heading, :above => others_heading
-  end
-
-  test "show nearby users with ability to follow" do
-    user = create(:user, :home_lon => 1.1, :home_lat => 1.1)
-    nearby_user = create(:user, :home_lon => 1.2, :home_lat => 1.2)
-    sign_in_as(user)
-
-    visit dashboard_path
-
-    within_content_body do
-      others_nearby_heading = find :element, "h2", :text => "Other nearby users"
-
-      assert_no_text "There are no other users who admit to mapping nearby yet"
-      assert_link nearby_user.display_name, :below => others_nearby_heading
-      assert_link "Follow", :below => others_nearby_heading
-
-      click_on "Follow"
-
-      followings_heading = find :element, "h2", :text => "Users you follow"
-      others_nearby_heading = find :element, "h2", :text => "Other nearby users"
-
-      assert_text "There are no other users who admit to mapping nearby yet"
-      assert_link nearby_user.display_name, :below => followings_heading, :above => others_nearby_heading
-      assert_link "Unfollow", :below => followings_heading, :above => others_nearby_heading
+      visit dashboard_path
+      assert_text "You have not followed any user yet."
     end
   end
 
-  test "show map with home marker if home location is set" do
-    user = create(:user, :display_name => "Fred Tester", :home_lon => 1.1, :home_lat => 1.1)
-    sign_in_as(user)
+  class JsTest < DashboardSystemTest
+    driven_by_selenium
 
-    visit dashboard_path
+    test "show users if have friends" do
+      user = create(:user, :home_lon => 1.1, :home_lat => 1.1)
+      friend_user = create(:user, :home_lon => 1.2, :home_lat => 1.2)
+      create(:follow, :follower => user, :following => friend_user)
+      create(:changeset, :user => friend_user)
+      sign_in_as(user)
 
-    within "#map" do
-      assert_no_text "Your location"
-      assert_no_link "Fred Tester"
+      visit dashboard_path
+      assert_no_text "You have not followed any user yet."
 
-      find(".maplibre-gl-marker").click
+      friends_heading = find :element, "h2", :text => "Users you follow"
+      others_heading = find :element, "h2", :text => "Other nearby users"
 
-      assert_text "Your location"
-      assert_link "Fred Tester"
-
-      click_on "Fred Tester"
+      assert_link friend_user.display_name, :below => friends_heading, :above => others_heading
     end
 
-    assert_current_path user_path(user)
+    test "show nearby users with ability to follow" do
+      user = create(:user, :home_lon => 1.1, :home_lat => 1.1)
+      nearby_user = create(:user, :home_lon => 1.2, :home_lat => 1.2)
+      sign_in_as(user)
+
+      visit dashboard_path
+
+      within_content_body do
+        others_nearby_heading = find :element, "h2", :text => "Other nearby users"
+
+        assert_no_text "There are no other users who admit to mapping nearby yet"
+        assert_link nearby_user.display_name, :below => others_nearby_heading
+        assert_link "Follow", :below => others_nearby_heading
+
+        click_on "Follow"
+
+        followings_heading = find :element, "h2", :text => "Users you follow"
+        others_nearby_heading = find :element, "h2", :text => "Other nearby users"
+
+        assert_text "There are no other users who admit to mapping nearby yet"
+        assert_link nearby_user.display_name, :below => followings_heading, :above => others_nearby_heading
+        assert_link "Unfollow", :below => followings_heading, :above => others_nearby_heading
+      end
+    end
+
+    test "show map with home marker if home location is set" do
+      user = create(:user, :display_name => "Fred Tester", :home_lon => 1.1, :home_lat => 1.1)
+      sign_in_as(user)
+
+      visit dashboard_path
+
+      within "#map" do
+        assert_no_text "Your location"
+        assert_no_link "Fred Tester"
+
+        find(".maplibre-gl-marker").click
+
+        assert_text "Your location"
+        assert_link "Fred Tester"
+
+        click_on "Fred Tester"
+      end
+
+      assert_current_path user_path(user)
+    end
   end
 end

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -11,154 +11,160 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     @diary_entry = create(:diary_entry)
   end
 
-  test "reply to diary entry should prefill the message subject" do
-    sign_in_as(create(:user))
-    visit diary_entries_path
+  class HtmlTest < DiaryEntrySystemTest
+    test "reply to diary entry should prefill the message subject" do
+      sign_in_as(create(:user))
+      visit diary_entries_path
 
-    click_on "Send a message to the author"
+      click_on "Send a message to the author"
 
-    assert_content "Send a new message"
-    assert_equal "Re: #{@diary_entry.title}", page.find_field("Subject").value
-  end
+      assert_content "Send a new message"
+      assert_equal "Re: #{@diary_entry.title}", page.find_field("Subject").value
+    end
 
-  test "deleted diary entries should be hidden for regular users" do
-    @deleted_entry = create(:diary_entry, :visible => false)
+    test "deleted diary entries should be hidden for regular users" do
+      @deleted_entry = create(:diary_entry, :visible => false)
 
-    sign_in_as(create(:user))
-    visit diary_entries_path
+      sign_in_as(create(:user))
+      visit diary_entries_path
 
-    assert_no_content @deleted_entry.title
-  end
+      assert_no_content @deleted_entry.title
+    end
 
-  test "deleted diary entries should be shown to administrators for review" do
-    @deleted_entry = create(:diary_entry, :visible => false)
+    test "deleted diary entries should be shown to administrators for review" do
+      @deleted_entry = create(:diary_entry, :visible => false)
 
-    sign_in_as(create(:administrator_user))
-    visit diary_entries_path
+      sign_in_as(create(:administrator_user))
+      visit diary_entries_path
 
-    assert_content @deleted_entry.title
-  end
+      assert_content @deleted_entry.title
+    end
 
-  test "deleted diary entries should not be shown to admins when the user is also deleted" do
-    @deleted_user = create(:user, :deleted)
-    @deleted_entry = create(:diary_entry, :visible => false, :user => @deleted_user)
+    test "deleted diary entries should not be shown to admins when the user is also deleted" do
+      @deleted_user = create(:user, :deleted)
+      @deleted_entry = create(:diary_entry, :visible => false, :user => @deleted_user)
 
-    sign_in_as(create(:administrator_user))
-    visit diary_entries_path
+      sign_in_as(create(:administrator_user))
+      visit diary_entries_path
 
-    assert_no_content @deleted_entry.title
-  end
+      assert_no_content @deleted_entry.title
+    end
 
-  test "deleted diary comments should be hidden for regular users" do
-    @deleted_comment = create(:diary_comment, :diary_entry => @diary_entry, :visible => false)
+    test "deleted diary comments should be hidden for regular users" do
+      @deleted_comment = create(:diary_comment, :diary_entry => @diary_entry, :visible => false)
 
-    sign_in_as(create(:user))
-    visit diary_entry_path(@diary_entry.user, @diary_entry)
+      sign_in_as(create(:user))
+      visit diary_entry_path(@diary_entry.user, @diary_entry)
 
-    assert_no_content @deleted_comment.body
-  end
+      assert_no_content @deleted_comment.body
+    end
 
-  test "deleted diary comments should be shown to administrators" do
-    @deleted_comment = create(:diary_comment, :diary_entry => @diary_entry, :visible => false)
+    test "deleted diary comments should be shown to administrators" do
+      @deleted_comment = create(:diary_comment, :diary_entry => @diary_entry, :visible => false)
 
-    sign_in_as(create(:administrator_user))
-    visit diary_entry_path(@diary_entry.user, @diary_entry)
+      sign_in_as(create(:administrator_user))
+      visit diary_entry_path(@diary_entry.user, @diary_entry)
 
-    assert_content @deleted_comment.body
-  end
+      assert_content @deleted_comment.body
+    end
 
-  test "should have links to preferred languages" do
-    sign_in_as(create(:user, :languages => %w[en-US pt-BR]))
-    visit diary_entries_path
+    test "should have links to preferred languages" do
+      sign_in_as(create(:user, :languages => %w[en-US pt-BR]))
+      visit diary_entries_path
 
-    assert_link "Diary Entries in English", :href => "/diary/en"
-    assert_link "Diary Entries in Brazilian Portuguese", :href => "/diary/pt-BR"
-    assert_link "Diary Entries in Portuguese", :href => "/diary/pt"
-    assert_no_link "Diary Entries in Russian"
-  end
+      assert_link "Diary Entries in English", :href => "/diary/en"
+      assert_link "Diary Entries in Brazilian Portuguese", :href => "/diary/pt-BR"
+      assert_link "Diary Entries in Portuguese", :href => "/diary/pt"
+      assert_no_link "Diary Entries in Russian"
+    end
 
-  test "should have new diary entry link on own diary entry page" do
-    user = create(:user)
-    diary_entry = create(:diary_entry, :user => user)
+    test "should have new diary entry link on own diary entry page" do
+      user = create(:user)
+      diary_entry = create(:diary_entry, :user => user)
 
-    sign_in_as(user)
-    visit diary_entry_path(diary_entry.user, diary_entry)
+      sign_in_as(user)
+      visit diary_entry_path(diary_entry.user, diary_entry)
 
-    within_content_heading do
-      assert_link "New Diary Entry"
+      within_content_heading do
+        assert_link "New Diary Entry"
+      end
+    end
+
+    test "should not have new diary entry link on other user's diary entry page" do
+      user = create(:user)
+      diary_entry = create(:diary_entry)
+
+      sign_in_as(user)
+      visit diary_entry_path(diary_entry.user, diary_entry)
+
+      within_content_heading do
+        assert_no_link "New Diary Entry"
+      end
+    end
+
+    test "should not be hidden on the list page" do
+      body = SecureRandom.alphanumeric(1998)
+      create(:diary_entry, :body => body)
+
+      visit diary_entries_path
+
+      assert_content body
+      assert_no_content I18n.t("diary_entries.diary_entry.full_entry")
+    end
+
+    test "should be hidden on the list page" do
+      body = SecureRandom.alphanumeric(2000)
+      create(:diary_entry, :body => body)
+
+      visit diary_entries_path
+
+      assert_no_content body
+      assert_content I18n.t("diary_entries.diary_entry.full_entry")
+    end
+
+    test "should be partially hidden on the list page" do
+      text1 = "a" * 500
+      text2 = "b" * 500
+      text3 = "c" * 999
+      text4 = "dd"
+      text5 = "ff"
+
+      body = "<p>#{text1}</p><div><p>#{text2}</p><p>#{text3}<a href='#'>#{text4}</a></p></div><p>#{text5}</p>"
+      create(:diary_entry, :body => body)
+
+      visit diary_entries_path
+
+      assert_content text1
+      assert_content text2
+      assert_no_content text3
+      assert_no_content text4
+      assert_no_content text5
+      assert_content I18n.t("diary_entries.diary_entry.full_entry")
+    end
+
+    test "should not be hidden on the show page" do
+      body = SecureRandom.alphanumeric(2001)
+      diary_entry = create(:diary_entry, :body => body)
+
+      visit diary_entry_path(diary_entry.user, diary_entry)
+
+      assert_content body
+      assert_no_content I18n.t("diary_entries.diary_entry.full_entry")
     end
   end
 
-  test "should not have new diary entry link on other user's diary entry page" do
-    user = create(:user)
-    diary_entry = create(:diary_entry)
+  class JsTest < DiaryEntrySystemTest
+    driven_by_selenium
 
-    sign_in_as(user)
-    visit diary_entry_path(diary_entry.user, diary_entry)
+    test "contents after diary entry should be below floated images" do
+      user = create(:user)
+      diary_entry = create(:diary_entry, :user => user, :body => "<img width=100 height=1000 align=left alt='Floated Image'>")
 
-    within_content_heading do
-      assert_no_link "New Diary Entry"
+      sign_in_as(user)
+      visit diary_entry_path(user, diary_entry)
+
+      img = find "img[alt='Floated Image']"
+      assert_link "Edit this entry", :below => img
     end
-  end
-
-  test "should not be hidden on the list page" do
-    body = SecureRandom.alphanumeric(1998)
-    create(:diary_entry, :body => body)
-
-    visit diary_entries_path
-
-    assert_content body
-    assert_no_content I18n.t("diary_entries.diary_entry.full_entry")
-  end
-
-  test "should be hidden on the list page" do
-    body = SecureRandom.alphanumeric(2000)
-    create(:diary_entry, :body => body)
-
-    visit diary_entries_path
-
-    assert_no_content body
-    assert_content I18n.t("diary_entries.diary_entry.full_entry")
-  end
-
-  test "should be partially hidden on the list page" do
-    text1 = "a" * 500
-    text2 = "b" * 500
-    text3 = "c" * 999
-    text4 = "dd"
-    text5 = "ff"
-
-    body = "<p>#{text1}</p><div><p>#{text2}</p><p>#{text3}<a href='#'>#{text4}</a></p></div><p>#{text5}</p>"
-    create(:diary_entry, :body => body)
-
-    visit diary_entries_path
-
-    assert_content text1
-    assert_content text2
-    assert_no_content text3
-    assert_no_content text4
-    assert_no_content text5
-    assert_content I18n.t("diary_entries.diary_entry.full_entry")
-  end
-
-  test "should not be hidden on the show page" do
-    body = SecureRandom.alphanumeric(2001)
-    diary_entry = create(:diary_entry, :body => body)
-
-    visit diary_entry_path(diary_entry.user, diary_entry)
-
-    assert_content body
-    assert_no_content I18n.t("diary_entries.diary_entry.full_entry")
-  end
-
-  test "contents after diary entry should be below floated images" do
-    user = create(:user)
-    diary_entry = create(:diary_entry, :user => user, :body => "<img width=100 height=1000 align=left alt='Floated Image'>")
-
-    sign_in_as(user)
-    visit diary_entry_path(user, diary_entry)
-
-    img = find "img[alt='Floated Image']"
-    assert_link "Edit this entry", :below => img
   end
 end

--- a/test/system/directions_test.rb
+++ b/test/system/directions_test.rb
@@ -3,6 +3,8 @@
 require "application_system_test_case"
 
 class DirectionsSystemTest < ApplicationSystemTestCase
+  driven_by_selenium
+
   test "updates route output on mode change" do
     visit directions_path
     stub_straight_routing(:start_instruction => "Start popup text")

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -37,25 +37,6 @@ class SearchTest < ApplicationSystemTestCase
       BODY
   end
 
-  test "click on 'where is this' sets search input value and makes reverse geocoding request with zoom" do
-    visit "/#map=15/51.76320/-0.00760"
-
-    assert_field "Search", :with => ""
-    click_on "Where is this?"
-
-    assert_field "Search", :with => "51.76320, -0.00760"
-    assert_link "Broxbourne, Hertfordshire, East of England, England, United Kingdom"
-  end
-
-  test "'Show address' from context menu makes reverse geocoding request with zoom" do
-    visit "/#map=15/51.76320/-0.00760"
-
-    find_by_id("map").right_click
-    click_on "Show address"
-
-    assert_link "Broxbourne, Hertfordshire, East of England, England, United Kingdom"
-  end
-
   test "query search link sets search input value" do
     visit search_path(:query => "2.341, 7.896")
 
@@ -68,25 +49,48 @@ class SearchTest < ApplicationSystemTestCase
     assert_field "Search", :with => "4.321, 9.876"
   end
 
-  test "search adds viewbox param to Nominatim link" do
-    visit "/"
+  class JsTest < SearchTest
+    driven_by_selenium
 
-    fill_in "query", :with => "paris"
-    click_on "Go"
+    test "click on 'where is this' sets search input value and makes reverse geocoding request with zoom" do
+      visit "/#map=15/51.76320/-0.00760"
 
-    within_sidebar do
-      assert_link "Nominatim", :href => /&viewbox=/
+      assert_field "Search", :with => ""
+      click_on "Where is this?"
+
+      assert_field "Search", :with => "51.76320, -0.00760"
+      assert_link "Broxbourne, Hertfordshire, East of England, England, United Kingdom"
     end
-  end
 
-  test "search adds zoom param to reverse Nominatim link" do
-    visit "/#map=7/1.234/6.789"
+    test "'Show address' from context menu makes reverse geocoding request with zoom" do
+      visit "/#map=15/51.76320/-0.00760"
 
-    fill_in "query", :with => "60 30"
-    click_on "Go"
+      find_by_id("map").right_click
+      click_on "Show address"
 
-    within_sidebar do
-      assert_link "Nominatim", :href => /&zoom=7/
+      assert_link "Broxbourne, Hertfordshire, East of England, England, United Kingdom"
+    end
+
+    test "search adds viewbox param to Nominatim link" do
+      visit "/"
+
+      fill_in "query", :with => "paris"
+      click_on "Go"
+
+      within_sidebar do
+        assert_link "Nominatim", :href => /&viewbox=/
+      end
+    end
+
+    test "search adds zoom param to reverse Nominatim link" do
+      visit "/#map=7/1.234/6.789"
+
+      fill_in "query", :with => "60 30"
+      click_on "Go"
+
+      within_sidebar do
+        assert_link "Nominatim", :href => /&zoom=7/
+      end
     end
   end
 end

--- a/test/system/select_language_test.rb
+++ b/test/system/select_language_test.rb
@@ -3,6 +3,8 @@
 require "application_system_test_case"
 
 class SelectLanguageTest < ApplicationSystemTestCase
+  driven_by_selenium
+
   test "can select language when logged out" do
     visit help_path
 

--- a/test/system/site_test.rb
+++ b/test/system/site_test.rb
@@ -9,113 +9,117 @@ class SiteTest < ApplicationSystemTestCase
     assert_selector "h1", :text => "OpenStreetMap"
   end
 
-  test "tooltip shows for Layers button" do
-    visit "/"
+  class JsTest < SiteTest
+    driven_by_selenium
 
-    assert_no_selector ".tooltip"
-    button = find ".control-layers .control-button"
-    button.hover
-    assert_selector ".tooltip", :text => "Layers"
-  end
+    test "tooltip shows for Layers button" do
+      visit "/"
 
-  test "tooltip shows for Legend button on Standard layer" do
-    visit "/"
-
-    assert_no_selector ".tooltip"
-    button = find ".control-legend .control-button"
-    button.hover
-    tooltip = find ".tooltip"
-    tooltip.assert_text "Legend"
-    tooltip.assert_no_text "not available"
-  end
-
-  test "tooltip shows for Legend button on a layer without a legend provided" do
-    visit "/#layers=H" # assumes that HOT layer has no legend
-
-    assert_no_selector ".tooltip"
-    button = find ".control-legend .control-button"
-    button.hover
-    tooltip = find ".tooltip"
-    tooltip.assert_text "Legend"
-    tooltip.assert_text "not available"
-  end
-
-  test "tooltip shows for query button when zoomed in" do
-    visit "/#map=14/0/0"
-
-    assert_no_selector ".tooltip"
-    button = find ".control-query .control-button"
-    button.hover
-    tooltip = find ".tooltip"
-    tooltip.assert_text "Query features"
-    tooltip.assert_no_text "Zoom in"
-  end
-
-  test "tooltips on low zoom levels for disabled control 'Edit'" do
-    check_control_tooltips_on_low_zoom "Edit"
-  end
-  test "tooltips on low zoom levels for disabled control 'Add a note to the map'" do
-    check_control_tooltips_on_low_zoom "Add a note to the map"
-  end
-  test "tooltips on low zoom levels for disabled control 'Query features'" do
-    check_control_tooltips_on_low_zoom "Query features"
-  end
-
-  test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Edit'" do
-    check_control_tooltips_on_high_zoom "Edit"
-  end
-  test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Add a note to the map'" do
-    check_control_tooltips_on_high_zoom "Add a note to the map"
-  end
-  test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Query features'" do
-    check_control_tooltips_on_high_zoom "Query features"
-  end
-
-  test "notes layer tooltip appears on zoom out" do
-    visit "/#map=10/40/-4" # depends on zoom levels where notes are allowed
-
-    within "#map" do
-      click_on "Layers"
+      assert_no_selector ".tooltip"
+      button = find ".control-layers .control-button"
+      button.hover
+      assert_selector ".tooltip", :text => "Layers"
     end
-    within "#map-ui" do
-      assert_field "Map Notes"
-      find_field("Map Notes").hover # try to trigger disabled tooltip
+
+    test "tooltip shows for Legend button on Standard layer" do
+      visit "/"
+
+      assert_no_selector ".tooltip"
+      button = find ".control-legend .control-button"
+      button.hover
+      tooltip = find ".tooltip"
+      tooltip.assert_text "Legend"
+      tooltip.assert_no_text "not available"
     end
-    within "#map" do
-      zoom_out = find_link("Zoom Out")
-      zoom_out.hover # un-hover the tooltip that's being tested
-      zoom_out.click(:shift)
+
+    test "tooltip shows for Legend button on a layer without a legend provided" do
+      visit "/#layers=H" # assumes that HOT layer has no legend
+
+      assert_no_selector ".tooltip"
+      button = find ".control-legend .control-button"
+      button.hover
+      tooltip = find ".tooltip"
+      tooltip.assert_text "Legend"
+      tooltip.assert_text "not available"
     end
-    within "#map-ui" do
-      assert_field "Map Notes", :disabled => true
-      find_field("Map Notes", :disabled => true).hover
+
+    test "tooltip shows for query button when zoomed in" do
+      visit "/#map=14/0/0"
+
+      assert_no_selector ".tooltip"
+      button = find ".control-query .control-button"
+      button.hover
+      tooltip = find ".tooltip"
+      tooltip.assert_text "Query features"
+      tooltip.assert_no_text "Zoom in"
     end
-    assert_selector ".tooltip", :text => "Zoom in to see"
-  end
 
-  private
+    test "tooltips on low zoom levels for disabled control 'Edit'" do
+      check_control_tooltips_on_low_zoom "Edit"
+    end
+    test "tooltips on low zoom levels for disabled control 'Add a note to the map'" do
+      check_control_tooltips_on_low_zoom "Add a note to the map"
+    end
+    test "tooltips on low zoom levels for disabled control 'Query features'" do
+      check_control_tooltips_on_low_zoom "Query features"
+    end
 
-  def check_control_tooltips_on_low_zoom(locator)
-    visit "/#map=10/0/0"
+    test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Edit'" do
+      check_control_tooltips_on_high_zoom "Edit"
+    end
+    test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Add a note to the map'" do
+      check_control_tooltips_on_high_zoom "Add a note to the map"
+    end
+    test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Query features'" do
+      check_control_tooltips_on_high_zoom "Query features"
+    end
 
-    assert_no_selector ".tooltip"
-    find_link(locator).hover
-    assert_selector ".tooltip", :text => "Zoom in to"
-  end
+    test "notes layer tooltip appears on zoom out" do
+      visit "/#map=10/40/-4" # depends on zoom levels where notes are allowed
 
-  def check_control_tooltips_on_high_zoom(locator)
-    visit "/#map=14/0/0"
+      within "#map" do
+        click_on "Layers"
+      end
+      within "#map-ui" do
+        assert_field "Map Notes"
+        find_field("Map Notes").hover # try to trigger disabled tooltip
+      end
+      within "#map" do
+        zoom_out = find_link("Zoom Out")
+        zoom_out.hover # un-hover the tooltip that's being tested
+        zoom_out.click(:shift)
+      end
+      within "#map-ui" do
+        assert_field "Map Notes", :disabled => true
+        find_field("Map Notes", :disabled => true).hover
+      end
+      assert_selector ".tooltip", :text => "Zoom in to see"
+    end
 
-    assert_no_selector ".tooltip"
-    find_link(locator).hover
-    assert_no_selector ".tooltip", :text => "Zoom in to"
-    find("h1").hover # un-hover original element
+    private
 
-    visit "#map=10/0/0"
-    find_link(locator, :class => "disabled") # Ensure that capybara has waited for JS to finish processing
+    def check_control_tooltips_on_low_zoom(locator)
+      visit "/#map=10/0/0"
 
-    assert_no_selector ".tooltip"
-    find_link(locator).hover
-    assert_selector ".tooltip", :text => "Zoom in to"
+      assert_no_selector ".tooltip"
+      find_link(locator).hover
+      assert_selector ".tooltip", :text => "Zoom in to"
+    end
+
+    def check_control_tooltips_on_high_zoom(locator)
+      visit "/#map=14/0/0"
+
+      assert_no_selector ".tooltip"
+      find_link(locator).hover
+      assert_no_selector ".tooltip", :text => "Zoom in to"
+      find("h1").hover # un-hover original element
+
+      visit "#map=10/0/0"
+      find_link(locator, :class => "disabled") # Ensure that capybara has waited for JS to finish processing
+
+      assert_no_selector ".tooltip"
+      find_link(locator).hover
+      assert_selector ".tooltip", :text => "Zoom in to"
+    end
   end
 end


### PR DESCRIPTION
Just a proposal: would it make sense to use rack-test for system tests, where possible?

If we can reduce the use of Selenium, the test suite will run faster and more reliably. The code in this PR is just a quick experiment, showing that only 40% of system tests need Selenium. The relevant output is the following:

```
272 runs, 1285 assertions, 53 failures, 55 errors, 0 skips
```