### PR TITLE
Drop subdomains from thunderforest layer URLs

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,8 +7,8 @@
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
 Rails.application.configure do
-  connect_src = [:self, "tile.openstreetmap.org", "*.tile.thunderforest.com", "tile.tracestrack.com", "*.openstreetmap.fr", "vector.openstreetmap.org", "api.maptiler.com"]
-  img_src = [:self, :data, "www.gravatar.com", "*.wp.com", "tile.openstreetmap.org", "gps.tile.openstreetmap.org", "*.tile.thunderforest.com", "tile.tracestrack.com", "*.openstreetmap.fr"]
+  connect_src = [:self, "tile.openstreetmap.org", "api.thunderforest.com", "tile.tracestrack.com", "*.openstreetmap.fr", "vector.openstreetmap.org", "api.maptiler.com"]
+  img_src = [:self, :data, "www.gravatar.com", "*.wp.com", "tile.openstreetmap.org", "gps.tile.openstreetmap.org", "api.thunderforest.com", "tile.tracestrack.com", "*.openstreetmap.fr"]
   script_src = [:self]
 
   connect_src << Settings.matomo["location"] if defined?(Settings.matomo)

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -40,8 +40,7 @@
   canEmbed: true
   canDownloadImage: true
   maxZoom: 21
-  tileUrl: "https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}{ratio}.png?apikey={apikey}"
-  subdomains: [a, b, c]
+  tileUrl: "https://api.thunderforest.com/cycle/{z}/{x}/{y}{ratio}.png?apikey={apikey}"
   credit:
     id: "thunderforest_credit"
     children:
@@ -59,9 +58,8 @@
   canEmbed: true
   canDownloadImage: true
   maxZoom: 21
-  tileUrl: "https://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}{ratio}.png?apikey={apikey}"
-  tileUrlDark: "https://{s}.tile.thunderforest.com/transport-dark/{z}/{x}/{y}{ratio}.png?apikey={apikey}"
-  subdomains: [a, b, c]
+  tileUrl: "https://api.thunderforest.com/transport/{z}/{x}/{y}{ratio}.png?apikey={apikey}"
+  tileUrlDark: "https://api.thunderforest.com/transport-dark/{z}/{x}/{y}{ratio}.png?apikey={apikey}"
   credit:
     id: "thunderforest_credit"
     children:


### PR DESCRIPTION
This mirrors https://github.com/openstreetmap/leaflet-osm/pull/56 to apply @gravitystorm's requested changes for the thunderforest layers.