### PR TITLE
Add Lakota to UI languages

### DIFF
--- a/config/ui_languages.yml
+++ b/config/ui_languages.yml
@@ -74,6 +74,8 @@
   :native_name: kurdî (latînî)
   :short_native_name: kurdî
   :short_native_note: latînî
+- :code: lkt
+  :native_name: Lakota
 - :code: lv
   :native_name: latviešu
 - :code: lb


### PR DESCRIPTION
This should fix one half of the current CI breakage.

The second half is that the translation strings shouldn't use "mediawiki magic" (as I see it described in code) to provide gendered variants to translation strings. Would @Nikerabbit be the right person to ping about this? I'm referring to entries like these:

https://github.com/openstreetmap/openstreetmap-website/blob/285b30cbbb971a3d92b027eced4d6d1b83f2280a/config/locales/lkt.yml#L13-L29