### PR TITLE
Use admin_level from extratags when classifying Nominatim search results

### DIFF
--- a/app/controllers/searches/nominatim_queries_controller.rb
+++ b/app/controllers/searches/nominatim_queries_controller.rb
@@ -33,16 +33,16 @@ module Searches
                         t "geocoder.search_osm_nominatim.prefix.#{klass}.#{type}", :default => type.tr("_", " ").capitalize
                       end
         if klass == "boundary" && type == "administrative"
-          rank = (place.attributes["address_rank"].to_i + 1) / 2
-          prefix_name = t "geocoder.search_osm_nominatim.admin_levels.level#{rank}", :default => prefix_name
           border_type = nil
           place_type = nil
+          admin_type = nil
           place_tags = %w[linked_place place]
           place.elements["extratags"].elements.each("tag") do |extratag|
             border_type = t "geocoder.search_osm_nominatim.border_types.#{extratag.attributes['value']}", :default => border_type if extratag.attributes["key"] == "border_type"
             place_type = t "geocoder.search_osm_nominatim.prefix.place.#{extratag.attributes['value']}", :default => place_type if place_tags.include?(extratag.attributes["key"])
+            admin_type = t "geocoder.search_osm_nominatim.admin_levels.level#{extratag.attributes['value']}", :default => admin_type if extratag.attributes["key"] == "admin_level"
           end
-          prefix_name = place_type || border_type || prefix_name
+          prefix_name = place_type || border_type || admin_type || prefix_name
         end
         prefix = t "geocoder.search_osm_nominatim.prefix_format", :name => prefix_name
         object_type = place.attributes["osm_type"]


### PR DESCRIPTION
### Description

One of the fallbacks for determining the category of a search result requires to know about the `admin_level`. So far this was guessed from the address rank which is not quite right. Nominatim now exports the original `admin_level` [in the extra tags](https://github.com/osm-search/Nominatim/issues/4019), so use that instead.

Fixes #6870.

### How has this been tested?

Only verified that "Sluis" from the original issue now reports as admin level 8:

<img width="452" height="500" alt="sluis" src="https://github.com/user-attachments/assets/07b3152c-bf55-4f5e-ad5c-1be9424ace00" />
