### PR TITLE
Allow meta description and search title to be translated

### DIFF
--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -20,8 +20,8 @@
 <% if Settings.key?(:publisher_url) -%>
 <%= tag.link :rel => "publisher", :href => Settings.publisher_url %>
 <% end -%>
-<%= tag.link :rel => "search", :type => "application/opensearchdescription+xml", :title => "OpenStreetMap Search", :href => asset_path("osm.xml") %>
-<%= tag.meta :name => "description", :content => "OpenStreetMap is the free wiki world map." %>
+<%= tag.link :rel => "search", :type => "application/opensearchdescription+xml", :title => t(".openstreetmap_search"), :href => asset_path("osm.xml") %>
+<%= tag.meta :name => "description", :content => t("layouts.intro_text") %>
 <%= opengraph_tags(@title, @opengraph_properties || {}) %>
 <% if flash[:matomo_goal] -%>
 <%= tag.meta :name => "matomo-goal", :content => flash[:matomo_goal] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1874,6 +1874,8 @@ en:
     header:
       select_language: Select Language
       loading: Loading...
+    meta:
+      openstreetmap_search: OpenStreetMap Search
     select_language_button:
       title: Select Language
     offline_flash:


### PR DESCRIPTION
Fixes #6527

This uses the same description as the default "og:description" for the site, to reduce the number of translations. Of the two alternative previous descriptions, the one in "og:description" more closely matches the language used on the about page, so let's go with that.

To be more explicit, here's the change in the html:

```diff
<link rel="search" type="application/opensearchdescription+xml" title="OpenStreetMap Search" href="/assets/osm-42b7b3fbcee2193e455a773db6cd3d34a2f48ca94547fed54901dd9d8307b02b.xml">
- <meta name="description" content="OpenStreetMap is the free wiki world map.">
+ <meta name="description" content="OpenStreetMap is a map of the world, created by people like you and free to use under an open licence.">
  <meta property="og:site_name" content="OpenStreetMap">
  <meta property="og:title" content="OpenStreetMap">
  <meta property="og:type" content="website">
  <meta property="og:url" content="http://localhost:3000/">
  <meta property="og:description" content="OpenStreetMap is a map of the world, created by people like you and free to use under an open licence.">
```
Note that this makes `<meta name="description">` become the same as `<meta property="og:description">` which I think is reasonable. The `<meta property="og:description">` has been translatable for a long time.