### PR TITLE
Enhance docker-compose with container names and healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   web:
+    container_name: openstreetmap-web
     build:
       context: .
     environment:
@@ -22,8 +23,15 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--timeout=5", "http://localhost:3000"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   db:
+    container_name: openstreetmap-db
     build:
       context: .
       dockerfile: docker/postgres/Dockerfile
@@ -40,6 +48,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 20
+      start_period: 10s
 
 volumes:
   web-tmp:


### PR DESCRIPTION
Added container names and healthchecks for web and db services.



```
services:
  web:
    container_name: openstreetmap-web

    healthcheck:
      test: ["CMD", "wget", "--spider", "--timeout=5", "http://localhost:3000"]
      interval: 30s
      timeout: 5s
      retries: 3
      start_period: 10s

  db:
    container_name: openstreetmap-db

```

<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->

### How has this been tested?
<!--Explain the steps you took to test your code.-->
