### PR TITLE
Disable `validateStyle` in production for minor initalisation performance gains on slower hardware

### DIFF
--- a/app/assets/javascripts/maplibre/map.js
+++ b/app/assets/javascripts/maplibre/map.js
@@ -20,6 +20,9 @@ OSM.MapLibre.Map = class extends maplibregl.Map {
       });
     }
     const map = super({
+      // Style validation only affects debug output.
+      // Style errors are usually reported to authors, who should validate the style in CI for better error messages.
+      validateStyle: false,
       ...rotationOptions,
       ...options
     });


### PR DESCRIPTION
### Description

This PR pulls the `validateStyle` improvementation from the minimap.
This currently is not a noticable optimisation for the minor map views, since their style is very light.

Some context: https://github.com/maplibre/maplibre-gl-js/pull/2390
It also allows the tree-shaker (assuming you have that, I have not tested how good this works) to tree shake some of maplibres code reducing bundle size.

### How has this been tested?

Running the minor map views.
