### PR TITLE
Add parse_html helper to tests

### DIFF
--- a/test/helpers/browse_helper_test.rb
+++ b/test/helpers/browse_helper_test.rb
@@ -79,31 +79,31 @@ class BrowseHelperTest < ActionView::TestCase
     add_old_tags_selection(node_v1)
 
     icon = element_icon("node", create(:node))
-    icon_dom = Rails::Dom::Testing.html_document_fragment.parse(icon)
+    icon_dom = parse_html(icon)
     assert_dom icon_dom, "img:root", :count => 1 do
       assert_dom "> @title", 0
     end
 
     icon = element_icon("node", create(:node, :deleted))
-    icon_dom = Rails::Dom::Testing.html_document_fragment.parse(icon)
+    icon_dom = parse_html(icon)
     assert_dom icon_dom, "img:root", :count => 1 do
       assert_dom "> @title", 0
     end
 
     icon = element_icon("node", node)
-    icon_dom = Rails::Dom::Testing.html_document_fragment.parse(icon)
+    icon_dom = parse_html(icon)
     assert_dom icon_dom, "img:root", :count => 1 do
       assert_dom "> @title", "building=yes, shop=gift, and tourism=museum"
     end
 
     icon = element_icon("node", node_v2)
-    icon_dom = Rails::Dom::Testing.html_document_fragment.parse(icon)
+    icon_dom = parse_html(icon)
     assert_dom icon_dom, "img:root", :count => 1 do
       assert_dom "> @title", "building=yes, shop=gift, and tourism=museum"
     end
 
     icon = element_icon("node", node_v1)
-    icon_dom = Rails::Dom::Testing.html_document_fragment.parse(icon)
+    icon_dom = parse_html(icon)
     assert_dom icon_dom, "img:root", :count => 1 do
       assert_dom "> @title", 0
     end

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -47,18 +47,18 @@ class BrowseTagsHelperTest < ActionView::TestCase
                      html
 
     html = format_value("wikidata", "Q42")
-    dom = Rails::Dom::Testing.html_document_fragment.parse html
+    dom = parse_html html
     assert_select dom, "a[title='The Q42 item on Wikidata'][href$='www.wikidata.org/entity/Q42?uselang=en']", :text => "Q42"
     assert_select dom, "button.wdt-preview>svg>path[fill]", 1
 
     html = format_value("operator:wikidata", "Q12;Q98")
-    dom = Rails::Dom::Testing.html_document_fragment.parse html
+    dom = parse_html html
     assert_select dom, "a[title='The Q12 item on Wikidata'][href$='www.wikidata.org/entity/Q12?uselang=en']", :text => "Q12"
     assert_select dom, "a[title='The Q98 item on Wikidata'][href$='www.wikidata.org/entity/Q98?uselang=en']", :text => "Q98"
     assert_select dom, "button.wdt-preview>svg>path[fill]", 1
 
     html = format_value("name:etymology:wikidata", "Q123")
-    dom = Rails::Dom::Testing.html_document_fragment.parse html
+    dom = parse_html html
     assert_select dom, "a[title='The Q123 item on Wikidata'][href$='www.wikidata.org/entity/Q123?uselang=en']", :text => "Q123"
     assert_select dom, "button.wdt-preview>svg>path[fill]", 1
 
@@ -70,7 +70,7 @@ class BrowseTagsHelperTest < ActionView::TestCase
                      html
 
     html = format_value("colour", "#f00")
