### PR TITLE
sync location hash on the "History" link in header navigation

### DIFF
--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -102,9 +102,10 @@ OSM.Router = function (map, rts) {
 
   function updateSecondaryNav() {
     $("header nav.secondary > ul > li > a").each(function () {
-      const active = $(this).attr("href") === location.pathname;
+      const active = new URL($(this).attr("href"), location.href).pathname === location.pathname;
 
       $(this)
+        .toggleClass("active", active)
         .toggleClass("text-secondary", !active)
         .toggleClass("text-secondary-emphasis", active);
     });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,8 +41,8 @@ module ApplicationHelper
 
   def secondary_nav_items
     items = [
-      [history_path, t("layouts.header.history")],
-      [export_path, t("layouts.header.export")],
+      [history_path, t("layouts.header.history"), { :class => ["geolink"] }],
+      [export_path, t("layouts.header.export"), { :class => ["geolink"] }],
       [traces_path, t("layouts.header.gps_traces")],
       [diary_entries_path, t("layouts.header.user_diaries")],
       [communities_path, t("layouts.header.communities")],

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -34,9 +34,9 @@
   </nav>
   <nav class="secondary d-flex flex-column flex-md-row gap-2 flex-grow-1 align-items-center">
     <ul id="secondary-nav-menu" class="nav flex-grow-1 justify-content-center justify-content-md-start" data-turbo-permanent>
-      <% secondary_nav_items.each do |path, label, options| %>
+      <% secondary_nav_items.each do |path, label, options = {}| %>
         <li class="nav-item pb-2 pb-md-0">
-          <%= link_to label, path, :class => ["nav-link", "px-1", "py-0", current_page?(path) ? "active text-secondary-emphasis" : "text-secondary"], **(options || {}) %>
+          <%= link_to label, path, :class => ["nav-link", "px-1", "py-0", current_page?(path) ? "active text-secondary-emphasis" : "text-secondary", options.delete(:class)], **options %>
         </li>
       <% end %>
       <li id="compact-secondary-nav" class="dropdown nav-item ms-auto pb-2 pb-md-0 collapse">


### PR DESCRIPTION
fixes https://github.com/openstreetmap/iD/issues/12287

Similarly to how exiting an iD edit session by clicking the OSM logo on the header bar brings you back to the last location in the mapping session, this should also work the same when clicking on the "History" button in the navigation menu. This can also be useful when opening the history page in a new browser tab while mapping, to check for recent edits in the area, etc.


Related code where this CSS class triggers the intended behaviour:

* https://github.com/openstreetmap/openstreetmap-website/blob/ef0f868da821ccc360eda5233af26845d959b45c/app/assets/javascripts/edit/id.js.erb#L57-L58
* https://github.com/openstreetmap/openstreetmap-website/blob/ef0f868da821ccc360eda5233af26845d959b45c/app/assets/javascripts/application.js#L53-L58