### PR TITLE
Ensure triggering of language search update

### DIFF
--- a/test/system/select_language_test.rb
+++ b/test/system/select_language_test.rb
@@ -14,7 +14,7 @@ class SelectLanguageTest < ApplicationSystemTestCase
     click_on "Select Language"
 
     assert_content "English"
-    fill_in "Search...", :with => "fra"
+    find_by_id("language_search").set("fra").send_keys(:tab)
     assert_no_content "English"
 
     click_on "français"
@@ -40,7 +40,7 @@ class SelectLanguageTest < ApplicationSystemTestCase
     click_on "Select Language"
 
     assert_content "English"
-    fill_in "Search...", :with => "fra"
+    find_by_id("language_search").set("fra").send_keys(:tab)
     assert_no_content "English"
 
     click_on "français"


### PR DESCRIPTION
As part of #6585 and an attempt to unfreeze #6424 I tried another method to input the language search term.