### PR TITLE
Block object-src in security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
     policy.img_src(*img_src)
     policy.manifest_src(:self)
     policy.media_src(:none)
-    policy.object_src(:self)
+    policy.object_src(:none)
     policy.plugin_types
     policy.script_src(*script_src)
     policy.style_src(:self)


### PR DESCRIPTION
This is ancient history from when we had a flash based editor though I'm not sure this rule was really needed even then.