### PR TITLE
Enforce declaration of local variables for partials

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -4,6 +4,8 @@ linter:
   rules:
     erb-no-instance-variables-in-partials:
       enabled: false
+    erb-strict-locals-required:
+      enabled: true
     html-anchor-require-href:
       enabled: false
     html-no-space-in-tag:

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,7 +85,7 @@ module ApplicationHelper
   # This allows us to render html into a flash message in a safe manner.
   def render_flash(flash)
     if flash.is_a?(Hash)
-      render flash.with_indifferent_access
+      render flash.deep_symbolize_keys
     else
       flash
     end

--- a/app/views/accounts/_go_public.html.erb
+++ b/app/views/accounts/_go_public.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <hr class="mb-3">
 <a name="public"></a>
 <h2><%= t ".heading" %></h2>

--- a/app/views/accounts/terms/_terms.html.erb
+++ b/app/views/accounts/terms/_terms.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <p id="first">
   <%= @text["intro"] %>
   <%= @text["next_with_decline"] %>

--- a/app/views/accounts/terms/_terms_declined_flash.html.erb
+++ b/app/views/accounts/terms/_terms_declined_flash.html.erb
@@ -1,1 +1,3 @@
+<%# locals: () %>
+
 <%= t ".terms_declined_html", :terms_declined_link => link_to(t(".terms_declined_link"), t(".terms_declined_url")) %>

--- a/app/views/api/notes/_comment.html.erb
+++ b/app/views/api/notes/_comment.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (comment:) %>
+
 <div class="note-comment" style="margin-top: 5px">
   <div class="note-comment-description" style="font-size: smaller; color: #999999">
     <% if comment.author.nil? -%>

--- a/app/views/api/notes/_description.html.erb
+++ b/app/views/api/notes/_description.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (description:) %>
+
 <div>
   <%= render :partial => "comment", :collection => description.comments %>
 </div>

--- a/app/views/api/notes/_entry.html.erb
+++ b/app/views/api/notes/_entry.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (entry:) %>
+
 <h2><%= t ".comment" %></h2>
 <%= render :partial => "comment", :object => entry %>
 <h2><%= t ".full" %></h2>

--- a/app/views/application/_auth_button.html.erb
+++ b/app/views/application/_auth_button.html.erb
@@ -1,4 +1,5 @@
 <%# locals: (provider:, preferred: false) %>
+
 <%= link_to auth_path(:provider => provider),
             :method => :post,
             :class => ["auth_button btn btn-outline-secondary border p-2", { "px-4 d-flex gap-3 justify-content-center align-items-center" => preferred }],

--- a/app/views/application/_auth_providers.html.erb
+++ b/app/views/application/_auth_providers.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <% prefered_auth_button_available = Auth.providers.include?(@preferred_auth_provider) %>
 
 <div>

--- a/app/views/application/_settings_menu.html.erb
+++ b/app/views/application/_settings_menu.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <% content_for :heading_class, "pb-0" %>
 
 <% content_for :heading do %>

--- a/app/views/application/_sidebar_header.html.erb
+++ b/app/views/application/_sidebar_header.html.erb
@@ -1,1 +1,3 @@
+<%# locals: (title:) %>
+
 <h2 class="me-4 text-break"><%= title %></h2>

--- a/app/views/browse/_common_details.html.erb
+++ b/app/views/browse/_common_details.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (common_details:) %>
+
 <h4>
   <%= if common_details.redacted?
         t "browse.redacted_version"

--- a/app/views/browse/_containing_relation.html.erb
+++ b/app/views/browse/_containing_relation.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (containing_relation:) %>
+
 <%= element_list_item "relation", containing_relation.relation do %>
   <%= linked_name = link_to printable_element_name(containing_relation.relation), containing_relation.relation
       if containing_relation.member_role.blank?

--- a/app/views/browse/_node.html.erb
+++ b/app/views/browse/_node.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (node:) %>
+
 <%= tag.div :class => ["mb-3 border-bottom border-secondary-subtle pb-3",
                        { "text-body-secondary" => node.redacted? && params[:show_redactions] }] do %>
   <% if node.redacted? && !params[:show_redactions] %>

