### PR TITLE
Include deleted messages when checking the rate limit

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -45,7 +45,7 @@ class MessagesController < ApplicationController
     @message.sender = current_user
     @message.sent_on = Time.now.utc
 
-    if current_user.sent_messages.where(:sent_on => (Time.now.utc - 1.hour)..).count >= current_user.max_messages_per_hour
+    if Message.where(:sender => current_user, :sent_on => (Time.now.utc - 1.hour)..).count >= current_user.max_messages_per_hour
       flash.now[:error] = t ".limit_exceeded"
       render :action => "new"
     elsif @message.save

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -191,12 +191,30 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     # Login as a normal user
     user = create(:user)
     recipient_user = create(:user)
+    message = create(:message, :unread, :sender => user, :recipient => recipient_user)
     session_for(user)
 
     # Check that sending a message fails when the message limit is hit
     assert_no_difference "ActionMailer::Base.deliveries.size" do
       assert_no_difference "Message.count" do
-        with_settings(:max_messages_per_hour => 0) do
+        with_settings(:max_messages_per_hour => 1) do
+          perform_enqueued_jobs do
+            post messages_path(:display_name => recipient_user.display_name,
+                               :message => { :title => "Test Message", :body => "Test message body" })
+            assert_response :success
+            assert_template "new"
+            assert_select ".alert.alert-danger", /wait a while/
+          end
+        end
+      end
+    end
+
+    message.update(:from_user_visible => false)
+
+    # Check that sending a message still fails when message is deleted
+    assert_no_difference "ActionMailer::Base.deliveries.size" do
+      assert_no_difference "Message.count" do
+        with_settings(:max_messages_per_hour => 1) do
           perform_enqueued_jobs do
             post messages_path(:display_name => recipient_user.display_name,
                                :message => { :title => "Test Message", :body => "Test message body" })


### PR DESCRIPTION
This ensures that the rate limit can't be bypassed by deleting each message after it is sent.