### PR TITLE
Add previous/next entry navigation to diary pages #6901

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/rails/devcontainer/features/activestorage": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/rails/devcontainer/features/activestorage@sha256:7fa8fff898ac33076ebf65631d3c6c902dc9bad87de3e5dfa645f3e2d7a35c07",
+      "integrity": "sha256:7fa8fff898ac33076ebf65631d3c6c902dc9bad87de3e5dfa645f3e2d7a35c07"
+    },
+    "ghcr.io/rails/devcontainer/features/postgres-client": {
+      "version": "1.2.0",
+      "resolved": "ghcr.io/rails/devcontainer/features/postgres-client@sha256:7e6b118646d6e0d82a9ec06e81ad1b5406f7042f0279d35fff3a7a612be7a050",
+      "integrity": "sha256:7e6b118646d6e0d82a9ec06e81ad1b5406f7042f0279d35fff3a7a612be7a050"
+    }
+  }
+}

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -71,6 +71,10 @@ class DiaryEntriesController < ApplicationController
         "article:published_time" => @diary_entry.created_at.xmlschema
       }
       @comments = can?(:unhide, DiaryComment) ? @diary_entry.comments : @diary_entry.visible_comments
+
+      # find the previous and next entries for the user, if they exist
+      @prev_entry = entries.where(DiaryEntry.arel_table[:id].lt(@diary_entry.id)).order(:id => :desc).first
+      @next_entry = entries.where(DiaryEntry.arel_table[:id].gt(@diary_entry.id)).order(:id => :asc).first
     else
       @title = t "diary_entries.no_such_entry.title", :id => params[:id]
       render :action => "no_such_entry", :status => :not_found

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -17,6 +17,15 @@
 <%= render @diary_entry, :user => @user, :truncated => false %>
 <%= share_buttons(:title => @diary_entry.title, :url => diary_entry_url(@diary_entry.user, @diary_entry)) %>
 
+<nav class="d-flex justify-content-between mb-3">
+  <div>
+      <button class="btn btn-outline-secondary">Previous Entry</button>
+  </div>
+  <div>
+      <button class="btn btn-outline-secondary">Next Entry</button>
+  </div>
+</nav>
+
 <div id="comments" class="comments mb-3 overflow-hidden">
   <div class="row border-bottom border-secondary-subtle">
     <h2 class="col"><%= t(".discussion") %></h2>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -17,18 +17,18 @@
 <%= render @diary_entry, :user => @user, :truncated => false %>
 <%= share_buttons(:title => @diary_entry.title, :url => diary_entry_url(@diary_entry.user, @diary_entry)) %>
 
-<nav class="diary-entry-navigation d-flex justify-content-between mb-3">
+<nav class="d-flex justify-content-between mb-3 pagination">
   <div>
     <% if @prev_entry %>
-      <%= link_to diary_entry_path(@user, @prev_entry), :class => "btn btn-outline-secondary" do %>
-      &laquo; <%= t(".previous_entry") %>
+      <%= link_to diary_entry_path(@user, @prev_entry), :class => "btn btn-outline-primary btn-sm" do %>
+      &lsaquo; <%= t(".previous_entry") %>
       <% end %>
     <% end %>
   </div>
   <div>
     <% if @next_entry %>
-      <%= link_to diary_entry_path(@user, @next_entry), :class => "btn btn-outline-secondary" do %>
-      <%= t(".next_entry") %> &raquo;
+      <%= link_to diary_entry_path(@user, @next_entry), :class => "btn btn-outline-primary btn-sm" do %>
+      <%= t(".next_entry") %> &rsaquo;
       <% end %>
     <% end %>
   </div>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -17,7 +17,7 @@
 <%= render @diary_entry, :user => @user, :truncated => false %>
 <%= share_buttons(:title => @diary_entry.title, :url => diary_entry_url(@diary_entry.user, @diary_entry)) %>
 
