### PR TITLE
Add URL prettification for plain texts

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -177,6 +177,15 @@ linkify:
       - "(?<key>[^\"?#<>/\\s]+)=(?<value>[^\"?#<>\\s]+)"
       path_template: "wiki/Tag:\\k<key>=\\k<value>"
       host: "https://wiki.openstreetmap.org"
+  display_rules:
+    - pattern: "osm\\.org/user/"
+      replacement: "@"
+    - pattern: "osm\\.org/(?<type>node|way|relation|changeset|note)/"
+      replacement: "\\k<type>/"
+    - pattern: "osm\\.wiki/Key:(?<key>[^\"?#<>/\\s]+)"
+      replacement: "\\k<key>=*"
+    - pattern: "osm\\.wiki/Tag:(?<key>[^\"?#<>/\\s]+)(?:=|%3D)(?<value>[^\"?#<>\\s]+)"
+      replacement: "\\k<key>=\\k<value>"
 # Main website hosts to match in linkify
 linkify_hosts: ["www.openstreetmap.org", "www.osm.org", "www.openstreetmap.com", "openstreetmap.org", "osm.org", "openstreetmap.com"]
 # Shorter host to replace main hosts

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -139,6 +139,44 @@ fossgis_valhalla_url: "https://valhalla1.openstreetmap.de/route"
 # Endpoints for Wikimedia integration
 wikidata_api_url: "https://www.wikidata.org/w/api.php"
 wikimedia_commons_url: "https://commons.wikimedia.org/wiki/"
+linkify:
+  detection_rules:
+    - patterns:
+      - "node/(?<id>\\d+)"
+      - "node (?<id>\\d{5,})"
+      - "n ?(?<id>\\d{5,})"
+      path_template: "node/\\k<id>"
+    - patterns:
+      - "way/(?<id>\\d+)"
+      - "way (?<id>\\d{5,})"
+      - "w ?(?<id>\\d{5,})"
+      path_template: "way/\\k<id>"
+    - patterns:
+      - "relation/(?<id>\\d+)"
+      - "relation (?<id>\\d{5,})"
+      - "r ?(?<id>\\d{5,})"
+      path_template: "relation/\\k<id>"
+    - patterns:
+      - "changeset/(?<id>\\d+)"
+      - "changeset (?<id>\\d{5,})"
+      - "cs ?(?<id>\\d{5,})"
+      path_template: "changeset/\\k<id>"
+    - patterns:
+      - "note/(?<id>\\d+)"
+      - "note (?<id>\\d{5,})"
+      path_template: "note/\\k<id>"
+    - patterns:
+      - "user/(?<username>\\S+)"
+      - "@(?<username>\\S+)"
+      path_template: "user/\\k<username>"
+    - patterns:
+      - "(?<key>[^\"?#<>/\\s]+)=\\*"
+      path_template: "wiki/Key:\\k<key>"
+      host: "https://wiki.openstreetmap.org"
+    - patterns:
+      - "(?<key>[^\"?#<>/\\s]+)=(?<value>[^\"?#<>\\s]+)"
+      path_template: "wiki/Tag:\\k<key>=\\k<value>"
+      host: "https://wiki.openstreetmap.org"
 # Main website hosts to match in linkify
 linkify_hosts: ["www.openstreetmap.org", "www.osm.org", "www.openstreetmap.com", "openstreetmap.org", "osm.org", "openstreetmap.com"]
 # Shorter host to replace main hosts

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -134,9 +134,12 @@ module RichText
 
     def format_link_text(url)
       url = shorten_host(url, Settings.linkify_hosts, Settings.linkify_hosts_replacement)
-      shorten_host(url, Settings.linkify_wiki_hosts, Settings.linkify_wiki_hosts_replacement) do |path|
+      url = shorten_host(url, Settings.linkify_wiki_hosts, Settings.linkify_wiki_hosts_replacement) do |path|
         path.sub(Regexp.new(Settings.linkify_wiki_optional_path_prefix || ""), "")
       end
+      Array.wrap(Settings.linkify&.display_rules)
+           .select { |rule| rule.pattern && rule.replacement }
+           .reduce(url) { |url, rule| url.sub(Regexp.new(rule.pattern), rule.replacement) }
     end
 
     def shorten_host(url, hosts, hosts_replacement)

--- a/lib/rich_text.rb
+++ b/lib/rich_text.rb
@@ -87,16 +87,24 @@ module RichText
     end
 
     def linkify(text, mode = :urls)
-      link_attr = 'rel="nofollow noopener noreferrer" dir="auto"'
-      Rinku.auto_link(ERB::Util.html_escape(text), mode, link_attr) do |url|
-        url = shorten_host(url, Settings.linkify_hosts, Settings.linkify_hosts_replacement)
-        shorten_host(url, Settings.linkify_wiki_hosts, Settings.linkify_wiki_hosts_replacement) do |path|
-          path.sub(Regexp.new(Settings.linkify_wiki_optional_path_prefix || ""), "")
-        end
-      end.html_safe
+      ERB::Util.html_escape(text)
+               .then { |html| auto_link(html, mode) }
+               .html_safe
     end
 
     private
