### PR TITLE
Adapt assertion to work on different architectures

### DIFF
--- a/test/jobs/trace_importer_job_test.rb
+++ b/test/jobs/trace_importer_job_test.rb
@@ -69,7 +69,7 @@ class TraceImporterJobTest < ActiveJob::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal trace.user.email, email.to[0]
     assert_match(/failure/, email.subject)
-    assert_match(/Start tag expected/, email.text_part.body.to_s, "should include parser error")
+    assert_match(/Fatal error:/, email.text_part.body.to_s, "should include parser error")
     assert_no_match(%r{jobs/trace_importer_job\.rb}, email.text_part.body.to_s, "should not include stack backtrace")
 
     ActionMailer::Base.deliveries.clear


### PR DESCRIPTION
This assertion was working well until recently. For some reason now it doesn't work on macOS, where the error from LibXML is different from what it was before.

On Debian 13 (Trixie), I can still see the error we have been expecting for over a year:

```
Fatal error: Start tag expected, '<' not found at :1.
```

However, on macOS 15.7.4 (Sequoia) I am now seeing:

```
Fatal error: Document is empty at :1.
```

I'm guessing this is a change in the underlying libxml2. I can see that on macOS I upgraded the library to 2.15.2 earlier this week (using Homebrew) Perhaps this has a slightly different behaviour from the 2.12.17 I have on Debian.