### PR TITLE
Add Zed to docs about Dev Containers

### DIFF
--- a/doc/DEVCONTAINER.md
+++ b/doc/DEVCONTAINER.md
@@ -135,10 +135,13 @@ VS Code is not the only way to work with devcontainers. Other options include:
 - [DevPod](https://devpod.sh): a CLI tool to work with devcontainers.
 - [VSCodium](https://vscodium.com): a Free/Libre alternative to VS Code.
 - [GitHub Codespaces](https://github.com/codespaces): GitHub's hosted IDE.
+- [Zed](https://zed.dev): a code editor
 
 ## Troubleshooting
 
 ### `‘ruby’: No such file or directory`
+
+Make sure that you are running commands from under the `vscode` user. Use `su vscode` to switch to this user.
 
 In some cases Ruby may not install correctly. If you see this message, run these two commands:
 


### PR DESCRIPTION
Zed [added](https://zed.dev/blog/dev-containers) support for Dev Containers in January of 2026. I tested the work of Dev Containers with this repository and the only remark is that Zed opens the terminal from under the `root` user, which is why you get an error:

`env: ‘ruby’: No such file or directory`

and `mise: not found`

Added information about this to Troubleshooting