### PR TITLE
Fix: Preserve OAuth referer through email confirmation flow

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -34,12 +34,16 @@ class ConfirmationsController < ApplicationController
         user.save!
         cookies.delete :_osm_anonymous_notes_count
         referer = safe_referer(params[:referer]) if params[:referer]
+        # Restore referer from session if not in params
+        referer ||= session[:referer]
 
         pending_user = session.delete(:pending_user)
 
         if user.id == pending_user
           session[:user] = user.id
           session[:fingerprint] = user.fingerprint
+          # Clear the stored referer from session
+          session.delete(:referer)
 
           redirect_to referer || welcome_path
         else
@@ -60,11 +64,14 @@ class ConfirmationsController < ApplicationController
     if user.nil? || user.id != session[:pending_user]
       flash[:error] = t ".failure", :name => params[:display_name]
     else
-      UserMailer.signup_confirm(user, user.generate_token_for(:new_user)).deliver_later
+      # Preserve referer from session when resending confirmation
+      referer = session[:referer]
+      UserMailer.signup_confirm(user, user.generate_token_for(:new_user), referer).deliver_later
       flash[:notice] = { :partial => "confirmations/resend_success_flash", :locals => { :email => user.email, :sender => Settings.email_from } }
     end
 
-    redirect_to login_path
+    # Preserve referer when redirecting back to login
+    redirect_to login_path(:referer => session[:referer])
   end
 
   def confirm_email

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,6 +21,9 @@ class SessionsController < ApplicationController
     @safe_referer = referer
     @safe_referer = nil if referer != params[:referer]
 
+    # Store referer in session to preserve OAuth flow through signup/confirmation
+    session[:referer] = referer if referer
+
     parse_oauth_referer referer
   end
 


### PR DESCRIPTION
# Fix: Preserve OAuth referer through email confirmation flow

## Changes
- Store referer in session when user reaches login/signup from OAuth flow
- Pass original OAuth referer to confirmation email instead of transformed welcome path
- Restore referer after email confirmation to redirect back to OAuth authorization page
- Preserve referer when resending confirmation email

Fixes issue where newly created accounts couldn't complete OAuth2 authorization after email confirmation. Users were being redirected to the home page instead of the OAuth authorization page.

Fixes #6699 

---

## Description
This PR addresses a bug in the OAuth2 authorization flow that affects newly created accounts. When a user creates an account through an OAuth2 client (like StreetComplete) and confirms their email, they should be redirected to the OAuth authorization page to complete the flow. Instead, they were being redirected to the home page, preventing the authorization from completing.

---

## Root Cause:
The OAuth referer URL was being lost during the email confirmation process. The referer parameter was either not stored in the session, transformed into a welcome path, or not retrieved after email confirmation.

---

## Solution:
This PR modifies three controllers to properly preserve the OAuth referer throughout the entire flow:

- **SessionsController:** Stores the referer in session when user reaches login page from OAuth flow  
- **UsersController:** Preserves the original referer during signup and passes it to the confirmation email (instead of a transformed welcome path)  
- **ConfirmationsController:** Restores the referer from session after email confirmation and redirects appropriately  

The fix ensures that the original OAuth authorization URL is maintained through:

- Login page → Signup page → Email confirmation → OAuth authorization page  
- Login page → Resend confirmation → Back to login → OAuth authorization page  

---

## How has this been tested?

### Test Environment:
- Local development instance with Docker  
- Created test OAuth2 application with client_id and redirect_uri  
- Ruby 3.1, Rails 7.0  

---

### Test Scenarios:

#### New account creation through OAuth flow:
- Navigate to `/oauth2/authorize?client_id=TEST_CLIENT&response_type=code`
- Click "Sign up" from login page
- Create new account with email
- Confirm email via confirmation link  
**Verified:** User is correctly redirected to OAuth authorization page  

#### Resend confirmation email:
- Navigate to OAuth authorization URL (not logged in)
- Enter a dummy email and click "Resend confirmation email"
- Return to login page
- Log in with existing account  
**Verified:** User is correctly redirected to OAuth authorization page (previously redirected to home page)  

#### Existing account login :
- Navigate to OAuth authorization URL
- Log in with existing confirmed account  
**Verified:** Still works correctly, redirects to OAuth authorization page  

#### Non-OAuth signup :
- Navigate directly to `/users/new`
- Create account without OAuth referer
- Confirm email  
**Verified:** User is redirected to welcome page as expected 

All tests passed successfully with the changes applied.
