### PR TITLE
On-site notifications

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -56,7 +56,7 @@ Metrics/BlockNesting:
 # Offense count: 23
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 342
+  Max: 343
 
 # Offense count: 72
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -42,6 +42,7 @@ class Ability
         can :update, :account_terms
         can :create, :account_pd_declaration
         can :read, :dashboard
+        can :index, :notification
         can [:read, :update], [:preferences, :profile]
         can [:create, :subscribe, :unsubscribe], DiaryEntry
         can [:update, :hide, :unhide], DiaryEntry, :user => user

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class NotificationsController < ApplicationController
+  layout :site_layout
+
+  before_action :authorize_web
+  before_action :set_locale
+
+  authorize_resource :class => false
+
+  before_action :check_database_readable
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class NotificationsController < ApplicationController
+  include PaginationMethods
+
   layout :site_layout
 
   before_action :authorize_web
@@ -11,6 +13,8 @@ class NotificationsController < ApplicationController
   before_action :check_database_readable
 
   def index
-    @notifications = UserNotifications.new(current_user)
+    records = UserNotifications.new(current_user).notification_records
+    @notifications = get_page_items(records)
+    @params = params.permit
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -9,4 +9,8 @@ class NotificationsController < ApplicationController
   authorize_resource :class => false
 
   before_action :check_database_readable
+
+  def index
+    @notifications = UserNotifications.new(current_user)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,8 @@ class User < ApplicationRecord
 
   has_many :reports
 
+  has_many :notifications, :as => :recipient, :class_name => "Noticed::Notification"
+
   has_many :social_links
   accepts_nested_attributes_for :social_links, :allow_destroy => true
 

--- a/app/models/user_notifications.rb
+++ b/app/models/user_notifications.rb
@@ -50,6 +50,28 @@ class UserNotifications
     end
   end
 
+  class DiaryCommentNotification < Notification
+    delegate :body, :to => :record
+    delegate :diary_entry, :to => :record
+    delegate :title, :to => :diary_entry, :prefix => true
+
+    def commenter
+      record.user
+    end
+
+    def comment_id
+      record.id
+    end
+
+    def comment_body
+      record.body
+    end
+
+    def diary_author
+      diary_entry.user
+    end
+  end
+
   class NoteCommentNotification < Notification
     delegate :note, :to => :record
     delegate :event, :to => :record
@@ -76,6 +98,7 @@ class UserNotifications
 
   LISTABLE_NOTIFICATIONS = %w[
     ChangesetCommentNotifier::Notification
+    DiaryCommentNotifier::Notification
     NoteCommentNotifier::Notification
   ].freeze
 

--- a/app/models/user_notifications.rb
+++ b/app/models/user_notifications.rb
@@ -72,6 +72,10 @@ class UserNotifications
     end
   end
 
+  class NewFollowerNotification < Notification
+    delegate :follower, :to => :record
+  end
+
   class NoteCommentNotification < Notification
     delegate :note, :to => :record
     delegate :event, :to => :record
@@ -99,6 +103,7 @@ class UserNotifications
   LISTABLE_NOTIFICATIONS = %w[
     ChangesetCommentNotifier::Notification
     DiaryCommentNotifier::Notification
+    NewFollowerNotifier::Notification
     NoteCommentNotifier::Notification
   ].freeze
 

--- a/app/models/user_notifications.rb
+++ b/app/models/user_notifications.rb
@@ -72,6 +72,62 @@ class UserNotifications
     end
   end
 
+  class GpxImportFailureNotification < Notification
+    def timestamp
+      @notification.created_at
+    end
+
+    def trace_filename
+      @notification.params[:trace_name]
+    end
+
+    def trace_description
+      @notification.params[:trace_description]
+    end
+
+    def trace_tags
+      @notification.params[:trace_tags]
+    end
+
+    def trace_possible_points
+      nil
+    end
+
+    def trace_points
+      nil
+    end
+
+    def error
+      @notification.params[:error]
+    end
+  end
+
+  class GpxImportSuccessNotification < Notification
+    delegate :timestamp, :to => :record
+
+    def trace_filename
+      record.name
+    end
+
+    def trace_description
+      record.description
+    end
+
+    def trace_tags
+      record.tags.map(&:tag)
+    end
+
+    def trace_possible_points
+      @notification.params[:possible_points]
+    end
+
+    def trace_points
+      record.size
+    end
+
+    delegate :user, :to => :record
+  end
+
   class NewFollowerNotification < Notification
     delegate :follower, :to => :record
   end
@@ -103,6 +159,8 @@ class UserNotifications
   LISTABLE_NOTIFICATIONS = %w[
     ChangesetCommentNotifier::Notification
     DiaryCommentNotifier::Notification
+    GpxImportFailureNotifier::Notification
+    GpxImportSuccessNotifier::Notification
     NewFollowerNotifier::Notification
     NoteCommentNotifier::Notification
   ].freeze

