### PR TITLE
Update route markers and context menu icons to cursor/flag metaphor (…

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -34,7 +34,7 @@ OSM.initializations.push(function (map) {
   const contextmenuItems = [
     {
       id: "menu-action-directions-from",
-      icon: "bi-play",
+      icon: "bi-cursor",
       text: OSM.i18n.t("javascripts.context.directions_from"),
       callback: () => {
         const params = new URLSearchParams({
@@ -46,7 +46,7 @@ OSM.initializations.push(function (map) {
     },
     {
       id: "menu-action-directions-to",
-      icon: "bi-stop",
+      icon: "bi-flag",
       text: OSM.i18n.t("javascripts.context.directions_to"),
       callback: () => {
         const params = new URLSearchParams({
@@ -88,7 +88,6 @@ OSM.initializations.push(function (map) {
     }
   ];
 
-  // Event bindings
   map.on("contextmenu", function (e) {
     map.osm_contextmenu.show(e, contextmenuItems);
     updateContextMenuState();
@@ -159,7 +158,7 @@ class ContextMenu {
         {
           name: "offset",
           options: {
-            offset: [0, 0] // no offset, exactly aligned to placement corner
+            offset: [0, 0]
           }
         },
         {

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -24,8 +24,8 @@ OSM.Directions = function (map) {
   };
 
   const endpoints = [
-    OSM.DirectionsEndpoint(map, $("input[name='route_from']"), { icon: "play", color: "var(--marker-green)" }, endpointDragCallback, endpointChangeCallback),
-    OSM.DirectionsEndpoint(map, $("input[name='route_to']"), { icon: "stop", color: "var(--marker-red)" }, endpointDragCallback, endpointChangeCallback)
+    OSM.DirectionsEndpoint(map, $("input[name='route_from']"), { icon: "start", color: "var(--marker-green)" }, endpointDragCallback, endpointChangeCallback),
+    OSM.DirectionsEndpoint(map, $("input[name='route_to']"), { icon: "destination", color: "var(--marker-red)" }, endpointDragCallback, endpointChangeCallback)
   ];
 
   const expires = new Date();

--- a/app/views/layouts/_markers.html.erb
+++ b/app/views/layouts/_markers.html.erb
@@ -18,8 +18,8 @@
          "tick" => { :"stroke-linecap" => "round", :"stroke-linejoin" => "round", :fill => "none", :d => "M7.157 14.649Q8.9 16 11.22 18.761 14.7 11.7 17.843 8.239" },
          "cross" => { :"stroke-linecap" => "round", :d => "m7.5 8 10 10m0-10-10 10" },
          "minus" => { :"stroke-linecap" => "round", :d => "M5.75 13h13.5" },
-         "play" => { :"stroke-linejoin" => "round", :fill => "#fff", :d => "M10 17.5v-9l7 4.5z" },
-         "stop" => { :"stroke-linejoin" => "round", :fill => "#fff", :d => "M9 9.5h7v7H9z" },
+         "start" => { :"stroke-linejoin" => "round", :fill => "#fff", :d => "M5.5 13h7v7l5-12z" },
+         "destination" => { :"stroke-linecap" => "round", :"stroke-linejoin" => "round", :fill => "#fff", :d => "M10 21 7 9c5-3 6 2 11 0l1 4c-5 2-6-3-11 0" },
          "dot" => { :"stroke-linecap" => "round", :fill => "#fff", :d => "M11.5 10a1 1 0 0 0 2 5 1 1 0 0 0-2-5" }
        } %>
 

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -51,7 +51,7 @@
   </div>
 
   <%= render :partial => "layouts/control_icons" %>
-  <%= render :partial => "layouts/markers", :locals => { :types => %w[dot cross tick plus play stop] } %>
+  <%= render :partial => "layouts/markers", :locals => { :types => %w[dot cross tick plus start destination] } %>
 
   <noscript>
     <div class="mt-5 p-3">


### PR DESCRIPTION
Resolves #929.

### Description
This PR updates the route markers and context menu icons to use standard navigation metaphors, replacing the previous "media player" style icons (triangle/square) that were causing user confusion.

* **Map Markers (`_markers.html.erb`):** Updated the internal SVG paths for the start and end markers. The start marker now uses a "navigation arrow" (cursor) and the end marker uses a "flag".
* **Context Menu (`contextmenu.js`):** Updated the Bootstrap icons to `bi-cursor` and `bi-flag` to ensure the menu options visually match the new map markers.

**Screenshots:**

<img width="1470" height="879" alt="Screenshot 2026-01-16 at 2 27 15 PM" src="https://github.com/user-attachments/assets/5556855d-1a2e-408d-bac9-0e112d5f445e" />
