### PR TITLE
Use rack by default for system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -19,36 +19,57 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   served_by :host => "rails-app", :port => capybara_server_port if capybara_server_port
 
-  def self.driven_by_selenium(config_name = "default", opts = {})
+  def self.register_selenium_driver(config_name = "default", opts = {})
     preferences = opts.fetch(:preferences, {}).reverse_merge(
       "intl.accept_languages" => "en"
     )
 
-    options = {
-      :name => config_name
-    }
+    headless = Settings.system_test_headless
+    driver_name = :"selenium_#{config_name}"
+
+    driver_options = { :browser => :firefox }
 
     if capybara_server_port
       selenium_host = "http://selenium-#{config_name}:4444"
-      options = options.merge(
+      driver_options = driver_options.merge(
         :url => selenium_host,
         :browser => :remote
       )
     end
 
-    driven_by(
-      :selenium,
-      :using => Settings.system_test_headless ? :headless_firefox : :firefox,
-      :options => options
-    ) do |options|
+    Capybara.register_driver driver_name do |app|
+      options = Selenium::WebDriver::Firefox::Options.new
+      options.add_argument("-headless") if headless
       preferences.each do |name, value|
         options.add_preference(name, value)
       end
       options.binary = Settings.system_test_firefox_binary if Settings.system_test_firefox_binary
+
+      Capybara::Selenium::Driver.new(app, **driver_options, :options => options)
+    end
+
+    driver_name
+  end
+
+  # Define a test that uses a full browser via Selenium, for use in test
+  # classes that default to rack_test but have individual tests needing
+  # JavaScript. Note: js_test blocks get a separate browser session, so
+  # you must call sign_in_as within the block if authentication is needed.
+  #
+  # Pass driver_opts to customize the Selenium driver, e.g. to set
+  # browser language preferences:
+  #   js_test "name", :driver => "de", :preferences => { "intl.accept_languages" => "de" }
+  def self.js_test(name, driver_opts = {}, &block)
+    config_name = driver_opts.delete(:driver) || "default"
+    driver = register_selenium_driver(config_name, driver_opts)
+    test(name) do
+      Capybara.using_driver(driver) do
+        instance_exec(&block)
+      end
     end
   end
 
-  driven_by_selenium
+  driven_by :rack_test
 
   def before_setup
     super

--- a/test/system/account_deletion_test.rb
+++ b/test/system/account_deletion_test.rb
@@ -8,7 +8,8 @@ class AccountDeletionTest < ApplicationSystemTestCase
     sign_in_as(@user)
   end
 
-  test "the status is deleted and the personal data removed" do
+  js_test "the status is deleted and the personal data removed" do
+    sign_in_as(@user)
     visit account_path
 
     click_on "Delete Account..."
@@ -22,7 +23,8 @@ class AccountDeletionTest < ApplicationSystemTestCase
     assert_equal "user_#{@user.id}", @user.display_name
   end
 
-  test "the user is signed out after deletion" do
+  js_test "the user is signed out after deletion" do
+    sign_in_as(@user)
     visit account_path
 
     click_on "Delete Account..."
@@ -33,7 +35,8 @@ class AccountDeletionTest < ApplicationSystemTestCase
     assert_content "Log In"
   end
 
-  test "the user is shown a confirmation flash message" do
+  js_test "the user is shown a confirmation flash message" do
+    sign_in_as(@user)
     visit account_path
 
     click_on "Delete Account..."

--- a/test/system/account_home_test.rb
+++ b/test/system/account_home_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class AccountHomeTest < ApplicationSystemTestCase
-  test "Go to Home Location works on map layout pages" do
+  js_test "Go to Home Location works on map layout pages" do
     user = create(:user, :display_name => "test user", :home_lat => 60, :home_lon => 30)
     sign_in_as(user)
 
@@ -20,7 +20,7 @@ class AccountHomeTest < ApplicationSystemTestCase
     assert_no_selector ".leaflet-marker-icon"
   end
 
-  test "Go to Home Location works on non-map layout pages" do
+  js_test "Go to Home Location works on non-map layout pages" do
     user = create(:user, :display_name => "test user", :home_lat => 60, :home_lon => 30)
     sign_in_as(user)
 
@@ -37,7 +37,7 @@ class AccountHomeTest < ApplicationSystemTestCase
     assert_no_selector ".leaflet-marker-icon"
   end
 
-  test "Go to Home Location is not available for users without home location" do
+  js_test "Go to Home Location is not available for users without home location" do
     user = create(:user, :display_name => "test user")
     sign_in_as(user)
 
@@ -48,7 +48,7 @@ class AccountHomeTest < ApplicationSystemTestCase
     assert_no_link "Go to Home Location"
   end
 
-  test "account home page shows a warning when visited by users without home location" do
+  js_test "account home page shows a warning when visited by users without home location" do
     user = create(:user, :display_name => "test user")
     sign_in_as(user)
 

--- a/test/system/browse_comment_links_test.rb
+++ b/test/system/browse_comment_links_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class BrowseCommentLinksTest < ApplicationSystemTestCase
-  test "visiting changeset comment link should pan to changeset" do
+  js_test "visiting changeset comment link should pan to changeset" do
     changeset = create(:changeset, :bbox => [30, 60, 30, 60])
     comment = create(:changeset_comment, :changeset => changeset, :body => "Linked changeset comment")
 
@@ -15,7 +15,7 @@ class BrowseCommentLinksTest < ApplicationSystemTestCase
     assert_match %r{map=\d+/60\.\d+/30\.\d+}, current_url
   end
 
-  test "visiting note comment link should pan to note" do
+  js_test "visiting note comment link should pan to note" do
     note = create(:note, :latitude => 59 * GeoRecord::SCALE, :longitude => 29 * GeoRecord::SCALE)
     create(:note_comment, :note => note, :body => "Note description")
     comment = create(:note_comment, :note => note, :body => "Linked note comment", :event => "commented")

--- a/test/system/changeset_comments_test.rb
+++ b/test/system/changeset_comments_test.rb
@@ -25,7 +25,7 @@ class ChangesetCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "can add a comment to a changeset" do
+  js_test "can add a comment to a changeset" do
     changeset = create(:changeset, :closed)
     user = create(:user)
     sign_in_as(user)
@@ -59,7 +59,7 @@ class ChangesetCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "moderators can hide comments" do
+  js_test "moderators can hide comments" do
     changeset = create(:changeset, :closed)
     create(:changeset_comment, :changeset => changeset, :body => "Unwanted comment")
 
@@ -92,7 +92,7 @@ class ChangesetCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "moderators can unhide comments" do
+  js_test "moderators can unhide comments" do
     changeset = create(:changeset, :closed)
     create(:changeset_comment, :changeset => changeset, :body => "Wanted comment", :visible => false)
 
@@ -125,7 +125,7 @@ class ChangesetCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "can subscribe" do
+  js_test "can subscribe" do
     changeset = create(:changeset, :closed)
     user = create(:user)
     sign_in_as(user)
@@ -142,7 +142,7 @@ class ChangesetCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "can't subscribe when blocked" do
+  js_test "can't subscribe when blocked" do
     changeset = create(:changeset, :closed)
     user = create(:user)
     sign_in_as(user)

--- a/test/system/changeset_elements_test.rb
+++ b/test/system/changeset_elements_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class ChangesetElementsTest < ApplicationSystemTestCase
-  test "can navigate between element subpages without losing comment input" do
+  js_test "can navigate between element subpages without losing comment input" do
     element_page_size = 20
     changeset = create(:changeset, :closed, :num_changes => 2 * (element_page_size + 1))
     ways = create_list(:way, element_page_size + 1, :with_history, :changeset => changeset)

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -16,7 +16,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     OmniAuth.config.test_mode = false
   end
 
-  test "can create note" do
+  js_test "can create note" do
     visit new_note_path(:anchor => "map=18/0/0")
 
     within_sidebar do
@@ -30,7 +30,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "cannot create new note when zoomed out" do
+  js_test "cannot create new note when zoomed out" do
     visit new_note_path(:anchor => "map=12/0/0")
 
     within_sidebar do
@@ -67,7 +67,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "can open new note page when zoomed out" do
+  js_test "can open new note page when zoomed out" do
     visit new_note_path(:anchor => "map=11/0/0")
 
     within_sidebar do
@@ -90,7 +90,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "cannot create note when api is readonly" do
+  js_test "cannot create note when api is readonly" do
     with_settings(:status => "api_readonly") do
       visit new_note_path(:anchor => "map=18/0/0")
 
@@ -100,7 +100,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "encouragement to contribute appears after 5 created notes and disappears after login" do
+  js_test "encouragement to contribute appears after 5 created notes and disappears after login" do
     check_encouragement_while_creating_notes(5)
 
     sign_in_as(create(:user))
@@ -108,7 +108,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     check_no_encouragement_while_logging_out
   end
 
-  test "encouragement to contribute appears after 5 created notes and disappears after email signup" do
+  js_test "encouragement to contribute appears after 5 created notes and disappears after email signup" do
     check_encouragement_while_creating_notes(5)
 
     sign_up_with_email
@@ -116,7 +116,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     check_no_encouragement_while_logging_out
   end
 
-  test "encouragement to contribute appears after 5 created notes and disappears after google signup" do
+  js_test "encouragement to contribute appears after 5 created notes and disappears after google signup" do
     check_encouragement_while_creating_notes(5)
 
     sign_up_with_google
@@ -124,7 +124,7 @@ class CreateNoteTest < ApplicationSystemTestCase
     check_no_encouragement_while_logging_out
   end
 
-  test "strict encouragement to contribute appears after 10 created notes and disappears after login" do
+  js_test "strict encouragement to contribute appears after 10 created notes and disappears after login" do
     check_strict_encouragement_while_creating_notes(5, 10)
 
     sign_in_as(create(:user))

--- a/test/system/dashboard_test.rb
+++ b/test/system/dashboard_test.rb
@@ -11,7 +11,7 @@ class DashboardSystemTest < ApplicationSystemTestCase
     assert_text "You have not followed any user yet."
   end
 
-  test "show users if have friends" do
+  js_test "show users if have friends" do
     user = create(:user, :home_lon => 1.1, :home_lat => 1.1)
     friend_user = create(:user, :home_lon => 1.2, :home_lat => 1.2)
     create(:follow, :follower => user, :following => friend_user)
@@ -27,7 +27,7 @@ class DashboardSystemTest < ApplicationSystemTestCase
     assert_link friend_user.display_name, :below => friends_heading, :above => others_heading
   end
 
-  test "show nearby users with ability to follow" do
+  js_test "show nearby users with ability to follow" do
     user = create(:user, :home_lon => 1.1, :home_lat => 1.1)
     nearby_user = create(:user, :home_lon => 1.2, :home_lat => 1.2)
     sign_in_as(user)
@@ -52,7 +52,7 @@ class DashboardSystemTest < ApplicationSystemTestCase
     end
   end
 
-  test "show map with home marker if home location is set" do
+  js_test "show map with home marker if home location is set" do
     user = create(:user, :display_name => "Fred Tester", :home_lon => 1.1, :home_lat => 1.1)
     sign_in_as(user)
 

--- a/test/system/diary_entry_test.rb
+++ b/test/system/diary_entry_test.rb
@@ -151,7 +151,7 @@ class DiaryEntrySystemTest < ApplicationSystemTestCase
     assert_no_content I18n.t("diary_entries.diary_entry.full_entry")
   end
 
-  test "contents after diary entry should be below floated images" do
+  js_test "contents after diary entry should be below floated images" do
     user = create(:user)
     diary_entry = create(:diary_entry, :user => user, :body => "<img width=100 height=1000 align=left alt='Floated Image'>")
 

--- a/test/system/directions_test.rb
+++ b/test/system/directions_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class DirectionsSystemTest < ApplicationSystemTestCase
-  test "updates route output on mode change" do
+  js_test "updates route output on mode change" do
     visit directions_path
     stub_straight_routing(:start_instruction => "Start popup text")
 
@@ -21,7 +21,7 @@ class DirectionsSystemTest < ApplicationSystemTestCase
     end
   end
 
-  test "swaps route endpoints on reverse button click" do
+  js_test "swaps route endpoints on reverse button click" do
     visit directions_path
     stub_straight_routing(:start_instruction => "Start popup text")
 
@@ -39,7 +39,7 @@ class DirectionsSystemTest < ApplicationSystemTestCase
     assert_equal start_location, find_by_id("route_to").value
   end
 
-  test "removes popup on sidebar close" do
+  js_test "removes popup on sidebar close" do
     visit directions_path
     stub_straight_routing(:start_instruction => "Start popup text")
 

--- a/test/system/element_current_version_test.rb
+++ b/test/system/element_current_version_test.rb
@@ -282,7 +282,7 @@ class ElementCurrentVersionTest < ApplicationSystemTestCase
     end
   end
 
-  test "relation member nodes should be visible on the map when viewing relations" do
+  js_test "relation member nodes should be visible on the map when viewing relations" do
     relation = create(:relation)
     node = create(:node)
     create(:relation_member, :relation => relation, :member => node)
@@ -292,7 +292,7 @@ class ElementCurrentVersionTest < ApplicationSystemTestCase
     assert_selector "#map .leaflet-overlay-pane path"
   end
 
-  test "map should center on a viewed node" do
+  js_test "map should center on a viewed node" do
     node = create(:node, :lat => 59.55555, :lon => 29.55555)
 
     visit node_path(node)

--- a/test/system/element_history_test.rb
+++ b/test/system/element_history_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class ElementHistoryTest < ApplicationSystemTestCase
-  test "shows history of a node" do
+  js_test "shows history of a node" do
     node = create(:node, :with_history, :version => 2, :lat => 60, :lon => 30)
     node_v1 = node.old_nodes.find_by(:version => 1)
     node_v2 = node.old_nodes.find_by(:version => 2)
@@ -28,7 +28,7 @@ class ElementHistoryTest < ApplicationSystemTestCase
     end
   end
 
-  test "shows history of a way" do
+  js_test "shows history of a way" do
     way = create(:way, :with_history, :version => 2)
     way_v1 = way.old_ways.find_by(:version => 1)
     way_v2 = way.old_ways.find_by(:version => 2)
@@ -50,7 +50,7 @@ class ElementHistoryTest < ApplicationSystemTestCase
     end
   end
 
-  test "shows history of a relation" do
+  js_test "shows history of a relation" do
     relation = create(:relation, :with_history, :version => 2)
     relation_v1 = relation.old_relations.find_by(:version => 1)
     relation_v2 = relation.old_relations.find_by(:version => 2)

--- a/test/system/embed_test.rb
+++ b/test/system/embed_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class EmbedTest < ApplicationSystemTestCase
-  test "shows localized report link" do
+  js_test "shows localized report link" do
     visit export_embed_path
     assert_link "Report a problem"
   end

--- a/test/system/german_embed_test.rb
+++ b/test/system/german_embed_test.rb
@@ -3,14 +3,7 @@
 require "application_system_test_case"
 
 class GermanEmbedTest < ApplicationSystemTestCase
-  driven_by_selenium(
-    "de",
-    :preferences => {
-      "intl.accept_languages" => "de"
-    }
-  )
-
-  test "shows localized report link" do
+  js_test "shows localized report link", :driver => "de", :preferences => { "intl.accept_languages" => "de" } do
     visit export_embed_path
     assert_link "Ein Problem melden"
   end

--- a/test/system/history_test.rb
+++ b/test/system/history_test.rb
@@ -5,7 +5,7 @@ require "application_system_test_case"
 class HistoryTest < ApplicationSystemTestCase
   PAGE_SIZE = 20
 
-  test "atom link on user's history is not modified" do
+  js_test "atom link on user's history is not modified" do
     user = create(:user)
     create(:changeset, :user => user, :num_changes => 1) do |changeset|
       create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "first-changeset-in-history")
