### PR TITLE
Add early timeout when connection cannot be established

### DIFF
--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -536,7 +536,7 @@ module OSM
 
   # Return the HTTP client to use
   def self.http_client
-    @http_client ||= Faraday.new(:request => { :timeout => 15 },
+    @http_client ||= Faraday.new(:request => { :open_timeout => 5, :timeout => 15 },
                                  :headers => { :user_agent => Settings.server_url })
   end
 


### PR DESCRIPTION
### Description
Configure Faraday’s `open_timeout` so that when a connection cannot be established, the request fails quickly instead of waiting for the longer `timeout`. See the Faraday docs [here](https://lostisland.github.io/faraday/#/customization/request-options?id=request-options) for details.

### How has this been tested?
TBD
