### PR TITLE
Fix: prevent form submission breaking language selector (#6598)

### DIFF
--- a/app/assets/javascripts/language_selector.js
+++ b/app/assets/javascripts/language_selector.js
@@ -12,3 +12,14 @@ $(document).on("click", "#select_language_dialog [data-language-code]", function
     location.reload();
   }
 });
+
+// Prevent accidental Enter key submits inside the language dialog
+$(document).on("keydown", "#select_language_dialog", function (e) {
+  if (e.key === "Enter" || e.keyCode === 13) {
+    // If the focused element is NOT inside a language option,
+    // block the default form submission.
+    if (!e.target.closest("[data-language-code]")) {
+      e.preventDefault();
+    }
+  }
+});


### PR DESCRIPTION
### Summary
This PR fixes issue #6598, where pressing **Enter** inside the language selector modal causes the modal to get stuck on an endless loading spinner.

### Root Cause
For logged-in users, the language selector loads a `<form>` inside the `select_language_list` Turbo Frame.  
Pressing Enter triggers an **unintended form submission**, but the server response is **not Turbo-frame compatible**, so Turbo cannot replace the frame content.

As a result:
- the Turbo Frame stays in the "loading" state,
- reopening the modal shows the spinner forever,
- only a full page refresh restores normal behavior.

Logged-out users do not see this bug because their modal contains no form.

### Fix
This change prevents the Enter key from causing a form submission inside the language selector modal.  
Avoiding the submission ensures the Turbo Frame continues to behave normally and reloads the language list as intended.

### Testing
- Reproduced issue locally using Docker environment.
- Verified that the spinner freeze no longer occurs when pressing Enter.
- Confirmed that both logged-in and logged-out behaviors remain correct.
- No regressions observed in language selection or modal behavior.

### Additional Notes
- Change follows project coding standards (ESLint for JS).
- Commit history is clean and scoped to the fix.
- Does not modify any localization files except `en.yml` if necessary (none needed here).
