### PR TITLE
Require password on sign up form submit

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -58,10 +58,10 @@
   <% if current_user.auth_uid.nil? %>
     <div class="row">
       <div class="col-sm">
-        <%= f.password_field :pass_crypt %>
+        <%= f.password_field :pass_crypt, :required => true %>
       </div>
       <div class="col-sm">
-        <%= f.password_field :pass_crypt_confirmation %>
+        <%= f.password_field :pass_crypt_confirmation, :required => true %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
### Description

Currently the `email` and the `display_name` have the basic html attribute `required="required"` which forces the users to enter something before submitting the form. It prevents them from submitting empty fields.

The `required="required"` is missing for both `password` and `password confirmation` fields, so I added it.

This change skips bootstrap and backend validations and uses the browsers builtin (limited) capabilities.
The user can still enter a too short password.

In case only rails validations after submit are desired, we might consider removing the `required="required"` attribute for the email and password.

Slightly related, html has `pattern` that can be used for client side validations, but the error messages are less helpful.

### How has this been tested?

I ran the existing testsuite and testing it myself in the browser.

### Related

Should there be more client side validations avoiding the blind submit and then fail? I may help with that.