### PR TITLE
Activate `zoomSnap` on raster based map styles

### DIFF
--- a/app/assets/javascripts/maplibre/map.js
+++ b/app/assets/javascripts/maplibre/map.js
@@ -42,6 +42,7 @@ OSM.MapLibre.SecondaryMap = class extends OSM.MapLibre.Map {
       maxPitch: 0,
       center: OSM.home ? [OSM.home.lon, OSM.home.lat] : [0, 0],
       zoom: OSM.home ? defaultHomeZoom : 0,
+      zoomSnap: 1.0,
       ...options
     });
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "leaflet": "^1.8.0",
     "leaflet.locatecontrol": "^0.87.0",
     "make-plural": "^8.1.0",
-    "maplibre-gl": "^5.6.0",
+    "maplibre-gl": "^5.17.0",
     "osm-community-index": "^6.0.0",
     "tag2link": "^2026.1.21"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,7 +1291,7 @@ make-plural@*, make-plural@^8.1.0:
   resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-8.1.0.tgz#cc7ee2fb10d764fd958051102267c058d768414a"
   integrity sha512-p8EfQ2LFxnU4KGc82hOYdUplQw0eoWJLzJVKyv2GR9sd4zkjA8bLSXLEmp/qE08c/cFTZOK8j6Ex80+Wey+4PA==
 
-maplibre-gl@^5.6.0:
+maplibre-gl@^5.17.0:
   version "5.17.0"
   resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-5.17.0.tgz#b7de18caf2c70d0ba98715803eea7f1e39581c36"
   integrity sha512-gwS6NpXBfWD406dtT5YfEpl2hmpMm+wcPqf04UAez/TxY1OBjiMdK2ZoMGcNIlGHelKc4+Uet6zhDdDEnlJVHA==


### PR DESCRIPTION
### Description

This PR adds the `zoomSnap` option.
The motivation behind this bump is:
- This partially resolves #6618 which was the blocker that @imagico identified.

`zoomSnap` does mean that on these zoom levels while I can still zoom to an fractional zoom level, this is not something that "sticks".

### How has this been tested?

Manually, by adding this code (honestly, I cannot tell a difference otherwise)

```diff
diff --git i/app/assets/javascripts/maplibre/map.js w/app/assets/javascripts/maplibre/map.js
index 73f780c2c..d2afd3ee2 100644
--- i/app/assets/javascripts/maplibre/map.js
+++ w/app/assets/javascripts/maplibre/map.js
@@ -44,5 +44,9 @@ OSM.MapLibre.SecondaryMap = class extends OSM.MapLibre.Map {
     });
+
+    this.on("zoom", () => {
+      console.log("Zoom level changed to", this.getZoom());
+    });
   }
 };
```

-> on master we allow zooming to fractional zooms, on this PR not.

Do note that this is currently limted to only 3/4 (only Keyboard, mouse, touch. No touchpad) interaction modes.
This is because we noticed that changing the touchpad was a bit tricky to make "feel good".