### PR TITLE
Improve visibility of element navigation by moving it above content 

### DIFF
--- a/app/views/elements/show.html.erb
+++ b/app/views/elements/show.html.erb
@@ -2,7 +2,32 @@
 
 <%= render "sidebar_header", :title => t("browse.#{@type}.title_html", :name => printable_element_name(@feature)) %>
 
-<%= render :partial => "browse/#{@type}", :object => @feature %>
+<div class="sticky-sm-top top-0 bg-body border-bottom pt-1 pb-1">
+  <nav>
+    <ol class="breadcrumb mb-1">
+      <li class="breadcrumb-item active" aria-current="page">
+        <%= tag.span t(@type, :scope => "browse.versions_navigation"), :class => "py-1 px-2 rounded bg-body-secondary" %>
+      </li>
+      <li class="breadcrumb-item">
+        <%= link_to t("browse.versions_navigation.history"), :controller => "old_#{@type.pluralize}" %>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="#versions-navigation-active-page-item" class="numbered_pagination_link link-body-emphasis">
+          <%= t "browse.versions_navigation.versions_label" %>
+        </a>
+      </li>
+    </ol>
+
+    <%= numbered_pagination(@feature.version, "versions-navigation-active-page-item", :active_page => @feature.version) do |v|
+          { :href => { :controller => "old_#{@type.pluralize}", :action => :show, :version => v },
+            :title => t("browse.versions_navigation.version", :version => v) }
+        end %>
+  </nav>
+</div>
+
+<div class="pt-3">
+  <%= render :partial => "browse/#{@type}", :object => @feature %>
+</div>
 
 <% if @feature.visible? %>
   <div class="secondary-actions mb-3">
@@ -13,24 +38,3 @@
     <% end %>
   </div>
 <% end %>
-
-<nav>
-  <ol class="breadcrumb mb-1">
-    <li class="breadcrumb-item active" aria-current="page">
-      <%= tag.span t(@type, :scope => "browse.versions_navigation"), :class => "py-1 px-2 rounded bg-body-secondary" %>
-    </li>
-    <li class="breadcrumb-item">
-      <%= link_to t("browse.versions_navigation.history"), :controller => "old_#{@type.pluralize}" %>
-    </li>
-    <li class="breadcrumb-item">
-      <a href="#versions-navigation-active-page-item" class="numbered_pagination_link link-body-emphasis">
-        <%= t "browse.versions_navigation.versions_label" %>
-      </a>
-    </li>
-  </ol>
-
-  <%= numbered_pagination(@feature.version, "versions-navigation-active-page-item", :active_page => @feature.version) do |v|
-        { :href => { :controller => "old_#{@type.pluralize}", :action => :show, :version => v },
-          :title => t("browse.versions_navigation.version", :version => v) }
-      end %>
-</nav>

--- a/app/views/old_elements/_actions.html.erb
+++ b/app/views/old_elements/_actions.html.erb
@@ -1,16 +1,4 @@
-<div class="secondary-actions mb-3">
-  <% if !@feature.redacted? %>
-    <%= link_to t("browse.download_xml"), send(:"api_#{@type}_version_path", *@feature.id) %>
-  <% elsif current_user&.moderator? %>
-    <% if !params[:show_redactions] %>
-      <%= link_to t(".view_redacted_data"), :params => { :show_redactions => true } %>
-    <% else %>
-      <%= link_to t(".view_redaction_message") %>
-    <% end %>
-  <% end %>
-</div>
-
-<nav>
+<nav class="sticky-top bg-body border-bottom pb-2 z-1">
   <ol class="breadcrumb mb-1">
     <li class="breadcrumb-item">
       <%= link_to t(@type, :scope => "browse.versions_navigation"), @current_feature %>
@@ -30,3 +18,15 @@
           :title => t("browse.versions_navigation.version", :version => v) }
       end %>
 </nav>
