### PR TITLE
No clever assistance in input intended for URIs

### DIFF
--- a/app/views/oauth2_applications/_form.html.erb
+++ b/app/views/oauth2_applications/_form.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (f:) %>
 
 <%= f.text_field :name %>
-<%= f.text_area :redirect_uri %>
+<%= f.text_area :redirect_uri, :autocorrect => "off", :autocapitalize => "off" %>
 <%= f.form_group :confidential do %>
   <%= f.check_box :confidential %>
 <% end %>


### PR DESCRIPTION
This is the textarea to enter URIs for OAuth redirections. On iPhone, it attempts to autocapitalize/autocorrect the entered text. This is annoying as I'm not trying to enter human-readable text there!

<img width="300" height="534" alt="Textarea to provide redirect URIs for OAuth applications. It contains the word 'http', with a capitalised H" src="https://github.com/user-attachments/assets/04d82fdd-85ff-4e45-81b5-6f92705904e2" />

Unlikely to actually affect anyone, but I noticed it the other day while I was reviewing the accessibility of the page, so I'm providing a fix.