### PR TITLE
Update Docker test of homepage description

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Test Basic Website
       run: |
         curl -siL http://127.0.0.1:3000 | egrep '^HTTP/1.1 200 OK'
-        curl -siL http://127.0.0.1:3000 | grep 'OpenStreetMap is the free wiki world map'
+        curl -siL http://127.0.0.1:3000 | grep 'OpenStreetMap is a map of the world'
         curl -siL http://127.0.0.1:3000/api/0.6/node/1 | grep 'Null Island'
     - name: Test Complete Suite
       run: |


### PR DESCRIPTION
Fixed the Docker test failure mentioned in https://github.com/openstreetmap/openstreetmap-website/pull/6569#issuecomment-3598543256 by updating the string we’re grepping for.