### PR TITLE
Disable some svgo plugins

### DIFF
--- a/config/image_optim.yml
+++ b/config/image_optim.yml
@@ -2,4 +2,4 @@ skip_missing_workers: true
 oxipng: false
 pngout: false
 svgo:
-  disable_plugins: ["cleanupIDs", "removeUnknownsAndDefaults"]
+  disable_plugins: ["cleanupIDs", "cleanupIds", "removeHiddenElems", "removeUnknownsAndDefaults"]


### PR DESCRIPTION
Hopefully fixes https://github.com/openstreetmap/iD/issues/12162

Currently, some iD spritesheet responses are empty:

- https://www.openstreetmap.org/assets/@openstreetmap/id/dist/img/community-sprite-c73f3fc74045def3e1f6acfe9cef9b59c16c455501ffd82f1196754fe48f203d.svg
- https://www.openstreetmap.org/assets/@openstreetmap/id/dist/img/temaki-sprite-c73f3fc74045def3e1f6acfe9cef9b59c16c455501ffd82f1196754fe48f203d.svg