### PR TITLE
Switch to shortbread style with absolute URLs

### DIFF
--- a/app/assets/javascripts/leaflet.shortbread.js
+++ b/app/assets/javascripts/leaflet.shortbread.js
@@ -3,26 +3,8 @@
 L.OSM.Shortbread = L.OSM.MaplibreGL.extend({
   onAdd: function (map) {
     L.OSM.MaplibreGL.prototype.onAdd.call(this, map);
-    const styleURL = "https://vector.openstreetmap.org/demo/shortbread/" + this.options.styleName;
-    this.getMaplibreMap().setStyle(styleURL, {
-      transformStyle: (previousStyle, nextStyle) => ({
-        ...nextStyle,
-        sprite: [...nextStyle.sprite.map(s => {
-          return {
-            ...s,
-            url: new URL(s.url, styleURL).href
-          };
-        })],
-        // URL will % encode the {} in glyph and source URL so assemble them manually
-        glyphs: (new URL(styleURL)).origin + nextStyle.glyphs,
-        sources: {
-          "versatiles-shortbread": {
-            ...nextStyle.sources["versatiles-shortbread"],
-            tiles: [(new URL(styleURL)).origin + nextStyle.sources["versatiles-shortbread"].tiles[0]]
-          }
-        }
-      })
-    });
+    const styleURL = "https://vector.openstreetmap.org/styles/shortbread/" + this.options.styleName;
+    this.getMaplibreMap().setStyle(styleURL);
   },
   onRemove: function (map) {
     L.OSM.MaplibreGL.prototype.onRemove.call(this, map);


### PR DESCRIPTION
This style and associated assets are served with CORS headers that allow use by openstreetmap.org or 127.0.0.1.

This has been tested with `rails server` and the CORS headers for openstreetmap.org were tested with cURL

Part of https://github.com/openstreetmap/operations/issues/1263