### PR TITLE
Add Human facing error messages when users without WebGL use 

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -4,7 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    can :read, [:feature_query, :layers_pane, :legend_pane, :share_pane, :languages_pane]
+    can :read, [:feature_query, :layers_pane, :legend_pane, :share_pane, :languages_pane, :webgl_error_pane]
     can :read, [Node, Way, Relation, OldNode, OldWay, OldRelation]
     can :read, [RelationMember, OldRelationMember]
     can [:show, :create], Note

--- a/app/assets/javascripts/leaflet.layers.js
+++ b/app/assets/javascripts/leaflet.layers.js
@@ -27,16 +27,20 @@ L.OSM.layers = function (options) {
 
         function shown() {
           const center = map.getCenter();
-          miniMap = new OSM.MapLibre.Map({
-            container,
-            style: layer.options.style,
-            interactive: false,
-            attributionControl: false,
-            fadeDuration: 0,
-            zoomSnap: layer.options.isVectorStyle ? 0 : 1,
-            center: [center.lng, center.lat],
-            zoom: getZoomForMiniMap()
-          });
+          try {
+            miniMap = new OSM.MapLibre.Map({
+              container,
+              style: layer.options.style,
+              interactive: false,
+              attributionControl: false,
+              fadeDuration: 0,
+              zoomSnap: layer.options.isVectorStyle ? 0 : 1,
+              center: [center.lng, center.lat],
+              zoom: getZoomForMiniMap()
+            });
+          } catch (error) {
+            return;
+          }
 
           if (layer.options.layerId === "openmaptiles_osm") {
             OSM.MapLibre.setOMTMapLanguage(miniMap);
@@ -46,8 +50,11 @@ L.OSM.layers = function (options) {
         }
 
         function hide() {
-          map.off("moveend", moved);
-          miniMap.remove();
+          // miniMap can be falsy if webgl is not supported
+          if (miniMap) {
+            map.off("moveend", moved);
+            miniMap.remove();
+          }
         }
 
         function moved() {

--- a/app/assets/javascripts/maplibre/map.js
+++ b/app/assets/javascripts/maplibre/map.js
@@ -6,6 +6,17 @@ maplibregl.Map.prototype._getUIString = function (key) {
   return OSM.i18n.t(`javascripts.map.${snakeCaseKey}`);
 };
 
+OSM.MapLibre.showWebGLError = function (container) {
+  const containerElement =
+    typeof container === "string" ? document.getElementById(container) : container;
+
+  if (containerElement) {
+    fetch("/panes/webgl_error")
+      .then(response => response.text())
+      .then(html => containerElement.innerHTML = html);
+  }
+};
+
 OSM.MapLibre.Map = class extends maplibregl.Map {
   constructor({ allowRotation, ...options } = {}) {
     const rotationOptions = {};
@@ -17,13 +28,24 @@ OSM.MapLibre.Map = class extends maplibregl.Map {
         bearingSnap: 180
       });
     }
-    const map = super({
-      // Style validation only affects debug output.
-      // Style errors are usually reported to authors, who should validate the style in CI for better error messages.
-      validateStyle: false,
-      ...rotationOptions,
-      ...options
-    });
+
+    let map;
+    try {
+      map = super({
+        // Style validation only affects debug output.
+        // Style errors are usually reported to authors, who should validate the style in CI for better error messages.
+        validateStyle: false,
+        ...rotationOptions,
+        ...options
+      });
+    } catch (error) {
+      const structuredError = JSON.parse(error.message);
+      if (structuredError.type === "webglcontextcreationerror") {
+        OSM.MapLibre.showWebGLError(options.container);
+      }
+      // the constructor panicked => we need to re-throw
+      throw error;
+    }
     if (allowRotation === false) {
       map.touchZoomRotate.disableRotation();
       map.keyboard.disableRotation();

--- a/app/assets/stylesheets/maplibre-gl-all.scss
+++ b/app/assets/stylesheets/maplibre-gl-all.scss
@@ -61,3 +61,26 @@
     background-color: $vibrant-green;
   }
 }
+
+.maplibre-error {
+  container-type: size;
+
+  p {
+    max-width: 600px;
+  }
+
+  /*
+   Show compact message for small-height containers.
+   For width-based container there is bootstrap
+   */
+  @container (max-height: 60px) {
+    p:not(.maplibre-error-compact) {
+      display: none !important;
+    }
+
+    .maplibre-error-compact {
+      display: block !important;
+      font-size: 0.75rem;
+    }
+  }
+}

--- a/app/controllers/webgl_error_panes_controller.rb
+++ b/app/controllers/webgl_error_panes_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class WebglErrorPanesController < ApplicationController
+  before_action :authorize_web
+  before_action :set_locale
+  authorize_resource :class => false
+
+  def show
+    render :layout => false
+  end
+end

--- a/app/views/webgl_error_panes/show.html.erb
+++ b/app/views/webgl_error_panes/show.html.erb
@@ -1,0 +1,17 @@
+<div class="maplibre-error w-100 h-100 d-flex flex-column align-items-center justify-content-center text-center p-3 fs-5 lh-base bg-info-subtle text-info-emphasis" data-bs-theme="light">
+  <p class="maplibre-error-compact d-none position-absolute bottom-0 start-0 end-0 py-1 px-2 m-0 fw-bold">
+    <%= t(".compact_message") %>
+  </p>
+  <p class="d-none d-md-block">
+    <%= t(".description", :your_browser_does_not_support_webgl => content_tag(:b, t(".your_browser_does_not_support_webgl"))).html_safe %>
+  </p>
+  <p>
+    <%= link_to t(".read_more_about_webgl_url"), :target => "_blank", :rel => "noopener", :class => "btn btn-link text-info-emphasis fw-bold" do %>
+      <b><%= t(".webgl_is_required_for_this_map") %></b><br>
+      <small>
+        <i class="bi bi-info-circle-fill" aria-hidden="true"></i>
+        <%= t(".read_more_about_webgl") %>
+      </small>
+    <% end %>
+  </p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2930,6 +2930,14 @@ en:
       image_dimensions_html: "Image will show the %{layer} layer at %{width} x %{height}"
       download: "Download"
       downloading: "Downloading..."
+  webgl_error_panes:
+    show:
+      compact_message: WebGL is required for this map.
+      description: "We are sorry, but it seems that %{your_browser_does_not_support_webgl}, a technology for rendering 3D graphics on the web."
+      your_browser_does_not_support_webgl: your browser does not support WebGL
+      webgl_is_required_for_this_map: WebGL is required to display this map.
+      read_more_about_webgl: "Read more"
+      read_more_about_webgl_url: https://wiki.openstreetmap.org/wiki/This_map_requires_WebGL
   traces:
     visibility:
       private: "Private (only shared as anonymous, unordered points)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,7 @@ OpenStreetMap::Application.routes.draw do
   resource :layers_pane, :path => "/panes/layers", :only => :show
   resource :legend_pane, :path => "/panes/legend", :only => :show
   resource :share_pane, :path => "/panes/share", :only => :show
+  resource :webgl_error_pane, :path => "/panes/webgl_error", :only => :show
   get "/id" => "site#id"
   resource :feature_query, :path => "query", :only => :show
   post "/user/:display_name/confirm/resend" => "confirmations#confirm_resend", :as => :user_confirm_resend

--- a/test/controllers/webgl_error_panes_controller_test.rb
+++ b/test/controllers/webgl_error_panes_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WebglErrorPanesControllerTest < ActionDispatch::IntegrationTest
+  ##
+  # test all routes which lead to this controller
+  def test_routes
+    assert_routing(
+      { :path => "/panes/webgl_error", :method => :get },
+      { :controller => "webgl_error_panes", :action => "show" }
+    )
+  end
+
+  def test_show
+    get webgl_error_pane_path, :xhr => true
+
+    assert_response :success
+    assert_template "webgl_error_panes/show"
+    assert_template :layout => false
+    assert_select "div.maplibre-error"
+  end
+end


### PR DESCRIPTION
### Description

There is no good way to fallback when a user without webgl comes, but we can add a better error message.

Basicaly fixes (except on the main map) https://github.com/openstreetmap/openstreetmap-website/issues/6240

### How has this been tested?

Using Firefox, in `about:config` set `webgl.disabled=true`.


| desktop | square | mobile | minimap |
|--------|--------|--------|-----|
| <img width="467" height="419" alt="image" src="https://github.com/user-attachments/assets/b0cf0e21-5add-4b28-9e81-5539aeec19ff" /> | <img width="768" height="564" alt="image" src="https://github.com/user-attachments/assets/b4271f66-c845-4c1f-b1d6-bbad2baedf98" /> | <img width="416" height="516" alt="image" src="https://github.com/user-attachments/assets/1a5703dd-e553-4d16-8348-21a32e548a69" /> | <img width="419" height="432" alt="image" src="https://github.com/user-attachments/assets/b1d32b6b-4bc6-4f0f-afef-0e344e3ba518" /> |