### PR TITLE
Re-enable actions for forked repos

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -2,8 +2,9 @@ name: Development Container
 
 on:
   push:
-    branches:
-      - master
+    branches-ignore:
+      - "dependabot/**"
+      - translatewiki
   pull_request:
 
 concurrency:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,9 @@
 name: Docker
 on:
   push:
-    branches:
-      - master
+    branches-ignore:
+      - "dependabot/**"
+      - translatewiki
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,9 @@
 name: Lint
 on:
   push:
-    branches:
-      - master
+    branches-ignore:
+      - "dependabot/**"
+      - translatewiki
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,9 @@
 name: Tests
 on:
   push:
-    branches:
-      - master
+    branches-ignore:
+      - "dependabot/**"
+      - translatewiki
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
Fixes #6822

I do think it's important to allow developers to run actions on their own forks before submitting a PR.

This is option 1 from https://github.com/openstreetmap/openstreetmap-website/issues/6822#issuecomment-4040867890