### PR TITLE
Add database_consistency gem

### DIFF
--- a/.database_consistency.yml
+++ b/.database_consistency.yml
@@ -1,0 +1,497 @@
+---
+# These checkers throw errors with our db, so they need
+# to be completely disabled.
+DatabaseConsistencyCheckers:
+  # https://github.com/djezzzl/database_consistency/issues/274
+  MissingDependentDestroyChecker:
+    enabled: false
+  # https://github.com/djezzzl/database_consistency/issues/217
+  ForeignKeyCascadeChecker:
+    enabled: false
+# The following is a TODO list
+Changeset:
+  changeset_tags:
+    MissingIndexChecker:
+      enabled: false
+  id:
+    ColumnPresenceChecker:
+      enabled: false
+  nodes:
+    MissingIndexChecker:
+      enabled: false
+  relations:
+    MissingIndexChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+  ways:
+    MissingIndexChecker:
+      enabled: false
+ChangesetComment:
+  author:
+    MissingDependentDestroyChecker:
+      enabled: false
+  body:
+    NullConstraintChecker:
+      enabled: false
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+  id:
+    ColumnPresenceChecker:
+      enabled: false
+    PrimaryKeyTypeChecker:
+      enabled: false
+ChangesetSubscription:
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+  index_changesets_subscribers_on_subscriber_id_and_changeset_id:
+    UniqueIndexChecker:
+      enabled: false
+  subscriber:
+    MissingDependentDestroyChecker:
+      enabled: false
+ChangesetTag:
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+DiaryComment:
+  diary_comments_entry_id_idx:
+    UniqueIndexChecker:
+      enabled: false
+  diary_entry:
+    MissingDependentDestroyChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+DiaryEntry:
+  language:
+    MissingDependentDestroyChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+DiaryEntrySubscription:
+  diary_entry:
+    MissingDependentDestroyChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+Follow:
+  follower:
+    MissingDependentDestroyChecker:
+      enabled: false
+  following:
+    MissingDependentDestroyChecker:
+      enabled: false
+Issue:
+  assigned_role:
+    EnumValueChecker:
+      enabled: false
+  id:
+    PrimaryKeyTypeChecker:
+      enabled: false
+  reportable_id+reportable_type:
+    MissingUniqueIndexChecker:
+      enabled: false
+  reported_user:
+    ForeignKeyTypeChecker:
+      enabled: false
+    MissingDependentDestroyChecker:
+      enabled: false
+  user_resolved:
+    ForeignKeyTypeChecker:
+      enabled: false
+    MissingDependentDestroyChecker:
+      enabled: false
+  user_updated:
+    ForeignKeyTypeChecker:
+      enabled: false
+    MissingDependentDestroyChecker:
+      enabled: false
+IssueComment:
+  id:
+    PrimaryKeyTypeChecker:
+      enabled: false
+  user:
+    ForeignKeyTypeChecker:
+      enabled: false
+    MissingDependentDestroyChecker:
+      enabled: false
+Language:
+  code:
+    PrimaryKeyTypeChecker:
+      enabled: false
+  diary_entries:
+    ForeignKeyTypeChecker:
+      enabled: false
+    MissingIndexChecker:
+      enabled: false
+  english_name:
+    NullConstraintChecker:
+      enabled: false
+Message:
+  recipient:
+    MissingDependentDestroyChecker:
+      enabled: false
+  sender:
+    MissingDependentDestroyChecker:
+      enabled: false
+Node:
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+  element_tags:
+    MissingIndexChecker:
+      enabled: false
+  id:
+    ColumnPresenceChecker:
+      enabled: false
+  old_nodes:
+    MissingIndexChecker:
+      enabled: false
+  tile:
+    NullConstraintChecker:
+      enabled: false
+NodeTag:
+  node:
+    MissingDependentDestroyChecker:
+      enabled: false
+Note:
+  author:
+    MissingDependentDestroyChecker:
+      enabled: false
+  id:
+    ColumnPresenceChecker:
+      enabled: false
+  tile:
+    NullConstraintChecker:
+      enabled: false
+NoteComment:
+  author:
+    MissingDependentDestroyChecker:
+      enabled: false
+  id:
+    ColumnPresenceChecker:
+      enabled: false
+  note:
+    MissingDependentDestroyChecker:
+      enabled: false
+NoteSubscription:
+  note:
+    MissingDependentDestroyChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+Oauth2Application:
+  redirect_uri:
+    NullConstraintChecker:
+      enabled: false
+  secret:
+    ColumnPresenceChecker:
+      enabled: false
+OldNode:
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+  current_node:
+    ForeignKeyChecker:
+      enabled: false
+  old_tags:
+    MissingIndexChecker:
+      enabled: false
+  redaction:
+    MissingDependentDestroyChecker:
+      enabled: false
+  tile:
+    NullConstraintChecker:
+      enabled: false
+  version:
+    NullConstraintChecker:
+      enabled: false
+OldNodeTag:
+  node_id:
+    NullConstraintChecker:
+      enabled: false
+  version:
+    NullConstraintChecker:
+      enabled: false
+OldRelation:
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+  current_relation:
+    ForeignKeyChecker:
+      enabled: false
+  old_members:
+    MissingIndexChecker:
+      enabled: false
+  old_tags:
+    MissingIndexChecker:
+      enabled: false
+  redaction:
+    MissingDependentDestroyChecker:
+      enabled: false
+  version:
+    NullConstraintChecker:
+      enabled: false
+OldRelationMember:
+  member_role:
+    NullConstraintChecker:
+      enabled: false
+  relation_id:
+    NullConstraintChecker:
+      enabled: false
+OldRelationTag:
+  relation_id:
+    NullConstraintChecker:
+      enabled: false
+  version:
+    NullConstraintChecker:
+      enabled: false
+OldWay:
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+  current_way:
+    ForeignKeyChecker:
+      enabled: false
+  old_nodes:
+    MissingIndexChecker:
+      enabled: false
+  old_tags:
+    MissingIndexChecker:
+      enabled: false
+  redaction:
+    MissingDependentDestroyChecker:
+      enabled: false
+  version:
+    NullConstraintChecker:
+      enabled: false
+OldWayNode:
+  node:
+    ForeignKeyChecker:
+      enabled: false
+  sequence_id:
+    NullConstraintChecker:
+      enabled: false
+  version:
+    NullConstraintChecker:
+      enabled: false
+  way:
+    ForeignKeyChecker:
+      enabled: false
+OldWayTag:
+  k:
+    NullConstraintChecker:
+      enabled: false
+  v:
+    NullConstraintChecker:
+      enabled: false
+  version:
+    NullConstraintChecker:
+      enabled: false
+  way_id:
+    NullConstraintChecker:
+      enabled: false
+Redaction:
+  id:
+    PrimaryKeyTypeChecker:
+      enabled: false
+  old_nodes:
+    MissingIndexChecker:
+      enabled: false
+  old_relations:
+    MissingIndexChecker:
+      enabled: false
+  old_ways:
+    MissingIndexChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+Relation:
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+  element_tags:
+    MissingIndexChecker:
+      enabled: false
+  id:
+    ColumnPresenceChecker:
+      enabled: false
+  old_relations:
+    MissingIndexChecker:
+      enabled: false
+  relation_members:
+    MissingIndexChecker:
+      enabled: false
+RelationMember:
+  member_role:
+    NullConstraintChecker:
+      enabled: false
+  relation:
+    MissingDependentDestroyChecker:
+      enabled: false
+RelationTag:
+  relation:
+    MissingDependentDestroyChecker:
+      enabled: false
+Report:
+  id:
+    PrimaryKeyTypeChecker:
+      enabled: false
+  user:
+    ForeignKeyTypeChecker:
+      enabled: false
+    MissingDependentDestroyChecker:
+      enabled: false
+SocialLink:
+  url:
+    NullConstraintChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+Trace:
+  description:
+    ColumnPresenceChecker:
+      enabled: false
+  gpx_files_user_id_idx:
+    RedundantIndexChecker:
+      enabled: false
+  inserted:
+    NullConstraintChecker:
+      enabled: false
+  tags:
+    ForeignKeyCascadeChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+Tracepoint:
+  timestamp:
+    ColumnPresenceChecker:
+      enabled: false
+Tracetag:
+  tag:
+    NullConstraintChecker:
+      enabled: false
+User:
+  blocks_revoked:
+    MissingIndexChecker:
+      enabled: false
+  creation_time:
+    NullConstraintChecker:
+      enabled: false
+  diary_entry_subscriptions:
+    MissingIndexChecker:
+      enabled: false
+  issue_comments:
+    ForeignKeyTypeChecker:
+      enabled: false
+  issues:
+    ForeignKeyTypeChecker:
+      enabled: false
+  lower(email):
+    MissingUniqueIndexChecker:
+      enabled: false
+  note_subscriptions:
+    MissingIndexChecker:
+      enabled: false
+  pass_crypt:
+    NullConstraintChecker:
+      enabled: false
+  preferences:
+    MissingIndexChecker:
+      enabled: false
+  reports:
+    ForeignKeyTypeChecker:
+      enabled: false
+  users_display_name_idx:
+    UniqueIndexChecker:
+      enabled: false
+  users_email_idx:
+    UniqueIndexChecker:
+      enabled: false
+UserBlock:
+  creator:
+    MissingDependentDestroyChecker:
+      enabled: false
+  ends_at:
+    NullConstraintChecker:
+      enabled: false
+  id:
+    PrimaryKeyTypeChecker:
+      enabled: false
+  reason:
+    NullConstraintChecker:
+      enabled: false
+  revoker:
+    MissingDependentDestroyChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+UserMute:
+  owner:
+    MissingDependentDestroyChecker:
+      enabled: false
+  subject:
+    MissingDependentDestroyChecker:
+      enabled: false
+UserPreference:
+  k:
+    NullConstraintChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+  v:
+    NullConstraintChecker:
+      enabled: false
+UserRole:
+  granter:
+    MissingDependentDestroyChecker:
+      enabled: false
+  id:
+    PrimaryKeyTypeChecker:
+      enabled: false
+  user:
+    MissingDependentDestroyChecker:
+      enabled: false
+Way:
+  changeset:
+    MissingDependentDestroyChecker:
+      enabled: false
+  element_tags:
+    MissingIndexChecker:
+      enabled: false
+  id:
+    ColumnPresenceChecker:
+      enabled: false
+  old_ways:
+    MissingIndexChecker:
+      enabled: false
+  way_nodes:
+    MissingIndexChecker:
+      enabled: false
+WayNode:
+  node:
+    MissingDependentDestroyChecker:
+      enabled: false
+  sequence_id:
+    NullConstraintChecker:
+      enabled: false
+  way:
+    MissingDependentDestroyChecker:
+      enabled: false
+WayTag:
+  way:
+    MissingDependentDestroyChecker:
+      enabled: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -138,3 +138,36 @@ jobs:
       run: bundle exec annotaterb models
     - name: Fail if model annotations are out of date
       run: git diff --exit-code
