### PR TITLE
Allow searching language by language code

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -214,7 +214,11 @@ $(function () {
           const query = $(this).val().toLowerCase();
           $(".language-item").each(function () {
             const text = $(this).text().toLowerCase();
-            $(this).toggle(text.indexOf(query) > -1);
+            // Get languageCode from link_to data attribute
+            const code = $(this).find("a").data("languageCode").toLowerCase();
+            // Show the item if the query matches either the language name or code
+            const matches = text.indexOf(query) > -1 || code.indexOf(query) > -1;
+            $(this).toggle(matches);
           });
         });
       }


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->
This PR is for issue : https://github.com/openstreetmap/openstreetmap-website/issues/6973
Two files have been modified: _select_language_list.html.erb in the views/languages_panes folder and application.js in the assets/javascripts folder.
In the first file, I added a `data-language-code` attribute to the `li` element of the `language-item`.
In the second file, I added a line to retrieve the value of this attribute, `data(languageCode)`, and added a check to ensure the query returns either the language name or the code. Thus, the `toggle` now uses the result of this check as its parameter.

### How has this been tested?
<!--Explain the steps you took to test your code.-->
For the tests, I used the ui. Here are the screenshots:
bg for Bulgarian
<img width="797" height="218" alt="Capture d’écran du 2026-04-15 16-31-01" src="https://github.com/user-attachments/assets/864f0136-ca7b-42bb-9ae7-63c27ad9b879" />
tr for Turkish
<img width="797" height="218" alt="Capture d’écran du 2026-04-15 16-31-41" src="https://github.com/user-attachments/assets/be1efe7f-c257-4308-85c8-7a3e9a121d13" />
