### PR TITLE
Expose the enhanced changeset stats via the API

### DIFF
--- a/app/views/api/changesets/_changeset.json.jbuilder
+++ b/app/views/api/changesets/_changeset.json.jbuilder
@@ -6,6 +6,9 @@ json.created_at changeset.created_at.xmlschema
 json.open changeset.open?
 json.comments_count changeset.comments.length
 json.changes_count changeset.num_changes
+json.created_count changeset.num_created_elements
+json.modified_count changeset.num_modified_elements
+json.deleted_count changeset.num_deleted_elements
 
 json.closed_at changeset.closed_at.xmlschema unless changeset.open?
 if changeset.bbox.complete?

--- a/app/views/api/changesets/_changeset.xml.builder
+++ b/app/views/api/changesets/_changeset.xml.builder
@@ -7,7 +7,10 @@ attrs = {
   "created_at" => changeset.created_at.xmlschema,
   "open" => changeset.open?,
   "comments_count" => changeset.comments.length,
-  "changes_count" => changeset.num_changes
+  "changes_count" => changeset.num_changes,
+  "created_count" => changeset.num_created_elements,
+  "modified_count" => changeset.num_modified_elements,
+  "deleted_count" => changeset.num_deleted_elements
 }
 attrs["closed_at"] = changeset.closed_at.xmlschema unless changeset.open?
 changeset.bbox.to_unscaled.add_bounds_to(attrs, "_") if changeset.bbox.complete?

--- a/test/controllers/api/changesets_controller_test.rb
+++ b/test/controllers/api/changesets_controller_test.rb
@@ -808,6 +808,9 @@ module Api
         end
         assert_dom "> @comments_count", changeset.comments.length.to_s
         assert_dom "> @changes_count", changeset.num_changes.to_s
+        assert_dom "> @created_count", changeset.num_created_elements.to_s
+        assert_dom "> @modified_count", changeset.num_modified_elements.to_s
+        assert_dom "> @deleted_count", changeset.num_deleted_elements.to_s
         yield if block_given?
       end
     end
@@ -824,6 +827,9 @@ module Api
       end
       assert_equal changeset.comments.length, js["changeset"]["comments_count"]
       assert_equal changeset.num_changes, js["changeset"]["changes_count"]
+      assert_equal changeset.num_created_elements, js["changeset"]["created_count"]
+      assert_equal changeset.num_modified_elements, js["changeset"]["modified_count"]
+      assert_equal changeset.num_deleted_elements, js["changeset"]["deleted_count"]
     end
 
     ##


### PR DESCRIPTION
Closes #6719

### Description

Adds 3 new properties to APIs that return changesets, for the enhanced changeset stats.



### How has this been tested?

unit tests and [localhost:3000](http://localhost:3000) using 
- `/api/0.6/changeset/3`
- `/api/0.6/changeset/3.json`
- `/api/0.6/changesets`
- `/api/0.6/changesets.json`
