### PR TITLE
Use Contributor Terms wording in signup prompt

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,7 +301,7 @@ en:
         title: "Terms"
         heading: "Terms"
         heading_ct: "Contributor terms"
-        read and accept with tou: "Please read the contributor agreement and the terms of use, check both checkboxes when done and then press the continue button."
+        read and accept with tou: "Please read the Contributor Terms and the Terms of Use, check both checkboxes when done, and then press \"Continue\"."
         contributor_terms_explain: "This agreement governs the terms for your existing and future contributions."
         read_ct: "I have read and agree to the above contributor terms"
         tou_explain:


### PR DESCRIPTION
## Summary
- update the English signup prompt to use the same Contributor Terms wording used elsewhere
- keep the change limited to the user-facing string referenced in the issue

## Testing
- not run (locale/string-only change)

Closes #6972.