### PR TITLE
Workaround for ruby 3.5.0 compatibility with delayed_job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,10 @@ gem "argon2"
 # Support brotli compression for assets
 gem "sprockets-exporters_pack"
 
+# Needed for ruby 3.5.0 compatibility with delayed_job
+# https://github.com/collectiveidea/delayed_job/issues/1239
+gem "benchmark"
+
 # Load rails plugins
 gem "actionpack-page_caching", ">= 1.2.0"
 gem "activerecord-import"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
+    benchmark (0.5.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -902,6 +903,7 @@ DEPENDENCIES
   argon2
   autoprefixer-rails
   aws-sdk-s3
+  benchmark
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.2)


### PR DESCRIPTION
This works around https://github.com/collectiveidea/delayed_job/issues/1239 which is causing a deprecation warning with ruby 3.4.7 that will become an error with 3.5.0:

```
/home/tom/.bundle/ruby/3.4.0/gems/delayed_job-4.1.13/lib/delayed/worker.rb:9: warning: /usr/share/ruby/benchmark.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
Also please contact the author of delayed_job-4.1.13 to request adding benchmark into its gemspec.
```