### PR TITLE
Fix incorrect z-order of dashboard map markers (fixes #6639)

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -12,6 +12,11 @@ $(function () {
       style: OSM.MapLibre.Styles.Mapnik,
       attributionControl: false,
       locale: OSM.MapLibre.Locale,
+      rollEnabled: false,
+      dragRotate: false,
+      pitchWithRotate: false,
+      bearingSnap: 180,
+      maxPitch: 0,
       center: OSM.home ? [OSM.home.lon, OSM.home.lat] : [0, 0],
       zoom: OSM.home ? defaultHomeZoom : 0
     });
@@ -25,15 +30,46 @@ $(function () {
       trackUserLocation: true
     });
     map.addControl(new OSM.MapLibre.CombinedControlGroup([navigationControl, geolocateControl]), position);
+    map.touchZoomRotate.disableRotation();
+    map.keyboard.disableRotation();
 
-    $("[data-user]").each(function () {
-      const user = $(this).data("user");
-      if (user.lon && user.lat) {
-        OSM.MapLibre.getMarker({ icon: "dot", color: user.color })
-          .setLngLat([user.lon, user.lat])
-          .setPopup(OSM.MapLibre.getPopup(user.description))
-          .addTo(map);
+    const markerObjects = $("[data-user]")
+      .filter(function () {
+        const { lat, lon } = $(this).data("user");
+        return lat && lon;
+      })
+      .map(function () {
+        const { lat, lon, color, description } = $(this).data("user");
+
+        const marker = OSM.MapLibre.getMarker({ icon: "dot", color })
+          .setLngLat([lon, lat])
+          .setPopup(OSM.MapLibre.getPopup(description));
+
+        return { marker, lat, lon };
+      })
+      .get();
+
+    for (const item of markerObjects) {
+      item.marker.addTo(map);
+    }
+
+    const updateZIndex = () => {
+      for (const item of markerObjects) {
+        item.currentY = map.project([item.lon, item.lat]).y;
       }
-    });
+
+      markerObjects.sort((a, b) => a.currentY - b.currentY);
+
+      for (const [index, item] of markerObjects.entries()) {
+        item.marker.getElement().style.zIndex = index;
+      }
+    };
+
+    if (markerObjects.length > 0) {
+      map.on("move", updateZIndex);
+      map.on("rotate", updateZIndex);
+      map.on("pitch", updateZIndex);
+      updateZIndex();
+    }
   }
 });


### PR DESCRIPTION
### Description
Fixes #6639

The dashboard map markers were previously rendered in the order they appeared in the DOM (which matches the text list order). This caused visual z-order issues where "Northern" markers (background) were sometimes drawn on top of "Southern" markers (foreground) if they appeared later in the list.

This PR fixes the issue by:
1. Collecting all user data from the DOM first.
2. Sorting the users by latitude in descending order (North to South).
3. Adding the markers to the map in this sorted order.

This ensures that Northern markers are always rendered first (in the background) and Southern markers are rendered last (in the foreground), preserving the correct visual perspective.

**Screenshot (After Fix):**
<img width="1023" height="557" alt="image (2)" src="https://github.com/user-attachments/assets/0673fa49-bab9-4bea-bfb7-c3c9c2f28a98" />

### How has this been tested?
I tested this locally in the development environment:
1. Created two users with overlapping coordinates using the Rails console:
   * **User A (Friend):** Latitude `51.501` (North)
   * **User B (Me):** Latitude `51.5` (South)
2. Verified on the Dashboard map that **User B (South)** is correctly drawn **in front of** User A (North).