### PR TITLE
Remove required attribute from social link fields marked for destruction

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -21,6 +21,7 @@ $(function () {
       if (destroyCheckbox) {
         destroyCheckbox.checked = true;
         row.addClass("d-none");
+        row.find("input[type='text']").removeAttr("required");
       } else {
         row.remove();
       }
@@ -29,7 +30,9 @@ $(function () {
     });
 
     $(".social_link_destroy input[type='checkbox']:checked").each(function () {
-      $(this).closest(".row").addClass("d-none");
+      const row = $(this).closest(".row");
+      row.addClass("d-none");
+      row.find("input[type='text']").removeAttr("required");
     });
 
     renumberSocialLinks();

--- a/test/system/profile_links_change_test.rb
+++ b/test/system/profile_links_change_test.rb
@@ -126,6 +126,59 @@ class ProfileLinksChangeTest < ApplicationSystemTestCase
     end
   end
 
+  test "can remove invalid link after validation error and resubmit" do
+    user = create(:user)
+
+    sign_in_as(user)
+    visit user_path(user)
+
+    within_content_body do
+      click_on "Edit Profile Details"
+      click_on "Edit Links"
+
+      click_on "Add Social Link"
+      fill_in "Social Profile Link 1", :with => "https://example.com/user/valid"
+      click_on "Add Social Link"
+
+      # Submit with second link empty to trigger validation error
+      click_on "Update Profile"
+
+      # Remove the invalid (empty) second link
+      click_on "Remove Social Profile Link 2"
+
+      # Resubmit - this should succeed
+      click_on "Update Profile"
+
+      assert_link "example.com/user/valid"
+    end
+  end
+
+  test "can remove persisted link after validation error and resubmit" do
+    user = create(:user)
+    create(:social_link, :user => user, :url => "https://example.com/user/first")
+
+    sign_in_as(user)
+    visit user_path(user)
+
+    within_content_body do
+      click_on "Edit Profile Details"
+      click_on "Edit Links"
+
+      click_on "Add Social Link"
+
+      # Submit with second link empty to trigger validation error
+      click_on "Update Profile"
+
+      # Remove the invalid (empty) second link
+      click_on "Remove Social Profile Link 2"
+
+      # Resubmit - this should succeed with the first link preserved
+      click_on "Update Profile"
+
+      assert_link "example.com/user/first"
+    end
+  end
+
   test "can add and remove multiple links" do
     user = create(:user)
 


### PR DESCRIPTION
## Summary

Fixes #6903

When a social link is removed via the "Remove" button after a validation error, the row is hidden with `d-none` but the URL input retains its `required` attribute (added by `bootstrap_form` from the model's presence validation). The browser blocks form submission with _"The invalid form control with name='user[social_links_attributes][1][url]' is not focusable"_ because a hidden required field cannot pass native HTML validation.

- Remove the `required` attribute from the URL text input when a social link row is marked for destruction
- Also handle the on-load case where `_destroy` checkboxes are already checked

## Test plan

- [ ] Added two system tests that reproduce the exact scenario from #6903: submit with an empty link to trigger validation, remove the empty link, resubmit
- [ ] Existing social link system tests continue to pass
- [ ] Manual verification: follow the steps in the issue and confirm form submits successfully after removing the invalid link

🤖 Generated with [Claude Code](https://claude.com/claude-code)