### PR TITLE
Avoid string interpolation into bash commands in Danger config

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -23,11 +23,17 @@ jobs:
           ruby-version: 3.3
           bundler-cache: true
       - name: Create base branch
+        env:
+          BASE_CLONE_URL: ${{ github.event.pull_request.base.repo.clone_url }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git fetch ${{ github.event.pull_request.base.repo.clone_url }} ${{ github.event.pull_request.base.sha }}:danger_base
+          git fetch "$BASE_CLONE_URL" "$BASE_SHA:danger_base"
       - name: Create head branch
+        env:
+          HEAD_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git fetch ${{ github.event.pull_request.head.repo.clone_url }} ${{ github.event.pull_request.head.sha }}:danger_head
+          git fetch "$HEAD_CLONE_URL" "$HEAD_SHA:danger_head"
       - name: Danger
         env:
           DANGER_GITHUB_BEARER_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Although the `clone_url` and `sha` are safe, other similar aspects of the pull request head are not (e.g. `head.ref`, `pull_request.title` etc) and these must not be interpolated.

So let's use the convention of putting such data into environment variables, where the contents are not interpolated into the bash commands and are instead passed directly to the called program.

https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable

---

Just to be clear, there's no problem with what we were doing before with those specific variables, but the interpolation is a habit we want to avoid getting into. 

I was reviewing this workflow because it uses `pull_request_target`, which runs with elevated permissions compared to the permissions normally available for `pull_request` workflows. It's been leveraged in recent security incidents elsewhere (e.g. [TanStack](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)), so I think the hardening is worth doing.