### PR TITLE
Update bundler to v4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1036,4 +1036,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.6.2
+   4.0.10


### PR DESCRIPTION
This updates bundler to v4 mostly to get rid of a lot of noisy warnings when using v2 with ruby 4.