### PR TITLE
Fix: Preserve OAuth referer when resending confirmation email 

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -60,11 +60,12 @@ class ConfirmationsController < ApplicationController
     if user.nil? || user.id != session[:pending_user]
       flash[:error] = t ".failure", :name => params[:display_name]
     else
-      UserMailer.signup_confirm(user, user.generate_token_for(:new_user)).deliver_later
+      referer = session[:referer]
+      UserMailer.signup_confirm(user, user.generate_token_for(:new_user), referer).deliver_later
       flash[:notice] = { :partial => "confirmations/resend_success_flash", :locals => { :email => user.email, :sender => Settings.email_from } }
     end
 
-    redirect_to login_path
+    redirect_to login_path(:referer => session[:referer])
   end
 
   def confirm_email

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -89,6 +89,7 @@ class UsersController < ApplicationController
             successful_login(current_user, referer)
           else
             session[:pending_user] = current_user.id
+            session[:referer] = params[:referer]
             UserMailer.signup_confirm(current_user, current_user.generate_token_for(:new_user), referer).deliver_later
             redirect_to :controller => :confirmations, :action => :confirm, :display_name => current_user.display_name
           end


### PR DESCRIPTION
# Description 

- When users sign up through an OAuth2 authorization flow and click "Resend confirmation email", the OAuth referer information is lost. The resent confirmation email does NOT contain the referer parameter with the oauth_return_url, causing the "Continue authorization" button to disappear from the welcome page after email confirmation.

- Note : After signup if user doesnt click on "resend confirmation" , the initial confirmation link which was sent to email properly redirects to welcome page with "Continue authorization" , the above issue occurs only when user clicks "Resend confirmation mail"

Related to #6699 

### Fix 
- Store referer in session during user signup
- Pass stored referer when resending confirmation email
- Include referer in redirect after resending confirmation

This ensures that users who sign up via OAuth2 and click 'Resend confirmation email' will still see the 'Continue authorization' button on the welcome page after confirming their account.

Added unit tests:
- test_confirm_success_with_oauth_referer: Verifies initial signup confirmation preserves OAuth referer
- test_confirm_resend_preserves_oauth_referer: Verifies resending confirmation also preserves OAuth referer (this test fails without the fix, proving the bug exists)

<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->
