### PR TITLE
Add a suffix to text of anonymous notes

### DIFF
--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -139,7 +139,7 @@ OSM.NewNote = function (map) {
 
     content.find("input[type=submit]").on("click", function (e) {
       const location = newNoteMarker.getLatLng().wrap();
-      const text = content.find("textarea").val();
+      const text = content.find("textarea").val() + (OSM.oauth ? "" : "\n\nvia OSM website");
 
       e.preventDefault();
       $(this).prop("disabled", true);


### PR DESCRIPTION
### Description

Partial solution #3932

All anonymous notes are suffixed with "via OSM website." Similar to StreetComplete (without hashtags :)

https://github.com/user-attachments/assets/70328eff-5f49-47f9-b955-1c809ee5f9e6

Just don't tell me we need to implement real tags and note versions in the data model. That's a huge overengineering for a simple problem. Metainformation in the text of notes does not bother anyone except the authors of notes who suffer from perfectionism. 

Hashtags and their equivalents already work great in other apps and help resolve notes. Let's first explore how website users use notes, and then consider what changes we need to make to the data model. 

We'll also finally find out if there are apps that use anonymous notes via the API.