### PR TITLE
Modernise svgo configuration so that it works

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "rtlcss"
 gem "autoprefixer-rails"
 
 # Use image_optim to optimise images
+gem "image_optim", :github => "tomhughes/image_optim", :ref => "svgo-config"
 gem "image_optim_rails"
 
 # Use argon2 for password hashing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,18 @@ GIT
     gd2-ffij (0.4.1.dev)
       ffi (>= 1.0.0)
 
+GIT
+  remote: https://github.com/tomhughes/image_optim.git
+  revision: 3ae8ac42f1c4d6a2da88bc218ca6e6b0a438551b
+  ref: svgo-config
+  specs:
+    image_optim (0.31.4)
+      exifr (~> 1.2, >= 1.2.2)
+      fspath (~> 3.0)
+      image_size (>= 1.5, < 4)
+      in_threads (~> 1.3)
+      progress (~> 3.0, >= 3.0.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -349,12 +361,6 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
       terminal-table (>= 1.5.1)
-    image_optim (0.31.4)
-      exifr (~> 1.2, >= 1.2.2)
-      fspath (~> 3.0)
-      image_size (>= 1.5, < 4)
-      in_threads (~> 1.3)
-      progress (~> 3.0, >= 3.0.1)
     image_optim_rails (0.5.0)
       image_optim (~> 0.24)
       railties
@@ -961,6 +967,7 @@ DEPENDENCIES
   http_accept_language (~> 2.1.1)
   i18n-js (~> 4.2.3)
   i18n-tasks
+  image_optim!
   image_optim_rails
   image_processing
   inline_svg


### PR DESCRIPTION
So svgo 2.x changed how things are configured, which [broke image_optim](https://github.com/toy/image_optim/issues/191) and it's default behaviour if an optimisation command errors is to ignore it and use the unoptimised image.

I can work on an upstream fix, but this is a workaround. Sadly it does require putting an svgo configuration file in the root directory.

This fixes #6892.