### PR TITLE
Refactor turbo-frame element to avoid multiline conditionals inside html attribute

### DIFF
--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -24,14 +24,14 @@
       <details <%= "open" if relation.relation_members.count < 10 %>>
         <summary><%= t ".members_count", :count => relation.relation_members.count %></summary>
         <% if relation.relation_members.count >= 10 %>
-          <turbo-frame id="member_relation_<%= relation.id %>"
-            <% if relation.is_a?(OldRelation) %>
-              <% path_params = [relation.relation_id, relation.version] %>
-              <% path_params << { :show_redactions => params[:show_redactions] } if params[:show_redactions] %>
-              src="<%= old_relation_members_path(*path_params) %>">
-            <% else %>
-              src="<%= relation_members_path(relation) %>">
-            <% end %>
+          <% if relation.is_a?(OldRelation) %>
+            <% path_params = [relation.relation_id, relation.version] %>
+            <% path_params << { :show_redactions => params[:show_redactions] } if params[:show_redactions] %>
+            <% src_path = old_relation_members_path(*path_params) %>
+          <% else %>
+            <% src_path = relation_members_path(relation) %>
+          <% end %>
+          <turbo-frame id="member_relation_<%= relation.id %>" src="<%= src_path %>">
             <div class="text-center my-2">
               <div class="spinner-border spinner-border-sm text-primary" role="status">
                 <span class="visually-hidden"><%= t("browse.start_rjs.loading") %></span>


### PR DESCRIPTION
While the original is perfectly valid erb, it's hard to read and hard for erblint to parse.

This refactor moves the multi-line conditional logic outside of the turbo-frame `src` html attribute.

This is needed before we can introduce the erblint [HardCodedString](https://github.com/Shopify/erb_lint/?tab=readme-ov-file#hardcodedstring) linter

### How has this been tested?

I checked with a local dev instance to make sure that the turbo frame worked with a relation with > 10 members
