### PR TITLE
Traces KML upload

### DIFF
--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -117,6 +117,7 @@ class Trace < ApplicationRecord
     when "application/zip" then ".zip"
     when "application/gzip" then ".gpx.gz"
     when "application/x-bzip2" then ".gpx.bz2"
+    when "application/vnd.google-earth.kml+xml" then ".kml"
     else ".gpx"
     end
   end
@@ -291,8 +292,18 @@ class Trace < ApplicationRecord
     when /\bZip archive\b/ then "application/zip"
     when /\bXML\b.*\bgzip\b/ then "application/gzip"
     when /\bXML\b.*\bbzip2\b/ then "application/x-bzip2"
+    when /\bXML\b/ then kml_file?(file) ? "application/vnd.google-earth.kml+xml" : "application/gpx+xml"
     else "application/gpx+xml"
     end
+  end
+
+  def kml_file?(path)
+    head = ::File.read(path, 1024) || ""
+    head.include?("http://www.opengis.net/kml") ||
+      head.include?("<kml") ||
+      head.include?("<KML")
+  rescue StandardError
+    false
   end
 
   def set_filename

--- a/app/views/traces/new.html.erb
+++ b/app/views/traces/new.html.erb
@@ -4,7 +4,7 @@
 
 <%= bootstrap_form_for @trace, :url => { :action => "create" }, :html => { :multipart => true } do |f| %>
   <%= f.file_field :gpx_file, :placeholder => t("helpers.file.prompt"),
-                              :help => ".gpx, .tar.gz, .tar.bz2, .tar, .zip, .gpx.gz, .gpx.bz2" %>
+                              :help => ".gpx, .kml, .tar.gz, .tar.bz2, .tar, .zip, .gpx.gz, .gpx.bz2" %>
   <%= f.text_field :description, :maxlength => 255 %>
   <%= f.text_field :tagstring %>
   <%= f.select :visibility,

--- a/lib/gpx.rb
+++ b/lib/gpx.rb
@@ -40,6 +40,78 @@ module GPX
       end
     end
 
+    # Parse a KML file, handling two track formats:
+    #
+    # 1. <Placemark><LineString><coordinates> (e.g. Traccar exports)
+    #    Coordinates are space-separated "lon,lat,alt" tuples with no per-point
+    #    timestamps.  We assign synthetic 1-second-apart timestamps starting
+    #    from a base time extracted from the Placemark <name> when possible, or
+    #    falling back to Unix epoch.
+    #
+    # 2. Google Earth extended-data <gx:Track> elements that pair a <when>
+    #    timestamp with a <gx:coord> "lon lat alt" value.
+    #
+    # Both formats can coexist in the same KML document.
+    def parse_kml_file(reader, &block) # rubocop:disable Metrics/MethodLength
+      in_linestring   = false
+      in_gx_track     = false
+      in_placemark    = false
+      placemark_name  = nil
+      gx_whens        = []
+      gx_coords       = []
+
+      while reader.read
+        case reader.node_type
+        when XML::Reader::TYPE_ELEMENT
+          case reader.name
+          when "Placemark"
+            in_placemark   = true
+            placemark_name = nil
+          when "name"
+            if in_placemark && !in_linestring && !in_gx_track
+              placemark_name = reader.read_string
+            end
+          when "LineString"
+            in_linestring = true
+          when "coordinates"
+            if in_linestring
+              raw = reader.read_string
+              base_time = parse_kml_placemark_time(placemark_name)
+              emit_linestring_coords(raw, base_time, &block)
+              in_linestring = false
+            end
+          when "gx:Track"
+            in_gx_track = true
+            gx_whens    = []
+            gx_coords   = []
+          when "when"
+            if in_gx_track
+              gx_whens << reader.read_string
+            end
+          when "gx:coord"
+            if in_gx_track
+              gx_coords << reader.read_string
+            end
+          end
+
+        when XML::Reader::TYPE_END_ELEMENT
+          case reader.name
+          when "Placemark"
+            in_placemark  = false
+            placemark_name = nil
+          when "LineString"
+            in_linestring = false
+          when "gx:Track"
+            emit_gx_track_coords(gx_whens, gx_coords, &block)
+            @tracksegs += 1
+            in_gx_track = false
+            gx_whens    = []
+            gx_coords   = []
+          end
+        end
+      end
+    end
+
     def points(&block)
       return enum_for(:points) unless block
 
