### PR TITLE
Resolve any open issues for a user when they are suspended

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -66,7 +66,7 @@ Metrics/BlockNesting:
 # Offense count: 26
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 340
+  Max: 350
 
 # Offense count: 58
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -127,8 +127,9 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
   def test_resolve_note_of_deleted_user
     target_user = create(:user)
     target_note = create(:note, :author => target_user)
-    issue = create(:issue, :reportable => target_note, :reported_user => target_user, :assigned_role => "moderator")
     target_user.soft_destroy!
+
+    issue = create(:issue, :reportable => target_note, :reported_user => target_user, :assigned_role => "moderator")
 
     session_for(create(:moderator_user))
     post resolve_issue_path(issue)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -405,10 +405,26 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "suspended", user.status
   end
 
+  def test_suspend_closes_issues
+    user = create(:user)
+    issue = create(:issue, :reportable => user)
+    user.suspend
+    assert_equal "suspended", user.status
+    assert_equal "resolved", issue.reload.status
+  end
+
   def test_hide
     user = create(:user)
     user.hide
     assert_equal "deleted", user.status
+  end
+
+  def test_hide_closes_issues
+    user = create(:user)
+    issue = create(:issue, :reportable => user)
+    user.hide
+    assert_equal "deleted", user.status
+    assert_equal "resolved", issue.reload.status
   end
 
   def test_soft_destroy
@@ -422,6 +438,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "deleted", user.status
     assert_not_predicate user, :visible?
     assert_not_predicate user, :active?
+  end
+
+  def test_soft_destroy_closes_issues
+    user = create(:user)
+    issue = create(:issue, :reportable => user)
+    user.soft_destroy
+    assert_equal "deleted", user.status
+    assert_equal "resolved", issue.reload.status
   end
 
   def test_soft_destroy_revokes_oauth2_tokens


### PR DESCRIPTION
As proposed by @Firefishy this automatically closes any issues that are open against a user when they get suspended.