### PR TITLE
Don't reinitialise i18n in maplibre code

### DIFF
--- a/app/assets/javascripts/maplibre.i18n.js
+++ b/app/assets/javascripts/maplibre.i18n.js
@@ -1,5 +1,3 @@
-//= require i18n
-
 OSM.MapLibre.Locale = {
   "GeolocateControl.FindMyLocation": OSM.i18n.t("javascripts.map.locate.title"),
   "GeolocateControl.LocationNotAvailable": OSM.i18n.t("javascripts.map.locate.not_available"),


### PR DESCRIPTION
This fixes #6624 by avoiding doing a second initialisation of the i18n system in the maplibre code - it is already initialised for all pages by `application.js` which is loaded before any page specific code like the dashboard code.