### PR TITLE
SpamScorer: normalise whitespace in comparable form

### DIFF
--- a/lib/spam_scorer/rich_text.rb
+++ b/lib/spam_scorer/rich_text.rb
@@ -38,7 +38,7 @@ module SpamScorer
     attr_reader :text
 
     def to_comparable_form(str)
-      str.downcase(:fold).unicode_normalize(:nfkc)
+      str.downcase(:fold).unicode_normalize(:nfkc).gsub(/\s+/u, " ")
     end
   end
 end

--- a/test/lib/spam_scorer_test.rb
+++ b/test/lib/spam_scorer_test.rb
@@ -44,4 +44,19 @@ class SpamScorerTest < ActiveSupport::TestCase
     scorer = SpamScorer.new_from_rich_text(r)
     assert_equal 160, scorer.score.round
   end
+
+  def test_to_comparable_form_collapses_unicode_whitespace
+    r = RichText.new("text", "x")
+    scorer = SpamScorer.new_from_rich_text(r)
+
+    input = "  A\u00A0\tB\n\nC"
+    assert_equal " a b c", scorer.send(:to_comparable_form, input)
+  end
+
+  def test_spammy_phrase_can_match_across_newlines_after_normalization
+    create(:spammy_phrase, :phrase => "foo bar")
+    r = RichText.new("markdown", "foo\nbar")
+    scorer = SpamScorer.new_from_rich_text(r)
+    assert_equal 40, scorer.score.round
+  end
 end


### PR DESCRIPTION
### Description
Collapse Unicode whitespace runs to a single space in SpamScorer::RichText#to_comparable_form to improve SpammyPhrase matching across newlines/tabs.

### How has this been tested?
Suitable tests have been added. Will be run as part of CI.