### PR TITLE
More padding for menu items on mobile devices

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -157,7 +157,7 @@ $(function () {
   function expandSecondaryMenuItem($item) {
     $item.children("a")
       .removeClass("dropdown-item")
-      .addClass("nav-link")
+      .addClass("nav-link px-1 py-0")
       .addClass(function () {
         return $(this).hasClass("active") ? "text-secondary-emphasis" : "text-secondary";
       });
@@ -168,7 +168,7 @@ $(function () {
   function collapseSecondaryMenuItem($item) {
     $item.children("a")
       .addClass("dropdown-item")
-      .removeClass("nav-link text-secondary text-secondary-emphasis");
+      .removeClass("nav-link px-1 py-0 text-secondary text-secondary-emphasis");
     $item.removeClass("nav-item").appendTo($collapsedSecondaryMenu);
     toggleCompactSecondaryNav();
   }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -129,10 +129,6 @@ nav.primary {
 }
 
 nav.secondary {
-  .nav-link {
-    padding: 0 0.3rem;
-  }
-
   .user-menu, .login-menu {
     width: 100%;
   }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -33,12 +33,12 @@
   <nav class="secondary d-flex flex-column flex-md-row gap-2 flex-grow-1 align-items-center">
     <ul id="secondary-nav-menu" class="nav flex-grow-1 justify-content-center justify-content-md-start" data-turbo-permanent>
       <% secondary_nav_items.each do |path, label, options| %>
-        <li class="nav-item">
-          <%= link_to label, path, :class => ["nav-link", current_page?(path) ? "active text-secondary-emphasis" : "text-secondary"], **(options || {}) %>
+        <li class="nav-item pb-2 pb-md-0">
+          <%= link_to label, path, :class => ["nav-link", "px-1", "py-0", current_page?(path) ? "active text-secondary-emphasis" : "text-secondary"], **(options || {}) %>
         </li>
       <% end %>
-      <li id="compact-secondary-nav" class="dropdown nav-item ms-auto collapse">
-        <button class="dropdown-toggle nav-link btn btn-outline-secondary border-0 bg-body text-secondary" type="button" data-bs-toggle="dropdown"><%= t ".more" %></button>
+      <li id="compact-secondary-nav" class="dropdown nav-item ms-auto pb-2 pb-md-0 collapse">
+        <button class="dropdown-toggle nav-link btn btn-outline-secondary px-1 py-0 border-0 bg-body text-secondary" type="button" data-bs-toggle="dropdown"><%= t ".more" %></button>
         <ul class="dropdown-menu">
         </ul>
       </li>


### PR DESCRIPTION
### Description

On mobile devices, it is quite inconvenient to click on menu items. Especially in the Russian localization, where as many as three lines appear. I suggest slightly increasing the line margins:

<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>

<img width="100%" src="https://github.com/user-attachments/assets/9b61dd99-9d49-4a61-a223-66e9104cbfd7" />
 <td>

<img width="100%"  src="https://github.com/user-attachments/assets/55e41d99-0cf8-4d75-8184-a874167f0ca6" />

<tr>
	<td>

<img width="100%" src="https://github.com/user-attachments/assets/900a6780-4e2b-4364-a258-0294a8c8a737" />
	<td>

<img width="100%" src="https://github.com/user-attachments/assets/0acfbab9-74d9-4cd4-86ec-b4e25ef758d6" />

</table>