### PR TITLE
Revert "upgrade iD to v2.39.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@mapbox/mapbox-gl-rtl-text": "^0.3.0",
     "@maplibre/maplibre-gl-leaflet": "^0.1.1",
     "@maptiler/maplibre-gl-omt-language": "^0.0.3",
-    "@openstreetmap/id": "2.39.0",
+    "@openstreetmap/id": "2.38.0",
     "bootstrap-icons": "^1.13.1",
     "i18n-js": "^4.5.1",
     "js-cookie": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,10 +401,10 @@
   resolved "https://registry.yarnpkg.com/@maptiler/maplibre-gl-omt-language/-/maplibre-gl-omt-language-0.0.3.tgz#3069f4522e911e341d6b79b09ce2943c71b6ffd7"
   integrity sha512-Rv5IaFyh9GuFu2BEAGvVvlVGmXt5Jbjd0XhIu0D4Tek81DPQEQryIIwDFTDR27W4NyAtozy8QltB+8SFr2C7mQ==
 
-"@openstreetmap/id@2.39.0":
-  version "2.39.0"
-  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.39.0.tgz#df8f43eba77501f12c4ff2eff7abf814cc815857"
-  integrity sha512-NRhaJ60k2LqCGR6X6bsU7jBL8LjDRAKiE5GW2Ziz+b0L4mHjCgNzkoUOJCh+mahbLz/aaOqkISuC4Oz++m/xuw==
+"@openstreetmap/id@2.38.0":
+  version "2.38.0"
+  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.38.0.tgz#66e6921a2e59d504e6f22d0c35c81bbad5550f02"
+  integrity sha512-5/Ib5kn8ppsCG+OfR7KqJqdCmsWTlzsKw5zV27DQeyPmy2Sf5CqAYi6wrFW3lerbabpNrhtCN7oaMmBATQpcEA==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/sexagesimal" "1.2.0"
@@ -419,12 +419,11 @@
     alif-toolkit "^1.3.0"
     core-js-bundle "^3.46.0"
     diacritics "1.3.0"
-    es-toolkit "^1.45.0"
     exifr "^7.1.3"
-    fast-deep-equal "~3.1.3"
-    fast-equals "^6.0.0"
+    fast-deep-equal "~3.1.1"
     fast-json-stable-stringify "2.1.0"
     idb-keyval "^6.2.2"
+    lodash-es "~4.17.15"
     marked "~17.0.0"
     node-diff3 "~3.2.0"
     osm-auth "^3.1.1"
@@ -905,11 +904,6 @@ es-module-lexer@^1.7.0:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
-es-toolkit@^1.45.0:
-  version "1.45.1"
-  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.45.1.tgz#21b28b2bd43178fd4c9c937c445d5bcaccce907b"
-  integrity sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==
-
 esbuild@^0.27.0:
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.27.3.tgz#5859ca8e70a3af956b26895ce4954d7e73bd27a8"
@@ -1082,15 +1076,10 @@ expect-type@^1.2.2:
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
   integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@~3.1.3:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@~3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-equals@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-6.0.0.tgz#719dedd2e126668b857b5e9d24e112e4acb2649a"
-  integrity sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==
 
 fast-json-stable-stringify@2.1.0, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -1295,6 +1284,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@~4.17.15:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
+  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
 
 lodash@*:
   version "4.17.23"


### PR DESCRIPTION
Reverts openstreetmap/openstreetmap-website#6915

https://github.com/openstreetmap/openstreetmap-website/pull/6916 is broken according to https://github.com/openstreetmap/openstreetmap-website/pull/6916#issuecomment-4092338351

https://github.com/openstreetmap/openstreetmap-website/pull/6915#issuecomment-4092162583 requests revert

note: I have no idea about possible side-effects of a downgrade, but maintainer requested it, so I hope it will be better than deploy of a broken iD on osm.org

