### PR TITLE
Remove CI guard on minitest/focus require

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,7 +34,7 @@ ENV["RAILS_ENV"] = "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "webmock/minitest"
-require "minitest/focus" unless ENV["CI"]
+require "minitest/focus"
 
 WebMock.disable_net_connect!(:allow_localhost => true, :allow => %w[selenium-default selenium-de selenium-nolang rails-app])
 


### PR DESCRIPTION
There is now a [Minitest/Focus cop](https://docs.rubocop.org/rubocop-minitest/cops_minitest.html#minitestfocus) in rubocop-minitest, which will catch any inadvertent usage of focus in a commit.

### How has this been tested?
<!--Explain the steps you took to test your code.-->

I changed one test from `def test_show` to `focus def test_show` and it was flagged by rubocop.