### PR TITLE
Use a healthcheck to ensure the docker db container is active

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     tty: true
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   db:
     build:
@@ -34,6 +35,11 @@ services:
     volumes:
       # Mount the Postgres data directory so it persists between runs
       - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
 
 volumes:
   web-tmp:


### PR DESCRIPTION
This is an extracted and reworked part of #6588

From the github actions runs, you can see the difference - when the db container is being started, the web container waits until the db is `healthy`

before:

```
 Container openstreetmap-website-db-1  Creating
 Container openstreetmap-website-db-1  Created
 Container openstreetmap-website-web-1  Creating
 Container openstreetmap-website-web-1  Created
 Container openstreetmap-website-db-1  Starting
 Container openstreetmap-website-db-1  Started
 Container openstreetmap-website-web-1  Starting
 Container openstreetmap-website-web-1  Started
```

after:

```
 Container openstreetmap-website-db-1  Creating
 Container openstreetmap-website-db-1  Created
 Container openstreetmap-website-web-1  Creating
 Container openstreetmap-website-web-1  Created
 Container openstreetmap-website-db-1  Starting
 Container openstreetmap-website-db-1  Started
 Container openstreetmap-website-db-1  Waiting
 Container openstreetmap-website-db-1  Healthy
 Container openstreetmap-website-web-1  Starting
 Container openstreetmap-website-web-1  Started
```

It's unclear if the lack of healthcheck was a genuine problem, but I think this PR implements a reasonable thing to do. Compared to the original PR, the `pg_isready` command is simplified since the additional options are unnecessary and it outputs useful exit-codes without any additional handling.