### PR TITLE
Render a not_found error for unavailable heatmaps

### DIFF
--- a/app/controllers/users/heatmaps_controller.rb
+++ b/app/controllers/users/heatmaps_controller.rb
@@ -40,6 +40,8 @@ module Users
             :to => to
           }
         end
+      else
+        head :not_found
       end
     end
   end


### PR DESCRIPTION
Render a not found error if we are used for a heatmap for a user that doesn't exist or isn't visible to the requesting party instead of trying to render the view and throwing an exception.

As discussed in https://github.com/openstreetmap/openstreetmap-website/pull/6564#issuecomment-3612295106 and subsequent comment this is thought to be the root cause behind some intermittent CI failures.