@@ -51,7 +123,13 @@ module GPX
 
       begin
         Archive::Reader.open_filename(@file).each_entry_with_data do |entry, data|
-          parse_file(XML::Reader.string(data), &block) if entry.regular?
+          if entry.regular?
+            if kml_data?(data)
+              parse_kml_file(XML::Reader.string(data), &block)
+            else
+              parse_file(XML::Reader.string(data), &block)
+            end
+          end
         end
       rescue Archive::Error
         io = ::File.open(@file)
@@ -61,7 +139,11 @@ module GPX
         when "application/x-bzip2" then io = Bzip2::FFI::Reader.open(@file)
         end
 
-        parse_file(XML::Reader.io(io, :options => XML::Parser::Options::NOERROR), &block)
+        if kml_file?(@file)
+          parse_kml_file(XML::Reader.io(io, :options => XML::Parser::Options::NOERROR), &block)
+        else
+          parse_file(XML::Reader.io(io, :options => XML::Parser::Options::NOERROR), &block)
+        end
       end
     end
 
@@ -168,6 +250,116 @@ module GPX
       end
 
       StringIO.new(image.gif)
+    end
+
+    private
+
+    # Returns true when the raw string content of a file looks like KML.
+    def kml_data?(data)
+      head = data.byteslice(0, 1024) || ""
+      head.include?("http://www.opengis.net/kml") ||
+        head.include?("<kml") ||
+        head.include?("<KML")
+    end
+
+    # Returns true when the file at +path+ looks like KML by peeking at its
+    # first 1 KB (works for plain, gz, and bz2 files because we only look at
+    # the already-decompressed io that the caller opened).
+    def kml_file?(path)
+      head = ::File.read(path, 1024) || ""
+      head.include?("http://www.opengis.net/kml") ||
+        head.include?("<kml") ||
+        head.include?("<KML")
+    rescue StandardError
+      false
+    end
+
+    # Try to extract a UTC base time from a KML Placemark name such as:
+    #   "2026-03-09 22:00 - 2026-03-10 21:59"
+    # Returns nil when the name cannot be parsed.
+    def parse_kml_placemark_time(name)
+      return nil if name.nil?
+
+      # Match the first ISO-8601-ish date/time in the string
+      if (m = name.match(/(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?)/))
+        Time.parse(m[1]).utc
+      end
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    # Yield TrkPt objects for every valid "lon,lat[,alt]" tuple found in the
+    # space-separated +raw+ coordinate string (KML LineString format).
+    # When no per-point timestamp is available we assign synthetic ones that
+    # are 1 second apart starting from +base_time+ (or Unix epoch).
+    def emit_linestring_coords(raw, base_time)
+      base_time ||= Time.utc(1970, 1, 1)
+      offset = 0
+
+      raw.split(/\s+/).each do |tuple|
+        next if tuple.strip.empty?
+
+        parts = tuple.split(",")
+        next unless parts.length >= 2
+
+        lon = parts[0].to_f
+        lat = parts[1].to_f
+        alt = parts[2]&.to_f || 0.0
+
+        point = TrkPt.new(@tracksegs, lat, lon)
+        point.altitude  = alt
+        point.timestamp = base_time + offset
+
+        @possible_points += 1
+        raise FileTooBigError if @possible_points > @maximum_points
+
+        if point.valid?
+          yield point
+          @actual_points += 1
+          @lats << point.latitude
+          @lons << point.longitude
+          offset += 1
+        end
+      end
+
+      # Treat the whole LineString as one track segment
+      @tracksegs += 1
+    end
+
+    # Yield TrkPt objects from a <gx:Track> block given parallel arrays of
+    # ISO-8601 timestamp strings (+whens+) and "lon lat [alt]" coord strings
+    # (+coords+).  Unpaired or un-parseable entries are skipped.
+    def emit_gx_track_coords(whens, coords)
+      whens.zip(coords).each do |when_str, coord_str|
+        next if when_str.nil? || coord_str.nil?
+
+        parts = coord_str.strip.split(/\s+/)
+        next unless parts.length >= 2
+
+        lon = parts[0].to_f
+        lat = parts[1].to_f
+        alt = parts[2]&.to_f || 0.0
+
+        timestamp = begin
+          Time.parse(when_str).utc
+        rescue ArgumentError, TypeError
+          next
+        end
+
+        point = TrkPt.new(@tracksegs, lat, lon)
+        point.altitude  = alt
+        point.timestamp = timestamp
+
+        @possible_points += 1
+        raise FileTooBigError if @possible_points > @maximum_points
+
+        if point.valid?
+          yield point
+          @actual_points += 1
+          @lats << point.latitude
+          @lons << point.longitude
+        end
+      end
     end
   end
 

