### PR TITLE
Describe burger menu as expanded/collapsed to assistive tech

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -193,9 +193,12 @@ $(function () {
     $(document).on("turbo:render", updateHeader);
   }, 0);
 
-  $("#menu-icon").on("click", function (e) {
+  const menuIcon = $("#menu-icon");
+  const header = $("header");
+  menuIcon.on("click", function (e) {
     e.preventDefault();
-    $("header").toggleClass("closed");
+    header.toggleClass("closed");
+    menuIcon.prop("ariaExpanded", !header.hasClass("closed"));
   });
 
   $("nav.primary li a").on("click", function () {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
       <%= t "layouts.project_name.title" %>
     </a>
     <%= render "layouts/select_language_button", :extra_classes => ["border-secondary border-opacity-10 d-md-none"] %>
-    <a href="#" id="menu-icon" class="d-md-none">
+    <a href="#" id="menu-icon" class="d-md-none" aria-expanded="false" aria-label="Main">
       <i class="bi bi-list lh-1 text-body-secondary"></i>
     </a>
   </h1>


### PR DESCRIPTION
When playing with VoiceOver on my phone the other day, I noticed that the burger menu (appears on narrow windows) didn't read like anything that suggests that it can be interacted with.

<img width="500" height="139" alt="Top navigation of the site, as it appears on narrow screens, sporting a burger menu on the top right corner" src="https://github.com/user-attachments/assets/3a4cbbeb-82ba-44a4-ab0f-10a17af1e913" />

Specifically, I'm getting the following:

> Heading level 1, _lingbend_, banner.

(I can't tell what that word in the middle actually is. A native English speaker was also consulted with similar confusion).

I'm not an accessibility expert so I'm sure someone can do a better job than me but, for the moment, a sprinkle of attributes seems to make it more useful in my limited tests. Now it reads:

> Main, heading level 1, visited, _lingbend_, banner, collapsed. Double tap to expand.

And when expanded:

> Main, heading level 1, visited, link, expanded. Double tap to collapse.