### PR TITLE
Fix map controls in user diary form

### DIFF
--- a/app/assets/javascripts/diary_entry.js
+++ b/app/assets/javascripts/diary_entry.js
@@ -37,7 +37,8 @@ $(function () {
 
     const position = $("html").attr("dir") === "rtl" ? "top-left" : "top-right";
     const navigationControl = new OSM.MapLibre.NavigationControl();
-    map.addControl(navigationControl, position);
+    const geolocateControl = new OSM.MapLibre.GeolocateControl();
+    map.addControl(new OSM.MapLibre.CombinedControlGroup([navigationControl, geolocateControl]), position);
 
     // Create marker if coordinates exist when map is shown
     if ($("#latitude").val() && $("#longitude").val()) {


### PR DESCRIPTION
On the "New Diary Entry", the map controls are not showing. There's only a empty control group:

<img width="700" height="688" alt="Illustration of the problem" src="https://github.com/user-attachments/assets/d046240c-f413-4ac9-ad1b-21135765bbe8" />

I'm guessing we want this to be the same as the "Edit Location" controls in the user profile, so I have copied a solution from there.