### PR TITLE
Use Noticed for notifications on GPX imports

### DIFF
--- a/app/jobs/trace_importer_job.rb
+++ b/app/jobs/trace_importer_job.rb
@@ -9,17 +9,26 @@ class TraceImporterJob < ApplicationJob
     if gpx.actual_points.positive?
       GpxImportSuccessNotifier.with(:record => trace, :possible_points => gpx.actual_points).deliver_later
     else
-      UserMailer.with(:trace => trace, :error => "0 points parsed ok. Do they all have lat,lng,alt,timestamp?").gpx_failure.deliver
-      trace.destroy
+      handle_import_failure_notification(trace, "0 points parsed ok. Do they all have lat,lng,alt,timestamp?")
     end
   rescue LibXML::XML::Error => e
     logger.info e.to_s
-    UserMailer.with(:trace => trace, :error => e).gpx_failure.deliver
-    trace.destroy
+    handle_import_failure_notification(trace, e.to_s)
   rescue StandardError => e
     logger.info e.to_s
     e.backtrace.each { |l| logger.info l }
-    UserMailer.with(:trace => trace, :error => "#{e}\n#{e.backtrace.join("\n")}").gpx_failure.deliver
+    handle_import_failure_notification(trace, "#{e}\n#{e.backtrace.join("\n")}")
+  end
+
+  private
+
+  def handle_import_failure_notification(trace, error)
+    GpxImportFailureNotifier.with(
+      :trace_name => trace.name,
+      :trace_description => trace.description,
+      :trace_tags => trace.tags.map(&:tag),
+      :error => error
+    ).deliver_later(trace.user)
     trace.destroy
   end
 end

--- a/app/jobs/trace_importer_job.rb
+++ b/app/jobs/trace_importer_job.rb
@@ -7,7 +7,7 @@ class TraceImporterJob < ApplicationJob
     gpx = trace.import
 
     if gpx.actual_points.positive?
-      UserMailer.with(:trace => trace, :possible_points => gpx.actual_points).gpx_success.deliver
+      GpxImportSuccessNotifier.with(:record => trace, :possible_points => gpx.actual_points).deliver_later
     else
       UserMailer.with(:trace => trace, :error => "0 points parsed ok. Do they all have lat,lng,alt,timestamp?").gpx_failure.deliver
       trace.destroy

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -70,16 +70,26 @@ class UserMailer < ApplicationMailer
   end
 
   def gpx_failure
-    trace, error = params.fetch_values(:trace, :error)
+    trace_name,
+    trace_description,
+    trace_tags,
+    error,
+    recipient = params.fetch_values(
+      :trace_name,
+      :trace_description,
+      :trace_tags,
+      :error,
+      :recipient
+    )
 
-    with_recipient_locale trace.user do
-      @to_user = trace.user.display_name
-      @trace_name = trace.name
-      @trace_description = trace.description
-      @trace_tags = trace.tags
+    with_recipient_locale recipient do
+      @to_user = recipient.display_name
+      @trace_name = trace_name
+      @trace_description = trace_description
+      @trace_tags = trace_tags
       @error = error
 
-      mail :to => trace.user.email,
+      mail :to => recipient.email,
            :subject => t(".subject")
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -52,10 +52,10 @@ class UserMailer < ApplicationMailer
   end
 
   def gpx_success
-    trace, possible_points = params.fetch_values(:trace, :possible_points)
+    trace, possible_points, recipient = params.fetch_values(:record, :possible_points, :recipient)
 
-    with_recipient_locale trace.user do
-      @to_user = trace.user.display_name
+    with_recipient_locale recipient do
+      @to_user = recipient.display_name
       @trace_url = show_trace_url(trace.user, trace)
       @trace_name = trace.name
       @trace_points = trace.size
@@ -64,7 +64,7 @@ class UserMailer < ApplicationMailer
       @possible_points = possible_points
       @my_traces_url = url_for(:controller => "traces", :action => "mine")
 
