### PR TITLE
Automatically provide a language in diary entries factory

### DIFF
--- a/test/controllers/diary_comments_controller_test.rb
+++ b/test/controllers/diary_comments_controller_test.rb
@@ -3,12 +3,6 @@
 require "test_helper"
 
 class DiaryCommentsControllerTest < ActionDispatch::IntegrationTest
-  def setup
-    super
-    # Create the default language for diary entries
-    create(:language, :code => "en")
-  end
-
   def test_routes
     assert_routing(
       { :path => "/user/username/diary/1/comments", :method => :post },

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -372,7 +372,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_show_profile_diaries
     user = create(:user)
-    create(:language, :code => "en")
     create(:diary_entry, :user => user, :title => "First Entry", :body => "First body")
     create(:diary_entry, :user => user, :title => "Second Entry", :body => "Second body")
     create(:diary_entry, :user => user, :title => "Third Entry", :body => "Third body")
@@ -393,7 +392,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   def test_show_profile_diaries_with_comments
     user = create(:user)
-    create(:language, :code => "en")
     entry = create(:diary_entry, :user => user, :title => "Entry with Comments")
     create(:diary_comment, :diary_entry => entry)
     create(:diary_comment, :diary_entry => entry)

--- a/test/factories/diary_entries.rb
+++ b/test/factories/diary_entries.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     sequence(:title) { |n| "Diary entry #{n}" }
     sequence(:body) { |n| "This is diary entry #{n}" }
 
+    language { Language.find_by(:code => "en") || create(:language, :code => "en") }
     user
   end
 end

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -6,7 +6,6 @@ class IssuesHelperTest < ActionView::TestCase
   attr_accessor :current_user
 
   def test_reportable_heading_diary_comment
-    create(:language, :code => "en")
     diary_entry = create(:diary_entry, :title => "A Discussion")
     diary_comment = create(:diary_comment, :diary_entry => diary_entry, :created_at => "2020-03-15", :updated_at => "2021-05-17")
 
@@ -20,7 +19,6 @@ class IssuesHelperTest < ActionView::TestCase
   end
 
   def test_reportable_heading_diary_entry
-    create(:language, :code => "en")
     diary_entry = create(:diary_entry, :title => "Important Subject", :created_at => "2020-03-24", :updated_at => "2021-05-26")
 
     heading = reportable_heading diary_entry

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -99,7 +99,6 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   def test_diary_comment_notification
-    create(:language, :code => "en")
     user = create(:user)
     other_user = create(:user)
     diary_entry = create(:diary_entry, :user => user)
@@ -142,7 +141,6 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   def test_changeset_comment_notification
-    create(:language, :code => "en")
     user = create(:user)
     other_user = create(:user)
     changeset = create(:changeset, :user => user)

--- a/test/models/diary_comment_test.rb
+++ b/test/models/diary_comment_test.rb
@@ -3,11 +3,6 @@
 require "test_helper"
 
 class DiaryCommentTest < ActiveSupport::TestCase
-  def setup
-    # Create the default language for diary entries
-    create(:language, :code => "en")
-  end
-
   test "body must be present" do
     comment = build(:diary_comment, :body => "")
     assert_not comment.valid?

--- a/test/models/diary_entry_test.rb
+++ b/test/models/diary_entry_test.rb
@@ -3,11 +3,6 @@
 require "test_helper"
 
 class DiaryEntryTest < ActiveSupport::TestCase
-  def setup
-    # Create the default language for diary entries
-    create(:language, :code => "en")
-  end
-
   def test_diary_entry_validations
     diary_entry_valid({})
     diary_entry_valid({ :title => "" }, :valid => false)

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -12,7 +12,6 @@ class IssueTest < ActiveSupport::TestCase
   end
 
   def test_reported_user
-    create(:language, :code => "en")
     user = create(:user)
     note = create(:note, :author => create(:user))
     anonymous_note = create(:note, :author => nil)

--- a/test/system/report_diary_comment_test.rb
+++ b/test/system/report_diary_comment_test.rb
@@ -4,7 +4,6 @@ require "application_system_test_case"
 
 class ReportDiaryCommentTest < ApplicationSystemTestCase
   def setup
-    create(:language, :code => "en")
     @diary_entry = create(:diary_entry)
     @comment = create(:diary_comment, :diary_entry => @diary_entry)
   end

--- a/test/system/report_diary_entry_test.rb
+++ b/test/system/report_diary_entry_test.rb
@@ -4,7 +4,6 @@ require "application_system_test_case"
 
 class ReportDiaryEntryTest < ApplicationSystemTestCase
   def setup
-    create(:language, :code => "en")
     @diary_entry = create(:diary_entry)
   end
 

--- a/test/system/user_logout_test.rb
+++ b/test/system/user_logout_test.rb
@@ -49,7 +49,6 @@ class UserLogoutTest < ApplicationSystemTestCase
   end
 
   test "Sign out after navigating diary entries with Turbo pagination" do
-    create(:language, :code => "en")
     create(:diary_entry, :title => "First Diary Entry")
     create_list(:diary_entry, 20) # rubocop:disable FactoryBot/ExcessiveCreateList
 


### PR DESCRIPTION
When working on something the other day, I noticed that the default setting for the diary entries factory (`create(:diary_entry)`) requires that a `Language` record for the English language exists in DB.

Should this be simplified? I am providing an option that is perhaps slightly hacky, but I think it works well for the use it gets in this codebase.