### PR TITLE
Split text search of notes and note comments in two

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -263,7 +263,10 @@ module Api
 
       # Add any text filter
       if params[:q]
-        @notes = @notes.joins(:comments).where("to_tsvector('english', note_comments.body) @@ plainto_tsquery('english', ?) OR to_tsvector('english', notes.description) @@ plainto_tsquery('english', ?)", params[:q], params[:q])
+        matched_notes = @notes.where("to_tsvector('english', notes.description) @@ plainto_tsquery('english', ?)", params[:q])
+        matched_note_comments = @notes.joins(:comments).where("to_tsvector('english', note_comments.body) @@ plainto_tsquery('english', ?)", params[:q])
+
+        @notes = matched_notes.union_all(matched_note_comments)
       end
 
       # Add any date filter


### PR DESCRIPTION
Postgres isn't able to figure out how to optimise the text search using the GIN indexes when presented with an OR that needs to search both tables but if we split the query in two ourselves and merge them back together with a union then it can use the indexes which can speed things up by two orders of magnitude.

Specifically testing with a query derived from real searches that hit use today I saw a reduction from 12000ms to 30ms or so which is around 400 times less, and that was testing on a slave that wasn't doing anything else.