### PR TITLE
Append '.geojson' to download filename of direction

### DIFF
--- a/app/views/directions/show.html.erb
+++ b/app/views/directions/show.html.erb
@@ -65,7 +65,7 @@
   </div>
 
   <p class="text-center">
-    <%= tag.a t(".download"), :id => "directions_route_download", :download => t(".filename") %>
+    <%= tag.a t(".download"), :id => "directions_route_download", :download => "#{t('.filename')}.geojson" %>
   </p>
 
   <p class="text-center">


### PR DESCRIPTION
This is for more broad Browser support in generated download name. 

Related #6388 with discussion in #6519