@@ -20,7 +20,7 @@ class HistoryTest < ApplicationSystemTestCase
     assert_css "link[type='application/atom+xml'][href$='#{user_path(user)}/history/feed']", :visible => false
   end
 
-  test "have only one list element on user's changesets page" do
+  js_test "have only one list element on user's changesets page" do
     user = create(:user)
     create_visible_changeset(user, "first-changeset-in-history")
     create_visible_changeset(user, "bottom-changeset-in-batch-2")
@@ -61,7 +61,7 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
-  test "user history starts before specified changeset" do
+  js_test "user history starts before specified changeset" do
     user = create(:user)
     changeset1 = create_visible_changeset(user, "1st-changeset-in-history")
     changeset2 = create_visible_changeset(user, "2nd-changeset-in-history")
@@ -89,7 +89,7 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
-  test "user history starts after specified changeset" do
+  js_test "user history starts after specified changeset" do
     user = create(:user)
     changeset0 = create(:changeset)
     changeset1 = create_visible_changeset(user, "1st-changeset-in-history")
@@ -117,7 +117,7 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
-  test "update sidebar when before param is included and map is moved" do
+  js_test "update sidebar when before param is included and map is moved" do
     changeset1 = create(:changeset, :num_changes => 1, :bbox => [5, 5, 5, 5])
     create(:changeset_tag, :changeset => changeset1, :k => "comment", :v => "changeset-at-fives")
     changeset2 = create(:changeset, :num_changes => 1, :bbox => [5.01, 5.01, 5.01, 5.01])
