### PR TITLE
Correct MIME type of exported directions GeoJSON

### DIFF
--- a/app/assets/javascripts/index/directions-route-output.js
+++ b/app/assets/javascripts/index/directions-route-output.js
@@ -130,7 +130,7 @@ OSM.DirectionsRouteOutput = function (map) {
       writeSteps(route);
     });
 
-    const blob = new Blob([JSON.stringify(polyline.toGeoJSON())], { type: "application/json" });
+    const blob = new Blob([JSON.stringify(polyline.toGeoJSON())], { type: "application/geo+json" });
     URL.revokeObjectURL(downloadURL);
     downloadURL = URL.createObjectURL(blob);
     $("#directions_route_download").prop("href", downloadURL);


### PR DESCRIPTION
When exporting directions as GeoJSON, create the file using a .geojson file extension based on the more specific MIME type for GeoJSON.

Fixes #6388.