### PR TITLE
Hide note resolving without comment button for users without map changes

### DIFF
--- a/app/assets/javascripts/index_modules/note.js
+++ b/app/assets/javascripts/index_modules/note.js
@@ -85,12 +85,13 @@ export default function (map) {
     const resolveButton = content.find("button[name='close']");
     const commentButton = content.find("button[name='comment']");
 
-    content.find("button[name]").prop("disabled", false);
     if (content.find("textarea").val() === "") {
       resolveButton.text(resolveButton.data("defaultActionText"));
+      resolveButton.prop("disabled", !resolveButton.data("canResolveWithoutComment"));
       commentButton.prop("disabled", true);
     } else {
       resolveButton.text(resolveButton.data("commentActionText"));
+      content.find("button[name]").prop("disabled", false);
     }
   }
 

--- a/app/helpers/note_helper.rb
+++ b/app/helpers/note_helper.rb
@@ -42,4 +42,8 @@ module NoteHelper
   def hard_anonymous_notes_limit_reached?(anonymous_notes_count)
     !current_user && anonymous_notes_count >= 10
   end
+
+  def can_resolve_without_comment?(current_user, note)
+    current_user.changesets_count.positive? || (note.comments.length > 1 && note.comments.last.author == current_user)
+  end
 end

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -75,11 +75,21 @@
                                        :data => { :method => "DELETE",
                                                   :url => api_note_url(@note, "json") } %>
           <% end -%>
-          <%= button_tag t(".resolve"), :name => "close", :class => "btn btn-primary",
-                                        :data => { :method => "POST",
-                                                   :url => close_api_note_url(@note, "json"),
-                                                   :default_action_text => t(".resolve"),
-                                                   :comment_action_text => t(".comment_and_resolve") } %>
+          <% if can_resolve_without_comment?(current_user, @note) -%>
+            <%= button_tag t(".resolve"), :name => "close", :class => "btn btn-primary",
+                                          :data => { :method => "POST",
+                                                     :url => close_api_note_url(@note, "json"),
+                                                     :default_action_text => t(".resolve"),
+                                                     :comment_action_text => t(".comment_and_resolve"),
+                                                     :can_resolve_without_comment => true } %>
+          <% else -%>
+            <%= button_tag t(".comment_and_resolve"), :name => "close", :class => "btn btn-primary",
+                                                      :disabled => true,
+                                                      :data => { :method => "POST",
+                                                                 :url => close_api_note_url(@note, "json"),
+                                                                 :default_action_text => t(".comment_and_resolve"),
+                                                                 :comment_action_text => t(".comment_and_resolve") } %>
+          <% end -%>
           <%= button_tag t(".comment"), :name => "comment", :class => "btn btn-primary", :disabled => true,
                                         :data => { :method => "POST",
                                                    :url => comment_api_note_url(@note, "json") } %>

--- a/test/system/note_comments_test.rb
+++ b/test/system/note_comments_test.rb
@@ -33,7 +33,8 @@ class NoteCommentsTest < ApplicationSystemTestCase
     within_sidebar do
       assert_no_content "Comment from #{user.display_name}"
       assert_no_content "Some newly added note comment"
-      assert_button "Resolve"
+      assert_no_button "Resolve"
+      assert_button "Comment & Resolve", :disabled => true
       assert_button "Comment", :disabled => true
 
       fill_in "text", :with => "Some newly added note comment"

--- a/test/system/resolve_note_test.rb
+++ b/test/system/resolve_note_test.rb
@@ -6,6 +6,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
   test "can resolve an open note" do
     note = create(:note_with_comments)
     user = create(:user)
+    create(:changeset, :user => user, :num_changes => 1)
     sign_in_as(user)
     visit note_path(note)
 
@@ -23,6 +24,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
   test "can resolve an open note with a comment" do
     note = create(:note_with_comments)
     user = create(:user)
+    create(:changeset, :user => user, :num_changes => 1)
     sign_in_as(user)
     visit note_path(note)
 
@@ -39,6 +41,32 @@ class ResolveNoteTest < ApplicationSystemTestCase
 
       assert_content "Resolved note ##{note.id}"
       assert_content "Note resolve text"
+    end
+  end
+
+  test "can't resolve an open note without map edits" do
+    note = create(:note)
+    user = create(:user)
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_no_button "Resolve"
+      assert_button "Comment & Resolve", :disabled => true
+      assert_button "Comment", :disabled => true
+    end
+  end
+
+  test "can resolve an open note when user authored the last comment" do
+    note = create(:note_with_comments)
+    user = create(:user)
+    create(:note_comment, :note => note, :author => user, :event => "commented")
+    sign_in_as(user)
+    visit note_path(note)
+
+    within_sidebar do
+      assert_button "Resolve"
+      assert_no_button "Comment & Resolve"
     end
   end
 
@@ -95,6 +123,7 @@ class ResolveNoteTest < ApplicationSystemTestCase
   test "can't resolve a note when blocked" do
     note = create(:note_with_comments)
     user = create(:user)
+    create(:changeset, :user => user, :num_changes => 1)
     sign_in_as(user)
     visit note_path(note)
     create(:user_block, :user => user)


### PR DESCRIPTION
### Description

Often, newcomers don't understand the OSM note workflow and click the `Resolve` button in the hopes that their changes will appear on the map. After that, they can reopen the note, even repeat it again.

The situation is further aggravated by the fact that in languages ​​like Russian, the translation is close in meaning to the word "Close", and beginners confuse this button, thinking it will close the tab.

I propose not to provide the option to close a note **without comment** if the user has not made any edits to the map.

This is not an API-level change, because in iD, for example, you typically close notes first and then submit map changes.

There's one special case: sometimes people accidentally reactivate a note. In this case, it's better to simply let the user close the note. For these cases, a check has been added to ensure that the last comment was made by the current user.

### How has this been tested?

Form for user without changesets:

<img width="50%" src="https://github.com/user-attachments/assets/bf85d3c2-d14f-434e-bcee-be991ffc93ad" />

For user without changesets with his comment:

<img width="50%" src="https://github.com/user-attachments/assets/187cd63a-c173-4c7b-9fe1-25a7d016b518" />

For user with changesets:

<img width="50%"  src="https://github.com/user-attachments/assets/29edb309-ecd9-4406-8438-9be45ef4907b" />

E2E-tests have also been added.

### About implementation

The initial button is selected on the server. An additional field `can_resolve_without_comment` is added to the button, which is checked on the JS side, when entering text.