@@ -143,7 +143,7 @@ class HistoryTest < ApplicationSystemTestCase
     assert_current_path history_path
   end
 
-  test "all changesets are listed when fully zoomed out" do
+  js_test "all changesets are listed when fully zoomed out" do
     user = create(:user)
     [-177, -90, 0, 90, 177].each do |lon|
       create(:changeset, :user => user, :num_changes => 1, :bbox => [lon - 1, 0, lon + 1, 1]) do |changeset|
@@ -162,7 +162,7 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
-  test "changesets at both sides of antimeridian are listed" do
+  js_test "changesets at both sides of antimeridian are listed" do
     user = create(:user)
     PAGE_SIZE.times do
       create(:changeset, :user => user, :num_changes => 1, :bbox => [176, 0, 178, 1]) do |changeset|
@@ -186,7 +186,7 @@ class HistoryTest < ApplicationSystemTestCase
     end
   end
 
-  test "changeset bbox is shown on the map and clickable" do
+  js_test "changeset bbox is shown on the map and clickable" do
     user = create(:user)
     changeset = create(:changeset, :user => user, :num_changes => 1, :bbox => [50, 50, 51, 51])
     create(:changeset_tag, :changeset => changeset, :k => "comment", :v => "Clickable changeset")

--- a/test/system/index_test.rb
+++ b/test/system/index_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class IndexTest < ApplicationSystemTestCase
-  test "should remove and add an overlay on share button click" do
+  js_test "should remove and add an overlay on share button click" do
     node = create(:node)
 
     visit node_path(node)
