### PR TITLE
Show Terms of Use notice to older users on login

### DIFF
--- a/app/controllers/concerns/session_methods.rb
+++ b/app/controllers/concerns/session_methods.rb
@@ -50,15 +50,15 @@ module SessionMethods
     # - If they were referred to the login, send them back there.
     # - Otherwise, send them to the home page.
     if !user.terms_seen
-      redirect_to account_terms_path(:referer => target)
+    	redirect_to account_terms_path(:referer => target)
     elsif user.blocked_on_view
-      redirect_to user.blocked_on_view, :referer => target
+    	redirect_to user.blocked_on_view, :referer => target
     else
-      redirect_to target
+    	flash[:warning] = t("sessions.tou_notice_html", :terms_link => view_context.link_to(t("layouts.terms_of_use"), "https://osmfoundation.org/wiki/Terms_of_Use")).html_safe if user.tou_agreed.nil?
+    	redirect_to target
     end
-
     session.delete(:remember_me)
-  end
+    end
 
   ##
   # process a failed login

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2214,6 +2214,7 @@ en:
         success: Contribution calendar updated.
         failure: Couldn't update the contribution calendar.
   sessions:
+    tou_notice_html: "By using this website or other infrastructure provided by the OpenStreetMap Foundation, you agree to the %{terms_link}."
     new:
       tab_title: "Log In"
       login_to_authorize_html: "Log in to OpenStreetMap to access %{client_app_name}."


### PR DESCRIPTION
Migrates the embedded map page (/export/embed.html) from Leaflet 
to MapLibre GL JS, consistent with the rest of the OSM website.

This change replaces the Leaflet map initialization and layer 
handling in the embed page with MapLibre equivalents, ensuring 
a consistent rendering experience across the site.

