### PR TITLE
update iD to v2.39.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@mapbox/mapbox-gl-rtl-text": "^0.3.0",
     "@maplibre/maplibre-gl-leaflet": "^0.1.1",
     "@maptiler/maplibre-gl-omt-language": "^0.0.3",
-    "@openstreetmap/id": "2.39.3",
+    "@openstreetmap/id": "2.39.5",
     "bootstrap-icons": "^1.13.1",
     "i18n-js": "^4.5.1",
     "js-cookie": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,10 +401,10 @@
   resolved "https://registry.yarnpkg.com/@maptiler/maplibre-gl-omt-language/-/maplibre-gl-omt-language-0.0.3.tgz#3069f4522e911e341d6b79b09ce2943c71b6ffd7"
   integrity sha512-Rv5IaFyh9GuFu2BEAGvVvlVGmXt5Jbjd0XhIu0D4Tek81DPQEQryIIwDFTDR27W4NyAtozy8QltB+8SFr2C7mQ==
 
-"@openstreetmap/id@2.39.3":
-  version "2.39.3"
-  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.39.3.tgz#1890518ac57cb868edfc8107da9f1861588faac8"
-  integrity sha512-eGzUpEs0yWTDN+SnayReS/4PHGPrhXGeRJDUxJ0ktiKvHwN+fWyuuJHRGktpPHWnQi5wmN4Lw2Ax03oa4I5EJw==
+"@openstreetmap/id@2.39.5":
+  version "2.39.5"
+  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.39.5.tgz#78a7d60d852d2169d6fe6c8e5d9bc55868b45852"
+  integrity sha512-9YbqvlJyJGnu5xwmuVoL+8IBTqjv+L0TiuH5RCuWpQKF8rqlvyYNNgPXog8T6yUIVLyRCRmY50oFDlQhRsveDw==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/sexagesimal" "1.2.0"


### PR DESCRIPTION
This fixes a crash (https://github.com/openstreetmap/iD/issues/12078) and a few cosmetic regressions. Full changelog: https://github.com/openstreetmap/iD/releases/tag/v2.39.4 + https://github.com/openstreetmap/iD/releases/tag/v2.39.5