### PR TITLE
Avoid language selector breaking on submit

### DIFF
--- a/app/assets/javascripts/language_selector.js
+++ b/app/assets/javascripts/language_selector.js
@@ -12,3 +12,7 @@ $(document).on("click", "#select_language_dialog [data-language-code]", function
     location.reload();
   }
 });
+
+$(document).on("submit", "#select_language_form", function (e) {
+  e.preventDefault();
+});

--- a/app/views/languages_panes/show.html.erb
+++ b/app/views/languages_panes/show.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "select_language_list" do %>
   <% if current_user&.id %>
-    <%= form_tag basic_preferences_path, :method => "PUT" do %>
+    <%= form_tag basic_preferences_path, :method => "PUT", :id => "select_language_form", "data-turbo" => false do %>
       <%= hidden_field_tag "referer", @source_page %>
       <%= hidden_field_tag "language", I18n.locale %>
       <%= render "select_language_list" %>


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/6598, closes https://github.com/openstreetmap/openstreetmap-website/pull/6599

Avoid submission of the language selection form as it is intended only as a filter for the options below. Submission not only doesn't make sense, it also breaks the form.

This is extracted from my comment at https://github.com/openstreetmap/openstreetmap-website/pull/6599#issuecomment-3636677922. I'm not adding tests because this is not trivial to test with Capybara. I have only tested manually, please others confirm that it fixes the problem for you.