### PR TITLE
Change Valhalla credit link to working URL

### DIFF
--- a/app/assets/javascripts/index/directions/fossgis_valhalla.js
+++ b/app/assets/javascripts/index/directions/fossgis_valhalla.js
@@ -58,7 +58,7 @@
         distance: leg.summary.length * 1000,
         time: leg.summary.time,
         credit: "Valhalla (FOSSGIS)",
-        creditlink: "https://gis-ops.com/global-open-valhalla-server-online/"
+        creditlink: "https://valhalla.openstreetmap.de/"
       };
     }
 


### PR DESCRIPTION
The current URL points to a non-existing site/url, at least as a temporary solution this should be better. 