@@ -23,7 +23,7 @@ class IndexTest < ApplicationSystemTestCase
     assert_selector "#content.overlay-right-sidebar"
   end
 
-  test "should add an overlay on close" do
+  js_test "should add an overlay on close" do
     node = create(:node)
 
     visit node_path(node)
@@ -41,7 +41,7 @@ class IndexTest < ApplicationSystemTestCase
     assert_selector "#content.overlay-right-sidebar"
   end
 
-  test "should not add overlay when not closing right menu popup" do
+  js_test "should not add overlay when not closing right menu popup" do
     node = create(:node)
 
     visit node_path(node)
@@ -72,7 +72,7 @@ class IndexTest < ApplicationSystemTestCase
     assert_selector "#content.overlay-right-sidebar"
   end
 
-  test "node included in edit link" do
+  js_test "node included in edit link" do
     node = create(:node)
     visit node_path(node)
     assert_selector "#editanchor[href*='?node=#{node.id}#']"
@@ -81,7 +81,7 @@ class IndexTest < ApplicationSystemTestCase
     assert_no_selector "#editanchor[href*='?node=#{node.id}#']"
   end
 
-  test "note included in edit link" do
+  js_test "note included in edit link" do
     note = create(:note_with_comments)
     visit note_path(note)
     assert_selector "#editanchor[href*='?note=#{note.id}#']"
@@ -90,7 +90,7 @@ class IndexTest < ApplicationSystemTestCase
     assert_no_selector "#editanchor[href*='?note=#{note.id}#']"
   end
 
-  test "can navigate from hidden note to visible note" do
+  js_test "can navigate from hidden note to visible note" do
     sign_in_as(create(:moderator_user))
     hidden_note = create(:note, :status => "hidden", :description => "Hidden Note Description")
     create(:note_comment, :note => hidden_note, :body => "this-is-a-hidden-note", :event => "opened")

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -46,7 +46,7 @@ class IssuesTest < ApplicationSystemTestCase
     assert_selector "strong", :text => "with kramdown"
   end
 
-  def test_view_issue_rich_text_container
+  js_test "view issue rich text container" do
     sign_in_as(create(:moderator_user))
     issue = create(:issue, :assigned_role => "moderator")
     issue.reports << create(:report, :details => "paragraph one\n\n---\n\nparagraph two")
@@ -185,7 +185,7 @@ class IssuesTest < ApplicationSystemTestCase
     assert_link I18n.t("issues.page.reports_count", :count => issue2.reports_count), :href => issue_path(issue2)
   end
 
-  def test_issues_pagination
+  js_test "issues pagination" do
     1.upto(8).each do |n|
       user = create(:user, :display_name => "extra_#{n}")
       create(:issue, :reportable => user, :reported_user => user, :assigned_role => "administrator")

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -24,7 +24,7 @@ class NoteCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "can add comment" do
+  js_test "can add comment" do
     note = create(:note_with_comments)
     user = create(:user)
     sign_in_as(user)
@@ -48,7 +48,7 @@ class NoteCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "can't add a comment when blocked" do
+  js_test "can't add a comment when blocked" do
     note = create(:note_with_comments)
     user = create(:user)
     sign_in_as(user)
