### PR TITLE
Rewrite search results URL when scrolling and restore sidebar position

### DIFF
--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -39,6 +39,7 @@ OSM.Search = function (map) {
 
   const markers = L.layerGroup().addTo(map);
   let processedResults = 0;
+  let searchIntersectionObserver;
 
   function clickSearchMore(e) {
     e.preventDefault();
@@ -55,6 +56,9 @@ OSM.Search = function (map) {
   function fetchReplace({ href }, $target) {
     return fetch(href, {
       method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
       body: new URLSearchParams(OSM.csrf)
     })
       .then(response => response.text())
@@ -62,7 +66,123 @@ OSM.Search = function (map) {
         const result = $(html);
         $target.replaceWith(result);
         result.filter("ul").children().each(showSearchResult);
+
+        enableSearchIntersectionObserver();
+
+        const params = new URLSearchParams(location.search);
+        const key = params.get("before") || params.get("after");
+
+        if (!key) return;
+
+        function tryRestore() {
+          let found = false;
+
+          $(".search_results_entry").each(function () {
+            const rowKey = getSearchResultKey(this);
+
+            if (rowKey === key) {
+              this.scrollIntoView();
+              found = true;
+              return false;
+            }
+          });
+
+          if (!found) {
+            const more = $(".search_more a:visible").first();
+
+            if (more.length) {
+              more.trigger("click");
+              setTimeout(tryRestore, 300);
+            }
+          }
+        }
+
+        tryRestore();
       });
+  }
+
+  function getSearchResultKey(element) {
+    const link = $(element).find("a.set_position");
+
+    const type = link.data("type");
+    const id = link.data("id");
+
+    if (type && id) {
+      return `${type}-${id}`;
+    }
+
+    const lat = link.data("lat");
+    const lon = link.data("lon");
+
+    if (lat && lon) {
+      return `latlon-${lat}-${lon}`;
+    }
+
+    return null;
+  }
+
+  function enableSearchIntersectionObserver() {
+    if (!window.IntersectionObserver) return;
+
+    let ignoreIntersectionEvents = true;
+
+    searchIntersectionObserver = new IntersectionObserver((entries) => {
+      if (ignoreIntersectionEvents) {
+        ignoreIntersectionEvents = false;
+        return;
+      }
+
+      let closestTargetToTop,
+          closestDistanceToTop = Infinity,
+          closestTargetToBottom,
+          closestDistanceToBottom = Infinity;
+
+      for (const entry of entries) {
+        if (entry.isIntersecting) continue;
+
+        const distanceToTop =
+          entry.rootBounds.top - entry.boundingClientRect.bottom;
+
+        const distanceToBottom =
+          entry.boundingClientRect.top - entry.rootBounds.bottom;
+
+        if (distanceToTop >= 0 && distanceToTop < closestDistanceToTop) {
+          closestDistanceToTop = distanceToTop;
+          closestTargetToTop = entry.target;
+        }
+
+        if (distanceToBottom >= 0 && distanceToBottom < closestDistanceToBottom) {
+          closestDistanceToBottom = distanceToBottom;
+          closestTargetToBottom = entry.target;
+        }
+      }
+
+      if (closestTargetToTop && closestDistanceToTop < closestDistanceToBottom) {
+        const key = getSearchResultKey(closestTargetToTop);
+
+        if (key) {
+          const params = new URLSearchParams(location.search);
+          params.set("before", key);
+          params.delete("after");
+
+          OSM.router.replace(
+            location.pathname + "?" + params.toString() + location.hash
+          );
+        }
+      } else if (closestTargetToBottom) {
+        const key = getSearchResultKey(closestTargetToBottom);
+
+        if (key) {
+          const params = new URLSearchParams(location.search);
+          params.set("after", key);
+          params.delete("before");
+
+          OSM.router.replace(
+            location.pathname + "?" + params.toString() + location.hash
+          );
+        }
+      }
+    }, { root: document.querySelector("#sidebar") });
   }
 
   function showSearchResult() {
@@ -81,6 +201,10 @@ OSM.Search = function (map) {
     markers.addLayer(marker);
     listItem.on("mouseover", () => $(marker.getElement()).addClass("active"));
     listItem.on("mouseout", () => $(marker.getElement()).removeClass("active"));
+
+    if (searchIntersectionObserver) {
+      searchIntersectionObserver.observe(listItem[0]);
+    }
   }
 
   function panToSearchResult(data) {
@@ -116,6 +240,8 @@ OSM.Search = function (map) {
   };
 
   page.load = function () {
+    enableSearchIntersectionObserver();
+
     $(".search_results_entry[data-href]").each(function (index) {
       const entry = $(this);
       fetchReplace(this.dataset, entry.children().first())
@@ -129,6 +255,17 @@ OSM.Search = function (map) {
           }
         });
     });
+
+    const params = new URLSearchParams(location.search);
+
+    if (params.has("before")) {
+      const sidebar = document.querySelector("#sidebar");
+
+      // scroll roughly to middle of the list instead of top
+      requestAnimationFrame(() => {
+        sidebar.scrollTop = sidebar.scrollHeight * 0.5;
+      });
+    }
 
     return map.getState();
   };


### PR DESCRIPTION
## Summary

This PR updates the search results sidebar so that the URL reflects the user's scroll position and browser back navigation restores the approximate location in the results list.

Previously, when navigating back from a search result, the search page would reload and start from the top of the list.

This change introduces scroll state tracking similar to the behavior implemented for the history page.

---

## How it works

1. **Scroll detection**
   - An `IntersectionObserver` watches `.search_results_entry` items inside the sidebar.
   - When a result leaves the viewport while scrolling, the URL is updated with:
     ```
     before=<result_key>
     ```
     or
     ```
     after=<result_key>
     ```

2. **URL state**
   - The URL is updated using `OSM.router.replace()` so history is preserved without creating extra entries.

3. **Scroll restoration**
   - When returning to `/search?...&before=<key>` via the browser back button:
     - search results load normally
     - additional result pages are fetched automatically if needed
     - once the target result appears, the sidebar scrolls to it.

4. **Observer safety**
   - Scroll restoration temporarily disables the observer to prevent URL updates during the restore process.

---

## Result

Users can now:

1. Search for a place
2. Scroll through multiple result pages
3. Open a result
4. Press browser **Back**

The sidebar will return **close to the previous scroll position** instead of restarting at the top.

---

## Demo

A short video demonstrating the behavior is attached below.

Steps shown:
1. Search `bank`
2. Scroll through multiple result pages
3. Open a result
4. Use browser back button
5. Sidebar restores near the previous scroll position


https://github.com/user-attachments/assets/4ab99d37-4e74-4794-a606-5ff8adc14ac1






---

## Closes

Fixes #6893