--- a/app/views/browse/_relation.html.erb
+++ b/app/views/browse/_relation.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (relation:) %>
+
 <%= tag.div :class => ["mb-3 border-bottom border-secondary-subtle pb-3",
                        { "text-body-secondary" => relation.redacted? && params[:show_redactions] }] do %>
   <% if relation.redacted? && !params[:show_redactions] %>

--- a/app/views/browse/_relation_member.html.erb
+++ b/app/views/browse/_relation_member.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (relation_member:) %>
+
 <%= element_list_item_with_strikethrough relation_member.member_type.downcase, relation_member.member do %>
   <%= t ".entry_#{'role_' if relation_member.member_role.present?}html",
         :type => t(".type.#{relation_member.member_type.downcase}"),

--- a/app/views/browse/_relation_member_frame.html.erb
+++ b/app/views/browse/_relation_member_frame.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (relation:, frame_id:) %>
+
 <turbo-frame id="<%= frame_id %>">
   <ul class="list-unstyled browse-element-list">
     <%= render :partial => "browse/relation_member", :collection => relation.relation_members, :as => :relation_member %>

--- a/app/views/browse/_tag.html.erb
+++ b/app/views/browse/_tag.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (tag:) %>
+
 <tr>
   <th class="py-1 border-secondary-subtle table-secondary fw-normal" dir="auto"><%= format_key(tag[0]) %></th>
   <td class="py-1 border-secondary-subtle border-start" dir="auto"><%= format_value(tag[0], tag[1]) %></td>

--- a/app/views/browse/_tag_details.html.erb
+++ b/app/views/browse/_tag_details.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (tag_details:) %>
+
 <% unless tag_details.empty? %>
   <h4><%= t ".tags" %></h4>
   <div class="mb-3 border border-secondary-subtle rounded overflow-hidden">

--- a/app/views/browse/_way.html.erb
+++ b/app/views/browse/_way.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (way:) %>
+
 <%= tag.div :class => ["mb-3 border-bottom border-secondary-subtle pb-3",
                        { "text-body-secondary" => way.redacted? && params[:show_redactions] }] do %>
   <% if way.redacted? && !params[:show_redactions] %>

--- a/app/views/changeset_comments/feeds/_comment.html.erb
+++ b/app/views/changeset_comments/feeds/_comment.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (comment:) %>
+
 <h2><%= t ".comment",
           :author => comment.author.display_name,
           :changeset_id => comment.changeset.id.to_s %></h2>

--- a/app/views/changeset_subscriptions/_heading.html.erb
+++ b/app/views/changeset_subscriptions/_heading.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (changeset:) %>
+
 <% title = changeset.comment || t(".title", :id => changeset.id) -%>
 <div class="mb-3">
   <div class="row">

--- a/app/views/changesets/_changeset.html.erb
+++ b/app/views/changesets/_changeset.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (changeset:) %>
+
 <%= tag.li :id => "changeset_#{changeset.id}", :data => { :changeset => changeset_data(changeset) }, :class => "list-group-item list-group-item-action" do %>
   <p class="fs-6 text-truncate text-wrap mb-2">
     <%= link_to changeset, :class => "changeset_id link-body-emphasis stretched-link" do %>

--- a/app/views/changesets/_changeset_line.html.erb
+++ b/app/views/changesets/_changeset_line.html.erb
@@ -1,4 +1,5 @@
 <%# locals: (changeset:, show_num_changes: true, show_num_comments: true) %>
+
 <div class="changeset_line d-flex gap-2 align-items-center">
   <span class="me-auto">
     <%= yield %>

--- a/app/views/changesets/_elements.html.erb
+++ b/app/views/changesets/_elements.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (type:, elements:, elements_count:, current_page:) %>
+
 <%= turbo_frame_tag "changeset_#{type.pluralize}" do %>
   <%= render :partial => "paging_nav", :locals => { :type => type, :elements_count => elements_count, :current_page => current_page } %>
   <ul class="list-unstyled browse-element-list" data-turbo="false">

--- a/app/views/changesets/_not_found_message.html.erb
+++ b/app/views/changesets/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p><%= t ".sorry", :id => params[:id] %></p>
 </div>

