### PR TITLE
Make AssetHelper work without precompiled assets

### DIFF
--- a/app/helpers/asset_helper.rb
+++ b/app/helpers/asset_helper.rb
@@ -2,8 +2,20 @@
 
 module AssetHelper
   def assets(directory)
-    Rails.application.assets_manifest.assets.keys.each_with_object({}) do |asset, assets|
-      assets[asset] = asset_path(asset) if asset.start_with?("#{directory}/")
+    if (manifest = Rails.application.assets_manifest.assets) && !manifest.empty?
+      # With precompiled assets
+      manifest.keys.each_with_object({}) do |asset, assets|
+        assets[asset] = asset_path(asset) if asset.start_with?("#{directory}/")
+      end
+    elsif (env = Rails.application.assets) && env.present?
+      # Without precompiled assets
+      env.paths
+         .filter { |path| path.include?(directory) }
+         .flat_map { |path| Dir.glob(File.join(path, "**", "*")) }
+         .filter_map { |path| env.find_asset(path) }
+         .each_with_object({}) do |asset, assets|
+           assets[asset.logical_path] = asset_path(asset.logical_path) if asset.logical_path.start_with?("#{directory}/")
+         end
     end
   end
 end

--- a/test/helpers/asset_helper_test.rb
+++ b/test/helpers/asset_helper_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 class AssetHelperTest < ActionView::TestCase
   def test_assets
-    assert_kind_of Hash, assets("iD")
+    asset_map = assets("@openstreetmap/id")
+    assert_kind_of Hash, asset_map
+    assert_operator asset_map.length, :>, 0
   end
 end


### PR DESCRIPTION
As seen in #6848 and in https://github.com/openstreetmap/openstreetmap-website/pull/6565#discussion_r2564737305, the mapping from Sprockets' Manifest is only available if there is a manifest, which isn't the case without precompiled assets.

Since the test also passed on an empty hash, this slipped through the cracks.