### PR TITLE
Hide the anonymous note creation form when the limit is exceeded

### DIFF
--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -149,7 +149,7 @@ OSM.NewNote = function (map) {
       createNote(location, text, (feature) => {
         if (typeof OSM.user === "undefined") {
           const anonymousNotesCount = Number(OSM.cookies.get("_osm_anonymous_notes_count")) || 0;
-          OSM.cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { expires: 30 });
+          OSM.cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { expires: 14 });
         }
         content.find("textarea").val("");
         addCreatedNoteMarker(feature);

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -34,4 +34,12 @@ module NoteHelper
               :class => "mw-100 d-inline-block align-bottom text-truncate text-wrap", :dir => "auto"
     end
   end
+
+  def soft_anonymous_notes_limit_reached?(anonymous_notes_count)
+    !current_user && anonymous_notes_count >= 5
+  end
+
+  def hard_anonymous_notes_limit_reached?(anonymous_notes_count)
+    !current_user && anonymous_notes_count >= 10
+  end
 end

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,15 +1,14 @@
 <% set_title(t(".title")) %>
 
 <%= render "sidebar_header", :title => t(".title") %>
-
 <div class="note">
   <p class="alert alert-info"><%= t(".intro") %></p>
   <% if !current_user %>
-    <div class="alert alert-warning pb-0">
+    <div class="alert <%= hard_anonymous_notes_limit_reached?(@anonymous_notes_count) ? "alert-danger" : "alert-warning" %> pb-0">
       <p><%= t ".anonymous_warning_html",
                :log_in => link_to(t(".anonymous_warning_log_in"), login_path(:referer => new_note_path)),
                :sign_up => link_to(t(".anonymous_warning_sign_up"), new_user_path) %></p>
-    <% if @anonymous_notes_count >= 10 %>
+    <% if soft_anonymous_notes_limit_reached?(@anonymous_notes_count) %>
       <p><%= t ".counter_warning_html",
                :x_anonymous_notes => t(".x_anonymous_notes", :count => @anonymous_notes_count),
                :contribute_by_yourself => link_to(t(".counter_warning_guide_link.text"), t(".counter_warning_guide_link.url")),
@@ -17,6 +16,7 @@
     <% end %>
     </div>
   <% end %>
+  <% if !hard_anonymous_notes_limit_reached?(@anonymous_notes_count) %>
   <p class="alert alert-warning" id="new-note-zoom-warning" hidden><%= t "javascripts.site.createnote_disabled_tooltip" %></p>
   <form action="#">
     <input type="hidden" name="lon" autocomplete="off">
@@ -28,4 +28,5 @@
       <%= submit_tag t(".add"), :name => "add", :disabled => 1, :class => "btn btn-primary" %>
     </div>
   </form>
+  <% end %>
 </div>

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -100,26 +100,34 @@ class CreateNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "encouragement to contribute appears after 10 created notes and disappears after login" do
-    check_encouragement_while_creating_notes(10)
+  test "encouragement to contribute appears after 5 created notes and disappears after login" do
+    check_encouragement_while_creating_notes(5)
 
     sign_in_as(create(:user))
 
     check_no_encouragement_while_logging_out
   end
 
-  test "encouragement to contribute appears after 10 created notes and disappears after email signup" do
-    check_encouragement_while_creating_notes(10)
+  test "encouragement to contribute appears after 5 created notes and disappears after email signup" do
+    check_encouragement_while_creating_notes(5)
 
     sign_up_with_email
 
     check_no_encouragement_while_logging_out
   end
 
-  test "encouragement to contribute appears after 10 created notes and disappears after google signup" do
-    check_encouragement_while_creating_notes(10)
+  test "encouragement to contribute appears after 5 created notes and disappears after google signup" do
+    check_encouragement_while_creating_notes(5)
 
     sign_up_with_google
+
+    check_no_encouragement_while_logging_out
+  end
+
+  test "strict encouragement to contribute appears after 10 created notes and disappears after login" do
+    check_strict_encouragement_while_creating_notes(5, 10)
+
+    sign_in_as(create(:user))
 
     check_no_encouragement_while_logging_out
   end
@@ -144,6 +152,32 @@ class CreateNoteTest < ApplicationSystemTestCase
 
     within_sidebar do
       assert_content(/already posted at least #{encouragement_threshold} anonymous note/)
+    end
+  end
+
+  def check_strict_encouragement_while_creating_notes(encouragement_threshold, strict_encouragement_threshold)
+    strict_encouragement_threshold.times do |n|
+      visit new_note_path(:anchor => "map=16/0/#{0.001 * n}")
+
+      within_sidebar do
+        if n < encouragement_threshold
+          assert_no_content(/already posted at least \d+ anonymous note/)
+        else
+          assert_content(/already posted at least \d+ anonymous note/)
+        end
+
+        fill_in "text", :with => "new note ##{n + 1}"
+        click_on "Add Note"
+
+        assert_content "new note ##{n + 1}"
+      end
+    end
+
+    visit new_note_path(:anchor => "map=16/0/#{0.001 * strict_encouragement_threshold}")
+
+    within_sidebar do
+      assert_content(/already posted at least #{strict_encouragement_threshold} anonymous note/)
+      assert_no_button "Add Note"
     end
   end
 


### PR DESCRIPTION
### Description

I am justifying this PR based on renewed interest in forum posts on this topic starting in the fall of this year https://community.openstreetmap.org/t/we-dont-need-anonymous-notes/105335/128 as well as from personal experience of resolving notes

1. After 10 notes, the create notes form hides and the warning is repainted red

<img width="60%" src="https://github.com/user-attachments/assets/de860bad-a682-4751-b0b5-40e1742760f1" />

2. The previous warning is displayed after 5 anonymous notes

3. I reduced the lifetime of cookies that count anonymous notes to two weeks to compensate for the limit a little

### How has this been tested?

Manual testing, as well as adding a new autotest 

### Explanation

Yes, the API is still not protected. Yes, you can open a private window. 

But at least it will stop stupid robots, and it will also stop some users who use notes for other purposes faster. It is also a small stick in the wheels of lazy vandals.