### PR TITLE
Add tooltip to changeset comment anchor icon

### DIFF
--- a/app/views/changesets/show.html.erb
+++ b/app/views/changesets/show.html.erb
@@ -50,7 +50,9 @@
                          :data => { :method => comment.visible ? "DELETE" : "POST",
                                     :url => api_changeset_comment_visibility_path(comment) } %>
         <% end %>
-        <%= link_to tag.i(:class => "align-bottom bi bi-link-45deg fs-6 lh-1", :aria => { :hidden => true }), "#c#{comment.id}" %>
+        <%= link_to tag.i(:class => "align-bottom bi bi-link-45deg fs-6 lh-1", :aria => { :hidden => true }),
+                        "#c#{comment.id}",
+                        :data => { :bs_toggle => "tooltip", :bs_title => t(".link_to_comment") } %>
       </small>
       <div class="mx-2">
         <%= comment.body.to_html %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,6 +549,7 @@ en:
       hidden_comment_by_html: "Hidden comment from %{user} %{time_ago}"
       hide_comment: "hide"
       unhide_comment: "unhide"
+      link_to_comment: "Link to this comment"
       comment: "Comment"
       changesetxml: "Changeset XML"
       osmchangexml: "osmChange XML"


### PR DESCRIPTION
## Summary

Fixes #6311

The `bi-link-45deg` icon next to each changeset comment had no tooltip, leaving users without any hint about what the icon does or what happens when clicked.

## Changes

**`app/views/changesets/show.html.erb`**

Added Bootstrap tooltip via `data-bs-toggle` and `data-bs-title` to the link-to-comment anchor:

```erb
<%= link_to tag.i(:class => "align-bottom bi bi-link-45deg fs-6 lh-1", :aria => { :hidden => true }),
                "#c\#{comment.id}",
                :data => { :bs_toggle => "tooltip", :bs_title => t(".link_to_comment") } %>
```

**`config/locales/en.yml`**

Added translation key under `changesets.show`:
```yaml
link_to_comment: "Link to this comment"
```