### PR TITLE
Fix map zooming out when closing History sidebar during zoom animation

### DIFF
--- a/app/assets/javascripts/index/history.js
+++ b/app/assets/javascripts/index/history.js
@@ -168,10 +168,11 @@ OSM.History = function (map) {
 
   function loadFirstChangesets() {
     const data = new URLSearchParams();
+    const isHistory = location.pathname === "/history";
 
     disableChangesetIntersectionObserver();
 
-    if (location.pathname === "/history") {
+    if (isHistory) {
       setBboxFetchData(data);
       const feedLink = $("link[type=\"application/atom+xml\"]"),
             feedHref = feedLink.attr("href").split("?")[0];
@@ -197,7 +198,7 @@ OSM.History = function (map) {
           sidebar.scrollTop = 0;
         }
 
-        updateMap();
+        updateMap(isHistory);
       });
   }
 
@@ -206,6 +207,7 @@ OSM.History = function (map) {
     e.stopPropagation();
 
     const div = $(this).parents(".changeset_more");
+    const isHistory = location.pathname === "/history";
 
     div.find(".pagination").addClass("invisible");
     div.find("[hidden]").prop("hidden", false);
@@ -225,7 +227,7 @@ OSM.History = function (map) {
         displayMoreChangesets(div, html);
         enableChangesetIntersectionObserver();
 
-        updateMap();
+        updateMap(isHistory);
       });
   }
 
@@ -269,7 +271,7 @@ OSM.History = function (map) {
     changesetsLayer.updateChangesetsGeometry(map);
   }
 
-  function updateMap() {
+  function updateMap(isHistory) {
     const changesets = $("[data-changeset]").map(function (index, element) {
       return $(element).data("changeset");
     }).get().filter(function (changeset) {
@@ -278,7 +280,7 @@ OSM.History = function (map) {
 
     changesetsLayer.updateChangesets(map, changesets);
 
-    if (location.pathname !== "/history") {
+    if (!isHistory) {
       const bounds = changesetsLayer.getBounds();
       if (bounds.isValid()) map.fitBounds(bounds);
     }


### PR DESCRIPTION
### Issue:

See #6509

Map zooms out unexpectedly when closing Changeset History during zoom animation 

### Cause:

When zooming the map, or opening the History sidebar, the moveEndListener is triggered.

Inside moveEndListener, location.pathname is /history, which causes loadFirstChangesets to be called.

loadFirstChangesets then calls updateMap().

Since loadFirstChangesets is asynchronous (due to fetch), if the History sidebar is closed while it is still executing, location.pathname changes to /.

This leads to map.fitBounds() being triggered, causing the map to zoom unexpectedly.

### Solution:

Store whether the current page is /history in a variable isHistory before executing the fetch in loadFirstChangesets() and loadMoreChangesets().

This prevents changes to pathname during the fetch from causing unintended calls to map.fitBounds() and ensures the map does not zoom unexpectedly.
### Screenshots

old version: 

https://github.com/user-attachments/assets/16283fd0-7abb-4b93-ae29-4b356b148b23

new version:

https://github.com/user-attachments/assets/58acd6bf-7c2d-42bc-bba1-c860a1e38bfe