### PR TITLE
Avoid using positive tabindexes

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -63,7 +63,7 @@
     <%= render :partial => "layouts/sidebar_close" %>
   </div>
 
-  <div id="map" tabindex="2" class="bg-body-secondary z-0"><%# herb:disable html-no-positive-tab-index %>
+  <div id="map" class="bg-body-secondary z-0">
   </div>
 
   <div id="attribution" class="d-none">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -46,21 +46,21 @@
 <%= bootstrap_form_tag(:action => "login", :html => { :id => "login_form" }) do |f| %>
   <%= hidden_field_tag("referer", h(params[:referer]), :autocomplete => "off") %>
 
-  <%= f.text_field :username, :label => t(".email or username"), :autofocus => true, :tabindex => 1, :value => params[:username] %>
+  <%= f.text_field :username, :label => t(".email or username"), :autofocus => true, :value => params[:username] %>
 
   <div class="d-flex flex-wrap column-gap-3 justify-content-between align-items-baseline mb-2">
     <%= f.label :password, t(".password") %>
     <small><%= link_to(t(".lost password link"), user_forgot_password_path) %></small>
   </div>
 
-  <%= f.password_field :password, :autocomplete => "on", :tabindex => 2, :value => "", :skip_label => true %>
+  <%= f.password_field :password, :autocomplete => "on", :value => "", :skip_label => true %>
 
   <%= f.form_group do %>
-    <%= f.check_box :remember_me, { :label => t(".remember"), :tabindex => 3, :checked => (params[:remember_me] == "true") }, "yes" %>
+    <%= f.check_box :remember_me, { :label => t(".remember"), :checked => (params[:remember_me] == "true") }, "yes" %>
   <% end %>
 
   <div class="mb-3">
-    <%= f.primary t(".login_button"), :tabindex => 4 %>
+    <%= f.primary t(".login_button") %>
   </div>
 <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -48,21 +48,20 @@
                                                                          t(".email_help.privacy_policy_url"),
                                                                          :title => t(".email_help.privacy_policy_title"),
                                                                          :target => :new)),
-                              :autofocus => true,
-                              :tabindex => 1 %>
+                              :autofocus => true %>
   <% else %>
     <%= f.hidden_field :email %>
   <% end %>
 
-  <%= f.text_field :display_name, :help => t(".display name description"), :tabindex => 2 %>
+  <%= f.text_field :display_name, :help => t(".display name description") %>
 
   <% if current_user.auth_uid.nil? %>
     <div class="row">
       <div class="col-sm">
-        <%= f.password_field :pass_crypt, :tabindex => 3 %>
+        <%= f.password_field :pass_crypt %>
       </div>
       <div class="col-sm">
-        <%= f.password_field :pass_crypt_confirmation, :tabindex => 4 %>
+        <%= f.password_field :pass_crypt_confirmation %>
       </div>
     </div>
   <% end %>
@@ -80,7 +79,7 @@
                                                                                     :target => :new)) %></p>
 
   <div class="mb-3">
-    <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary", :tabindex => 5) %>
+    <%= submit_tag(t(".continue"), :name => "continue", :id => "continue", :class => "btn btn-primary") %>
   </div>
 <% end %>
 


### PR DESCRIPTION
The use of positive tabindexes is widely discouraged. Instead, we should order the elements of the page in the same order as they are displayed, which they are already.

Previously the tab indexes did match the order that these elements were shown on the page, but the lack of tabindexes on certain other elements was used to "skip over" things like explanatory links in forms. This made these other elements hard to focus, and meant that overall the focus skipped around the page unintuitively.

It is less confusing for keyboard users if the focus just moves around in the same order that the elements are shown on the page, which is also the same order they appear in the html.

See https://herb-tools.dev/linter/rules/html-no-positive-tab-index and the list of references on that page, for further discussion.
