### PR TITLE
Incorrect english term for `leisure=track`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1161,7 +1161,7 @@ en:
           sports_centre: "Sports Centre"
           stadium: "Stadium"
           swimming_pool: "Swimming Pool"
-          track: "Running Track"
+          track: "Racetrack (Non-Motorsport)"
           water_park: "Water Park"
           "yes": "Leisure"
         lock:


### PR DESCRIPTION
Changed english term for `leisure=track`
See #6788