--- a/app/models/user_notifications.rb
+++ b/app/models/user_notifications.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class UserNotifications
+  class Notification
+    def self.from(notification)
+      event_type_name = event_type_name_of(notification)
+      klass = "UserNotifications::#{event_type_name}Notification".constantize
+      klass.new(notification)
+    end
+
+    # Takes "ChangesetCommentNotifier::Notification", returns "ChangesetComment"
+    def self.event_type_name_of(notification)
+      notification.class.name.sub("Notifier::Notification", "")
+    end
+
+    def initialize(notification)
+      @notification = notification
+    end
+
+    delegate :record, :to => :@notification
+
+    def to_partial_path
+      event_type_name = self.class.event_type_name_of(@notification)
+      "notifications/#{event_type_name.underscore}"
+    end
+
+    def timestamp
+      record.created_at
+    end
+  end
+
+  include Enumerable
+
+  LISTABLE_NOTIFICATIONS = [].freeze
+
+  def initialize(user)
+    @user = user
+  end
+
+  def each(&)
+    @user
+      .notifications
+      .where(:type => LISTABLE_NOTIFICATIONS)
+      .newest_first
+      .map { |instance| Notification.from(instance) }
+      .each(&)
+  end
+
+  def empty?
+    none?
+  end
+end

--- a/app/models/user_notifications.rb
+++ b/app/models/user_notifications.rb
@@ -29,9 +29,32 @@ class UserNotifications
     end
   end
 
+  class ChangesetCommentNotification < Notification
+    delegate :changeset, :to => :record
+    delegate :id, :to => :changeset, :prefix => true
+
+    def changeset_summary
+      changeset.comment
+    end
+
+    def commenter
+      record.author
+    end
+
+    def comment_id
+      record.id
+    end
+
+    def comment_body
+      record.body
+    end
+  end
+
   include Enumerable
 
-  LISTABLE_NOTIFICATIONS = [].freeze
+  LISTABLE_NOTIFICATIONS = %w[
+    ChangesetCommentNotifier::Notification
+  ].freeze
 
   def initialize(user)
     @user = user

--- a/app/models/user_notifications.rb
+++ b/app/models/user_notifications.rb
@@ -50,10 +50,33 @@ class UserNotifications
     end
   end
 
+  class NoteCommentNotification < Notification
+    delegate :note, :to => :record
+    delegate :event, :to => :record
+    delegate :id, :to => :note, :prefix => true
+
+    def comment_body
+      record.body
+    end
+
+    def comment_id
+      record.id
+    end
+
+    def commenter
+      record.author
+    end
+
+    def note_text
+      note.description
+    end
+  end
+
   include Enumerable
 
   LISTABLE_NOTIFICATIONS = %w[
     ChangesetCommentNotifier::Notification
+    NoteCommentNotifier::Notification
   ].freeze
 
   def initialize(user)

--- a/app/models/user_notifications.rb
+++ b/app/models/user_notifications.rb
@@ -165,17 +165,18 @@ class UserNotifications
     NoteCommentNotifier::Notification
   ].freeze
 
+  def self.wrap(notification_records)
+    notification_records.map { |record| Notification.from(record) }
+  end
+
   def initialize(user)
     @user = user
   end
 
-  def each(&)
+  def notification_records(&)
     @user
       .notifications
       .where(:type => LISTABLE_NOTIFICATIONS)
-      .newest_first
-      .map { |instance| Notification.from(instance) }
-      .each(&)
   end
 
   def empty?

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -64,6 +64,7 @@
               <span class="badge count-number"><%= number_with_delimiter(current_user.new_messages.size) %></span>
             <% end %>
             <%= link_to t("users.show.my profile"), current_user, :class => "dropdown-item" %>
+            <%= link_to t("users.show.my_notifications"), notifications_path, :class => "dropdown-item" %>
             <%= link_to t("users.show.my_account"), account_path, :class => "dropdown-item" %>
             <%= link_to t("users.show.my_preferences"), basic_preferences_path, :class => "dropdown-item" %>
             <div class="dropdown-divider"></div>

