### PR TITLE
Check response.ok before parsing JSON in query tool

### DIFF
--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -171,7 +171,12 @@ OSM.Query = function (map) {
       credentials: OSM.OVERPASS_CREDENTIALS ? "include" : "same-origin",
       signal: $section.data("ajax").signal
     })
-      .then(response => response.json())
+      .then(response => {
+        if (response.ok) {
+          return response.json();
+        }
+        throw new Error(response.statusText || response.status);
+      })
       .then(function (results) {
         let elements = results.elements;
 

--- a/test/system/query_features_test.rb
+++ b/test/system/query_features_test.rb
@@ -214,6 +214,7 @@ class QueryFeaturesSystemTest < ApplicationSystemTestCase
                 elements = data.includes("is_in") ? #{enclosing_elements.to_json} : #{nearby_elements.to_json};
 
           return Promise.resolve({
+            ok: true,
             json: () => Promise.resolve({ elements })
           });
         }


### PR DESCRIPTION
Added a if-else to check response.ok before parsing JSON in query tool

<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
This PR fixes issue #6667.
The query tool no longer crashes when the network or server returns an error.

## Problem
The query tool tried to read every response as JSON.
When the Overpass API returned an error page or the request failed, this caused unclear errors like:

`JSON.parse: unexpected character at line 1 column 1 of the JSON data`

## Solution
The tool now checks the response status before reading JSON.
If the request fails, it shows a clear message, for example:

`Error contacting https://overpass-api.de/api/interpreter: Failed to fetch`

### How has this been tested?

- Linting passes (eslint, erb_lint, rubocop)

- Manually testing network failure using browser offline mode
 The tool now shows “Failed to fetch”

- Normal queries still work as expected

Fixes #6667
