### PR TITLE
Clarify fixup commits and branching guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,8 @@ For simple commits the one line summary is often enough and the body of the comm
 If you have forked on GitHub then the best way to submit your patches is to push your changes back to GitHub and open a Pull Request on GitHub.
 
 If your pull request is small, for example one or two commits each containing only a few lines of code, then it is easy for the maintainers to review.
-Please ensure your commit history is clean. Avoid including "fixup" commits. If you have added a fixup commit (for example to fix a rubocop warning, or because you changed your own new code) please combine the fixup commit into the commit that introduced the problem. `git rebase -i` is very useful for this.
+
+Please ensure your commit history is clean and avoid including "fixup" commits. If you have added a fixup commit (for example to fix a rubocop warning, or because you changed your own new code) please combine the fixup commit into the commit that introduced the problem. `git rebase -i` is very useful for this.
 
 > [!IMPORTANT]
 > If you are creating a larger pull request, then please help the maintainers with making the reviews as straightforward as possible:


### PR DESCRIPTION
### Description
This PR updates `CONTRIBUTING.md` to address unclear guidelines regarding commit history and branching, as raised in #6592.

**Specific changes:**
* **Branching:** Added explicit advice in the "How to Contribute" section to create a feature branch and avoid working directly on `master`.
* **Commit History:** Moved the guidance on avoiding "fixup" commits from the "Large Pull Requests" tip to the main "Pull Requests" body. This clarifies that a clean commit history is expected for all contributions, not just large ones.

Fixes #6592

### How has this been tested?
This is a documentation-only change.
* I verified that the Markdown syntax renders correctly.