### PR TITLE
Fix context menu link color in light mode

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1014,6 +1014,7 @@ img.trace_image {
   .dropdown-item {
     &:hover, &:active {
       background-color: $gray-200;
+      color: var(--bs-dropdown-link-hover-color);
     }
   }
   &.cm_dropdown {


### PR DESCRIPTION
Fixes #6537

### Description
It appears that the intent was to make the 'active' state the same as the 'hover' state for the map context menu. Make it so.

### How has this been tested?
Manual test