### PR TITLE
Put `require` calls outside modules unless necessary

### DIFF
--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
+require "time"
+require "rexml/parsers/sax2parser"
+require "rexml/text"
+
 # The OSM module provides support functions for OSM.
 module OSM
-  require "time"
-  require "rexml/parsers/sax2parser"
-  require "rexml/text"
-
   # The base class for API Errors.
   class APIError < RuntimeError
     def initialize(message = "Generic API Error")


### PR DESCRIPTION
Very minor thing, but I'm not sure about `require` calls within modules, unless there's a specific reason for them which I don't think is the case here.

These could probably be removed entirely, similar to https://github.com/openstreetmap/openstreetmap-website/pull/6461, but since it's `lib/` I'm less bothered about that.

Another discussion could be had about moving everything in `lib/` to `app/lib/` as I believe that's the recommendation these days (see https://github.com/rails/rails/issues/37835#issuecomment-782843222). However perhaps some items do belong under `lib/`, if they are considered to be something that can be extracted to a gem and used by other projects. Let me know if you have thoughts.