### PR TITLE
Take entrances into account for routing start and end points

### DIFF
--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -95,9 +95,20 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, marker, dragCallback, cha
     if (g1) endpoint.cachedReverseGeocode = g1;
   };
 
+  function findPreferredEntrance(entrances, types) {
+    if (!entrances) return null;
+
+    for (const t of types) {
+      const matchId = entrances.find(e => e.type === t);
+      if (matchId) return matchId;
+    }
+
+    return null;
+  }
+
   function getGeocode() {
     const viewbox = map.getBounds().toBBoxString(), // <sw lon>,<sw lat>,<ne lon>,<ne lat>
-          geocodeUrl = OSM.NOMINATIM_URL + "search?" + new URLSearchParams({ q: endpoint.value, format: "json", viewbox, limit: 1 });
+          geocodeUrl = OSM.NOMINATIM_URL + "search?" + new URLSearchParams({ q: endpoint.value, format: "json", viewbox, limit: 1, entrances: 1 });
 
     endpoint.geocodeRequest = new AbortController();
     fetch(geocodeUrl, { signal: endpoint.geocodeRequest.signal })
@@ -114,7 +125,7 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, marker, dragCallback, cha
         return;
       }
 
-      setLatLng(L.latLng(json[0]));
+      setLatLng(L.latLng(findPreferredEntrance(json[0].entrances, ["main", "yes"]) || json[0]));
 
       endpoint.value = json[0].display_name;
       input.val(json[0].display_name);


### PR DESCRIPTION
### Description

Nominatim has been able for a while to [return entrances](https://nominatim.org/2025/09/13/entrances.html)  of buildings and similiar way area features. This PR introduces entrance-awareness to the router UI: when searching for a place for the routing start and end points, it requests entrances from Nominatim. If suitable entrances (`main` or `yes`) come back, their location will be used for routing instead of the centroid of the feature.

I've kept the implementation fairly simple for now. Nominatim returns the full set of tags for each entrance. So one could do something much more elaborate by looking into level and access tags. For example, it would be nice to choose the right entrance for the choose mode of transportation. Right now I consider this just a starting point for creating a positive feedback loop between improved entrance tagging and the OSM UI. 

_Warning:_ the Nominatim servers currently only have entrances edited in the last six months but a reimport for all servers is imminent. If you want to test this locally, use poldi which is newly imported.

### How has this been tested?

Here is what a route from Berlin Airport to the center looks at the starting point before the change:

<img width="640" alt="entrances_before" src="https://github.com/user-attachments/assets/26f975c0-d7c1-4bef-acd9-9ee3d3daadc1" />

And here the same thing afterwards.

<img width="640" alt="entrances_after" src="https://github.com/user-attachments/assets/4e1eaf4b-a187-4b80-b02d-2bd0e3c30c82" />

No new unit tests added, sorry.