-<nav class="d-flex justify-content-between mb-3">
+<nav class="diary-entry-navigation d-flex justify-content-between mb-3">
   <div>
     <% if @prev_entry %>
       <%= link_to diary_entry_path(@user, @prev_entry), :class => "btn btn-outline-secondary" do %>

--- a/app/views/diary_entries/show.html.erb
+++ b/app/views/diary_entries/show.html.erb
@@ -19,10 +19,18 @@
 
 <nav class="d-flex justify-content-between mb-3">
   <div>
-      <button class="btn btn-outline-secondary">Previous Entry</button>
+    <% if @prev_entry %>
+      <%= link_to diary_entry_path(@user, @prev_entry), :class => "btn btn-outline-secondary" do %>
+      &laquo; <%= t(".previous_entry") %>
+      <% end %>
+    <% end %>
   </div>
   <div>
-      <button class="btn btn-outline-secondary">Next Entry</button>
+    <% if @next_entry %>
+      <%= link_to diary_entry_path(@user, @next_entry), :class => "btn btn-outline-secondary" do %>
+      <%= t(".next_entry") %> &raquo;
+      <% end %>
+    <% end %>
   </div>
 </nav>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -628,6 +628,8 @@ en:
       leave_a_comment: "Leave a comment"
       login_to_leave_a_comment_html: "%{login_link} to leave a comment"
       login: "Log in"
+      previous_entry: "Previous Entry"
+      next_entry: "Next Entry"
     no_such_entry:
       title: "No such diary entry"
       heading: "No entry with the id: %{id}"

--- a/test/controllers/diary_entries_controller_test.rb
+++ b/test/controllers/diary_entries_controller_test.rb
@@ -956,6 +956,47 @@ class DiaryEntriesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_show_with_previous_and_next_links
+    user = create(:user)
+
+    entry1 = create(:diary_entry, :user => user)
+    entry2 = create(:diary_entry, :user => user)
+    entry3 = create(:diary_entry, :user => user)
+
+    get diary_entry_path(user.display_name, entry2)
+
+    assert_response :success
+
+    assert_select "nav.diary-entry-navigation a[href=?]", diary_entry_path(user.display_name, entry1)
+    assert_select "nav.diary-entry-navigation a[href=?]", diary_entry_path(user.display_name, entry3)
+  end
+
+  def test_show_without_previous_link_for_first_entry
+    user = create(:user)
+
+    entry1 = create(:diary_entry, :user => user)
+    entry2 = create(:diary_entry, :user => user)
+
+    get diary_entry_path(user.display_name, entry1)
+
+    assert_response :success
+
+    assert_select "nav.diary-entry-navigation a[href=?]", diary_entry_path(user.display_name, entry2)
+  end
+
+  def test_show_without_next_link_for_last_entry
+    user = create(:user)
+
+    entry1 = create(:diary_entry, :user => user)
+    entry2 = create(:diary_entry, :user => user)
+
+    get diary_entry_path(user.display_name, entry2)
+
+    assert_response :success
+
+    assert_select "nav.diary-entry-navigation a[href=?]", diary_entry_path(user.display_name, entry1)
+  end
+
   private
 
   def check_diary_index(*entries)


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
Addresses #6901 — diary pages currently have no previous/next navigation, requiring users to return to the diary overview to move between entries.

This PR adds a navigation bar above the comments section with Previous Entry and Next Entry links. The links are conditionally rendered. If there is no previous or next entry, the corresponding button is hidden.

The adjacent entries are looked up in the controller using the diary entry's ID to find the nearest entry before and after in the same user's diary.

### How has this been tested?
Manually verified the nav bar renders correctly above the comments section on a diary entry page. 
Three test cases were added to the diary entries controller test:
- Middle entry shows both previous and next links
- First entry shows only a next link
- Last entry shows only a previous link

### Screenshot
<img width="986" height="284" alt="Screenshot 2026-05-16 232748" src="https://github.com/user-attachments/assets/05eff0d0-bc64-4003-9503-3f93314c079f" />
