### PR TITLE
Another libxml2 issue + strengthen negative assertions

### DIFF
--- a/test/jobs/trace_importer_job_test.rb
+++ b/test/jobs/trace_importer_job_test.rb
@@ -47,15 +47,15 @@ class TraceImporterJobTest < ActiveJob::TestCase
   def test_error_notification
     # Check that the user gets a failure notification when something goes badly wrong
     trace = create(:trace)
-    trace.stub(:import, -> { raise }) do
+    trace.stub(:import, -> { raise "Test Exception" }) do
       TraceImporterJob.perform_now(trace)
     end
 
     email = ActionMailer::Base.deliveries.last
     assert_equal trace.user.email, email.to[0]
     assert_match(/failure/, email.subject)
-    assert_no_match(/Start tag expected/, email.text_part.body.to_s, "should not include parser error")
-    assert_match(%r{jobs/trace_importer_job\.rb}, email.text_part.body.to_s, "should include stack backtrace")
+    assert_match(/Test Exception/, email.text_part.body.to_s, "should show the exception message")
+    assert_exception_backtrace(email)
 
     ActionMailer::Base.deliveries.clear
   end
@@ -70,7 +70,7 @@ class TraceImporterJobTest < ActiveJob::TestCase
     assert_equal trace.user.email, email.to[0]
     assert_match(/failure/, email.subject)
     assert_match(/Fatal error:/, email.text_part.body.to_s, "should include parser error")
-    assert_no_match(%r{jobs/trace_importer_job\.rb}, email.text_part.body.to_s, "should not include stack backtrace")
+    assert_no_exception_backtrace(email)
 
     ActionMailer::Base.deliveries.clear
   end
@@ -85,8 +85,22 @@ class TraceImporterJobTest < ActiveJob::TestCase
     assert_equal trace.user.email, email.to[0]
     assert_match(/failure/, email.subject)
     assert_match(/Fatal error:/, email.text_part.body.to_s, "should include parser error")
-    assert_no_match(%r{jobs/trace_importer_job\.rb}, email.text_part.body.to_s, "should not include stack backtrace")
+    assert_no_exception_backtrace(email)
 
     ActionMailer::Base.deliveries.clear
+  end
+
+  private
+
+  def exception_backtrace_matcher
+    %r{jobs/trace_importer_job\.rb}
+  end
+
+  def assert_exception_backtrace(email)
+    assert_match(exception_backtrace_matcher, email.text_part.body.to_s, "should include stack backtrace")
+  end
+
+  def assert_no_exception_backtrace(email)
+    assert_no_match(exception_backtrace_matcher, email.text_part.body.to_s, "should not include stack backtrace")
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/openstreetmap/openstreetmap-website/pull/6902, where I tweaked an assertion to work reliably on macOS, after what appears to be a change of behaviour in libxml2. At the time I missed another instance of the same issue, so that's it changed here.

Additionally, a separate commit refactors negative assertions in the same test, which is something I'm always wary of. That sort of assertion can pass accidentally all too easily, due to a typo or whatever. I try to avoid them, and if not at least base them on the same code as the counterpart positive assertion