### PR TITLE
Fix login tab order for "Lost your password?" link

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -48,19 +48,14 @@
 
   <%= f.text_field :username, :label => t(".email or username"), :autofocus => true, :value => params[:username] %>
 
+  <%= f.password_field :password, :label => t(".password"), :autocomplete => "on", :value => "" %>
+
   <div class="d-flex flex-wrap column-gap-3 justify-content-between align-items-baseline mb-2">
-    <%= f.label :password, t(".password") %>
+    <%= f.form_group do %>
+      <%= f.check_box :remember_me, { :label => t(".remember"), :checked => (params[:remember_me] == "true") }, "yes" %>
+      <%= f.primary t(".login_button") %>
+    <% end %>
     <small><%= link_to(t(".lost password link"), user_forgot_password_path) %></small>
-  </div>
-
-  <%= f.password_field :password, :autocomplete => "on", :value => "", :skip_label => true %>
-
-  <%= f.form_group do %>
-    <%= f.check_box :remember_me, { :label => t(".remember"), :checked => (params[:remember_me] == "true") }, "yes" %>
-  <% end %>
-
-  <div class="mb-3">
-    <%= f.primary t(".login_button") %>
   </div>
 <% end %>
 


### PR DESCRIPTION
Closes #6925

### Summary
Moves the "Lost your password?" link to right side ,  opposite to the login button, to fix incorrect tab order and improve accessibility.

### Problem
The link was previously placed before the password input in the DOM, causing keyboard navigation to focus it before the password field.

### Solution
Repositioned the link below the login button using Bootstrap utilities, ensuring proper tab flow without introducing custom CSS.

### Result
Updated tab order:
username → password → remember → login → lost password

### Screenshots
**Before**
<img width="708" height="291" alt="image" src="https://github.com/user-attachments/assets/0ffa89ab-2758-4242-ae5a-f5704ecdcbbd" />

**After**
<img width="783" height="489" alt="image" src="https://github.com/user-attachments/assets/7fa269ca-b7d0-4298-8da2-9e6ac3f8c088" />

Closes #6925