--- a/app/views/notifications/_changeset_comment.html.erb
+++ b/app/views/notifications/_changeset_comment.html.erb
@@ -1,0 +1,53 @@
+<%# locals: (notification:) %>
+
+<article class="user-notification">
+  <div class="row align-items-center">
+    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
+      <%= link_to(
+            t(".headline"),
+            changeset_path(
+              notification.changeset,
+              :anchor => "c#{notification.comment_id}"
+            )
+          ) %>
+    </h2>
+    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(notification.timestamp) %></p>
+  </div>
+
+  <div class="row">
+    <div class="col-1 text-center">
+      <%= link_to(
+            user_thumbnail(notification.commenter, :class => "img-fluid"),
+            user_url(notification.commenter),
+            :target => "_blank", :rel => "noopener"
+          ) %>
+    </div>
+    <div class="col-11">
+      <p class="text-body-secondary mb-1 event-description">
+        <% if notification.changeset_summary %>
+          <%= t(
+                ".description_with_summary_html",
+                :commenter_name_with_link => link_to(
+                  notification.commenter.display_name,
+                  notification.commenter
+                ),
+                :changeset_id_with_link => link_to("##{notification.changeset_id}", notification.changeset),
+                :changeset_summary => notification.changeset_summary
+              ) %>
+        <% else %>
+          <%= t(
+                ".description_without_summary_html",
+                :commenter_name_with_link => link_to(
+                  notification.commenter.display_name,
+                  notification.commenter
+                ),
+                :changeset_id_with_link => link_to("##{notification.changeset_id}", notification.changeset)
+              ) %>
+        <% end %>
+      </p>
+      <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
+        <%= notification.comment_body.to_html %>
+      </blockquote>
+    </div>
+  </div>
+</article>

--- a/app/views/notifications/_diary_comment.html.erb
+++ b/app/views/notifications/_diary_comment.html.erb
@@ -1,0 +1,48 @@
+<%# locals: (notification:) %>
+
+<article class="user-notification">
+  <div class="row align-items-center">
+    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
+      <%= link_to(
+            t(".headline"),
+            diary_entry_path(
+              notification.diary_author,
+              notification.diary_entry,
+              :anchor => "c#{notification.comment_id}"
+            )
+          ) %>
+    </h2>
+    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(notification.timestamp) %></p>
+  </div>
+
+  <div class="row">
+    <div class="col-1 text-center">
+      <%= link_to(
+            user_thumbnail(notification.commenter, :class => "img-fluid"),
+            user_url(notification.commenter),
+            :target => "_blank", :rel => "noopener"
+          ) %>
+    </div>
+    <div class="col-11">
+      <p class="text-body-secondary mb-1">
+        <%= t(
+              ".description_html",
+              :commenter_name_with_link => link_to(
+                notification.commenter.display_name,
+                notification.commenter
+              ),
+              :diary_entry_title_with_link => link_to(
+                notification.diary_entry_title,
+                diary_entry_path(
+                  notification.diary_author,
+                  notification.diary_entry
+                )
+              )
+            ) %>
+      </p>
+      <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
+        <%= notification.comment_body.to_html %>
+      </blockquote>
+    </div>
+  </div>
+</article>

--- a/app/views/notifications/_gpx_details.html.erb
+++ b/app/views/notifications/_gpx_details.html.erb
@@ -1,0 +1,24 @@
+<%# locals: (notification:) %>
+
+<dl>
+  <dt><%= t(".filename") %></dt>
+  <dd><%= notification.trace_filename %></dd>
+
+  <dt><%= t(".description") %></dt>
+  <dd><%= notification.trace_description %></dd>
+
+  <% if notification.trace_tags.length.positive? %>
+    <dt><%= t(".tags") %></dt>
+    <dd><%= notification.trace_tags.join(", ") %></dd>
+  <% end %>
+
+  <% if notification.trace_possible_points %>
+    <dt><%= t(".total_points") %></dt>
+    <dd><%= notification.trace_possible_points %></dd>
+  <% end %>
+
+  <% if notification.trace_points %>
+    <dt><%= t(".imported_points") %></dt>
+    <dd><%= notification.trace_points %></dd>
+  <% end %>
+</dl>

--- a/app/views/notifications/_gpx_import_failure.html.erb
+++ b/app/views/notifications/_gpx_import_failure.html.erb
@@ -1,0 +1,23 @@
+<%# locals: (notification:) %>
+
+<article class="user-notification">
+  <div class="row align-items-center">
+    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
+      <%= t(".headline") %>
+    </h2>
+    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(notification.timestamp) %></p>
+  </div>
+
+  <div class="row">
+    <div class="col-1 text-center">
+      <span class="text-danger"></span>
+    </div>
+    <div class="col-4">
+      <%= render "notifications/gpx_details", :notification => notification %>
+    </div>
+    <dl class="col-7">
+      <dt><%= t(".error_message") %></dt>
+      <dd><pre><%= notification.error %></pre></dd>
+    </dl>
+  </div>
+</article>

