### PR TITLE
Suppress install prompt on non-SPA-like pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -97,6 +97,10 @@ window.updateLinks = function (loc, zoom, layers, object) {
     .toggleClass("disabled", editDisabled);
 };
 
+window.addEventListener("beforeinstallprompt", e => {
+  if (!OSM.Router) e.preventDefault();
+});
+
 $(function () {
   // NB: Turns Turbo Drive off by default. Turbo Drive must be opt-in on a per-link and per-form basis
   // See https://turbo.hotwired.dev/reference/drive#turbo.session.drive


### PR DESCRIPTION
Fixes #6406 by denying the prompts on all pages not using `router.js`. This includes pages of the sign up and log in flow, copyright, about, trace, diary, user and other lesser used pages (https://github.com/openstreetmap/openstreetmap-website/pull/1558#issuecomment-306334341).