### PR TITLE
Add moderation zones where anonymous notes are not allowed

### DIFF
--- a/.devcontainer/Dockerfile.postgres
+++ b/.devcontainer/Dockerfile.postgres
@@ -1,0 +1,8 @@
+# Would use postgis:15-3.5, but it doesn't work with Apple Silicon
+# (https://github.com/postgis/docker-postgis/issues/216).
+# Therefore we use postgres:15 and apt-install Postgis ourselves.
+FROM postgres:15
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    postgresql-15-postgis-3

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -36,7 +36,9 @@ services:
     restart: unless-stopped
 
   postgres:
-    image: postgres:15
+    build:
+      context: .
+      dockerfile: ./Dockerfile.postgres
     restart: unless-stopped
     networks:
     - default

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -123,6 +123,10 @@ jobs:
         cache: yarn
     - name: Install node modules
       run: bundle exec bin/yarn install
+    - name: Install packages
+      run: |
+        sudo apt-get -yqq update
+        sudo apt-get -yqq install postgresql-postgis
     - name: Setup database
       run: |
         sudo systemctl start postgresql
@@ -157,6 +161,10 @@ jobs:
         cache: yarn
     - name: Install node modules
       run: bundle exec bin/yarn install
+    - name: Install packages
+      run: |
+        sudo apt-get -yqq update
+        sudo apt-get -yqq install postgresql-postgis
     - name: Setup database
       run: |
         sudo systemctl start postgresql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get -yqq update
-        sudo apt-get -yqq install memcached libvips-dev xvfb mesa-utils libgl1-mesa-dri
+        sudo apt-get -yqq install memcached libvips-dev xvfb mesa-utils libgl1-mesa-dri postgresql-postgis
     - name: Create database
       run: |
         sudo systemctl start postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ source "https://rubygems.org"
 gem "rails", "~> 8.1.0"
 gem "turbo-rails"
 
-# Use postgres as the database
+# Use postgres+postgis as the database
+gem "activerecord-postgis"
 gem "pg"
 
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,10 @@ GEM
       timeout (>= 0.4.0)
     activerecord-import (2.2.0)
       activerecord (>= 4.2)
+    activerecord-postgis (0.5.1)
+      activerecord (>= 8.1.0, < 8.2)
+      pg
+      rgeo-activerecord (>= 8.0)
     activestorage (8.1.3)
       actionpack (= 8.1.3)
       activejob (= 8.1.3)
@@ -784,6 +788,10 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
+    rgeo (3.1.0)
+    rgeo-activerecord (8.1.0)
+      activerecord (>= 8.1, < 8.2)
+      rgeo (>= 3.0)
     rinku (2.0.6)
     rotp (6.3.0)
     rouge (4.7.0)
@@ -922,6 +930,7 @@ DEPENDENCIES
   actionpack-page_caching (>= 1.2.0)
   active_record_union
   activerecord-import
+  activerecord-postgis
   addressable (~> 2.8)
   annotaterb
   argon2

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -89,6 +89,8 @@ module Api
       lat = OSM.parse_float(params[:lat], OSM::APIBadUserInput, "lat was not a number")
       description = params[:text]
 
+      raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any?(:lon => lon, :lat => lat)
+
       # Get note's author info (for logged in users - user_id, for logged out users - IP address)
       note_author_info = author_info
 

--- a/app/models/moderation_zone.rb
+++ b/app/models/moderation_zone.rb
@@ -32,4 +32,13 @@ class ModerationZone < ApplicationRecord
   validates :name, :presence => true
   validates :reason, :presence => true
   validates :zone, :presence => true
+
+  def self.falls_within_any?(lon:, lat:)
+    factory = RGeo::Cartesian.simple_factory(:srid => 4326)
+    point = factory.point(lon, lat)
+
+    where(
+      arel_table[:zone].st_contains(point)
+    ).exists?
+  end
 end

