### PR TITLE
Expand robots.txt to stop pages robots are getting stuck in

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,9 +6,9 @@
 
 User-agent: *
 Disallow: /user/*/traces/
+Disallow: /user/*/history
 Allow: /user/
-Disallow: /traces/tag/
-Disallow: /traces/page/
+Disallow: /traces
 Disallow: /api/
 Disallow: /edit
 Disallow: /changeset
@@ -20,6 +20,8 @@ Disallow: /login
 Disallow: /geocoder
 Disallow: /history
 Disallow: /message
+Disallow: /oauth2
+Disallow: /search
 Disallow: /trace/
 Disallow: /*lat=
 Disallow: /*node=


### PR DESCRIPTION
I reviewed some of the bot user-agents requests to osm.org and noticed them requesting every single page for some pages. With the pagination changes these are relatively fast, but every time they go back to the page a new item has changed the pagnation points so the bot can try to re-scan the entire list.

There's also a couple endpoints bots shouldn't use because they are themselves searches or they're only used for authentication, which a bot doesn't do.