-      mail :to => trace.user.email,
+      mail :to => recipient.email,
            :subject => t(".subject")
     end
   end

--- a/app/notifiers/gpx_import_failure_notifier.rb
+++ b/app/notifiers/gpx_import_failure_notifier.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class GpxImportFailureNotifier < ApplicationNotifier
+  deliver_by :email do |config|
+    config.mailer = "UserMailer"
+    config.method = "gpx_failure"
+  end
+end

--- a/app/notifiers/gpx_import_success_notifier.rb
+++ b/app/notifiers/gpx_import_success_notifier.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class GpxImportSuccessNotifier < ApplicationNotifier
+  recipients -> { record.user }
+
+  validates :record, :presence => true
+
+  deliver_by :email do |config|
+    config.mailer = "UserMailer"
+    config.method = "gpx_success"
+  end
+end

--- a/test/jobs/trace_importer_job_test.rb
+++ b/test/jobs/trace_importer_job_test.rb
@@ -36,7 +36,9 @@ class TraceImporterJobTest < ActiveJob::TestCase
     end
 
     trace.stub(:import, gpx) do
-      TraceImporterJob.perform_now(trace)
+      perform_enqueued_jobs do
+        TraceImporterJob.perform_now(trace)
+      end
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -50,7 +52,9 @@ class TraceImporterJobTest < ActiveJob::TestCase
     # Check that the user gets a failure notification when something goes badly wrong
     trace = create(:trace)
     trace.stub(:import, -> { raise "Test Exception" }) do
-      TraceImporterJob.perform_now(trace)
+      perform_enqueued_jobs do
+        TraceImporterJob.perform_now(trace)
+      end
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -65,7 +69,9 @@ class TraceImporterJobTest < ActiveJob::TestCase
   def test_parse_error_notification
     trace = create(:trace, :inserted => false, :fixture => "jpg")
     Rails.logger.silence do
-      TraceImporterJob.perform_now(trace)
+      perform_enqueued_jobs do
+        TraceImporterJob.perform_now(trace)
+      end
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -80,7 +86,9 @@ class TraceImporterJobTest < ActiveJob::TestCase
   def test_gz_parse_error_notification
     trace = create(:trace, :inserted => false, :fixture => "jpg.gz")
     Rails.logger.silence do
-      TraceImporterJob.perform_now(trace)
+      perform_enqueued_jobs do
+        TraceImporterJob.perform_now(trace)
+      end
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/test/jobs/trace_importer_job_test.rb
+++ b/test/jobs/trace_importer_job_test.rb
@@ -14,7 +14,9 @@ class TraceImporterJobTest < ActiveJob::TestCase
     end
 
     trace.stub(:import, gpx) do
-      TraceImporterJob.perform_now(trace)
+      perform_enqueued_jobs do
+        TraceImporterJob.perform_now(trace)
+      end
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -39,7 +39,7 @@ class UserMailerPreview < ActionMailer::Preview
   def gpx_success
     user = create(:user, :languages => [I18n.locale])
     trace = create(:trace, :user => user)
-    UserMailer.with(:trace => trace, :possible_points => trace.size + 2).gpx_success
+    UserMailer.with(:record => trace, :possible_points => trace.size + 2, :recipient => trace.user).gpx_success
   end
 
   def gpx_failure

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -50,7 +50,13 @@ class UserMailerPreview < ActionMailer::Preview
     rescue LibXML::XML::Error => e
       e.message
     end
-    UserMailer.with(:trace => trace, :error => error).gpx_failure
+    UserMailer.with(
+      :trace_name => trace.name,
+      :trace_description => trace.description,
+      :trace_tags => trace.tags,
+      :error => error,
+      :recipient => trace.user
+    ).gpx_failure
   end
 
   def message_notification

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -78,13 +78,29 @@ class UserMailerTest < ActionMailer::TestCase
     assert_includes email.text_part.body, url
   end
 
