### PR TITLE
Remove dark mode filter CSS

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -13,7 +13,6 @@ $bootstrap-icons-font-dir: "bootstrap-icons/font/fonts";
 
 body {
   font-size: $typeheight;
-  --dark-mode-map-filter: none;
 }
 
 time[title] {
@@ -414,27 +413,6 @@ nav.primary, nav.secondary {
 
   .leaflet-control-scale-line {
     border-color: rgba(var(--bs-light-rgb), .75) !important;
-  }
-}
-
-@mixin dark-map-color-scheme {
-  .leaflet-tile-container,
-  #legend .filtered-image {
-    filter: var(--dark-mode-map-filter);
-  }
-
-  .leaflet-tile-container .leaflet-tile {
-    filter: none;
-  }
-}
-
-body[data-map-theme="dark"] {
-  @include dark-map-color-scheme;
-}
-
-@include color-mode(dark) {
-  body:not([data-map-theme]) {
-    @include dark-map-color-scheme;
   }
 }
 

--- a/app/views/legend_panes/show.html.erb
+++ b/app/views/legend_panes/show.html.erb
@@ -6,9 +6,9 @@
           <% description = entry["name"].map { |feature_name| t ".entries.#{feature_name}" }.join(" · ") %>
           <td>
             <% if entry["image"] %>
-              <%= image_tag "legend/#{layer_name}/#{entry['image']}", :class => "filtered-image d-block mx-auto", :alt => description %>
+              <%= image_tag "legend/#{layer_name}/#{entry['image']}", :class => "d-block mx-auto", :alt => description %>
             <% else %>
-              <%= legend_svg_tag :class => "filtered-image d-block mx-auto", **entry, :title => description %>
+              <%= legend_svg_tag :class => "d-block mx-auto", **entry, :title => description %>
             <% end %>
           </td>
           <td><%= description %></td>


### PR DESCRIPTION
This controversial addition won't work with maplibre in this implementation anyway, and it is practically unused nowadays.