### PR TITLE
Document project roles, permissions, and eligibility criteria

### DIFF
--- a/doc/ROLES.md
+++ b/doc/ROLES.md
@@ -1,0 +1,36 @@
+# Project Roles
+
+Everyone can contribute to the project. Everyone can create and comment on issues and pull requests, review PRs, and generally help out.
+
+There are only two roles that grant extra permissions to contributors, and those extra permissions are quite small.
+
+## Maintainers
+
+The primary goal of the group of maintainers is to ensure the long-term success of the project.
+
+This goal can be achieved by ensuring the project meets the needs of the mapping community, maintaining code quality, making it easy to contribute, and building the team of people involved in development.
+
+The additional permissions granted allow maintainers to:
+
+* Merge pull requests. Note that anyone can review PRs, not just maintainers. It's only the final merge that is restricted.
+* Approve Github Actions runs for first-time contributors
+* View and handle security reports
+* Grant roles to contributors. Nominations can be from contributors and/or current maintainers, and are discussed and agreed upon by the existing maintainers
+* Other administrative work, including changing some project settings (like enabling CI workflows, creating new labels)
+
+To become eligible for the maintainer role, contributors should show a consistent history of quality in their pull requests, a history of helping other people when reviewing code, and a history of providing actionable guidance to other contributors.
+
+## Triagers
+
+The primary goal of the triagers is to reduce the need for maintainers to manage issues and pull requests.
+
+This goal can be achieved by keeping the issues list small, each issue on topic, and discussions focussed and productive. Anyone in the community can help with most of this work. However, triagers have extra permissions that can help in certain situations.
+
+These additional permissions allow triagers to:
+
+* Close any issue. This can include duplicate issues, off-topic issues, spam, etc
+* Add labels to any issue. This can help highlight bugs, pull requests that need changes, etc
+* Rename or edit any issue description. This can be useful when new contributors use the wrong terminology, etc
+* Edit issue relationships and create subissues
+
+To become eligible for the triager role, contributors should show a wide knowledge of both this project and the wider OSM ecosystem, along with a consistent history of helpful comments in the repo.


### PR DESCRIPTION
The aim of this is both transparency around these roles, but also some support to contributors so that they know what's involved.

Most of this comes from things I've said previously during presentations (e.g. [SotM-EU 2023 - Maintaining OpenStreetMap.org](https://www.youtube.com/watch?v=99_ecrNOMPs)) and during individual issue and PR comment threads. But I think it's worth putting these down in writing in one place.