### PR TITLE
Fix directions panel re-submit after closing results

### DIFF
--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -141,7 +141,7 @@ OSM.Directions = function (map) {
     e.stopPropagation();
     routeOutput.remove();
     sidebarReadyPromise = null;
-    map.setSidebarOverlaid(true);
+    map.setSidebarOverlaid(!endpoints[0].latlng || !endpoints[1].latlng);s
   }
 
   setEngine("fossgis_osrm_car");


### PR DESCRIPTION
When the directions results panel is closed, the sidebar was always 
     hidden via setSidebarOverlaid(true). This prevented users from 
     re-submitting the route by pressing Enter.
     
     Fixed by only overlaying the sidebar if endpoints are missing, 
     matching the same logic used on page load.