+
+<div class="secondary-actions mb-3">
+  <% if !@feature.redacted? %>
+    <%= link_to t("browse.download_xml"), send(:"api_#{@type}_version_path", *@feature.id) %>
+  <% elsif current_user&.moderator? %>
+    <% if !params[:show_redactions] %>
+      <%= link_to t(".view_redacted_data"), :params => { :show_redactions => true } %>
+    <% else %>
+      <%= link_to t(".view_redaction_message") %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/old_elements/index.html.erb
+++ b/app/views/old_elements/index.html.erb
@@ -1,6 +1,28 @@
 <% set_title(t(".#{@type}.title_html", :name => printable_element_name(@feature))) %>
 
 <%= render "sidebar_header", :title => t(".#{@type}.title_html", :name => printable_element_name(@feature)) %>
+<nav class="sticky-top bg-body border-bottom pb-2 z-1">
+  <ol class="breadcrumb mb-1">
+    <li class="breadcrumb-item">
+      <%= link_to t(@type, :scope => "browse.versions_navigation"), @current_feature %>
+    </li>
+    <li class="breadcrumb-item active">
+      <% if params[:show_redactions] || params[:before] || params[:after] %>
+        <%= link_to t("browse.versions_navigation.history"), {}, :class => "py-1 px-2 rounded bg-body-secondary" %>
+      <% else %>
+        <%= tag.span t("browse.versions_navigation.history"), :class => "py-1 px-2 rounded bg-body-secondary" %>
+      <% end %>
+    </li>
+    <li class="breadcrumb-item">
+      <%= t "browse.versions_navigation.versions_label" %>
+    </li>
+  </ol>
+
+  <%= numbered_pagination(@current_feature.version, "versions-navigation-active-page-item") do |v|
+        { :href => { :action => :show, :version => v },
+          :title => t("browse.versions_navigation.version", :version => v) }
+      end %>
+</nav>
 
 <% if @newer_features_version %>
   <ul id="newer_element_versions_navigation" class="pagination justify-content-center">
@@ -39,26 +61,3 @@
     <% end %>
   <% end %>
 </div>
-
-<nav>
-  <ol class="breadcrumb mb-1">
-    <li class="breadcrumb-item">
-      <%= link_to t(@type, :scope => "browse.versions_navigation"), @current_feature %>
-    </li>
-    <li class="breadcrumb-item active">
-      <% if params[:show_redactions] || params[:before] || params[:after] %>
-        <%= link_to t("browse.versions_navigation.history"), {}, :class => "py-1 px-2 rounded bg-body-secondary" %>
-      <% else %>
-        <%= tag.span t("browse.versions_navigation.history"), :class => "py-1 px-2 rounded bg-body-secondary" %>
-      <% end %>
-    </li>
-    <li class="breadcrumb-item">
-      <%= t "browse.versions_navigation.versions_label" %>
-    </li>
-  </ol>
-
-  <%= numbered_pagination(@current_feature.version, "versions-navigation-active-page-item") do |v|
-        { :href => { :action => :show, :version => v },
-          :title => t("browse.versions_navigation.version", :version => v) }
-      end %>
-</nav>


### PR DESCRIPTION
### Description #6759


This change improves the visibility of the element navigation bar in the sidebar.

Previously, the navigation (`Node / History / Versions`) appeared after the element content (tags, changeset details, etc.), which meant users often had to scroll to access it when elements had many tags.

This PR moves the navigation `<nav>` block directly below the sidebar header and applies Bootstrap utility classes to keep it visible while scrolling.

Changes made:

* Reordered the HTML layout so the navigation appears above the element content.
* Added Bootstrap utility classes (`sticky-top`, `bg-body`, `border-bottom`, `pb-2`, `z-1`) so the navigation remains visible while scrolling.

Files modified:

* `app/views/elements/show.html.erb`
* `app/views/old_elements/index.html.erb`
* `app/views/old_elements/_actions.html.erb`

This improves usability when browsing elements with long tag lists or version histories.

### How has this been tested?

Tested locally using the development environment with Docker.

Steps:

1. Started the Rails server locally.
2. Created a test node in the Rails console.
3. Added many tags to the node to create a long scrollable sidebar.
4. Verified that the navigation bar now appears directly below the element title and remains visible while scrolling.

Test pages checked:

* `/node/:id`
* `/node/:id/history`
* `/node/:id/:version`
<img width="349" height="631" alt="image" src="https://github.com/user-attachments/assets/c8b3c7a6-6322-4dd9-9a55-acbca0fdf085" />
