### PR TITLE
Reduce gemfile constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem "jbuilder", "~> 2.7"
 gem "bootsnap", :require => false
 
 # Use rtlcss for RTL conversion
-gem "mini_racer", "~> 0.21.0"
 gem "rtlcss"
 
 # Use autoprefixer to generate CSS prefixes

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "terser"
 gem "jquery-rails"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem "jbuilder", "~> 2.7"
+gem "jbuilder"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", :require => false
@@ -53,38 +53,38 @@ gem "benchmark"
 gem "actionpack-page_caching"
 gem "activerecord-import"
 gem "active_record_union"
-gem "bootstrap", "~> 5.3.2"
-gem "bootstrap_form", "~> 5.0"
+gem "bootstrap"
+gem "bootstrap_form"
 gem "cancancan"
 gem "config"
 gem "delayed_job_active_record"
 gem "dry-validation"
 gem "frozen_record"
-gem "http_accept_language", "~> 2.1.1"
-gem "i18n-js", "~> 4.2.3"
+gem "http_accept_language"
+gem "i18n-js"
 gem "openstreetmap-deadlock_retry", :require => "deadlock_retry"
 gem "rack-cors"
-gem "rails-i18n", "~> 8.1.0"
+gem "rails-i18n"
 gem "rails_param"
 gem "rinku", :require => "rails_rinku"
 gem "strong_migrations"
 gem "validates_email_format_of"
 
 # Native OSM extensions
-gem "quad_tile", "~> 1.0.1"
+gem "quad_tile"
 
 # Sanitise URIs
-gem "addressable", "~> 2.8"
+gem "addressable"
 gem "rack-uri_sanitizer"
 
-gem "omniauth", "~> 2.1.3"
+gem "omniauth"
 gem "omniauth-apple"
 gem "omniauth-facebook"
 gem "omniauth-github"
 gem "omniauth-google-oauth2"
 gem "omniauth-mediawiki"
 gem "omniauth-microsoft_graph"
-gem "omniauth-rails_csrf_protection", "~> 2.0"
+gem "omniauth-rails_csrf_protection"
 
 # Doorkeeper for OAuth2
 gem "doorkeeper"
@@ -115,8 +115,8 @@ gem "maxminddb"
 gem "rotp"
 
 # Load memcache client in case we are using it
-gem "connection_pool", "< 4.0.0"
-gem "dalli", "< 6.0.0"
+gem "connection_pool"
+gem "dalli"
 
 # Load canonical-rails to generate canonical URLs
 gem "canonical-rails", :github => "commonlit/canonical-rails", :ref => "bump-rails-8-1"
@@ -155,7 +155,7 @@ gem "open3"
 gem "digest"
 
 # Notifications
-gem "noticed", "~> 3.0.0"
+gem "noticed"
 
 # Gems useful for development
 group :development do
@@ -180,7 +180,7 @@ group :test do
   gem "minitest"
   gem "minitest-focus", :require => false
   gem "minitest-mock"
-  gem "puma", "~> 8.0"
+  gem "puma"
   gem "rails-controller-testing"
   gem "rubocop"
   gem "rubocop-capybara"
@@ -201,7 +201,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "rackup"
   gem "teaspoon"
-  gem "teaspoon-mocha", "~> 2.3.3"
+  gem "teaspoon-mocha"
   gem "webrick"
 
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "jquery-rails"
 gem "jbuilder", "~> 2.7"
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", ">= 1.4.2", :require => false
+gem "bootsnap", :require => false
 
 # Use rtlcss for RTL conversion
 gem "mini_racer", "~> 0.21.0"
@@ -51,7 +51,7 @@ gem "sprockets-exporters_pack"
 gem "benchmark"
 
 # Load rails plugins
-gem "actionpack-page_caching", ">= 1.2.0"
+gem "actionpack-page_caching"
 gem "activerecord-import"
 gem "active_record_union"
 gem "bootstrap", "~> 5.3.2"
@@ -63,13 +63,13 @@ gem "dry-validation"
 gem "frozen_record"
 gem "http_accept_language", "~> 2.1.1"
 gem "i18n-js", "~> 4.2.3"
-gem "openstreetmap-deadlock_retry", ">= 1.3.1", :require => "deadlock_retry"
+gem "openstreetmap-deadlock_retry", :require => "deadlock_retry"
 gem "rack-cors"
 gem "rails-i18n", "~> 8.1.0"
 gem "rails_param"
-gem "rinku", ">= 2.0.6", :require => "rails_rinku"
+gem "rinku", :require => "rails_rinku"
 gem "strong_migrations"
-gem "validates_email_format_of", ">= 1.5.1"
+gem "validates_email_format_of"
 
 # Native OSM extensions
 gem "quad_tile", "~> 1.0.1"
@@ -82,8 +82,8 @@ gem "omniauth", "~> 2.1.3"
 gem "omniauth-apple"
 gem "omniauth-facebook"
 gem "omniauth-github"
-gem "omniauth-google-oauth2", ">= 0.6.0"
-gem "omniauth-mediawiki", ">= 0.0.4"
+gem "omniauth-google-oauth2"
+gem "omniauth-mediawiki"
 gem "omniauth-microsoft_graph"
 gem "omniauth-rails_csrf_protection", "~> 2.0"
 
@@ -99,7 +99,7 @@ gem "kramdown"
 gem "aasm"
 
 # XML parsing and generation