--- a/app/views/changesets/_paging_nav.html.erb
+++ b/app/views/changesets/_paging_nav.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (type:, elements_count:, current_page:) %>
+
 <% pages_count = element_pages_count elements_count %>
 <% if pages_count == 1 %>
   <h4 class="fs-5">

--- a/app/views/confirmations/_resend_success_flash.html.erb
+++ b/app/views/confirmations/_resend_success_flash.html.erb
@@ -1,2 +1,4 @@
+<%# locals: (email:, sender:) %>
+
 <p><%= t ".confirmation_sent", :email => email %></p>
 <p><%= t ".whitelist", :sender => sender %></p>

--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (contact:, type:) %>
+
 <% user_data = {
      :lon => contact.home_lon,
      :lat => contact.home_lat,

--- a/app/views/dashboards/_popup.html.erb
+++ b/app/views/dashboards/_popup.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (popup:, type:) %>
+
 <div class="user_popup row g-0 mx-1">
   <div class="col-auto mx-1">
     <%= user_thumbnail popup %>

--- a/app/views/diary_entries/_diary_comment.html.erb
+++ b/app/views/diary_entries/_diary_comment.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (diary_comment:) %>
+
 <div class="row diary-comment border-bottom py-3<%= " text-body-secondary bg-danger bg-opacity-10" unless diary_comment.visible? %>">
   <div class="col-auto pe-0 text-center">
     <%= user_thumbnail diary_comment.user %>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (diary_entry:, truncated:) %>
+
 <article class="diary_post border-top border-secondary-subtle py-3<%= " text-body-secondary px-3 bg-danger bg-opacity-10" unless diary_entry.visible %> user_<%= diary_entry.user.id %>">
   <%= render :partial => "diary_entry_heading", :object => diary_entry, :as => "diary_entry" %>
 

--- a/app/views/diary_entries/_diary_entry_heading.html.erb
+++ b/app/views/diary_entries/_diary_entry_heading.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (diary_entry:) %>
+
 <div class="mb-3">
   <% if @user %>
     <h2><%= link_to diary_entry.title, diary_entry_path(diary_entry.user, diary_entry) %></h2>

--- a/app/views/diary_entries/_form.html.erb
+++ b/app/views/diary_entries/_form.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (f:) %>
+
 <%= f.text_field :title %>
 <%= f.richtext_field :body, :cols => 80, :rows => 20, :format => @diary_entry.body_format %>
 <%= f.collection_select :language_code, Language.order(:english_name), :code, :name %>

--- a/app/views/diary_entries/_location.html.erb
+++ b/app/views/diary_entries/_location.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (location:) %>
+
 <%= t ".location" %>
 
 <%= link_to root_path(:anchor => "map=14/#{location.latitude}/#{location.longitude}") do

--- a/app/views/diary_entries/_navigation.html.erb
+++ b/app/views/diary_entries/_navigation.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <nav class="secondary-actions">
   <ul>
     <% unless params[:friends] or params[:nearby] -%>

--- a/app/views/diary_entries/_page.html.erb
+++ b/app/views/diary_entries/_page.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <h4><%= t ".recent_entries" %></h4>
 

--- a/app/views/diary_entries/_profile_diaries.html.erb
+++ b/app/views/diary_entries/_profile_diaries.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (diary_entries:) %>
+
 <% if diary_entries.present? %>
   <h2 class="text-body-secondary fs-5 mt-4"><%= t(".latest_diaries") %></h2>
   <div class="row row-cols-1 row-cols-md-2 g-4">

--- a/app/views/errors/_contact.html.erb
+++ b/app/views/errors/_contact.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <p><%= t ".contact_the_community_html",
          :contact_link => link_to(t(".contact"), t(".contact_url"),
                                   :title => t(".contact_url_title")) %></p>

--- a/app/views/issues/_comments.html.erb
+++ b/app/views/issues/_comments.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (comments:) %>
+
 <div>
   <% comments.each do |comment| %>
     <div class="row">

--- a/app/views/issues/_page.html.erb
+++ b/app/views/issues/_page.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <turbo-frame id="pagination" target="_top">
   <% if @issues.length == 0 %>
     <p>

--- a/app/views/issues/_reports.html.erb
+++ b/app/views/issues/_reports.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (reports:) %>
+
 <% reports.each do |report| %>
   <div class="row">
     <div class="col-auto">

--- a/app/views/issues/reporters/_reporters.html.erb
+++ b/app/views/issues/reporters/_reporters.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (issue:) %>
+
 <%= turbo_frame_tag "#{dom_id(issue)}_reporters", :data => { :turbo => false } do %>
   <% @unique_reporters[issue.id][:users].each do |reporter| %>
     <%= link_to reporter.display_name, reporter, :class => "d-block text-truncate", :title => reporter.display_name %>

--- a/app/views/languages_panes/_select_language_list.html.erb
+++ b/app/views/languages_panes/_select_language_list.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div class="mb-3 px-2">
   <%= text_field_tag :language_search,
                      params[:language_search],

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <% unless (banner = next_banner()).nil? %>
   <%= tag.div :id => "banner", :class => "d-md-block d-none position-relative", :data => { :bs_theme => (banner[:dark] ? "dark" : "light") } do %>
     <%= link_to (image_tag banner[:img], :srcset => banner[:srcset], :alt => banner[:alt], :title => banner[:alt]), banner[:link] %>

--- a/app/views/layouts/_content.html.erb
+++ b/app/views/layouts/_content.html.erb
@@ -1,8 +1,10 @@
+<%# locals: () %>
+
 <div id="content" class="<%= content_for :content_class %>">
   <% if content_for? :content %>
     <%= yield :content %>
   <% else %>
-    <%= render :partial => "layouts/flash", :locals => { :flash => flash } %>
+    <%= render :partial => "layouts/flash" %>
     <% if content_for? :heading %>
       <div class="content-heading bg-body-secondary border-bottom border-secondary-subtle">
         <div class="content-inner position-relative m-auto <%= yield :heading_class %>">

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <% [[:error, :danger], [:warning, :warning], [:notice, :success]].each do |flash_type, bootstrap_type| %>
   <% if flash[flash_type] %>
     <%= tag.div :class => "alert alert-dismissible alert-#{bootstrap_type} mb-0 rounded-0",

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <%= tag.head :data => application_data do %>
   <%= render :partial => "layouts/meta" %>
   <%= javascript_include_tag "turbo", :type => "module" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <header class="d-flex bg-body flex-column flex-md-row h-auto position-relative text-nowrap closed z-3">
   <h1 class="d-flex m-0 align-items-center fw-semibold">
     <a href="<%= root_path %>" class="icon-link gap-1 me-auto text-body-emphasis text-decoration-none geolink">

--- a/app/views/layouts/_markers.html.erb
+++ b/app/views/layouts/_markers.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (types:) %>
+
 <svg width="0" height="0" class="end-100 position-absolute">
   <defs>
     <linearGradient id="fill" x1="0" x2="0" y1="0" y2="40" gradientUnits="userSpaceOnUse">

--- a/app/views/layouts/_meta.html.erb
+++ b/app/views/layouts/_meta.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <% [57, 60, 72, 76, 114, 120, 144, 152, 180].each do |size| -%>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (autofocus:, extra_classes:) %>
+
 <% search_query = if params[:query]
                     params[:query]
                   elsif params[:lat] && params[:lon]

--- a/app/views/layouts/_select_language_button.html.erb
+++ b/app/views/layouts/_select_language_button.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (extra_classes:) %>
+
 <%= tag.button (inline_svg_tag "icons/language.svg"),
                :type => "button",
                :class => ["btn btn-outline-secondary align-self-stretch py-1 px-2", *extra_classes],

--- a/app/views/layouts/_sidebar_close.html.erb
+++ b/app/views/layouts/_sidebar_close.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div class="sidebar-close-controls sticky-top z-0">
   <div class="position-absolute end-0 m-2 rounded-5 bg-body-tertiary shadow-sm">
     <button type="button" disabled class="btn-close d-block p-2 invisible"></button>

--- a/app/views/messages/mailboxes/_heading.html.erb
+++ b/app/views/messages/mailboxes/_heading.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (active_link_path:) %>
+
 <% content_for :heading_class, "pb-0" %>
 
 <% content_for :heading do %>

--- a/app/views/messages/mailboxes/_message.html.erb
+++ b/app/views/messages/mailboxes/_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (message:) %>
+
 <%= tag.tr(:id => "inbox-#{message.id}", :class => { "table-success" => !message.message_read? }) do %>
   <td><%= link_to message.sender.display_name, user_path(message.sender), :class => "username d-inline-block text-truncate text-wrap align-bottom", :dir => "auto" %></td>
   <td><%= link_to message.title, message_path(message) %></td>

--- a/app/views/messages/mailboxes/_messages_table.html.erb
+++ b/app/views/messages/mailboxes/_messages_table.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (columns:, messages:) %>
+
 <table class="table table-sm align-middle messages-table">
   <thead>
     <tr>

--- a/app/views/messages/outboxes/_message.html.erb
+++ b/app/views/messages/outboxes/_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (message:) %>
+
 <%= tag.tr(:id => "outbox-#{message.id}") do %>
   <td><%= link_to message.recipient.display_name, user_path(message.recipient), :class => "username d-inline-block text-truncate text-wrap align-bottom", :dir => "auto" %></td>
   <td><%= link_to message.title, message_path(message) %></td>

--- a/app/views/nodes/_not_found_message.html.erb
+++ b/app/views/nodes/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p><%= t ".sorry", :id => params[:id] %></p>
 </div>

--- a/app/views/notes/_not_found_message.html.erb
+++ b/app/views/notes/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p><%= t ".sorry", :id => params[:id] %></p>
 </div>

--- a/app/views/notes/_notes_paging_nav.html.erb
+++ b/app/views/notes/_notes_paging_nav.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <nav>
   <% link_class = "page-link icon-link text-center text-nowrap" %>
   <ul class="pagination">

--- a/app/views/oauth2_applications/_application.html.erb
+++ b/app/views/oauth2_applications/_application.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (application:) %>
+
 <tr>
   <td class="align-middle">
     <ul class="list-unstyled mb-0">

--- a/app/views/oauth2_applications/_form.html.erb
+++ b/app/views/oauth2_applications/_form.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (f:) %>
+
 <%= f.text_field :name %>
 <%= f.text_area :redirect_uri %>
 <%= f.form_group :confidential do %>

--- a/app/views/oauth2_authorized_applications/_application.html.erb
+++ b/app/views/oauth2_authorized_applications/_application.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (application:) %>
+
 <tr>
   <td class="align-middle">
     <%= application.name %>

--- a/app/views/old_elements/_actions.html.erb
+++ b/app/views/old_elements/_actions.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div class="secondary-actions mb-3">
   <% if !@feature.redacted? %>
     <%= link_to t("browse.download_xml"), send(:"api_#{@type}_version_path", *@feature.id) %>

--- a/app/views/old_nodes/_not_found_message.html.erb
+++ b/app/views/old_nodes/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p>
     <% if params[:version] %>

--- a/app/views/old_relation_members/_not_found_message.html.erb
+++ b/app/views/old_relation_members/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p>
     <% if params[:version] %>

--- a/app/views/old_relations/_not_found_message.html.erb
+++ b/app/views/old_relations/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p>
     <% if params[:version] %>

--- a/app/views/old_ways/_not_found_message.html.erb
+++ b/app/views/old_ways/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p>
     <% if params[:version] %>

--- a/app/views/preferences/preferences/_navigation.html.erb
+++ b/app/views/preferences/preferences/_navigation.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <ul class="nav nav-tabs">
   <li class="nav-item">
     <%= link_to t(".preferences"), basic_preferences_path, :class => { "nav-link" => true, "active" => controller_name == "basic_preferences" } %>

--- a/app/views/preferences/preferences/_update_success_flash.html.erb
+++ b/app/views/preferences/preferences/_update_success_flash.html.erb
@@ -1,1 +1,3 @@
+<%# locals: () %>
+
 <%= t ".message" %>

--- a/app/views/profiles/profile_sections/_navigation.html.erb
+++ b/app/views/profiles/profile_sections/_navigation.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <ul class="nav nav-tabs">
   <li class="nav-item">
     <%= link_to t(".description"), profile_description_path, :class => { "nav-link" => true, "active" => controller_name == "descriptions" } %>

--- a/app/views/redactions/_redaction.html.erb
+++ b/app/views/redactions/_redaction.html.erb
@@ -1,1 +1,3 @@
+<%# locals: (redaction:) %>
+
 <li><%= link_to redaction.title, redaction %></li>

--- a/app/views/relation_members/_not_found_message.html.erb
+++ b/app/views/relation_members/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p><%= t ".sorry", :id => params[:id] %></p>
 </div>

--- a/app/views/relations/_not_found_message.html.erb
+++ b/app/views/relations/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p><%= t ".sorry", :id => params[:id] %></p>
 </div>

--- a/app/views/sessions/_suspended_flash.html.erb
+++ b/app/views/sessions/_suspended_flash.html.erb
@@ -1,2 +1,4 @@
+<%# locals: () %>
+
 <p><%= t ".suspended" %></p>
 <p><%= t ".contact_support_html", :support_link => mail_to(Settings.support_email, t(".support")) %></p>

--- a/app/views/shared/_markdown_help.html.erb
+++ b/app/views/shared/_markdown_help.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <h5>
   <%= t ".heading_html", :kramdown_link => link_to(t(".kramdown"), t(".kramdown_url")) %>
 </h5>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (older_id:, newer_id:, translation_scope: nil) %>
+
 <% if older_id || newer_id %>
 
 <% translation_scope ||= "shared.pagination.#{controller.controller_name}" %>

--- a/app/views/shared/_richtext_field.html.erb
+++ b/app/views/shared/_richtext_field.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (object:, attribute:, object_name:, id:, type:, options:, builder:) %>
+
 <div class="richtext_container">
   <ul class="nav nav-tabs mb-3">
     <li class="nav-item">

--- a/app/views/shared/_section_divider.html.erb
+++ b/app/views/shared/_section_divider.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (text:) %>
+
 <div class="d-flex align-items-center my-1">
   <hr class="flex-grow-1 border-secondary" role="separator">
   <span class="mx-3 text-secondary"><%= text %></span>

--- a/app/views/site/_about_section.html.erb
+++ b/app/views/site/_about_section.html.erb
@@ -1,4 +1,6 @@
-<%= tag.section :id => local_assigns[:id] do %>
+<%# locals: (icon:, title:, id: nil) %>
+
+<%= tag.section :id => id do %>
   <div class="d-flex align-items-center gap-2 mb-2">
     <%= inline_svg_tag "about/#{icon}.svg", :class => "flex-shrink-0" %>
     <h2 class="flex-grow-1 mb-0"><%= t ".#{title}_title" %></h2>

--- a/app/views/site/_add_a_note.html.erb
+++ b/app/views/site/_add_a_note.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <p><%= t ".para_1" %></p>
 <p><%= t ".para_2_html",
          :note_icon => link_to(

--- a/app/views/site/_any_questions.html.erb
+++ b/app/views/site/_any_questions.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <h2><%= t ".title" %></h2>
 <div class="d-flex align-items-center gap-2">
   <%= inline_svg_tag "welcome/question.svg", :class => "flex-shrink-0 align-self-start" %>

--- a/app/views/site/_id.html.erb
+++ b/app/views/site/_id.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <%= javascript_include_tag "edit/id" %>
 
 <div id="map" class="h-100">

--- a/app/views/site/_potlatch.html.erb
+++ b/app/views/site/_potlatch.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div class="container">
   <p><%= t ".removed" %></p>
   <p><%= t ".desktop_application_html", :download_link => link_to(t(".download"), t(".download_url")) %></p>

--- a/app/views/site/_potlatch2.html.erb
+++ b/app/views/site/_potlatch2.html.erb
@@ -1,1 +1,3 @@
+<%# locals: () %>
+
 <%= render :partial => "potlatch" %>

--- a/app/views/social_links/_show.html.erb
+++ b/app/views/social_links/_show.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (social_links:) %>
+
 <ul class="list-unstyled social_links mb-0">
   <% social_links.each do |social_link| %>
     <li>

--- a/app/views/traces/_page.html.erb
+++ b/app/views/traces/_page.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= render "shared/pagination",
              :newer_id => @newer_traces_id,

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (trace:) %>
+
 <tr>
   <td>
     <% if Settings.status != "gpx_offline" %>

--- a/app/views/traces/feeds/_description.html.erb
+++ b/app/views/traces/feeds/_description.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (trace:) %>
+
 <%= image_tag trace_icon_url(trace.user, trace) %>
 <% if trace.size -%>
 <%= t ".description_with_count", :count => trace.size, :user => trace.user.display_name %>

--- a/app/views/user_blocks/_block.html.erb
+++ b/app/views/user_blocks/_block.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (block:) %>
+
 <tr>
   <% if @show_user_name %>
     <td><%= link_to block.user.display_name, block.user, :class => "username d-inline-block text-truncate text-wrap", :dir => "auto" %></td>

--- a/app/views/user_blocks/_navigation.html.erb
+++ b/app/views/user_blocks/_navigation.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <ul class="nav nav-tabs">
   <li class="nav-item">
     <%= link_to t(".all_blocks"),

--- a/app/views/user_blocks/_page.html.erb
+++ b/app/views/user_blocks/_page.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= render "shared/pagination",
              :translation_scope => "shared.pagination.user_blocks",

--- a/app/views/user_mailer/_gpx_details.html.erb
+++ b/app/views/user_mailer/_gpx_details.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <p><%= t ".details" %></p>
 
 <dl>

--- a/app/views/user_mailer/_message_body.html.erb
+++ b/app/views/user_mailer/_message_body.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (body:) %>
+
 <table style="font-size: 15px; margin: 15px 0px; background-color: #eee; width: 100%">
   <tr>
     <td style="width: 50px; min-width: 50px; vertical-align: top; padding: 15px">

--- a/app/views/users/_auth_association.html.erb
+++ b/app/views/users/_auth_association.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <p><%= t ".heading" %></p>
 <p><%= t ".option_1" %></p>
 <p><%= t ".option_2" %></p>

--- a/app/views/users/_role_icons.html.erb
+++ b/app/views/users/_role_icons.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <% UserRole::ALL_ROLES.each do |role| %>
   <% if current_user&.administrator? %>
     <% if @user.role?(role) %>

--- a/app/views/users/_sidebar_section.html.erb
+++ b/app/views/users/_sidebar_section.html.erb
@@ -1,4 +1,5 @@
-<%# locals: (present: false, edit_title: nil, edit_path: nil) %>
+<%# locals: (present: false, edit_title:, edit_path:) %>
+
 <% editable = edit_title && edit_path && current_user && @user == current_user %>
 <% edit_button_classes = %w[btn btn-sm btn-outline-primary py-0 w-100 overflow-hidden] %>
 <% if present %>

--- a/app/views/users/changeset_comments/_page.html.erb
+++ b/app/views/users/changeset_comments/_page.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= render "shared/pagination",
              :newer_id => @newer_comments_id,

--- a/app/views/users/diary_comments/_page.html.erb
+++ b/app/views/users/diary_comments/_page.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <%= render "shared/pagination",
              :newer_id => @newer_comments_id,

--- a/app/views/users/lists/_page.html.erb
+++ b/app/views/users/lists/_page.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <% unless @users.empty? %>
     <%= form_tag users_list_path, :method => :put do %>

--- a/app/views/users/lists/_user.html.erb
+++ b/app/views/users/lists/_user.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (user:) %>
+
 <tr>
   <td>
     <%= user_thumbnail(user) %>

--- a/app/views/ways/_not_found_message.html.erb
+++ b/app/views/ways/_not_found_message.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <div>
   <p><%= t ".sorry", :id => params[:id] %></p>
 </div>


### PR DESCRIPTION
I'm working on enabling the `erb-no-instance-variables-in-partials` linter but as a first step and to make that easier this enables the optional `erb-strict-locals-required` linter and fixes all our partials to declare their local variables.