### PR TITLE
Make the diary comment log in UI a regular paragraph

### DIFF
--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -36,15 +36,14 @@
 </div>
 
 <div>
+  <h3 id="newcomment"><%= t ".leave_a_comment" %></h3>
   <% if current_user %>
-    <h3 id="newcomment"><%= t ".leave_a_comment" %></h3>
-
     <%= bootstrap_form_for @diary_entry.comments.new, :url => comment_diary_entry_path(@diary_entry.user, @diary_entry) do |f| %>
       <%= f.richtext_field :body, :cols => 80, :rows => 20, :hide_label => true %>
       <%= f.primary %>
     <% end %>
   <% else %>
-    <h3 id="newcomment"><%= t(".login_to_leave_a_comment_html", :login_link => link_to(t(".login"), login_path(:referer => request.fullpath))) %></h3>
+    <p><%= t(".login_to_leave_a_comment_html", :login_link => link_to(t(".login"), login_path(:referer => request.fullpath))) %></p>
   <% end %>
 </div>
 


### PR DESCRIPTION
This changes the UI on diary entries, to make the "log in" suggestion into regular text. Previously, it was presented as an `h3` header, which is jarring.

Current behaviour:

<img width="543" height="206" alt="1002" src="https://github.com/user-attachments/assets/df3e15a8-3082-4013-a986-99a152cec8ff" />

Proposed:

<img width="543" height="270" alt="1001" src="https://github.com/user-attachments/assets/0dccdb06-4ba6-4eb3-b86c-965990109683" />