--- a/app/models/moderation_zone.rb
+++ b/app/models/moderation_zone.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: moderation_zones
+#
+#  id            :bigint           not null, primary key
+#  name          :string           not null
+#  reason        :string           not null
+#  reason_format :enum             default("markdown")
+#  zone          :st_polygon       not null, polygon, 4326
+#  ends_at       :datetime
+#  creator_id    :bigint           not null
+#  revoker_id    :bigint
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_moderation_zones_on_creator_id  (creator_id)
+#  index_moderation_zones_on_revoker_id  (revoker_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (creator_id => users.id)
+#  fk_rails_...  (revoker_id => users.id)
+#
+class ModerationZone < ApplicationRecord
+  belongs_to :creator, :class_name => "User"
+  belongs_to :revoker, :class_name => "User", :optional => true
+
+  validates :name, :presence => true
+  validates :reason, :presence => true
+  validates :zone, :presence => true
+end

--- a/db/migrate/20260113142804_enable_postgis.rb
+++ b/db/migrate/20260113142804_enable_postgis.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnablePostgis < ActiveRecord::Migration[8.1]
+  def change
+    enable_extension "postgis"
+  end
+end

--- a/db/migrate/20260113144310_create_moderation_zones.rb
+++ b/db/migrate/20260113144310_create_moderation_zones.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateModerationZones < ActiveRecord::Migration[8.1]
+  def change
+    create_table :moderation_zones do |t|
+      t.string :name, :null => false
+      t.string :reason, :null => false
+      t.column :reason_format, :format_enum, :default => "markdown"
+      t.st_polygon :zone, :srid => 4326, :null => false
+      t.datetime :ends_at
+
+      t.references :creator, :null => false, :foreign_key => { :to_table => :users }
+      t.references :revoker, :foreign_key => { :to_table => :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1018,6 +1018,43 @@ ALTER SEQUENCE public.messages_id_seq OWNED BY public.messages.id;
 
 
 --
+-- Name: moderation_zones; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.moderation_zones (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    reason character varying NOT NULL,
+    reason_format public.format_enum DEFAULT 'markdown'::public.format_enum,
+    zone public.geometry(Polygon,4326) NOT NULL,
+    ends_at timestamp(6) without time zone,
+    creator_id bigint NOT NULL,
+    revoker_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: moderation_zones_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.moderation_zones_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: moderation_zones_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.moderation_zones_id_seq OWNED BY public.moderation_zones.id;
+
+
+--
 -- Name: node_tags; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1867,6 +1904,13 @@ ALTER TABLE ONLY public.messages ALTER COLUMN id SET DEFAULT nextval('public.mes
 
 
 --
+-- Name: moderation_zones id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.moderation_zones ALTER COLUMN id SET DEFAULT nextval('public.moderation_zones_id_seq'::regclass);
+
+
+--
 -- Name: note_comments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2192,6 +2236,14 @@ ALTER TABLE ONLY public.languages
 
 ALTER TABLE ONLY public.messages
     ADD CONSTRAINT messages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: moderation_zones moderation_zones_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.moderation_zones
+    ADD CONSTRAINT moderation_zones_pkey PRIMARY KEY (id);
 
 
 --
@@ -2737,6 +2789,20 @@ CREATE INDEX index_issues_on_status ON public.issues USING btree (status);
 --
 
 CREATE INDEX index_issues_on_updated_by ON public.issues USING btree (updated_by);
+
+
+--
+-- Name: index_moderation_zones_on_creator_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_moderation_zones_on_creator_id ON public.moderation_zones USING btree (creator_id);
+
+
+--
+-- Name: index_moderation_zones_on_revoker_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_moderation_zones_on_revoker_id ON public.moderation_zones USING btree (revoker_id);
 
 
 --
@@ -3297,6 +3363,14 @@ ALTER TABLE ONLY public.social_links
 
 
 --
+-- Name: moderation_zones fk_rails_6a0b70e3da; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.moderation_zones
+    ADD CONSTRAINT fk_rails_6a0b70e3da FOREIGN KEY (creator_id) REFERENCES public.users(id);
+
+
+--
 -- Name: oauth_access_tokens fk_rails_732cb83ab7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3366,6 +3440,14 @@ ALTER TABLE ONLY public.user_mutes
 
 ALTER TABLE ONLY public.oauth_access_tokens
     ADD CONSTRAINT fk_rails_ee63f25419 FOREIGN KEY (resource_owner_id) REFERENCES public.users(id) NOT VALID;
+
+
+--
+-- Name: moderation_zones fk_rails_f2132b7340; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.moderation_zones
+    ADD CONSTRAINT fk_rails_f2132b7340 FOREIGN KEY (revoker_id) REFERENCES public.users(id);
 
 
 --
@@ -3701,6 +3783,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('21'),
 ('20260223105922'),
 ('20260218183352'),
+('20260113144310'),
 ('20260113142804'),
 ('20251218105716'),
 ('20251121134648'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31,6 +31,20 @@ COMMENT ON EXTENSION btree_gist IS 'support for indexing common datatypes in GiS
 
 
 --
+-- Name: postgis; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION postgis; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION postgis IS 'PostGIS geometry and geography spatial types and functions';
+
+
+--
 -- Name: format_enum; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -3687,6 +3701,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('21'),
 ('20260223105922'),
 ('20260218183352'),
+('20260113142804'),
 ('20251218105716'),
 ('20251121134648'),
 ('20250704143751'),

--- a/doc/MANUAL_INSTALL.md
+++ b/doc/MANUAL_INSTALL.md
@@ -21,7 +21,7 @@ sudo apt-get update
 sudo apt-get install ruby ruby-dev ruby-bundler \
                      libvips-dev libxml2-dev libxslt1-dev \
                      nodejs build-essential git-core \
-                     postgresql postgresql-contrib libpq-dev \
+                     postgresql postgresql-contrib postgresql-postgis libpq-dev \
                      libsasl2-dev libffi-dev libgd-dev \
                      libarchive-dev libyaml-dev libbz2-dev npm
 sudo npm install --global yarn
@@ -40,7 +40,7 @@ sudo npm install --global yarn
 sudo dnf install ruby ruby-devel rubygem-rdoc rubygem-bundler \
                  rubygems libxml2-devel nodejs gcc gcc-c++ git \
                  postgresql postgresql-server \
-                 postgresql-contrib libpq-devel \
+                 postgresql-contrib postgis libpq-devel \
                  perl-podlators libffi-devel gd-devel \
                  libarchive-devel libyaml-devel bzip2-devel \
                  nodejs-yarn vips-devel

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,4 +1,11 @@
+# Would use postgis:14-3.5, but it doesn't work with Apple Silicon
+# (https://github.com/postgis/docker-postgis/issues/216).
+# Therefore we use postgres:14 and apt-install Postgis ourselves.
 FROM postgres:14
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    postgresql-14-postgis-3
 
 # Add db init script to install OSM-specific Postgres user.
 ADD docker/postgres/openstreetmap-postgres-init.sh /docker-entrypoint-initdb.d/

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -19,8 +19,18 @@ module OSM
 
   # Raised when access is denied.
   class APIAccessDenied < APIError
-    def initialize
-      super("Access denied")
+    def initialize(message = "Access denied")
+      super
+    end
+
+    def status
+      :forbidden
+    end
+  end
+
+  class APIModerationZoneError < APIAccessDenied
+    def initialize(message = "You don't have permissions to make changes in this zone, as it is currently protected by moderators")
+      super
     end
 
     def status

--- a/test/factories/moderation_zones.rb
+++ b/test/factories/moderation_zones.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :moderation_zone do
+    sequence(:name) { |n| "Moderation Zone #{n}" }
+    sequence(:reason) { |n| "Reason #{n}" }
+    creator { association :user }
+
+    trait :seville_cathedral do
+      zone do
+        <<~GEOMETRY
+          POLYGON((
+            -5.994110 37.386714,
+            -5.993954 37.385371,
+            -5.993621 37.385124,
+            -5.992162 37.385239,
+            -5.992264 37.386309,
+            -5.992506 37.386467,
+            -5.992559 37.386842,
+            -5.994110 37.386714
+          ))
+        GEOMETRY
+      end
+    end
+  end
+end

--- a/test/models/moderation_zone_test.rb
+++ b/test/models/moderation_zone_test.rb
@@ -3,4 +3,16 @@
 require "test_helper"
 
 class ModerationZoneTest < ActiveSupport::TestCase
+  def test_falls_within_any
+    create(:moderation_zone, :seville_cathedral)
+
+    # Dead center
+    assert ModerationZone.falls_within_any?(:lat => 37.385972, :lon => -5.993149)
+
+    # Inside, near the boundary
+    assert ModerationZone.falls_within_any?(:lat => 37.386658, :lon => -5.994024)
+
+    # Outside, near the boundary
+    assert_not ModerationZone.falls_within_any?(:lat => 37.386769, :lon => -5.994185)
+  end
 end

--- a/test/models/moderation_zone_test.rb
+++ b/test/models/moderation_zone_test.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ModerationZoneTest < ActiveSupport::TestCase
+end


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/6570 (Enable PostGIS).

This PR introduces "moderation zones" where anonymous notes are not allowed. It also enables PostGIS in the process.

This addresses https://github.com/openstreetmap/operations/issues/1362 partially:
- Within the moderation zones, only unauthenticated users are blocked, not "recent" ones. We can measure the success of this one before moving on to recent accounts which are a bit more complex.
- No UI for moderators to define the zones. This will be implemented in a future PR.

### Interacting with PostGIS
In PostGIS terms, these zones are defined as geometries as opposed to geographies. This is consistent with the rest of the API.

Two gem options are available:
- [activerecord-postgis-adapter](https://github.com/rgeo/activerecord-postgis-adapter):
	- "Classic" gem, 15 years old.
	- Requires setting `adapter: postgis` which can be a headache when moving between branches.
	- Doesn't work well when using geography-enabled functions such as `ST_Covers`. Probably can be added by implementing the operations with Arel.
	- Does work well with `ST_Contains`.
	- Works with Ruby 3.2, probably lower but I haven't checked.
- [activerecord-postgis](https://github.com/seuros/activerecord-postgis) (current choice):
	- Very recent gem, 1 year old, I only discovered it by accident.
	- Doesn't require changing `config/database.yml`.
	- Works with geography-enabled functions such as `ST_Covers` by interpolating params into `?`, but not with Arel (can be added though).
	- Requires Ruby 3.3 minimum (although as mentioned Ruby 3.2 is about to enter EOL).
	- Claims not to be based on monkeypatching in comparison to the competition (I haven't looked into this).

In common to both:
- They are drop-in replacements for each other, at least as long as you stick to geometry functions.
- Both support Arel queries for geometry, which is the way I have implemented the query.
- They use [RGeo](https://github.com/rgeo/rgeo) behind the scenes to encapsulate GIS objects. This requires creating them with one of [several available factories](https://github.com/rgeo/rgeo/blob/main/doc/Which-factory-should-I-use.md). I have gone for `RGeo::Cartesian.simple_factory` as it appears to just work. If we changed to one of the others, we'd need the gem [ffi-geos](https://github.com/dark-panda/ffi-geos). This is not made clear in the documentation.
 
I haven't found a big argument for either, but I have gone for the newer one if only because of the simplicity of not having to update `config/database.yml`.

### Future work
- If an unauthenticated user writes a long, thoughtful note, submits it, but then it fails because it was a moderation zone... they have wasted their time, if not lost their work. Therefore we may want a way for clients to tell ahead of time if a specific location has a block. Probably an API such as `GET /api/0.6/notes/allowed?lat=X&lon=Y`.
- There's no UI to define the zones. We'll need a CRUD for moderators to use.