### PR TITLE
Set secure and httponly attributes for TOTP cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -283,7 +283,9 @@ class ApplicationController < ActionController::Base
       cookies["_osm_totp_token"] = {
         :value => ROTP::TOTP.new(Settings.totp_key, :interval => 3600).now,
         :domain => Settings.totp_domain,
-        :expires => 1.hour.from_now
+        :expires => 1.hour.from_now,
+        :secure => Settings.server_protocol == "https",
+        :httponly => true
       }
     end
   end


### PR DESCRIPTION
I don't think either matters much (and secure is defaulting to on in production anyway) but it doesn't do any harm either.