### PR TITLE
Add unsaved changes warning to message and diary forms

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 //= require matomo
 //= require richtext
 //= require language_selector
+//= require unsaved_changes
 
 {
   const application_data = $("head").data();

--- a/app/assets/javascripts/unsaved_changes.js
+++ b/app/assets/javascripts/unsaved_changes.js
@@ -1,0 +1,50 @@
+(function () {
+  function beforeUnloadListener(event) {
+    event.preventDefault();
+    // Legacy support for older browsers.
+    event.returnValue = true;
+  };
+
+  // A function that adds a `beforeunload` listener if there are unsaved changes.
+  function onChangedForm() {
+    addEventListener("beforeunload", beforeUnloadListener);
+    document.body.dataset.unsavedChanges = "true";
+  };
+
+  // A function that removes the `beforeunload` listener when the page's unsaved changes are resolved.
+  function onAllChangesSaved() {
+    removeEventListener("beforeunload", beforeUnloadListener);
+    delete document.body.dataset.unsavedChanges;
+  };
+
+  // Return current state of form, used to compare against later
+  function formState(form) {
+    return new URLSearchParams(new FormData(form)).toString();
+  }
+
+  $(document).on("turbo:load ready", function () {
+    $("form[data-unsaved-changes-warning]").each(function () {
+      // Get initial state of each form tagged with attribute
+      const form = this;
+      const initialState = formState(form);
+      let warningEnabled = false;
+
+      // Check if form has changed, and set flag for warning as appropriate
+      function updateWarning() {
+        const isChanged = (formState(form) !== initialState);
+
+        if (isChanged && !warningEnabled) {
+          onChangedForm();
+          warningEnabled = true;
+        } else if (!isChanged && warningEnabled) {
+          onAllChangesSaved();
+          warningEnabled = false;
+        }
+      }
+
+      $(form).on("input change", updateWarning);
+      $(form).on("submit", onAllChangesSaved);
+    });
+  });
+}()
+);

--- a/app/assets/javascripts/unsaved_changes.js
+++ b/app/assets/javascripts/unsaved_changes.js
@@ -1,35 +1,28 @@
 (function () {
   function beforeUnloadListener(event) {
     event.preventDefault();
-    // Legacy support for older browsers.
-    event.returnValue = true;
   };
 
-  // A function that adds a `beforeunload` listener if there are unsaved changes.
   function onChangedForm() {
     addEventListener("beforeunload", beforeUnloadListener);
     document.body.dataset.unsavedChanges = "true";
   };
 
-  // A function that removes the `beforeunload` listener when the page's unsaved changes are resolved.
   function onAllChangesSaved() {
     removeEventListener("beforeunload", beforeUnloadListener);
     delete document.body.dataset.unsavedChanges;
   };
 
-  // Return current state of form, used to compare against later
   function formState(form) {
     return new URLSearchParams(new FormData(form)).toString();
   }
 
   $(document).on("turbo:load ready", function () {
     $("form[data-unsaved-changes-warning]").each(function () {
-      // Get initial state of each form tagged with attribute
       const form = this;
       const initialState = formState(form);
       let warningEnabled = false;
 
-      // Check if form has changed, and set flag for warning as appropriate
       function updateWarning() {
         const isChanged = (formState(form) !== initialState);
 

--- a/app/views/diary_entries/edit.html.erb
+++ b/app/views/diary_entries/edit.html.erb
@@ -6,6 +6,6 @@
   <h1><%= @title %></h1>
 <% end %>
 
-<%= bootstrap_form_for @diary_entry, :url => diary_entry_path(current_user, @diary_entry), :html => { :method => :put } do |f| %>
+<%= bootstrap_form_for @diary_entry, :url => diary_entry_path(current_user, @diary_entry), :html => { :method => :put, :data => { :unsaved_changes_warning => true } } do |f| %>
   <%= render "form", :f => f, :diary_entry => @diary_entry, :lat => @lat, :lon => @lon, :zoom => @zoom %>
 <% end %>

--- a/app/views/diary_entries/new.html.erb
+++ b/app/views/diary_entries/new.html.erb
@@ -6,6 +6,6 @@
   <h1><%= @title %></h1>
 <% end %>
 
-<%= bootstrap_form_for @diary_entry do |f| %>
+<%= bootstrap_form_for @diary_entry, :html => { :data => { :unsaved_changes_warning => true } } do |f| %>
 <%= render "form", :f => f, :diary_entry => @diary_entry, :lat => @lat, :lon => @lon, :zoom => @zoom %>
 <% end %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t(".send_message_to_html", :name => link_to(@message.recipient.display_name, @message.recipient)) %></h1>
 <% end %>
 
-<%= bootstrap_form_for @message do |f| %>
+<%= bootstrap_form_for @message, :html => { :data => { :unsaved_changes_warning => true } } do |f| %>
   <%= hidden_field_tag :display_name, @message.recipient.display_name, :autocomplete => "off" %>
   <%= f.text_field :title %>
   <%= f.richtext_field :body, :cols => 80, :rows => 20 %>

--- a/test/system/unsaved_changes_test.rb
+++ b/test/system/unsaved_changes_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class UnsavedChangesTest < ApplicationSystemTestCase
+  def setup
+    create(:language, :code => "en")
+  end
+
+  test "warn before leaving unsaved diary entry form" do
+    user = create(:user)
+    sign_in_as(user)
+
+    visit new_diary_entry_path
+    fill_in "Subject", :with => "A Diary Entry Title"
+    fill_in "Body", :with => "This is the body."
+
+    assert_selector "body[data-unsaved-changes]"
+  end
+
+  test "does not warn when publishing diary entry" do
+    user = create(:user)
+    sign_in_as(user)
+
+    visit new_diary_entry_path
+    fill_in "Subject", :with => "A Diary Entry Title"
+    fill_in "Body", :with => "This is the body."
+
+    assert_selector "body[data-unsaved-changes]"
+    click_on "Publish"
+    assert_no_selector "body[data-unsaved-changes]"
+
+    assert_current_path diary_entry_path(user, DiaryEntry.last)
+    assert_text "A Diary Entry Title"
+  end
+
+  test "warns before leaving unsaved message form" do
+    sender = create(:user)
+    recipient = create(:user)
+    sign_in_as sender
+
+    visit new_message_path(recipient)
+    fill_in "Subject", :with => "A Message Title"
+
+    assert_selector "body[data-unsaved-changes]"
+  end
+
+  test "message form does not warn before changes" do
+    sender = create(:user)
+    recipient = create(:user)
+    sign_in_as sender
+
+    visit new_message_path(recipient)
+    assert_no_selector "body[data-unsaved-changes]"
+
+    fill_in "Subject", :with => "A Message Title"
+    fill_in "Body", :with => "A body"
+
+    click_on "Send"
+
+    assert_no_current_path new_message_path(recipient)
+  end
+end


### PR DESCRIPTION
<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->
Addresses #4898, addresses data loss from accidental navigation aspect of #7044

Users writing diary entries or messages can accidentally navigate away from the page and lose their work. This adds the built-in browser warning (using the `beforeunload` event) when a user tries to leave a page with edits in progress.

The JavaScript should be able to be used on other forms across the site by adding the `data-unsaved-changes-warning` attribute to relevant form elements.

Reference: [developer.chrome.com/docs/web-platform/page-lifecycle-api#the_beforeunload_event](https://developer.chrome.com/docs/web-platform/page-lifecycle-api#the_beforeunload_event)
### How has this been tested?
<!--Explain the steps you took to test your code.-->
Manually verified that warning appears when trying to navigate away from page with content in diary entry and messages creation, and editing for the former. 

Four test cases were added to a new test file for unsaved changes:
 - Warn before leaving unsaved diary entry form
 - Does not warn when publishing diary entry
 - Warns before leaving unsaved message form 
 - Message form does not warn before any changes are made