+  database_consistency:
+    env:
+      RAILS_ENV: test
+    name: Database Consistency
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Setup ruby
+      uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
+      with:
+        ruby-version: ${{ env.ruby }}
+        rubygems: 3.4.10
+        bundler-cache: true
+    - name: Configure rails
+      run: |
+        cp config/github.database.yml config/database.yml
+        cp config/example.storage.yml config/storage.yml
+    - name: Cache node modules
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        cache: yarn
+    - name: Install node modules
+      run: bundle exec bin/yarn install
+    - name: Setup database
+      run: |
+        sudo systemctl start postgresql
+        sudo -u postgres createuser -s $(id -un)
+        createdb openstreetmap
+        bundle exec rails db:schema:load
+    - name: Run Database Consistency
+      run: bundle exec database_consistency

--- a/Gemfile
+++ b/Gemfile
@@ -193,6 +193,7 @@ end
 
 group :development, :test do
   gem "annotaterb"
+  gem "database_consistency"
   gem "factory_bot_rails"
   gem "rackup"
   gem "teaspoon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    database_consistency (2.1.2)
+      activerecord (>= 3.2)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -931,6 +933,7 @@ DEPENDENCIES
   danger
   danger-auto_label
   dartsass-sprockets
+  database_consistency
   debug
   debug_inspector
   delayed_job_active_record


### PR DESCRIPTION
This PR adds the [database_consistency gem](https://github.com/djezzzl/database_consistency/), which compares our database structure and model definitions to ensure they are both consistent.

For example, we have many model attributes which are required by the database, but don't have any corresponding presence checkers in the model. Or things like table ids or user references being defined as `integer` instead of `bigint` (which I missed when I created issues and reports, for example! Oops).

Having this gem will help guide contributors, when they are adding new tables to the database. I appreciate hasn't happened very frequently in the past. I've used this gem for many years on my own projects.

As usual with linting tools, I've set this up to have a TODO list which suppresses existing issues. This means that we can work on these in the background, while preventing any new issues in new work. I've also set it up to run in CI. I've not yet added it to either the documentation or to the overcommit configuration, mostly because it's so rare that anyone is making any relevant changes.