--- a/app/views/notifications/_gpx_import_success.html.erb
+++ b/app/views/notifications/_gpx_import_success.html.erb
@@ -1,0 +1,29 @@
+<%# locals: (notification:) %>
+
+<article class="user-notification">
+  <div class="row align-items-center">
+    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
+      <%= link_to t(".headline"), show_trace_path(notification.user, notification.record) %>
+    </h2>
+    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(notification.timestamp) %></p>
+  </div>
+
+  <div class="row">
+    <div class="col-1 text-center">
+      <% if Settings.status != "gpx_offline" %>
+        <% if notification.record.inserted %>
+          <%= link_to trace_icon(notification.record),
+                      show_trace_path(notification.record.user, notification.record),
+                      :class => "d-inline-block" %>
+        <% else %>
+          <span class="text-danger"><%= t ".pending" %></span>
+        <% end %>
+      <% end %>
+    </div>
+    <div class="col-11">
+      <%= render "notifications/gpx_details", :notification => notification %>
+    </div>
+  </div>
+  <p class="col-3 text-center">
+  </p>
+</article>

--- a/app/views/notifications/_new_follower.html.erb
+++ b/app/views/notifications/_new_follower.html.erb
@@ -1,0 +1,33 @@
+<%# locals: (notification:) %>
+
+<article class="user-notification">
+  <div class="row align-items-center">
+    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold"><%= t(".headline") %></h2>
+    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(notification.timestamp) %></p>
+  </div>
+
+  <div class="row">
+    <div class="col-1 text-center">
+      <%= link_to(
+            user_thumbnail(notification.follower, :class => "img-fluid"),
+            user_url(notification.follower),
+            :target => "_blank", :rel => "noopener"
+          ) %>
+    </div>
+    <div class="col-11">
+      <p class="text-body-secondary mb-1">
+        <%= t(
+              ".description_html",
+              :follower_name_with_link => link_to(
+                notification.follower.display_name,
+                notification.follower
+              ),
+              :link => link_to(
+                t(".link_text"),
+                follow_url(notification.follower)
+              )
+            ) %>
+      </p>
+    </div>
+  </div>
+</article>

--- a/app/views/notifications/_note_comment.html.erb
+++ b/app/views/notifications/_note_comment.html.erb
@@ -1,0 +1,44 @@
+<%# locals: (notification:) %>
+
+<article class="user-notification">
+  <div class="row align-items-center">
+    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
+      <%= link_to(
+            t(".headline.#{notification.event}"),
+            note_path(
+              notification.note,
+              :anchor => "c#{notification.comment_id}"
+            )
+          ) %>
+    </h2>
+    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(notification.timestamp) %></p>
+  </div>
+
+  <div class="row">
+    <div class="col-1 text-center">
+      <%= link_to(
+            user_thumbnail(notification.commenter, :class => "img-fluid"),
+            user_url(notification.commenter),
+            :target => "_blank", :rel => "noopener"
+          ) %>
+    </div>
+    <div class="col-11">
+      <p class="text-body-secondary mb-1">
+      <%= t(
+            ".description.#{notification.event}_html",
+            :commenter_name_with_link => link_to(
+              notification.commenter.display_name,
+              notification.commenter
+            ),
+            :note_id_with_link => link_to("##{notification.note_id}", notification.note),
+            :note_text => notification.note_text
+          ) %>
+      </p>
+      <% if notification.comment_body.present? %>
+        <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
+          <%= notification.comment_body.to_html %>
+        </blockquote>
+      <% end %>
+    </div>
+  </div>
+</article>

--- a/app/views/notifications/_page.html.erb
+++ b/app/views/notifications/_page.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (notifications:, params:) %>
+
+<turbo-frame id="pagination" target="_top" data-turbo="false">
+  <% UserNotifications.wrap(notifications.items).each do |notification| %>
+    <%= render :partial => notification.to_partial_path, :object => notification, :as => :notification %>
+    <hr>
+  <% end %>
+
+  <%= render "pagination", :paginator => notifications, :params => params %>
+</turbo-frame>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :heading do %>
+  <h1><%= t ".title" %></h1>
+  <p class="mb-0">
+    <%= t(
+          ".point_to_preferences_html",
+          :link => link_to(t(".link_text"), notification_preferences_path)
+        ) %>
+  </p>
+<% end %>
+
+<p><%= t(".no_notifications") %></p>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -8,13 +8,8 @@
   </p>
 <% end %>
 
-<% if @notifications.empty? %>
+<% if @notifications.items.empty? %>
   <p><%= t(".no_notifications") %></p>
 <% else %>
-  <div class="container">
-    <% @notifications.each do |notification| %>
-      <%= render :partial => notification.to_partial_path, :object => notification, :as => :notification %>
-      <hr>
-    <% end %>
-  </div>
+  <%= render "page", :notifications => @notifications, :params => @params %>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -8,4 +8,13 @@
   </p>
 <% end %>
 
