### PR TITLE
Send bulk user confirmations through the state machine

### DIFF
--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -35,7 +35,7 @@ module Users
     def update
       ids = params.fetch(:user, {}).keys.collect(&:to_i)
 
-      User.where(:id => ids).update_all(:status => "confirmed") if params[:confirm]
+      User.where(:id => ids).each(&:confirm!) if params[:confirm]
       User.where(:id => ids).each(&:suspend_if_possible!) if params[:suspend]
 
       redirect_to url_for(params.permit(:status, :username, :ip, :edits, :before, :after))


### PR DESCRIPTION
This ensure that bulk actions performed on users from the list screen go through the state machine and trigger any additional actions (not that there are any currently for confirm) rather than updating the database directly.