### PR TITLE
rbenv install: show which versions are available

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -273,7 +273,7 @@ After installing a version of Ruby with `rbenv` (the latest stable version is a 
 rbenv local $VERSION
 ```
 
-Where `$VERSION` is the version you installed. Then install bundler:
+Where `$VERSION` is the version you installed. You can see a list of available versions by running `rbenv versions`. Then install bundler:
 
 ```bash
 gem install bundler


### PR DESCRIPTION
While setting up an environment in the development server, I realised I didn't know which Ruby versions were available. I had to run `rbenv versions`, which answered my question, but might not be obvious to others.