@@ -92,7 +92,7 @@ class NoteCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "can subscribe" do
+  js_test "can subscribe" do
     note = create(:note_with_comments)
     user = create(:user)
     sign_in_as(user)
@@ -109,7 +109,7 @@ class NoteCommentsTest < ApplicationSystemTestCase
     end
   end
 
-  test "can unsubscribe" do
+  js_test "can unsubscribe" do
     note = create(:note_with_comments)
     user = create(:user)
     create(:note_subscription, :note => note, :user => user)

--- a/test/system/note_layer_test.rb
+++ b/test/system/note_layer_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class NoteLayerTest < ApplicationSystemTestCase
-  test "note marker should have description as a title" do
+  js_test "note marker should have description as a title" do
     position = (1.1 * GeoRecord::SCALE).to_i
     create(:note, :latitude => position, :longitude => position) do |note|
       create(:note_comment, :note => note, :body => "Note description", :event => "opened")
@@ -15,7 +15,7 @@ class NoteLayerTest < ApplicationSystemTestCase
     end
   end
 
-  test "note marker should not have a title if the note has no visible description" do
+  js_test "note marker should not have a title if the note has no visible description" do
     position = (1.1 * GeoRecord::SCALE).to_i
     create(:note, :latitude => position, :longitude => position) do |note|
       create(:note_comment, :note => note, :body => "Note description is hidden", :event => "opened", :visible => false)
@@ -28,7 +28,7 @@ class NoteLayerTest < ApplicationSystemTestCase
     end
   end
 
-  test "note marker should not have a title if the note has no visible description and comments" do
+  js_test "note marker should not have a title if the note has no visible description and comments" do
     position = (1.1 * GeoRecord::SCALE).to_i
     create(:note, :latitude => position, :longitude => position) do |note|
       create(:note_comment, :note => note, :body => "Note description is hidden", :event => "opened", :visible => false)

--- a/test/system/oauth2_test.rb
+++ b/test/system/oauth2_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class Oauth2Test < ApplicationSystemTestCase
-  def test_authorized_applications
+  js_test "authorized applications" do
     sign_in_as(create(:user))
     visit oauth_authorized_applications_path
 

--- a/test/system/profile_image_change_test.rb
+++ b/test/system/profile_image_change_test.rb
@@ -35,7 +35,7 @@ class ProfileImageChangeTest < ApplicationSystemTestCase
     end
   end
 
-  test "can add and remove image" do
+  js_test "can add and remove image" do
     user = create(:user)
 
     sign_in_as(user)
@@ -82,7 +82,7 @@ class ProfileImageChangeTest < ApplicationSystemTestCase
     end
   end
 
-  test "can add image by clicking the placeholder image" do
+  js_test "can add image by clicking the placeholder image" do
     user = create(:user)
 
     sign_in_as(user)

--- a/test/system/profile_links_change_test.rb
+++ b/test/system/profile_links_change_test.rb
@@ -27,7 +27,7 @@ class ProfileLinksChangeTest < ApplicationSystemTestCase
     end
   end
 
-  test "can add and remove social link without submitting" do
+  js_test "can add and remove social link without submitting" do
     user = create(:user)
 
     sign_in_as(user)
@@ -49,7 +49,7 @@ class ProfileLinksChangeTest < ApplicationSystemTestCase
     end
   end
 
-  test "can add and remove social links" do
+  js_test "can add and remove social links" do
     user = create(:user)
 
     sign_in_as(user)
@@ -79,7 +79,7 @@ class ProfileLinksChangeTest < ApplicationSystemTestCase
     end
   end
 
-  test "can control social links using keyboard without submitting" do
+  js_test "can control social links using keyboard without submitting" do
     user = create(:user)
 
     sign_in_as(user)
@@ -98,7 +98,7 @@ class ProfileLinksChangeTest < ApplicationSystemTestCase
     end
   end
 
-  test "can control social links using keyboard" do
+  js_test "can control social links using keyboard" do
     user = create(:user)
 
     sign_in_as(user)
@@ -126,7 +126,7 @@ class ProfileLinksChangeTest < ApplicationSystemTestCase
     end
   end
 
-  test "can add and remove multiple links" do
+  js_test "can add and remove multiple links" do
     user = create(:user)
 
     sign_in_as(user)

--- a/test/system/query_features_test.rb
+++ b/test/system/query_features_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class QueryFeaturesSystemTest < ApplicationSystemTestCase
-  test "sorts enclosing features correctly" do
+  js_test "sorts enclosing features correctly" do
     visit "/#map=15/54.18315/7.88473"
 
     within "#map" do
@@ -76,7 +76,7 @@ class QueryFeaturesSystemTest < ApplicationSystemTestCase
     end
   end
 
-  test "sorts enclosing features correctly across antimeridian" do
+  js_test "sorts enclosing features correctly across antimeridian" do
     visit "/#map=15/60/30"
 
     within "#map" do
@@ -130,7 +130,7 @@ class QueryFeaturesSystemTest < ApplicationSystemTestCase
     end
   end
 
-  test "sorts enclosing features correctly with multiple bboxes across antimeridian" do
+  js_test "sorts enclosing features correctly with multiple bboxes across antimeridian" do
     visit "/#map=15/-16.155/179.995"
 
     within "#map" do

--- a/test/system/redaction_destroy_test.rb
+++ b/test/system/redaction_destroy_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class RedactionDestroyTest < ApplicationSystemTestCase
-  test "fails to delete nonempty redaction" do
+  js_test "fails to delete nonempty redaction" do
     redaction = create(:redaction, :title => "Some-unwanted-data-redaction")
     create(:old_node, :redaction => redaction)
 
