### PR TITLE
Pull changeset comment rich text into separate method

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -201,6 +201,7 @@ class Changeset < ApplicationRecord
   end
 
   def comment = tags["comment"].presence
+  def comment_html = comment ? RichText.new("text", comment).to_html : nil
 
   ##
   # set the auto-close time to be one hour in the future unless

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -8,7 +8,7 @@
 </h4>
 
 <p class="fs-6 overflow-x-auto mb-2" dir="auto">
-  <%= RichText.new("text", common_details.changeset.comment || t("browse.no_comment")) %>
+  <%= common_details.changeset.comment_html || t("browse.no_comment") %>
 </p>
 
 <div class="mb-3">

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="mb-3 border-bottom border-secondary-subtle pb-3">
   <p class="fs-6 overflow-x-auto" dir="auto">
-    <%= RichText.new("text", @changeset.comment || t("browse.no_comment")) %>
+    <%= @changeset.comment_html || t("browse.no_comment") %>
   </p>
   <%= tag.p :class => "details", :data => { :changeset => changeset_data(@changeset) } do %>
     <%= changeset_details(@changeset) %>

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -408,6 +408,15 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_show_linkified_comment
+    changeset = create(:changeset)
+    create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "Check out http://example.com/ & special <characters>!")
+    sidebar_browse_check :changeset_path, changeset.id, "changesets/show"
+    assert_dom "p", :text => %r{Check out http://example.com/ & special <characters>!} do
+      assert_dom "a[href='http://example.com/']", :text => "http://example.com/"
+    end
+  end
+
   def test_show_closed_changeset
     changeset = create(:changeset, :closed)
 


### PR DESCRIPTION
Addresses https://github.com/openstreetmap/openstreetmap-website/pull/6597#discussion_r2601656153 and fixes #6615 by adding a separate method to the changeset model that _actually_ outputs HTML.

I also added a test checking for changeset comment linkification to prevent repeats of #6615.