### PR TITLE
upgrade iD to v2.39.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@mapbox/mapbox-gl-rtl-text": "^0.3.0",
     "@maplibre/maplibre-gl-leaflet": "^0.1.1",
     "@maptiler/maplibre-gl-omt-language": "^0.0.3",
-    "@openstreetmap/id": "2.39.2",
+    "@openstreetmap/id": "2.39.3",
     "bootstrap-icons": "^1.13.1",
     "i18n-js": "^4.5.1",
     "js-cookie": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,10 +401,10 @@
   resolved "https://registry.yarnpkg.com/@maptiler/maplibre-gl-omt-language/-/maplibre-gl-omt-language-0.0.3.tgz#3069f4522e911e341d6b79b09ce2943c71b6ffd7"
   integrity sha512-Rv5IaFyh9GuFu2BEAGvVvlVGmXt5Jbjd0XhIu0D4Tek81DPQEQryIIwDFTDR27W4NyAtozy8QltB+8SFr2C7mQ==
 
-"@openstreetmap/id@2.39.2":
-  version "2.39.2"
-  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.39.2.tgz#4ff28bab74d21c40347a0e1d4368d993422218eb"
-  integrity sha512-7DLc7L8uHvwFzm0+k0iCiAysJd0Oi730mephpctuMIU3s2Cf2kw575xwyOwWYxroQrfkQe+pBtqnic7v+qUzPA==
+"@openstreetmap/id@2.39.3":
+  version "2.39.3"
+  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.39.3.tgz#1890518ac57cb868edfc8107da9f1861588faac8"
+  integrity sha512-eGzUpEs0yWTDN+SnayReS/4PHGPrhXGeRJDUxJ0ktiKvHwN+fWyuuJHRGktpPHWnQi5wmN4Lw2Ax03oa4I5EJw==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/sexagesimal" "1.2.0"


### PR DESCRIPTION
This includes a revert to prevent problematic behaviour of the newly introduced preset change logic. Fixing https://github.com/openstreetmap/iD/issues/12068