### PR TITLE
Fix geolocate `background-color` not being properly applied and improve css maintainability

### DIFF
--- a/app/assets/stylesheets/maplibre-gl-all.scss
+++ b/app/assets/stylesheets/maplibre-gl-all.scss
@@ -35,8 +35,8 @@
         background-image: none;
       }
 
-      &.maplibregl-ctrl-geolocate-active .maplibregl-ctrl-icon {
-        color: $vibrant-green;
+      &.maplibregl-ctrl-geolocate-active {
+        background-color: $vibrant-green;
       }
     }
   }


### PR DESCRIPTION
### Description

not sure when this broke or why I did it like this before..

| before | after |
|--------|--------|
| <img width="935" height="653" alt="image" src="https://github.com/user-attachments/assets/8cdf7e50-16b5-4f2e-91dd-5da1cd6fd249" /> | <img width="1561" height="788" alt="image" src="https://github.com/user-attachments/assets/9fbea7ca-7465-464f-a282-34dd135106c2" /> | 

### How has this been tested?

Manually