### PR TITLE
Option to disable parallel tests

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -62,3 +62,5 @@ system_test_headless: true
 # Override Firefox binary used in system tests
 # You can add this to config/settings/test.local.yml which is git-ignored
 #system_test_firefox_binary:
+# Split test suite into parallel workers, when appropriate
+enable_parallel_tests: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,7 +48,7 @@ module ActiveSupport
       # Running in the devcontainer. Can't figure out how
       # to run things in parallel at the moment, so for now
       # we are not doing it.
-    else
+    elsif Settings.enable_parallel_tests
       # Run tests in parallel with specified workers
       parallelize(:workers => :number_of_processors)
 


### PR DESCRIPTION
For a while now I have had intermittent issues on macOS, where running the tests would cause a segmentation fault at random:

```
$ bin/rails test
Running 2488 tests in parallel using 8 processes
PABLOS_RUBY_DIR/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/pg-1.6.3-arm64-darwin/lib/pg/connection.rb:944: [BUG] Segmentation fault at 0x00
00000102eb4b14
ruby 4.0.1 (2026-01-13 revision e04267a14b) +YJIT +PRISM [arm64-darwin24]

-- Crash Report log information --------------------------------------------
   See Crash Report log file in one of the following locations:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0060 p:---- s:0345 e:000344 l:y b:---- CFUNC  :connect_start
c:0059 p:0136 s:0340 e:000339 l:y b:0001 METHOD PABLOS_RUBY_DIR/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/pg-1.6.3-arm64-darwin/lib/pg/con
nection.rb:944
(...about 70k lines...)
600000000000-600020000000 rw-
[IMPORTANT]
Don't forget to include the Crash Report log file under
DiagnosticReports directory in bug reports.

302000000-3028d4000 r-- PABLOS_RUBY_DIR/ruby/4.0.1/lib/libruby.4.0.dylib
fc0000000-1000000000 ---
1000000000-7000000000 ---
600000000000-600020000000 rw-
[IMPORTANT]
Don't forget to include the Crash Report log file under
DiagnosticReports directory in bug reports.
```

On investigation, I think this only happens when tests are running in parallel. Therefore I'm adding an option to disable parallel tests, which then I can set myself in my macOS environment:
```
# config/settings/test.local.yml
enable_parallel_tests: false
```