### PR TITLE
Update OSM Carto repository URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://wiki.openstreetmap.org/wiki/Website_internationalization#How_to_translate
     about: Please read about how to use Translatewiki to correct translations
   - name: There is an issue with the default map layer shown on the front page
-    url: https://github.com/gravitystorm/openstreetmap-carto
+    url: https://github.com/openstreetmap-carto/openstreetmap-carto
     about: Please share your feedback with the OpenStreetMap-Carto team
   - name: There is an issue with the iD editor used on the Edit tab
     url: https://github.com/openstreetmap/iD


### PR DESCRIPTION
OSM Carto has been moved to a new organisation recently.

Ref: https://github.com/openstreetmap-carto/openstreetmap-carto/pull/5157