-<p><%= t(".no_notifications") %></p>
+<% if @notifications.empty? %>
+  <p><%= t(".no_notifications") %></p>
+<% else %>
+  <div class="container">
+    <% @notifications.each do |notification| %>
+      <%= render :partial => notification.to_partial_path, :object => notification, :as => :notification %>
+      <hr>
+    <% end %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,6 +615,15 @@ en:
       headline: Changeset comment
       description_with_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link} (\"%{changeset_summary}\")"
       description_without_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link}"
+    note_comment:
+      headline:
+        commented: Note comment
+        closed: Note resolved
+        reopened: Note reopened
+      description:
+        commented_html: "User %{commenter_name_with_link} left a comment on note %{note_id_with_link} (\"%{note_text}\")"
+        closed_html: "User %{commenter_name_with_link} resolved note %{note_id_with_link} (\"%{note_text}\")"
+        reopened_html: "User %{commenter_name_with_link} reopened note %{note_id_with_link} (\"%{note_text}\")"
   diary_entries:
     new:
       title: New Diary Entry

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,6 +615,18 @@ en:
       headline: Changeset comment
       description_with_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link} (\"%{changeset_summary}\")"
       description_without_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link}"
+    gpx_details:
+      filename: Filename
+      description: Description
+      tags: Tags
+      total_points: Total number of points
+      imported_points: Number of imported points
+    gpx_import_failure:
+      headline: GPS trace could not be imported
+      error_message: Error message
+    gpx_import_success:
+      headline: GPS trace imported successfully
+      description_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link} (\"%{changeset_text}\")"
     new_follower:
       headline: New follower
       description_html: "User %{follower_name_with_link} started following you. You can %{link} if you wish."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -624,6 +624,9 @@ en:
         commented_html: "User %{commenter_name_with_link} left a comment on note %{note_id_with_link} (\"%{note_text}\")"
         closed_html: "User %{commenter_name_with_link} resolved note %{note_id_with_link} (\"%{note_text}\")"
         reopened_html: "User %{commenter_name_with_link} reopened note %{note_id_with_link} (\"%{note_text}\")"
+    diary_comment:
+      headline: Diary comment
+      description_html: "User %{commenter_name_with_link} left a comment on diary entry \"%{diary_entry_title_with_link}\""
   diary_entries:
     new:
       title: New Diary Entry

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -611,6 +611,10 @@ en:
       no_notifications: You have no notifications at the moment
       point_to_preferences_html: "You can adjust how you receive notifications in %{link}."
       link_text: the preferences section
+    changeset_comment:
+      headline: Changeset comment
+      description_with_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link} (\"%{changeset_summary}\")"
+      description_without_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link}"
   diary_entries:
     new:
       title: New Diary Entry

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3130,6 +3130,11 @@ en:
         newer: Newer Entries
         oldest: Oldest Entries
         newest: Newest Entries
+      notifications:
+        older: Older Notifications
+        newer: Newer Notifications
+        oldest: Oldest Notifications
+        newest: Newest Notifications
       issues:
         older: Older Issues
         newer: Newer Issues

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,6 +615,10 @@ en:
       headline: Changeset comment
       description_with_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link} (\"%{changeset_summary}\")"
       description_without_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link}"
+    new_follower:
+      headline: New follower
+      description_html: "User %{follower_name_with_link} started following you. You can %{link} if you wish."
+      link_text: follow them back
     note_comment:
       headline:
         commented: Note comment

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -605,6 +605,12 @@ en:
       followed_diaries: "diary entries"
       nearby_changesets: "nearby user changesets"
       nearby_diaries: "nearby user diary entries"
+  notifications:
+    index:
+      title: Notifications
+      no_notifications: You have no notifications at the moment
+      point_to_preferences_html: "You can adjust how you receive notifications in %{link}."
+      link_text: the preferences section
   diary_entries:
     new:
       title: New Diary Entry
@@ -3226,6 +3232,7 @@ en:
       my traces: My Traces
       my notes: My Notes
       my messages: My Messages
+      my_notifications: My Notifications
       my profile: My Profile
       my_account: My Account
       my comments: My Comments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -356,6 +356,8 @@ OpenStreetMap::Application.routes.draw do
   get "/preferences", :to => redirect(:path => "/preferences/basic"), :as => nil
   get "/preferences/edit", :to => redirect(:path => "/preferences/basic"), :as => nil
 
+  resources :notifications, :only => [:index]
+
   # friendships
   scope "/user/:display_name" do
     resource :follow, :only => [:create, :destroy, :show], :path => "follow"

