### PR TITLE
Refactor more of the internal coordiante usage to `{ lat, lng }`

### DIFF
--- a/app/assets/javascripts/index/contextmenu.js
+++ b/app/assets/javascripts/index/contextmenu.js
@@ -20,15 +20,13 @@ OSM.initializations.push(function (map) {
     return $input.val();
   };
 
-  const latLngFromContext = () =>
-    L.latLng($contextMenu.data("lat"), $contextMenu.data("lng"));
+  const latLngFromContext = () => L.latLng($contextMenu.data("lat"), $contextMenu.data("lng"));
 
-  const croppedLatLon = () =>
-    OSM.cropLocation(latLngFromContext(), map.getZoom());
+  const croppedLatLng = () => OSM.cropLocation(latLngFromContext(), map.getZoom());
 
   const routeWithLatLon = (path, extraParams = {}) => {
-    const [lat, lon] = croppedLatLon();
-    OSM.router.route(`${path}?` + new URLSearchParams({ lat, lon, ...extraParams }));
+    const { lat, lng } = croppedLatLng();
+    OSM.router.route(`${path}?` + new URLSearchParams({ lat, lon: lng, ...extraParams }));
   };
 
   const contextmenuItems = [
@@ -37,8 +35,9 @@ OSM.initializations.push(function (map) {
       icon: "bi-cursor",
       text: OSM.i18n.t("javascripts.context.directions_from"),
       callback: () => {
+        const { lat, lng } = croppedLatLng();
         const params = new URLSearchParams({
-          from: croppedLatLon().join(","),
+          from: `${lat},${lng}`,
           to: getDirectionsCoordinates($("#route_to"))
         });
         OSM.router.route(`/directions?${params}`);
@@ -49,9 +48,10 @@ OSM.initializations.push(function (map) {
       icon: "bi-flag",
       text: OSM.i18n.t("javascripts.context.directions_to"),
       callback: () => {
+        const { lat, lng } = croppedLatLng();
         const params = new URLSearchParams({
           from: getDirectionsCoordinates($("#route_from")),
-          to: croppedLatLon().join(",")
+          to: `${lat},${lng}`
         });
         OSM.router.route(`/directions?${params}`);
       }

--- a/app/assets/javascripts/index/directions-endpoint.js
+++ b/app/assets/javascripts/index/directions-endpoint.js
@@ -20,7 +20,8 @@ OSM.DirectionsEndpoint = function Endpoint(map, input, marker, dragCallback, cha
   };
 
   function markerDragListener(e) {
-    const latlng = L.latLng(OSM.cropLocation(e.target.getLatLng(), map.getZoom()));
+    const { lat, lng } = OSM.cropLocation(e.target.getLatLng(), map.getZoom());
+    const latlng = L.latLng(lat, lng);
 
     if (endpoint.geocodeRequest) endpoint.geocodeRequest.abort();
     delete endpoint.geocodeRequest;

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -5,7 +5,7 @@
 
 OSM.Directions = function (map) {
   let controller = null; // the AbortController for the current route request if a route request is in progress
-  let lastLocation = [];
+  let lastLocation = null;
   let chosenEngine;
 
   let sidebarReadyPromise = null;
@@ -185,21 +185,21 @@ OSM.Directions = function (map) {
     }
   });
 
-  function sendstartinglocation({ latlng: { lat, lng } }) {
-    map.fire("startinglocation", { latlng: [lat, lng] });
+  function sendstartinglocation({ lat, lng }) {
+    map.fire("startinglocation", { lat, lng });
   }
 
-  function startingLocationListener({ latlng }) {
+  function startingLocationListener({ lat, lng }) {
     if (endpoints[0].value) return;
 
-    endpoints[0].setValue(latlng.join(", "));
+    endpoints[0].setValue(`${lat}, ${lng}`);
   }
 
-  map.on("locationfound", ({ latlng: { lat, lng } }) =>
-    lastLocation = [lat, lng]
-  ).on("locateactivate", () => {
-    map.once("startinglocation", startingLocationListener);
-  });
+  map
+    .on("locationfound", ({ latlng: { lat, lng } }) => lastLocation = { lat, lng })
+    .on("locateactivate", () => {
+      map.once("startinglocation", startingLocationListener);
+    });
 
   function initializeFromParams() {
     const params = new URLSearchParams(location.search),
@@ -207,7 +207,8 @@ OSM.Directions = function (map) {
 
     if (params.has("engine")) setEngine(params.get("engine"));
 
-    endpoints[0].setValue(params.get("from") || route[0] || lastLocation.join(", "));
+    const lastLocationAsString = lastLocation ? `${lastLocation.lat}, ${lastLocation.lng}` : "";
+    endpoints[0].setValue(params.get("from") || route[0] || lastLocationAsString);
     endpoints[1].setValue(params.get("to") || route[1] || "");
   }
 
@@ -229,9 +230,9 @@ OSM.Directions = function (map) {
       pt.y += 20;
 
       const ll = map.containerPointToLatLng(pt);
-      const llWithPrecision = OSM.cropLocation(ll, map.getZoom());
+      const { lat, lng } = OSM.cropLocation(ll, map.getZoom());
 
-      endpoints[type === "from" ? 0 : 1].setValue(llWithPrecision.join(", "));
+      endpoints[type === "from" ? 0 : 1].setValue(`${lat}, ${lng}`);
     });
 
     map.on("locationfound", sendstartinglocation);

--- a/app/assets/javascripts/index/directions.js
+++ b/app/assets/javascripts/index/directions.js
@@ -185,7 +185,7 @@ OSM.Directions = function (map) {
     }
   });
 
-  function sendstartinglocation({ lat, lng }) {
+  function sendStartingLocation({ lat, lng }) {
     map.fire("startinglocation", { lat, lng });
   }
 
@@ -235,7 +235,7 @@ OSM.Directions = function (map) {
       endpoints[type === "from" ? 0 : 1].setValue(`${lat}, ${lng}`);
     });
 
-    map.on("locationfound", sendstartinglocation);
+    map.on("locationfound", sendStartingLocation);
 
     endpoints[0].enableListeners();
     endpoints[1].enableListeners();
@@ -274,7 +274,7 @@ OSM.Directions = function (map) {
 
     $("#sidebar .sidebar-close-controls button").off("click", closeButtonListener);
     $("#map").off("dragend dragover drop");
-    map.off("locationfound", sendstartinglocation);
+    map.off("locationfound", sendStartingLocation);
 
     endpoints[0].disableListeners();
     endpoints[1].disableListeners();

--- a/app/assets/javascripts/index/export.js
+++ b/app/assets/javascripts/index/export.js
@@ -10,8 +10,8 @@ OSM.Export = function (map) {
 
   function getBounds() {
     return L.latLngBounds(
-      L.latLng($("#minlat").val(), $("#minlon").val()),
-      L.latLng($("#maxlat").val(), $("#maxlon").val()));
+      { lat: $("#minlat").val(), lng: $("#minlon").val() },
+      { lat: $("#maxlat").val(), lng: $("#maxlon").val() });
   }
 
   function boundsChanged() {
@@ -60,16 +60,15 @@ OSM.Export = function (map) {
   }
 
   function setBounds(bounds) {
-    const truncated = [bounds.getSouthWest(), bounds.getNorthEast()]
-      .map(c => OSM.cropLocation(c, map.getZoom()));
-    $("#minlon").val(truncated[0][1]);
-    $("#minlat").val(truncated[0][0]);
-    $("#maxlon").val(truncated[1][1]);
-    $("#maxlat").val(truncated[1][0]);
+    const sw = OSM.cropLocation(bounds.getSouthWest(), map.getZoom());
+    $("#minlon").val(sw.lng);
+    $("#minlat").val(sw.lat);
+    const ne = OSM.cropLocation(bounds.getNorthEast(), map.getZoom());
+    $("#maxlon").val(ne.lng);
+    $("#maxlat").val(ne.lat);
 
     $("#export_overpass").attr("href",
-                               "https://overpass-api.de/api/map?bbox=" +
-                               truncated.map(p => p.reverse()).join());
+                               `https://overpass-api.de/api/map?bbox=${sw.lng},${sw.lat},${ne.lng},${ne.lat}`);
   }
 
   function validateControls() {

--- a/app/assets/javascripts/index/history-changesets-layer.js
+++ b/app/assets/javascripts/index/history-changesets-layer.js
@@ -125,8 +125,8 @@ OSM.HistoryChangesetsLayer = L.FeatureGroup.extend({
     mapViewPixelBounds.max.y += mapViewExpansion;
 
     for (const changeset of this._changesets.values()) {
-      const changesetNorthWestLatLng = L.latLng(changeset.bbox.maxlat, changeset.bbox.minlon),
-            changesetSouthEastLatLng = L.latLng(changeset.bbox.minlat, changeset.bbox.maxlon),
+      const changesetNorthWestLatLng = { lat: changeset.bbox.maxlat, lng: changeset.bbox.minlon },
+            changesetSouthEastLatLng = { lat: changeset.bbox.minlat, lng: changeset.bbox.maxlon },
             changesetCenterLng = (changesetNorthWestLatLng.lng + changesetSouthEastLatLng.lng) / 2,
             shiftInWorldCircumferences = Math.round((changesetCenterLng - mapViewCenterLng) / 360);
 

--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -120,7 +120,7 @@ OSM.NewNote = function (map) {
     let markerLatlng;
 
     if (params.has("lat") && params.has("lon")) {
-      markerLatlng = L.latLng(params.get("lat"), params.get("lon"));
+      markerLatlng = { lat: params.get("lat"), lng: params.get("lon") };
     } else {
       markerLatlng = map.getCenter();
     }

--- a/app/assets/javascripts/index/note.js
+++ b/app/assets/javascripts/index/note.js
@@ -6,8 +6,8 @@ OSM.Note = function (map) {
     OSM.loadSidebarContent(path, function () {
       const data = $(".details").data();
       if (!data) return;
-      const latLng = L.latLng(data.coordinates.split(","));
-      initialize(path, id, map.getBounds().contains(latLng));
+      const [lat, lng] = data.coordinates.split(",").map(parseFloat);
+      initialize(path, id, map.getBounds().contains({ lat, lng }));
     });
   };
 

--- a/app/assets/javascripts/index/query.js
+++ b/app/assets/javascripts/index/query.js
@@ -26,9 +26,9 @@ OSM.initializations.push(function (map) {
   });
 
   function clickHandler(e) {
-    const [lat, lon] = OSM.cropLocation(e.latlng, map.getZoom());
+    const { lat, lng } = OSM.cropLocation(e.latlng, map.getZoom());
 
-    OSM.router.route("/query?" + new URLSearchParams({ lat, lon }));
+    OSM.router.route("/query?" + new URLSearchParams({ lat, lon: lng }));
   }
 
   function enableQueryMode() {
@@ -270,9 +270,9 @@ OSM.Query = function (map) {
   function queryOverpass(latlng) {
     const bounds = map.getBounds(),
           zoom = map.getZoom(),
-          bbox = [bounds.getSouthWest(), bounds.getNorthEast()]
-            .map(c => OSM.cropLocation(c, zoom))
-            .join(),
+          sw = OSM.cropLocation(bounds.getSouthWest(), zoom),
+          ne = OSM.cropLocation(bounds.getNorthEast(), zoom),
+          bbox = `${sw.lat},${sw.lng},${ne.lat},${ne.lng}`,
           geom = `geom(${bbox})`,
           radius = 10 * Math.pow(1.5, 19 - zoom),
           here = `(around:${radius},${latlng})`,

--- a/app/assets/javascripts/index/search.js
+++ b/app/assets/javascripts/index/search.js
@@ -26,9 +26,9 @@ OSM.initializations.push(function (map) {
     e.preventDefault();
     $("header").addClass("closed");
     const zoom = map.getZoom();
-    const [lat, lon] = OSM.cropLocation(map.getCenter(), zoom);
+    const { lat, lng } = OSM.cropLocation(map.getCenter(), zoom);
 
-    OSM.router.route("/search?" + new URLSearchParams({ lat, lon, zoom }));
+    OSM.router.route("/search?" + new URLSearchParams({ lat, lon: lng, zoom }));
   });
 });
 

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -141,7 +141,9 @@ L.OSM.Map = L.Map.extend({
     const params = {};
 
     if (marker && this.hasLayer(marker)) {
-      [params.mlat, params.mlon] = OSM.cropLocation(marker.getLatLng(), this.getZoom());
+      const { lat, lng } = OSM.cropLocation(marker.getLatLng(), this.getZoom());
+      params.mlat = lat;
+      params.mlon = lng;
     }
 
     let url = location.protocol + "//" + OSM.SERVER_URL + "/";
@@ -223,7 +225,8 @@ L.OSM.Map = L.Map.extend({
       latLng = marker.getLatLng();
     }
 
-    return `geo:${OSM.cropLocation(latLng, zoom).join(",")}?z=${zoom}`;
+    const { lat, lng } = OSM.cropLocation(latLng, zoom);
+    return `geo:${lat},${lng}?z=${zoom}`;
   },
 
   addObject: function (object, callback) {

--- a/app/assets/javascripts/osm.js.erb
+++ b/app/assets/javascripts/osm.js.erb
@@ -196,7 +196,8 @@ OSM = {
 
     layers = layers.replace("M", "");
 
-    let hash = "#map=" + [zoom, ...OSM.cropLocation(center, zoom)].join("/");
+    const { lat, lng } = OSM.cropLocation(center, zoom);
+    let hash = `#map=${zoom}/${lat}/${lng}`;
 
     if (layers) {
       hash += "&layers=" + layers;
@@ -214,13 +215,16 @@ OSM = {
   cropLocation: function (latLng, zoom) {
     const precision = OSM.zoomPrecision(zoom),
           wrapped = latLng.wrap();
-    return [wrapped.lat, wrapped.lng].map(c => c.toFixed(precision));
+    return {
+      lat: wrapped.lat.toFixed(precision),
+      lng: wrapped.lng.toFixed(precision)
+    };
   },
 
   locationCookie: function (map) {
     const zoom = map.getZoom(),
-          center = OSM.cropLocation(map.getCenter(), zoom).reverse();
-    return [...center, zoom, map.getLayersCode()].join("|");
+          { lat, lng } = OSM.cropLocation(map.getCenter(), zoom);
+    return [lng, lat, zoom, map.getLayersCode()].join("|");
   },
 
   showAlert: function (title, message) {

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -70,10 +70,9 @@ $(function () {
     map.on("click", function (e) {
       if (!$("#updatehome").is(":checked")) return;
 
-      const [lat, lon] = OSM.cropLocation(e.lngLat, map.getZoom() + 1);
-
+      const { lat, lng } = OSM.cropLocation(L.latLng(e.lngLat.lat, e.lngLat.lng), map.getZoom() + 1);
       $("#home_lat").val(lat);
-      $("#home_lon").val(lon);
+      $("#home_lon").val(lng);
 
       clearDeletedText();
       respondToHomeLatLonUpdate();


### PR DESCRIPTION
### Description

Both maplibre and leaflet know `{ lat, lng }`, but if the array shorthand is used we exchange which is which.
It is likely best to get this refactored away.

Notthing final, there will have to be more of these PRs, but I hope that by cutting effort from my staging area => so that this becomes simpler to review and merge.

### How has this been tested?

Looking at every case and seeing that Munich is not in the ocean.