### PR TITLE
Stop arguments in path or query from being interpreted as hashes

### DIFF
--- a/lib/tag2link.rb
+++ b/lib/tag2link.rb
@@ -12,7 +12,7 @@ module Tag2link
     url_template = @dict[key]
     return nil unless url_template
 
-    url_template.gsub("$1", value)
+    url_template.gsub("$1", value.sub(/^#/, ""))
   end
 
   def self.build_dict(data)

--- a/test/lib/tag2link_test.rb
+++ b/test/lib/tag2link_test.rb
@@ -16,6 +16,11 @@ class Tag2linkTest < ActiveSupport::TestCase
     assert_equal "https://www.wikidata.org/entity/Q936", url
   end
 
+  def test_link_strips_path_terminators
+    url = Tag2link.link("hashtags", "#maproulette")
+    assert_equal "https://resultmaps.neis-one.org/osm-changesets?comment=maproulette", url
+  end
+
   def test_build_dict_rejects_deprecated_and_third_party
     data = [
       { "key" => "Key:example", "url" => "http://example.com/$1", "rank" => "deprecated", "source" => "osmwiki:P8" },


### PR DESCRIPTION
Remove leading '#' from value in URL template replacement.
Closes #6508.