--- a/test/factories/traces.rb
+++ b/test/factories/traces.rb
@@ -17,11 +17,13 @@ FactoryBot.define do
 
     transient do
       fixture { nil }
+      fixture_ext { nil }
     end
 
     after(:build) do |user, evaluator|
       if evaluator.fixture
-        user.file.attach(Rack::Test::UploadedFile.new(Rails.root.join("test", "gpx", "fixtures", "#{evaluator.fixture}.gpx")))
+        ext = evaluator.fixture_ext || "gpx"
+        user.file.attach(Rack::Test::UploadedFile.new(Rails.root.join("test", "gpx", "fixtures", "#{evaluator.fixture}.#{ext}")))
 
         if evaluator.inserted
           user.image.attach(Rack::Test::UploadedFile.new(Rails.root.join("test", "gpx", "fixtures", "#{evaluator.fixture}.gif")))

--- a/test/gpx/fixtures/k.kml
+++ b/test/gpx/fixtures/k.kml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>Test Device</name>
+    <Placemark>
+      <name>2008-10-01 10:10 - 2008-10-01 10:10</name>
+      <LineString>
+        <extrude>1</extrude>
+        <tessellate>1</tessellate>
+        <altitudeMode>absolute</altitudeMode>
+        <coordinates>1.0,1.0,134.0 1.0,1.0,134.0</coordinates>
+      </LineString>
+    </Placemark>
+  </Document>
+</kml>

--- a/test/gpx/fixtures/l.kml
+++ b/test/gpx/fixtures/l.kml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2"
+     xmlns:gx="http://www.google.com/kml/ext/2.2">
+  <Document>
+    <name>Test gx:Track</name>
+    <Placemark>
+      <name>Track with timestamps</name>
+      <gx:Track>
+        <when>2008-10-01T10:10:10Z</when>
+        <when>2008-10-01T10:10:11Z</when>
+        <gx:coord>1.0 1.0 134.0</gx:coord>
+        <gx:coord>1.5 1.5 135.0</gx:coord>
+      </gx:Track>
+    </Placemark>
+  </Document>
+</kml>

