### PR TITLE
Add translation migration health check

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -18,7 +18,7 @@ data:
     ## Default:
     - config/locales/en.yml
     ## More files:
-    # - config/locales/**/*.%{locale}.yml
+    - config/locales/%{locale}.yml
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules
@@ -114,7 +114,8 @@ search:
 #   deepl_options:
 #     formality: prefer_less
 ## Do not consider these keys missing:
-# ignore_missing:
+ignore_missing:
+  - 'site.about.*_*' # wrapped and stored in about_section
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
 
@@ -136,6 +137,9 @@ ignore_unused:
   - 'time.formats.friendly' # used for formatting dates / times in a friendly way
   - 'activerecord.errors.models.user_mute.attributes.subject.format' # used for formatting error message during validation in user_mute.rb
   - 'activerecord.errors.models.user_mute.is_already_muted' # used as part of error message during validation in user_mute.rb
+  - 'site.copyright.legal_babble.*'
+  - 'site.about_section.*'
+  - 'profiles.*.update.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/lib/tasks/i18n_report.rake
+++ b/lib/tasks/i18n_report.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :i18n do
+  desc "List keys missing in non-base locales"
+  task :unmigrated_keys => :environment do
+    require "i18n/tasks"
+
+    i18n = I18n::Tasks::BaseTask.new
+    unused_map = Hash.new { |h, k| h[k] = [] }
+    base_locale = i18n.base_locale.to_s
+    i18n.locales.each do |locale|
+      i18n.unused_tree(:locale => locale)[locale]&.depth_first do |node|
+        unused_map[node.full_key.split(".", 2)[1]] << locale unless node.children?
+      end
+    end
+    unmigrated_keys = unused_map
+                      .reject { |_, locales| locales.include?(base_locale) }
+                      .transform_values { |locales| locales.sort.join(" ") }
+                      .sort_by { |key, _| key }
+                      .to_h
+    puts unmigrated_keys.to_yaml
+    exit unmigrated_keys.keys.size
+  end
+end


### PR DESCRIPTION
I've cobbled a script together that checks for unmigrated translations, which can be run to see if translatewiki's localisations are up to date regarding _key moves_. If not successful, the commit shouldn't be published on osm.org.