### PR TITLE
Clarify email privacy signup wording

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3183,7 +3183,7 @@ en:
         privacy_policy: privacy policy
         privacy_policy_url: https://osmfoundation.org/wiki/Privacy_Policy
         privacy_policy_title: OSMF privacy policy including section on email addresses
-        html: 'Your address is not displayed publicly, see our %{privacy_policy_link} for more information.'
+        html: 'Your email address will not be displayed publicly; see our %{privacy_policy_link} for more information.'
       or: "or"
       use external auth: "or sign up with a third party"
       verify_human: Verify you're a human


### PR DESCRIPTION
## Summary
- say "email address" instead of just "address" in the signup help text
- use future tense to match the behavior being described

## Testing
- not run (locale string change only)

Fixes #6971.