### PR TITLE
Enable erb_lint hard coded string linter

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -3,6 +3,13 @@ linters:
   AllowedScriptType:
     enabled: true
     disallow_inline_scripts: true
+  HardCodedString:
+    enabled: false # We're using a custom version of this, see below
+  # Add our own linter, refs https://github.com/Shopify/erb_lint/pull/397
+  CustomHardCodedString:
+    enabled: true
+    exclude:
+     - 'app/views/shared/_markdown_help.html.erb'
   Rubocop:
     enabled: true
     rubocop_config:
@@ -25,6 +32,8 @@ linters:
   SelfClosingTag:
     enabled: false
   SpaceInHtmlTag:
+    enabled: true
+  NoUnusedDisable:
     enabled: true
 exclude:
   - '**/vendor/**'

--- a/.erb_linters/custom_hard_coded_string.rb
+++ b/.erb_linters/custom_hard_coded_string.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "better_html/tree/tag"
+require "active_support/core_ext/string/inflections"
+
+module ERBLint
+  module Linters
+    # A customised version of the HardCodedString linter, adding `&middot;` as not needing translation
+    # Checks for hardcoded strings. Useful if you want to ensure a string can be translated using i18n.
+    class CustomHardCodedString < HardCodedString
+      include LinterRegistry
+
+      NO_TRANSLATION_NEEDED = Set.new([
+                                        "&nbsp;",
+                                        "&amp;",
+                                        "&lt;",
+                                        "&gt;",
+                                        "&quot;",
+                                        "&copy;",
+                                        "&reg;",
+                                        "&trade;",
+                                        "&hellip;",
+                                        "&mdash;",
+                                        "&bull;",
+                                        "&ldquo;",
+                                        "&rdquo;",
+                                        "&lsquo;",
+                                        "&rsquo;",
+                                        "&larr;",
+                                        "&rarr;",
+                                        "&darr;",
+                                        "&uarr;",
+                                        "&ensp;",
+                                        "&emsp;",
+                                        "&thinsp;",
+                                        "&times;",
+                                        "&laquo;",
+                                        "&raquo;",
+                                        "&middot;"
+                                      ])
+
+      private
+
+      def check_string?(str)
+        string = str.gsub(/\s*/, "")
+        string.length > 1 && !NO_TRANSLATION_NEEDED.include?(string)
+      end
+    end
+  end
+end

--- a/app/views/share_panes/show.html.erb
+++ b/app/views/share_panes/show.html.erb
@@ -54,7 +54,7 @@
       <%= label_tag "mapnik_scale", t(".scale"), :class => "col-auto col-form-label" %>
       <div class="col-auto">
         <div class="input-group flex-nowrap">
-          <span class="input-group-text">1 : </span>
+          <span class="input-group-text">1 : </span><%# erb_lint:disable CustomHardCodedString %>
           <%= text_field_tag "mapnik_scale", nil, :class => "form-control", :autocomplete => "off" %>
         </div>
       </div>


### PR DESCRIPTION
The implementation uses a customised linter, to add `&middot;` to the list of punctuation that doesn't need translating.

We can remove our customised linter when this list becomes a config option, see https://github.com/Shopify/erb_lint/pull/397

This follows on from #6569 and #6583 (see also #6627) and will prevent these types of problems from recurring.