### PR TITLE
Update documentation on firefox binary config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ You can view test coverage statistics by browsing the `coverage` directory.
 The tests are automatically run on Pull Requests and other commits via github actions. The results shown are within the PR display on github.
 
 > [!TIP]
-> **System tests** use Selenium with Firefox for browser automation. On Ubuntu 24.04, if Firefox is installed via snap, you may need to override the Firefox binary path in `config/settings.local.yml`:
+> **System tests** use Selenium with Firefox for browser automation. On Ubuntu 24.04, if Firefox is installed via snap, you may need to override the Firefox binary path in `config/settings/test.local.yml`:
 >
 > ```yaml
 > system_test_firefox_binary: /snap/firefox/current/usr/lib/firefox/firefox

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -60,4 +60,5 @@ doorkeeper_signing_key: |
 # Run system tests using headless Firefox
 system_test_headless: true
 # Override Firefox binary used in system tests
+# You can add this to config/settings/test.local.yml which is git-ignored
 #system_test_firefox_binary:


### PR DESCRIPTION
This setting can't be put into the config/settings.local.yml file, since [that file is ignored in the test environment](https://github.com/rubyconfig/config/blob/5e192a5ede17f90f972131f976ea69f3473c8c92/README.md#L183). Instead, we can use config/settings/test.local.yml file, which is git-ignored.
