### PR TITLE
Avoid zombie Hardware Upgrade Fund translations

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -62,7 +62,7 @@
         <%= link_to t("layouts.help"), help_path, :class => header_nav_link_class(help_path) %>
       </li>
       <li class="nav-item">
-        <%= link_to t("layouts.donate"), Settings.donation_url, :class => header_nav_link_class(Settings.donation_url), :target => :new %>
+        <%= link_to t("layouts.donate_link"), Settings.donation_url, :class => header_nav_link_class(Settings.donation_url), :target => :new %>
       </li>
       <li class="nav-item">
         <%= link_to t("layouts.about"), about_path, :class => header_nav_link_class(about_path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1859,7 +1859,7 @@ en:
     about: About
     copyright: Copyright
     communities: Communities
-    donate: Donate
+    donate_link: Donate
     learn_more: "Learn More"
     more: More
     header:


### PR DESCRIPTION
Renamed the string for the Donate navigation bar link introduced in #6617 to prevent ancient Hardware Upgrade Fund translations from reappearing via Translatewiki.net.

Fixes #6819.