### PR TITLE
Fix GPX import mailers, which expected different tag objects

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -60,7 +60,7 @@ class UserMailer < ApplicationMailer
       @trace_name = trace.name
       @trace_points = trace.size
       @trace_description = trace.description
-      @trace_tags = trace.tags
+      @trace_tags = trace.tags.map(&:tag)
       @possible_points = possible_points
       @my_traces_url = url_for(:controller => "traces", :action => "mine")
 

--- a/app/views/user_mailer/_gpx_details.html.erb
+++ b/app/views/user_mailer/_gpx_details.html.erb
@@ -15,7 +15,7 @@
   <dd><%= trace_description %></dd>
   <% if trace_tags.length > 0 %>
     <dt><%= t ".tags" %></dt>
-    <dd><%= trace_tags.map(&:tag).join(", ") %></dd>
+    <dd><%= trace_tags.join(", ") %></dd>
   <% end %>
   <% if possible_points %>
     <dt><%= t ".total_points" %></dt>

--- a/app/views/user_mailer/_gpx_details.text.erb
+++ b/app/views/user_mailer/_gpx_details.text.erb
@@ -10,7 +10,7 @@
 	<%= @trace_description %>
 <% if @trace_tags.length > 0 %>
 <%= t ".tags" %>
-	<%= @trace_tags.map(&:tag).join(", ") %>
+	<%= @trace_tags.join(", ") %>
 <% end %>
 <% if @possible_points %>
 <%= t ".total_points" %>

--- a/test/jobs/trace_importer_job_test.rb
+++ b/test/jobs/trace_importer_job_test.rb
@@ -6,7 +6,7 @@ require "minitest/mock"
 class TraceImporterJobTest < ActiveJob::TestCase
   def test_success_notification
     # Check that the user gets a success notification when the trace has valid points
-    trace = create(:trace)
+    trace = create(:trace, :tags => build_list(:tracetag, 2))
 
     gpx = Minitest::Mock.new
     def gpx.actual_points
@@ -28,7 +28,7 @@ class TraceImporterJobTest < ActiveJob::TestCase
 
   def test_failure_notification
     # Check that the user gets a failure notification when the trace has no valid points
-    trace = create(:trace)
+    trace = create(:trace, :tags => build_list(:tracetag, 2))
 
     gpx = Minitest::Mock.new
     def gpx.actual_points

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -38,13 +38,13 @@ class UserMailerPreview < ActionMailer::Preview
 
   def gpx_success
     user = create(:user, :languages => [I18n.locale])
-    trace = create(:trace, :user => user)
+    trace = create(:trace, :user => user, :tags => build_list(:tracetag, 2))
     UserMailer.with(:record => trace, :possible_points => trace.size + 2, :recipient => trace.user).gpx_success
   end
 
   def gpx_failure
     user = create(:user, :languages => [I18n.locale])
-    trace = create(:trace, :user => user)
+    trace = build(:trace, :user => user, :tags => build_list(:tracetag, 2))
     error = begin
       LibXML::XML::Parser.string("<gpx>").parse
     rescue LibXML::XML::Error => e
@@ -53,7 +53,7 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.with(
       :trace_name => trace.name,
       :trace_description => trace.description,
-      :trace_tags => trace.tags,
+      :trace_tags => trace.tags.map(&:tag),
       :error => error,
       :recipient => trace.user
     ).gpx_failure

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -80,26 +80,25 @@ class UserMailerTest < ActionMailer::TestCase
 
   def test_gpx_failure
     trace = build(:trace, :tags => build_list(:tracetag, 2))
+    tag_strings = trace.tags.map(&:tag)
     email = UserMailer.with(
       :trace_name => trace.name,
       :trace_description => trace.description,
-      :trace_tags => trace.tags,
+      :trace_tags => tag_strings,
       :error => "some error",
       :recipient => trace.user
     ).gpx_failure
 
-    tags = trace.tags.map(&:tag)
     assert_match trace.name, email.html_part.body.to_s
     assert_match trace.description, email.html_part.body.to_s
-    assert_match tags[0], email.html_part.body.to_s
-    assert_match tags[1], email.html_part.body.to_s
+    assert_match tag_strings[0], email.html_part.body.to_s
+    assert_match tag_strings[1], email.html_part.body.to_s
     assert_match "some error", email.html_part.body.to_s
 
-    tags = trace.tags.map(&:tag)
     assert_match trace.name, email.text_part.body.to_s
     assert_match trace.description, email.text_part.body.to_s
-    assert_match tags[0], email.text_part.body.to_s
-    assert_match tags[1], email.text_part.body.to_s
+    assert_match tag_strings[0], email.text_part.body.to_s
+    assert_match tag_strings[1], email.text_part.body.to_s
     assert_match "some error", email.text_part.body.to_s
   end
 


### PR DESCRIPTION
Fixes the issue reported at https://github.com/openstreetmap/openstreetmap-website/pull/6939#issuecomment-4378657196

The problem is that the mailers for GPX import success and failure have different expectations on the format of the tag list:

- `gpx_success` expects the tags to be in DB and be available as `Tracetag` instances, associated to the given `Trace`.
- `gpx_failure` doesn't have anything in DB to go by. It receives details of the failed trace in explicit arguments `trace_name`, `trace_description`, `trace_tags`. This last one is just a list of strings, not ActiveRecord objects.