### PR TITLE
Use red heart in donate attribution

### DIFF
--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -59,7 +59,7 @@ L.OSM.Map = L.Map.extend({
         }).prop("outerHTML")
       });
 
-      attribution += credit.donate ? " &hearts; " : ". ";
+      attribution += credit.donate ? " ♥️ " : ". ";
       attribution += makeCredit(credit);
       attribution += ". ";
 


### PR DESCRIPTION
### Description

In most fonts, the current heart is monochrome. As noted in #6517, the Make a Donation button is hard to find. This is one way to make it more visible.

### How has this been tested?

<img width="490" height="136" alt="Снимок экрана 2025-12-09 в 00 23 27" src="https://github.com/user-attachments/assets/b6abfc79-95fb-4408-8679-56084e32ce1f" />
<img width="490" height="136" alt="Снимок экрана 2025-12-09 в 00 23 05" src="https://github.com/user-attachments/assets/f99a747b-3eff-48c0-aaf9-d13837fc1a55" />

