### PR TITLE
Fix month label index desync causing missing labels

### DIFF
--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -3,6 +3,7 @@ $(document).on("turbo:frame-load", function () {
   const weekInfo = getWeekInfo();
   const maxPerDay = heatmap.data("max-per-day");
   const weekdayLabels = heatmap.find("[data-weekday]");
+  const monthLabelStartIndex = Math.min(...heatmap.find("[data-month]").get().map(l => l.dataset.month));
   let weekColumn = 1;
   let previousMonth = null;
 
@@ -24,7 +25,7 @@ $(document).on("turbo:frame-load", function () {
       weekColumn++;
       const currentMonth = getMonthOfThisWeek(date);
       if (previousMonth === null) {
-        previousMonth = currentMonth;
+        previousMonth = currentMonth + (Math.round((monthLabelStartIndex - currentMonth) / 12) * 12);
         heatmap.find(`[data-month]:has( ~ [data-month="${previousMonth}"])`).remove();
         heatmap.find("[data-month]").first().css("grid-column-start", 2);
       }


### PR DESCRIPTION
Since JS trims the heatmap data to align with the calendar-dependent start of the week, the point where monotonic month indices snap back a year can differ between calendars.

This misalignment desynchronizes month label indices and can cause month labels to be skipped.

The fix makes the label handling logic agnostic to yearly offsets.