### PR TITLE
fix social links sub,mission

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -20,6 +20,9 @@ $(function () {
 
       if (destroyCheckbox) {
         destroyCheckbox.checked = true;
+        row.find("input, select, textarea").each(function () {
+          if (this !== destroyCheckbox) this.disabled = true;
+        });
         row.addClass("d-none");
       } else {
         row.remove();
@@ -29,6 +32,10 @@ $(function () {
     });
 
     $(".social_link_destroy input[type='checkbox']:checked").each(function () {
+      const destroyCheckbox = this;
+      $(this).closest(".row").find("input, select, textarea").each(function () {
+        if (this !== destroyCheckbox) this.disabled = true;
+      });
       $(this).closest(".row").addClass("d-none");
     });
 

--- a/test/system/profile_links_change_test.rb
+++ b/test/system/profile_links_change_test.rb
@@ -79,6 +79,30 @@ class ProfileLinksChangeTest < ApplicationSystemTestCase
     end
   end
 
+  test "can submit after removing a blank social link" do
+    user = create(:user)
+
+    sign_in_as(user)
+    visit user_path(user)
+
+    within_content_body do
+      click_on "Edit Profile Details"
+      click_on "Edit Links"
+
+      click_on "Add Social Link"
+      fill_in "Social Profile Link 1", :with => "https://example.com/user/fred"
+      click_on "Add Social Link"
+
+      assert_field "Social Profile Link 2", :with => ""
+
+      click_on "Remove Social Profile Link 2"
+      click_on "Update Profile"
+
+      assert_link "example.com/user/fred"
+      assert_no_field "Social Profile Link 2"
+    end
+  end
+
   test "can control social links using keyboard without submitting" do
     user = create(:user)
 


### PR DESCRIPTION
### Description

Fixes #6903

When a user adds a social link, leaves the second input invalid, and then removes it, clicking "Update Profile" silently fails. The browser console shows:

```
The invalid form control with name='user[social_links_attributes][1][url]' is not focusable.
```

The browser's native HTML5 validation still holds a reference to the removed field, blocking form submission without any visible feedback to the user.

This fix ensures that when a social link input is removed, its validation constraints are cleared so the form can submit correctly.

### How has this been tested?

1. Visited Edit Profile → Links tab with no existing links
2. Added a valid URL (`https://example.com`) in the first input
3. Clicked "Add Social Link" — a second input appeared
4. Left the second input empty/invalid
5. Clicked "Remove" on the second input
6. Clicked "Update Profile" — form now submits successfully ✅
7. Verified the fix does not break the normal add/remove/submit flow
8. Ran the full test suite with `bundle exec rails test:all` — all tests pass