+
+    def auto_link(text, mode)
+      link_attr = 'rel="nofollow noopener noreferrer" dir="auto"'
+      Rinku.auto_link(text, mode, link_attr) { |url| format_link_text(url) }
+    end
+
+    def format_link_text(url)
+      url = shorten_host(url, Settings.linkify_hosts, Settings.linkify_hosts_replacement)
+      shorten_host(url, Settings.linkify_wiki_hosts, Settings.linkify_wiki_hosts_replacement) do |path|
+        path.sub(Regexp.new(Settings.linkify_wiki_optional_path_prefix || ""), "")
+      end
+    end
 
     def shorten_host(url, hosts, hosts_replacement)
       %r{^(https?://([^/]*))(.*)$}.match(url) do |m|

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -394,6 +394,96 @@ class RichTextTest < ActiveSupport::TestCase
     end
   end
 
+  def test_text_to_html_linkify_openstreetmap_links
+    with_settings(:server_url => "www.openstreetmap.org", :server_protocol => "https") do
+      cases = {
+        "https://www.openstreetmap.org/note/4655490" =>
+          ["note/4655490", "https://www.openstreetmap.org/note/4655490"],
+
+        "https://www.openstreetmap.org/changeset/163353772" =>
+          ["changeset/163353772", "https://www.openstreetmap.org/changeset/163353772"],
+
+        "https://www.openstreetmap.org/way/1249366504" =>
+          ["way/1249366504", "https://www.openstreetmap.org/way/1249366504"],
+
+        "https://www.openstreetmap.org/way/1249366504/history" =>
+          ["way/1249366504/history", "https://www.openstreetmap.org/way/1249366504/history"],
+
+        "https://www.openstreetmap.org/way/1249366504/history/2" =>
+          ["way/1249366504/history/2", "https://www.openstreetmap.org/way/1249366504/history/2"],
+
+        "https://www.openstreetmap.org/node/12639964186" =>
+          ["node/12639964186", "https://www.openstreetmap.org/node/12639964186"],
+
+        "https://www.openstreetmap.org/relation/7876483" =>
+          ["relation/7876483", "https://www.openstreetmap.org/relation/7876483"],
+
+        "https://www.openstreetmap.org/user/aharvey" =>
+          ["@aharvey", "https://www.openstreetmap.org/user/aharvey"],
+
+        "https://wiki.openstreetmap.org/wiki/Key:boundary" =>
+          ["boundary=*", "https://wiki.openstreetmap.org/wiki/Key:boundary"],
+
+        "https://wiki.openstreetmap.org/wiki/Tag:boundary=place" =>
+          ["boundary=place", "https://wiki.openstreetmap.org/wiki/Tag:boundary=place"],
+
+        "boundary=*" =>
+          ["boundary=*", "https://wiki.openstreetmap.org/wiki/Key:boundary"],
+
+        "boundary=place" =>
+          ["boundary=place", "https://wiki.openstreetmap.org/wiki/Tag:boundary=place"],
+
+        "node/12639964186" =>
+          ["node/12639964186", "https://www.openstreetmap.org/node/12639964186"],
+
+        "node 12639964186" =>
+          ["node/12639964186", "https://www.openstreetmap.org/node/12639964186"],
+
+        "n12639964186" =>
+          ["node/12639964186", "https://www.openstreetmap.org/node/12639964186"],
+
+        "way/1249366504" =>
+          ["way/1249366504", "https://www.openstreetmap.org/way/1249366504"],
+
+        "way 1249366504" =>
+          ["way/1249366504", "https://www.openstreetmap.org/way/1249366504"],
+
+        "w1249366504" =>
+          ["way/1249366504", "https://www.openstreetmap.org/way/1249366504"],
+
+        "relation/7876483" =>
+          ["relation/7876483", "https://www.openstreetmap.org/relation/7876483"],
+
+        "relation 7876483" =>
+          ["relation/7876483", "https://www.openstreetmap.org/relation/7876483"],
+
+        "r7876483" =>
+          ["relation/7876483", "https://www.openstreetmap.org/relation/7876483"],
+
+        "changeset/163353772" =>
+          ["changeset/163353772", "https://www.openstreetmap.org/changeset/163353772"],
+
+        "changeset 163353772" =>
+          ["changeset/163353772", "https://www.openstreetmap.org/changeset/163353772"],
+
+        "note/4655490" =>
+          ["note/4655490", "https://www.openstreetmap.org/note/4655490"],
+
+        "note 4655490" =>
+          ["note/4655490", "https://www.openstreetmap.org/note/4655490"]
+      }
+
+      cases.each do |input, (expected_text, expected_href)|
+        r = RichText.new("text", input)
+        assert_html r do
+          assert_dom "a", :count => 1, :text => expected_text do
+            assert_dom "> @href", expected_href
+          end
+        end
+      end
+    end
+  end
+
   def test_text_to_html_linkify_no_year_misinterpretation
     r = RichText.new("text", "We thought there was no way 2020 could be worse than 2019. We were wrong. Please note 2025 is the first square year since OSM started. In that year, some osmlab repos switched from node 22 to bun 1.3.")
     assert_html r do


### PR DESCRIPTION
This mostly resolves #5780 by extending `linkify` to recognize and normalize common OSM and wiki references, automatically linking them to their canonical URLs.
It keeps the general URL-shortening improvements from #5844 and, as a successor to #5861, ensures that links remain stable and valid even when the text is reprocessed without rich text links.

The new `linkify` flow is now a three-stage pipeline:
#### Understand the reference 🧭
`expand_link_shorthands` pattern-matches common reference shorthands and expands them into full canonical URLs.
#### Add a hyperlink 🔗
This step, done by `Rinku.auto_link`, remains unchanged. It detects URLs and wraps them in `<a>` tags.
#### Make it look pretty 💅
`format_link_text` builds on #5844 and extends it to shorten link texts that match predefined patterns further. The `href` always remains the canonical URL that Rinku found.

---

The pre-processing and post-processing stages use a centralized rulebook defined in `Settings.linkify`. #5862 could be adapted to use this block as well.

I turned the table from https://github.com/openstreetmap/openstreetmap-website/issues/5780#issue-2905009904 into an end-to-end `test_text_to_html_linkify_openstreetmap_links`, dropping only a few enhancements not yet implemented.