@@ -18,7 +18,7 @@ class RedactionDestroyTest < ApplicationSystemTestCase
     assert_text "Some-unwanted-data-redaction"
   end
 
-  test "deletes empty redaction" do
+  js_test "deletes empty redaction" do
     redaction = create(:redaction, :title => "No-unwanted-data-redaction")
 
     sign_in_as create(:moderator_user)

--- a/test/system/resolve_note_test.rb
+++ b/test/system/resolve_note_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class ResolveNoteTest < ApplicationSystemTestCase
-  test "can resolve an open note" do
+  js_test "can resolve an open note" do
     note = create(:note_with_comments)
     user = create(:user)
     sign_in_as(user)
@@ -20,7 +20,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "can resolve an open note with a comment" do
+  js_test "can resolve an open note with a comment" do
     note = create(:note_with_comments)
     user = create(:user)
     sign_in_as(user)
@@ -42,7 +42,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "can reactivate a closed note" do
+  js_test "can reactivate a closed note" do
     note = create(:note_with_comments, :closed)
     user = create(:user)
     sign_in_as(user)
@@ -60,7 +60,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "can hide an open note as moderator" do
+  js_test "can hide an open note as moderator" do
     note = create(:note_with_comments)
     user = create(:moderator_user)
     sign_in_as(user)
@@ -75,7 +75,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "can hide a closed note as moderator" do
+  js_test "can hide a closed note as moderator" do
     note = create(:note_with_comments, :closed)
     user = create(:moderator_user)
     sign_in_as(user)
@@ -92,7 +92,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "can't resolve a note when blocked" do
+  js_test "can't resolve a note when blocked" do
     note = create(:note_with_comments)
     user = create(:user)
     sign_in_as(user)
@@ -116,7 +116,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
     end
   end
 
-  test "can't reactivate a note when blocked" do
+  js_test "can't reactivate a note when blocked" do
     note = create(:note_with_comments, :closed)
     user = create(:user)
     sign_in_as(user)

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -37,7 +37,7 @@ class SearchTest < ApplicationSystemTestCase
       BODY
   end
 
-  test "click on 'where is this' sets search input value and makes reverse geocoding request with zoom" do
+  js_test "click on 'where is this' sets search input value and makes reverse geocoding request with zoom" do
     visit "/#map=15/51.76320/-0.00760"
 
     assert_field "Search", :with => ""
@@ -47,7 +47,7 @@ class SearchTest < ApplicationSystemTestCase
     assert_link "Broxbourne, Hertfordshire, East of England, England, United Kingdom"
   end
 
-  test "'Show address' from context menu makes reverse geocoding request with zoom" do
+  js_test "'Show address' from context menu makes reverse geocoding request with zoom" do
     visit "/#map=15/51.76320/-0.00760"
 
     find_by_id("map").right_click
@@ -68,7 +68,7 @@ class SearchTest < ApplicationSystemTestCase
     assert_field "Search", :with => "4.321, 9.876"
   end
 
-  test "search adds viewbox param to Nominatim link" do
+  js_test "search adds viewbox param to Nominatim link" do
     visit "/"
 
     fill_in "query", :with => "paris"
@@ -79,7 +79,7 @@ class SearchTest < ApplicationSystemTestCase
     end
   end
 
-  test "search adds zoom param to reverse Nominatim link" do
+  js_test "search adds zoom param to reverse Nominatim link" do
     visit "/#map=7/1.234/6.789"
 
     fill_in "query", :with => "60 30"

--- a/test/system/select_language_test.rb
+++ b/test/system/select_language_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class SelectLanguageTest < ApplicationSystemTestCase
-  test "can select language when logged out" do
+  js_test "can select language when logged out" do
     visit help_path
 
     within_content_heading do
@@ -25,7 +25,7 @@ class SelectLanguageTest < ApplicationSystemTestCase
     end
   end
 
-  test "can select language when logged in" do
+  js_test "can select language when logged in" do
     user = create(:user, :display_name => "LanguageTestUser")
     sign_in_as(user)
 

--- a/test/system/site_test.rb
+++ b/test/system/site_test.rb
@@ -3,13 +3,13 @@
 require "application_system_test_case"
 
 class SiteTest < ApplicationSystemTestCase
-  test "visiting the index" do
+  js_test "visiting the index" do
     visit "/"
 
     assert_selector "h1", :text => "OpenStreetMap"
   end
 
-  test "tooltip shows for Layers button" do
+  js_test "tooltip shows for Layers button" do
     visit "/"
 
     assert_no_selector ".tooltip"
@@ -18,7 +18,7 @@ class SiteTest < ApplicationSystemTestCase
     assert_selector ".tooltip", :text => "Layers"
   end
 
-  test "tooltip shows for Legend button on Standard layer" do
+  js_test "tooltip shows for Legend button on Standard layer" do
     visit "/"
 
     assert_no_selector ".tooltip"
@@ -29,7 +29,7 @@ class SiteTest < ApplicationSystemTestCase
     tooltip.assert_no_text "not available"
   end
 
-  test "tooltip shows for Legend button on a layer without a legend provided" do
+  js_test "tooltip shows for Legend button on a layer without a legend provided" do
     visit "/#layers=H" # assumes that HOT layer has no legend
 
     assert_no_selector ".tooltip"
@@ -40,7 +40,7 @@ class SiteTest < ApplicationSystemTestCase
     tooltip.assert_text "not available"
   end
 
