### PR TITLE
Improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,27 @@
 version: 2
 updates:
+  - package-ecosystem: "bundler"
+    versioning-strategy: "increase-if-necessary"
+    directory: "/"
+    ignore:
+      - dependency-name: rails
+        update-types: version-update:semver-minor
+    groups:
+      rails:
+        applies-to: version-updates
+        patterns:
+          - rails
+      rubocop:
+        applies-to: version-updates
+        patterns:
+          - rubocop*
+      dependencies:
+        applies-to: version-updates
+        exclude-patterns:
+          - rails
+          - rubocop*
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "npm"
     versioning-strategy: "increase-if-necessary"
     directory: "/"


### PR DESCRIPTION
As discussed at SOTM-EU this updates the dependabot configuration to process non urgent update once a week and group them into a smaller number of PRs and enables that for ruby as well as npm and actions.

Updates will be grouped into one PR for each ecosystem except ruby where rails and rubocop are separated out.

Updates to rails other than patch updates are excluded altogether.