-  def test_gpx_failure_no_trace_link
-    trace = create(:trace)
-    email = UserMailer.with(:trace => trace, :error => "some error").gpx_failure
-    url = url_helpers.show_trace_url(trace.user, trace)
+  def test_gpx_failure
+    trace = build(:trace, :tags => build_list(:tracetag, 2))
+    email = UserMailer.with(
+      :trace_name => trace.name,
+      :trace_description => trace.description,
+      :trace_tags => trace.tags,
+      :error => "some error",
+      :recipient => trace.user
+    ).gpx_failure
 
-    assert_select parse_html_body(email), "a[href='#{url}']", :count => 0
-    assert_not_includes email.text_part.body, url
+    tags = trace.tags.map(&:tag)
+    assert_match trace.name, email.html_part.body.to_s
+    assert_match trace.description, email.html_part.body.to_s
+    assert_match tags[0], email.html_part.body.to_s
+    assert_match tags[1], email.html_part.body.to_s
+    assert_match "some error", email.html_part.body.to_s
+
+    tags = trace.tags.map(&:tag)
+    assert_match trace.name, email.text_part.body.to_s
+    assert_match trace.description, email.text_part.body.to_s
+    assert_match tags[0], email.text_part.body.to_s
+    assert_match tags[1], email.text_part.body.to_s
+    assert_match "some error", email.text_part.body.to_s
   end
 
   def test_message_notification

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -54,7 +54,7 @@ class UserMailerTest < ActionMailer::TestCase
       create(:tracetag, :trace => t, :tag => "two&three")
       create(:tracetag, :trace => t, :tag => "four<five")
     end
-    email = UserMailer.with(:trace => trace, :possible_points => 100).gpx_success
+    email = UserMailer.with(:record => trace, :possible_points => 100, :recipient => trace.user).gpx_success
 
     assert_match("one, two&amp;three, four&lt;five", email.html_part.body.to_s)
     assert_match("one, two&three, four<five", email.text_part.body.to_s)
@@ -62,7 +62,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   def test_gpx_success_all_traces_link
     trace = create(:trace)
-    email = UserMailer.with(:trace => trace, :possible_points => 100).gpx_success
+    email = UserMailer.with(:record => trace, :possible_points => 100, :recipient => trace.user).gpx_success
     url = url_helpers.url_for(:controller => "traces", :action => "mine")
 
     assert_select parse_html_body(email), "a[href='#{url}']"
@@ -71,7 +71,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   def test_gpx_success_trace_link
     trace = create(:trace)
-    email = UserMailer.with(:trace => trace, :possible_points => 100).gpx_success
+    email = UserMailer.with(:record => trace, :possible_points => 100, :recipient => trace.user).gpx_success
     url = url_helpers.show_trace_url(trace.user, trace)
 
     assert_select parse_html_body(email), "a[href='#{url}']", :text => trace.name


### PR DESCRIPTION
Following https://github.com/openstreetmap/openstreetmap-website/pull/6837, and sibling to https://github.com/openstreetmap/openstreetmap-website/pull/6933, this converts some more code to use Noticed instead of using mailers directly.

The success notification was the simpler of the two. I only needed to adapt the mailer to use the recipient explicitly given in the params, as opposed to extracting it from the trace. This was raised by @tomhughes during review.

The failure notification is a bit more involved. First the two easy changes:
- Same as with success, the recipient is given explicitly instead of extracted from the trace.
- I changed the test because a) it depended on the trace record being available and b) I don't like that sort of negative assertion it was using.

More importantly, there's the issue that the current code deletes the trace immediately after delivering the email synchronously. To work around this, the notifier will not receive a `record`, only the metadata as explicit arguments, and the recipient will be given explicitly in the `deliver_later` call.

In any case, and as mentioned by @gravitystorm, this raises the question of what to do when we implement on-site notifications and these refer to deleted records. This might involve creating a new model `OnsiteNotification` that doesn't require other records, instead of piggybacking on the existing `Noticed::Notifications`.