### PR TITLE
Swap confirm and suspend actions

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -194,7 +194,7 @@
 
             <% if @user.may_suspend? %>
               <li>
-                <%= link_to t(".suspend_user"), user_status_path(@user, :event => "suspend"), :method => :put, :data => { :confirm => t(".confirm") } %>
+                <%= link_to t(".suspend_user"), user_status_path(@user, :event => "suspend"), :method => :put, :data => { :confirm => t(".confirm") }, :class => "link-danger" %>
               </li>
             <% end %>
 


### PR DESCRIPTION
As requested by @Firefishy at #osmf-operations. Also coloured the "suspend" action in danger red.

<img width="736" height="87" alt="Links to Confirm or Suspend a user. The second one in red to express danger" src="https://github.com/user-attachments/assets/661f5764-ad4f-40e5-b733-a6661e205b99" />

Something that annoys me of these action links: the confirmation modal is common to both (and other links that can appear here) and simply reads "Confirm" in English. I would have preferred a descriptive "Suspend user %{user_name}" (etc) or similar, to further help prevent an accident. Thoughts? It's a bit of a faff, with all the i18n strings, wouldn't do it as part of this PR anyway.