### PR TITLE
Avoid suggesting support can create accounts

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3168,7 +3168,7 @@ en:
       tab_title: "Sign Up"
       signup_to_authorize_html: "Sign up with OpenStreetMap to access %{client_app_name}."
       no_auto_account_create: "Unfortunately we are not currently able to create an account for you automatically."
-      please_contact_support_html: 'Please contact %{support_link} to arrange for an account to be created - we will try and deal with the request as quickly as possible.'
+      please_contact_support_html: 'Please contact %{support_link} for assistance - we will try and deal with the request as quickly as possible.'
       support: support
       about:
         header: Free and editable.


### PR DESCRIPTION
The original plan was that administrator would manually create accounts for people that were blocked by an ACL but this is not actually what we do because we need people to read and agree the terms.

The error still suggests that we will create the account though, so let's fix that...