### PR TITLE
Add Donate to navigation bar

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -62,6 +62,9 @@
         <%= link_to t("layouts.help"), help_path, :class => header_nav_link_class(help_path) %>
       </li>
       <li class="nav-item">
+        <%= link_to t("layouts.donate"), Settings.donation_url, :class => header_nav_link_class(Settings.donation_url), :target => :new %>
+      </li>
+      <li class="nav-item">
         <%= link_to t("layouts.about"), about_path, :class => header_nav_link_class(about_path) %>
       </li>
       <li id="compact-secondary-nav" class="dropdown nav-item ms-auto">

--- a/app/views/site/copyright.html.erb
+++ b/app/views/site/copyright.html.erb
@@ -43,9 +43,10 @@
       <%= legal_babble_paragraph "lead_1" %>
     </p>
     <p class="lead">
-      <%= legal_babble_paragraph "lead_2", :links => %w[learn_more_about_osm osm_blog weeklyosm osm_foundation making_donation],
+      <%= legal_babble_paragraph "lead_2", :links => %w[learn_more_about_osm osm_blog weeklyosm osm_foundation],
                                            :local_links => { :get_started_mapping => new_user_path,
-                                                             :osm_community => communities_path } %>
+                                                             :osm_community => communities_path,
+                                                             :making_donation => Settings.donation_url } %>
     </p>
     <h3><%= t ".legal_babble.licensing_title" %></h3>
     <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2398,7 +2398,6 @@ en:
         lead_2_osm_foundation: OSM Foundation
         lead_2_osm_foundation_url: https://osmfoundation.org/
         lead_2_making_donation: making a donation
-        lead_2_making_donation_url: https://supporting.openstreetmap.org/
         licensing_title: OpenStreetMap licensing
         licensing_1_html: |
           OpenStreetMap is %{open} data, licensed under the

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1859,6 +1859,7 @@ en:
     about: About
     copyright: Copyright
     communities: Communities
+    donate: Donate
     learn_more: "Learn More"
     more: More
     header:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -139,6 +139,8 @@ fossgis_valhalla_url: "https://valhalla1.openstreetmap.de/route"
 # Endpoints for Wikimedia integration
 wikidata_api_url: "https://www.wikidata.org/w/api.php"
 wikimedia_commons_url: "https://commons.wikimedia.org/wiki/"
+# URL to donation form
+donation_url: "https://supporting.openstreetmap.org/donate/"
 # Linkification rules
 linkify:
   detection_rules:


### PR DESCRIPTION
Added a Donate link to the sitewide navigation bar. Similar to #6600, but supporting.openstreetmap.org opens in a new tab instead of an iframe. Pulled the URL to the donation site into a configuration variable since it doesn’t need to be localized per occurrence.

Before | After
----|----
<img width="1080" height="810" alt="History, Export, GPS Traces, User Diaries, Communities, Copyright, Help, and About" src="https://github.com/user-attachments/assets/b3567fdc-d021-45f5-aa30-dbd5296557d2" /> | <img width="1080" height="810" alt="History, Export, GPS Traces, User Diaries, Communities, Copyright, and Help; Donate and About in More overflow menu" src="https://github.com/user-attachments/assets/0014b68e-0a46-4e5e-8116-af67bff82cc4" />

I considered creating a landing page as suggested in https://github.com/openstreetmap/openstreetmap-website/pull/6600#issuecomment-3638068481, but it wasn’t clear what the landing page should say that isn’t already on the landing page at supporting.openstreetmap.org. So I just kept things as simple as possible.

Fixes #6517.