### PR TITLE
Simplify AssetHelper logic paths

### DIFF
--- a/app/helpers/asset_helper.rb
+++ b/app/helpers/asset_helper.rb
@@ -2,20 +2,16 @@
 
 module AssetHelper
   def assets(directory)
-    if (manifest = Rails.application.assets_manifest.assets) && !manifest.empty?
-      # With precompiled assets
-      manifest.keys.each_with_object({}) do |asset, assets|
-        assets[asset] = asset_path(asset) if asset.start_with?("#{directory}/")
+    asset_list = Rails.application.assets_manifest.assets.keys
+    if asset_list.empty?
+      # when assets are not precompiled
+      env = Rails.application.assets
+      env.each_file do |path|
+        asset_list << env[path]&.logical_path if path.include?(directory)
       end
-    elsif (env = Rails.application.assets) && env.present?
-      # Without precompiled assets
-      env.paths
-         .filter { |path| path.include?(directory) }
-         .flat_map { |path| Dir.glob(File.join(path, "**", "*")) }
-         .filter_map { |path| env.find_asset(path) }
-         .each_with_object({}) do |asset, assets|
-           assets[asset.logical_path] = asset_path(asset.logical_path) if asset.logical_path.start_with?("#{directory}/")
-         end
+    end
+    asset_list.each_with_object({}) do |asset, assets|
+      assets[asset] = asset_path(asset) if asset&.start_with?("#{directory}/")
     end
   end
 end


### PR DESCRIPTION
As Tom pointed out in https://github.com/openstreetmap/openstreetmap-website/pull/6856#discussion_r2886028755, the check for the Sprockets Environment is unnecessary.
This means the fallback getter can be integrated better into the logic.