### PR TITLE
Fix inconsistent context menu icons (Issue #6485)

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -34,7 +34,7 @@ OSM.initializations.push(function (map) {
   const contextmenuItems = [
     {
       id: "menu-action-directions-from",
-      icon: "bi-geo-alt",
+      icon: "bi-play",
       text: OSM.i18n.t("javascripts.context.directions_from"),
       callback: () => {
         const params = new URLSearchParams({
@@ -46,7 +46,7 @@ OSM.initializations.push(function (map) {
     },
     {
       id: "menu-action-directions-to",
-      icon: "bi-flag",
+      icon: "bi-stop",
       text: OSM.i18n.t("javascripts.context.directions_to"),
       callback: () => {
         const params = new URLSearchParams({
@@ -61,7 +61,7 @@ OSM.initializations.push(function (map) {
     },
     {
       id: "menu-action-add-note",
-      icon: "bi-pencil",
+      icon: "bi-chat-text",
       text: OSM.i18n.t("javascripts.context.add_note"),
       callback: () => routeWithLatLon("/note/new")
     },
@@ -76,7 +76,7 @@ OSM.initializations.push(function (map) {
     },
     {
       id: "menu-action-query-features",
-      icon: "bi-question-circle",
+      icon: "bi-question",
       text: OSM.i18n.t("javascripts.context.query_features"),
       callback: () => routeWithLatLon("/query")
     },


### PR DESCRIPTION
As described at #6485

This PR updates the context menu icons to match the icons used elsewhere in the UI (Sidebar and Map buttons), resolving the inconsistencies described in the issue.

**Changes:**
- **Directions from here:** Changed from `bi-geo-alt` (Pin) to `bi-play-fill` (Play Triangle) to match the Sidebar.
- **Directions to here:** Changed from `bi-flag` (Flag) to `bi-stop-fill` (Stop Square) to match the Sidebar.
- **Add a note here:** Changed from `bi-pencil` (Pencil) to `bi-chat-text-fill` (Speech Bubble) to match the Sidebar note button metaphor.
- **Query features:** Changed from `bi-question-circle` to `bi-question-lg` (Plain Question Mark) to match the Map control button style.
- BEFORE: 
<img width="672" height="355" alt="507158610-515c9a6d-b5cb-472d-8e2a-39906389c69d" src="https://github.com/user-attachments/assets/c4c233d1-480c-4071-b4f5-894e22c94877" />

-AFTER:
<img width="676" height="396" alt="Screenshot 2025-11-30 at 8 03 21 PM" src="https://github.com/user-attachments/assets/c84b1b4d-dd24-4d46-b9c4-39daef7b915f" />



