### PR TITLE
Remove unnecessary map bounds adjustment on exiting changeset history

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -277,11 +277,6 @@ OSM.History = function (map) {
     });
 
     changesetsLayer.updateChangesets(map, changesets);
-
-    if (location.pathname !== "/history") {
-      const bounds = changesetsLayer.getBounds();
-      if (bounds.isValid()) map.fitBounds(bounds);
-    }
   }
 
   page.pushstate = page.popstate = function (path) {


### PR DESCRIPTION
### Issue:

See #6509

Map zooms out unexpectedly when closing Changeset History during zoom animation 

### Cause:

When zooming the map, opening the History sidebar, or clicking a changeset, the moveEndListener is triggered.

Inside moveEndListener, location.pathname is /history, which causes loadFirstChangesets to be called.

loadFirstChangesets then calls updateMap().

Since loadFirstChangesets is asynchronous (due to fetch), if the History sidebar is closed while it is still executing, location.pathname changes to /.

This leads to map.fitBounds() being triggered, causing the map to zoom unexpectedly.

### Solution:

Store whether the current page is /history in a variable isHistory before executing the fetch in loadFirstChangesets() and loadMoreChangesets().

This prevents changes to pathname during the fetch from causing unintended calls to map.fitBounds() and ensures the map does not zoom unexpectedly.
### Screenshots

old version: 

https://github.com/user-attachments/assets/16283fd0-7abb-4b93-ae29-4b356b148b23

new version:

https://github.com/user-attachments/assets/58acd6bf-7c2d-42bc-bba1-c860a1e38bfe