-  test "tooltip shows for query button when zoomed in" do
+  js_test "tooltip shows for query button when zoomed in" do
     visit "/#map=14/0/0"
 
     assert_no_selector ".tooltip"
@@ -51,27 +51,27 @@ class SiteTest < ApplicationSystemTestCase
     tooltip.assert_no_text "Zoom in"
   end
 
-  test "tooltips on low zoom levels for disabled control 'Edit'" do
+  js_test "tooltips on low zoom levels for disabled control 'Edit'" do
     check_control_tooltips_on_low_zoom "Edit"
   end
-  test "tooltips on low zoom levels for disabled control 'Add a note to the map'" do
+  js_test "tooltips on low zoom levels for disabled control 'Add a note to the map'" do
     check_control_tooltips_on_low_zoom "Add a note to the map"
   end
-  test "tooltips on low zoom levels for disabled control 'Query features'" do
+  js_test "tooltips on low zoom levels for disabled control 'Query features'" do
     check_control_tooltips_on_low_zoom "Query features"
   end
 
-  test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Edit'" do
+  js_test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Edit'" do
     check_control_tooltips_on_high_zoom "Edit"
   end
-  test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Add a note to the map'" do
+  js_test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Add a note to the map'" do
     check_control_tooltips_on_high_zoom "Add a note to the map"
   end
-  test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Query features'" do
+  js_test "no zoom-in tooltips on high zoom levels, then tooltips appear after zoom out for control 'Query features'" do
     check_control_tooltips_on_high_zoom "Query features"
   end
 
-  test "notes layer tooltip appears on zoom out" do
+  js_test "notes layer tooltip appears on zoom out" do
     visit "/#map=10/40/-4" # depends on zoom levels where notes are allowed
 
     within "#map" do

--- a/test/system/unknown_language_embed_test.rb
+++ b/test/system/unknown_language_embed_test.rb
@@ -3,14 +3,7 @@
 require "application_system_test_case"
 
 class UnknownLanguageEmbedTest < ApplicationSystemTestCase
-  driven_by_selenium(
-    "nolang",
-    :preferences => {
-      "intl.accept_languages" => "unknown-language"
-    }
-  )
-
-  test "shows report link in fallback language" do
+  js_test "shows report link in fallback language", :driver => "nolang", :preferences => { "intl.accept_languages" => "unknown-language" } do
     visit export_embed_path
     assert_link "Report a problem"
   end

--- a/test/system/user_email_change_test.rb
+++ b/test/system/user_email_change_test.rb
@@ -9,7 +9,7 @@ class UserEmailChangeTest < ApplicationSystemTestCase
     stub_request(:get, /.*gravatar.com.*d=404/).to_return(:status => 404)
   end
 
-  test "User can change their email address" do
+  js_test "User can change their email address" do
     user = create(:user)
     sign_in_as(user)
 

--- a/test/system/user_login_test.rb
+++ b/test/system/user_login_test.rb
@@ -23,7 +23,7 @@ class UserLoginTest < ApplicationSystemTestCase
     assert_button "Second User"
   end
 
-  test "Warn on login page when already logged in with referer link" do
+  js_test "Warn on login page when already logged in with referer link" do
     user1 = create(:user, :display_name => "First User")
     sign_in_as(user1)
 

--- a/test/system/user_logout_test.rb
+++ b/test/system/user_logout_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class UserLogoutTest < ApplicationSystemTestCase
-  test "Sign out via link" do
+  js_test "Sign out via link" do
     user = create(:user)
     sign_in_as(user)
     assert_no_content "Log In"
@@ -13,7 +13,7 @@ class UserLogoutTest < ApplicationSystemTestCase
     assert_content "Log In"
   end
 
-  test "Sign out via link with referer" do
+  js_test "Sign out via link with referer" do
     user = create(:user)
     sign_in_as(user)
     visit traces_path
@@ -48,7 +48,7 @@ class UserLogoutTest < ApplicationSystemTestCase
     assert_content "Public GPS Traces"
   end
 
-  test "Sign out after navigating diary entries with Turbo pagination" do
+  js_test "Sign out after navigating diary entries with Turbo pagination" do
     create(:language, :code => "en")
     create(:diary_entry, :title => "First Diary Entry")
     create_list(:diary_entry, 20) # rubocop:disable FactoryBot/ExcessiveCreateList
@@ -62,7 +62,7 @@ class UserLogoutTest < ApplicationSystemTestCase
     end
   end
 
-  test "Sign out after navigating issues with Turbo pagination" do
+  js_test "Sign out after navigating issues with Turbo pagination" do
     first_target_user = create(:user, :display_name => "First Target User")
     create(:issue, :reportable => first_target_user, :reported_user => first_target_user)
     create_list(:issue, 50) # rubocop:disable FactoryBot/ExcessiveCreateList
@@ -76,7 +76,7 @@ class UserLogoutTest < ApplicationSystemTestCase
     end
   end
 
-  test "Sign out after navigating traces with Turbo pagination" do
+  js_test "Sign out after navigating traces with Turbo pagination" do
     create(:trace, :fixture => "a", :name => "First Trace")
     create_list(:trace, 20, :fixture => "a") # rubocop:disable FactoryBot/ExcessiveCreateList
 
@@ -89,7 +89,7 @@ class UserLogoutTest < ApplicationSystemTestCase
     end
   end
 
-  test "Sign out after navigating changeset comments with Turbo pagination" do
+  js_test "Sign out after navigating changeset comments with Turbo pagination" do
     user = create(:user)
     create(:changeset_comment, :author => user, :body => "First Changeset Comment")
     create_list(:changeset_comment, 20, :author => user) # rubocop:disable FactoryBot/ExcessiveCreateList
