### PR TITLE
Add datalist to display multiple search results

### DIFF
--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -53,7 +53,8 @@
                 </svg>
               </span>
             </div>
-            <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2 ps-4", :dir => "auto" %>
+            <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "off", :class => "form-control py-1 px-2 ps-4", :dir => "auto", :list => "from_suggestions" %>
+            <datalist id="from_suggestions"></datalist>
           </div>
           <div class="d-flex align-items-center">
             <div class="routing_marker_column position-absolute">
@@ -63,7 +64,8 @@
                 </svg>
               </span>
             </div>
-            <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "on", :class => "form-control py-1 px-2 ps-4", :dir => "auto" %>
+            <%= text_field_tag "route_to", params[:to], :placeholder => t("site.search.to"), :autocomplete => "off", :class => "form-control py-1 px-2 ps-4", :dir => "auto", :list => "to_suggestions" %>
+            <datalist id="to_suggestions"></datalist>
           </div>
         </div>
         <%= button_tag inline_svg_tag("search/reverse_directions.svg", :class => "d-block"),


### PR DESCRIPTION

<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
Fixes #6368 

This PR adds a suggestion menu similar to Valhalla to give users options to choose from.
- Increase query limit from 1 to 5 to show more options
- Populate datalist with search results for user selection

<img width="769" height="760" alt="Screenshot 2026-02-01 004347" src="https://github.com/user-attachments/assets/236c3772-e0d6-48f3-9420-b17ea0c2de33" />

It uses `<datalist>` that are not the best in appearance but is getting the job done. Problem with `<ul>`  and `<div>` was that options menu was getting clipped off by directions-output sidebar.

### How has this been tested?
- Manually tested in the browser by entering locations with multiple matches and selecting options  from the suggestion list
- Linting test
