### PR TITLE
Use media queries to hide menus instead of JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -112,10 +112,14 @@ $(function () {
     const windowWidth = $(window).width();
 
     if (windowWidth < breakpointWidth) {
-      $("body").addClass("small-nav");
       expandAllSecondaryMenuItems();
     } else {
-      $("body").removeClass("small-nav");
+      if (secondaryMenuItems.length === 0) {
+        $expandedSecondaryMenu.find("li:not(#compact-secondary-nav)").each(function () {
+          secondaryMenuItems.push([this, $(this).width()]);
+        });
+        moreItemWidth = $("#compact-secondary-nav").width();
+      }
       const availableWidth = $expandedSecondaryMenu.width();
       secondaryMenuItems.forEach(function (item) {
         $(item[0]).remove();
@@ -179,11 +183,6 @@ $(function () {
    * to defer the measurement slightly as a workaround.
    */
   setTimeout(function () {
-    $expandedSecondaryMenu.find("li:not(#compact-secondary-nav)").each(function () {
-      secondaryMenuItems.push([this, $(this).width()]);
-    });
-    moreItemWidth = $("#compact-secondary-nav").width();
-
     updateHeader();
 
     $(window).resize(updateHeader);

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -151,7 +151,7 @@ nav.primary, nav.secondary {
   display: none;
 }
 
-body.small-nav {
+@include media-breakpoint-down(md) {
   header {
     height: auto;
     min-height: $headerHeight;


### PR DESCRIPTION
fixes #6523

### Description

Currently, on mobile devices, you can see opened menu items and banners within a few milliseconds.

https://github.com/user-attachments/assets/6522c80f-b557-4f43-8610-6966fe36a420

This is because the style that hides them is applied using JavaScript by setting the `small-nav` class to `<body>`. In the code, it looks like:

https://github.com/openstreetmap/openstreetmap-website/blob/5b3210c5f637596ed65e75c2173990055b11fe5c/app/assets/javascripts/application.js#L115-L119

This can be replaced with a media query that will be applied without waiting for JavaScript to be applied.

However, now you need to fill in the `secondaryMenuItems` array only if the screen size is mobile. Otherwise, the width of the menu items will always remain 0. This is important if you had a narrow window when loading the site, but then you expanded it.