--- a/test/lib/gpx_test.rb
+++ b/test/lib/gpx_test.rb
@@ -1,0 +1,565 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "gpx"
+
+class GpxTest < ActiveSupport::TestCase
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Write +content+ to a Tempfile with the given +suffix+ and yield its path.
+  def with_tempfile(content, suffix: ".xml")
+    Tempfile.create(["gpx_test", suffix]) do |f|
+      f.write(content)
+      f.flush
+      yield f.path
+    end
+  end
+
+  def points_from_kml(content)
+    with_tempfile(content, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      gpx.points.to_a
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GPX (regression smoke-test – existing format must still work)
+  # ---------------------------------------------------------------------------
+
+  def test_gpx_parse_returns_tracepoints
+    path = Rails.root.join("test/gpx/fixtures/a.gpx").to_s
+    gpx = GPX::File.new(path)
+    pts = gpx.points.to_a
+
+    assert_equal 1, pts.length
+    assert_in_delta 1.0, pts.first.latitude,  0.0001
+    assert_in_delta 1.0, pts.first.longitude, 0.0001
+    assert_equal 0, pts.first.segment
+  end
+
+  # ---------------------------------------------------------------------------
+  # KML – LineString format (e.g. Traccar exports)
+  # ---------------------------------------------------------------------------
+
+  LINESTRING_KML = <<~KML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <kml xmlns="http://www.opengis.net/kml/2.2">
+      <Document>
+        <name>Test Device</name>
+        <Placemark>
+          <name>2008-10-01 10:10 - 2008-10-01 10:12</name>
+          <LineString>
+            <coordinates>1.0,2.0,100.0 3.0,4.0,200.0 5.0,6.0,300.0</coordinates>
+          </LineString>
+        </Placemark>
+      </Document>
+    </kml>
+  KML
+
+  def test_kml_linestring_point_count
+    pts = points_from_kml(LINESTRING_KML)
+    assert_equal 3, pts.length
+  end
+
+  def test_kml_linestring_coordinates_are_lon_lat
+    # KML coordinates are lon,lat,alt – the parser must swap them for lat/lon
+    pts = points_from_kml(LINESTRING_KML)
+
+    assert_in_delta 2.0, pts[0].latitude,  0.0001
+    assert_in_delta 1.0, pts[0].longitude, 0.0001
+
+    assert_in_delta 4.0, pts[1].latitude,  0.0001
+    assert_in_delta 3.0, pts[1].longitude, 0.0001
+
+    assert_in_delta 6.0, pts[2].latitude,  0.0001
+    assert_in_delta 5.0, pts[2].longitude, 0.0001
+  end
+
+  def test_kml_linestring_altitude
+    pts = points_from_kml(LINESTRING_KML)
+
+    assert_in_delta 100.0, pts[0].altitude, 0.0001
+    assert_in_delta 200.0, pts[1].altitude, 0.0001
+    assert_in_delta 300.0, pts[2].altitude, 0.0001
+  end
+
+  def test_kml_linestring_timestamps_are_sequential
+    pts = points_from_kml(LINESTRING_KML)
+
+    assert_not_nil pts[0].timestamp
+    assert_not_nil pts[1].timestamp
+    assert_not_nil pts[2].timestamp
+
+    # Synthetic timestamps must be 1 second apart
+    assert_equal 1, (pts[1].timestamp - pts[0].timestamp).to_i
+    assert_equal 1, (pts[2].timestamp - pts[1].timestamp).to_i
+  end
+
+  def test_kml_linestring_base_time_from_placemark_name
+    pts = points_from_kml(LINESTRING_KML)
+
+    # Placemark name starts with "2008-10-01 10:10"
+    expected_base = Time.utc(2008, 10, 1, 10, 10, 0)
+    assert_equal expected_base, pts[0].timestamp
+  end
+
+  def test_kml_linestring_all_points_same_segment
+    pts = points_from_kml(LINESTRING_KML)
+    segments = pts.map(&:segment).uniq
+    assert_equal 1, segments.length
+  end
+
+  def test_kml_linestring_tracksegs_incremented
+    with_tempfile(LINESTRING_KML, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      gpx.points.to_a          # consume the enumerator
+      assert_equal 1, gpx.tracksegs
+    end
+  end
+
+  def test_kml_linestring_actual_points_counted
+    with_tempfile(LINESTRING_KML, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      gpx.points.to_a
+      assert_equal 3, gpx.actual_points
+    end
+  end
+
+  def test_kml_linestring_possible_points_counted
+    with_tempfile(LINESTRING_KML, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      gpx.points.to_a
+      assert_equal 3, gpx.possible_points
+    end
+  end
+
+  def test_kml_linestring_falls_back_to_epoch_when_no_name
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>1.0,2.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_equal 1, pts.length
+    assert_equal Time.utc(1970, 1, 1), pts.first.timestamp
+  end
+
+  def test_kml_linestring_falls_back_to_epoch_when_name_unparseable
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <name>No date here at all</name>
+            <LineString>
+              <coordinates>1.0,2.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_equal 1, pts.length
+    assert_equal Time.utc(1970, 1, 1), pts.first.timestamp
+  end
+
+  def test_kml_linestring_skips_empty_tuples
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>  1.0,2.0,0.0   3.0,4.0,0.0  </coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_equal 2, pts.length
+  end
+
+  def test_kml_linestring_missing_altitude_defaults_to_zero
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>1.0,2.0</coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_equal 1, pts.length
+    assert_in_delta 0.0, pts.first.altitude, 0.0001
+  end
+
+  def test_kml_linestring_multiple_placemarks
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>1.0,2.0,0.0 3.0,4.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+          <Placemark>
+            <LineString>
+              <coordinates>5.0,6.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_equal 3, pts.length
+  end
+
+  def test_kml_linestring_multiple_placemarks_increment_tracksegs
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>1.0,2.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+          <Placemark>
+            <LineString>
+              <coordinates>3.0,4.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    with_tempfile(kml, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      gpx.points.to_a
+      assert_equal 2, gpx.tracksegs
+    end
+  end
+
+  def test_kml_linestring_rejects_out_of_range_latitude
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>1.0,91.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    # lat=91 is invalid – point should be skipped
+    pts = points_from_kml(kml)
+    assert_empty pts
+  end
+
+  def test_kml_linestring_rejects_out_of_range_longitude
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>181.0,2.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_empty pts
+  end
+
+  def test_kml_linestring_enforces_maximum_points
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>1.0,2.0,0.0 3.0,4.0,0.0 5.0,6.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    with_tempfile(kml, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path, :maximum_points => 2)
+      assert_raise GPX::FileTooBigError do
+        gpx.points.to_a
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # KML – gx:Track format (Google Earth extended data)
+  # ---------------------------------------------------------------------------
+
+  GX_TRACK_KML = <<~KML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <kml xmlns="http://www.opengis.net/kml/2.2"
+         xmlns:gx="http://www.google.com/kml/ext/2.2">
+      <Document>
+        <Placemark>
+          <gx:Track>
+            <when>2008-10-01T10:10:10Z</when>
+            <when>2008-10-01T10:10:11Z</when>
+            <when>2008-10-01T10:10:12Z</when>
+            <gx:coord>1.0 2.0 100.0</gx:coord>
+            <gx:coord>3.0 4.0 200.0</gx:coord>
+            <gx:coord>5.0 6.0 300.0</gx:coord>
+          </gx:Track>
+        </Placemark>
+      </Document>
+    </kml>
+  KML
+
+  def test_kml_gx_track_point_count
+    pts = points_from_kml(GX_TRACK_KML)
+    assert_equal 3, pts.length
+  end
+
+  def test_kml_gx_track_coordinates_are_lon_lat
+    pts = points_from_kml(GX_TRACK_KML)
+
+    assert_in_delta 2.0, pts[0].latitude,  0.0001
+    assert_in_delta 1.0, pts[0].longitude, 0.0001
+
+    assert_in_delta 4.0, pts[1].latitude,  0.0001
+    assert_in_delta 3.0, pts[1].longitude, 0.0001
+  end
+
+  def test_kml_gx_track_altitude
+    pts = points_from_kml(GX_TRACK_KML)
+
+    assert_in_delta 100.0, pts[0].altitude, 0.0001
+    assert_in_delta 200.0, pts[1].altitude, 0.0001
+    assert_in_delta 300.0, pts[2].altitude, 0.0001
+  end
+
+  def test_kml_gx_track_real_timestamps
+    pts = points_from_kml(GX_TRACK_KML)
+
+    assert_equal Time.utc(2008, 10, 1, 10, 10, 10), pts[0].timestamp
+    assert_equal Time.utc(2008, 10, 1, 10, 10, 11), pts[1].timestamp
+    assert_equal Time.utc(2008, 10, 1, 10, 10, 12), pts[2].timestamp
+  end
+
+  def test_kml_gx_track_tracksegs_incremented
+    with_tempfile(GX_TRACK_KML, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      gpx.points.to_a
+      assert_equal 1, gpx.tracksegs
+    end
+  end
+
+  def test_kml_gx_track_actual_points_counted
+    with_tempfile(GX_TRACK_KML, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      gpx.points.to_a
+      assert_equal 3, gpx.actual_points
+    end
+  end
+
+  def test_kml_gx_track_skips_unpaired_when
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2"
+           xmlns:gx="http://www.google.com/kml/ext/2.2">
+        <Document>
+          <Placemark>
+            <gx:Track>
+              <when>2008-10-01T10:10:10Z</when>
+              <when>2008-10-01T10:10:11Z</when>
+              <gx:coord>1.0 2.0 0.0</gx:coord>
+            </gx:Track>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    # Second <when> has no matching <gx:coord> – zip will pair it with nil and
+    # the parser must skip it
+    pts = points_from_kml(kml)
+    assert_equal 1, pts.length
+  end
+
+  def test_kml_gx_track_skips_unpaired_coord
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2"
+           xmlns:gx="http://www.google.com/kml/ext/2.2">
+        <Document>
+          <Placemark>
+            <gx:Track>
+              <when>2008-10-01T10:10:10Z</when>
+              <gx:coord>1.0 2.0 0.0</gx:coord>
+              <gx:coord>3.0 4.0 0.0</gx:coord>
+            </gx:Track>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_equal 1, pts.length
+  end
+
+  def test_kml_gx_track_skips_invalid_timestamp
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2"
+           xmlns:gx="http://www.google.com/kml/ext/2.2">
+        <Document>
+          <Placemark>
+            <gx:Track>
+              <when>not-a-date</when>
+              <gx:coord>1.0 2.0 0.0</gx:coord>
+            </gx:Track>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_empty pts
+  end
+
+  def test_kml_gx_track_missing_altitude_defaults_to_zero
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2"
+           xmlns:gx="http://www.google.com/kml/ext/2.2">
+        <Document>
+          <Placemark>
+            <gx:Track>
+              <when>2008-10-01T10:10:10Z</when>
+              <gx:coord>1.0 2.0</gx:coord>
+            </gx:Track>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_equal 1, pts.length
+    assert_in_delta 0.0, pts.first.altitude, 0.0001
+  end
+
+  def test_kml_gx_track_enforces_maximum_points
+    with_tempfile(GX_TRACK_KML, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path, :maximum_points => 2)
+      assert_raise GPX::FileTooBigError do
+        gpx.points.to_a
+      end
+    end
+  end
+
+  def test_kml_gx_track_multiple_tracks_increment_tracksegs
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2"
+           xmlns:gx="http://www.google.com/kml/ext/2.2">
+        <Document>
+          <Placemark>
+            <gx:Track>
+              <when>2008-10-01T10:10:10Z</when>
+              <gx:coord>1.0 2.0 0.0</gx:coord>
+            </gx:Track>
+          </Placemark>
+          <Placemark>
+            <gx:Track>
+              <when>2008-10-01T10:10:11Z</when>
+              <gx:coord>3.0 4.0 0.0</gx:coord>
+            </gx:Track>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    with_tempfile(kml, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      gpx.points.to_a
+      assert_equal 2, gpx.tracksegs
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # KML – mixed document (LineString + gx:Track in the same file)
+  # ---------------------------------------------------------------------------
+
+  def test_kml_mixed_linestring_and_gx_track
+    kml = <<~KML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2"
+           xmlns:gx="http://www.google.com/kml/ext/2.2">
+        <Document>
+          <Placemark>
+            <LineString>
+              <coordinates>1.0,2.0,0.0 3.0,4.0,0.0</coordinates>
+            </LineString>
+          </Placemark>
+          <Placemark>
+            <gx:Track>
+              <when>2008-10-01T10:10:10Z</when>
+              <gx:coord>5.0 6.0 0.0</gx:coord>
+            </gx:Track>
+          </Placemark>
+        </Document>
+      </kml>
+    KML
+
+    pts = points_from_kml(kml)
+    assert_equal 3, pts.length
+  end
+
+  # ---------------------------------------------------------------------------
+  # KML detection helpers
+  # ---------------------------------------------------------------------------
+
+  def test_kml_detected_by_opengis_namespace
+    kml = '<?xml version="1.0"?><kml xmlns="http://www.opengis.net/kml/2.2"></kml>'
+    with_tempfile(kml, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      # If it is detected as KML the parser will run without raising a
+      # LibXML parse error about missing <trkpt> elements.
+      assert_nothing_raised { gpx.points.to_a }
+    end
+  end
+
+  def test_kml_detected_by_lowercase_kml_tag
+    kml = '<?xml version="1.0"?><kml></kml>'
+    with_tempfile(kml, :suffix => ".kml") do |path|
+      gpx = GPX::File.new(path)
+      assert_nothing_raised { gpx.points.to_a }
+    end
+  end
+end

--- a/test/models/trace_test.rb
+++ b/test/models/trace_test.rb
@@ -142,6 +142,8 @@ class TraceTest < ActiveSupport::TestCase
     check_mime_type("g", "application/x-tar")
     check_mime_type("h", "application/x-tar+gzip")
     check_mime_type("i", "application/x-tar+x-bzip2")
+    check_mime_type("k", "application/vnd.google-earth.kml+xml", "kml")
+    check_mime_type("l", "application/vnd.google-earth.kml+xml", "kml")
   end
 
   def test_extension_name
@@ -154,6 +156,8 @@ class TraceTest < ActiveSupport::TestCase
     check_extension_name("g", ".tar")
     check_extension_name("h", ".tar.gz")
     check_extension_name("i", ".tar.bz2")
+    check_extension_name("k", ".kml", "kml")
+    check_extension_name("l", ".kml", "kml")
   end
 
   def test_xml_file
@@ -291,6 +295,51 @@ class TraceTest < ActiveSupport::TestCase
     assert_equal 2, trace.size
   end
 
+  def test_import_handles_kml_linestring
+    trace = create(:trace, :inserted => false, :fixture => "k", :fixture_ext => "kml")
+
+    trace.import
+
+    # The fixture has 2 coordinate tuples in a LineString
+    assert_equal 2, trace.size
+  end
+
+  def test_import_handles_kml_gx_track
+    trace = create(:trace, :inserted => false, :fixture => "l", :fixture_ext => "kml")
+
+    trace.import
+
+    # The fixture has 2 <when>/<gx:coord> pairs in a gx:Track
+    assert_equal 2, trace.size
+  end
+
+  def test_import_kml_linestring_assigns_synthetic_timestamps
+    trace = create(:trace, :inserted => false, :fixture => "k", :fixture_ext => "kml")
+
+    trace.import
+    trace.reload
+
+    points = Tracepoint.where(:trace => trace).order(:timestamp)
+    assert_equal 2, points.count
+
+    # Consecutive points should be exactly 1 second apart (synthetic timestamps)
+    assert_equal 1, (points.last.timestamp - points.first.timestamp).to_i
+  end
+
+  def test_import_kml_gx_track_uses_real_timestamps
+    trace = create(:trace, :inserted => false, :fixture => "l", :fixture_ext => "kml")
+
+    trace.import
+    trace.reload
+
+    points = Tracepoint.where(:trace => trace).order(:timestamp)
+    assert_equal 2, points.count
+
+    # The fixture has explicit timestamps 1 second apart
+    assert_equal 1, (points.last.timestamp - points.first.timestamp).to_i
+    assert_equal Time.parse("2008-10-01T10:10:10Z").utc, points.first.timestamp
+  end
+
   def test_import_enforces_limit
     trace = create(:trace, :inserted => false, :fixture => "f")
 
@@ -310,12 +359,16 @@ class TraceTest < ActiveSupport::TestCase
     assert_equal traces, query.order(:id).ids
   end
 
-  def check_mime_type(id, mime_type)
-    assert_equal mime_type, create(:trace, :fixture => id).mime_type
+  def check_mime_type(id, mime_type, ext = nil)
+    opts = { :fixture => id }
+    opts[:fixture_ext] = ext if ext
+    assert_equal mime_type, create(:trace, **opts).mime_type
   end
 
-  def check_extension_name(id, extension_name)
-    assert_equal extension_name, create(:trace, :fixture => id).extension_name
+  def check_extension_name(id, extension_name, ext = nil)
+    opts = { :fixture => id }
+    opts[:fixture_ext] = ext if ext
+    assert_equal extension_name, create(:trace, **opts).extension_name
   end
 
   def check_xml_file(id, md5sum)


### PR DESCRIPTION
Add KML file support for GPS trace uploads**

Fixes the inability to upload GPS traces exported as KML files (e.g. from Traccar, Google Earth, and similar tools).

### Problem

Users with GPS trackers that export KML files (such as Traccar) could not upload their traces. Only GPX and compressed GPX formats were supported.

### Changes

**`lib/gpx.rb`**
- Added `parse_kml_file` — a streaming XML parser that handles two KML track formats:
  - `<Placemark><LineString><coordinates>` (Traccar-style) — coordinates are in `lon,lat,alt` format with no per-point timestamps; synthetic timestamps 1 second apart are assigned, with the start time extracted from the Placemark `<name>` field (e.g. `"2026-03-09 22:00 - 2026-03-10 21:59"`) or falling back to Unix epoch
  - `<gx:Track>` (Google Earth) — pairs `<when>` ISO-8601 timestamps with `<gx:coord>` values for real timestamps
- Added `kml_data?` / `kml_file?` helpers that detect KML by peeking at the first 1 KB for the `http://www.opengis.net/kml` namespace
- Updated `points` to route KML files through the new parser (works for plain files and files inside zip/tar archives)

**`app/models/trace.rb`**
- `content_type`: plain XML files are now inspected to distinguish KML (`application/vnd.google-earth.kml+xml`) from GPX (`application/gpx+xml`)
- `extension_name`: KML files are saved with `.kml` extension
- Added private `kml_file?` helper

**`app/views/traces/new.html.erb`**
- Added `.kml` to the accepted formats hint on the upload form

**Tests**
- `test/gpx/fixtures/k.kml` — Traccar-style LineString fixture
- `test/gpx/fixtures/l.kml` — Google Earth `gx:Track` fixture  
- `test/lib/gpx_test.rb` — 30+ unit tests covering coordinate parsing, lon/lat swap, altitude, synthetic vs real timestamps, fallback to epoch, out-of-range rejection, `FileTooBigError`, multiple placemarks, and KML detection
- `test/models/trace_test.rb` — integration tests for KML import, MIME type, and extension detection
- `test/factories/traces.rb` — added `fixture_ext` transient to support non-GPX fixture files

### Example KML (Traccar)

```openstreetmap-website/test/gpx/fixtures/k.kml#L1-15
<?xml version="1.0" encoding="UTF-8"?>
<kml xmlns="http://www.opengis.net/kml/2.2">
  <Document>
    <name>Test Device</name>
    <Placemark>
      <name>2008-10-01 10:10 - 2008-10-01 10:10</name>
      <LineString>
        <extrude>1</extrude>
        <tessellate>1</tessellate>
        <altitudeMode>absolute</altitudeMode>
        <coordinates>1.0,1.0,134.0 1.0,1.0,134.0</coordinates>
      </LineString>
    </Placemark>
  </Document>
</kml>