@@ -103,7 +103,7 @@ class UserLogoutTest < ApplicationSystemTestCase
     end
   end
 
-  test "Sign out after navigating diary comments with Turbo pagination" do
+  js_test "Sign out after navigating diary comments with Turbo pagination" do
     create(:language, :code => "en")
     user = create(:user)
     create(:diary_comment, :user => user, :body => "First Diary Comment")
@@ -118,7 +118,7 @@ class UserLogoutTest < ApplicationSystemTestCase
     end
   end
 
-  test "Sign out after navigating users with Turbo pagination" do
+  js_test "Sign out after navigating users with Turbo pagination" do
     create(:user, :display_name => "First User")
     create_list(:user, 50) # rubocop:disable FactoryBot/ExcessiveCreateList
 
@@ -131,16 +131,16 @@ class UserLogoutTest < ApplicationSystemTestCase
     end
   end
 
-  test "Sign out after navigating user blocks with Turbo pagination" do
+  js_test "Sign out after navigating user blocks with Turbo pagination" do
     check_sign_out_after_turbo_pagination_on_block_pages user_blocks_path
   end
 
-  test "Sign out after navigating issued user blocks with Turbo pagination" do
+  js_test "Sign out after navigating issued user blocks with Turbo pagination" do
     creator = create(:moderator_user)
     check_sign_out_after_turbo_pagination_on_block_pages user_issued_blocks_path(creator), :creator => creator
   end
 
-  test "Sign out after navigating received user blocks with Turbo pagination" do
+  js_test "Sign out after navigating received user blocks with Turbo pagination" do
     receiver = create(:user)
     check_sign_out_after_turbo_pagination_on_block_pages user_received_blocks_path(receiver), :receiver => receiver
   end

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -9,7 +9,7 @@ class UserSignupTest < ApplicationSystemTestCase
     stub_request(:get, /.*gravatar.com.*d=404/).to_return(:status => 404)
   end
 
-  test "Sign up with confirmation email" do
+  js_test "Sign up with confirmation email" do
     visit root_path
 
     click_on "Sign Up"
@@ -40,7 +40,7 @@ class UserSignupTest < ApplicationSystemTestCase
     assert_content "Welcome!"
   end
 
-  test "Sign up with confirmation email resending" do
+  js_test "Sign up with confirmation email resending" do
     visit root_path
 
     click_on "Sign Up"

--- a/test/system/user_status_change_test.rb
+++ b/test/system/user_status_change_test.rb
@@ -3,12 +3,8 @@
 require "application_system_test_case"
 
 class UserStatusChangeTest < ApplicationSystemTestCase
-  def setup
-    admin = create(:administrator_user)
-    sign_in_as(admin)
-  end
-
-  test "Admin can unsuspend a user" do
+  js_test "Admin can unsuspend a user" do
+    sign_in_as(create(:administrator_user))
     user = create(:user, :suspended)
     visit user_path(user)
     accept_confirm do
@@ -20,7 +16,8 @@ class UserStatusChangeTest < ApplicationSystemTestCase
     assert_equal "active", user.status
   end
 
-  test "Admin can suspend a user" do
+  js_test "Admin can suspend a user" do
+    sign_in_as(create(:administrator_user))
     # There's another instance of "Suspend" in the page.
     # This test uses a more specific text, putting it in
     # a variable to avoid a misspelling when doing
@@ -38,7 +35,8 @@ class UserStatusChangeTest < ApplicationSystemTestCase
     assert_equal "suspended", user.status
   end
 
-  test "Admin can confirm a user" do
+  js_test "Admin can confirm a user" do
+    sign_in_as(create(:administrator_user))
     user = create(:user, :suspended)
     visit user_path(user)
     accept_confirm do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -3,12 +3,8 @@
 require "application_system_test_case"
 
 class UsersTest < ApplicationSystemTestCase
-  def setup
-    admin = create(:administrator_user)
-    sign_in_as(admin)
-  end
-
-  test "all users can be selected" do
+  js_test "all users can be selected" do
+    sign_in_as(create(:administrator_user))
     create_list(:user, 100)
 
     visit users_list_path


### PR DESCRIPTION
This speeds up the system tests whereever a full-blown JS engine is not required. When it is, we can either use `js_test` to mark one specific test, or `driven_by_selenium` to make the whole file us the full browser.

This is a variation on #6497. It switches to use rack by default, and then a custom `js_test` to run tests with selenium (i.e. using a full browser) when necessary. It also has a class-level `driven_by_selenium` for when the whole file needs javascript.

Things to consider:
* In the files with mixed use of `test` and `js_test`, you need to run any `sign_in_as` within the `js_test` block. Otherwise you log in using the default `rack_test` driver and then the selenium driver isn't logged in.
* I'm not convinced that the `driven_by_selenium` option is actually a good idea, but I'm interested in feedback. It means that some js-is-required tests use `js_test` but others use `test` (when there's a class-level `driven_by_selenium`). I think it might be more confusing to do it this way, compared to just using `js_test` throughout.
* If we keep the class-level statement, I would be open to renaming it to something like `all_tests_need_js` or somesuch.
* I measured about a 10%-15% speedup across the system tests with this approach, because many tests still need javascript. This is for a variety of reasons, some of which could be refactored (e.g. using positional `:before/:after` in assertions). But are the overall savings worth the effort?

Overall though, I think it's an improvement on the split-classes (or potential metaprogramming) approach in #6497

Feedback welcome.