### PR TITLE
Change "Sea Food" to "Seafood" in English strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1455,7 +1455,7 @@ en:
           pet: "Pet Shop"
           pet_grooming: "Pet Grooming"
           photo: "Photo Shop"
-          seafood: "Sea Food"
+          seafood: "Seafood"
           second_hand: "Second-hand Shop"
           sewing: "Sewing Shop"
           shoes: "Shoe Shop"


### PR DESCRIPTION
The spelling "Seafood" is much more common.