### PR TITLE
Logo Refresh

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="d-flex bg-body flex-column flex-md-row text-nowrap closed z-3">
   <h1 class="d-flex m-0 align-items-center fw-semibold">
-    <a href="<%= root_path %>" class="icon-link gap-1 me-auto text-body-emphasis text-decoration-none geolink">
+    <a href="<%= root_path %>" class="icon-link gap-1 me-auto text-body-emphasis text-decoration-none geolink" onclick="if(window.location.pathname === '/') { location.reload(); return false; } return true;">
       <%= image_tag "osm_logo.svg", :alt => t("layouts.logo.alt_text"), :size => 30 %>
       <%= t "layouts.project_name.title" %>
     </a>


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->

Addressing issue [#6651](https://github.com/openstreetmap/openstreetmap-website/issues/6651) by adding automatic page refresh functionality when clicking the OpenStreetMap logo, eliminating the need for pressing F5.

### How has this been tested?
<!--Explain the steps you took to test your code.-->

**Desktop Testing:**
- [x] Clicked logo on homepage (`/`) → page refreshes automatically
- [x] Clicked logo on `/about` → navigates to homepage
- [x] Clicked logo on `/communities` → navigates to homepage
- [x] Clicked logo on `/export` → navigates to homepage
- [x] Clicked logo on `/copyright` → navigates to homepage

**Mobile Testing:**
- [x] Tested in Chrome DevTools responsive mode (iPhone, Android)
- [x] Verified touch events work correctly
- [x] Confirmed behavior matches desktop

**Code Quality Checks (via Docker):**
- [x] **Rubocop**: 912 files inspected, no offenses detected ✓
- [x] **ERB Lint**: No errors found in ERB files ✓
- [x] **JavaScript**: Inline code follows standard syntax ✓

**Browser Compatibility:**
- [x] Chrome - tested
- [x] Firefox - tested
- [x] Safari - tested 