--- a/test/controllers/notifications/changeset_comment_view_test.rb
+++ b/test/controllers/notifications/changeset_comment_view_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Notifications
+  class ChangesetCommentViewTest < ActionView::TestCase
+    def test_render_without_summary
+      changeset_comment = build_stubbed(
+        :changeset_comment,
+        :body => "Insightful comment"
+      )
+      notification = build_stubbed(:notification, :record => changeset_comment)
+      notification_wrapper = UserNotifications::ChangesetCommentNotification.new(notification)
+
+      render "notifications/changeset_comment", :notification => notification_wrapper
+
+      assert_dom ".user-notification" do
+        assert_dom "h2", "Changeset comment"
+        assert_not_dom "p", /\("/
+        assert_dom "time", "less than 1 minute ago"
+        assert_dom "blockquote", "Insightful comment"
+      end
+    end
+
+    def test_render_with_summary
+      summary_tag = build_stubbed(
+        :changeset_tag,
+        :k => "comment",
+        :v => "This is a summary"
+      )
+      changeset = build_stubbed(:changeset, :changeset_tags => [summary_tag])
+      changeset_comment = build_stubbed(
+        :changeset_comment,
+        :changeset => changeset,
+        :body => "Insightful comment"
+      )
+      notification = build_stubbed(:notification, :record => changeset_comment)
+      notification_wrapper = UserNotifications::ChangesetCommentNotification.new(notification)
+
+      render "notifications/changeset_comment", :notification => notification_wrapper
+
+      assert_dom ".user-notification" do
+        assert_dom "h2", "Changeset comment"
+        assert_dom "time", "less than 1 minute ago"
+        assert_dom ".event-description", /\("This is a summary"\)/
+        assert_dom "blockquote", "Insightful comment"
+      end
+    end
+  end
+end

--- a/test/controllers/notifications/diary_comment_view_test.rb
+++ b/test/controllers/notifications/diary_comment_view_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Notifications
+  class DiaryCommentViewTest < ActionView::TestCase
+    def test_render
+      diary_comment = build_stubbed(:diary_comment)
+      notification = build_stubbed(:notification, :record => diary_comment)
+      notification_wrapper = UserNotifications::DiaryCommentNotification.new(notification)
+
+      render "notifications/diary_comment", :notification => notification_wrapper
+
+      assert_dom ".user-notification h2", "Diary comment"
+      assert_dom ".user-notification time", "less than 1 minute ago"
+      assert_dom ".user-notification blockquote", diary_comment.body
+    end
+  end
+end

--- a/test/controllers/notifications/gpx_import_failure_view_test.rb
+++ b/test/controllers/notifications/gpx_import_failure_view_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Notifications
+  class GpxImportFailureViewTest < ActionView::TestCase
+    def test_render
+      notification = build_stubbed(
+        :notification,
+        :notifier_class => GpxImportFailureNotifier,
+        :notifier_params => {
+          :trace_name => "random-file.jpg",
+          :trace_description => "Random file",
+          :trace_tags => %w[random file],
+          :error => "Ooops, wrong file"
+        }
+      )
+
+      notification_wrapper = UserNotifications::GpxImportFailureNotification.new(notification)
+
+      render "notifications/gpx_import_failure", :notification => notification_wrapper
+
+      assert_dom ".user-notification h2", "GPS trace could not be imported"
+      assert_dom ".user-notification time", "less than 1 minute ago"
+      assert_dom ".user-notification dd", "random-file.jpg"
+      assert_dom ".user-notification dd", "Random file"
+      assert_dom ".user-notification dd", "random, file"
+      assert_dom ".user-notification pre", "Ooops, wrong file"
+    end
+  end
+end

--- a/test/controllers/notifications/gpx_import_success_view_test.rb
+++ b/test/controllers/notifications/gpx_import_success_view_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Notifications
+  class GpxImportSuccessViewTest < ActionView::TestCase
+    def test_render
+      trace = build_stubbed(
+        :trace,
+        :name => "test-trace-file.gpx",
+        :description => "Test trace file"
+      )
+      notification = build_stubbed(
+        :notification,
+        :record => trace,
+        :notifier_class => GpxImportSuccessNotifier,
+        :notifier_params => {
+          :possible_points => 5
+        }
+      )
+
+      notification_wrapper = UserNotifications::GpxImportSuccessNotification.new(notification)
+
+      render "notifications/gpx_import_success", :notification => notification_wrapper
+
+      assert_dom ".user-notification h2", "GPS trace imported successfully"
+      assert_dom ".user-notification time", "less than 1 minute ago"
+      assert_dom ".user-notification dd", "test-trace-file.gpx"
+      assert_dom ".user-notification dd", "Test trace file"
+      assert_dom ".user-notification dd", "5"
+    end
+  end
+end

--- a/test/controllers/notifications/new_follower_view_test.rb
+++ b/test/controllers/notifications/new_follower_view_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Notifications
+  class NewFollowerViewTest < ActionView::TestCase
+    def test_render
+      follower = build_stubbed(:user, :display_name => "Follower")
+      follow = build_stubbed(:follow, :follower => follower)
+
+      notification = build_stubbed(:notification, :record => follow, :notifier_class => NewFollowerNotifier)
+      notification_wrapper = UserNotifications::NewFollowerNotification.new(notification)
+
+      render "notifications/new_follower", :notification => notification_wrapper
+
+      assert_dom ".user-notification h2", "New follower"
+      assert_dom ".user-notification time", "less than 1 minute ago"
+      assert_dom ".user-notification p", "User Follower started following you. You can follow them back if you wish."
+    end
+  end
+end

--- a/test/controllers/notifications/note_comment_view_test.rb
+++ b/test/controllers/notifications/note_comment_view_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Notifications
+  class NoteCommentViewTest < ActionView::TestCase
+    def test_render_commented
+      note_comment = build_stubbed(
+        :note_comment,
+        :author => build_stubbed(:user),
+        :event => "commented"
+      )
+      notification = build_stubbed(:notification, :record => note_comment)
+      notification_wrapper = UserNotifications::NoteCommentNotification.new(notification)
+
+      render "notifications/note_comment", :notification => notification_wrapper
+
+      assert_dom ".user-notification h2", "Note comment"
+      assert_dom ".user-notification time", "less than 1 minute ago"
+      assert_dom ".user-notification blockquote", note_comment.body
+    end
+
+    def test_render_closed_with_comment
+      comment_author = build_stubbed(
+        :user,
+        :display_name => "Helpful Commenter"
+      )
+      note = build_stubbed(:note)
+      note_comment = build_stubbed(
+        :note_comment,
+        :author => comment_author,
+        :note => note,
+        :event => "closed"
+      )
+      notification = build_stubbed(:notification, :record => note_comment)
+      notification_wrapper = UserNotifications::NoteCommentNotification.new(notification)
+
+      render "notifications/note_comment", :notification => notification_wrapper
+
+      assert_dom ".user-notification h2", "Note resolved"
+      assert_dom ".user-notification time", "less than 1 minute ago"
+      assert_dom ".user-notification blockquote", note_comment.body
+    end
+
+    def test_render_closed_without_comment
+      comment_author = build_stubbed(
+        :user,
+        :display_name => "Helpful Commenter"
+      )
+      note = build_stubbed(:note)
+      note_comment = build_stubbed(
+        :note_comment,
+        :author => comment_author,
+        :note => note,
+        :event => "closed",
+        :body => ""
+      )
+      notification = Struct.new(:record).new(note_comment)
+      notification_wrapper = UserNotifications::NoteCommentNotification.new(notification)
+
+      render "notifications/note_comment", :notification => notification_wrapper
+
+      assert_dom ".user-notification h2", "Note resolved"
+      assert_dom ".user-notification time", "less than 1 minute ago"
+      assert_not_dom ".user-notification blockquote"
+    end
+
+    def test_render_reopened
+      comment_author = build_stubbed(
+        :user,
+        :display_name => "Helpful Commenter"
+      )
+      note = build_stubbed(:note)
+      note_comment = build_stubbed(
+        :note_comment,
+        :author => comment_author,
+        :note => note,
+        :event => "reopened",
+        :body => ""
+      )
+      notification = Struct.new(:record).new(note_comment)
+      notification_wrapper = UserNotifications::NoteCommentNotification.new(notification)
+
+      render "notifications/note_comment", :notification => notification_wrapper
+
+      assert_dom ".user-notification h2", "Note reopened"
+      assert_dom ".user-notification time", "less than 1 minute ago"
+      assert_not_dom ".user-notification blockquote"
+    end
+  end
+end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  def test_routes
+    assert_routing(
+      { :path => "/notifications", :method => :get },
+      { :controller => "notifications", :action => "index" }
+    )
+  end
+
+  def test_index
+    session_for(create(:user))
+    get notifications_path
+
+    assert_response :success
+    assert_template "index"
+  end
+
+  def test_index_unauthorized
+    get notifications_path
+
+    assert_redirected_to login_path(:referer => notifications_path)
+  end
+end

--- a/test/factories/notifications.rb
+++ b/test/factories/notifications.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :notification, :class => "ApplicationNotifier::Notification" do
+    initialize_with do
+      notifier_class = self.notifier_class || "#{record.class.name}Notifier".constantize
+      notification_class = notifier_class::Notification
+      notification_class.new
+    end
+
+    recipient :factory => :user
+
+    event do
+      association :notifier, :record => record, :notifier_class => notifier_class, :params => notifier_params
+    end
+
+    transient do
+      record { nil }
+      notifier_class { nil }
+      notifier_params { nil }
+    end
+  end
+
+  factory :notifier, :class => "ApplicationNotifier" do
+    initialize_with do
+      notifier_class = self.notifier_class || "#{record.class.name}Notifier".constantize
+      notifier_class.new(:record => record)
+    end
+
+    transient do
+      notifier_class { nil }
+    end
+  end
+
   factory :changeset_comment_notification, :class => "ChangesetCommentNotifier::Notification" do
     event :factory => :changeset_comment_notifier
     recipient :factory => :user

--- a/test/system/web_notifications_test.rb
+++ b/test/system/web_notifications_test.rb
@@ -32,6 +32,31 @@ class WebNotificationsTest < ApplicationSystemTestCase
     assert_text "User Commenter left a comment on changeset"
   end
 
+  test "pagination" do
+    changeset_author = create(:user)
+    commenter = create(:user, :display_name => "Commenter")
+    1.upto(30).each do |i|
+      setup_changeset_comment(
+        :changeset_author => changeset_author,
+        :commenter => commenter,
+        :comment_attrs => {
+          :body => "This is comment number #{i}"
+        }
+      )
+    end
+
+    sign_in_as(changeset_author)
+
+    click_on changeset_author.display_name
+    click_on "My Notifications"
+
+    assert_text "This is comment number 30"
+    assert_no_text "This is comment number 10"
+    click_on "Older Notifications"
+    assert_no_text "This is comment number 30"
+    assert_text "This is comment number 10"
+  end
+
   private
 
   def setup_changeset_comment(changeset_author:, commenter:, comment_attrs: {})

--- a/test/system/web_notifications_test.rb
+++ b/test/system/web_notifications_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class WebNotificationsTest < ApplicationSystemTestCase
+  test "no notifications available" do
+    user = create(:user)
+    sign_in_as(user)
+
+    click_on user.display_name
+    click_on "My Notifications"
+
+    assert_text "Notifications"
+    assert_text "You have no notifications"
+  end
+end

--- a/test/system/web_notifications_test.rb
+++ b/test/system/web_notifications_test.rb
@@ -13,4 +13,33 @@ class WebNotificationsTest < ApplicationSystemTestCase
     assert_text "Notifications"
     assert_text "You have no notifications"
   end
+
+  test "read latest notifications" do
+    changeset_author = create(:user)
+    commenter = create(:user, :display_name => "Commenter")
+    setup_changeset_comment(
+      :changeset_author => changeset_author,
+      :commenter => commenter
+    )
+
+    sign_in_as(changeset_author)
+
+    click_on changeset_author.display_name
+    click_on "My Notifications"
+
+    assert_text "Notifications"
+    assert_text "Changeset comment"
+    assert_text "User Commenter left a comment on changeset"
+  end
+
+  private
+
+  def setup_changeset_comment(changeset_author:, commenter:, comment_attrs: {})
+    changeset = create(:changeset, :user => changeset_author)
+    create(:changeset_subscription, :changeset => changeset, :subscriber => changeset_author)
+
+    comment = create(:changeset_comment, :changeset => changeset, :author => commenter, **comment_attrs)
+    create(:changeset_subscription, :changeset => changeset, :subscriber => commenter)
+    ChangesetCommentNotifier.with(:record => comment).deliver
+  end
 end


### PR DESCRIPTION
Partially addresses https://github.com/openstreetmap/openstreetmap-website/issues/7018

This implements on-site notifications. The risk of scope creep is high on a feature like this, so I have kept it intentionally simple. It can be improved over time, as we learn more.

To see it in action, you can visit https://pablobm.apis.dev.openstreetmap.org/notifications (credentials: `mapper`//`password`). As of writing these lines, all types of notifications are present and it should look a bit like this:

<img width="1816" height="4134" alt="The proposed Notifications page, showing a list of notifications: changeset comments, note comments, new followers, etc" src="https://github.com/user-attachments/assets/893d8907-ef78-48fa-9eef-ee79169f8a24" />

Notifications are listed in a dedicated page so that client apps (eg: JOSM) can easily link to them.

What is not implemented:
- Marking notifications as seen/read. That's its own can of design worms.
- Similarly, any indication (number, red dot, etc) that there are unseen/unread notifications.
- Any means to delete/hide notifications.
- Hiding notifications that refer to items that have been made invisible (eg: a note was hidden). An email notification won't disappear from your inbox just because it refers to something that was removed, so it's not super important to do it here immediately.
- Dealing with N+1 queries. I am not sure that it's worth it, with 20 items per page and 6 different types of content. Perhaps fragment caching would be better here, but I think this should be done separately.
- Showing only an excerpt of potentially large pieces of text (eg: long diary comment). Again, several approaches are possible, so let's discuss it separately.

The design can also lend itself to a lot of discussion. I gave it a few iterations and ended up with something that I think works, even if it can be improved over time.
