### PR TITLE
Embrace bug in bootstrap_form which will be future behaviour

### DIFF
--- a/config/initializers/bootstrap_form.rb
+++ b/config/initializers/bootstrap_form.rb
@@ -4,3 +4,12 @@
 Rails.application.reloader.to_prepare do
   BootstrapForm::FormBuilder.include BootstrapForm::Inputs::RichtextField
 end
+
+BootstrapForm.configure do |config|
+  # As of writing these lines, if this is not set it will behave differently
+  # in dev and prod. See https://github.com/bootstrap-ruby/bootstrap_form/pull/779
+  #
+  # Additionally, a `true` setting will generate markup more conformant
+  # with WAI-ARIA, which hopefully will be more accessible.
+  config.group_around_collections = true
+end


### PR DESCRIPTION
<!-- obsidian --><p>While working on <a href="https://github.com/openstreetmap/openstreetmap-website/pull/7001" class="external-link" target="_blank" rel="noopener nofollow">https://github.com/openstreetmap/openstreetmap-website/pull/7001</a>, I discovered a bug in bootstrap_form which, as I write these lines, behaves slightly differently in dev and prod when it renders collections of checkboxes.</p>
<p>Right now there's only one instance of this in the app, with another coming should the PR linked above be merged. This is a comparison of how the existing instance renders:</p>

development | production
-- | --
<img width="441" height="261" alt="Form to edit OAuth applications, as rendered in development mode" src="https://github.com/user-attachments/assets/55fb1ac7-a048-4093-a950-3b22fa74f6da" /> | <img width="441" height="261" alt="Form to edit OAuth applications, as rendered in production mode" src="https://github.com/user-attachments/assets/0dc71c1c-4e4a-4c5b-8a9b-78f4d8def262" />



<p>Not much of a difference at the moment, in visual terms. In the development version, the heading "Permissions" is slightly smaller because it's a <code>&#x3C;label></code> as opposed to a <code>&#x3C;div></code> in production. The actually important part is that the development version has some additional <code>aria-*</code> and <code>role</code> attributes that are supposed to better conform to WAI-ARIA, as per <a href="https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria" class="external-link" target="_blank" rel="noopener nofollow">https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria</a></p>
<p>The bug has been solved upstream now. It's not yet published in the gem, so the difference exists in our app currently. When this happens, the behaviour will be like in production everywhere.</p>
<p>So I could just wait, but there are two reasons why I wanted to be proactive here:</p>
<ul>
<li>When the bug is fixed, the default behaviour will be the non WAI-ARIA conformant... for now. This is for backwards compatibility, but the author of bootstrap_form plans to make the accessible behaviour default in the future.</li>
<li>In my other PR the change was more obvious and I found myself having to change a template to adapt. Since I'm at it, I'd rather go for the more accessible option now.</li>
</ul>
<p>On the other hand:</p>
<ul>
<li>After my changes to the template that was giving me grief, the result appears to work with either configuration. So we could forget this, go for the current default, and deal with any changes in the future should they arise.</li>
</ul>