-    dom = Rails::Dom::Testing.html_document_fragment.parse html
+    dom = parse_html html
     assert_select dom, "svg>rect>@fill", "#f00"
     assert_match(/#f00$/, html)
 
@@ -84,7 +84,7 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_dom_equal "<a href=\"https://example.com\" rel=\"nofollow\" dir=\"auto\">https://example.com</a>;hello;<a href=\"https://example.net\" rel=\"nofollow\" dir=\"auto\">https://example.net</a>", html
 
     html = format_value("website", "https://routing.openstreetmap.de/routed-car/route/v1/driving/-3.68,57.63;-3.68,57.61")
-    dom = Rails::Dom::Testing.html_document_fragment.parse html
+    dom = parse_html html
     assert_select dom, "a", 1
 
     html = format_value("website", "example.com/page")

--- a/test/helpers/changesets_helper_test.rb
+++ b/test/helpers/changesets_helper_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class ChangesetsHelperTest < ActionView::TestCase
   def test_changeset_user_link
     changeset = create(:changeset)
-    changeset_user_link_dom = Rails::Dom::Testing.html_document_fragment.parse changeset_user_link(changeset)
+    changeset_user_link_dom = parse_html changeset_user_link(changeset)
     assert_dom changeset_user_link_dom, "a:root", :text => changeset.user.display_name do
       assert_dom "> @href", "/user/#{ERB::Util.u(changeset.user.display_name)}"
     end
@@ -21,7 +21,7 @@ class ChangesetsHelperTest < ActionView::TestCase
     changeset = create(:changeset, :created_at => Time.utc(2007, 1, 1, 0, 0, 0), :user => create(:user, :data_public => false))
     # We need to explicitly reset the closed_at to some point in the future, and avoid the before_save callback
     changeset.update_column(:closed_at, Time.now.utc + 1.day) # rubocop:disable Rails/SkipsModelValidations
-    changeset_details_dom = Rails::Dom::Testing.html_document_fragment.parse "<div>#{changeset_details(changeset)}</div>"
+    changeset_details_dom = parse_html "<div>#{changeset_details(changeset)}</div>"
     assert_dom changeset_details_dom, ":root", :text => /^Created .* by anonymous$/ do
       assert_dom "> time", :count => 1 do
         assert_dom "> @title", "Mon, 01 Jan 2007 00:00:00 +0000"
@@ -31,7 +31,7 @@ class ChangesetsHelperTest < ActionView::TestCase
     end
 
     changeset = create(:changeset, :created_at => Time.utc(2007, 1, 1, 0, 0, 0), :closed_at => Time.utc(2007, 1, 2, 0, 0, 0))
-    changeset_details_dom = Rails::Dom::Testing.html_document_fragment.parse "<div>#{changeset_details(changeset)}</div>"
+    changeset_details_dom = parse_html "<div>#{changeset_details(changeset)}</div>"
     assert_dom changeset_details_dom, ":root", :text => /^Closed .* by #{changeset.user.display_name}$/ do
       assert_dom "> time", :count => 1 do
         assert_dom "> @title", :html => "Created: Mon, 01 Jan 2007 00:00:00 +0000\nClosed: Tue, 02 Jan 2007 00:00:00 +0000"

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -12,7 +12,7 @@ class IssuesHelperTest < ActionView::TestCase
 
     heading = reportable_heading diary_comment
 
-    dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
+    dom_heading = parse_html "<p>#{heading}</p>"
     assert_dom dom_heading, ":root", "Diary Comment A Discussion, comment ##{diary_comment.id} created on 15 March 2020 at 00:00, updated on 17 May 2021 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", diary_entry_url(diary_entry.user, diary_entry, :anchor => "comment#{diary_comment.id}")
@@ -25,7 +25,7 @@ class IssuesHelperTest < ActionView::TestCase
 
     heading = reportable_heading diary_entry
 
-    dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
+    dom_heading = parse_html "<p>#{heading}</p>"
     assert_dom dom_heading, ":root", "Diary Entry Important Subject created on 24 March 2020 at 00:00, updated on 26 May 2021 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", diary_entry_url(diary_entry.user, diary_entry)
@@ -37,7 +37,7 @@ class IssuesHelperTest < ActionView::TestCase
 
     heading = reportable_heading note
 
-    dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
+    dom_heading = parse_html "<p>#{heading}</p>"
     assert_dom dom_heading, ":root", "Note ##{note.id} created on 14 March 2020 at 00:00, updated on 16 May 2021 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", note_url(note)
@@ -49,7 +49,7 @@ class IssuesHelperTest < ActionView::TestCase
 
     heading = reportable_heading user
 
-    dom_heading = Rails::Dom::Testing.html_document_fragment.parse "<p>#{heading}</p>"
+    dom_heading = parse_html "<p>#{heading}</p>"
     assert_dom dom_heading, ":root", "User Someone created on 18 July 2020 at 00:00"
     assert_dom dom_heading, "a", 1 do
       assert_dom "> @href", user_url(user)

--- a/test/helpers/note_helper_test.rb
+++ b/test/helpers/note_helper_test.rb
@@ -10,7 +10,7 @@ class NoteHelperTest < ActionView::TestCase
     date = Time.utc(2014, 3, 5, 21, 37, 45)
     user = create(:user)
 
-    note_event_dom = Rails::Dom::Testing.html_document_fragment.parse "<div>#{note_event('opened', date, nil)}</div>"
+    note_event_dom = parse_html "<div>#{note_event('opened', date, nil)}</div>"
     assert_dom note_event_dom, ":root", :text => /^Created by anonymous .* ago$/ do
       assert_dom "> a", :count => 0
       assert_dom "> time", :count => 1 do
@@ -19,7 +19,7 @@ class NoteHelperTest < ActionView::TestCase
       end
     end
 
-    note_event_dom = Rails::Dom::Testing.html_document_fragment.parse "<div>#{note_event('closed', date, user)}</div>"
+    note_event_dom = parse_html "<div>#{note_event('closed', date, user)}</div>"
     assert_dom note_event_dom, ":root", :text => /^Resolved by #{user.display_name} .* ago$/ do
       assert_dom "> a", :count => 1, :text => user.display_name do
         assert_dom "> @href", "/user/#{ERB::Util.u(user.display_name)}"
@@ -39,12 +39,12 @@ class NoteHelperTest < ActionView::TestCase
 
     assert_equal "deleted", note_author(deleted_user)
 
-    note_author_dom = Rails::Dom::Testing.html_document_fragment.parse note_author(user)
+    note_author_dom = parse_html note_author(user)
     assert_dom note_author_dom, "a:root", :text => user.display_name do
       assert_dom "> @href", "/user/#{ERB::Util.u(user.display_name)}"
     end
 
-    note_author_dom = Rails::Dom::Testing.html_document_fragment.parse note_author(user, :only_path => false)
+    note_author_dom = parse_html note_author(user, :only_path => false)
     assert_dom note_author_dom, "a:root", :text => user.display_name do
       assert_dom "> @href", "http://test.host/user/#{ERB::Util.u(user.display_name)}"
     end

--- a/test/helpers/numbered_pagination_helper_test.rb
+++ b/test/helpers/numbered_pagination_helper_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class NumberedPaginationHelperTest < ActionView::TestCase
   def test_numbered_pagination1
     pagination = numbered_pagination(1, "active_page") { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 1 do
       assert_dom "> li", 1 do
         check_page_link sample_item_data(1)
@@ -15,7 +15,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination1_active1
     pagination = numbered_pagination(1, "active_page", :active_page => 1) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 1 do
       assert_dom "> li", 1 do
         check_page_link sample_item_data(1), :active => true
@@ -25,7 +25,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination5
     pagination = numbered_pagination(5, "active_page") { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 1 do
       assert_dom "> li", 5 do |items|
         items.each_with_index do |item, i|
@@ -37,7 +37,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination6
     pagination = numbered_pagination(6, "active_page") { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do
         check_page_link sample_item_data(1)
@@ -55,7 +55,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination6_active1
     pagination = numbered_pagination(6, "active_page", :active_page => 1) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 2 do |items|
         check_page_link items.shift, sample_item_data(1), :active => true
@@ -74,7 +74,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination6_active2
     pagination = numbered_pagination(6, "active_page", :active_page => 2) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 3 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -93,7 +93,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination6_active3
     pagination = numbered_pagination(6, "active_page", :active_page => 3) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -112,7 +112,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination6_active4
     pagination = numbered_pagination(6, "active_page", :active_page => 4) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -131,7 +131,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination6_active5
     pagination = numbered_pagination(6, "active_page", :active_page => 5) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -150,7 +150,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination6_active6
     pagination = numbered_pagination(6, "active_page", :active_page => 6) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -169,7 +169,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_window_start_include
     pagination = numbered_pagination(50, "active_page", :window_half_size => 3, :active_page => 3) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -190,7 +190,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_window_start_touch
     pagination = numbered_pagination(50, "active_page", :window_half_size => 3, :active_page => 5) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -213,7 +213,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_window_start_touch_almost
     pagination = numbered_pagination(50, "active_page", :window_half_size => 3, :active_page => 6) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -237,7 +237,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_window_middle
     pagination = numbered_pagination(50, "active_page", :window_half_size => 3, :active_page => 43) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -261,7 +261,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_window_end_touch
     pagination = numbered_pagination(50, "active_page", :window_half_size => 3, :active_page => 46) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -284,7 +284,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_window_end_beyond
     pagination = numbered_pagination(50, "active_page", :window_half_size => 3) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -302,7 +302,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_step
     pagination = numbered_pagination(35, "active_page", :step_size => 10, :window_half_size => 0) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -324,7 +324,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_step_end_touch
     pagination = numbered_pagination(31, "active_page", :step_size => 10, :window_half_size => 0) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -345,7 +345,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_step_window
     pagination = numbered_pagination(35, "active_page", :active_page => 15, :step_size => 10, :window_half_size => 1) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)
@@ -371,7 +371,7 @@ class NumberedPaginationHelperTest < ActionView::TestCase
 
   def test_numbered_pagination_step_window_touch
     pagination = numbered_pagination(35, "active_page", :active_page => 12, :step_size => 10, :window_half_size => 1) { |n| sample_item_data n }
-    pagination_dom = Rails::Dom::Testing.html_document_fragment.parse(pagination)
+    pagination_dom = parse_html(pagination)
     assert_dom pagination_dom, "ul", :count => 3 do |lists|
       assert_dom lists[0], "> li", 1 do |items|
         check_page_link items.shift, sample_item_data(1)

--- a/test/helpers/share_buttons_helper_test.rb
+++ b/test/helpers/share_buttons_helper_test.rb
@@ -7,7 +7,7 @@ class ShareButtonsHelperTest < ActionView::TestCase
 
   def test_share_buttons
     buttons = share_buttons(:title => "Diary Entry Title", :url => "https://osm.example.com/some/diary/entry")
-    buttons_dom = Rails::Dom::Testing.html_document_fragment.parse(buttons)
+    buttons_dom = parse_html(buttons)
 
     SHARE_BUTTONS_CONFIG.each do |icon|
       assert_dom buttons_dom, "div:has(a i.bi.bi-#{icon[:icon] || icon[:site]})", :count => 1 do

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -154,7 +154,7 @@ class UserMailerTest < ActionMailer::TestCase
   private
 
   def parse_html_body(email)
-    Rails::Dom::Testing.html_document_fragment.parse(email.html_part.body)
+    parse_html(email.html_part.body)
   end
 
   def url_helpers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -415,5 +415,9 @@ module ActiveSupport
       assert_template template
       assert_template :layout => "xhr"
     end
+
+    def parse_html(html)
+      Rails::Dom::Testing.html_document_fragment.parse(html)
+    end
   end
 end


### PR DESCRIPTION
Like @hlfan I noticed when reviewing #6877 that there was further scope for sharing the HTML parsing boilerplate so that is what this does by moving much of `parse_html_body` up to a shared `parse_html` method that can be used by the helper tests.

It also fixes one remaining mailer test that #6877 missed to use `parse_html_body`.