### PR TITLE
Use meta protocol for memcached connections

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module OpenStreetMap
     config.active_record.schema_format = :sql unless Settings.status == "database_offline"
 
     # Use memcached for caching if required
-    config.cache_store = :mem_cache_store, Settings.memcache_servers, { :namespace => "rails:cache" } if Settings.key?(:memcache_servers)
+    config.cache_store = :mem_cache_store, Settings.memcache_servers, { :protocol => :meta, :namespace => "rails:cache" } if Settings.key?(:memcache_servers)
 
     # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
     # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/rate_limits.rb
+++ b/config/initializers/rate_limits.rb
@@ -4,14 +4,14 @@ require "rate_limiter"
 
 SIGNUP_IP_LIMITER = if Settings.memcache_servers && Settings.signup_ip_per_day && Settings.signup_ip_max_burst
                       RateLimiter.new(
-                        Dalli::Client.new(Settings.memcache_servers, :namespace => "rails:signup:ip"),
+                        Dalli::Client.new(Settings.memcache_servers, :protocol => :meta, :namespace => "rails:signup:ip"),
                         86400, Settings.signup_ip_per_day, Settings.signup_ip_max_burst
                       )
                     end
 
 SIGNUP_EMAIL_LIMITER = if Settings.memcache_servers && Settings.signup_email_per_day && Settings.signup_email_max_burst
                          RateLimiter.new(
-                           Dalli::Client.new(Settings.memcache_servers, :namespace => "rails:signup:email"),
+                           Dalli::Client.new(Settings.memcache_servers, :protocol => :meta, :namespace => "rails:signup:email"),
                            86400, Settings.signup_email_per_day, Settings.signup_email_max_burst
                          )
                        end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,7 +3,7 @@
 # Be sure to restart your server when you modify this file.
 
 if Settings.key?(:memcache_servers)
-  Rails.application.config.session_store :mem_cache_store, :memcache_server => Settings.memcache_servers, :namespace => "rails:session", :key => "_osm_session", :same_site => :lax
+  Rails.application.config.session_store :mem_cache_store, :memcache_server => Settings.memcache_servers, :protocol => :meta, :namespace => "rails:session", :key => "_osm_session", :same_site => :lax
 else
   Rails.application.config.session_store :cache_store, :key => "_osm_session", :cache => ActiveSupport::Cache::MemoryStore.new, :same_site => :lax
 end


### PR DESCRIPTION
This fixes a deprecation warning and prepares for dalli 5.x which will switch to meta as the only supported protocol.

See https://github.com/petergoldstein/dalli/blob/main/5_0_ROADMAP.md and https://github.com/petergoldstein/dalli/blob/main/5.0-Upgrade.md for more.