### PR TITLE
Update Docker Desktop Homebrew URL in DOCKER.md

### DIFF
--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -14,7 +14,7 @@ These instructions are designed for setting up `openstreetmap-website` for devel
 ### Mac
 
 - Use Docker Desktop via [docker.com Download](https://www.docker.com/products/docker-desktop/).
-- Or [Homebrew](https://formulae.brew.sh/cask/docker).
+- Or [Homebrew](https://formulae.brew.sh/cask/docker-desktop).
 
 ### Linux
 


### PR DESCRIPTION
### Description

_Just a tiny change._

https://formulae.brew.sh/cask/docker is a 404 page now. The new URL is https://formulae.brew.sh/cask/docker-desktop.

### How has this been tested?

I've opened the new URL and it loads successfully.
