### PR TITLE
Deduplicate trace image handling

### DIFF
--- a/app/helpers/trace_helper.rb
+++ b/app/helpers/trace_helper.rb
@@ -1,23 +1,21 @@
 # frozen_string_literal: true
 
 module TraceHelper
+  def trace_image(trace, animated: false, only_path: true, **options)
+    args = [trace.user, trace, { :only_path => only_path }]
+    src = animated ? trace_picture_url(*args) : trace_icon_url(*args)
+    image_tag(src, { :class => "trace_image", :alt => "" }.merge(options))
+  end
+
   def link_to_tag(tag)
     link_to(tag, :tag => tag, :page => nil)
   end
 
   def trace_icon(trace, options = {})
-    options[:class] ||= "trace_image"
-    options[:alt] ||= ""
-
-    image_tag trace_icon_path(trace.user, trace),
-              options.merge(:size => 50)
+    trace_image(trace, :size => 50, **options)
   end
 
   def trace_picture(trace, options = {})
-    options[:class] ||= "trace_image"
-    options[:alt] ||= ""
-
-    image_tag trace_picture_path(trace.user, trace),
-              options.merge(:size => 250)
+    trace_image(trace, :animated => true, :size => 250, **options)
   end
 end

--- a/app/views/traces/feeds/_description.html.erb
+++ b/app/views/traces/feeds/_description.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (trace:) %>
 
-<%= image_tag trace_icon_url(trace.user, trace), :alt => "" %>
+<%= trace_image(trace, :only_path => false) %>
 <% if trace.size -%>
 <%= t ".description_with_count", :count => trace.size, :user => trace.user.display_name %>
 <% else -%>


### PR DESCRIPTION
Even with absolute image paths, we can deduplicate the trace image attribute assignment.