### PR TITLE
Avoid polluting the logs with non-descriptive i18n exceptions

### DIFF
--- a/lib/osm_community_index.rb
+++ b/lib/osm_community_index.rb
@@ -21,7 +21,7 @@ module OsmCommunityIndex
         id = community.id
 
         strings = community_locale_yaml[id] || {}
-        strings["name"] = resolve_name(community, community_locale_yaml, community_en_yaml)
+        strings["name"] = resolve_name(community, community_locale_yaml, community_en_yaml, locale)
 
         obj.deep_merge!("osm_community_index" => { "communities" => { id => strings } })
       end
@@ -30,7 +30,7 @@ module OsmCommunityIndex
     end
   end
 
-  def self.resolve_name(community, community_locale_yaml, community_en_yaml)
+  def self.resolve_name(community, community_locale_yaml, community_en_yaml, locale_name)
     # If theres an explicitly translated name then use that
     translated_name = community_locale_yaml.dig(community.id, "name")
     return translated_name if translated_name
@@ -42,8 +42,8 @@ module OsmCommunityIndex
     # Change the `{community}` placeholder to `%{community}` and use Ruby's Kernel.format to fill it in.
     begin
       translated_name = format(template.gsub("{", "%{"), { :community => community_name }) if template && community_name
-    rescue KeyError => e
-      Rails.logger.warn e.full_message
+    rescue KeyError
+      Rails.logger.warn "Could not find a translated name for community #{community.id.inspect} in locale #{locale_name.inspect}"
     end
     return translated_name if translated_name
 

--- a/test/lib/osm_community_index_test.rb
+++ b/test/lib/osm_community_index_test.rb
@@ -9,7 +9,7 @@ class CountryTest < ActiveSupport::TestCase
     community_locale_yaml = {}
     community_en_yaml = {}
 
-    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml)
+    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml, "en")
     assert_equal("Community Name", name)
   end
 
@@ -19,7 +19,7 @@ class CountryTest < ActiveSupport::TestCase
     community_locale_yaml = {}
     community_en_yaml = {}
 
-    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml)
+    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml, "en")
     assert_equal("Chapter Name", name)
   end
 
@@ -29,7 +29,7 @@ class CountryTest < ActiveSupport::TestCase
     community_locale_yaml = { "foo-chapter" => { "name" => "Translated Chapter Name" } }
     community_en_yaml = {}
 
-    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml)
+    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml, "en")
     assert_equal("Translated Chapter Name", name)
   end
 
@@ -39,7 +39,7 @@ class CountryTest < ActiveSupport::TestCase
     community_locale_yaml = { "_communities" => { "communityname" => "Translated Community" }, "_defaults" => { "osm-lc" => { "name" => "{community} Chapter" } } }
     community_en_yaml = {}
 
-    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml)
+    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml, "en")
     assert_equal("Translated Community Chapter", name)
   end
 
@@ -49,7 +49,7 @@ class CountryTest < ActiveSupport::TestCase
     community_locale_yaml = { "_communities" => { "communityname" => "Translated Community" }, "_defaults" => { "osm-lc" => { "name" => "{comminauté} Chapter" } } }
     community_en_yaml = {}
 
-    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml)
+    name = OsmCommunityIndex.resolve_name(community, community_locale_yaml, community_en_yaml, "en")
     assert_equal("Community Name", name)
   end
 end


### PR DESCRIPTION
For a while, I have noticed that my development logs are full of exceptions like the following, which cause a lot of noise:
```
WORKSPACE/openstreetmap-website/lib/osm_community_index.rb:44:in 'Kernel#format': key{مجتمع} not found ([38;2;190;132;255m1;4mKeyError)
    from WORKSPACE/openstreetmap-website/lib/osm_community_index.rb:44:in 'OsmCommunityIndex.resolve_name'
    from WORKSPACE/openstreetmap-website/lib/osm_community_index.rb:24:in 'block (2 levels) in OsmCommunityIndex.add_to_i18n'
    from RUBY_INSTALL/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/frozen_record-0.27.4/lib/frozen_record/scope.rb:248:in 'Array#each'
    from RUBY_INSTALL/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/frozen_record-0.27.4/lib/frozen_record/scope.rb:248:in 'Enumerable#each_with_object'
    from RUBY_INSTALL/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/frozen_record-0.27.4/lib/frozen_record/scope.rb:248:in 'Kernel#public_send'
    from RUBY_INSTALL/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/frozen_record-0.27.4/lib/frozen_record/scope.rb:248:in 'FrozenRecord::Scope#method_missing'
    from WORKSPACE/openstreetmap-website/lib/osm_community_index.rb:20:in 'block in OsmCommunityIndex.add_to_i18n'
    from WORKSPACE/openstreetmap-website/lib/osm_community_index.rb:14:in 'Array#each'
    from WORKSPACE/openstreetmap-website/lib/osm_community_index.rb:14:in 'OsmCommunityIndex.add_to_i18n'
    from WORKSPACE/openstreetmap-website/config/initializers/osm_community_index.rb:4:in 'block in <main>'
    (...to a total of about 60 frames per instance...)
```
This change reduces the logging to something more manageable and, I hope, descriptive. I think! My description of the issue might be wrong, please let me know.