### PR TITLE
Rename heatmap label to Contribution Calendar

### DIFF
--- a/app/assets/javascripts/heatmap.js
+++ b/app/assets/javascripts/heatmap.js
@@ -66,13 +66,13 @@ $(document).on("turbo:frame-load", function () {
   }
 
   function getTooltipText(date, value) {
-    const localizedDate = OSM.i18n.l("date.formats.heatmap", date);
+    const localizedDate = OSM.i18n.l("date.formats.contribution_calendar", date);
 
     if (value > 0) {
-      return OSM.i18n.t("javascripts.heatmap.tooltip.contributions", { count: value, date: localizedDate });
+      return OSM.i18n.t("javascripts.contribution_calendar.tooltip.contributions", { count: value, date: localizedDate });
     }
 
-    return OSM.i18n.t("javascripts.heatmap.tooltip.no_contributions", { date: localizedDate });
+    return OSM.i18n.t("javascripts.contribution_calendar.tooltip.no_contributions", { date: localizedDate });
   }
 
   function getWeekInfo() {

--- a/app/views/profiles/heatmaps/show.html.erb
+++ b/app/views/profiles/heatmaps/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <%= bootstrap_form_for current_user, :url => { :action => :update } do |f| %>
-  <%= f.check_box :public_heatmap, :label => t(".show_heatmap_in_public"), :checked => current_user.public_heatmap? %>
+  <%= f.check_box :public_heatmap, :label => t(".show_contribution_calendar_in_public"), :checked => current_user.public_heatmap? %>
 
   <%= f.primary t(".save") %>
   <%= link_to t(".cancel"), current_user, :class => "btn btn-link" %>

--- a/app/views/profiles/profile_sections/_navigation.html.erb
+++ b/app/views/profiles/profile_sections/_navigation.html.erb
@@ -17,6 +17,6 @@
     <%= link_to t(".location"), profile_location_path, :class => { "nav-link" => true, "active" => controller_name == "locations" } %>
   </li>
   <li class="nav-item">
-    <%= link_to t(".heatmap"), profile_heatmap_path, :class => { "nav-link" => true, "active" => controller_name == "heatmaps" } %>
+    <%= link_to t(".contribution_calendar"), profile_heatmap_path, :class => { "nav-link" => true, "active" => controller_name == "heatmaps" } %>
   </li>
 </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -292,7 +292,7 @@
 <% end %>
 <% if owned %>
   <div class="mt-2">
-    <%= link_to t(".edit_heatmap"), profile_heatmap_path, :class => "btn btn-sm w-100 btn-outline-primary edit_heatmap_button" %>
+    <%= link_to t(".edit_contribution_calendar"), profile_heatmap_path, :class => "btn btn-sm w-100 btn-outline-primary edit_heatmap_button" %>
   </div>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
     dir: ltr
   date:
     formats:
-      heatmap: "%B %-d"
+      contribution_calendar: "%B %-d"
   time:
     formats:
       friendly: "%e %B %Y at %H:%M"
@@ -2147,7 +2147,7 @@ en:
         image: Image
         company: Company
         location: Location
-        heatmap: Heatmap
+        contribution_calendar: Contribution Calendar
     descriptions:
       show:
         title: Edit Profile
@@ -2208,13 +2208,13 @@ en:
         failure: Couldn't update profile location.
     heatmaps:
       show:
-        title: Configure Heatmap
-        show_heatmap_in_public: "Show the heatmap on your profile page"
-        save: Update Heatmap Configuration
+        title: Configure Contribution Calendar
+        show_contribution_calendar_in_public: "Show the contribution calendar on your profile page"
+        save: Update Contribution Calendar Configuration
         cancel: Cancel
       update:
-        success: Heatmap updated.
-        failure: Couldn't update the heatmap.
+        success: Contribution calendar updated.
+        failure: Couldn't update the contribution calendar.
   sessions:
     new:
       tab_title: "Log In"
@@ -3248,7 +3248,7 @@ en:
       change_image: Change Image
       edit_company: Edit Company
       edit_location: Edit Location
-      edit_heatmap: Configure Heatmap
+      edit_contribution_calendar: Configure Contribution Calendar
       contributions:
         one: "%{count} contribution in the last year"
         other: "%{count} contributions in the last year"
@@ -3726,7 +3726,7 @@ en:
     home:
       marker_title: My home location
       not_set: Home location is not set for your account
-    heatmap:
+    contribution_calendar:
       tooltip:
         no_contributions: "No contributions on %{date}"
         contributions:

--- a/test/controllers/profiles/heatmaps_controller_test.rb
+++ b/test/controllers/profiles/heatmaps_controller_test.rb
@@ -49,7 +49,7 @@ module Profiles
       follow_redirect!
       assert_response :success
       assert_template :show
-      assert_dom ".alert-success", :text => "Heatmap updated."
+      assert_dom ".alert-success", :text => "Contribution calendar updated."
 
       assert_not_predicate user.reload, :public_heatmap?
       refute_select heatmap_selector
@@ -60,7 +60,7 @@ module Profiles
       follow_redirect!
       assert_response :success
       assert_template :show
-      assert_dom ".alert-success", :text => "Heatmap updated."
+      assert_dom ".alert-success", :text => "Contribution calendar updated."
 
       assert_predicate user.reload, :public_heatmap?
       assert_select heatmap_selector


### PR DESCRIPTION
Closes #6849

This PR renames the user-facing "Heatmap" feature in the profile section to "Contribution Calendar" to better reflect its purpose as a temporal activity overview (similar to GitHub’s contribution graph), rather than a geographic heatmap.

### Changes

* Updated user-facing labels from **"Heatmap" → "Contribution Calendar"**
* Updated relevant i18n keys in `config/locales/en.yml`
* Renamed related translation keys (e.g., `edit_heatmap` → `edit_contribution_calendar`, `show_heatmap_in_public` → `show_contribution_calendar_in_public`)
* Updated success messages and UI text accordingly
* Updated controller tests to reflect new text
* Preserved the existing `heatmaps` namespace to maintain correct Rails i18n scoping and avoid breaking relative lookups

### Notes

* Based on reviewer feedback, translation keys were updated while keeping namespace structure intact
* Changes are limited to `en.yml` as other locales are managed externally via TranslateWiki

### Previous PR

This replaces #6884.

The previous PR was unintentionally closed after a rebase operation temporarily aligned the branch with `master`, resulting in no diff. Since GitHub treats such branches as having no changes, the PR was automatically closed and could not be reopened once the history diverged again.

This PR restores the intended changes with a clean, linear commit history.
