### PR TITLE
Migrate the user diary to be maplibre based

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,25 +1,11 @@
 //= require maplibre.map
-//= require maplibre.i18n
 //= require maplibre.combinedcontrolgroup
 
 $(function () {
-  const defaultHomeZoom = 11;
   let map;
 
   if ($("#map").length) {
-    map = new maplibregl.Map({
-      container: "map",
-      style: OSM.MapLibre.Styles.Mapnik,
-      attributionControl: false,
-      locale: OSM.MapLibre.Locale,
-      rollEnabled: false,
-      dragRotate: false,
-      pitchWithRotate: false,
-      bearingSnap: 180,
-      maxPitch: 0,
-      center: OSM.home ? [OSM.home.lon, OSM.home.lat] : [0, 0],
-      zoom: OSM.home ? defaultHomeZoom : 0
-    });
+    map = new maplibregl.Map(OSM.MapLibre.defaultSecondaryMapOptions);
 
     const position = $("html").attr("dir") === "rtl" ? "top-left" : "top-right";
     const navigationControl = new maplibregl.NavigationControl({ showCompass: false });

--- a/app/assets/javascripts/maplibre.map.js
+++ b/app/assets/javascripts/maplibre.map.js
@@ -1,4 +1,5 @@
 //= require maplibre-gl/dist/maplibre-gl
+//= require maplibre.i18n
 
 OSM.MapLibre.Styles.Mapnik = {
   version: 8,
@@ -19,6 +20,21 @@ OSM.MapLibre.Styles.Mapnik = {
       source: "osm"
     }
   ]
+};
+
+OSM.MapLibre.defaultHomeZoom = 11;
+OSM.MapLibre.defaultSecondaryMapOptions = {
+  container: "map",
+  style: OSM.MapLibre.Styles.Mapnik,
+  attributionControl: false,
+  locale: OSM.MapLibre.Locale,
+  rollEnabled: false,
+  dragRotate: false,
+  pitchWithRotate: false,
+  bearingSnap: 180,
+  maxPitch: 0,
+  center: OSM.home ? [OSM.home.lon, OSM.home.lat] : [0, 0],
+  zoom: OSM.home ? OSM.MapLibre.defaultHomeZoom : 0
 };
 
 // Helper function to create Leaflet style (SVG comes from Leaflet) markers for MapLibre


### PR DESCRIPTION
### Description

This Pull request migrates the user diary page to be maplibre based.

Same as https://github.com/openstreetmap/openstreetmap-website/pull/6675 this is map does not have rotation, yaw and pich.

It fixes the the following bugs:
- when i add the coordinates in the fields and then click "use map", this previously did not set the center correctly
- rounding of the zoom buttons

I did not do these changes, even though they seem sensible to me:
- adding attribution to the map (it was not there beforehand..)
- adding the "locate me"-GPS button (it was not there beforehand..)

### How has this been tested?

Manually, by all the 3 expected interraction modes:
- enter into fields, click "use map"
- click to set marker
- drag marker