### PR TITLE
Fix string that was not translatable

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
       <%= t "layouts.project_name.title" %>
     </a>
     <%= render "layouts/select_language_button", :extra_classes => ["border-secondary border-opacity-10 d-md-none"] %>
-    <a href="#" id="menu-icon" class="d-md-none" aria-expanded="false" aria-label="Main">
+    <a href="#" id="menu-icon" class="d-md-none" aria-expanded="false" aria-label="<%= t("layouts.main_navigation") %>">
       <i class="bi bi-list lh-1 text-body-secondary"></i>
     </a>
   </h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1832,6 +1832,7 @@ en:
       title: OpenStreetMap
     logo:
       alt_text: OpenStreetMap logo
+    main_navigation: Main
     layer_info: "Layer Info"
     start_mapping: Start Mapping
     intro_header: Welcome to OpenStreetMap!


### PR DESCRIPTION
Failed to translatableisify (!) a string at https://github.com/openstreetmap/openstreetmap-website/pull/7008. This adds it. Thanks to @hlfan for noticing.