### PR TITLE
Fix social link form resubmission after removing invalid link

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -30,7 +30,9 @@ $(function () {
     });
 
     $(".social_link_destroy input[type='checkbox']:checked").each(function () {
-      $(this).closest(".row").addClass("d-none");
+      const row = $(this).closest(".row");
+      row.addClass("d-none");
+      row.find("input[type='text']").removeAttr("required");
     });
 
     renumberSocialLinks();

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -21,6 +21,7 @@ $(function () {
       if (destroyCheckbox) {
         destroyCheckbox.checked = true;
         row.addClass("d-none");
+        row.find("input[type='text']").removeAttr("required");
       } else {
         row.remove();
       }

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -30,9 +30,7 @@ $(function () {
     });
 
     $(".social_link_destroy input[type='checkbox']:checked").each(function () {
-      const row = $(this).closest(".row");
-      row.addClass("d-none");
-      row.find("input[type='text']").removeAttr("required");
+      $(this).closest(".row").addClass("d-none").find("input[type='text']").removeAttr("required");
     });
 
     renumberSocialLinks();

--- a/test/system/profile_links_change_test.rb
+++ b/test/system/profile_links_change_test.rb
@@ -168,4 +168,30 @@ class ProfileLinksChangeTest < ApplicationSystemTestCase
       assert_link "example.com/d"
     end
   end
+
+  test "can remove invalid link after validation error and resubmit" do
+    user = create(:user)
+
+    sign_in_as(user)
+    visit user_path(user)
+
+    within_content_body do
+      click_on "Edit Profile Details"
+      click_on "Edit Links"
+      click_on "Add Social Link"
+      fill_in "Social Profile Link 1", :with => "https://example.com/valid"
+      click_on "Add Social Link"
+      click_on "Update Profile"
+
+      assert_field "Social Profile Link 2"
+
+      click_on "Remove Social Profile Link 2"
+
+      assert_no_field "Social Profile Link 2"
+
+      click_on "Update Profile"
+
+      assert_link "example.com/valid"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #6903.

When a social link row is removed after a validation error, the row is hidden (`d-none`) and the `_destroy` checkbox is checked, but the text input keeps its `required` attribute. HTML5 validation then blocks form submission because it cannot focus the hidden required field.

This adds a single line to strip the `required` attribute from the text input when marking a social link for destruction.

## Reproduction

1. Go to profile links editor with no existing links
2. Add a valid URL, then add a second empty social link
3. Submit - server returns validation error on the empty link
4. Remove the errored link
5. Try to submit again - **before this fix**, nothing happens and the console logs "invalid form control is not focusable"

## Test plan

- Added system test covering the exact reproduction scenario
- Existing social link tests continue to pass (add, remove, keyboard navigation, multi-link management)