### PR TITLE
Add validation of report parameters

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,12 +12,11 @@ class ReportsController < ApplicationController
   before_action :check_database_writable, :only => [:new, :create]
 
   def new
-    if required_new_report_params_present?
-      @report = Report.new
-      @report.issue = Issue.find_or_initialize_by(create_new_report_params)
-    else
-      head :bad_request
-    end
+    return head :bad_request unless required_new_report_params_present?
+    return redirect_to root_url, :warning => t(".invalid_report_params") unless new_report_params_valid?
+
+    @report = Report.new
+    @report.issue = Issue.find_or_initialize_by(create_new_report_params)
   end
 
   def create
@@ -44,6 +43,16 @@ class ReportsController < ApplicationController
 
   def required_new_report_params_present?
     create_new_report_params["reportable_id"].present? && create_new_report_params["reportable_type"].present?
+  end
+
+  def new_report_params_valid?
+    id = create_new_report_params["reportable_id"]
+    type = create_new_report_params["reportable_type"]
+
+    (type == "DiaryComment" && DiaryComment.exists?(id)) ||
+      (type == "DiaryEntry" && DiaryEntry.exists?(id)) ||
+      (type == "Note" && Note.exists?(id)) ||
+      (type == "User" && User.exists?(id))
   end
 
   def create_new_report_params

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1709,6 +1709,7 @@ en:
           personal_label: This note contains personal data
           abusive_label: This note is abusive
           other_label: Other
+      invalid_report_params: The item you are trying to report could not be found
     create:
       successful_report: Your report has been registered successfully
       provide_details: Please provide the required details

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -10,6 +10,21 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
     assert_response :bad_request
   end
 
+  def test_new_invalid_parameters
+    target_user = create(:user)
+    session_for(target_user)
+
+    # Invalid id
+    get new_report_path(:reportable_id => target_user.id + 1, :reportable_type => "User")
+    assert_redirected_to root_path
+    assert_match(/The item you are trying to report could not be found/, flash[:warning])
+
+    # Invalid type
+    get new_report_path(:reportable_id => target_user.id, :reportable_type => "Users")
+    assert_redirected_to root_path
+    assert_match(/The item you are trying to report could not be found/, flash[:warning])
+  end
+
   def test_new_report_without_login
     target_user = create(:user)
     get new_report_path(:reportable_id => target_user.id, :reportable_type => "User")


### PR DESCRIPTION
Fixes #6970

Adds validation of the id and type parameters when creating a new report. 

Previously, if you tried to report a nonexistent user or entry, you would be taken to a confusing page where you are reporting "/reports/new". Now, if the type or id are invalid, the user gets redirected to the main page and a warning popup telling the user "The item you are trying to report could not be found".

This situation is hard to run across from the typical user flow, but it's still good to protect against.