-gem "libxml-ruby", ">= 2.0.5"
+gem "libxml-ruby"
 gem "rexml"
 
 # Use for HTML sanitisation
@@ -175,7 +175,7 @@ end
 # Gems needed for running tests
 group :test do
   gem "brakeman"
-  gem "capybara", ">= 2.15"
+  gem "capybara"
   gem "erb_lint", :require => false
   gem "jwt"
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -931,7 +931,7 @@ DEPENDENCIES
   active_record_union
   activerecord-import
   activerecord-postgis
-  addressable (~> 2.8)
+  addressable
   annotaterb
   argon2
   autoprefixer-rails
@@ -940,16 +940,16 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  bootstrap (~> 5.3.2)
-  bootstrap_form (~> 5.0)
+  bootstrap
+  bootstrap_form
   brakeman
   bzip2-ffi
   cancancan
   canonical-rails!
   capybara
   config
-  connection_pool (< 4.0.0)
-  dalli (< 6.0.0)
+  connection_pool
+  dalli
   danger
   danger-auto_label
   dartsass-sprockets
@@ -970,14 +970,14 @@ DEPENDENCIES
   gd2-ffij!
   herb
   htmlentities
-  http_accept_language (~> 2.1.1)
-  i18n-js (~> 4.2.3)
+  http_accept_language
+  i18n-js
   i18n-tasks
   image_optim!
   image_optim_rails
   image_processing
   inline_svg
-  jbuilder (~> 2.7)
+  jbuilder
   jquery-rails
   jwt
   kramdown
@@ -988,15 +988,15 @@ DEPENDENCIES
   minitest
   minitest-focus
   minitest-mock
-  noticed (~> 3.0.0)
-  omniauth (~> 2.1.3)
+  noticed
+  omniauth
   omniauth-apple
   omniauth-facebook
   omniauth-github
   omniauth-google-oauth2
   omniauth-mediawiki
   omniauth-microsoft_graph
-  omniauth-rails_csrf_protection (~> 2.0)
+  omniauth-rails_csrf_protection
   open3
   openstreetmap-deadlock_retry
   opentelemetry-exporter-otlp
@@ -1004,14 +1004,14 @@ DEPENDENCIES
   opentelemetry-sdk
   overcommit
   pg
-  puma (~> 8.0)
-  quad_tile (~> 1.0.1)
+  puma
+  quad_tile
   rack-cors
   rack-uri_sanitizer
   rackup
   rails (~> 8.1.0)
   rails-controller-testing
-  rails-i18n (~> 8.1.0)
+  rails-i18n
   rails_param
   rexml
   rinku
@@ -1032,7 +1032,7 @@ DEPENDENCIES
   sprockets-exporters_pack
   strong_migrations
   teaspoon
-  teaspoon-mocha (~> 2.3.3)
+  teaspoon-mocha
   terser
   timeout
   turbo-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -927,7 +927,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  actionpack-page_caching (>= 1.2.0)
+  actionpack-page_caching
   active_record_union
   activerecord-import
   activerecord-postgis
@@ -939,14 +939,14 @@ DEPENDENCIES
   benchmark
   better_errors
   binding_of_caller
-  bootsnap (>= 1.4.2)
+  bootsnap
   bootstrap (~> 5.3.2)
   bootstrap_form (~> 5.0)
   brakeman
   bzip2-ffi
   cancancan
   canonical-rails!
-  capybara (>= 2.15)
+  capybara
   config
   connection_pool (< 4.0.0)
   dalli (< 6.0.0)
@@ -981,7 +981,7 @@ DEPENDENCIES
   jquery-rails
   jwt
   kramdown
-  libxml-ruby (>= 2.0.5)
+  libxml-ruby
   listen
   marcel
   maxminddb
@@ -994,12 +994,12 @@ DEPENDENCIES
   omniauth-apple
   omniauth-facebook
   omniauth-github
-  omniauth-google-oauth2 (>= 0.6.0)
-  omniauth-mediawiki (>= 0.0.4)
+  omniauth-google-oauth2
+  omniauth-mediawiki
   omniauth-microsoft_graph
   omniauth-rails_csrf_protection (~> 2.0)
   open3
-  openstreetmap-deadlock_retry (>= 1.3.1)
+  openstreetmap-deadlock_retry
   opentelemetry-exporter-otlp
   opentelemetry-instrumentation-all
   opentelemetry-sdk
@@ -1015,7 +1015,7 @@ DEPENDENCIES
   rails-i18n (~> 8.1.0)
   rails_param
   rexml
-  rinku (>= 2.0.6)
+  rinku
   rotp
   rtlcss
   rubocop
@@ -1039,10 +1039,10 @@ DEPENDENCIES
   turbo-rails
   unicode-display_width
   uri (< 1.0.0)
-  validates_email_format_of (>= 1.5.1)
+  validates_email_format_of
   vendorer
   webmock
   webrick
 
 BUNDLED WITH
-   4.0.10
+  4.0.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -985,7 +985,6 @@ DEPENDENCIES
   listen
   marcel
   maxminddb
-  mini_racer (~> 0.21.0)
   minitest
   minitest-focus
   minitest-mock


### PR DESCRIPTION
Follows on from  #7063

* Removes the minimum version constraints
* Removes an explicit dependency that is no longer required
* Remove the pessimistic version constraints that dependabot was (until yesterday) ignoring anyway.