### PR TITLE
Configure dependabot to respect Gemfile constraints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
-    versioning-strategy: "increase-if-necessary"
+    versioning-strategy: "lockfile-only"
     directory: "/"
-    ignore:
-      - dependency-name: rails
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
-      - dependency-name: sass-embedded
-      - dependency-name: uri
     groups:
       rails:
         applies-to: version-updates


### PR DESCRIPTION
This allows us to use constraints in the Gemfile, without having to remember to repeat them in the dependabot configuration.

---

The original "increase-if-required" strategy will ignore all constraints that we have in our Gemfile. If a new gem is released, with a version that's too high for the constraint, then dependabot will just merrily edit the Gemfile and change the constraint to match the new version. To avoid this from happening to gems where we know that the new version will break stuff, we therefore have to have a second list of gems, telling dependabot to keep the current version. This seems strange to me, like we're trying to override an override.

I propose the following:
* We change to a "lockfile-only" strategy (this PR). Dependabot will not propose an upgrade if it breaks the constraints in the Gemfile. Dependabot therefore behaves like `bundle update`.
* We keep the pessimistic locks for `rails`, `sass-embedded` and `uri`, since they are clearly there for a reason.
* We remove all the other pessimistic locks from the Gemfile (e.g. `"dalli", "< 6.0.0"` and `"rails-i18n", "~> 8.1.0"`) since they are effectively meaningless (PR to follow). Dependabot itself is the last author of many these constraints, so clearly if we're happy for it just to try bumping the versions and check the results in CI, then we should be happy just to remove the constraint and we'll still see the outcome in CI anyway.
* We can also remove all the minimum constraints (e.g. `"validates_email_format_of", ">= 1.5.1"`). Given this is an application, not a library, I think it's incredibly unlikely to see a `bundle update` causing a gem version being downgraded *and* the downgraded version ending up below the nominal minimum *and* for this to cause a breakage *and* for the breakage not to be picked up by CI. Removing the minimum constraints helps keep the Gemfile simple and discourages more unnecessary constraints creeping back in.

