### PR TITLE
Migrate the edit location page from leaflet to Maplibre

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,25 +1,11 @@
 //= require maplibre.map
-//= require maplibre.i18n
 //= require maplibre.combinedcontrolgroup
 
 $(function () {
-  const defaultHomeZoom = 11;
   let map;
 
   if ($("#map").length) {
-    map = new maplibregl.Map({
-      container: "map",
-      style: OSM.MapLibre.Styles.Mapnik,
-      attributionControl: false,
-      locale: OSM.MapLibre.Locale,
-      rollEnabled: false,
-      dragRotate: false,
-      pitchWithRotate: false,
-      bearingSnap: 180,
-      maxPitch: 0,
-      center: OSM.home ? [OSM.home.lon, OSM.home.lat] : [0, 0],
-      zoom: OSM.home ? defaultHomeZoom : 0
-    });
+    map = new maplibregl.Map(OSM.MapLibre.defaultSecondaryMapOptions);
 
     const position = $("html").attr("dir") === "rtl" ? "top-left" : "top-right";
     const navigationControl = new maplibregl.NavigationControl({ showCompass: false });

--- a/app/assets/javascripts/maplibre.map.js
+++ b/app/assets/javascripts/maplibre.map.js
@@ -1,4 +1,5 @@
 //= require maplibre-gl/dist/maplibre-gl
+//= require maplibre.i18n
 
 OSM.MapLibre.Styles.Mapnik = {
   version: 8,
@@ -19,6 +20,21 @@ OSM.MapLibre.Styles.Mapnik = {
       source: "osm"
     }
   ]
+};
+
+OSM.MapLibre.defaultHomeZoom = 11;
+OSM.MapLibre.defaultSecondaryMapOptions = {
+  container: "map",
+  style: OSM.MapLibre.Styles.Mapnik,
+  attributionControl: false,
+  locale: OSM.MapLibre.Locale,
+  rollEnabled: false,
+  dragRotate: false,
+  pitchWithRotate: false,
+  bearingSnap: 180,
+  maxPitch: 0,
+  center: OSM.home ? [OSM.home.lon, OSM.home.lat] : [0, 0],
+  zoom: OSM.home ? OSM.MapLibre.defaultHomeZoom : 0
 };
 
 // Helper function to create Leaflet style (SVG comes from Leaflet) markers for MapLibre

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,10 +1,8 @@
 //= require maplibre.map
-//= require maplibre.i18n
 //= require maplibre.combinedcontrolgroup
 //= require ./home_location_name-endpoint
 
 $(function () {
-  const defaultHomeZoom = 11;
   let map, marker, deleted_lat, deleted_lon, deleted_home_name, homeLocationNameGeocoder, savedLat, savedLon;
 
   if ($("#social_links").length) {
@@ -52,19 +50,7 @@ $(function () {
   }
 
   if ($("#map").length) {
-    map = new maplibregl.Map({
-      container: "map",
-      style: OSM.MapLibre.Styles.Mapnik,
-      attributionControl: false,
-      locale: OSM.MapLibre.Locale,
-      rollEnabled: false,
-      dragRotate: false,
-      pitchWithRotate: false,
-      bearingSnap: 180,
-      maxPitch: 0,
-      center: OSM.home ? [OSM.home.lon, OSM.home.lat] : [0, 0],
-      zoom: OSM.home ? defaultHomeZoom : 0
-    });
+    map = new maplibregl.Map(OSM.MapLibre.defaultSecondaryMapOptions);
 
     savedLat = $("#home_lat").val();
     savedLon = $("#home_lon").val();
@@ -132,7 +118,7 @@ $(function () {
       const lat = $("#home_lat").val(),
             lon = $("#home_lon").val();
 
-      map.flyTo({ center: [lon, lat], zoom: defaultHomeZoom });
+      map.flyTo({ center: [lon, lat], zoom: OSM.MapLibre.defaultHomeZoom });
     });
 
     $("#home_delete").click(function () {
@@ -204,10 +190,10 @@ $(function () {
   }
 
   function isCloseEnoughToMapCenter(location) {
-    const inputPt = map.project(location),
-          centerPt = map.project(map.getCenter());
+    const inputPt = map.project(location);
+    const centerPt = map.project(map.getCenter());
 
-    return Math.sqrt(Math.pow(centerPt.x - inputPt.x, 2) + Math.pow(centerPt.y - inputPt.y, 2)) < 10;
+    return centerPt.dist(inputPt) < 10;
   }
 
   function clearDeletedText() {


### PR DESCRIPTION
### Description

This PR migrates the edit location page from leaflet to maplibre.

This has two intentional changes:
- When clicking on the "Show" button, we now "fly" there instead of "fast-zoom-jump" (does not look very polished).
  I can change this to the previous behaviour, but that did not seem entirely intentional.
- the zoom buttons have rounded corners like on the main map

I disabled rotation, pich and yaw for this one, since for selecting a location you likely want this.

### How has this been tested?

Via docker, manually starting the map, interactig with it.
Locations get set appropriately, all buttons work.