### PR TITLE
Configure queues for new notification system

### DIFF
--- a/config/initializers/noticed.rb
+++ b/config/initializers/noticed.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Noticed::EventJob.queue_as :notifiers
+  Noticed::DeliveryMethods::Email.queue_as :mailers
+end


### PR DESCRIPTION
After further investigation of #6924 it appears that the situation is:

* The initial `Noticed::EventJob` is sent to the `default` queue and the only direct way to override that is with the `:queue` option on the call to `deliver` with no simple way to set a default.
* When delivering an email the event job will queue a `Noticed::DeliveryMethod::Email` job to the `default` queue unless the `queue` option is set by the `deliver_by` block for the event with no simple way to set a global default.

So what this does is to patch the job classes, based on the ideas in https://github.com/excid3/noticed/issues/294, https://github.com/excid3/noticed/discussions/324 and https://github.com/excid3/noticed?tab=readme-ov-file#custom-noticed-model-methods.

While doing this I also confirmed that using `deliver_later` on a notification is pointless as it's actually just an alias for `deliver` so I've changed that as well.