### PR TITLE
Break instruction lines in directions table

### DIFF
--- a/app/assets/javascripts/index/directions-route-output.js
+++ b/app/assets/javascripts/index/directions-route-output.js
@@ -96,7 +96,7 @@ OSM.DirectionsRouteOutput = function (map) {
         row.append("<td class='ps-3'>");
       }
 
-      row.append(`<td><b>${i + 1}.</b> ${instruction}`);
+      row.append(`<td class="text-break"><b>${i + 1}.</b> ${instruction}`);
       row.append("<td class='pe-3 distance text-body-secondary text-end'>" + formatStepDistance(...translateDistanceUnits(dist)));
 
       row.on("click", function () {


### PR DESCRIPTION
Valhalla chains exit destinations together in a way that doesn't natively wrap to the next line.

For https://osm.org/way/124190939, this starts to break the layout.

<img src="https://github.com/user-attachments/assets/c8e96fa8-30bf-4b4b-80f1-849c1900ce0a" />
