### PR TITLE
Fix invalid <p> nesting in comment rendering

### DIFF
--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -7,9 +7,9 @@
   #<%= link_to_unless_current common_details.version, :controller => "old_#{@type.pluralize}", :action => :show, :version => common_details.version %>
 </h4>
 
-<p class="fs-6 overflow-x-auto mb-2" dir="auto">
+<div class="fs-6 overflow-x-auto mb-2">
   <%= common_details.changeset.comment_html || t("browse.no_comment") %>
-</p>
+</div>
 
 <div class="mb-3">
   <div>

--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -3,9 +3,9 @@
 <%= render "sidebar_header", :title => t(".title", :id => @changeset.id) %>
 
 <div class="mb-3 border-bottom border-secondary-subtle pb-3">
-  <p class="fs-6 overflow-x-auto" dir="auto">
+  <div class="fs-6 overflow-x-auto">
     <%= @changeset.comment_html || t("browse.no_comment") %>
-  </p>
+  </div>
   <%= tag.p :class => "details", :data => { :changeset => changeset_data(@changeset) } do %>
     <%= changeset_details(@changeset) %>
   <% end %>


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/pull/6623#issuecomment-3669442629 by not using paragraphs to wrap the rich text content invalidly. Thanks @deevroman for pointing this out!