### PR TITLE
Add Terms of Use notice to welcome banner

### DIFF
--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -35,10 +35,14 @@
         <button type="button" class="btn-close position-absolute end-0 top-0 m-2 rounded-5 p-2" aria-label="<%= t("javascripts.close") %>"></button>
         <h2 class="me-4 text-break"><%= t "layouts.intro_header" %></h2>
         <p class="fs-6 fw-light"><%= t "layouts.intro_text" %></p>
-        <p class="fs-6 fw-light"><%= t "layouts.hosting_partners_2024_html",
+        <p class="fs-7 fw-light"><%= t "layouts.hosting_partners_2024_html",
                                        :fastly => link_to(t("layouts.partners_fastly"), "https://www.fastly.com/"),
                                        :corpmembers => link_to(t("layouts.partners_corpmembers"), "https://osmfoundation.org/wiki/Corporate_Members"),
                                        :partners => link_to(t("layouts.partners_partners"), "https://hardware.openstreetmap.org/thanks/") %>
+        </p>
+        <p class="fs-7 fw-light">
+          <%= t "layouts.welcome_tou_notice_html",
+                :terms_link => link_to(t("layouts.terms_of_use"), t("site.about_section.legal_1_1_terms_of_use_url")) %>
         </p>
         <div class="d-flex gap-2">
           <a class="btn btn-primary w-100 d-flex align-items-center justify-content-center" href="<%= about_path %>"><%= t("layouts.learn_more") %></a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1842,6 +1842,8 @@ en:
     partners_fastly: "Fastly"
     partners_corpmembers: "OSMF corporate members"
     partners_partners: "partners"
+    welcome_tou_notice_html: "By using this website or other infrastructure provided by the OpenStreetMap Foundation, you agree to the %{terms_link}."
+    terms_of_use: "Terms of Use"
     tou: "Terms of Use"
     nothing_to_preview: "Nothing to preview."
     learn_more: "Learn More"


### PR DESCRIPTION
Closes #6791

Adds a Terms of Use notice to the welcome banner displayed to unauthenticated users on the map page.

Implementation details:

- Added a new translation string `layouts.welcome_tou_notice_html` in `config/locales/en.yml`.
- Appended the notice to the existing welcome banner in `app/views/layouts/map.html.erb`.
- Kept `layouts.hosting_partners_2024_html` unchanged since it is reused on other pages.

The notice includes a link to the Terms of Use.

Pointing towards https://osmfoundation.org/wiki/Terms_of_Use
<img width="357" height="539" alt="image" src="https://github.com/user-attachments/assets/b1f5ddb8-b56c-49f2-b380-de0d9485da6f" />
