### PR TITLE
Improve accessibility of note action buttons

### DIFF
--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -80,7 +80,7 @@
                                                    :url => close_api_note_url(@note, "json"),
                                                    :default_action_text => t(".resolve"),
                                                    :comment_action_text => t(".comment_and_resolve") } %>
-          <%= button_tag t(".comment"), :name => "comment", :class => "btn btn-primary", :disabled => true,
+          <%= button_tag t(".comment"), :name => "comment", :class => "btn btn-outline-primary", :disabled => true,
                                         :data => { :method => "POST",
                                                    :url => comment_api_note_url(@note, "json") } %>
         </div>


### PR DESCRIPTION
### Description

Fixes openstreetmap/iD#11948

Improve keyboard accessibility of note action buttons.

Previously both **Resolve** and **Comment** buttons used the `btn-primary` Bootstrap variant, making the focused button difficult to distinguish when navigating via keyboard.

This change updates the secondary **Comment** action to use `btn-outline-primary`, improving visual contrast between buttons while staying consistent with Bootstrap styling used in the project.

### How has this been tested?

1. Ran the OpenStreetMap website locally using Docker.
2. Created a test note and opened the note page.
3. Navigated between buttons using the **TAB** key.
4. Verified that the focused button is now clearly distinguishable.
5. Confirmed no layout or functional regressions.


Normal mode  : 
<img width="316" height="240" alt="image" src="https://github.com/user-attachments/assets/8bf64c1e-85a9-488a-bd5b-cf303f4d83c9" />

edit mode : 
<img width="339" height="259" alt="image" src="https://github.com/user-attachments/assets/daec6175-eea5-4177-abf6-44e9a0757e7d" />

edit mode using TAB : 
<img width="336" height="257" alt="image" src="https://github.com/user-attachments/assets/37b8fe9e-2c2f-4d46-b914-c202fd80de8a" />
