### PR TITLE
Run script/misc/update-wiki-pages

### DIFF
--- a/config/wiki_pages.yml
+++ b/config/wiki_pages.yml
@@ -204,6 +204,7 @@ ca:
     man_made=wastewater_plant: Ca:Tag:man made=wastewater plant
     name=Herfy: Ca:Tag:name=Herfy
     natural=cliff: Ca:Tag:natural=cliff
+    natural=spring: Ca:Tag:natural=spring
     network=VE:T:PO: Ca:Tag:network=VE:T:PO
     office=notary: Ca:Tag:office=notary
     oneway=yes: Ca:Tag:oneway=yes
@@ -529,6 +530,7 @@ cs:
     group_only: Cs:Key:group only
     handrail: Cs:Key:handrail
     happy_hours: Cs:Key:happy hours
+    hazard: Cs:Key:hazard
     hazmat: Cs:Key:hazmat
     hazmat:water: Cs:Key:hazmat:water
     healthcare: Cs:Key:healthcare
@@ -778,6 +780,7 @@ cs:
     railway:signal:combined:shape: Cs:Key:railway:signal:combined:shape
     railway:signal:combined:shortened: Cs:Key:railway:signal:combined:shortened
     railway:signal:combined:type: Cs:Key:railway:signal:combined:type
+    railway:signal:combined_repeated: Cs:Key:railway:signal:combined repeated
     railway:signal:crossing: Cs:Key:railway:signal:crossing
     railway:signal:crossing:deactivated: Cs:Key:railway:signal:crossing:deactivated
     railway:signal:crossing:form: Cs:Key:railway:signal:crossing:form
@@ -791,10 +794,8 @@ cs:
     railway:signal:crossing_repeated:form: Cs:Key:railway:signal:crossing repeated:form
     railway:signal:departure: Cs:Key:railway:signal:departure
     railway:signal:departure:deactivated: Cs:Key:railway:signal:departure:deactivated
-    railway:signal:departure:form: Cs:Key:railway:signal:departure:form
     railway:signal:distant: Cs:Key:railway:signal:distant
     railway:signal:distant:deactivated: Cs:Key:railway:signal:distant:deactivated
-    railway:signal:distant:form: Cs:Key:railway:signal:distant:form
     railway:signal:distant:repeated: Cs:Key:railway:signal:distant:repeated
     railway:signal:distant:shape: Cs:Key:railway:signal:distant:shape
     railway:signal:distant:shortened: Cs:Key:railway:signal:distant:shortened
@@ -814,30 +815,23 @@ cs:
     railway:signal:main:shortened: Cs:Key:railway:signal:main:shortened
     railway:signal:main:type: Cs:Key:railway:signal:main:type
     railway:signal:main_repeated: Cs:Key:railway:signal:main repeated
-    railway:signal:main_repeated:deactivated: Cs:Key:railway:signal:main repeated:deactivated
-    railway:signal:main_repeated:form: Cs:Key:railway:signal:main repeated:form
     railway:signal:main_repeated:shortened: Cs:Key:railway:signal:main repeated:shortened
     railway:signal:minor: Cs:Key:railway:signal:minor
     railway:signal:minor:deactivated: Cs:Key:railway:signal:minor:deactivated
-    railway:signal:minor:form: Cs:Key:railway:signal:minor:form
     railway:signal:minor:shortened: Cs:Key:railway:signal:minor:shortened
     railway:signal:route: Cs:Key:railway:signal:route
     railway:signal:route:deactivated: Cs:Key:railway:signal:route:deactivated
-    railway:signal:route:form: Cs:Key:railway:signal:route:form
     railway:signal:shunting: Cs:Key:railway:signal:shunting
     railway:signal:shunting:deactivated: Cs:Key:railway:signal:shunting:deactivated
-    railway:signal:shunting:form: Cs:Key:railway:signal:shunting:form
     railway:signal:snowplow: Cs:Key:railway:signal:snowplow
     railway:signal:snowplow:deactivated: Cs:Key:railway:signal:snowplow:deactivated
     railway:signal:snowplow:form: Cs:Key:railway:signal:snowplow:form
     railway:signal:speed_limit: Cs:Key:railway:signal:speed limit
     railway:signal:speed_limit:deactivated: Cs:Key:railway:signal:speed limit:deactivated
-    railway:signal:speed_limit:form: Cs:Key:railway:signal:speed limit:form
     railway:signal:speed_limit:speed: Cs:Key:railway:signal:speed limit:speed
     railway:signal:speed_limit_distant: Cs:Key:railway:signal:speed limit distant
     railway:signal:speed_limit_distant:deactivated: Cs:Key:railway:signal:speed limit
       distant:deactivated
-    railway:signal:speed_limit_distant:form: Cs:Key:railway:signal:speed limit distant:form
     railway:signal:speed_limit_distant:speed: Cs:Key:railway:signal:speed limit distant:speed
     railway:signal:station: Cs:Key:railway:signal:station
     railway:signal:station:caption: Cs:Key:railway:signal:station:caption
@@ -845,6 +839,20 @@ cs:
     railway:signal:station:form: Cs:Key:railway:signal:station:form
     railway:signal:station_distant: Cs:Key:railway:signal:station distant
     railway:signal:station_distant:deactivated: Cs:Key:railway:signal:station distant:deactivated
+    railway:signal:stop: Cs:Key:railway:signal:stop
+    railway:signal:stop:caption: Cs:Key:railway:signal:stop:caption
+    railway:signal:stop:carriages: Cs:Key:railway:signal:stop:carriages
+    railway:signal:stop:deactivated: Cs:Key:railway:signal:stop:deactivated
+    railway:signal:stop:form: Cs:Key:railway:signal:stop:form
+    railway:signal:train_protection: Cs:Key:railway:signal:train protection
+    railway:signal:train_protection:deactivated: Cs:Key:railway:signal:train protection:deactivated
+    railway:signal:train_protection:form: Cs:Key:railway:signal:train protection:form
+    railway:signal:whistle: Cs:Key:railway:signal:whistle
+    railway:signal:whistle:deactivated: Cs:Key:railway:signal:whistle:deactivated
+    railway:signal:whistle:form: Cs:Key:railway:signal:whistle:form
+    railway:signal:wrong_road: Cs:Key:railway:signal:wrong road
+    railway:signal:wrong_road:deactivated: Cs:Key:railway:signal:wrong road:deactivated
+    railway:signal:wrong_road:form: Cs:Key:railway:signal:wrong road:form
     railway:track_ref: Cs:Key:railway:track ref
     ramp: Cs:Key:ramp
     ramp:bicycle: Cs:Key:ramp:bicycle
@@ -1088,6 +1096,7 @@ cs:
     amenity=animal_boarding: Cs:Tag:amenity=animal boarding
     amenity=animal_breeding: Cs:Tag:amenity=animal breeding
     amenity=animal_shelter: Cs:Tag:amenity=animal shelter
+    amenity=animal_training: Cs:Tag:amenity=animal training
     amenity=arts_centre: Cs:Tag:amenity=arts centre
     amenity=artwork: Cs:Tag:amenity=artwork
     amenity=atm: Cs:Tag:amenity=atm
@@ -2221,7 +2230,6 @@ cs:
     shop=fishmonger: Cs:Tag:shop=fishmonger
     shop=flooring: Cs:Tag:shop=flooring
     shop=florist: Cs:Tag:shop=florist
-    shop=flower: Cs:Tag:shop=flower
     shop=flowers: Cs:Tag:shop=flowers
     shop=frame: Cs:Tag:shop=frame
     shop=free_flying: Cs:Tag:shop=free flying
@@ -2549,6 +2557,7 @@ da:
     cycleway: Da:Key:cycleway
     description: Da:Key:description
     diet:vegan: Da:Key:diet:vegan
+    education: Da:Key:education
     fee: Da:Key:fee
     fireplace: Da:Key:fireplace
     group_only: Da:Key:group only
@@ -2595,6 +2604,11 @@ da:
     camp_site=standard: Da:Tag:camp site=standard
     cemetery=wood: Da:Tag:cemetery=wood
     cycleway=lane: Da:Tag:cycleway=lane
+    education=college: Da:Tag:education=college
+    education=folk_high_school: Da:Tag:education=folk high school
+    education=kindergarten: Da:Tag:education=kindergarten
+    education=school: Da:Tag:education=school
+    education=university: Da:Tag:education=university
     genus=Acer: Da:Tag:genus=Acer
     highway=bridleway: Da:Tag:highway=bridleway
     highway=cycleway: Da:Tag:highway=cycleway
@@ -2783,6 +2797,7 @@ de:
     cabins: DE:Key:cabins
     cables: DE:Key:cables
     camera:type: DE:Key:camera:type
+    camp_site: DE:Key:camp site
     canoe: DE:Key:canoe
     capacity: DE:Key:capacity
     capacity:*: DE:Key:capacity:*
@@ -2910,6 +2925,7 @@ de:
     denotation: DE:Key:denotation
     departures_board: DE:Key:departures board
     departures_board:speech_output: DE:Key:departures board:speech output
+    depot: DE:Key:depot
     descent: DE:Key:descent
     description: DE:Key:description
     designation: DE:Key:designation
@@ -2955,6 +2971,7 @@ de:
     drive_in: DE:Key:drive in
     drive_through: DE:Key:drive through
     duration: DE:Key:duration
+    educational: DE:Key:educational
     ele: DE:Key:ele
     ele:NHN: DE:Key:ele:NHN
     electric_bicycle: DE:Key:electric bicycle
@@ -2966,6 +2983,7 @@ de:
     emergency: DE:Key:emergency
     emergency:phone: DE:Key:emergency:phone
     emergency_telephone_code: DE:Key:emergency telephone code
+    emergency_vehicle: DE:Key:emergency vehicle
     end_date: DE:Key:end date
     enforcement: DE:Key:enforcement
     engineer: DE:Key:engineer
@@ -2998,6 +3016,7 @@ de:
     fixme: DE:Key:fixme
     flag:type: DE:Key:flag:type
     floating: DE:Key:floating
+    flow_direction: DE:Key:flow direction
     flow_rate: DE:Key:flow rate
     foot: DE:Key:foot
     footway: DE:Key:footway
@@ -3022,6 +3041,7 @@ de:
     fuel:diesel: DE:Key:fuel:diesel
     fuel:e10: DE:Key:fuel:e10
     fuel:e5: DE:Key:fuel:e5
+    fuel:h35: DE:Key:fuel:h35
     fuel:h70: DE:Key:fuel:h70
     fuel:lpg: DE:Key:fuel:lpg
     garden:style: DE:Key:garden:style
@@ -3283,6 +3303,7 @@ de:
     operator:MNC: DE:Key:operator:MNC
     operator:type: DE:Key:operator:type
     operator:wikidata: DE:Key:operator:wikidata
+    orchard: DE:Key:orchard
     organic: DE:Key:organic
     orientation: DE:Key:orientation
     origin: DE:Key:origin
@@ -3316,6 +3337,7 @@ de:
     permanent_camping: DE:Key:permanent camping
     pet: DE:Key:pet
     phone: DE:Key:phone
+    physically_present: DE:Key:physically present
     pilgrimage: DE:Key:pilgrimage
     pipeline: DE:Key:pipeline
     piste:difficulty: DE:Key:piste:difficulty
@@ -3409,12 +3431,14 @@ de:
     recycling_type: DE:Key:recycling type
     red_turn:right:bicycle: DE:Key:red turn:right:bicycle
     ref: DE:Key:ref
+    ref:EGID: DE:Key:ref:EGID
     ref:GAS_MD: DE:Key:ref:GAS MD
     ref:IFOPT: DE:Key:ref:IFOPT
     ref:WDPA: DE:Key:ref:WDPA
     ref:bufa: DE:Key:ref:bufa
     ref:fgkz: DE:Key:ref:fgkz
     ref:id: DE:Key:ref:id
+    ref:manufacturer_inventory: DE:Key:ref:manufacturer inventory
     ref:mobil-parken.de: DE:Key:ref:mobil-parken.de
     ref:operator_inventory: DE:Key:ref:operator inventory
     ref:sprockhoff: DE:Key:ref:sprockhoff
@@ -3453,6 +3477,7 @@ de:
     route_marker: DE:Key:route marker
     route_ref: DE:Key:route ref
     ruins: DE:Key:ruins
+    rwn_ref: DE:Key:rwn ref
     sac_scale: DE:Key:sac scale
     salt: DE:Key:salt
     sauna: DE:Key:sauna
@@ -3644,6 +3669,7 @@ de:
     weather:thermometer: DE:Key:weather:thermometer
     weather:wind_vane: DE:Key:weather:wind vane
     website: DE:Key:website
+    website:*: DE:Key:website:*
     website:menu: DE:Key:website:menu
     website:regulation: DE:Key:website:regulation
     wetland: DE:Key:wetland
@@ -4180,6 +4206,7 @@ de:
     club=sport: DE:Tag:club=sport
     club=student: DE:Tag:club=student
     club=youth: DE:Tag:club=youth
+    college=adult_education: DE:Tag:college=adult education
     communication=line: DE:Tag:communication=line
     community_centre=community_hall: DE:Tag:community centre=community hall
     community_centre=cultural_centre: DE:Tag:community centre=cultural centre
@@ -4302,6 +4329,7 @@ de:
     crossing=unmarked: DE:Tag:crossing=unmarked
     crossing=zebra: DE:Tag:crossing=zebra
     cuisine=asian: DE:Tag:cuisine=asian
+    cuisine=austrian: DE:Tag:cuisine=austrian
     cuisine=brazilian: DE:Tag:cuisine=brazilian
     cuisine=burger: DE:Tag:cuisine=burger
     cuisine=chinese: DE:Tag:cuisine=chinese
@@ -4317,6 +4345,7 @@ de:
     cuisine=seafood: DE:Tag:cuisine=seafood
     cuisine=sushi: DE:Tag:cuisine=sushi
     cuisine=thai: DE:Tag:cuisine=thai
+    cuisine=viennese: DE:Tag:cuisine=viennese
     cuisine=vietnamese: DE:Tag:cuisine=vietnamese
     culvert=arch: DE:Tag:culvert=arch
     culvert=box: DE:Tag:culvert=box
@@ -4432,6 +4461,7 @@ de:
     fence_type=railing: DE:Tag:fence type=railing
     fire_class=*: DE:Tag:fire class=*
     flood_prone=yes: DE:Tag:flood prone=yes
+    flow_direction=both: DE:Tag:flow direction=both
     foot=designated: DE:Tag:foot=designated
     foot=use_sidepath: DE:Tag:foot=use sidepath
     foot=yes: DE:Tag:foot=yes
@@ -5706,6 +5736,7 @@ de:
     station=subway: DE:Tag:station=subway
     statue=equestrian: DE:Tag:statue=equestrian
     stone_type=conciliation_cross: DE:Tag:stone type=conciliation cross
+    structure=wall_mount: DE:Tag:structure=wall mount
     studio=audio: DE:Tag:studio=audio
     studio=radio: DE:Tag:studio=radio
     studio=video: DE:Tag:studio=video
@@ -5743,6 +5774,7 @@ de:
     surface=fine_gravel: DE:Tag:surface=fine gravel
     surface=grass: DE:Tag:surface=grass
     surface=grass_paver: DE:Tag:surface=grass paver
+    surface=grass_paver:lanes: DE:Tag:surface=grass paver:lanes
     surface=gravel: DE:Tag:surface=gravel
     surface=ground: DE:Tag:surface=ground
     surface=metal: DE:Tag:surface=metal
@@ -5791,6 +5823,7 @@ de:
     tourism=aquarium: DE:Tag:tourism=aquarium
     tourism=artwork: DE:Tag:tourism=artwork
     tourism=attraction: DE:Tag:tourism=attraction
+    tourism=camp_pitch: DE:Tag:tourism=camp pitch
     tourism=camp_site: DE:Tag:tourism=camp site
     tourism=caravan_site: DE:Tag:tourism=caravan site
     tourism=chalet: DE:Tag:tourism=chalet
@@ -5965,6 +5998,7 @@ de:
     transformer=distribution: DE:Tag:transformer=distribution
     transformer=generator: DE:Tag:transformer=generator
     transformer=main: DE:Tag:transformer=main
+    trees=apple_trees: DE:Tag:trees=apple trees
     tunnel=building_passage: DE:Tag:tunnel=building passage
     tunnel=culvert: DE:Tag:tunnel=culvert
     type=associatedStreet: DE:Tag:type=associatedStreet
@@ -6147,6 +6181,7 @@ el:
   key:
     abutters: El:Key:abutters
     amenity: El:Key:amenity
+    aquaculture: El:Key:aquaculture
     assisted_trail: El:Key:assisted trail
     bridge: El:Key:bridge
     building: El:Key:building
@@ -6154,27 +6189,43 @@ el:
     building:levels: El:Key:building:levels
     bus_bay: El:Key:bus bay
     change: El:Key:change
+    circumference: El:Key:circumference
+    crop: El:Key:crop
     delivery: El:Key:delivery
+    denotation: El:Key:denotation
     destination: El:Key:destination
     drive_in: El:Key:drive in
     drive_through: El:Key:drive through
     embankment: El:Key:embankment
     embedded_rails: El:Key:embedded rails
+    farmyard: El:Key:farmyard
     ford: El:Key:ford
     frontage_road: El:Key:frontage road
+    genus: El:Key:genus
+    geological: El:Key:geological
+    glacier:part: El:Key:glacier:part
+    glacier:type: El:Key:glacier:type
+    grassland: El:Key:grassland
     height: El:Key:height
     highway: El:Key:highway
     ice_road: El:Key:ice road
     incline: El:Key:incline
+    irrigated: El:Key:irrigated
     junction: El:Key:junction
     lamp_mount: El:Key:lamp mount
     lamp_type: El:Key:lamp type
+    landcover: El:Key:landcover
+    landuse: El:Key:landuse
     lane_markings: El:Key:lane markings
     lanes: El:Key:lanes
+    leaf_cycle: El:Key:leaf cycle
+    leaf_type: El:Key:leaf type
     light:colour: El:Key:light:colour
     light:count: El:Key:light:count
     light:method: El:Key:light:method
     lit: El:Key:lit
+    maintained: El:Key:maintained
+    managed: El:Key:managed
     manufacturer: El:Key:manufacturer
     maxspeed: El:Key:maxspeed
     minspeed: El:Key:minspeed
@@ -6192,55 +6243,151 @@ el:
     park_ride: El:Key:park ride
     parking: El:Key:parking
     passing_places: El:Key:passing places
+    planted_date: El:Key:planted date
     priority: El:Key:priority
     priority_road: El:Key:priority road
+    protected: El:Key:protected
     sac_scale: El:Key:sac scale
+    seamark:marine_farm:category: El:Key:seamark:marine farm:category
+    seasonal: El:Key:seasonal
+    self_harvesting: El:Key:self harvesting
     service: El:Key:service
+    shelter_type: El:Key:shelter type
     shop: El:Key:shop
     shoulder: El:Key:shoulder
+    shrubbery:density: El:Key:shrubbery:density
+    shrubbery:shape: El:Key:shrubbery:shape
     side_road: El:Key:side road
     sidewalk: El:Key:sidewalk
     smoothness: El:Key:smoothness
+    species: El:Key:species
     surface: El:Key:surface
     tactile_paving: El:Key:tactile paving
     takeaway: El:Key:takeaway
+    taxon: El:Key:taxon
+    tidal: El:Key:tidal
     toll: El:Key:toll
     tracktype: El:Key:tracktype
     traffic_calming: El:Key:traffic calming
     trail_visibility: El:Key:trail visibility
     trailblazed: El:Key:trailblazed
     trailblazed:visibility: El:Key:trailblazed:visibility
+    tree_lined: El:Key:tree lined
     tunnel: El:Key:tunnel
     turn: El:Key:turn
+    volcano:status: El:Key:volcano:status
+    volcano:type: El:Key:volcano:type
     width: El:Key:width
     winter_road: El:Key:winter road
   tag:
+    amenity=arts_centre: El:Tag:amenity=arts centre
+    amenity=atm: El:Tag:amenity=atm
+    amenity=baby_hatch: El:Tag:amenity=baby hatch
+    amenity=bank: El:Tag:amenity=bank
     amenity=bar: El:Tag:amenity=bar
     amenity=bbq: El:Tag:amenity=bbq
+    amenity=bench: El:Tag:amenity=bench
     amenity=bicycle_parking: El:Tag:amenity=bicycle parking
     amenity=bicycle_rental: El:Tag:amenity=bicycle rental
+    amenity=bicycle_repair_station: El:Tag:amenity=bicycle repair station
+    amenity=bicycle_wash: El:Tag:amenity=bicycle wash
     amenity=biergarten: El:Tag:amenity=biergarten
+    amenity=boat_rental: El:Tag:amenity=boat rental
+    amenity=boat_sharing: El:Tag:amenity=boat sharing
+    amenity=boat_storage: El:Tag:amenity=boat storage
+    amenity=brothel: El:Tag:amenity=brothel
+    amenity=bureau_de_change: El:Tag:amenity=bureau de change
     amenity=bus_station: El:Tag:amenity=bus station
     amenity=cafe: El:Tag:amenity=cafe
     amenity=car_pooling: El:Tag:amenity=car pooling
     amenity=car_rental: El:Tag:amenity=car rental
     amenity=car_sharing: El:Tag:amenity=car sharing
     amenity=car_wash: El:Tag:amenity=car wash
+    amenity=casino: El:Tag:amenity=casino
+    amenity=charging_station: El:Tag:amenity=charging station
+    amenity=check_in: El:Tag:amenity=check in
+    amenity=cinema: El:Tag:amenity=cinema
+    amenity=clinic: El:Tag:amenity=clinic
+    amenity=college: El:Tag:amenity=college
+    amenity=community_centre: El:Tag:amenity=community centre
+    amenity=compressed_air: El:Tag:amenity=compressed air
+    amenity=conference_centre: El:Tag:amenity=conference centre
+    amenity=courthouse: El:Tag:amenity=courthouse
+    amenity=dancing_school: El:Tag:amenity=dancing school
+    amenity=dentist: El:Tag:amenity=dentist
+    amenity=doctors: El:Tag:amenity=doctors
+    amenity=dog_toilet: El:Tag:amenity=dog toilet
+    amenity=dressing_room: El:Tag:amenity=dressing room
     amenity=drinking_water: El:Tag:amenity=drinking water
+    amenity=driver_training: El:Tag:amenity=driver training
+    amenity=driving_school: El:Tag:amenity=driving school
+    amenity=events_venue: El:Tag:amenity=events venue
+    amenity=exhibition_centre: El:Tag:amenity=exhibition centre
     amenity=fast_food: El:Tag:amenity=fast food
+    amenity=ferry_terminal: El:Tag:amenity=ferry terminal
+    amenity=fire_station: El:Tag:amenity=fire station
+    amenity=first_aid_school: El:Tag:amenity=first aid school
     amenity=food_court: El:Tag:amenity=food court
+    amenity=fountain: El:Tag:amenity=fountain
     amenity=fuel: El:Tag:amenity=fuel
+    amenity=gambling: El:Tag:amenity=gambling
+    amenity=give_box: El:Tag:amenity=give box
+    amenity=grit_bin: El:Tag:amenity=grit bin
+    amenity=hospital: El:Tag:amenity=hospital
     amenity=ice_cream: El:Tag:amenity=ice cream
     amenity=kindergarten: El:Tag:amenity=kindergarten
     amenity=language_school: El:Tag:amenity=language school
     amenity=library: El:Tag:amenity=library
+    amenity=lounge: El:Tag:amenity=lounge
+    amenity=love_hotel: El:Tag:amenity=love hotel
+    amenity=mailroom: El:Tag:amenity=mailroom
+    amenity=money_transfer: El:Tag:amenity=money transfer
     amenity=motorcycle_parking: El:Tag:amenity=motorcycle parking
+    amenity=music_school: El:Tag:amenity=music school
+    amenity=music_venue: El:Tag:amenity=music venue
+    amenity=nightclub: El:Tag:amenity=nightclub
+    amenity=nursing_home: El:Tag:amenity=nursing home
+    amenity=parcel_locker: El:Tag:amenity=parcel locker
+    amenity=parking: El:Tag:amenity=parking
+    amenity=parking_entrance: El:Tag:amenity=parking entrance
+    amenity=parking_space: El:Tag:amenity=parking space
+    amenity=payment_centre: El:Tag:amenity=payment centre
+    amenity=payment_terminal: El:Tag:amenity=payment terminal
+    amenity=pharmacy: El:Tag:amenity=pharmacy
+    amenity=planetarium: El:Tag:amenity=planetarium
+    amenity=police: El:Tag:amenity=police
+    amenity=post_box: El:Tag:amenity=post box
+    amenity=post_depot: El:Tag:amenity=post depot
+    amenity=post_office: El:Tag:amenity=post office
+    amenity=prison: El:Tag:amenity=prison
     amenity=pub: El:Tag:amenity=pub
     amenity=public_bookcase: El:Tag:amenity=public bookcase
+    amenity=ranger_station: El:Tag:amenity=ranger station
+    amenity=research_institute: El:Tag:amenity=research institute
     amenity=restaurant: El:Tag:amenity=restaurant
     amenity=school: El:Tag:amenity=school
+    amenity=shelter: El:Tag:amenity=shelter
+    amenity=shower: El:Tag:amenity=shower
+    amenity=social_centre: El:Tag:amenity=social centre
+    amenity=social_facility: El:Tag:amenity=social facility
+    amenity=stage: El:Tag:amenity=stage
+    amenity=stripclub: El:Tag:amenity=stripclub
+    amenity=studio: El:Tag:amenity=studio
+    amenity=surf_school: El:Tag:amenity=surf school
+    amenity=swingerclub: El:Tag:amenity=swingerclub
     amenity=taxi: El:Tag:amenity=taxi
+    amenity=theatre: El:Tag:amenity=theatre
+    amenity=townhall: El:Tag:amenity=townhall
+    amenity=toy_library: El:Tag:amenity=toy library
+    amenity=traffic_park: El:Tag:amenity=traffic park
+    amenity=training: El:Tag:amenity=training
     amenity=university: El:Tag:amenity=university
+    amenity=vehicle_inspection: El:Tag:amenity=vehicle inspection
+    amenity=veterinary: El:Tag:amenity=veterinary
+    amenity=weighbridge: El:Tag:amenity=weighbridge
+    aquaculture=fish: El:Tag:aquaculture=fish
+    aquaculture=seaweed: El:Tag:aquaculture=seaweed
+    barrier=hedge: El:Tag:barrier=hedge
     barrier=height_restrictor: El:Tag:barrier=height restrictor
     bicycle_road=yes: El:Tag:bicycle road=yes
     bridge=aqueduct: El:Tag:bridge=aqueduct
@@ -6251,6 +6398,7 @@ el:
     bridge=movable: El:Tag:bridge=movable
     bridge=trestle: El:Tag:bridge=trestle
     bridge=viaduct: El:Tag:bridge=viaduct
+    building=greenhouse: El:Tag:building=greenhouse
     culvert=arch: El:Tag:culvert=arch
     culvert=box: El:Tag:culvert=box
     culvert=inverted_siphon: El:Tag:culvert=inverted siphon
@@ -6261,10 +6409,40 @@ el:
     cycleway=track: El:Tag:cycleway=track
     emergency=ladder_site: El:Tag:emergency=ladder site
     emergency=phone: El:Tag:emergency=phone
+    farmyard=stockyard: El:Tag:farmyard=stockyard
     footway=crossing: El:Tag:footway=crossing
     footway=sidewalk: El:Tag:footway=sidewalk
     footway=traffic_island: El:Tag:footway=traffic island
+    ford=stepping_stones: El:Tag:ford=stepping stones
     genus=Tilia: El:Tag:genus=Tilia
+    geological=columnar_jointing: El:Tag:geological=columnar jointing
+    geological=cone: El:Tag:geological=cone
+    geological=dyke: El:Tag:geological=dyke
+    geological=fault: El:Tag:geological=fault
+    geological=fold: El:Tag:geological=fold
+    geological=giants_kettle: El:Tag:geological=giants kettle
+    geological=glacial_erratic: El:Tag:geological=glacial erratic
+    geological=hoodoo: El:Tag:geological=hoodoo
+    geological=inselberg: El:Tag:geological=inselberg
+    geological=limestone_pavement: El:Tag:geological=limestone pavement
+    geological=meteor_crater: El:Tag:geological=meteor crater
+    geological=monocline: El:Tag:geological=monocline
+    geological=moraine: El:Tag:geological=moraine
+    geological=outcrop: El:Tag:geological=outcrop
+    geological=palaeontological_site: El:Tag:geological=palaeontological site
+    geological=pingo: El:Tag:geological=pingo
+    geological=rock_glacier: El:Tag:geological=rock glacier
+    geological=sinkhole: El:Tag:geological=sinkhole
+    geological=tor: El:Tag:geological=tor
+    geological=unconformity: El:Tag:geological=unconformity
+    geological=volcanic_caldera_rim: El:Tag:geological=volcanic caldera rim
+    geological=volcanic_lava_field: El:Tag:geological=volcanic lava field
+    geological=volcanic_lava_flow: El:Tag:geological=volcanic lava flow
+    geological=volcanic_lava_tube: El:Tag:geological=volcanic lava tube
+    geological=volcanic_vent: El:Tag:geological=volcanic vent
+    glacier:type=mountain: El:Tag:glacier:type=mountain
+    glacier:type=rock: El:Tag:glacier:type=rock
+    hazard=hole: El:Tag:hazard=hole
     highway=bridleway: El:Tag:highway=bridleway
     highway=bus_guideway: El:Tag:highway=bus guideway
     highway=bus_stop: El:Tag:highway=bus stop
@@ -6321,39 +6499,195 @@ el:
     highway=turning_loop: El:Tag:highway=turning loop
     highway=unclassified: El:Tag:highway=unclassified
     highway=via_ferrata: El:Tag:highway=via ferrata
+    historic=bomb_crater: El:Tag:historic=bomb crater
+    irrigation=pivot: El:Tag:irrigation=pivot
     junction=roundabout: El:Tag:junction=roundabout
+    landuse=allotments: El:Tag:landuse=allotments
+    landuse=animal_keeping: El:Tag:landuse=animal keeping
+    landuse=aquaculture: El:Tag:landuse=aquaculture
+    landuse=basin: El:Tag:landuse=basin
+    landuse=brownfield: El:Tag:landuse=brownfield
+    landuse=cemetery: El:Tag:landuse=cemetery
+    landuse=civic_admin: El:Tag:landuse=civic admin
+    landuse=commercial: El:Tag:landuse=commercial
+    landuse=conservation: El:Tag:landuse=conservation
+    landuse=construction: El:Tag:landuse=construction
+    landuse=depot: El:Tag:landuse=depot
+    landuse=education: El:Tag:landuse=education
+    landuse=fairground: El:Tag:landuse=fairground
+    landuse=farmland: El:Tag:landuse=farmland
+    landuse=farmyard: El:Tag:landuse=farmyard
+    landuse=flowerbed: El:Tag:landuse=flowerbed
+    landuse=forest: El:Tag:landuse=forest
+    landuse=forestry: El:Tag:landuse=forestry
+    landuse=garages: El:Tag:landuse=garages
+    landuse=grass: El:Tag:landuse=grass
+    landuse=greenery: El:Tag:landuse=greenery
+    landuse=greenfield: El:Tag:landuse=greenfield
+    landuse=greenhouse_horticulture: El:Tag:landuse=greenhouse horticulture
+    landuse=harbour: El:Tag:landuse=harbour
+    landuse=highway: El:Tag:landuse=highway
+    landuse=industrial: El:Tag:landuse=industrial
+    landuse=institutional: El:Tag:landuse=institutional
+    landuse=landfill: El:Tag:landuse=landfill
+    landuse=logging: El:Tag:landuse=logging
+    landuse=meadow: El:Tag:landuse=meadow
+    landuse=military: El:Tag:landuse=military
+    landuse=orchard: El:Tag:landuse=orchard
+    landuse=plant_nursery: El:Tag:landuse=plant nursery
+    landuse=port: El:Tag:landuse=port
+    landuse=quarry: El:Tag:landuse=quarry
+    landuse=railway: El:Tag:landuse=railway
+    landuse=recreation_ground: El:Tag:landuse=recreation ground
+    landuse=religious: El:Tag:landuse=religious
+    landuse=reservoir: El:Tag:landuse=reservoir
+    landuse=residential: El:Tag:landuse=residential
+    landuse=retail: El:Tag:landuse=retail
+    landuse=salt_pond: El:Tag:landuse=salt pond
+    landuse=village_green: El:Tag:landuse=village green
+    landuse=vineyard: El:Tag:landuse=vineyard
+    landuse=winter_sports: El:Tag:landuse=winter sports
+    leaf_type=broadleaved: El:Tag:leaf type=broadleaved
+    leaf_type=needleleaved: El:Tag:leaf type=needleleaved
+    leisure=garden: El:Tag:leisure=garden
+    leisure=park: El:Tag:leisure=park
     man_made=adit: El:Tag:man made=adit
+    man_made=cairn: El:Tag:man made=cairn
     man_made=gantry: El:Tag:man made=gantry
+    military=bombcrater: El:Tag:military=bombcrater
     natural=arch: El:Tag:natural=arch
+    natural=arete: El:Tag:natural=arete
+    natural=bare_rock: El:Tag:natural=bare rock
+    natural=bay: El:Tag:natural=bay
+    natural=beach: El:Tag:natural=beach
+    natural=blockfield: El:Tag:natural=blockfield
+    natural=blowhole: El:Tag:natural=blowhole
+    natural=cape: El:Tag:natural=cape
+    natural=cave_entrance: El:Tag:natural=cave entrance
+    natural=cliff: El:Tag:natural=cliff
+    natural=coastline: El:Tag:natural=coastline
+    natural=crater: El:Tag:natural=crater
+    natural=crevasse: El:Tag:natural=crevasse
+    natural=dune: El:Tag:natural=dune
+    natural=earth_bank: El:Tag:natural=earth bank
     natural=fell: El:Tag:natural=fell
+    natural=fumarole: El:Tag:natural=fumarole
+    natural=geyser: El:Tag:natural=geyser
+    natural=glacier: El:Tag:natural=glacier
+    natural=gorge: El:Tag:natural=gorge
+    natural=grass: El:Tag:natural=grass
     natural=grassland: El:Tag:natural=grassland
+    natural=gully: El:Tag:natural=gully
     natural=heath: El:Tag:natural=heath
+    natural=hill: El:Tag:natural=hill
+    natural=hot_spring: El:Tag:natural=hot spring
+    natural=isthmus: El:Tag:natural=isthmus
     natural=moor: El:Tag:natural=moor
+    natural=mountain_range: El:Tag:natural=mountain range
+    natural=mud: El:Tag:natural=mud
+    natural=peak: El:Tag:natural=peak
+    natural=peninsula: El:Tag:natural=peninsula
+    natural=plant: El:Tag:natural=plant
+    natural=reef: El:Tag:natural=reef
+    natural=ridge: El:Tag:natural=ridge
+    natural=rock: El:Tag:natural=rock
+    natural=saddle: El:Tag:natural=saddle
+    natural=sand: El:Tag:natural=sand
+    natural=scree: El:Tag:natural=scree
     natural=scrub: El:Tag:natural=scrub
+    natural=shingle: El:Tag:natural=shingle
+    natural=shoal: El:Tag:natural=shoal
     natural=shrubbery: El:Tag:natural=shrubbery
+    natural=sinkhole: El:Tag:natural=sinkhole
+    natural=spring: El:Tag:natural=spring
+    natural=stone: El:Tag:natural=stone
+    natural=strait: El:Tag:natural=strait
     natural=tree: El:Tag:natural=tree
     natural=tree_group: El:Tag:natural=tree group
     natural=tree_row: El:Tag:natural=tree row
     natural=tree_stump: El:Tag:natural=tree stump
     natural=tundra: El:Tag:natural=tundra
+    natural=valley: El:Tag:natural=valley
+    natural=volcano: El:Tag:natural=volcano
+    natural=water: El:Tag:natural=water
+    natural=wetland: El:Tag:natural=wetland
     natural=wood: El:Tag:natural=wood
     parking=multi-storey: El:Tag:parking=multi-storey
     parking=rooftop: El:Tag:parking=rooftop
     parking=surface: El:Tag:parking=surface
     parking=underground: El:Tag:parking=underground
     power=portal: El:Tag:power=portal
+    recreation_ground=showground: El:Tag:recreation ground=showground
+    refitted=yes: El:Tag:refitted=yes
     religion=jewish: El:Tag:religion=jewish
+    seamark:type=marine_farm: El:Tag:seamark:type=marine farm
     service=alley: El:Tag:service=alley
     service=drive-through: El:Tag:service=drive-through
     service=driveway: El:Tag:service=driveway
     service=emergency_access: El:Tag:service=emergency access
     service=parking_aisle: El:Tag:service=parking aisle
     service=slipway: El:Tag:service=slipway
+    shelter_type=basic_hut: El:Tag:shelter type=basic hut
+    shelter_type=bomb_shelter: El:Tag:shelter type=bomb shelter
+    shelter_type=field_shelter: El:Tag:shelter type=field shelter
+    shelter_type=gazebo: El:Tag:shelter type=gazebo
+    shelter_type=lean_to: El:Tag:shelter type=lean to
+    shelter_type=pavilion: El:Tag:shelter type=pavilion
+    shelter_type=pergola: El:Tag:shelter type=pergola
+    shelter_type=picnic_shelter: El:Tag:shelter type=picnic shelter
+    shelter_type=public_transport: El:Tag:shelter type=public transport
+    shelter_type=rock_shelter: El:Tag:shelter type=rock shelter
+    shelter_type=sun_shelter: El:Tag:shelter type=sun shelter
+    shelter_type=weather_shelter: El:Tag:shelter type=weather shelter
+    shelter_type=wetterpilz: El:Tag:shelter type=wetterpilz
+    sinkhole=pit: El:Tag:sinkhole=pit
     sport=karting: El:Tag:sport=karting
     sport=motocross: El:Tag:sport=motocross
     sport=motor: El:Tag:sport=motor
     station=light_rail: El:Tag:station=light rail
     station=subway: El:Tag:station=subway
+    surface=acrylic: El:Tag:surface=acrylic
+    surface=artificial_turf: El:Tag:surface=artificial turf
+    surface=asphalt: El:Tag:surface=asphalt
+    surface=bricks: El:Tag:surface=bricks
+    surface=carpet: El:Tag:surface=carpet
+    surface=chipseal: El:Tag:surface=chipseal
+    surface=clay: El:Tag:surface=clay
+    surface=cobblestone: El:Tag:surface=cobblestone
+    surface=compacted: El:Tag:surface=compacted
+    surface=concrete: El:Tag:surface=concrete
+    surface=concrete:lanes: El:Tag:surface=concrete:lanes
+    surface=concrete:plates: El:Tag:surface=concrete:plates
+    surface=dirt: El:Tag:surface=dirt
+    surface=earth: El:Tag:surface=earth
+    surface=fibre_reinforced_polymer_grate: El:Tag:surface=fibre reinforced polymer
+      grate
+    surface=fine_gravel: El:Tag:surface=fine gravel
+    surface=grass: El:Tag:surface=grass
+    surface=grass_paver: El:Tag:surface=grass paver
+    surface=gravel: El:Tag:surface=gravel
+    surface=ground: El:Tag:surface=ground
+    surface=metal: El:Tag:surface=metal
+    surface=metal_grid: El:Tag:surface=metal grid
+    surface=mud: El:Tag:surface=mud
+    surface=paved: El:Tag:surface=paved
+    surface=paving_stones: El:Tag:surface=paving stones
+    surface=paving_stones:lanes: El:Tag:surface=paving stones:lanes
+    surface=pebblestone: El:Tag:surface=pebblestone
+    surface=plastic: El:Tag:surface=plastic
+    surface=rock: El:Tag:surface=rock
+    surface=rubber: El:Tag:surface=rubber
+    surface=sand: El:Tag:surface=sand
+    surface=sett: El:Tag:surface=sett
+    surface=shells: El:Tag:surface=shells
+    surface=snow: El:Tag:surface=snow
+    surface=stepping_stones: El:Tag:surface=stepping stones
+    surface=tartan: El:Tag:surface=tartan
+    surface=tiles: El:Tag:surface=tiles
+    surface=unhewn_cobblestone: El:Tag:surface=unhewn cobblestone
+    surface=unpaved: El:Tag:surface=unpaved
+    surface=wood: El:Tag:surface=wood
+    surface=woodchips: El:Tag:surface=woodchips
     tower:type=lighting: El:Tag:tower:type=lighting
     traffic_calming=bump: El:Tag:traffic calming=bump
     traffic_calming=chicane: El:Tag:traffic calming=chicane
@@ -6378,8 +6712,27 @@ el:
     tunnel=canal: El:Tag:tunnel=canal
     tunnel=culvert: El:Tag:tunnel=culvert
     tunnel=flooded: El:Tag:tunnel=flooded
+    volcano:status=active: El:Tag:volcano:status=active
+    volcano:status=dormant: El:Tag:volcano:status=dormant
+    volcano:status=extinct: El:Tag:volcano:status=extinct
+    volcano:type=caldera: El:Tag:volcano:type=caldera
+    volcano:type=lava_dome: El:Tag:volcano:type=lava dome
+    volcano:type=maar: El:Tag:volcano:type=maar
+    volcano:type=scoria: El:Tag:volcano:type=scoria
+    volcano:type=shield: El:Tag:volcano:type=shield
+    volcano:type=stratovolcano: El:Tag:volcano:type=stratovolcano
+    waterway=soakhole: El:Tag:waterway=soakhole
+    waterway=stream_end: El:Tag:waterway=stream end
     wetland=bog: El:Tag:wetland=bog
+    wetland=dambo: El:Tag:wetland=dambo
+    wetland=fen: El:Tag:wetland=fen
+    wetland=mangrove: El:Tag:wetland=mangrove
+    wetland=marsh: El:Tag:wetland=marsh
+    wetland=reedbed: El:Tag:wetland=reedbed
+    wetland=saltmarsh: El:Tag:wetland=saltmarsh
     wetland=swamp: El:Tag:wetland=swamp
+    wetland=tidalflat: El:Tag:wetland=tidalflat
+    wetland=wet_meadow: El:Tag:wetland=wet meadow
 en:
   key:
     '*:backward': Key:*:backward
@@ -6432,8 +6785,10 @@ en:
     INEGI:*: Key:INEGI:*
     INEGI:CVE_MUN: Key:INEGI:CVE MUN
     INEGI:MUNID: Key:INEGI:MUNID
+    ISO3166-1: Key:ISO3166-1
     ISO3166-1:alpha2: Key:ISO3166-1:alpha2
     ISO3166-1:alpha3: Key:ISO3166-1:alpha3
+    ISO3166-1:numeric: Key:ISO3166-1:numeric
     ISO3166-2: Key:ISO3166-2
     KKR:code: Key:KKR:code
     LINZ2OSM:dataset: Key:LINZ2OSM:dataset
@@ -6468,14 +6823,10 @@ en:
     Shop: Key:Shop
     Socket:type2_combo: Key:Socket:type2 combo
     TARC: Key:TARC
-    TMC: Key:TMC
-    TMC:Direction: Key:TMC:Direction
-    TMC:LocationCode: Key:TMC:LocationCode
-    TMC:NextLocationCode: Key:TMC:NextLocationCode
-    TMC:PrevLocationCode: Key:TMC:PrevLocationCode
     URL: Key:URL
     WDPA_ID:ref: Key:WDPA ID:ref
     WLAN: Key:WLAN
+    a: Key:a
     abandoned: Key:abandoned
     'abandoned:': 'Key:abandoned:'
     abandoned:*: Key:abandoned:*
@@ -6500,6 +6851,7 @@ en:
     access_control: Key:access control
     access_sign: Key:access sign
     accommodation: Key:accommodation
+    accreditation:url: Key:accreditation:url
     accuracy: Key:accuracy
     accuracy:meters: Key:accuracy:meters
     acres: Key:acres
@@ -6522,6 +6874,8 @@ en:
     addr:city:ar: Key:addr:city:ar
     addr:city:de: Key:addr:city:de
     addr:city:en: Key:addr:city:en
+    addr:city:es: Key:addr:city:es
+    addr:city:fr: Key:addr:city:fr
     addr:city:it: Key:addr:city:it
     addr:city:scl: Key:addr:city:scl
     addr:city:simc: Key:addr:city:simc
@@ -6603,6 +6957,7 @@ en:
     admin_level: Key:admin level
     admin_title: Key:admin title
     admin_type:PH: Key:admin type:PH
+    adopted: Key:adopted
     adr_les: Key:adr les
     advertising: Key:advertising
     aerial: Key:aerial
@@ -6623,6 +6978,7 @@ en:
     agricultural: Key:agricultural
     agroecology: Key:agroecology
     air_conditioning: Key:air conditioning
+    air_rescue_service: Key:air rescue service
     airside: Key:airside
     alcohol: Key:alcohol
     alt_addr:housenumber: Key:alt addr:housenumber
@@ -6631,6 +6987,7 @@ en:
     alt_name:arc: Key:alt name:arc
     alt_name:azb: Key:alt name:azb
     alt_name:be: Key:alt name:be
+    alt_name:br: Key:alt name:br
     alt_name:ca: Key:alt name:ca
     alt_name:ckb: Key:alt name:ckb
     alt_name:cnr: Key:alt name:cnr
@@ -6648,13 +7005,16 @@ en:
     alt_name:kea: Key:alt name:kea
     alt_name:ko: Key:alt name:ko
     alt_name:ks: Key:alt name:ks
+    alt_name:la: Key:alt name:la
     alt_name:lrc: Key:alt name:lrc
     alt_name:mg: Key:alt name:mg
+    alt_name:mi: Key:alt name:mi
     alt_name:ms-Arab: Key:alt name:ms-Arab
     alt_name:mzn: Key:alt name:mzn
     alt_name:pl: Key:alt name:pl
     alt_name:pnb: Key:alt name:pnb
     alt_name:ps: Key:alt name:ps
+    alt_name:rm: Key:alt name:rm
     alt_name:ru: Key:alt name:ru
     alt_name:sd: Key:alt name:sd
     alt_name:syc: Key:alt name:syc
@@ -6674,6 +7034,7 @@ en:
     apartheid_free_zone: Key:apartheid free zone
     app:*: Key:app:*
     app_operated: Key:app operated
+    appointment: Key:appointment
     aquaculture: Key:aquaculture
     archaeological_site: Key:archaeological site
     archaeological_type: Key:archaeological type
@@ -6696,6 +7057,7 @@ en:
     artist:wikimedia_commons: Key:artist:wikimedia commons
     artist:wikipedia: Key:artist:wikipedia
     artist_name: Key:artist name
+    artwork:creation_year: Key:artwork:creation year
     artwork:subject:wikidata: Key:artwork:subject:wikidata
     artwork:subject:wikipedia: Key:artwork:subject:wikipedia
     artwork_subject: Key:artwork subject
@@ -6795,6 +7157,7 @@ en:
     bicycle:oneway: Key:bicycle:oneway
     bicycle:physical: Key:bicycle:physical
     bicycle:practical: Key:bicycle:practical
+    bicycle:pushing: Key:bicycle:pushing
     bicycle:right: Key:bicycle:right
     bicycle:type: Key:bicycle:type
     bicycle_bypass: Key:bicycle bypass
@@ -6841,8 +7204,11 @@ en:
     brand:es: Key:brand:es
     brand:fr: Key:brand:fr
     brand:ja: Key:brand:ja
+    brand:ko: Key:brand:ko
     brand:main: Key:brand:main
     brand:remarketed: Key:brand:remarketed
+    brand:ru: Key:brand:ru
+    brand:uk: Key:brand:uk
     brand:ur: Key:brand:ur
     brand:website: Key:brand:website
     brand:wikidata: Key:brand:wikidata
@@ -6854,6 +7220,7 @@ en:
     brand:wikipedia:es: Key:brand:wikipedia:es
     brand:wikipedia:fr: Key:brand:wikipedia:fr
     brand:wikipedia:it: Key:brand:wikipedia:it
+    brand:zh: Key:brand:zh
     breakfast: Key:breakfast
     brewery: Key:brewery
     bridge: Key:bridge
@@ -7013,10 +7380,12 @@ en:
     castle_type: Key:castle type
     castle_type:cs: Key:castle type:cs
     castle_type:de: Key:castle type:de
+    cat: Key:cat
     categorie_piscicole: Key:categorie piscicole
     category: Key:category
     catenary_mast:attachment: Key:catenary mast:attachment
     catenary_mast:supporting: Key:catenary mast:supporting
+    catering: Key:catering
     cave:name: Key:cave:name
     cave:ref: Key:cave:ref
     cellar:use: Key:cellar:use
@@ -7085,6 +7454,7 @@ en:
     club: Key:club
     club-mate: Key:club-mate
     coach: Key:coach
+    coastline: Key:coastline
     coastline:survey_quality: Key:coastline:survey quality
     coat_of_arms: Key:coat of arms
     cocktails: Key:cocktails
@@ -7161,6 +7531,7 @@ en:
     construction:building: Key:construction:building
     construction:highway: Key:construction:highway
     construction:power: Key:construction:power
+    construction:railway: Key:construction:railway
     construction:railway:etcs: Key:construction:railway:etcs
     construction:website: Key:construction:website
     construction_date: Key:construction date
@@ -7187,6 +7558,7 @@ en:
     contact:linkedin: Key:contact:linkedin
     contact:mail: Key:contact:mail
     contact:mastodon: Key:contact:mastodon
+    contact:max: Key:contact:max
     contact:mobile: Key:contact:mobile
     contact:ok: Key:contact:ok
     contact:phone: Key:contact:phone
@@ -7196,6 +7568,7 @@ en:
     contact:sip: Key:contact:sip
     contact:skype: Key:contact:skype
     contact:sms: Key:contact:sms
+    contact:spotify: Key:contact:spotify
     contact:street: Key:contact:street
     contact:telegram: Key:contact:telegram
     contact:tiktok: Key:contact:tiktok
@@ -7229,10 +7602,13 @@ en:
     counselling_type:*: Key:counselling type:*
     count: Key:count
     country: Key:country
+    country_code_iso3166_1_alpha_2: Key:country code iso3166 1 alpha 2
     couplings: Key:couplings
     couplings:diameters: Key:couplings:diameters
     couplings:type: Key:couplings:type
+    course: Key:course
     courts: Key:courts
+    cover: Key:cover
     covered: Key:covered
     craft: Key:craft
     crane:type: Key:crane:type
@@ -7251,6 +7627,7 @@ en:
     crossing:island: Key:crossing:island
     crossing:kerb_extension: Key:crossing:kerb extension
     crossing:light: Key:crossing:light
+    crossing:lit: Key:crossing:lit
     crossing:markings: Key:crossing:markings
     crossing:markings:colour: Key:crossing:markings:colour
     crossing:markings:condition: Key:crossing:markings:condition
@@ -7261,6 +7638,7 @@ en:
     crossing:supervision: Key:crossing:supervision
     crossing:whistle: Key:crossing:whistle
     crossing_ref: Key:crossing ref
+    crown_type: Key:crown type
     cruising: Key:cruising
     cs_dir:backward: Key:cs dir:backward
     cs_dir:forward: Key:cs dir:forward
@@ -7392,11 +7770,29 @@ en:
     description: Key:description
     description:ar: Key:description:ar
     description:bicycle: Key:description:bicycle
+    description:en: Key:description:en
     design: Key:design
     design:ref: Key:design:ref
     designation: Key:designation
     destination: Key:destination
     destination:*: Key:destination:*
+    destination:access:*: Key:destination:access:*
+    destination:access:bicycle: Key:destination:access:bicycle
+    destination:access:bus: Key:destination:access:bus
+    destination:access:caravan: Key:destination:access:caravan
+    destination:access:foot: Key:destination:access:foot
+    destination:access:goods: Key:destination:access:goods
+    destination:access:hazmat: Key:destination:access:hazmat
+    destination:access:hazmat:explosive: Key:destination:access:hazmat:explosive
+    destination:access:hazmat:water: Key:destination:access:hazmat:water
+    destination:access:hgv: Key:destination:access:hgv
+    destination:access:maxaxleload: Key:destination:access:maxaxleload
+    destination:access:maxheight: Key:destination:access:maxheight
+    destination:access:maxweight: Key:destination:access:maxweight
+    destination:access:maxweightrating: Key:destination:access:maxweightrating
+    destination:access:maxwidth: Key:destination:access:maxwidth
+    destination:access:moped: Key:destination:access:moped
+    destination:access:moto: Key:destination:access:moto
     destination:ar: Key:destination:ar
     destination:arrow: Key:destination:arrow
     destination:arrow:backward: Key:destination:arrow:backward
@@ -7478,6 +7874,7 @@ en:
     dhm_id: Key:dhm id
     diameter: Key:diameter
     diameter:range: Key:diameter:range
+    diameter_crown: Key:diameter crown
     dibavod:id: Key:dibavod:id
     diet: Key:diet
     'diet:': 'Key:diet:'
@@ -7494,6 +7891,7 @@ en:
     diet:sugar_free: Key:diet:sugar free
     diet:vegan: Key:diet:vegan
     diet:vegetarian: Key:diet:vegetarian
+    diff:ref:FR:RNB: Key:diff:ref:FR:RNB
     digital_access: Key:digital access
     dinner: Key:dinner
     diocese: Key:diocese
@@ -7580,6 +7978,7 @@ en:
     doorstep:wikimedia_commons: Key:doorstep:wikimedia commons
     double_tracked_motor_vehicle: Key:double tracked motor vehicle
     draft: Key:draft
+    drain: Key:drain
     draisine: Key:draisine
     drawbar_slot: Key:drawbar slot
     dress_code: Key:dress code
@@ -7641,8 +8040,10 @@ en:
     ele:natural: Key:ele:natural
     ele:wgs84: Key:ele:wgs84
     electric_bicycle: Key:electric bicycle
+    electric_car: Key:electric car
     electric_mofa: Key:electric mofa
     electric_scooter: Key:electric scooter
+    electric_vehicle: Key:electric vehicle
     electricity: Key:electricity
     electrified: Key:electrified
     electrified:contact_line: Key:electrified:contact line
@@ -7664,11 +8065,13 @@ en:
     emergency:*: Key:emergency:*
     emergency:_prefix: 'Key:emergency: prefix'
     emergency:amenity: Key:emergency:amenity
+    emergency:logistic_entry: Key:emergency:logistic entry
     emergency:phone: Key:emergency:phone
     emergency:plan: Key:emergency:plan
     emergency:social_facility: Key:emergency:social facility
     emergency_room: Key:emergency room
     emergency_telephone_code: Key:emergency telephone code
+    emergency_vehicle: Key:emergency vehicle
     employee: Key:employee
     end_date: Key:end date
     end_date:edtf: Key:end date:edtf
@@ -7706,6 +8109,7 @@ en:
     exit:carriages:forward: Key:exit:carriages:forward
     exit_to: Key:exit to
     expected_rcn_route_relations: Key:expected rcn route relations
+    expected_rwn_route_relations: Key:expected rwn route relations
     expressway: Key:expressway
     extinguishing:medium: Key:extinguishing:medium
     faa: Key:faa
@@ -7728,6 +8132,7 @@ en:
     fdot:sis: Key:fdot:sis
     fee: Key:fee
     fee:conditional: Key:fee:conditional
+    fee:description: Key:fee:description
     fee:disabled: Key:fee:disabled
     fee:disabled_assistant: Key:fee:disabled assistant
     fee:icom_member: Key:fee:icom member
@@ -7811,6 +8216,7 @@ en:
     format:top: Key:format:top
     fortification_type: Key:fortification type
     forward: Key:forward
+    foundation_date: Key:foundation date
     fountain: Key:fountain
     free_flying:ground_handling: Key:free flying:ground handling
     free_refill: Key:free refill
@@ -7903,7 +8309,6 @@ en:
     fuel:svo: Key:fuel:svo
     fuel:taxfree_diesel: Key:fuel:taxfree diesel
     full_name: Key:full name
-    functional_road_class: Key:functional road class
     funicular: Key:funicular
     furniture: Key:furniture
     fut_ref: Key:fut ref
@@ -8016,6 +8421,7 @@ en:
     guidepost: Key:guidepost
     guidepost:hiking: Key:guidepost:hiking
     guidepost_shape: Key:guidepost shape
+    guidepost_shape=fingers: Key:guidepost shape=fingers
     gun_emplacement_type: Key:gun emplacement type
     gun_turret: Key:gun turret
     gutter: Key:gutter
@@ -8062,6 +8468,7 @@ en:
     heated: Key:heated
     heater: Key:heater
     heating: Key:heating
+    heating:input: Key:heating:input
     hedge: Key:hedge
     height: Key:height
     height:hub: Key:height:hub
@@ -8076,6 +8483,7 @@ en:
     hgv:national_network: Key:hgv:national network
     hgv:repair: Key:hgv:repair
     hgv_articulated: Key:hgv articulated
+    high_heels: Key:high heels
     high_water_mark: Key:high water mark
     highchair: Key:highchair
     highspeed: Key:highspeed
@@ -8088,6 +8496,7 @@ en:
     hiking: Key:hiking
     historic: Key:historic
     historic:civilization: Key:historic:civilization
+    historic:date: Key:historic:date
     historic:era: Key:historic:era
     historic:period: Key:historic:period
     history: Key:history
@@ -8131,6 +8540,9 @@ en:
     in_service: Key:in service
     incline: Key:incline
     incline:across: Key:incline:across
+    indication:*: Key:indication:*
+    indication:man_made: Key:indication:man made
+    indication:power: Key:indication:power
     indoor: Key:indoor
     indoor_seating: Key:indoor seating
     indoormark: Key:indoormark
@@ -8152,6 +8564,7 @@ en:
     inscription:6: Key:inscription:6
     inscription:ar: Key:inscription:ar
     inscription:language: Key:inscription:language
+    inscription:script: Key:inscription:script
     inscription:url: Key:inscription:url
     instagram: Key:instagram
     int_name: Key:int name
@@ -8252,6 +8665,7 @@ en:
     kneipp_water_cure:*: Key:kneipp water cure:*
     kons:decision_number: Key:kons:decision number
     kons:inscription_date: Key:kons:inscription date
+    kons:official_name: Key:kons:official name
     kudish: Key:kudish
     kurb: Key:kurb
     lacounty:ain: Key:lacounty:ain
@@ -8319,6 +8733,7 @@ en:
     left: Key:left
     left:country: Key:left:country
     legal: Key:legal
+    legal_type: Key:legal type
     leisure: Key:leisure
     length: Key:length
     level: Key:level
@@ -8343,6 +8758,7 @@ en:
     light:power: Key:light:power
     light_rail: Key:light rail
     lighting:perceived: Key:lighting:perceived
+    lightning_protection: Key:lightning protection
     line: Key:line
     line_arrangement: Key:line arrangement
     line_attachement: Key:line attachement
@@ -8394,11 +8810,14 @@ en:
     long_name:arc: Key:long name:arc
     long_name:azb: Key:long name:azb
     long_name:de: Key:long name:de
+    long_name:en: Key:long name:en
     long_name:es: Key:long name:es
     long_name:fa: Key:long name:fa
     long_name:fr: Key:long name:fr
     long_name:gr: Key:long name:gr
     long_name:grc: Key:long name:grc
+    long_name:it: Key:long name:it
+    long_name:nl: Key:long name:nl
     long_name:pnb: Key:long name:pnb
     long_name:sr: Key:long name:sr
     long_name:syc: Key:long name:syc
@@ -8561,8 +8980,11 @@ en:
     monitoring: Key:monitoring
     'monitoring:': 'Key:monitoring:'
     monitoring:*: Key:monitoring:*
+    monitoring:air_pressure: Key:monitoring:air pressure
     monitoring:air_quality: Key:monitoring:air quality
     monitoring:bicycle: Key:monitoring:bicycle
+    monitoring:dissolved_oxygen: Key:monitoring:dissolved oxygen
+    monitoring:flow_rate: Key:monitoring:flow rate
     monitoring:galileo: Key:monitoring:galileo
     monitoring:glonass: Key:monitoring:glonass
     monitoring:gps: Key:monitoring:gps
@@ -8580,6 +9002,8 @@ en:
     monitoring:tide_gauge: Key:monitoring:tide gauge
     monitoring:traffic: Key:monitoring:traffic
     monitoring:water_level: Key:monitoring:water level
+    monitoring:water_temperature: Key:monitoring:water temperature
+    monitoring:water_turbidity: Key:monitoring:water turbidity
     monitoring:weather: Key:monitoring:weather
     monorail: Key:monorail
     montana_stream_access_class: Key:montana stream access class
@@ -8612,6 +9036,7 @@ en:
     motorcycle:tyres: Key:motorcycle:tyres
     motorcycle_parking: Key:motorcycle parking
     motorhome: Key:motorhome
+    motorhome_stopover: Key:motorhome stopover
     motorroad: Key:motorroad
     motorway: Key:motorway
     mountain_pass: Key:mountain pass
@@ -8666,6 +9091,7 @@ en:
     name:az-Arab: Key:name:az-Arab
     name:azb: Key:name:azb
     name:ba: Key:name:ba
+    name:backward: Key:name:backward
     name:bal: Key:name:bal
     name:ban: Key:name:ban
     name:bar: Key:name:bar
@@ -8741,8 +9167,10 @@ en:
     name:egl: Key:name:egl
     name:el: Key:name:el
     name:en: Key:name:en
+    name:en-boont: Key:name:en-boont
     name:eo: Key:name:eo
     name:es: Key:name:es
+    name:es-u-sd-usnm: Key:name:es-u-sd-usnm
     name:esu: Key:name:esu
     name:et: Key:name:et
     name:etymology: Key:name:etymology
@@ -8756,6 +9184,7 @@ en:
     name:etymology:wikipedia:it: Key:name:etymology:wikipedia:it
     name:eu: Key:name:eu
     name:eu-x-gaceria: Key:name:eu-x-gaceria
+    name:evn: Key:name:evn
     name:ext: Key:name:ext
     name:fa: Key:name:fa
     name:ff: Key:name:ff
@@ -8765,7 +9194,9 @@ en:
     name:fj: Key:name:fj
     name:fkv: Key:name:fkv
     name:fo: Key:name:fo
+    name:forward: Key:name:forward
     name:fr: Key:name:fr
+    name:fr-gallo: Key:name:fr-gallo
     name:frp: Key:name:frp
     name:frr: Key:name:frr
     name:fur: Key:name:fur
@@ -8896,6 +9327,7 @@ en:
     name:mhn: Key:name:mhn
     name:mhr: Key:name:mhr
     name:mi: Key:name:mi
+    name:mi-u-sd-nzwko: Key:name:mi-u-sd-nzwko
     name:mia: Key:name:mia
     name:mic: Key:name:mic
     name:min: Key:name:min
@@ -8940,6 +9372,7 @@ en:
     name:nov: Key:name:nov
     name:nrf: Key:name:nrf
     name:nrm: Key:name:nrm
+    name:nrn: Key:name:nrn
     name:nso: Key:name:nso
     name:nuk: Key:name:nuk
     name:nv: Key:name:nv
@@ -8977,6 +9410,9 @@ en:
     name:pot: Key:name:pot
     name:prefix: Key:name:prefix
     name:prefix:be: Key:name:prefix:be
+    name:prefix:de: Key:name:prefix:de
+    name:prefix:fr: Key:name:prefix:fr
+    name:prefix:it: Key:name:prefix:it
     name:pronunciation: Key:name:pronunciation
     name:ps: Key:name:ps
     name:pt: Key:name:pt
@@ -9012,6 +9448,7 @@ en:
     name:sc: Key:name:sc
     name:scn: Key:name:scn
     name:sco: Key:name:sco
+    name:scz: Key:name:scz
     name:sd: Key:name:sd
     name:se: Key:name:se
     name:sg: Key:name:sg
@@ -9076,6 +9513,7 @@ en:
     name:ug: Key:name:ug
     name:uk: Key:name:uk
     name:uk-Latn: Key:name:uk-Latn
+    name:uk:word_stress: Key:name:uk:word stress
     name:umu: Key:name:umu
     name:unm: Key:name:unm
     name:ur: Key:name:ur
@@ -9089,6 +9527,7 @@ en:
     name:vo: Key:name:vo
     name:vro: Key:name:vro
     name:wa: Key:name:wa
+    name:wal: Key:name:wal
     name:war: Key:name:war
     name:was: Key:name:was
     name:wikipedia: Key:name:wikipedia
@@ -9171,6 +9610,7 @@ en:
     network: Key:network
     network:ar: Key:network:ar
     network:de: Key:network:de
+    network:en: Key:network:en
     network:fr: Key:network:fr
     network:grc: Key:network:grc
     network:guid: Key:network:guid
@@ -9204,6 +9644,7 @@ en:
     not: Key:not
     'not:': 'Key:not:'
     not:*: Key:not:*
+    not:amenity: Key:not:amenity
     not:brand: Key:not:brand
     not:brand:wikidata: Key:not:brand:wikidata
     not:building: Key:not:building
@@ -9246,6 +9687,7 @@ en:
     observatory:type: Key:observatory:type
     obstacle: Key:obstacle
     obstacle:parking: Key:obstacle:parking
+    obstacle:wheelchair: Key:obstacle:wheelchair
     office: Key:office
     official_name: Key:official name
     official_name:ar: Key:official name:ar
@@ -9264,6 +9706,7 @@ en:
     official_name:glk: Key:official name:glk
     official_name:gr: Key:official name:gr
     official_name:grc: Key:official name:grc
+    official_name:it: Key:official name:it
     official_name:kea: Key:official name:kea
     official_name:kk-Arab: Key:official name:kk-Arab
     official_name:kmr: Key:official name:kmr
@@ -9273,6 +9716,7 @@ en:
     official_name:pl: Key:official name:pl
     official_name:pnb: Key:official name:pnb
     official_name:ps: Key:official name:ps
+    official_name:rm: Key:official name:rm
     official_name:ru: Key:official name:ru
     official_name:sd: Key:official name:sd
     official_name:syc: Key:official name:syc
@@ -9285,6 +9729,7 @@ en:
     ohm:name: Key:ohm:name
     ohv: Key:ohv
     ois:fixme: Key:ois:fixme
+    old_addr:full: Key:old addr:full
     old_addr:housename: Key:old addr:housename
     old_addr:housenumber: Key:old addr:housenumber
     old_addr:place: Key:old addr:place
@@ -9376,6 +9821,7 @@ en:
     operator:ar: Key:operator:ar
     operator:be: Key:operator:be
     operator:de: Key:operator:de
+    operator:email: Key:operator:email
     operator:en: Key:operator:en
     operator:es: Key:operator:es
     operator:fr: Key:operator:fr
@@ -9383,6 +9829,8 @@ en:
     operator:ja: Key:operator:ja
     operator:phone: Key:operator:phone
     operator:ref:CH:UID: Key:operator:ref:CH:UID
+    operator:ref:FR:SIREN: Key:operator:ref:FR:SIREN
+    operator:ref:inn: Key:operator:ref:inn
     operator:ref:kpp: Key:operator:ref:kpp
     operator:ref:ogrn: Key:operator:ref:ogrn
     operator:ru: Key:operator:ru
@@ -9437,6 +9885,7 @@ en:
     overtaking:hgv: Key:overtaking:hgv
     overtaking:motor_vehicle: Key:overtaking:motor vehicle
     owner: Key:owner
+    owner:ref:CH:UID: Key:owner:ref:CH:UID
     owner:wikidata: Key:owner:wikidata
     ownership: Key:ownership
     paifang:gables: Key:paifang:gables
@@ -9506,6 +9955,7 @@ en:
       output
     passenger_lines: Key:passenger lines
     passing_places: Key:passing places
+    pastry: Key:pastry
     patrolled: Key:patrolled
     pattern: Key:pattern
     paved:date: Key:paved:date
@@ -9538,6 +9988,7 @@ en:
     payment:contactless: Key:payment:contactless
     payment:credit_cards: Key:payment:credit cards
     payment:cryptocurrencies: Key:payment:cryptocurrencies
+    payment:dankort: Key:payment:dankort
     payment:debit_cards: Key:payment:debit cards
     payment:description: Key:payment:description
     payment:diners_club: Key:payment:diners club
@@ -9545,6 +9996,7 @@ en:
     payment:dkv: Key:payment:dkv
     payment:e_zpass: Key:payment:e zpass
     payment:easycard: Key:payment:easycard
+    payment:easypark: Key:payment:easypark
     payment:edy: Key:payment:edy
     payment:electronic_purses: Key:payment:electronic purses
     payment:ep_easycard: Key:payment:ep easycard
@@ -9556,6 +10008,7 @@ en:
     payment:goldback: Key:payment:goldback
     payment:good_to_go: Key:payment:good to go
     payment:google_pay: Key:payment:google pay
+    payment:grits: Key:payment:grits
     payment:i-pass: Key:payment:i-pass
     payment:icsf: Key:payment:icsf
     payment:ipass: Key:payment:ipass
@@ -9576,6 +10029,7 @@ en:
     payment:notes:change: Key:payment:notes:change
     payment:notes:denominations: Key:payment:notes:denominations
     payment:onchain: Key:payment:onchain
+    payment:operator: Key:payment:operator
     payment:opus: Key:payment:opus
     payment:others: Key:payment:others
     payment:paypal: Key:payment:paypal
@@ -9585,6 +10039,7 @@ en:
     payment:pluxee: Key:payment:pluxee
     payment:prepaid_ticket: Key:payment:prepaid ticket
     payment:pro100: Key:payment:pro100
+    payment:qr_code: Key:payment:qr code
     payment:shell: Key:payment:shell
     payment:sodexo: Key:payment:sodexo
     payment:stored_value_card: Key:payment:stored value card
@@ -9600,6 +10055,7 @@ en:
     payment:visa_debit: Key:payment:visa debit
     payment:visa_electron: Key:payment:visa electron
     payment:wechat: Key:payment:wechat
+    payment:western_union: Key:payment:western union
     payment:wire_transfer: Key:payment:wire transfer
     pcode: Key:pcode
     pedagogy: Key:pedagogy
@@ -9609,10 +10065,12 @@ en:
     permit: Key:permit
     person:date_of_birth: Key:person:date of birth
     person:date_of_death: Key:person:date of death
+    person:name: Key:person:name
     pet: Key:pet
     pets: Key:pets
     phoenixbikeguide: Key:phoenixbikeguide
     phone: Key:phone
+    phone:AU: Key:phone:AU
     phone:NL: Key:phone:NL
     phone:mnemonic: Key:phone:mnemonic
     photograph: Key:photograph
@@ -9667,6 +10125,7 @@ en:
     plant:type: Key:plant:type
     plant_community: Key:plant community
     planted_date: Key:planted date
+    plaque: Key:plaque
     platform:width: Key:platform:width
     platform_lift: Key:platform lift
     platform_lift:maxlength:physical: Key:platform lift:maxlength:physical
@@ -9685,6 +10144,7 @@ en:
     pmfsefin:idedif: Key:pmfsefin:idedif
     point: Key:point
     pole: Key:pole
+    pole:maxload: Key:pole:maxload
     poles: Key:poles
     police: Key:police
     police:FR: Key:police:FR
@@ -9773,22 +10233,28 @@ en:
     railtrail: Key:railtrail
     railway: Key:railway
     railway:*: Key:railway:*
+    railway:acses: Key:railway:acses
     railway:asfa: Key:railway:asfa
     railway:atb: Key:railway:atb
     railway:atc: Key:railway:atc
     railway:atms: Key:railway:atms
     railway:ato: Key:railway:ato
+    railway:atp: Key:railway:atp
+    railway:aws: Key:railway:aws
     railway:ballastless: Key:railway:ballastless
     railway:block_section: Key:railway:block section
     railway:cbtc: Key:railway:cbtc
     railway:ctc: Key:railway:ctc
     railway:ctcs: Key:railway:ctcs
+    railway:electricity: Key:railway:electricity
+    railway:electricity:jumpering: Key:railway:electricity:jumpering
     railway:etcs: Key:railway:etcs
     railway:gnt: Key:railway:gnt
     railway:interlaced: Key:railway:interlaced
     railway:ktcs: Key:railway:ktcs
     railway:kvb: Key:railway:kvb
     railway:local_operated: Key:railway:local operated
+    railway:ls: Key:railway:ls
     railway:lzb: Key:railway:lzb
     railway:maximum_current: Key:railway:maximum current
     railway:milestone:catenary_mast: Key:railway:milestone:catenary mast
@@ -9805,10 +10271,10 @@ en:
     railway:signal:*: Key:railway:signal:*
     railway:signal:brake_test: Key:railway:signal:brake test
     railway:signal:combined: Key:railway:signal:combined
+    railway:signal:combined_repeated: Key:railway:signal:combined repeated
     railway:signal:country: Key:railway:signal:country
     railway:signal:distant: Key:railway:signal:distant
     railway:signal:distant:form: Key:railway:signal:distant:form
-    railway:signal:distant:height: Key:railway:signal:distant:height
     railway:signal:distant:repeated: Key:railway:signal:distant:repeated
     railway:signal:distant:shape: Key:railway:signal:distant:shape
     railway:signal:distant:states: Key:railway:signal:distant:states
@@ -9829,6 +10295,8 @@ en:
     railway:signal:prefix: Key:railway:signal:prefix
     railway:signal:shunting: Key:railway:signal:shunting
     railway:signal:shunting_repeated: Key:railway:signal:shunting repeated
+    railway:signal:slope: Key:railway:signal:slope
+    railway:signal:slope:incline: Key:railway:signal:slope:incline
     railway:signal:speed_limit: Key:railway:signal:speed limit
     railway:signal:speed_limit:form: Key:railway:signal:speed limit:form
     railway:signal:speed_limit:height: Key:railway:signal:speed limit:height
@@ -9838,13 +10306,19 @@ en:
     railway:signal:speed_limit_distant:states: Key:railway:signal:speed limit distant:states
     railway:signal:station: Key:railway:signal:station
     railway:signal:station_distant: Key:railway:signal:station distant
+    railway:signal:stop: Key:railway:signal:stop
+    railway:signal:train_protection: Key:railway:signal:train protection
     railway:signal:traversable: Key:railway:signal:traversable
     railway:signal:traversable:type: Key:railway:signal:traversable:type
+    railway:signal:whistle: Key:railway:signal:whistle
+    railway:signal:wrong_road: Key:railway:signal:wrong road
     railway:signal_box: Key:railway:signal box
     railway:ssc: Key:railway:ssc
+    railway:tcb: Key:railway:tcb
     railway:tilting: Key:railway:tilting
     railway:tmacs: Key:railway:tmacs
     railway:tow: Key:railway:tow
+    railway:tpws: Key:railway:tpws
     railway:track_class: Key:railway:track class
     railway:track_ref: Key:railway:track ref
     railway:track_type: Key:railway:track type
@@ -9884,6 +10358,7 @@ en:
     recycling:aluminium: Key:recycling:aluminium
     recycling:beverage_cartons: Key:recycling:beverage cartons
     recycling:cartons: Key:recycling:cartons
+    recycling:coffee_capsules: Key:recycling:coffee capsules
     recycling:drugs: Key:recycling:drugs
     recycling:electrical_appliances: Key:recycling:electrical appliances
     recycling:fire_extinguishers: Key:recycling:fire extinguishers
@@ -9908,6 +10383,7 @@ en:
     reef: Key:reef
     ref: Key:ref
     ref/ref:supercharge_info: Key:ref/ref:supercharge info
+    ref:*: Key:ref:*
     ref:AGESIC: Key:ref:AGESIC
     ref:AQ:apa: Key:ref:AQ:apa
     ref:AU-NSW:mooring: Key:ref:AU-NSW:mooring
@@ -9915,12 +10391,19 @@ en:
     ref:BRN: Key:ref:BRN
     ref:BY:trade_register: Key:ref:BY:trade register
     ref:CEF: Key:ref:CEF
+    ref:CH-GE:CODE_SLCE: Key:ref:CH-GE:CODE SLCE
     ref:CH-GE:CODE_VOIE: Key:ref:CH-GE:CODE VOIE
+    ref:CH-GE:NO_COMM: Key:ref:CH-GE:NO COMM
     ref:CH-GE:REG: Key:ref:CH-GE:REG
     ref:CH-GE:archi: Key:ref:CH-GE:archi
+    ref:CH-GE:dip:etab: Key:ref:CH-GE:dip:etab
     ref:CH-GE:noms: Key:ref:CH-GE:noms
     ref:CH:UID: Key:ref:CH:UID
+    ref:CH:bafu.vec25-seen: Key:ref:CH:bafu.vec25-seen
+    ref:CH:bfs:HISTID: Key:ref:CH:bfs:HISTID
     ref:CH:hls-dhs: Key:ref:CH:hls-dhs
+    ref:CH:hydro: Key:ref:CH:hydro
+    ref:CH:kantonsnum: Key:ref:CH:kantonsnum
     ref:CN:usci: Key:ref:CN:usci
     ref:CNES: Key:ref:CNES
     ref:DK:cvr: Key:ref:DK:cvr
@@ -9932,12 +10415,14 @@ en:
     ref:ESID: Key:ref:ESID
     ref:EU:ENTSOE_EIC: Key:ref:EU:ENTSOE EIC
     ref:EU:EVSE: Key:ref:EU:EVSE
+    ref:EU:PLC: Key:ref:EU:PLC
     ref:EU:bwid: Key:ref:EU:bwid
     ref:EUS:getxo:id: Key:ref:EUS:getxo:id
     ref:FR:42C: Key:ref:FR:42C
     ref:FR:ANFR: Key:ref:FR:ANFR
     ref:FR:ARCEP: Key:ref:FR:ARCEP
     ref:FR:Allocine: Key:ref:FR:Allocine
+    ref:FR:Angers:pompiers: Key:ref:FR:Angers:pompiers
     ref:FR:CAIRN: Key:ref:FR:CAIRN
     ref:FR:CCBG: Key:ref:FR:CCBG
     ref:FR:CEF: Key:ref:FR:CEF
@@ -9946,6 +10431,8 @@ en:
     ref:FR:Enedis: Key:ref:FR:Enedis
     ref:FR:FANTOIR:left: Key:ref:FR:FANTOIR:left
     ref:FR:FANTOIR:right: Key:ref:FR:FANTOIR:right
+    ref:FR:FFT: Key:ref:FR:FFT
+    ref:FR:FFTT: Key:ref:FR:FFTT
     ref:FR:FINESS: Key:ref:FR:FINESS
     ref:FR:FreeMobile: Key:ref:FR:FreeMobile
     ref:FR:Grenoble:trees: Key:ref:FR:Grenoble:trees
@@ -9954,13 +10441,16 @@ en:
     ref:FR:Joconde: Key:ref:FR:Joconde
     ref:FR:LaPoste: Key:ref:FR:LaPoste
     ref:FR:MemorialGenWeb: Key:ref:FR:MemorialGenWeb
+    ref:FR:Merimee: Key:ref:FR:Merimee
     ref:FR:NAF: Key:ref:FR:NAF
     ref:FR:Orange: Key:ref:FR:Orange
     ref:FR:Orange:NRO: Key:ref:FR:Orange:NRO
     ref:FR:Orange_mobile: Key:ref:FR:Orange mobile
     ref:FR:PTT: Key:ref:FR:PTT
     ref:FR:PTT:NRA: Key:ref:FR:PTT:NRA
+    ref:FR:Palissy: Key:ref:FR:Palissy
     ref:FR:RAF: Key:ref:FR:RAF
+    ref:FR:RESARAIL: Key:ref:FR:RESARAIL
     ref:FR:RNA: Key:ref:FR:RNA
     ref:FR:RNB: Key:ref:FR:RNB
     ref:FR:RPPS: Key:ref:FR:RPPS
@@ -9971,6 +10461,7 @@ en:
     ref:FR:SIREN: Key:ref:FR:SIREN
     ref:FR:SIRET: Key:ref:FR:SIRET
     ref:FR:SITCOM: Key:ref:FR:SITCOM
+    ref:FR:SNCF: Key:ref:FR:SNCF
     ref:FR:TUC: Key:ref:FR:TUC
     ref:FR:fantoir: Key:ref:FR:fantoir
     ref:FR:gdo: Key:ref:FR:gdo
@@ -9994,6 +10485,7 @@ en:
     ref:HR:e-matica: Key:ref:HR:e-matica
     ref:HU:edid: Key:ref:HU:edid
     ref:HU:kir_site: Key:ref:HU:kir site
+    ref:HU:mkasz: Key:ref:HU:mkasz
     ref:HU:om: Key:ref:HU:om
     ref:HU:vatin: Key:ref:HU:vatin
     ref:IE:census2015: Key:ref:IE:census2015
@@ -10005,6 +10497,7 @@ en:
     ref:INEP: Key:ref:INEP
     ref:INSEE: Key:ref:INSEE
     ref:ISTAT: Key:ref:ISTAT
+    ref:JP:invoice_issuer: Key:ref:JP:invoice issuer
     ref:LOCODE: Key:ref:LOCODE
     ref:LV:addr: Key:ref:LV:addr
     ref:MA:HCP: Key:ref:MA:HCP
@@ -10012,9 +10505,9 @@ en:
     ref:NBd: Key:ref:NBd
     ref:NLPG:UPRN:1: Key:ref:NLPG:UPRN:1
     ref:NO:buskerudbyen: Key:ref:NO:buskerudbyen
+    ref:NO:orgnr: Key:ref:NO:orgnr
     ref:NPLG:UPRN:1: Key:ref:NPLG:UPRN:1
     ref:NVRID: Key:ref:NVRID
-    ref:PLC: Key:ref:PLC
     ref:ProRail: Key:ref:ProRail
     ref:REI: Key:ref:REI
     ref:RS:grad: Key:ref:RS:grad
@@ -10094,6 +10587,7 @@ en:
     ref:codcat: Key:ref:codcat
     ref:color: Key:ref:color
     ref:colour: Key:ref:colour
+    ref:colour_tx: Key:ref:colour tx
     ref:coop: Key:ref:coop
     ref:corine_land_cover: Key:ref:corine land cover
     ref:crs: Key:ref:crs
@@ -10107,6 +10601,7 @@ en:
     ref:dhis2: Key:ref:dhis2
     ref:doc: Key:ref:doc
     ref:dove: Key:ref:dove
+    ref:drobne_pamatky: Key:ref:drobne pamatky
     ref:e-matica: Key:ref:e-matica
     ref:edubase: Key:ref:edubase
     ref:edubase:group: Key:ref:edubase:group
@@ -10117,6 +10612,7 @@ en:
     ref:find_a_grave: Key:ref:find a grave
     ref:gbfs: Key:ref:gbfs
     ref:gemeentecode: Key:ref:gemeentecode
+    ref:gewiss: Key:ref:gewiss
     ref:gnbc: Key:ref:gnbc
     ref:gnis: Key:ref:gnis
     ref:goingelectric: Key:ref:goingelectric
@@ -10141,6 +10637,7 @@ en:
     ref:id: Key:ref:id
     ref:idescat: Key:ref:idescat
     ref:ifsc: Key:ref:ifsc
+    ref:inaturalist.org: Key:ref:inaturalist.org
     ref:industrial: Key:ref:industrial
     ref:ine: Key:ref:ine
     ref:ipac: Key:ref:ipac
@@ -10150,6 +10647,7 @@ en:
     ref:kmr: Key:ref:kmr
     ref:kons: Key:ref:kons
     ref:kozterkep: Key:ref:kozterkep
+    ref:kulturminne: Key:ref:kulturminne
     ref:landcode: Key:ref:landcode
     ref:landsdeelcode: Key:ref:landsdeelcode
     ref:lau: Key:ref:lau
@@ -10164,6 +10662,7 @@ en:
     ref:linz:road_id: Key:ref:linz:road id
     ref:linz:topo50_id: Key:ref:linz:topo50 id
     ref:lor: Key:ref:lor
+    ref:manufacturer_inventory: Key:ref:manufacturer inventory
     ref:masaf: Key:ref:masaf
     ref:mastr: Key:ref:mastr
     ref:mcrb: Key:ref:mcrb
@@ -10228,6 +10727,7 @@ en:
     ref:taskey: Key:ref:taskey
     ref:temples.ru: Key:ref:temples.ru
     ref:tenbruggencate: Key:ref:tenbruggencate
+    ref:tesla: Key:ref:tesla
     ref:thc: Key:ref:thc
     ref:tiploc: Key:ref:tiploc
     ref:udir_nsr: Key:ref:udir nsr
@@ -10355,6 +10855,7 @@ en:
     ruins: Key:ruins
     'ruins:': 'Key:ruins:'
     ruins:*: Key:ruins:*
+    ruins:building: Key:ruins:building
     rungs: Key:rungs
     rv: Key:rv
     rwn_ref: Key:rwn ref
@@ -10383,11 +10884,13 @@ en:
     school: Key:school
     'school:': 'Key:school:'
     school:*: Key:school:*
+    school:CH-GE: Key:school:CH-GE
     school:boarding: Key:school:boarding
     school:federation:name: Key:school:federation:name
     school:gender: Key:school:gender
     school:language: Key:school:language
     school:selective: Key:school:selective
+    school:special_needs: Key:school:special needs
     school:trust: Key:school:trust
     school:trust:name: Key:school:trust:name
     school:trust:type: Key:school:trust:type
@@ -10602,6 +11105,7 @@ en:
     sector: Key:sector
     security_desk: Key:security desk
     segregated: Key:segregated
+    self_catering: Key:self catering
     self_checkout: Key:self checkout
     self_harvesting: Key:self harvesting
     self_service: Key:self service
@@ -10720,14 +11224,17 @@ en:
     short_name:ckb: Key:short name:ckb
     short_name:cnr: Key:short name:cnr
     short_name:de: Key:short name:de
+    short_name:en: Key:short name:en
     short_name:es: Key:short name:es
     short_name:fa: Key:short name:fa
     short_name:fr: Key:short name:fr
     short_name:fur: Key:short name:fur
     short_name:gr: Key:short name:gr
     short_name:grc: Key:short name:grc
+    short_name:it: Key:short name:it
     short_name:kea: Key:short name:kea
     short_name:pl: Key:short name:pl
+    short_name:rm: Key:short name:rm
     short_name:syc: Key:short name:syc
     short_name:ug: Key:short name:ug
     short_name:ur: Key:short name:ur
@@ -10791,8 +11298,11 @@ en:
     socket: Key:socket
     socket:*: Key:socket:*
     socket:chademo: Key:socket:chademo
+    socket:multi: Key:socket:multi
+    socket:multi:type: Key:socket:multi:type
     socket:nacs: Key:socket:nacs
     socket:schuko: Key:socket:schuko
+    socket:secured: Key:socket:secured
     socket:sev1011_t13: Key:socket:sev1011 t13
     socket:sev1011_t15: Key:socket:sev1011 t15
     socket:sev1011_t23: Key:socket:sev1011 t23
@@ -10801,6 +11311,7 @@ en:
     socket:type2: Key:socket:type2
     socket:type2:output: Key:socket:type2:output
     socket:type2_combo: Key:socket:type2 combo
+    socket:type2_combo:output: Key:socket:type2 combo:output
     socket:type3: Key:socket:type3
     socket:type3c: Key:socket:type3c
     socket:typee: Key:socket:typee
@@ -10960,6 +11471,7 @@ en:
     status: Key:status
     step:condition: Key:step:condition
     step:contrast: Key:step:contrast
+    step:height: Key:step:height
     step:stair_nosing: Key:step:stair nosing
     step_count: Key:step count
     steps: Key:steps
@@ -10975,6 +11487,7 @@ en:
     stop: Key:stop
     stop:direction: Key:stop:direction
     stop_id: Key:stop id
+    stopsign: Key:stopsign
     storage_area: Key:storage area
     stove: Key:stove
     stranded: Key:stranded
@@ -10991,7 +11504,12 @@ en:
     studio: Key:studio
     sub_sea: Key:sub sea
     subject: Key:subject
+    subject:de: Key:subject:de
+    subject:en: Key:subject:en
+    subject:fr: Key:subject:fr
+    subject:it: Key:subject:it
     subject:name: Key:subject:name
+    subject:nl: Key:subject:nl
     subject:ref:CH:hls-dhs: Key:subject:ref:CH:hls-dhs
     subject:wikidata: Key:subject:wikidata
     subject:wikimedia_commons: Key:subject:wikimedia commons
@@ -11005,6 +11523,7 @@ en:
     substance: Key:substance
     substation: Key:substation
     subway: Key:subway
+    summit:cross: Key:summit:cross
     summit:register: Key:summit:register
     supervised: Key:supervised
     support: Key:support
@@ -11077,6 +11596,7 @@ en:
     tclid: Key:tclid
     technical_type: Key:technical type
     technology: Key:technology
+    technology:mobile_phone: Key:technology:mobile phone
     tee: Key:tee
     telecom: Key:telecom
     telecom:medium: Key:telecom:medium
@@ -11171,6 +11691,8 @@ en:
     tours: Key:tours
     tower:*: Key:tower:*
     tower:construction: Key:tower:construction
+    tower:function: Key:tower:function
+    tower:insulated: Key:tower:insulated
     tower:type: Key:tower:type
     townhall:type: Key:townhall:type
     towpath: Key:towpath
@@ -11275,11 +11797,14 @@ en:
     uir_adr:ADRESA_KOD: Key:uir adr:ADRESA KOD
     unisex: Key:unisex
     unit: Key:unit
+    university: Key:university
     unsigned: Key:unsigned
     unsigned_ref: Key:unsigned ref
     ups: Key:ups
     urban: Key:urban
+    urbanbrussels:inscription_date: Key:urbanbrussels:inscription date
     url: Key:url
+    url:1: Key:url:1
     url:bathing_water: Key:url:bathing water
     url:goingelectric: Key:url:goingelectric
     url:imher: Key:url:imher
@@ -11295,6 +11820,7 @@ en:
     utm: Key:utm
     vaccination: Key:vaccination
     vacuum_cleaner: Key:vacuum cleaner
+    vacuum_cleaner:fee: Key:vacuum cleaner:fee
     validate:ants:yellow: Key:validate:ants:yellow
     valley: Key:valley
     valve: Key:valve
@@ -11361,6 +11887,7 @@ en:
     waterway: Key:waterway
     waterway:sign: Key:waterway:sign
     waterway:type: Key:waterway:type
+    wayside_shrine: Key:wayside shrine
     weather:hygrometer: Key:weather:hygrometer
     weather_protection: Key:weather protection
     website: Key:website
@@ -11368,8 +11895,11 @@ en:
     website:*: Key:website:*
     website:1: Key:website:1
     website:booking: Key:website:booking
+    website:catalogue: Key:website:catalogue
+    website:events: Key:website:events
     website:map: Key:website:map
     website:menu: Key:website:menu
+    website:opening_hours: Key:website:opening hours
     website:orders: Key:website:orders
     website:regulation: Key:website:regulation
     website:reservation: Key:website:reservation
@@ -11379,6 +11909,7 @@ en:
     wheelchair: Key:wheelchair
     wheelchair:description: Key:wheelchair:description
     wheelchair:turning_circle: Key:wheelchair:turning circle
+    wheelchair:url: Key:wheelchair:url
     whitewater: Key:whitewater
     whitewater:name: Key:whitewater:name
     whitewater:rapid_grade: Key:whitewater:rapid grade
@@ -11419,6 +11950,7 @@ en:
     wikipedia:pl: Key:wikipedia:pl
     wikipedia:pnb: Key:wikipedia:pnb
     wikipedia:ps: Key:wikipedia:ps
+    wikipedia:rm: Key:wikipedia:rm
     wikipedia:sd: Key:wikipedia:sd
     wikipedia:ug: Key:wikipedia:ug
     wikipedia:ur: Key:wikipedia:ur
@@ -11474,6 +12006,7 @@ en:
     zone: Key:zone
     zone:Brupass: Key:zone:Brupass
     zone:De_Lijn: Key:zone:De Lijn
+    zone:HSL: Key:zone:HSL
     zone:NMBS_SNCB: Key:zone:NMBS SNCB
     zone:TEC: Key:zone:TEC
     zone:maxspeed: Key:zone:maxspeed
@@ -11524,11 +12057,124 @@ en:
     actuator=manual: Tag:actuator=manual
     actuator=pneumatic_cylinder: Tag:actuator=pneumatic cylinder
     addr:TW:dataset=137998: Tag:addr:TW:dataset=137998
+    addr:city=Batifa: Tag:addr:city=Batifa
+    addr:city=Carouge_GE: Tag:addr:city=Carouge GE
+    addr:city=Corsier_GE: Tag:addr:city=Corsier GE
     addr:city=Genève: Tag:addr:city=Genève
+    addr:city=Grand-Lancy: Tag:addr:city=Grand-Lancy
+    addr:city=London: Tag:addr:city=London
+    addr:country=AD: Tag:addr:country=AD
+    addr:country=AG: Tag:addr:country=AG
+    addr:country=AL: Tag:addr:country=AL
+    addr:country=AM: Tag:addr:country=AM
+    addr:country=AR: Tag:addr:country=AR
+    addr:country=AT: Tag:addr:country=AT
+    addr:country=AU: Tag:addr:country=AU
+    addr:country=BA: Tag:addr:country=BA
+    addr:country=BE: Tag:addr:country=BE
+    addr:country=BG: Tag:addr:country=BG
+    addr:country=BN: Tag:addr:country=BN
+    addr:country=BR: Tag:addr:country=BR
+    addr:country=CA: Tag:addr:country=CA
+    addr:country=CF: Tag:addr:country=CF
     addr:country=CH: Tag:addr:country=CH
+    addr:country=CL: Tag:addr:country=CL
+    addr:country=CZ: Tag:addr:country=CZ
+    addr:country=DE: Tag:addr:country=DE
+    addr:country=DJ: Tag:addr:country=DJ
+    addr:country=DK: Tag:addr:country=DK
+    addr:country=DM: Tag:addr:country=DM
+    addr:country=EE: Tag:addr:country=EE
+    addr:country=EG: Tag:addr:country=EG
+    addr:country=ER: Tag:addr:country=ER
+    addr:country=ES: Tag:addr:country=ES
+    addr:country=FI: Tag:addr:country=FI
+    addr:country=FR: Tag:addr:country=FR
+    addr:country=GB: Tag:addr:country=GB
+    addr:country=GD: Tag:addr:country=GD
+    addr:country=GG: Tag:addr:country=GG
+    addr:country=GH: Tag:addr:country=GH
+    addr:country=GQ: Tag:addr:country=GQ
+    addr:country=GR: Tag:addr:country=GR
+    addr:country=GW: Tag:addr:country=GW
+    addr:country=HR: Tag:addr:country=HR
+    addr:country=HU: Tag:addr:country=HU
+    addr:country=IE: Tag:addr:country=IE
+    addr:country=IM: Tag:addr:country=IM
+    addr:country=IN: Tag:addr:country=IN
+    addr:country=IT: Tag:addr:country=IT
+    addr:country=JE: Tag:addr:country=JE
+    addr:country=JM: Tag:addr:country=JM
+    addr:country=JP: Tag:addr:country=JP
+    addr:country=KI: Tag:addr:country=KI
+    addr:country=KM: Tag:addr:country=KM
+    addr:country=KW: Tag:addr:country=KW
+    addr:country=KZ: Tag:addr:country=KZ
+    addr:country=LI: Tag:addr:country=LI
+    addr:country=LT: Tag:addr:country=LT
+    addr:country=LU: Tag:addr:country=LU
+    addr:country=LV: Tag:addr:country=LV
+    addr:country=MC: Tag:addr:country=MC
+    addr:country=MD: Tag:addr:country=MD
+    addr:country=ME: Tag:addr:country=ME
+    addr:country=MH: Tag:addr:country=MH
+    addr:country=MK: Tag:addr:country=MK
+    addr:country=MR: Tag:addr:country=MR
+    addr:country=MS: Tag:addr:country=MS
+    addr:country=MT: Tag:addr:country=MT
+    addr:country=MV: Tag:addr:country=MV
+    addr:country=NO: Tag:addr:country=NO
+    addr:country=NU: Tag:addr:country=NU
+    addr:country=NZ: Tag:addr:country=NZ
+    addr:country=PE: Tag:addr:country=PE
+    addr:country=PH: Tag:addr:country=PH
+    addr:country=PL: Tag:addr:country=PL
+    addr:country=PT: Tag:addr:country=PT
+    addr:country=RO: Tag:addr:country=RO
+    addr:country=RU: Tag:addr:country=RU
+    addr:country=SB: Tag:addr:country=SB
+    addr:country=SE: Tag:addr:country=SE
+    addr:country=SI: Tag:addr:country=SI
+    addr:country=SK: Tag:addr:country=SK
+    addr:country=SM: Tag:addr:country=SM
+    addr:country=ST: Tag:addr:country=ST
+    addr:country=SV: Tag:addr:country=SV
+    addr:country=TC: Tag:addr:country=TC
+    addr:country=TD: Tag:addr:country=TD
+    addr:country=TK: Tag:addr:country=TK
+    addr:country=TO: Tag:addr:country=TO
+    addr:country=TT: Tag:addr:country=TT
+    addr:country=TW: Tag:addr:country=TW
     addr:country=US: Tag:addr:country=US
+    addr:country=UY: Tag:addr:country=UY
+    addr:country=UZ: Tag:addr:country=UZ
+    addr:country=VA: Tag:addr:country=VA
+    addr:country=VC: Tag:addr:country=VC
+    addr:country=VG: Tag:addr:country=VG
+    addr:country=WS: Tag:addr:country=WS
+    addr:country=XK: Tag:addr:country=XK
+    addr:floor=1: Tag:addr:floor=1
+    addr:floor=2: Tag:addr:floor=2
+    addr:floor=3: Tag:addr:floor=3
     addr:housenumber:signed=no: Tag:addr:housenumber:signed=no
+    addr:housenumber=1: Tag:addr:housenumber=1
+    addr:state=ACT: Tag:addr:state=ACT
+    addr:state=AL: Tag:addr:state=AL
+    addr:state=AZ: Tag:addr:state=AZ
+    addr:state=CA: Tag:addr:state=CA
+    addr:state=DE: Tag:addr:state=DE
+    addr:state=MS: Tag:addr:state=MS
+    addr:state=NSW: Tag:addr:state=NSW
+    addr:state=NT: Tag:addr:state=NT
+    addr:state=OR: Tag:addr:state=OR
+    addr:state=PR: Tag:addr:state=PR
+    addr:state=QLD: Tag:addr:state=QLD
+    addr:state=SA: Tag:addr:state=SA
+    addr:state=TAS: Tag:addr:state=TAS
+    addr:state=VIC: Tag:addr:state=VIC
+    addr:state=WA: Tag:addr:state=WA
     addr:type=water: Tag:addr:type=water
+    addr=separate: Tag:addr=separate
     admin_level=1: Tag:admin level=1
     admin_level=10: Tag:admin level=10
     admin_level=11: Tag:admin level=11
@@ -11637,6 +12283,7 @@ en:
     airmark=beacon: Tag:airmark=beacon
     ale_supply=limited: Tag:ale supply=limited
     allotments=plot: Tag:allotments=plot
+    alt_name:signed=yes: Tag:alt name:signed=yes
     amenity=Kneippbecken: Tag:amenity=Kneippbecken
     amenity=administration: Tag:amenity=administration
     amenity=advertising: Tag:amenity=advertising
@@ -11646,6 +12293,7 @@ en:
     amenity=animal_breeding: Tag:amenity=animal breeding
     amenity=animal_effluent_disposal: Tag:amenity=animal effluent disposal
     amenity=animal_hitch: Tag:amenity=animal hitch
+    amenity=animal_scales: Tag:amenity=animal scales
     amenity=animal_shelter: Tag:amenity=animal shelter
     amenity=animal_training: Tag:amenity=animal training
     amenity=archive: Tag:amenity=archive
@@ -12029,6 +12677,7 @@ en:
     area:highway=trunk: Tag:area:highway=trunk
     area:highway=trunk_link: Tag:area:highway=trunk link
     area:highway=turning_circle: Tag:area:highway=turning circle
+    area:highway=turntable: Tag:area:highway=turntable
     artwork_subject=sheela-na-gig: Tag:artwork subject=sheela-na-gig
     artwork_subject=street_art: Tag:artwork subject=street art
     artwork_type=architecture: Tag:artwork type=architecture
@@ -12040,6 +12689,7 @@ en:
     artwork_type=installation: Tag:artwork type=installation
     artwork_type=land_art: Tag:artwork type=land art
     artwork_type=living_sculpture: Tag:artwork type=living sculpture
+    artwork_type=medallion: Tag:artwork type=medallion
     artwork_type=mosaic: Tag:artwork type=mosaic
     artwork_type=mural: Tag:artwork type=mural
     artwork_type=relief: Tag:artwork type=relief
@@ -12088,6 +12738,7 @@ en:
     attraction=historic: Tag:attraction=historic
     attraction=kiddie_ride: Tag:attraction=kiddie ride
     attraction=maze: Tag:attraction=maze
+    attraction=model_railway: Tag:attraction=model railway
     attraction=roller_coaster: Tag:attraction=roller coaster
     attraction=seaplane_ride: Tag:attraction=seaplane ride
     attraction=slide: Tag:attraction=slide
@@ -12366,10 +13017,13 @@ en:
     bridge=simple_brunnel: Tag:bridge=simple brunnel
     bridge=trestle: Tag:bridge=trestle
     bridge=viaduct: Tag:bridge=viaduct
+    building:architecture=craftsman: Tag:building:architecture=craftsman
+    building:levels=0: Tag:building:levels=0
     building:part=balcony: Tag:building:part=balcony
     building:part=column: Tag:building:part=column
     building:part=corridor: Tag:building:part=corridor
     building:part=porch: Tag:building:part=porch
+    building:part=roof: Tag:building:part=roof
     building:part=steps: Tag:building:part=steps
     building:part=yes: Tag:building:part=yes
     building:use=stable: Tag:building:use=stable
@@ -12398,6 +13052,7 @@ en:
     building=carport: Tag:building=carport
     building=castle: Tag:building=castle
     building=cathedral: Tag:building=cathedral
+    building=cellar: Tag:building=cellar
     building=central_office: Tag:building=central office
     building=changing_rooms: Tag:building=changing rooms
     building=chapel: Tag:building=chapel
@@ -12452,6 +13107,7 @@ en:
     building=goat_shed: Tag:building=goat shed
     building=government: Tag:building=government
     building=government_office: Tag:building=government office
+    building=granary: Tag:building=granary
     building=grandstand: Tag:building=grandstand
     building=greenhouse: Tag:building=greenhouse
     building=ground_station: Tag:building=ground station
@@ -12481,9 +13137,11 @@ en:
     building=marquee: Tag:building=marquee
     building=maybe: Tag:building=maybe
     building=military: Tag:building=military
+    building=miniature: Tag:building=miniature
     building=mink_shed: Tag:building=mink shed
     building=mobile_home: Tag:building=mobile home
     building=monastery: Tag:building=monastery
+    building=mortuary: Tag:building=mortuary
     building=mosque: Tag:building=mosque
     building=museum: Tag:building=museum
     building=no: Tag:building=no
@@ -12523,6 +13181,7 @@ en:
     building=sheepfold: Tag:building=sheepfold
     building=shepherd_shelter: Tag:building=shepherd shelter
     building=ship: Tag:building=ship
+    building=shophouse: Tag:building=shophouse
     building=show_house: Tag:building=show house
     building=shower: Tag:building=shower
     building=shrine: Tag:building=shrine
@@ -12613,6 +13272,7 @@ en:
     canoe=portage: Tag:canoe=portage
     canoe=put_in: Tag:canoe=put in
     canoe=put_in;egress: Tag:canoe=put in;egress
+    canoe=unknown: Tag:canoe=unknown
     capital=4: Tag:capital=4
     capital=5: Tag:capital=5
     capital=6: Tag:capital=6
@@ -12684,6 +13344,7 @@ en:
     club=freemasonry: Tag:club=freemasonry
     club=golf: Tag:club=golf
     club=hunting: Tag:club=hunting
+    club=juggling: Tag:club=juggling
     club=linux: Tag:club=linux
     club=military_cadets: Tag:club=military cadets
     club=model_railway: Tag:club=model railway
@@ -12697,6 +13358,7 @@ en:
     club=social: Tag:club=social
     club=sport: Tag:club=sport
     club=student: Tag:club=student
+    club=surf_life_saving: Tag:club=surf life saving
     club=tourism: Tag:club=tourism
     club=veterans: Tag:club=veterans
     club=youth: Tag:club=youth
@@ -12705,12 +13367,14 @@ en:
     coastline:survey_quality=inadequate: Tag:coastline:survey quality=inadequate
     coastline=bogus: Tag:coastline=bogus
     collection_times:signed=no: Tag:collection times:signed=no
+    college=adult_education: Tag:college=adult education
     commons=lets: Tag:commons=lets
     communication:radio=fm: Tag:communication:radio=fm
     communication:television=dvb-t: Tag:communication:television=dvb-t
     communication:television=dvb-t2: Tag:communication:television=dvb-t2
     communication=line: Tag:communication=line
     communication=mobile_phone: Tag:communication=mobile phone
+    community_centre:for=entrepreneur: Tag:community centre:for=entrepreneur
     community_centre=chitalishte: Tag:community centre=chitalishte
     community_centre=club_home: Tag:community centre=club home
     community_centre=community_hall: Tag:community centre=community hall
@@ -12790,6 +13454,8 @@ en:
     cooling:method=mechanical_draft: Tag:cooling:method=mechanical draft
     cooling:method=natural_draft: Tag:cooling:method=natural draft
     cooperative=agricultural: Tag:cooperative=agricultural
+    country=EU: Tag:country=EU
+    country=UN: Tag:country=UN
     covered=no: Tag:covered=no
     covered=yes: Tag:covered=yes
     craft=agricultural_engines: Tag:craft=agricultural engines
@@ -12907,6 +13573,7 @@ en:
     crane:type=portal_crane: Tag:crane:type=portal crane
     crane:type=tower_crane: Tag:crane:type=tower crane
     crane:type=travel_lift: Tag:crane:type=travel lift
+    created_by=Osm.Org_Tags_Editor: Tag:created by=Osm.Org Tags Editor
     crematorium=pet: Tag:crematorium=pet
     crop=asparagus: Tag:crop=asparagus
     crop=aspargus: Tag:crop=aspargus
@@ -12942,6 +13609,7 @@ en:
     crossing=informal: Tag:crossing=informal
     crossing=marked: Tag:crossing=marked
     crossing=no: Tag:crossing=no
+    crossing=separate: Tag:crossing=separate
     crossing=traffic_signals: Tag:crossing=traffic signals
     crossing=uncontrolled: Tag:crossing=uncontrolled
     crossing=unknown: Tag:crossing=unknown
@@ -12955,6 +13623,7 @@ en:
     cuisine=arab: Tag:cuisine=arab
     cuisine=arepa: Tag:cuisine=arepa
     cuisine=asian: Tag:cuisine=asian
+    cuisine=austrian: Tag:cuisine=austrian
     cuisine=açaí: Tag:cuisine=açaí
     cuisine=bagel: Tag:cuisine=bagel
     cuisine=barbecue: Tag:cuisine=barbecue
@@ -13019,6 +13688,7 @@ en:
     cuisine=sandwich: Tag:cuisine=sandwich
     cuisine=sausage: Tag:cuisine=sausage
     cuisine=sausage;hot_dog: Tag:cuisine=sausage;hot dog
+    cuisine=savory_pancakes: Tag:cuisine=savory pancakes
     cuisine=seafood: Tag:cuisine=seafood
     cuisine=soup: Tag:cuisine=soup
     cuisine=spanish: Tag:cuisine=spanish
@@ -13028,6 +13698,7 @@ en:
     cuisine=surinamese: Tag:cuisine=surinamese
     cuisine=sushi: Tag:cuisine=sushi
     cuisine=syrian: Tag:cuisine=syrian
+    cuisine=tacos: Tag:cuisine=tacos
     cuisine=tapas: Tag:cuisine=tapas
     cuisine=tea: Tag:cuisine=tea
     cuisine=tea_house: Tag:cuisine=tea house
@@ -13037,6 +13708,7 @@ en:
     cuisine=thai: Tag:cuisine=thai
     cuisine=turkish: Tag:cuisine=turkish
     cuisine=venezuelan: Tag:cuisine=venezuelan
+    cuisine=viennese: Tag:cuisine=viennese
     cuisine=vietnamese: Tag:cuisine=vietnamese
     cuisine=waffle: Tag:cuisine=waffle
     cuisine=wings: Tag:cuisine=wings
@@ -13131,7 +13803,11 @@ en:
     damage:type=explosion: Tag:damage:type=explosion
     damage:type=war: Tag:damage:type=war
     dataset=buildings: Tag:dataset=buildings
+    date=C16: Tag:date=C16
+    date=C17: Tag:date=C17
+    date=C18: Tag:date=C18
     date=C19: Tag:date=C19
+    date=C20: Tag:date=C20
     defensive=bergfried: Tag:defensive=bergfried
     defensive=donjon: Tag:defensive=donjon
     defensive=keep: Tag:defensive=keep
@@ -13180,6 +13856,8 @@ en:
     designation=restricted_byway: Tag:designation=restricted byway
     designation=shared_path: Tag:designation=shared path
     destroyed=yes: Tag:destroyed=yes
+    diet:excipient_free=no: Tag:diet:excipient free=no
+    diet:excipient_free=yes: Tag:diet:excipient free=yes
     diet:kosher=only: Tag:diet:kosher=only
     diet:kosher=yes: Tag:diet:kosher=yes
     diet:meat=yes: Tag:diet:meat=yes
@@ -13224,6 +13902,7 @@ en:
     drink:viez=takeaway: Tag:drink:viez=takeaway
     drink:viez=yes: Tag:drink:viez=yes
     drink=beer: Tag:drink=beer
+    drinking_straw=yes: Tag:drinking straw=yes
     driveway=pipestem: Tag:driveway=pipestem
     dual_carriageway=no: Tag:dual carriageway=no
     dual_carriageway=yes: Tag:dual carriageway=yes
@@ -13231,6 +13910,7 @@ en:
     education=college: Tag:education=college
     education=cooking_school: Tag:education=cooking school
     education=exercise_area: Tag:education=exercise area
+    education=folk_high_school: Tag:education=folk high school
     education=kindergarten: Tag:education=kindergarten
     education=school: Tag:education=school
     education=university: Tag:education=university
@@ -13250,11 +13930,15 @@ en:
     embassy=nunciature: Tag:embassy=nunciature
     embassy=residence: Tag:embassy=residence
     embassy=yes: Tag:embassy=yes
+    embassy=yes;mission: Tag:embassy=yes;mission
     embedded_rails=light_rail: Tag:embedded rails=light rail
     embedded_rails=tram: Tag:embedded rails=tram
+    emergency:camp_area=yes: Tag:emergency:camp area=yes
     emergency:social_facility:for=displaced_people: Tag:emergency:social facility:for=displaced
       people
     emergency:social_facility=shelter: Tag:emergency:social facility=shelter
+    emergency:staging_area=rescue: Tag:emergency:staging area=rescue
+    emergency:waiting_area=yes: Tag:emergency:waiting area=yes
     emergency=access_point: Tag:emergency=access point
     emergency=aed: Tag:emergency=aed
     emergency=air_rescue_service: Tag:emergency=air rescue service
@@ -13289,6 +13973,7 @@ en:
     emergency=fire_water_pond: Tag:emergency=fire water pond
     emergency=first_aid: Tag:emergency=first aid
     emergency=first_aid_kit: Tag:emergency=first aid kit
+    emergency=helisign: Tag:emergency=helisign
     emergency=key_depot: Tag:emergency=key depot
     emergency=ladder_site: Tag:emergency=ladder site
     emergency=landing_site: Tag:emergency=landing site
@@ -13510,6 +14195,7 @@ en:
     generator:type=vertical_axis: Tag:generator:type=vertical axis
     generator:type=water_wheel: Tag:generator:type=water wheel
     generator:type=zuppinger_water_wheel: Tag:generator:type=zuppinger water wheel
+    genus:fr=Chêne: Tag:genus:fr=Chêne
     genus=Acer: Tag:genus=Acer
     genus=Platanus: Tag:genus=Platanus
     genus=Quercus: Tag:genus=Quercus
@@ -13594,13 +14280,14 @@ en:
     government=watercourse_management: Tag:government=watercourse management
     government=youth_welfare_department: Tag:government=youth welfare department
     grass=amenity_grassland: Tag:grass=amenity grassland
+    grave:marker=headstone: Tag:grave:marker=headstone
+    grave:marker=temporary_cross: Tag:grave:marker=temporary cross
     grit_bin: Tag:grit bin
     guest_house=agritourism: Tag:guest house=agritourism
     guest_house=albergue: Tag:guest house=albergue
     guest_house=bed_and_breakfast: Tag:guest house=bed and breakfast
     guest_house=kontrakan: Tag:guest house=kontrakan
     guest_house=student_accommodation: Tag:guest house=student accommodation
-    guest_house=student_accomodation: Tag:guest house=student accomodation
     guidepost=simple: Tag:guidepost=simple
     hairdresser=barber: Tag:hairdresser=barber
     handle=crank: Tag:handle=crank
@@ -13900,6 +14587,7 @@ en:
     highway=trunk_link: Tag:highway=trunk link
     highway=turning_circle: Tag:highway=turning circle
     highway=turning_loop: Tag:highway=turning loop
+    highway=turntable: Tag:highway=turntable
     highway=unclassified: Tag:highway=unclassified
     highway=unsurfaced: Tag:highway=unsurfaced
     highway=via_ferrata: Tag:highway=via ferrata
@@ -13912,6 +14600,7 @@ en:
     historic=aqueduct: Tag:historic=aqueduct
     historic=archaeological_site: Tag:historic=archaeological site
     historic=battlefield: Tag:historic=battlefield
+    historic=binding_stone: Tag:historic=binding stone
     historic=bomb_crater: Tag:historic=bomb crater
     historic=boundary_stone: Tag:historic=boundary stone
     historic=building: Tag:historic=building
@@ -13937,9 +14626,11 @@ en:
     historic=folly: Tag:historic=folly
     historic=fort: Tag:historic=fort
     historic=gallows: Tag:historic=gallows
+    historic=granary: Tag:historic=granary
     historic=heritage: Tag:historic=heritage
     historic=high_cross: Tag:historic=high cross
     historic=highwater_mark: Tag:historic=highwater mark
+    historic=hogback: Tag:historic=hogback
     historic=hollow_way: Tag:historic=hollow way
     historic=house: Tag:historic=house
     historic=lavoir: Tag:historic=lavoir
@@ -13955,6 +14646,7 @@ en:
     historic=milestone: Tag:historic=milestone
     historic=millstone: Tag:historic=millstone
     historic=mine: Tag:historic=mine
+    historic=mine_adit: Tag:historic=mine adit
     historic=mine_shaft: Tag:historic=mine shaft
     historic=minecart: Tag:historic=minecart
     historic=missile: Tag:historic=missile
@@ -13995,6 +14687,7 @@ en:
     historic=wayside_chapel: Tag:historic=wayside chapel
     historic=wayside_cross: Tag:historic=wayside cross
     historic=wayside_shrine: Tag:historic=wayside shrine
+    historic=wine_press: Tag:historic=wine press
     historic=wreck: Tag:historic=wreck
     historic=yes: Tag:historic=yes
     holding_position:type=ILS: Tag:holding position:type=ILS
@@ -14108,7 +14801,21 @@ en:
     inlet=kerb_opening: Tag:inlet=kerb opening
     inlet=screen: Tag:inlet=screen
     inlet=valve: Tag:inlet=valve
+    inscription:language=bg: Tag:inscription:language=bg
+    inscription:language=de: Tag:inscription:language=de
+    inscription:language=en: Tag:inscription:language=en
+    inscription:language=en;fr: Tag:inscription:language=en;fr
+    inscription:language=eo: Tag:inscription:language=eo
+    inscription:language=fi: Tag:inscription:language=fi
     inscription:language=fr: Tag:inscription:language=fr
+    inscription:language=fr;en: Tag:inscription:language=fr;en
+    inscription:language=fr;la: Tag:inscription:language=fr;la
+    inscription:language=it: Tag:inscription:language=it
+    inscription:language=la: Tag:inscription:language=la
+    inscription:language=nl: Tag:inscription:language=nl
+    inscription:language=pt: Tag:inscription:language=pt
+    inscription:readability=legible: Tag:inscription:readability=legible
+    inscription=-: Tag:inscription=-
     insurance=health: Tag:insurance=health
     internet_access=no: Tag:internet access=no
     internet_access=terminal: Tag:internet access=terminal
@@ -14129,6 +14836,7 @@ en:
     junction=uncontrolled: Tag:junction=uncontrolled
     junction=yes: Tag:junction=yes
     karst=yes: Tag:karst=yes
+    kids_area=designated: Tag:kids area=designated
     kitchen=no: Tag:kitchen=no
     kitchen=separate: Tag:kitchen=separate
     kitchen=yes: Tag:kitchen=yes
@@ -14328,6 +15036,7 @@ en:
     leisure=marina: Tag:leisure=marina
     leisure=maze: Tag:leisure=maze
     leisure=miniature_golf: Tag:leisure=miniature golf
+    leisure=mixed-use_track: Tag:leisure=mixed-use track
     leisure=music_venue: Tag:leisure=music venue
     leisure=nature_reserve: Tag:leisure=nature reserve
     leisure=outdoor_seating: Tag:leisure=outdoor seating
@@ -14360,6 +15069,7 @@ en:
     leisure=summer_camp: Tag:leisure=summer camp
     leisure=sunbathing: Tag:leisure=sunbathing
     leisure=swimming_area: Tag:leisure=swimming area
+    leisure=swimming_platform: Tag:leisure=swimming platform
     leisure=swimming_pool: Tag:leisure=swimming pool
     leisure=swing: Tag:leisure=swing
     leisure=table_tennis_table: Tag:leisure=table tennis table
@@ -14374,6 +15084,9 @@ en:
     leisure=wellness: Tag:leisure=wellness
     leisure=wildlife_hide: Tag:leisure=wildlife hide
     leisure=yes: Tag:leisure=yes
+    level=-1: Tag:level=-1
+    level=0: Tag:level=0
+    level=1: Tag:level=1
     level_crossing=automatic_barrier: Tag:level crossing=automatic barrier
     level_crossing=traffic_signals: Tag:level crossing=traffic signals
     level_crossing=uncontrolled: Tag:level crossing=uncontrolled
@@ -14406,6 +15119,7 @@ en:
     line_management=transpose: Tag:line management=transpose
     lines=phone: Tag:lines=phone
     lit=no: Tag:lit=no
+    loc_name:signed=yes: Tag:loc name:signed=yes
     locality=subtownland: Tag:locality=subtownland
     locality=townland: Tag:locality=townland
     location:transition=yes: Tag:location:transition=yes
@@ -14420,6 +15134,9 @@ en:
     location=surface: Tag:location=surface
     location=underground: Tag:location=underground
     location=underwater: Tag:location=underwater
+    logainm:ref=No_entry: Tag:logainm:ref=No entry
+    logainm:url=No_entry: Tag:logainm:url=No entry
+    logainm:url=No_entry_exist: Tag:logainm:url=No entry exist
     logistics=goods_distribution: Tag:logistics=goods distribution
     logistics=railway: Tag:logistics=railway
     logistics=spaceflight: Tag:logistics=spaceflight
@@ -14450,6 +15167,7 @@ en:
     man_made=bridge: Tag:man made=bridge
     man_made=bunker: Tag:man made=bunker
     man_made=bunker_silo: Tag:man made=bunker silo
+    man_made=cable_landing_station: Tag:man made=cable landing station
     man_made=cairn: Tag:man made=cairn
     man_made=campanile: Tag:man made=campanile
     man_made=carpet_hanger: Tag:man made=carpet hanger
@@ -14642,10 +15360,36 @@ en:
     marker=plate: Tag:marker=plate
     marker=post: Tag:marker=post
     marker=stone: Tag:marker=stone
+    material=aluminium: Tag:material=aluminium
+    material=asphalt: Tag:material=asphalt
+    material=bamboo: Tag:material=bamboo
+    material=basalt: Tag:material=basalt
+    material=brass: Tag:material=brass
+    material=bronze: Tag:material=bronze
+    material=ceramic: Tag:material=ceramic
     material=concrete: Tag:material=concrete
+    material=copper: Tag:material=copper
     material=epoxy: Tag:material=epoxy
+    material=fiberglass: Tag:material=fiberglass
+    material=glass: Tag:material=glass
+    material=gold: Tag:material=gold
+    material=granite: Tag:material=granite
+    material=iron: Tag:material=iron
+    material=laterite: Tag:material=laterite
+    material=marble: Tag:material=marble
+    material=metal: Tag:material=metal
     material=paving_stones: Tag:material=paving stones
+    material=plastic: Tag:material=plastic
+    material=reinforced_concrete: Tag:material=reinforced concrete
+    material=sand: Tag:material=sand
+    material=sandstone: Tag:material=sandstone
+    material=stainless_steel: Tag:material=stainless steel
+    material=steel: Tag:material=steel
+    material=stone: Tag:material=stone
     material=tufa: Tag:material=tufa
+    material=vinyl: Tag:material=vinyl
+    material=wood: Tag:material=wood
+    material=wood;metal: Tag:material=wood;metal
     maxheight=default: Tag:maxheight=default
     maxspeed:type=AU:rural: Tag:maxspeed:type=AU:rural
     maxspeed:type=AU:urban: Tag:maxspeed:type=AU:urban
@@ -14711,6 +15455,7 @@ en:
     memorial:type=stolperstein: Tag:memorial:type=stolperstein
     memorial=bench: Tag:memorial=bench
     memorial=blue_plaque: Tag:memorial=blue plaque
+    memorial=broken_column: Tag:memorial=broken column
     memorial=bust: Tag:memorial=bust
     memorial=cenotaph: Tag:memorial=cenotaph
     memorial=cross: Tag:memorial=cross
@@ -14764,7 +15509,6 @@ en:
     mofa=use_sidepath: Tag:mofa=use sidepath
     monastery:type=friary: Tag:monastery:type=friary
     monument=statue: Tag:monument=statue
-    mooring=commercial: Tag:mooring=commercial
     mooring=cruise: Tag:mooring=cruise
     mooring=declaration: Tag:mooring=declaration
     mooring=ferry: Tag:mooring=ferry
@@ -14967,6 +15711,7 @@ en:
     network=CN:YN: Tag:network=CN:YN
     network=CN:expressway: Tag:network=CN:expressway
     network=CN:national: Tag:network=CN:national
+    network=CO-OP: Tag:network=CO-OP
     network=CR:national: Tag:network=CR:national
     network=EC:national: Tag:network=EC:national
     network=EC:provincial: Tag:network=EC:provincial
@@ -15006,6 +15751,7 @@ en:
     network=SE:LS: Tag:network=SE:LS
     network=SE:LV: Tag:network=SE:LV
     network=SE:RV: Tag:network=SE:RV
+    network=Swisscovery: Tag:network=Swisscovery
     network=TH:national: Tag:network=TH:national
     network=TTC: Tag:network=TTC
     network=US:ADHS: Tag:network=US:ADHS
@@ -15077,6 +15823,7 @@ en:
     network=US:NJ:Gloucester: Tag:network=US:NJ:Gloucester
     network=US:NJ:Passaic: Tag:network=US:NJ:Passaic
     network=US:NM: Tag:network=US:NM
+    network=US:NM:Doña_Ana: Tag:network=US:NM:Doña Ana
     network=US:NV: Tag:network=US:NV
     network=US:NV:Clark: Tag:network=US:NV:Clark
     network=US:NY: Tag:network=US:NY
@@ -15379,6 +16126,7 @@ en:
     office=water_utility: Tag:office=water utility
     office=wedding_planner: Tag:office=wedding planner
     office=yes: Tag:office=yes
+    official_name:signed=no: Tag:official name:signed=no
     on_demand=yes: Tag:on demand=yes
     oneway:bicycle=-1: Tag:oneway:bicycle=-1
     oneway:bicycle=yes: Tag:oneway:bicycle=yes
@@ -15396,12 +16144,17 @@ en:
     opening_hours=closed: Tag:opening hours=closed
     operational_status=closed: Tag:operational status=closed
     operational_status=out_of_order: Tag:operational status=out of order
+    operator:type=association: Tag:operator:type=association
+    operator:type=cooperative: Tag:operator:type=cooperative
+    operator:type=haute_école_spécialisée: Tag:operator:type=haute école spécialisée
+    operator:type=intergovernmental: Tag:operator:type=intergovernmental
     operator=Agentschap_Wegen_en_Verkeer: Tag:operator=Agentschap Wegen en Verkeer
     operator=Agentschap_voor_Natuur_en_Bos: Tag:operator=Agentschap voor Natuur en
       Bos
     operator=Bundesrepublik_Deutschland: Tag:operator=Bundesrepublik Deutschland
     operator=Cambio: Tag:operator=Cambio
     operator=CiteeCar: Tag:operator=CiteeCar
+    operator=DB_InfraGO_AG: Tag:operator=DB InfraGO AG
     operator=Drive_Carsharing: Tag:operator=Drive Carsharing
     operator=Enedis: Tag:operator=Enedis
     operator=Flinkster: Tag:operator=Flinkster
@@ -15430,6 +16183,7 @@ en:
     operator=stadtmobil: Tag:operator=stadtmobil
     operator=teilAuto: Tag:operator=teilAuto
     orchard=meadow_orchard: Tag:orchard=meadow orchard
+    orchard=plantation: Tag:orchard=plantation
     organ=yes: Tag:organ=yes
     outdoor_seating=patio: Tag:outdoor seating=patio
     outdoor_seating=terrace: Tag:outdoor seating=terrace
@@ -15487,6 +16241,7 @@ en:
     path=sidewalk: Tag:path=sidewalk
     path=traffic_island: Tag:path=traffic island
     path=trail: Tag:path=trail
+    payment=gpn_qris: Tag:payment=gpn qris
     permit=climbing_skills_certificate: Tag:permit=climbing skills certificate
     pharmacy=yes: Tag:pharmacy=yes
     piercing=yes: Tag:piercing=yes
@@ -15501,10 +16256,14 @@ en:
     piste:type=downhill: Tag:piste:type=downhill
     piste:type=fatbike: Tag:piste:type=fatbike
     piste:type=hike: Tag:piste:type=hike
+    piste:type=ice_skate: Tag:piste:type=ice skate
     piste:type=nordic: Tag:piste:type=nordic
+    piste:type=playground: Tag:piste:type=playground
     piste:type=ski_jump: Tag:piste:type=ski jump
     piste:type=ski_jump_landing: Tag:piste:type=ski jump landing
     piste:type=sled: Tag:piste:type=sled
+    piste:type=sleigh: Tag:piste:type=sleigh
+    piste:type=snow_park: Tag:piste:type=snow park
     piste:type=snowmobile: Tag:piste:type=snowmobile
     piste:type=yes: Tag:piste:type=yes
     place=allotments: Tag:place=allotments
@@ -15584,6 +16343,10 @@ en:
     plant:type=reciprocating_engine: Tag:plant:type=reciprocating engine
     plant:type=solar_photovoltaic_panel: Tag:plant:type=solar photovoltaic panel
     plant:type=steam_turbine: Tag:plant:type=steam turbine
+    plaque=dedication_plaque: Tag:plaque=dedication plaque
+    plaque=here_lived: Tag:plaque=here lived
+    plaque=here_stayed: Tag:plaque=here stayed
+    plaque=here_was_born: Tag:plaque=here was born
     playground=activitypanel: Tag:playground=activitypanel
     playground=aerialrotator: Tag:playground=aerialrotator
     playground=agility_trail: Tag:playground=agility trail
@@ -15700,6 +16463,7 @@ en:
     port=cargo: Tag:port=cargo
     port=fishing: Tag:port=fishing
     port=roro: Tag:port=roro
+    portage=unknown: Tag:portage=unknown
     post_office=bureau: Tag:post office=bureau
     post_office=post_annex: Tag:post office=post annex
     post_office=post_partner: Tag:post office=post partner
@@ -15709,6 +16473,7 @@ en:
     power=cable: Tag:power=cable
     power=cable_distribution_cabinet: Tag:power=cable distribution cabinet
     power=catenary_mast: Tag:power=catenary mast
+    power=catenary_portal: Tag:power=catenary portal
     power=circuit: Tag:power=circuit
     power=compensator: Tag:power=compensator
     power=connection: Tag:power=connection
@@ -15836,6 +16601,12 @@ en:
     radio_transponder:category=directional: Tag:radio transponder:category=directional
     radio_transponder:category=rotating_pattern: Tag:radio transponder:category=rotating
       pattern
+    railway:electricity:jumpering=bridged: Tag:railway:electricity:jumpering=bridged
+    railway:electricity:jumpering=closed: Tag:railway:electricity:jumpering=closed
+    railway:electricity:jumpering=no: Tag:railway:electricity:jumpering=no
+    railway:electricity:jumpering=possible: Tag:railway:electricity:jumpering=possible
+    railway:electricity=joint: Tag:railway:electricity=joint
+    railway:electricity=power_supply: Tag:railway:electricity=power supply
     railway:radio=gsm-r: Tag:railway:radio=gsm-r
     railway:signal:distant:shape=FR:R: Tag:railway:signal:distant:shape=FR:R
     railway:signal:distant:states=FR:(A): Tag:railway:signal:distant:states=FR:(A)
@@ -15848,6 +16619,75 @@ en:
     railway:signal:distant:states=FR:R+(A): Tag:railway:signal:distant:states=FR:R+(A)
     railway:signal:distant:states=FR:R+A: Tag:railway:signal:distant:states=FR:R+A
     railway:signal:distant:states=FR:VL: Tag:railway:signal:distant:states=FR:VL
+    railway:signal:distant:type=FR:R1: Tag:railway:signal:distant:type=FR:R1
+    railway:signal:distant:type=FR:R2: Tag:railway:signal:distant:type=FR:R2
+    railway:signal:distant:type=FR:R3: Tag:railway:signal:distant:type=FR:R3
+    railway:signal:distant:type=FR:R4: Tag:railway:signal:distant:type=FR:R4
+    railway:signal:distant:type=FR:R5: Tag:railway:signal:distant:type=FR:R5
+    railway:signal:distant:type=FR:R6: Tag:railway:signal:distant:type=FR:R6
+    railway:signal:main:clearing_light=no: Tag:railway:signal:main:clearing light=no
+    railway:signal:main:clearing_light=yes: Tag:railway:signal:main:clearing light=yes
+    railway:signal:main:height=high: Tag:railway:signal:main:height=high
+    railway:signal:main:height=low: Tag:railway:signal:main:height=low
+    railway:signal:main:plates=FR:F: Tag:railway:signal:main:plates=FR:F
+    railway:signal:main:plates=FR:GA: Tag:railway:signal:main:plates=FR:GA
+    railway:signal:main:plates=FR:NF: Tag:railway:signal:main:plates=FR:NF
+    railway:signal:main:shape=FR:A: Tag:railway:signal:main:shape=FR:A
+    railway:signal:main:shape=FR:C: Tag:railway:signal:main:shape=FR:C
+    railway:signal:main:shape=FR:F: Tag:railway:signal:main:shape=FR:F
+    railway:signal:main:shape=FR:H: Tag:railway:signal:main:shape=FR:H
+    railway:signal:main:shape=FR:K: Tag:railway:signal:main:shape=FR:K
+    railway:signal:main:states=FR:(A): Tag:railway:signal:main:states=FR:(A)
+    railway:signal:main:states=FR:(M): Tag:railway:signal:main:states=FR:(M)
+    railway:signal:main:states=FR:(R): Tag:railway:signal:main:states=FR:(R)
+    railway:signal:main:states=FR:(R)+(A): Tag:railway:signal:main:states=FR:(R)+(A)
+    railway:signal:main:states=FR:(R)+A: Tag:railway:signal:main:states=FR:(R)+A
+    railway:signal:main:states=FR:(RR): Tag:railway:signal:main:states=FR:(RR)
+    railway:signal:main:states=FR:(RR)+(A): Tag:railway:signal:main:states=FR:(RR)+(A)
+    railway:signal:main:states=FR:(RR)+A: Tag:railway:signal:main:states=FR:(RR)+A
+    railway:signal:main:states=FR:(S): Tag:railway:signal:main:states=FR:(S)
+    railway:signal:main:states=FR:(VL): Tag:railway:signal:main:states=FR:(VL)
+    railway:signal:main:states=FR:A: Tag:railway:signal:main:states=FR:A
+    railway:signal:main:states=FR:C: Tag:railway:signal:main:states=FR:C
+    railway:signal:main:states=FR:CV: Tag:railway:signal:main:states=FR:CV
+    railway:signal:main:states=FR:M: Tag:railway:signal:main:states=FR:M
+    railway:signal:main:states=FR:R: Tag:railway:signal:main:states=FR:R
+    railway:signal:main:states=FR:R+(A): Tag:railway:signal:main:states=FR:R+(A)
+    railway:signal:main:states=FR:R+A: Tag:railway:signal:main:states=FR:R+A
+    railway:signal:main:states=FR:RR: Tag:railway:signal:main:states=FR:RR
+    railway:signal:main:states=FR:RR+(A): Tag:railway:signal:main:states=FR:RR+(A)
+    railway:signal:main:states=FR:RR+A: Tag:railway:signal:main:states=FR:RR+A
+    railway:signal:main:states=FR:S: Tag:railway:signal:main:states=FR:S
+    railway:signal:main:states=FR:VL: Tag:railway:signal:main:states=FR:VL
+    railway:signal:main:type=FR:A: Tag:railway:signal:main:type=FR:A
+    railway:signal:main:type=FR:A1: Tag:railway:signal:main:type=FR:A1
+    railway:signal:main:type=FR:A2: Tag:railway:signal:main:type=FR:A2
+    railway:signal:main:type=FR:A3: Tag:railway:signal:main:type=FR:A3
+    railway:signal:main:type=FR:C: Tag:railway:signal:main:type=FR:C
+    railway:signal:main:type=FR:C1: Tag:railway:signal:main:type=FR:C1
+    railway:signal:main:type=FR:C2: Tag:railway:signal:main:type=FR:C2
+    railway:signal:main:type=FR:C3: Tag:railway:signal:main:type=FR:C3
+    railway:signal:main:type=FR:F: Tag:railway:signal:main:type=FR:F
+    railway:signal:main:type=FR:F1: Tag:railway:signal:main:type=FR:F1
+    railway:signal:main:type=FR:F2: Tag:railway:signal:main:type=FR:F2
+    railway:signal:main:type=FR:F3: Tag:railway:signal:main:type=FR:F3
+    railway:signal:main:type=FR:F4: Tag:railway:signal:main:type=FR:F4
+    railway:signal:main:type=FR:F5: Tag:railway:signal:main:type=FR:F5
+    railway:signal:main:type=FR:H: Tag:railway:signal:main:type=FR:H
+    railway:signal:main:type=FR:H1: Tag:railway:signal:main:type=FR:H1
+    railway:signal:main:type=FR:H2: Tag:railway:signal:main:type=FR:H2
+    railway:signal:main:type=FR:H3: Tag:railway:signal:main:type=FR:H3
+    railway:signal:main:type=FR:H4: Tag:railway:signal:main:type=FR:H4
+    railway:signal:main:type=FR:H5: Tag:railway:signal:main:type=FR:H5
+    railway:signal:main:type=FR:H6: Tag:railway:signal:main:type=FR:H6
+    railway:signal:main:type=FR:H7: Tag:railway:signal:main:type=FR:H7
+    railway:signal:main:type=FR:K1: Tag:railway:signal:main:type=FR:K1
+    railway:signal:main:type=FR:K2: Tag:railway:signal:main:type=FR:K2
+    railway:signal:main:type=K1: Tag:railway:signal:main:type=K1
+    railway:signal:main:type=K2: Tag:railway:signal:main:type=K2
+    railway:signal:shunting:shape=FR:A: Tag:railway:signal:shunting:shape=FR:A
+    railway:signal:shunting:shape=FR:K: Tag:railway:signal:shunting:shape=FR:K
+    railway:signal:shunting:type=FR:A2: Tag:railway:signal:shunting:type=FR:A2
     railway:signal_box=electric: Tag:railway:signal box=electric
     railway:signal_box=electronic: Tag:railway:signal box=electronic
     railway:signal_box=mechanical: Tag:railway:signal box=mechanical
@@ -15915,6 +16755,8 @@ en:
     recycling_type=centre: Tag:recycling type=centre
     recycling_type=container: Tag:recycling type=container
     recycling_type=reverse_vending_machine: Tag:recycling type=reverse vending machine
+    ref:CH-GE:CODE_VOIE=none: Tag:ref:CH-GE:CODE VOIE=none
+    ref:isil=none: Tag:ref:isil=none
     ref=SS676: Tag:ref=SS676
     refitted=yes: Tag:refitted=yes
     refrigerated=yes: Tag:refrigerated=yes
@@ -15929,6 +16771,7 @@ en:
     religion=muslim: Tag:religion=muslim
     religion=none: Tag:religion=none
     religion=pagan: Tag:religion=pagan
+    religion=sapta_darma: Tag:religion=sapta darma
     religion=self-realization_fellowship: Tag:religion=self-realization fellowship
     religion=shamanic: Tag:religion=shamanic
     religion=shinto: Tag:religion=shinto
@@ -15937,6 +16780,7 @@ en:
     religion=zoroastrian: Tag:religion=zoroastrian
     removed:power=line: Tag:removed:power=line
     rental=appliance: Tag:rental=appliance
+    rental=bike_trailer: Tag:rental=bike trailer
     rental=boat: Tag:rental=boat
     rental=book: Tag:rental=book
     rental=clothes: Tag:rental=clothes
@@ -15981,6 +16825,7 @@ en:
     roller_coaster=support: Tag:roller coaster=support
     roller_coaster=track: Tag:roller coaster=track
     roof:material=roof_tiles: Tag:roof:material=roof tiles
+    roof:shape=apse_gabled: Tag:roof:shape=apse gabled
     roof:shape=bellcast_gable: Tag:roof:shape=bellcast gable
     roof:shape=butterfly: Tag:roof:shape=butterfly
     roof:shape=cone: Tag:roof:shape=cone
@@ -15992,6 +16837,7 @@ en:
     roof:shape=gabled: Tag:roof:shape=gabled
     roof:shape=gabled_height_moved: Tag:roof:shape=gabled height moved
     roof:shape=gambrel: Tag:roof:shape=gambrel
+    roof:shape=half-dome: Tag:roof:shape=half-dome
     roof:shape=half-hipped: Tag:roof:shape=half-hipped
     roof:shape=half_hipped: Tag:roof:shape=half hipped
     roof:shape=hip-and-gable: Tag:roof:shape=hip-and-gable
@@ -16028,6 +16874,7 @@ en:
     route=fitness_trail: Tag:route=fitness trail
     route=foot: Tag:route=foot
     route=funicular: Tag:route=funicular
+    route=golf: Tag:route=golf
     route=hiking: Tag:route=hiking
     route=historic: Tag:route=historic
     route=horse: Tag:route=horse
@@ -16047,6 +16894,7 @@ en:
     route=railway: Tag:route=railway
     route=road: Tag:route=road
     route=running: Tag:route=running
+    route=safari: Tag:route=safari
     route=share_taxi: Tag:route=share taxi
     route=shuttle_train: Tag:route=shuttle train
     route=ski: Tag:route=ski
@@ -16552,6 +17400,7 @@ en:
     shop=baking_supplies: Tag:shop=baking supplies
     shop=balloon: Tag:shop=balloon
     shop=bathroom_furnishing: Tag:shop=bathroom furnishing
+    shop=battery: Tag:shop=battery
     shop=bbq: Tag:shop=bbq
     shop=beauty: Tag:shop=beauty
     shop=bed: Tag:shop=bed
@@ -16595,6 +17444,7 @@ en:
     shop=cleaning_supplies: Tag:shop=cleaning supplies
     shop=clothes: Tag:shop=clothes
     shop=coffee: Tag:shop=coffee
+    shop=coffee_roasting: Tag:shop=coffee roasting
     shop=collector: Tag:shop=collector
     shop=communication: Tag:shop=communication
     shop=computer: Tag:shop=computer
@@ -16842,6 +17692,7 @@ en:
     shop=vape: Tag:shop=vape
     shop=variety_store: Tag:shop=variety store
     shop=vehicles: Tag:shop=vehicles
+    shop=vending: Tag:shop=vending
     shop=vending_machine: Tag:shop=vending machine
     shop=video: Tag:shop=video
     shop=video_games: Tag:shop=video games
@@ -16864,12 +17715,14 @@ en:
     shop=windows: Tag:shop=windows
     shop=wine: Tag:shop=wine
     shop=winery: Tag:shop=winery
+    shop=wood: Tag:shop=wood
     shop=wool: Tag:shop=wool
     shop=yes: Tag:shop=yes
     sidewalk:both:surface=rock: Tag:sidewalk:both:surface=rock
     sidewalk:both=separate: Tag:sidewalk:both=separate
     sidewalk:left=separate: Tag:sidewalk:left=separate
     sidewalk:right=separate: Tag:sidewalk:right=separate
+    sidewalk=bad: Tag:sidewalk=bad
     sidewalk=both: Tag:sidewalk=both
     sidewalk=separate: Tag:sidewalk=separate
     sidewalk=yes: Tag:sidewalk=yes
@@ -17027,9 +17880,12 @@ en:
     spacecraft:landing=rocket: Tag:spacecraft:landing=rocket
     spacecraft:landing=spaceplane: Tag:spacecraft:landing=spaceplane
     species=Acer_platanoides: Tag:species=Acer platanoides
+    species=Castanea_sativa: Tag:species=Castanea sativa
+    species=Castanea␣sativa: Tag:species=Castanea␣sativa
     species=Quercus_robur: Tag:species=Quercus robur
     species=Tilia_cordata: Tag:species=Tilia cordata
     sport=10pin: Tag:sport=10pin
+    sport=5pin: Tag:sport=5pin
     sport=8pin: Tag:sport=8pin
     sport=9pin: Tag:sport=9pin
     sport=BASE: Tag:sport=BASE
@@ -17096,6 +17952,7 @@ en:
     sport=dog_agility: Tag:sport=dog agility
     sport=dog_racing: Tag:sport=dog racing
     sport=dragon_boat: Tag:sport=dragon boat
+    sport=duckpin: Tag:sport=duckpin
     sport=equestrian: Tag:sport=equestrian
     sport=fencing: Tag:sport=fencing
     sport=field_hockey: Tag:sport=field hockey
@@ -17110,6 +17967,7 @@ en:
     sport=free_flying: Tag:sport=free flying
     sport=freediving: Tag:sport=freediving
     sport=funnel_ball: Tag:sport=funnel ball
+    sport=futnet: Tag:sport=futnet
     sport=futsal: Tag:sport=futsal
     sport=gaelic_football: Tag:sport=gaelic football
     sport=gaelic_games: Tag:sport=gaelic games
@@ -17124,6 +17982,7 @@ en:
     sport=hiking: Tag:sport=hiking
     sport=hockey: Tag:sport=hockey
     sport=hopscotch: Tag:sport=hopscotch
+    sport=hornussen: Tag:sport=hornussen
     sport=horse_racing: Tag:sport=horse racing
     sport=horse_riding: Tag:sport=horse riding
     sport=horseshoes: Tag:sport=horseshoes
@@ -17186,6 +18045,7 @@ en:
     sport=rugby_league: Tag:sport=rugby league
     sport=rugby_union: Tag:sport=rugby union
     sport=running: Tag:sport=running
+    sport=russian_skittles: Tag:sport=russian skittles
     sport=safety_training: Tag:sport=safety training
     sport=sailing: Tag:sport=sailing
     sport=scuba_diving: Tag:sport=scuba diving
@@ -17239,7 +18099,13 @@ en:
     sports=aikido: Tag:sports=aikido
     sports=athletics: Tag:sports=athletics
     spring:type=hot: Tag:spring:type=hot
+    start_date=C11: Tag:start date=C11
+    start_date=C12: Tag:start date=C12
+    start_date=C13: Tag:start date=C13
+    start_date=C14: Tag:start date=C14
+    start_date=C15: Tag:start date=C15
     start_date=C16: Tag:start date=C16
+    start_date=C17: Tag:start date=C17
     start_date=C18: Tag:start date=C18
     start_date=C19: Tag:start date=C19
     state=alternate: Tag:state=alternate
@@ -17301,7 +18167,6 @@ en:
     substation=traction: Tag:substation=traction
     substation=transition: Tag:substation=transition
     substation=transmission: Tag:substation=transmission
-    summit:cross=yes: Tag:summit:cross=yes
     surface:colour=rainbow: Tag:surface:colour=rainbow
     surface=acrylic: Tag:surface=acrylic
     surface=artificial_grass: Tag:surface=artificial grass
@@ -17329,6 +18194,7 @@ en:
     surface=granite: Tag:surface=granite
     surface=grass: Tag:surface=grass
     surface=grass_paver: Tag:surface=grass paver
+    surface=grass_paver:lanes: Tag:surface=grass paver:lanes
     surface=gravel: Tag:surface=gravel
     surface=ground: Tag:surface=ground
     surface=hard: Tag:surface=hard
@@ -17398,6 +18264,7 @@ en:
     tactile_paving=partial: Tag:tactile paving=partial
     tactile_paving=yes: Tag:tactile paving=yes
     tank_trap=czech_hedgehog: Tag:tank trap=czech hedgehog
+    target=FR: Tag:target=FR
     taxi_type=motorcycle: Tag:taxi type=motorcycle
     taxi_vehicle=motorcycle: Tag:taxi vehicle=motorcycle
     taxon:en=Palm: Tag:taxon:en=Palm
@@ -17407,6 +18274,7 @@ en:
     telecom:medium=copper: Tag:telecom:medium=copper
     telecom:medium=fibre: Tag:telecom:medium=fibre
     telecom=antenna: Tag:telecom=antenna
+    telecom=cable_landing_station: Tag:telecom=cable landing station
     telecom=central_office: Tag:telecom=central office
     telecom=connection_point: Tag:telecom=connection point
     telecom=cross-connect: Tag:telecom=cross-connect
@@ -17433,8 +18301,10 @@ en:
     toddler_area=no: Tag:toddler area=no
     toddler_area=shared: Tag:toddler area=shared
     toilets:access=customers: Tag:toilets:access=customers
+    toilets:wash=bidet_spray: Tag:toilets:wash=bidet spray
     toilets:wash=no: Tag:toilets:wash=no
     toilets:wash=shower: Tag:toilets:wash=shower
+    toilets:wash=washlet: Tag:toilets:wash=washlet
     toilets:wash=water_dipper: Tag:toilets:wash=water dipper
     toll:designated=yes: Tag:toll:designated=yes
     toll=yes: Tag:toll=yes
@@ -17522,6 +18392,7 @@ en:
     tower:type=transposing: Tag:tower:type=transposing
     tower:type=watchtower: Tag:tower:type=watchtower
     townhall:type=barangay: Tag:townhall:type=barangay
+    townhall:type=municipality: Tag:townhall:type=municipality
     townhall:type=town: Tag:townhall:type=town
     townhall:type=village: Tag:townhall:type=village
     trade=agricultural_supplies: Tag:trade=agricultural supplies
@@ -17946,6 +18817,7 @@ en:
     wall=stone_wall: Tag:wall=stone wall
     wall=tire_barrier: Tag:wall=tire barrier
     wall=training_wall: Tag:wall=training wall
+    wall=yes: Tag:wall=yes
     war_memorial=yes: Tag:war memorial=yes
     waste=ash: Tag:waste=ash
     waste=cigarettes: Tag:waste=cigarettes
@@ -18121,6 +18993,7 @@ eo:
     highway=street_lamp: Eo:Tag:highway=street lamp
     leaf_cycle=evergreen: Eo:Tag:leaf cycle=evergreen
     leisure=picnic_table: Eo:Tag:leisure=picnic table
+    man_made=dyke: Eo:Tag:man made=dyke
     man_made=lighthouse: Eo:Tag:man made=lighthouse
     natural=reef: Eo:Tag:natural=reef
     place=country: Eo:Tag:place=country
@@ -18145,6 +19018,7 @@ eo:
     shop=bakery: Eo:Tag:shop=bakery
     shop=shoes: Eo:Tag:shop=shoes
     surface=dirt: Eo:Tag:surface=dirt
+    water=basin: Eo:Tag:water=basin
     waterway=river: Eo:Tag:waterway=river
 es:
   key:
@@ -18308,6 +19182,9 @@ es:
     crop: ES:Key:crop
     crossing: ES:Key:crossing
     crossing:island: ES:Key:crossing:island
+    crossing:markings: ES:Key:crossing:markings
+    crossing:signed: ES:Key:crossing:signed
+    crossing_ref: ES:Key:crossing ref
     cuisine: ES:Key:cuisine
     currency: ES:Key:currency
     currency:*: ES:Key:currency:*
@@ -19384,6 +20261,7 @@ es:
     craft=winery: ES:Tag:craft=winery
     crop=soy: ES:Tag:crop=soy
     crop=sugarcane: ES:Tag:crop=sugarcane
+    crossing:markings=zebra: ES:Tag:crossing:markings=zebra
     crossing=marked: ES:Tag:crossing=marked
     crossing=no: ES:Tag:crossing=no
     crossing=traffic_signals: ES:Tag:crossing=traffic signals
@@ -19550,6 +20428,7 @@ es:
     footway=sidewalk: ES:Tag:footway=sidewalk
     ford=stepping_stones: ES:Tag:ford=stepping stones
     ford=yes: ES:Tag:ford=yes
+    fortification_type=hill_fort: ES:Tag:fortification type=hill fort
     fountain=bubbler: ES:Tag:fountain=bubbler
     garden:type=botanical: ES:Tag:garden:type=botanical
     generator:method=combustion: ES:Tag:generator:method=combustion
@@ -19957,6 +20836,7 @@ es:
     man_made=tell: ES:Tag:man made=tell
     man_made=threshing_floor: ES:Tag:man made=threshing floor
     man_made=tower: ES:Tag:man made=tower
+    man_made=trapping_pit: ES:Tag:man made=trapping pit
     man_made=video_wall: ES:Tag:man made=video wall
     man_made=wastewater_plant: ES:Tag:man made=wastewater plant
     man_made=water_tap: ES:Tag:man made=water tap
@@ -20805,6 +21685,7 @@ es:
     tower:type=cooling: ES:Tag:tower:type=cooling
     tower:type=defensive: ES:Tag:tower:type=defensive
     tower:type=lightning_protection: ES:Tag:tower:type=lightning protection
+    tower:type=lightning_rod: ES:Tag:tower:type=lightning rod
     tower:type=minaret: ES:Tag:tower:type=minaret
     tower:type=observation: ES:Tag:tower:type=observation
     tower:type=watchtower: ES:Tag:tower:type=watchtower
@@ -20859,6 +21740,7 @@ es:
     vending=flowers: ES:Tag:vending=flowers
     vending=food: ES:Tag:vending=food
     vending=fuel: ES:Tag:vending=fuel
+    vending=honey: ES:Tag:vending=honey
     vending=ice_cream: ES:Tag:vending=ice cream
     vending=ice_cubes: ES:Tag:vending=ice cubes
     vending=milk: ES:Tag:vending=milk
@@ -20876,6 +21758,7 @@ es:
     vending=telephone_vouchers: ES:Tag:vending=telephone vouchers
     vending=toll: ES:Tag:vending=toll
     vending=toys: ES:Tag:vending=toys
+    vending=umbrellas: ES:Tag:vending=umbrellas
     vending=water: ES:Tag:vending=water
     wall=brick: ES:Tag:wall=brick
     wall=castle_wall: ES:Tag:wall=castle wall
@@ -21110,6 +21993,7 @@ fi:
     narrow: Fi:Key:narrow
     natural: Fi:Key:natural
     note: Fi:Key:note
+    opening_hours: Fi:Key:opening hours
     operator: Fi:Key:operator
     pihatie: Fi:Key:pihatie
     place: Fi:Key:place
@@ -21284,6 +22168,7 @@ fr:
     bicycle_parking: FR:Key:bicycle parking
     bike_ride: FR:Key:bike ride
     bin: FR:Key:bin
+    blind: FR:Key:blind
     board_type: FR:Key:board type
     boat: FR:Key:boat
     bollard: FR:Key:bollard
@@ -21312,9 +22197,12 @@ fr:
     bus:lanes: FR:Key:bus:lanes
     bus_bay: FR:Key:bus bay
     busway: FR:Key:busway
+    button_operated: FR:Key:button operated
     cables: FR:Key:cables
     cafe: FR:Key:cafe
     camera:direction: FR:Key:camera:direction
+    camera:mount: FR:Key:camera:mount
+    camera:type: FR:Key:camera:type
     camp_site: FR:Key:camp site
     capacity: FR:Key:capacity
     capacity:charging: FR:Key:capacity:charging
@@ -21406,6 +22294,7 @@ fr:
     diet:kosher: FR:Key:diet:kosher
     diet:vegan: FR:Key:diet:vegan
     diet:vegetarian: FR:Key:diet:vegetarian
+    diff:ref:FR:RNB: FR:Key:diff:ref:FR:RNB
     diocese: FR:Key:diocese
     diplomatic: FR:Key:diplomatic
     direction: FR:Key:direction
@@ -21527,6 +22416,7 @@ fr:
     kerb: FR:Key:kerb
     kindergarten:FR: FR:Key:kindergarten:FR
     ladder: FR:Key:ladder
+    lamp_mount: FR:Key:lamp mount
     landfill:waste: FR:Key:landfill:waste
     landuse: FR:Key:landuse
     lane_markings: FR:Key:lane markings
@@ -21614,6 +22504,7 @@ fr:
     noref: FR:Key:noref
     note: FR:Key:note
     nudism: FR:Key:nudism
+    obstacle:wheelchair: FR:Key:obstacle:wheelchair
     office: FR:Key:office
     official_name: FR:Key:official name
     old_name: FR:Key:old name
@@ -21655,6 +22546,10 @@ fr:
     parking:right: FR:Key:parking:right
     parking:right:orientation: FR:Key:parking:right:orientation
     parking_space: FR:Key:parking space
+    passenger_information_display: FR:Key:passenger information display
+    passenger_information_display:speech_output: FR:Key:passenger information display:speech
+      output
+    pastry: FR:Key:pastry
     paved:date: FR:Key:paved:date
     payment: FR:Key:payment
     payment:*: FR:Key:payment:*
@@ -21708,9 +22603,11 @@ fr:
     ref:CD:CNOP: FR:Key:ref:CD:CNOP
     ref:CEF: FR:Key:ref:CEF
     ref:CH-GE:noms: FR:Key:ref:CH-GE:noms
+    ref:EGID: FR:Key:ref:EGID
     ref:ERDF:gdo: FR:Key:ref:ERDF:gdo
     ref:EU:ENTSOE_EIC: FR:Key:ref:EU:ENTSOE EIC
     ref:EU:EVSE: FR:Key:ref:EU:EVSE
+    ref:EU:PLC: FR:Key:ref:EU:PLC
     ref:FR:42C: FR:Key:ref:FR:42C
     ref:FR:ANFR: FR:Key:ref:FR:ANFR
     ref:FR:ARCEP: FR:Key:ref:FR:ARCEP
@@ -21724,10 +22621,12 @@ fr:
     ref:FR:FreeMobile: FR:Key:ref:FR:FreeMobile
     ref:FR:Joconde: FR:Key:ref:FR:Joconde
     ref:FR:MemorialGenWeb: FR:Key:ref:FR:MemorialGenWeb
+    ref:FR:Merimee: FR:Key:ref:FR:Merimee
     ref:FR:NAF: FR:Key:ref:FR:NAF
     ref:FR:Orange: FR:Key:ref:FR:Orange
     ref:FR:Orange_mobile: FR:Key:ref:FR:Orange mobile
     ref:FR:PTT: FR:Key:ref:FR:PTT
+    ref:FR:Palissy: FR:Key:ref:FR:Palissy
     ref:FR:RNA: FR:Key:ref:FR:RNA
     ref:FR:RNB: FR:Key:ref:FR:RNB
     ref:FR:ROE: FR:Key:ref:FR:ROE
@@ -21749,7 +22648,6 @@ fr:
     ref:FR:museofile: FR:Key:ref:FR:museofile
     ref:INSEE: FR:Key:ref:INSEE
     ref:MA:HCP: FR:Key:ref:MA:HCP
-    ref:PLC: FR:Key:ref:PLC
     ref:RTE:codnat: FR:Key:ref:RTE:codnat
     ref:UAI: FR:Key:ref:UAI
     ref:mhs: FR:Key:ref:mhs
@@ -21758,6 +22656,7 @@ fr:
     ref:sandre: FR:Key:ref:sandre
     ref:seed: FR:Key:ref:seed
     reg_name: FR:Key:reg name
+    region:type: FR:Key:region:type
     related_law:FR:NOR: FR:Key:related law:FR:NOR
     religion: FR:Key:religion
     rental: FR:Key:rental
@@ -21842,6 +22741,7 @@ fr:
     step_count: FR:Key:step count
     stop: FR:Key:stop
     strapline: FR:Key:strapline
+    stroller: FR:Key:stroller
     substation: FR:Key:substation
     supervised: FR:Key:supervised
     support: FR:Key:support
@@ -21997,6 +22897,7 @@ fr:
     amenity=bureau_de_change: FR:Tag:amenity=bureau de change
     amenity=bus_station: FR:Tag:amenity=bus station
     amenity=cafe: FR:Tag:amenity=cafe
+    amenity=canteen: FR:Tag:amenity=canteen
     amenity=car_pooling: FR:Tag:amenity=car pooling
     amenity=car_rental: FR:Tag:amenity=car rental
     amenity=car_sharing: FR:Tag:amenity=car sharing
@@ -22136,6 +23037,7 @@ fr:
     attraction=animal: FR:Tag:attraction=animal
     attraction=carousel: FR:Tag:attraction=carousel
     attraction=water_slide: FR:Tag:attraction=water slide
+    audio_loop=yes: FR:Tag:audio loop=yes
     barrier=bar: FR:Tag:barrier=bar
     barrier=barrier_board: FR:Tag:barrier=barrier board
     barrier=block: FR:Tag:barrier=block
@@ -22717,6 +23619,7 @@ fr:
     man_made=cross: FR:Tag:man made=cross
     man_made=cutline: FR:Tag:man made=cutline
     man_made=dovecote: FR:Tag:man made=dovecote
+    man_made=dyke: FR:Tag:man made=dyke
     man_made=embankment: FR:Tag:man made=embankment
     man_made=flagpole: FR:Tag:man made=flagpole
     man_made=flare: FR:Tag:man made=flare
@@ -22845,6 +23748,7 @@ fr:
     office=surveyor: FR:Tag:office=surveyor
     office=transport: FR:Tag:office=transport
     office=travel_agent: FR:Tag:office=travel agent
+    office=university: FR:Tag:office=university
     oneway=-1: FR:Tag:oneway=-1
     oneway=no: FR:Tag:oneway=no
     oneway=yes: FR:Tag:oneway=yes
@@ -22971,6 +23875,7 @@ fr:
     railway=ventilation_shaft: FR:Tag:railway=ventilation shaft
     railway=wash: FR:Tag:railway=wash
     railway=water_crane: FR:Tag:railway=water crane
+    railway=yard: FR:Tag:railway=yard
     recycling_type=centre: FR:Tag:recycling type=centre
     recycling_type=container: FR:Tag:recycling type=container
     religion=buddhist: FR:Tag:religion=buddhist
@@ -22991,6 +23896,7 @@ fr:
     residential=apartments: FR:Tag:residential=apartments
     residential=halting_site: FR:Tag:residential=halting site
     roof:shape=gabled: FR:Tag:roof:shape=gabled
+    roof:shape=side_hipped: FR:Tag:roof:shape=side hipped
     route=bicycle: FR:Tag:route=bicycle
     route=bus: FR:Tag:route=bus
     route=coach: FR:Tag:route=coach
@@ -23460,6 +24366,7 @@ gl:
 he:
   key:
     fax: He:Key:fax
+    wikipedia: He:Key:wikipedia
   tag:
     religion=jewish: He:Tag:religion=jewish
     religion=muslim: He:Tag:religion=muslim
@@ -23566,28 +24473,38 @@ hu:
     religion=buddhist: Hu:Tag:religion=buddhist
 id:
   key:
+    amenity: Id:Key:amenity
+    barrier: Id:Key:barrier
     boundary: Id:Key:boundary
+    bridge: Id:Key:bridge
     building: Id:Key:building
+    check_date: Id:Key:check date
     frequency: Id:Key:frequency
     highway: Id:Key:highway
     landuse: Id:Key:landuse
+    lanes: Id:Key:lanes
     place: Id:Key:place
+    sac_scale: Id:Key:sac scale
+    service: Id:Key:service
+    shop: Id:Key:shop
+    turn: Id:Key:turn
     waterway: Id:Key:waterway
   tag:
     access=destination: Id:Tag:access=destination
     access=no: Id:Tag:access=no
     access=permissive: Id:Tag:access=permissive
     access=private: Id:Tag:access=private
+    amenity=ferry_terminal: Id:Tag:amenity=ferry terminal
     amenity=school: Id:Tag:amenity=school
     barrier=bollard: Id:Tag:barrier=bollard
     barrier=gate: Id:Tag:barrier=gate
     barrier=swing_gate: Id:Tag:barrier=swing gate
+    building=apartments: Id:Tag:building=apartments
     building=mosque: Id:Tag:building=mosque
     building=terraced_house: Id:Tag:building=terraced house
     genus=Acer: Id:Tag:genus=Acer
     genus=Platanus: Id:Tag:genus=Platanus
     guest_house=student_accommodation: Id:Tag:guest house=student accommodation
-    guest_house=student_accomodation: Id:Tag:guest house=student accomodation
     highway=bus_guideway: Id:Tag:highway=bus guideway
     highway=busway: Id:Tag:highway=busway
     highway=escape: Id:Tag:highway=escape
@@ -23614,6 +24531,7 @@ id:
     leaf_cycle=evergreen: Id:Tag:leaf cycle=evergreen
     man_made=culvert: Id:Tag:man made=culvert
     motor_vehicle=no: Id:Tag:motor vehicle=no
+    natural=tree: Id:Tag:natural=tree
     place=square: Id:Tag:place=square
     power=cable: Id:Tag:power=cable
     power=catenary_mast: Id:Tag:power=catenary mast
@@ -23628,6 +24546,8 @@ id:
     religion=taoist: Id:Tag:religion=taoist
     restriction=no_u_turn: Id:Tag:restriction=no u turn
     route=bus: Id:Tag:route=bus
+    route=ferry: Id:Tag:route=ferry
+    shop=deli: Id:Tag:shop=deli
     shop=pawnbroker: Id:Tag:shop=pawnbroker
     tourism=guest_house: Id:Tag:tourism=guest house
     waterway=river: Id:Tag:waterway=river
@@ -23676,6 +24596,7 @@ it:
     building:levels: IT:Key:building:levels
     cables: IT:Key:cables
     capacity: IT:Key:capacity
+    capacity:disabled: IT:Key:capacity:disabled
     castle_type: IT:Key:castle type
     circuits: IT:Key:circuits
     cocktails: IT:Key:cocktails
@@ -23742,6 +24663,9 @@ it:
     it:fvg:ctrn:revision: IT:Key:it:fvg:ctrn:revision
     junction: IT:Key:junction
     kerb: IT:Key:kerb
+    lamp_model: IT:Key:lamp model
+    lamp_mount: IT:Key:lamp mount
+    lamp_type: IT:Key:lamp type
     landuse: IT:Key:landuse
     lanes:psv: IT:Key:lanes:psv
     layer: IT:Key:layer
@@ -23806,6 +24730,7 @@ it:
     railway: IT:Key:railway
     recycling_type: IT:Key:recycling type
     ref: IT:Key:ref
+    ref:EGID: IT:Key:ref:EGID
     ref:REI: IT:Key:ref:REI
     ref:catasto: IT:Key:ref:catasto
     ref:cin: IT:Key:ref:cin
@@ -23868,6 +24793,8 @@ it:
   tag:
     access=customers: IT:Tag:access=customers
     access=private: IT:Tag:access=private
+    admin_level=4: IT:Tag:admin level=4
+    admin_level=8: IT:Tag:admin level=8
     advertising=billboard: IT:Tag:advertising=billboard
     advertising=column: IT:Tag:advertising=column
     advertising=flag: IT:Tag:advertising=flag
@@ -23928,6 +24855,7 @@ it:
     amenity=nightclub: IT:Tag:amenity=nightclub
     amenity=parcel_locker: IT:Tag:amenity=parcel locker
     amenity=parking: IT:Tag:amenity=parking
+    amenity=parking_space: IT:Tag:amenity=parking space
     amenity=payment_terminal: IT:Tag:amenity=payment terminal
     amenity=pharmacy: IT:Tag:amenity=pharmacy
     amenity=photo_booth: IT:Tag:amenity=photo booth
@@ -24002,8 +24930,11 @@ it:
     building=train_station: IT:Tag:building=train station
     building=yes: IT:Tag:building=yes
     castle_type=fortress: IT:Tag:castle type=fortress
+    club=sport: IT:Tag:club=sport
     club=youth: IT:Tag:club=youth
     craft=agricultural_engines: IT:Tag:craft=agricultural engines
+    craft=atelier: IT:Tag:craft=atelier
+    craft=bag_repair: IT:Tag:craft=bag repair
     craft=bakery: IT:Tag:craft=bakery
     craft=basket_maker: IT:Tag:craft=basket maker
     craft=beekeeper: IT:Tag:craft=beekeeper
@@ -24013,32 +24944,49 @@ it:
     craft=brewery: IT:Tag:craft=brewery
     craft=builder: IT:Tag:craft=builder
     craft=cabinet_maker: IT:Tag:craft=cabinet maker
+    craft=candlemaker: IT:Tag:craft=candlemaker
+    craft=car_painter: IT:Tag:craft=car painter
     craft=car_repair: IT:Tag:craft=car repair
     craft=carpenter: IT:Tag:craft=carpenter
+    craft=carpet_cleaner: IT:Tag:craft=carpet cleaner
     craft=carpet_layer: IT:Tag:craft=carpet layer
     craft=caterer: IT:Tag:craft=caterer
     craft=chimney_sweeper: IT:Tag:craft=chimney sweeper
+    craft=cleaning: IT:Tag:craft=cleaning
     craft=clockmaker: IT:Tag:craft=clockmaker
+    craft=clothes_mending: IT:Tag:craft=clothes mending
     craft=confectionery: IT:Tag:craft=confectionery
     craft=cooper: IT:Tag:craft=cooper
     craft=dental_technician: IT:Tag:craft=dental technician
     craft=distillery: IT:Tag:craft=distillery
+    craft=door_construction: IT:Tag:craft=door construction
     craft=dressmaker: IT:Tag:craft=dressmaker
     craft=electrician: IT:Tag:craft=electrician
     craft=electronics_repair: IT:Tag:craft=electronics repair
+    craft=elevator: IT:Tag:craft=elevator
     craft=embroiderer: IT:Tag:craft=embroiderer
     craft=engraver: IT:Tag:craft=engraver
+    craft=fence_maker: IT:Tag:craft=fence maker
     craft=floorer: IT:Tag:craft=floorer
     craft=gardener: IT:Tag:craft=gardener
+    craft=glassblower: IT:Tag:craft=glassblower
     craft=glaziery: IT:Tag:craft=glaziery
+    craft=goldsmith: IT:Tag:craft=goldsmith
     craft=grinding_mill: IT:Tag:craft=grinding mill
+    craft=gunsmith: IT:Tag:craft=gunsmith
     craft=handicraft: IT:Tag:craft=handicraft
     craft=hvac: IT:Tag:craft=hvac
     craft=insulation: IT:Tag:craft=insulation
+    craft=interior_decorator: IT:Tag:craft=interior decorator
+    craft=interior_work: IT:Tag:craft=interior work
     craft=jeweller: IT:Tag:craft=jeweller
     craft=joiner: IT:Tag:craft=joiner
     craft=key_cutter: IT:Tag:craft=key cutter
+    craft=laboratory: IT:Tag:craft=laboratory
+    craft=lapidary: IT:Tag:craft=lapidary
+    craft=leather: IT:Tag:craft=leather
     craft=locksmith: IT:Tag:craft=locksmith
+    craft=luthier: IT:Tag:craft=luthier
     craft=metal_construction: IT:Tag:craft=metal construction
     craft=mint: IT:Tag:craft=mint
     craft=musical_instrument: IT:Tag:craft=musical instrument
@@ -24046,14 +24994,20 @@ it:
     craft=optician: IT:Tag:craft=optician
     craft=organ_builder: IT:Tag:craft=organ builder
     craft=painter: IT:Tag:craft=painter
+    craft=paperhanger: IT:Tag:craft=paperhanger
     craft=parquet_layer: IT:Tag:craft=parquet layer
+    craft=paver: IT:Tag:craft=paver
+    craft=pest_control: IT:Tag:craft=pest control
     craft=photographer: IT:Tag:craft=photographer
     craft=photographic_laboratory: IT:Tag:craft=photographic laboratory
+    craft=photovoltaic: IT:Tag:craft=photovoltaic
     craft=piano_tuner: IT:Tag:craft=piano tuner
     craft=plasterer: IT:Tag:craft=plasterer
     craft=plumber: IT:Tag:craft=plumber
     craft=pottery: IT:Tag:craft=pottery
+    craft=printer: IT:Tag:craft=printer
     craft=printmaker: IT:Tag:craft=printmaker
+    craft=restoration: IT:Tag:craft=restoration
     craft=rigger: IT:Tag:craft=rigger
     craft=roofer: IT:Tag:craft=roofer
     craft=saddler: IT:Tag:craft=saddler
@@ -24062,16 +25016,22 @@ it:
     craft=scaffolder: IT:Tag:craft=scaffolder
     craft=sculptor: IT:Tag:craft=sculptor
     craft=shoemaker: IT:Tag:craft=shoemaker
+    craft=signmaker: IT:Tag:craft=signmaker
     craft=stand_builder: IT:Tag:craft=stand builder
     craft=stonemason: IT:Tag:craft=stonemason
+    craft=stove_fitter: IT:Tag:craft=stove fitter
     craft=sun_protection: IT:Tag:craft=sun protection
     craft=tailor: IT:Tag:craft=tailor
+    craft=tatami: IT:Tag:craft=tatami
     craft=tiler: IT:Tag:craft=tiler
     craft=tinsmith: IT:Tag:craft=tinsmith
     craft=toolmaker: IT:Tag:craft=toolmaker
     craft=turner: IT:Tag:craft=turner
     craft=upholsterer: IT:Tag:craft=upholsterer
     craft=watchmaker: IT:Tag:craft=watchmaker
+    craft=water_well_drilling: IT:Tag:craft=water well drilling
+    craft=weaver: IT:Tag:craft=weaver
+    craft=welder: IT:Tag:craft=welder
     craft=window_construction: IT:Tag:craft=window construction
     craft=winery: IT:Tag:craft=winery
     crossing=traffic_signals: IT:Tag:crossing=traffic signals
@@ -24094,6 +25054,7 @@ it:
     geological=outcrop: IT:Tag:geological=outcrop
     geological=palaeontological_site: IT:Tag:geological=palaeontological site
     geological=tor: IT:Tag:geological=tor
+    geological=volcanic_caldera_rim: IT:Tag:geological=volcanic caldera rim
     highway=bus_stop: IT:Tag:highway=bus stop
     highway=crossing: IT:Tag:highway=crossing
     highway=cycleway: IT:Tag:highway=cycleway
@@ -24116,11 +25077,13 @@ it:
     highway=service: IT:Tag:highway=service
     highway=services: IT:Tag:highway=services
     highway=steps: IT:Tag:highway=steps
+    highway=street_lamp: IT:Tag:highway=street lamp
     highway=tertiary: IT:Tag:highway=tertiary
     highway=track: IT:Tag:highway=track
     highway=trunk: IT:Tag:highway=trunk
     highway=trunk_link: IT:Tag:highway=trunk link
     highway=unclassified: IT:Tag:highway=unclassified
+    historic=anchor: IT:Tag:historic=anchor
     historic=archaeological_site: IT:Tag:historic=archaeological site
     historic=castle: IT:Tag:historic=castle
     historic=castle_wall: IT:Tag:historic=castle wall
@@ -24165,6 +25128,7 @@ it:
     man_made=works: IT:Tag:man made=works
     meadow=pasture: IT:Tag:meadow=pasture
     memorial=stolperstein: IT:Tag:memorial=stolperstein
+    name=McDonald's: IT:Tag:name=McDonald's
     natural=bare_rock: IT:Tag:natural=bare rock
     natural=cape: IT:Tag:natural=cape
     natural=grassland: IT:Tag:natural=grassland
@@ -24185,7 +25149,10 @@ it:
     oneway=alternating: IT:Tag:oneway=alternating
     parking=street_side: IT:Tag:parking=street side
     parking_space=charging: IT:Tag:parking space=charging
+    parking_space=disabled: IT:Tag:parking space=disabled
     path=desire: IT:Tag:path=desire
+    piste:type=downhill: IT:Tag:piste:type=downhill
+    piste:type=nordic: IT:Tag:piste:type=nordic
     place=allotments: IT:Tag:place=allotments
     place=archipelago: IT:Tag:place=archipelago
     place=borough: IT:Tag:place=borough
@@ -24309,6 +25276,7 @@ it:
     vending=parcel_pickup: IT:Tag:vending=parcel pickup
     vending=parking_tickets: IT:Tag:vending=parking tickets
     vending=toll: IT:Tag:vending=toll
+    waste=recycling: IT:Tag:waste=recycling
     water=basin: IT:Tag:water=basin
     waterway=ditch: IT:Tag:waterway=ditch
     waterway=rapids: IT:Tag:waterway=rapids
@@ -24383,6 +25351,7 @@ ja:
     bar: JA:Key:bar
     barrier: JA:Key:barrier
     baseball: JA:Key:baseball
+    baseball:bullpen: JA:Key:baseball:bullpen
     basin: JA:Key:basin
     bath:type: JA:Key:bath:type
     bbq: JA:Key:bbq
@@ -24453,6 +25422,7 @@ ja:
     carpenter: JA:Key:carpenter
     carriage: JA:Key:carriage
     castle_type: JA:Key:castle type
+    cat: JA:Key:cat
     cave:name: JA:Key:cave:name
     cemetery: JA:Key:cemetery
     change: JA:Key:change
@@ -24472,11 +25442,13 @@ ja:
     communication:television: JA:Key:communication:television
     community_centre: JA:Key:community centre
     community_centre:for: JA:Key:community centre:for
+    company: JA:Key:company
     condition: JA:Key:condition
     conditional: JA:Key:conditional
     construction: JA:Key:construction
     construction:website: JA:Key:construction:website
     construction_end_expected: JA:Key:construction end expected
+    consulting: JA:Key:consulting
     contact: JA:Key:contact
     contact:*: JA:Key:contact:*
     contact:email: JA:Key:contact:email
@@ -24524,6 +25496,7 @@ ja:
     denomination: JA:Key:denomination
     denotation: JA:Key:denotation
     departures_board: JA:Key:departures board
+    depot: JA:Key:depot
     depth: JA:Key:depth
     descent: JA:Key:descent
     description: JA:Key:description
@@ -24536,6 +25509,7 @@ ja:
     diet: JA:Key:diet
     diet:*: JA:Key:diet:*
     direction: JA:Key:direction
+    disc_golf: JA:Key:disc golf
     dispensing: JA:Key:dispensing
     display: JA:Key:display
     distance: JA:Key:distance
@@ -24575,6 +25549,7 @@ ja:
     faces: JA:Key:faces
     factory: JA:Key:factory
     fair_trade: JA:Key:fair trade
+    farmyard: JA:Key:farmyard
     fast_food: JA:Key:fast food
     fax: JA:Key:fax
     fee: JA:Key:fee
@@ -24638,6 +25613,7 @@ ja:
     grassland: JA:Key:grassland
     group_only: JA:Key:group only
     guest_house: JA:Key:guest house
+    guide: JA:Key:guide
     guidepost: JA:Key:guidepost
     handrail: JA:Key:handrail
     happy_hours: JA:Key:happy hours
@@ -24695,6 +25671,7 @@ ja:
     junction:ref: JA:Key:junction:ref
     karaoke: JA:Key:karaoke
     kerb: JA:Key:kerb
+    kick_scooter: JA:Key:kick scooter
     kids_area: JA:Key:kids area
     ladder: JA:Key:ladder
     lamp_mount: JA:Key:lamp mount
@@ -24842,6 +25819,7 @@ ja:
     payment:*: JA:Key:payment:*
     payment:coins: JA:Key:payment:coins
     phone: JA:Key:phone
+    piercing: JA:Key:piercing
     pilgrimage: JA:Key:pilgrimage
     piste:difficulty: JA:Key:piste:difficulty
     piste:type: JA:Key:piste:type
@@ -24881,6 +25859,7 @@ ja:
     recycling_type: JA:Key:recycling type
     reef: JA:Key:reef
     ref: JA:Key:ref
+    ref:JP:invoice_issuer: JA:Key:ref:JP:invoice issuer
     ref:cobe: JA:Key:ref:cobe
     ref:isil: JA:Key:ref:isil
     ref:shop:num: JA:Key:ref:shop:num
@@ -24898,6 +25877,9 @@ ja:
     reservation: JA:Key:reservation
     residential: JA:Key:residential
     resource: JA:Key:resource
+    reusable_packaging: JA:Key:reusable packaging
+    reusable_packaging:accept: JA:Key:reusable packaging:accept
+    reusable_packaging:offer: JA:Key:reusable packaging:offer
     right: JA:Key:right
     roadtrain: JA:Key:roadtrain
     roller_coaster: JA:Key:roller coaster
@@ -24964,6 +25946,7 @@ ja:
     stars: JA:Key:stars
     start_date: JA:Key:start date
     station: JA:Key:station
+    statue: JA:Key:statue
     step:contrast: JA:Key:step:contrast
     step_count: JA:Key:step count
     stile: JA:Key:stile
@@ -25033,9 +26016,12 @@ ja:
     url: JA:Key:url
     usage: JA:Key:usage
     utility: JA:Key:utility
+    vacuum_cleaner: JA:Key:vacuum cleaner
     vehicle: JA:Key:vehicle
     viewpoint: JA:Key:viewpoint
     visibility: JA:Key:visibility
+    volcano:status: JA:Key:volcano:status
+    volcano:type: JA:Key:volcano:type
     voltage: JA:Key:voltage
     washing_machine: JA:Key:washing machine
     waste: JA:Key:waste
@@ -25139,6 +26125,7 @@ ja:
     amenity=administration: JA:Tag:amenity=administration
     amenity=animal_boarding: JA:Tag:amenity=animal boarding
     amenity=animal_breeding: JA:Tag:amenity=animal breeding
+    amenity=animal_hitch: JA:Tag:amenity=animal hitch
     amenity=animal_shelter: JA:Tag:amenity=animal shelter
     amenity=animal_training: JA:Tag:amenity=animal training
     amenity=archive: JA:Tag:amenity=archive
@@ -25153,8 +26140,11 @@ ja:
     amenity=bicycle_parking: JA:Tag:amenity=bicycle parking
     amenity=bicycle_rental: JA:Tag:amenity=bicycle rental
     amenity=bicycle_repair_station: JA:Tag:amenity=bicycle repair station
+    amenity=bicycle_wash: JA:Tag:amenity=bicycle wash
     amenity=biergarten: JA:Tag:amenity=biergarten
     amenity=binoculars: JA:Tag:amenity=binoculars
+    amenity=blood_bank: JA:Tag:amenity=blood bank
+    amenity=boat_rental: JA:Tag:amenity=boat rental
     amenity=boat_sharing: JA:Tag:amenity=boat sharing
     amenity=boat_storage: JA:Tag:amenity=boat storage
     amenity=brothel: JA:Tag:amenity=brothel
@@ -25166,11 +26156,15 @@ ja:
     amenity=car_sharing: JA:Tag:amenity=car sharing
     amenity=car_wash: JA:Tag:amenity=car wash
     amenity=casino: JA:Tag:amenity=casino
+    amenity=chair: JA:Tag:amenity=chair
     amenity=charging_station: JA:Tag:amenity=charging station
+    amenity=check_in: JA:Tag:amenity=check in
+    amenity=checkpoint: JA:Tag:amenity=checkpoint
     amenity=childcare: JA:Tag:amenity=childcare
     amenity=cinema: JA:Tag:amenity=cinema
     amenity=clinic: JA:Tag:amenity=clinic
     amenity=clock: JA:Tag:amenity=clock
+    amenity=clothes_dryer: JA:Tag:amenity=clothes dryer
     amenity=college: JA:Tag:amenity=college
     amenity=community_centre: JA:Tag:amenity=community centre
     amenity=compressed_air: JA:Tag:amenity=compressed air
@@ -25181,10 +26175,15 @@ ja:
     amenity=crematorium: JA:Tag:amenity=crematorium
     amenity=crypt: JA:Tag:amenity=crypt
     amenity=customs: JA:Tag:amenity=customs
+    amenity=dancing_school: JA:Tag:amenity=dancing school
     amenity=dentist: JA:Tag:amenity=dentist
     amenity=device_charging_station: JA:Tag:amenity=device charging station
+    amenity=dive_centre: JA:Tag:amenity=dive centre
     amenity=doctor: JA:Tag:amenity=doctor
     amenity=doctors: JA:Tag:amenity=doctors
+    amenity=dog_parking: JA:Tag:amenity=dog parking
+    amenity=dog_toilet: JA:Tag:amenity=dog toilet
+    amenity=dog_wash: JA:Tag:amenity=dog wash
     amenity=dojo: JA:Tag:amenity=dojo
     amenity=dressing_room: JA:Tag:amenity=dressing room
     amenity=drinking_water: JA:Tag:amenity=drinking water
@@ -25198,41 +26197,61 @@ ja:
     amenity=fast_food: JA:Tag:amenity=fast food
     amenity=feeding_place: JA:Tag:amenity=feeding place
     amenity=ferry_terminal: JA:Tag:amenity=ferry terminal
+    amenity=festival_grounds: JA:Tag:amenity=festival grounds
     amenity=financial_advice: JA:Tag:amenity=financial advice
     amenity=fire_station: JA:Tag:amenity=fire station
+    amenity=first_aid_school: JA:Tag:amenity=first aid school
     amenity=food_court: JA:Tag:amenity=food court
+    amenity=food_sharing: JA:Tag:amenity=food sharing
+    amenity=foot_shower: JA:Tag:amenity=foot shower
     amenity=fountain: JA:Tag:amenity=fountain
+    amenity=fridge: JA:Tag:amenity=fridge
     amenity=fuel: JA:Tag:amenity=fuel
     amenity=funeral_hall: JA:Tag:amenity=funeral hall
     amenity=gambling: JA:Tag:amenity=gambling
     amenity=game_feeding: JA:Tag:amenity=game feeding
+    amenity=give_box: JA:Tag:amenity=give box
     amenity=grave_yard: JA:Tag:amenity=grave yard
     amenity=grit_bin: JA:Tag:amenity=grit bin
+    amenity=hitching_post: JA:Tag:amenity=hitching post
     amenity=hookah_lounge: JA:Tag:amenity=hookah lounge
     amenity=hospital: JA:Tag:amenity=hospital
     amenity=hunting_stand: JA:Tag:amenity=hunting stand
+    amenity=hydrant: JA:Tag:amenity=hydrant
     amenity=ice_cream: JA:Tag:amenity=ice cream
     amenity=internet_cafe: JA:Tag:amenity=internet cafe
     amenity=juice_bar: JA:Tag:amenity=juice bar
     amenity=karaoke_box: JA:Tag:amenity=karaoke box
+    amenity=kick-scooter_parking: JA:Tag:amenity=kick-scooter parking
+    amenity=kick-scooter_rental: JA:Tag:amenity=kick-scooter rental
     amenity=kindergarten: JA:Tag:amenity=kindergarten
     amenity=kiosk: JA:Tag:amenity=kiosk
+    amenity=kitchen: JA:Tag:amenity=kitchen
+    amenity=kneipp_water_cure: JA:Tag:amenity=kneipp water cure
     amenity=language_school: JA:Tag:amenity=language school
     amenity=lavoir: JA:Tag:amenity=lavoir
+    amenity=left_luggage: JA:Tag:amenity=left luggage
     amenity=letter_box: JA:Tag:amenity=letter box
     amenity=library: JA:Tag:amenity=library
     amenity=library_dropoff: JA:Tag:amenity=library dropoff
     amenity=loading_dock: JA:Tag:amenity=loading dock
+    amenity=locker: JA:Tag:amenity=locker
+    amenity=lost_property_office: JA:Tag:amenity=lost property office
+    amenity=lounge: JA:Tag:amenity=lounge
     amenity=lounger: JA:Tag:amenity=lounger
     amenity=love_hotel: JA:Tag:amenity=love hotel
+    amenity=luggage_locker: JA:Tag:amenity=luggage locker
+    amenity=mailroom: JA:Tag:amenity=mailroom
     amenity=marketplace: JA:Tag:amenity=marketplace
     amenity=microwave: JA:Tag:amenity=microwave
     amenity=mist_spraying_cooler: JA:Tag:amenity=mist spraying cooler
     amenity=mobile_library: JA:Tag:amenity=mobile library
+    amenity=mobile_money_agent: JA:Tag:amenity=mobile money agent
     amenity=monastery: JA:Tag:amenity=monastery
     amenity=money_transfer: JA:Tag:amenity=money transfer
     amenity=mortuary: JA:Tag:amenity=mortuary
     amenity=motorcycle_parking: JA:Tag:amenity=motorcycle parking
+    amenity=motorcycle_rental: JA:Tag:amenity=motorcycle rental
     amenity=music_school: JA:Tag:amenity=music school
     amenity=music_venue: JA:Tag:amenity=music venue
     amenity=nightclub: JA:Tag:amenity=nightclub
@@ -25241,10 +26260,12 @@ ja:
     amenity=parking: JA:Tag:amenity=parking
     amenity=parking_entrance: JA:Tag:amenity=parking entrance
     amenity=parking_space: JA:Tag:amenity=parking space
+    amenity=payment_centre: JA:Tag:amenity=payment centre
     amenity=payment_terminal: JA:Tag:amenity=payment terminal
     amenity=pharmacy: JA:Tag:amenity=pharmacy
     amenity=photo_booth: JA:Tag:amenity=photo booth
     amenity=piano: JA:Tag:amenity=piano
+    amenity=place_of_mourning: JA:Tag:amenity=place of mourning
     amenity=place_of_worship: JA:Tag:amenity=place of worship
     amenity=planetarium: JA:Tag:amenity=planetarium
     amenity=police: JA:Tag:amenity=police
@@ -25252,6 +26273,7 @@ ja:
     amenity=post_box: JA:Tag:amenity=post box
     amenity=post_depot: JA:Tag:amenity=post depot
     amenity=post_office: JA:Tag:amenity=post office
+    amenity=power_supply: JA:Tag:amenity=power supply
     amenity=prep_school: JA:Tag:amenity=prep school
     amenity=printer: JA:Tag:amenity=printer
     amenity=prison: JA:Tag:amenity=prison
@@ -25259,6 +26281,7 @@ ja:
     amenity=public_bath: JA:Tag:amenity=public bath
     amenity=public_bookcase: JA:Tag:amenity=public bookcase
     amenity=public_building: JA:Tag:amenity=public building
+    amenity=ranger_station: JA:Tag:amenity=ranger station
     amenity=reception_desk: JA:Tag:amenity=reception desk
     amenity=recycling: JA:Tag:amenity=recycling
     amenity=refugee_site: JA:Tag:amenity=refugee site
@@ -25272,6 +26295,7 @@ ja:
     amenity=sauna: JA:Tag:amenity=sauna
     amenity=school: JA:Tag:amenity=school
     amenity=security_booth: JA:Tag:amenity=security booth
+    amenity=security_control: JA:Tag:amenity=security control
     amenity=shelter: JA:Tag:amenity=shelter
     amenity=shower: JA:Tag:amenity=shower
     amenity=ski_school: JA:Tag:amenity=ski school
@@ -25280,7 +26304,9 @@ ja:
     amenity=social_facility: JA:Tag:amenity=social facility
     amenity=stage: JA:Tag:amenity=stage
     amenity=stripclub: JA:Tag:amenity=stripclub
+    amenity=student_accommodation: JA:Tag:amenity=student accommodation
     amenity=studio: JA:Tag:amenity=studio
+    amenity=surf_school: JA:Tag:amenity=surf school
     amenity=swimming_pool: JA:Tag:amenity=swimming pool
     amenity=swingerclub: JA:Tag:amenity=swingerclub
     amenity=table: JA:Tag:amenity=table
@@ -25294,10 +26320,13 @@ ja:
     amenity=trade_school: JA:Tag:amenity=trade school
     amenity=traffic_park: JA:Tag:amenity=traffic park
     amenity=training: JA:Tag:amenity=training
+    amenity=trolley_bay: JA:Tag:amenity=trolley bay
     amenity=university: JA:Tag:amenity=university
+    amenity=vacuum_cleaner: JA:Tag:amenity=vacuum cleaner
     amenity=vehicle_inspection: JA:Tag:amenity=vehicle inspection
     amenity=vending_machine: JA:Tag:amenity=vending machine
     amenity=veterinary: JA:Tag:amenity=veterinary
+    amenity=washing_machine: JA:Tag:amenity=washing machine
     amenity=waste_basket: JA:Tag:amenity=waste basket
     amenity=waste_disposal: JA:Tag:amenity=waste disposal
     amenity=waste_transfer_station: JA:Tag:amenity=waste transfer station
@@ -25306,6 +26335,31 @@ ja:
     amenity=watering_place: JA:Tag:amenity=watering place
     amenity=weighbridge: JA:Tag:amenity=weighbridge
     amenity=winery: JA:Tag:amenity=winery
+    aquaculture=fish: JA:Tag:aquaculture=fish
+    aquaculture=seaweed: JA:Tag:aquaculture=seaweed
+    archaeological_site=amphitheatre: JA:Tag:archaeological site=amphitheatre
+    archaeological_site=baths: JA:Tag:archaeological site=baths
+    archaeological_site=cairn: JA:Tag:archaeological site=cairn
+    archaeological_site=church: JA:Tag:archaeological site=church
+    archaeological_site=city: JA:Tag:archaeological site=city
+    archaeological_site=cliff_dwelling: JA:Tag:archaeological site=cliff dwelling
+    archaeological_site=crannog: JA:Tag:archaeological site=crannog
+    archaeological_site=earthwork: JA:Tag:archaeological site=earthwork
+    archaeological_site=enclosure: JA:Tag:archaeological site=enclosure
+    archaeological_site=fortification: JA:Tag:archaeological site=fortification
+    archaeological_site=geoglyph: JA:Tag:archaeological site=geoglyph
+    archaeological_site=grave_field: JA:Tag:archaeological site=grave field
+    archaeological_site=hut_circle: JA:Tag:archaeological site=hut circle
+    archaeological_site=megalith: JA:Tag:archaeological site=megalith
+    archaeological_site=necropolis: JA:Tag:archaeological site=necropolis
+    archaeological_site=petroglyph: JA:Tag:archaeological site=petroglyph
+    archaeological_site=rock_painting: JA:Tag:archaeological site=rock painting
+    archaeological_site=roman_circus: JA:Tag:archaeological site=roman circus
+    archaeological_site=roman_villa: JA:Tag:archaeological site=roman villa
+    archaeological_site=settlement: JA:Tag:archaeological site=settlement
+    archaeological_site=tomb: JA:Tag:archaeological site=tomb
+    archaeological_site=trap_pit: JA:Tag:archaeological site=trap pit
+    archaeological_site=tumulus: JA:Tag:archaeological site=tumulus
     artwork_type=bust: JA:Tag:artwork type=bust
     artwork_type=mural: JA:Tag:artwork type=mural
     artwork_type=sculpture: JA:Tag:artwork type=sculpture
@@ -25342,6 +26396,15 @@ ja:
     barrier=toll_booth: JA:Tag:barrier=toll booth
     barrier=turnstile: JA:Tag:barrier=turnstile
     barrier=wall: JA:Tag:barrier=wall
+    basin=aeration: JA:Tag:basin=aeration
+    basin=cooling: JA:Tag:basin=cooling
+    basin=detention: JA:Tag:basin=detention
+    basin=evaporation: JA:Tag:basin=evaporation
+    basin=footbath: JA:Tag:basin=footbath
+    basin=infiltration: JA:Tag:basin=infiltration
+    basin=retention: JA:Tag:basin=retention
+    basin=settling: JA:Tag:basin=settling
+    basin=water_regeneration: JA:Tag:basin=water regeneration
     bath:type=onsen: JA:Tag:bath:type=onsen
     bay=fjord: JA:Tag:bay=fjord
     bicycle=designated: JA:Tag:bicycle=designated
@@ -25449,12 +26512,15 @@ ja:
     building=transportation: JA:Tag:building=transportation
     building=university: JA:Tag:building=university
     building=warehouse: JA:Tag:building=warehouse
+    building=wayside_shrine: JA:Tag:building=wayside shrine
     bus=no: JA:Tag:bus=no
     busway=opposite_lane: JA:Tag:busway=opposite lane
     castle_type=fortress: JA:Tag:castle type=fortress
     castle_type=shiro: JA:Tag:castle type=shiro
     cemetery=grave: JA:Tag:cemetery=grave
     cemetery=sector: JA:Tag:cemetery=sector
+    cemetery=war_cemetery: JA:Tag:cemetery=war cemetery
+    cemetery=wood: JA:Tag:cemetery=wood
     ceremonial_gate=torii: JA:Tag:ceremonial gate=torii
     clothes=wedding: JA:Tag:clothes=wedding
     club=fan: JA:Tag:club=fan
@@ -25522,7 +26588,9 @@ ja:
     craft=winery: JA:Tag:craft=winery
     crop=flowers: JA:Tag:crop=flowers
     crop=rice: JA:Tag:crop=rice
+    crop=tea: JA:Tag:crop=tea
     cuisine=barbecue: JA:Tag:cuisine=barbecue
+    cuisine=beef_bowl: JA:Tag:cuisine=beef bowl
     cuisine=brazilian: JA:Tag:cuisine=brazilian
     cuisine=coffee_shop: JA:Tag:cuisine=coffee shop
     cuisine=dessert: JA:Tag:cuisine=dessert
@@ -25531,6 +26599,7 @@ ja:
     cuisine=japanese: JA:Tag:cuisine=japanese
     cuisine=pancake: JA:Tag:cuisine=pancake
     cuisine=regional: JA:Tag:cuisine=regional
+    cuisine=soup: JA:Tag:cuisine=soup
     cuisine=sushi: JA:Tag:cuisine=sushi
     cycle_network=JP:prefectural: JA:Tag:cycle network=JP:prefectural
     cycleway:both=no: JA:Tag:cycleway:both=no
@@ -25550,6 +26619,12 @@ ja:
     denomination=tiantai: JA:Tag:denomination=tiantai
     diplomatic=consulate: JA:Tag:diplomatic=consulate
     diplomatic=embassy: JA:Tag:diplomatic=embassy
+    dog=designated: JA:Tag:dog=designated
+    dog=leashed: JA:Tag:dog=leashed
+    dog=no: JA:Tag:dog=no
+    dog=outside: JA:Tag:dog=outside
+    dog=unleashed: JA:Tag:dog=unleashed
+    dog=yes: JA:Tag:dog=yes
     education=cooking_school: JA:Tag:education=cooking school
     education=kindergarten: JA:Tag:education=kindergarten
     emergency:social_facility=shelter: JA:Tag:emergency:social facility=shelter
@@ -25576,6 +26651,7 @@ ja:
     emergency=fire_water_pond: JA:Tag:emergency=fire water pond
     emergency=first_aid: JA:Tag:emergency=first aid
     emergency=first_aid_kit: JA:Tag:emergency=first aid kit
+    emergency=helisign: JA:Tag:emergency=helisign
     emergency=landing_site: JA:Tag:emergency=landing site
     emergency=life_ring: JA:Tag:emergency=life ring
     emergency=lifeguard: JA:Tag:emergency=lifeguard
@@ -25589,6 +26665,7 @@ ja:
     emergency=water_tank: JA:Tag:emergency=water tank
     entrance=main: JA:Tag:entrance=main
     entrance=staircase: JA:Tag:entrance=staircase
+    entrance=yes: JA:Tag:entrance=yes
     fast_food=cafeteria: JA:Tag:fast food=cafeteria
     flood_prone=yes: JA:Tag:flood prone=yes
     foot=designated: JA:Tag:foot=designated
@@ -25644,10 +26721,31 @@ ja:
     genus=Acer: JA:Tag:genus=Acer
     genus=Platanus: JA:Tag:genus=Platanus
     genus=Quercus: JA:Tag:genus=Quercus
+    geological=columnar_jointing: JA:Tag:geological=columnar jointing
+    geological=cone: JA:Tag:geological=cone
+    geological=dyke: JA:Tag:geological=dyke
     geological=fault: JA:Tag:geological=fault
+    geological=fold: JA:Tag:geological=fold
+    geological=giants_kettle: JA:Tag:geological=giants kettle
+    geological=glacial_erratic: JA:Tag:geological=glacial erratic
+    geological=hoodoo: JA:Tag:geological=hoodoo
+    geological=inselberg: JA:Tag:geological=inselberg
+    geological=limestone_pavement: JA:Tag:geological=limestone pavement
+    geological=meteor_crater: JA:Tag:geological=meteor crater
+    geological=monocline: JA:Tag:geological=monocline
     geological=moraine: JA:Tag:geological=moraine
     geological=outcrop: JA:Tag:geological=outcrop
     geological=palaeontological_site: JA:Tag:geological=palaeontological site
+    geological=pingo: JA:Tag:geological=pingo
+    geological=rock_glacier: JA:Tag:geological=rock glacier
+    geological=sinkhole: JA:Tag:geological=sinkhole
+    geological=tor: JA:Tag:geological=tor
+    geological=unconformity: JA:Tag:geological=unconformity
+    geological=volcanic_caldera_rim: JA:Tag:geological=volcanic caldera rim
+    geological=volcanic_lava_field: JA:Tag:geological=volcanic lava field
+    geological=volcanic_lava_flow: JA:Tag:geological=volcanic lava flow
+    geological=volcanic_lava_tube: JA:Tag:geological=volcanic lava tube
+    geological=volcanic_vent: JA:Tag:geological=volcanic vent
     golf=bunker: JA:Tag:golf=bunker
     golf=driving_range: JA:Tag:golf=driving range
     golf=fairway: JA:Tag:golf=fairway
@@ -25658,6 +26756,7 @@ ja:
     government=register_office: JA:Tag:government=register office
     government=tax: JA:Tag:government=tax
     government=transportation: JA:Tag:government=transportation
+    guest_house=student_accommodation: JA:Tag:guest house=student accommodation
     guidepost=simple: JA:Tag:guidepost=simple
     hairdresser=barber: JA:Tag:hairdresser=barber
     healthcare:speciality=gynaecology: JA:Tag:healthcare:speciality=gynaecology
@@ -25715,13 +26814,18 @@ ja:
     highway=turning_loop: JA:Tag:highway=turning loop
     highway=unclassified: JA:Tag:highway=unclassified
     historic=aircraft: JA:Tag:historic=aircraft
+    historic=anchor: JA:Tag:historic=anchor
+    historic=aqueduct: JA:Tag:historic=aqueduct
     historic=archaeological_site: JA:Tag:historic=archaeological site
     historic=battlefield: JA:Tag:historic=battlefield
+    historic=bomb_crater: JA:Tag:historic=bomb crater
     historic=boundary_stone: JA:Tag:historic=boundary stone
     historic=building: JA:Tag:historic=building
     historic=cannon: JA:Tag:historic=cannon
     historic=castle: JA:Tag:historic=castle
+    historic=castle_wall: JA:Tag:historic=castle wall
     historic=charcoal_pile: JA:Tag:historic=charcoal pile
+    historic=church: JA:Tag:historic=church
     historic=city_gate: JA:Tag:historic=city gate
     historic=citywalls: JA:Tag:historic=citywalls
     historic=farm: JA:Tag:historic=farm
@@ -25731,19 +26835,29 @@ ja:
     historic=highwater_mark: JA:Tag:historic=highwater mark
     historic=house: JA:Tag:historic=house
     historic=locomotive: JA:Tag:historic=locomotive
+    historic=manor: JA:Tag:historic=manor
     historic=memorial: JA:Tag:historic=memorial
     historic=milestone: JA:Tag:historic=milestone
+    historic=mine: JA:Tag:historic=mine
+    historic=mine_adit: JA:Tag:historic=mine adit
+    historic=mine_shaft: JA:Tag:historic=mine shaft
+    historic=minecart: JA:Tag:historic=minecart
     historic=monastery: JA:Tag:historic=monastery
     historic=monument: JA:Tag:historic=monument
     historic=optical_telegraph: JA:Tag:historic=optical telegraph
     historic=pillory: JA:Tag:historic=pillory
+    historic=railway_car: JA:Tag:historic=railway car
+    historic=railway_station: JA:Tag:historic=railway station
     historic=road: JA:Tag:historic=road
     historic=ruins: JA:Tag:historic=ruins
     historic=rune_stone: JA:Tag:historic=rune stone
     historic=ship: JA:Tag:historic=ship
     historic=stone: JA:Tag:historic=stone
+    historic=tank: JA:Tag:historic=tank
     historic=tomb: JA:Tag:historic=tomb
+    historic=tower: JA:Tag:historic=tower
     historic=tree_shrine: JA:Tag:historic=tree shrine
+    historic=vehicle: JA:Tag:historic=vehicle
     historic=wayside_cross: JA:Tag:historic=wayside cross
     historic=wayside_shrine: JA:Tag:historic=wayside shrine
     historic=wreck: JA:Tag:historic=wreck
@@ -25753,19 +26867,26 @@ ja:
     industrial=bakery: JA:Tag:industrial=bakery
     industrial=brewery: JA:Tag:industrial=brewery
     industrial=brickyard: JA:Tag:industrial=brickyard
+    industrial=communication: JA:Tag:industrial=communication
+    industrial=concrete_plant: JA:Tag:industrial=concrete plant
+    industrial=construction_company: JA:Tag:industrial=construction company
     industrial=depot: JA:Tag:industrial=depot
     industrial=distributor: JA:Tag:industrial=distributor
+    industrial=electrical: JA:Tag:industrial=electrical
     industrial=factory: JA:Tag:industrial=factory
     industrial=furniture: JA:Tag:industrial=furniture
     industrial=grinding_mill: JA:Tag:industrial=grinding mill
     industrial=heating_station: JA:Tag:industrial=heating station
     industrial=ice_factory: JA:Tag:industrial=ice factory
     industrial=machine_shop: JA:Tag:industrial=machine shop
+    industrial=metal_processing: JA:Tag:industrial=metal processing
     industrial=mine: JA:Tag:industrial=mine
     industrial=mobile_equipment: JA:Tag:industrial=mobile equipment
     industrial=oil: JA:Tag:industrial=oil
     industrial=oil_mill: JA:Tag:industrial=oil mill
     industrial=port: JA:Tag:industrial=port
+    industrial=recycling: JA:Tag:industrial=recycling
+    industrial=refinery: JA:Tag:industrial=refinery
     industrial=salt_pond: JA:Tag:industrial=salt pond
     industrial=sawmill: JA:Tag:industrial=sawmill
     industrial=scrap_yard: JA:Tag:industrial=scrap yard
@@ -25775,26 +26896,34 @@ ja:
     industrial=trucking: JA:Tag:industrial=trucking
     industrial=warehouse: JA:Tag:industrial=warehouse
     industrial=well_cluster: JA:Tag:industrial=well cluster
+    industrial=wellsite: JA:Tag:industrial=wellsite
     informal=yes: JA:Tag:informal=yes
     information=board: JA:Tag:information=board
     information=guidepost: JA:Tag:information=guidepost
     information=map: JA:Tag:information=map
+    information=post: JA:Tag:information=post
+    information=stele: JA:Tag:information=stele
     information=tactile_map: JA:Tag:information=tactile map
     information=tactile_model: JA:Tag:information=tactile model
+    information=visitor_centre: JA:Tag:information=visitor centre
     junction=circular: JA:Tag:junction=circular
     junction=roundabout: JA:Tag:junction=roundabout
     junction=yes: JA:Tag:junction=yes
     landcover=trees: JA:Tag:landcover=trees
     landuse=allotments: JA:Tag:landuse=allotments
+    landuse=animal_keeping: JA:Tag:landuse=animal keeping
+    landuse=apiary: JA:Tag:landuse=apiary
     landuse=aquaculture: JA:Tag:landuse=aquaculture
     landuse=basin: JA:Tag:landuse=basin
     landuse=brownfield: JA:Tag:landuse=brownfield
     landuse=cemetery: JA:Tag:landuse=cemetery
     landuse=churchyard: JA:Tag:landuse=churchyard
     landuse=commercial: JA:Tag:landuse=commercial
+    landuse=conservation: JA:Tag:landuse=conservation
     landuse=construction: JA:Tag:landuse=construction
     landuse=depot: JA:Tag:landuse=depot
     landuse=education: JA:Tag:landuse=education
+    landuse=fairground: JA:Tag:landuse=fairground
     landuse=farm: JA:Tag:landuse=farm
     landuse=farmland: JA:Tag:landuse=farmland
     landuse=farmyard: JA:Tag:landuse=farmyard
@@ -25802,9 +26931,12 @@ ja:
     landuse=forest: JA:Tag:landuse=forest
     landuse=garages: JA:Tag:landuse=garages
     landuse=grass: JA:Tag:landuse=grass
+    landuse=greenery: JA:Tag:landuse=greenery
     landuse=greenfield: JA:Tag:landuse=greenfield
     landuse=greenhouse_horticulture: JA:Tag:landuse=greenhouse horticulture
+    landuse=highway: JA:Tag:landuse=highway
     landuse=industrial: JA:Tag:landuse=industrial
+    landuse=institutional: JA:Tag:landuse=institutional
     landuse=landfill: JA:Tag:landuse=landfill
     landuse=logging: JA:Tag:landuse=logging
     landuse=meadow: JA:Tag:landuse=meadow
@@ -25823,6 +26955,7 @@ ja:
     landuse=retail: JA:Tag:landuse=retail
     landuse=salt_pond: JA:Tag:landuse=salt pond
     landuse=traffic_island: JA:Tag:landuse=traffic island
+    landuse=tree_pit: JA:Tag:landuse=tree pit
     landuse=village_green: JA:Tag:landuse=village green
     landuse=vineyard: JA:Tag:landuse=vineyard
     landuse=winter_sports: JA:Tag:landuse=winter sports
@@ -25847,6 +26980,7 @@ ja:
     leisure=bowling_alley: JA:Tag:leisure=bowling alley
     leisure=common: JA:Tag:leisure=common
     leisure=dance: JA:Tag:leisure=dance
+    leisure=disc_golf_course: JA:Tag:leisure=disc golf course
     leisure=dog_park: JA:Tag:leisure=dog park
     leisure=escape_game: JA:Tag:leisure=escape game
     leisure=firepit: JA:Tag:leisure=firepit
@@ -25856,7 +26990,10 @@ ja:
     leisure=garden: JA:Tag:leisure=garden
     leisure=golf_course: JA:Tag:leisure=golf course
     leisure=hackerspace: JA:Tag:leisure=hackerspace
+    leisure=hammock: JA:Tag:leisure=hammock
+    leisure=high_ropes_course: JA:Tag:leisure=high ropes course
     leisure=horse_riding: JA:Tag:leisure=horse riding
+    leisure=hot_tub: JA:Tag:leisure=hot tub
     leisure=ice_rink: JA:Tag:leisure=ice rink
     leisure=marina: JA:Tag:leisure=marina
     leisure=miniature_golf: JA:Tag:leisure=miniature golf
@@ -25870,84 +27007,134 @@ ja:
     leisure=resort: JA:Tag:leisure=resort
     leisure=sauna: JA:Tag:leisure=sauna
     leisure=schoolyard: JA:Tag:leisure=schoolyard
+    leisure=shooting_ground: JA:Tag:leisure=shooting ground
     leisure=slipway: JA:Tag:leisure=slipway
     leisure=sports_centre: JA:Tag:leisure=sports centre
     leisure=sports_hall: JA:Tag:leisure=sports hall
     leisure=stadium: JA:Tag:leisure=stadium
     leisure=summer_camp: JA:Tag:leisure=summer camp
+    leisure=sunbathing: JA:Tag:leisure=sunbathing
     leisure=swimming_area: JA:Tag:leisure=swimming area
     leisure=swimming_pool: JA:Tag:leisure=swimming pool
     leisure=tanning_salon: JA:Tag:leisure=tanning salon
     leisure=track: JA:Tag:leisure=track
+    leisure=trampoline_park: JA:Tag:leisure=trampoline park
     leisure=water_park: JA:Tag:leisure=water park
+    leisure=wildlife_hide: JA:Tag:leisure=wildlife hide
     lifeguard=tower: JA:Tag:lifeguard=tower
     line=bay: JA:Tag:line=bay
     line=busbar: JA:Tag:line=busbar
     man_made=adit: JA:Tag:man made=adit
+    man_made=advertising: JA:Tag:man made=advertising
     man_made=animal_trap: JA:Tag:man made=animal trap
     man_made=antenna: JA:Tag:man made=antenna
     man_made=avalanche_protection: JA:Tag:man made=avalanche protection
     man_made=beacon: JA:Tag:man made=beacon
     man_made=beehive: JA:Tag:man made=beehive
+    man_made=bell: JA:Tag:man made=bell
+    man_made=bird_feeder: JA:Tag:man made=bird feeder
+    man_made=birdhouse: JA:Tag:man made=birdhouse
+    man_made=borehole: JA:Tag:man made=borehole
     man_made=breakwater: JA:Tag:man made=breakwater
     man_made=bridge: JA:Tag:man made=bridge
     man_made=bunker_silo: JA:Tag:man made=bunker silo
     man_made=cairn: JA:Tag:man made=cairn
     man_made=campanile: JA:Tag:man made=campanile
+    man_made=carpet_hanger: JA:Tag:man made=carpet hanger
     man_made=cellar_entrance: JA:Tag:man made=cellar entrance
+    man_made=ceremonial_gate: JA:Tag:man made=ceremonial gate
+    man_made=charge_point: JA:Tag:man made=charge point
     man_made=chiller: JA:Tag:man made=chiller
     man_made=chimney: JA:Tag:man made=chimney
+    man_made=clarifier: JA:Tag:man made=clarifier
     man_made=clearcut: JA:Tag:man made=clearcut
     man_made=column: JA:Tag:man made=column
     man_made=communications_tower: JA:Tag:man made=communications tower
+    man_made=compass_rose: JA:Tag:man made=compass rose
+    man_made=compressor: JA:Tag:man made=compressor
+    man_made=cooling: JA:Tag:man made=cooling
     man_made=cooling_tower: JA:Tag:man made=cooling tower
     man_made=courtyard: JA:Tag:man made=courtyard
     man_made=crane: JA:Tag:man made=crane
+    man_made=crane_rail: JA:Tag:man made=crane rail
     man_made=cross: JA:Tag:man made=cross
     man_made=cutline: JA:Tag:man made=cutline
     man_made=dike: JA:Tag:man made=dike
+    man_made=dolphin: JA:Tag:man made=dolphin
     man_made=dovecote: JA:Tag:man made=dovecote
     man_made=dyke: JA:Tag:man made=dyke
     man_made=embankment: JA:Tag:man made=embankment
+    man_made=excavation: JA:Tag:man made=excavation
     man_made=flagpole: JA:Tag:man made=flagpole
     man_made=flare: JA:Tag:man made=flare
     man_made=footwear_decontamination: JA:Tag:man made=footwear decontamination
+    man_made=frost_fan: JA:Tag:man made=frost fan
+    man_made=fuel_pump: JA:Tag:man made=fuel pump
     man_made=gantry: JA:Tag:man made=gantry
+    man_made=gas_well: JA:Tag:man made=gas well
     man_made=gasometer: JA:Tag:man made=gasometer
     man_made=geoglyph: JA:Tag:man made=geoglyph
     man_made=goods_conveyor: JA:Tag:man made=goods conveyor
+    man_made=graduation_tower: JA:Tag:man made=graduation tower
     man_made=groyne: JA:Tag:man made=groyne
+    man_made=guard_stone: JA:Tag:man made=guard stone
+    man_made=guy_wire: JA:Tag:man made=guy wire
+    man_made=heap: JA:Tag:man made=heap
+    man_made=hongsalmun: JA:Tag:man made=hongsalmun
     man_made=hot_water_tank: JA:Tag:man made=hot water tank
+    man_made=iljumun: JA:Tag:man made=iljumun
     man_made=insect_hotel: JA:Tag:man made=insect hotel
     man_made=kiln: JA:Tag:man made=kiln
     man_made=lighthouse: JA:Tag:man made=lighthouse
+    man_made=manhole: JA:Tag:man made=manhole
     man_made=mast: JA:Tag:man made=mast
+    man_made=maypole: JA:Tag:man made=maypole
+    man_made=milk_churn_stand: JA:Tag:man made=milk churn stand
     man_made=mineshaft: JA:Tag:man made=mineshaft
     man_made=monitoring_station: JA:Tag:man made=monitoring station
+    man_made=nesting_site: JA:Tag:man made=nesting site
     man_made=obelisk: JA:Tag:man made=obelisk
     man_made=observatory: JA:Tag:man made=observatory
+    man_made=offshore_platform: JA:Tag:man made=offshore platform
+    man_made=oil_gas_separator: JA:Tag:man made=oil gas separator
+    man_made=outfall: JA:Tag:man made=outfall
+    man_made=oxidation_ditch: JA:Tag:man made=oxidation ditch
+    man_made=paifang: JA:Tag:man made=paifang
     man_made=petroleum_well: JA:Tag:man made=petroleum well
     man_made=pier: JA:Tag:man made=pier
     man_made=pipeline: JA:Tag:man made=pipeline
     man_made=planter: JA:Tag:man made=planter
     man_made=power_hydro: JA:Tag:man made=power hydro
+    man_made=pump: JA:Tag:man made=pump
+    man_made=pumping_rig: JA:Tag:man made=pumping rig
     man_made=pumping_station: JA:Tag:man made=pumping station
+    man_made=quay: JA:Tag:man made=quay
     man_made=reservoir_covered: JA:Tag:man made=reservoir covered
     man_made=satellite_dish: JA:Tag:man made=satellite dish
+    man_made=sewer_vent: JA:Tag:man made=sewer vent
+    man_made=sign: JA:Tag:man made=sign
     man_made=silo: JA:Tag:man made=silo
     man_made=ski_jump: JA:Tag:man made=ski jump
+    man_made=snow_cannon: JA:Tag:man made=snow cannon
     man_made=snow_fence: JA:Tag:man made=snow fence
     man_made=snow_net: JA:Tag:man made=snow net
+    man_made=soccer_goal: JA:Tag:man made=soccer goal
+    man_made=spoil_heap: JA:Tag:man made=spoil heap
+    man_made=spring_box: JA:Tag:man made=spring box
     man_made=storage_tank: JA:Tag:man made=storage tank
     man_made=street_cabinet: JA:Tag:man made=street cabinet
     man_made=stupa: JA:Tag:man made=stupa
     man_made=surveillance: JA:Tag:man made=surveillance
     man_made=survey_point: JA:Tag:man made=survey point
+    man_made=tailings_pond: JA:Tag:man made=tailings pond
     man_made=telescope: JA:Tag:man made=telescope
+    man_made=threshing_floor: JA:Tag:man made=threshing floor
     man_made=torii: JA:Tag:man made=torii
     man_made=tower: JA:Tag:man made=tower
     man_made=tunnel: JA:Tag:man made=tunnel
     man_made=utility_pole: JA:Tag:man made=utility pole
+    man_made=ventilation_shaft: JA:Tag:man made=ventilation shaft
+    man_made=video_wall: JA:Tag:man made=video wall
     man_made=wastewater_plant: JA:Tag:man made=wastewater plant
     man_made=water_tap: JA:Tag:man made=water tap
     man_made=water_tower: JA:Tag:man made=water tower
@@ -25958,9 +27145,24 @@ ja:
     man_made=windmill: JA:Tag:man made=windmill
     man_made=windpump: JA:Tag:man made=windpump
     man_made=works: JA:Tag:man made=works
+    man_made=yes: JA:Tag:man made=yes
     manhole=telecom: JA:Tag:manhole=telecom
+    memorial=bench: JA:Tag:memorial=bench
+    memorial=blue_plaque: JA:Tag:memorial=blue plaque
+    memorial=bust: JA:Tag:memorial=bust
+    memorial=cenotaph: JA:Tag:memorial=cenotaph
+    memorial=cross: JA:Tag:memorial=cross
+    memorial=ghost_bike: JA:Tag:memorial=ghost bike
+    memorial=obelisk: JA:Tag:memorial=obelisk
+    memorial=peace_pole: JA:Tag:memorial=peace pole
     memorial=plaque: JA:Tag:memorial=plaque
+    memorial=pulpulak: JA:Tag:memorial=pulpulak
+    memorial=sculpture: JA:Tag:memorial=sculpture
+    memorial=statue: JA:Tag:memorial=statue
     memorial=stele: JA:Tag:memorial=stele
+    memorial=stolperstein: JA:Tag:memorial=stolperstein
+    memorial=stone: JA:Tag:memorial=stone
+    memorial=war_memorial: JA:Tag:memorial=war memorial
     microbrewery=yes: JA:Tag:microbrewery=yes
     military=airfield: JA:Tag:military=airfield
     military=ammunition: JA:Tag:military=ammunition
@@ -25986,18 +27188,25 @@ ja:
     natural=bare_rock: JA:Tag:natural=bare rock
     natural=bay: JA:Tag:natural=bay
     natural=beach: JA:Tag:natural=beach
+    natural=beaver_dam: JA:Tag:natural=beaver dam
+    natural=birds_nest: JA:Tag:natural=birds nest
+    natural=blockfield: JA:Tag:natural=blockfield
     natural=blowhole: JA:Tag:natural=blowhole
     natural=cape: JA:Tag:natural=cape
     natural=cave_entrance: JA:Tag:natural=cave entrance
     natural=cliff: JA:Tag:natural=cliff
     natural=coastline: JA:Tag:natural=coastline
+    natural=crevasse: JA:Tag:natural=crevasse
     natural=desert: JA:Tag:natural=desert
+    natural=dune: JA:Tag:natural=dune
+    natural=earth_bank: JA:Tag:natural=earth bank
     natural=fell: JA:Tag:natural=fell
     natural=fumarole: JA:Tag:natural=fumarole
     natural=geyser: JA:Tag:natural=geyser
     natural=glacier: JA:Tag:natural=glacier
     natural=gorge: JA:Tag:natural=gorge
     natural=grassland: JA:Tag:natural=grassland
+    natural=gully: JA:Tag:natural=gully
     natural=heath: JA:Tag:natural=heath
     natural=hill: JA:Tag:natural=hill
     natural=hot_spring: JA:Tag:natural=hot spring
@@ -26023,9 +27232,11 @@ ja:
     natural=spring: JA:Tag:natural=spring
     natural=stone: JA:Tag:natural=stone
     natural=strait: JA:Tag:natural=strait
+    natural=termite_mound: JA:Tag:natural=termite mound
     natural=tree: JA:Tag:natural=tree
     natural=tree_row: JA:Tag:natural=tree row
     natural=tree_stump: JA:Tag:natural=tree stump
+    natural=tundra: JA:Tag:natural=tundra
     natural=valley: JA:Tag:natural=valley
     natural=volcano: JA:Tag:natural=volcano
     natural=water: JA:Tag:natural=water
@@ -26045,33 +27256,57 @@ ja:
     noname=yes: JA:Tag:noname=yes
     office=accountant: JA:Tag:office=accountant
     office=administrative: JA:Tag:office=administrative
+    office=adoption_agency: JA:Tag:office=adoption agency
     office=advertising_agency: JA:Tag:office=advertising agency
+    office=airline: JA:Tag:office=airline
     office=architect: JA:Tag:office=architect
     office=association: JA:Tag:office=association
+    office=bail_bond_agent: JA:Tag:office=bail bond agent
+    office=broadcaster: JA:Tag:office=broadcaster
+    office=chamber: JA:Tag:office=chamber
     office=charity: JA:Tag:office=charity
     office=company: JA:Tag:office=company
     office=construction_company: JA:Tag:office=construction company
+    office=consulting: JA:Tag:office=consulting
     office=cooperative: JA:Tag:office=cooperative
     office=courier: JA:Tag:office=courier
     office=coworking: JA:Tag:office=coworking
     office=diplomatic: JA:Tag:office=diplomatic
     office=educational_institution: JA:Tag:office=educational institution
     office=employment_agency: JA:Tag:office=employment agency
+    office=energy_supplier: JA:Tag:office=energy supplier
+    office=engineer: JA:Tag:office=engineer
     office=estate_agent: JA:Tag:office=estate agent
+    office=event_management: JA:Tag:office=event management
     office=financial: JA:Tag:office=financial
     office=financial_advisor: JA:Tag:office=financial advisor
+    office=forestry: JA:Tag:office=forestry
+    office=foundation: JA:Tag:office=foundation
     office=geodesist: JA:Tag:office=geodesist
+    office=gongo: JA:Tag:office=gongo
     office=government: JA:Tag:office=government
+    office=graphic_design: JA:Tag:office=graphic design
+    office=guide: JA:Tag:office=guide
+    office=harbour_master: JA:Tag:office=harbour master
     office=insurance: JA:Tag:office=insurance
+    office=interior_design: JA:Tag:office=interior design
     office=it: JA:Tag:office=it
     office=lawyer: JA:Tag:office=lawyer
+    office=lifeguard: JA:Tag:office=lifeguard
     office=logistics: JA:Tag:office=logistics
+    office=lost_property: JA:Tag:office=lost property
     office=moving_company: JA:Tag:office=moving company
     office=newspaper: JA:Tag:office=newspaper
     office=ngo: JA:Tag:office=ngo
+    office=notary: JA:Tag:office=notary
+    office=pest_control: JA:Tag:office=pest control
     office=political_party: JA:Tag:office=political party
     office=politician: JA:Tag:office=politician
+    office=private_investigator: JA:Tag:office=private investigator
+    office=property_management: JA:Tag:office=property management
+    office=publisher: JA:Tag:office=publisher
     office=quango: JA:Tag:office=quango
+    office=railway: JA:Tag:office=railway
     office=real_estate_agent: JA:Tag:office=real estate agent
     office=religion: JA:Tag:office=religion
     office=research: JA:Tag:office=research
@@ -26081,7 +27316,15 @@ ja:
     office=telecommunication: JA:Tag:office=telecommunication
     office=therapist: JA:Tag:office=therapist
     office=translator: JA:Tag:office=translator
+    office=transport: JA:Tag:office=transport
+    office=travel_agent: JA:Tag:office=travel agent
     office=tutoring: JA:Tag:office=tutoring
+    office=union: JA:Tag:office=union
+    office=university: JA:Tag:office=university
+    office=visa: JA:Tag:office=visa
+    office=water_utility: JA:Tag:office=water utility
+    office=wedding_planner: JA:Tag:office=wedding planner
+    office=yes: JA:Tag:office=yes
     oneway=alternating: JA:Tag:oneway=alternating
     oneway=reversible: JA:Tag:oneway=reversible
     parking=layby: JA:Tag:parking=layby
@@ -26204,13 +27447,26 @@ ja:
     service=siding: JA:Tag:service=siding
     service=spur: JA:Tag:service=spur
     service=yard: JA:Tag:service=yard
+    shelter_type=basic_hut: JA:Tag:shelter type=basic hut
+    shelter_type=bomb_shelter: JA:Tag:shelter type=bomb shelter
+    shelter_type=field_shelter: JA:Tag:shelter type=field shelter
     shelter_type=gazebo: JA:Tag:shelter type=gazebo
+    shelter_type=lean_to: JA:Tag:shelter type=lean to
+    shelter_type=pavilion: JA:Tag:shelter type=pavilion
+    shelter_type=pergola: JA:Tag:shelter type=pergola
+    shelter_type=picnic_shelter: JA:Tag:shelter type=picnic shelter
+    shelter_type=public_transport: JA:Tag:shelter type=public transport
+    shelter_type=rock_shelter: JA:Tag:shelter type=rock shelter
+    shelter_type=sun_shelter: JA:Tag:shelter type=sun shelter
+    shelter_type=weather_shelter: JA:Tag:shelter type=weather shelter
+    shelter_type=wetterpilz: JA:Tag:shelter type=wetterpilz
     shop=agrarian: JA:Tag:shop=agrarian
     shop=alcohol: JA:Tag:shop=alcohol
     shop=anime: JA:Tag:shop=anime
     shop=antiques: JA:Tag:shop=antiques
     shop=appliance: JA:Tag:shop=appliance
     shop=art: JA:Tag:shop=art
+    shop=atv: JA:Tag:shop=atv
     shop=baby_goods: JA:Tag:shop=baby goods
     shop=bag: JA:Tag:shop=bag
     shop=bakery: JA:Tag:shop=bakery
@@ -26219,21 +27475,27 @@ ja:
     shop=bed: JA:Tag:shop=bed
     shop=beverages: JA:Tag:shop=beverages
     shop=bicycle: JA:Tag:shop=bicycle
+    shop=boat: JA:Tag:shop=boat
     shop=bookmaker: JA:Tag:shop=bookmaker
     shop=books: JA:Tag:shop=books
     shop=boutique: JA:Tag:shop=boutique
     shop=brewing_supplies: JA:Tag:shop=brewing supplies
+    shop=building_materials: JA:Tag:shop=building materials
     shop=butcher: JA:Tag:shop=butcher
     shop=camera: JA:Tag:shop=camera
+    shop=camp: JA:Tag:shop=camp
     shop=candles: JA:Tag:shop=candles
+    shop=cannabis: JA:Tag:shop=cannabis
     shop=car: JA:Tag:shop=car
     shop=car_parts: JA:Tag:shop=car parts
     shop=car_repair: JA:Tag:shop=car repair
+    shop=caravan: JA:Tag:shop=caravan
     shop=carpet: JA:Tag:shop=carpet
     shop=charity: JA:Tag:shop=charity
     shop=cheese: JA:Tag:shop=cheese
     shop=chemist: JA:Tag:shop=chemist
     shop=chocolate: JA:Tag:shop=chocolate
+    shop=cleaning_supplies: JA:Tag:shop=cleaning supplies
     shop=clothes: JA:Tag:shop=clothes
     shop=coffee: JA:Tag:shop=coffee
     shop=collector: JA:Tag:shop=collector
@@ -26242,6 +27504,7 @@ ja:
     shop=convenience: JA:Tag:shop=convenience
     shop=copyshop: JA:Tag:shop=copyshop
     shop=cosmetics: JA:Tag:shop=cosmetics
+    shop=country_store: JA:Tag:shop=country store
     shop=craft: JA:Tag:shop=craft
     shop=curtain: JA:Tag:shop=curtain
     shop=dairy: JA:Tag:shop=dairy
@@ -26249,14 +27512,17 @@ ja:
     shop=department_store: JA:Tag:shop=department store
     shop=dive: JA:Tag:shop=dive
     shop=doityourself: JA:Tag:shop=doityourself
+    shop=doors: JA:Tag:shop=doors
     shop=dry_cleaning: JA:Tag:shop=dry cleaning
     shop=e-cigarette: JA:Tag:shop=e-cigarette
+    shop=eggs: JA:Tag:shop=eggs
     shop=electrical: JA:Tag:shop=electrical
     shop=electronics: JA:Tag:shop=electronics
     shop=energy: JA:Tag:shop=energy
     shop=erotic: JA:Tag:shop=erotic
     shop=estate_agent: JA:Tag:shop=estate agent
     shop=fabric: JA:Tag:shop=fabric
+    shop=fan: JA:Tag:shop=fan
     shop=farm: JA:Tag:shop=farm
     shop=fashion: JA:Tag:shop=fashion
     shop=fashion_accessories: JA:Tag:shop=fashion accessories
@@ -26265,6 +27531,7 @@ ja:
     shop=fishmonger: JA:Tag:shop=fishmonger
     shop=flooring: JA:Tag:shop=flooring
     shop=florist: JA:Tag:shop=florist
+    shop=food: JA:Tag:shop=food
     shop=frame: JA:Tag:shop=frame
     shop=frozen_food: JA:Tag:shop=frozen food
     shop=fuel: JA:Tag:shop=fuel
@@ -26273,6 +27540,8 @@ ja:
     shop=gambling: JA:Tag:shop=gambling
     shop=games: JA:Tag:shop=games
     shop=garden_centre: JA:Tag:shop=garden centre
+    shop=garden_furniture: JA:Tag:shop=garden furniture
+    shop=garden_machinery: JA:Tag:shop=garden machinery
     shop=gas: JA:Tag:shop=gas
     shop=general: JA:Tag:shop=general
     shop=gift: JA:Tag:shop=gift
@@ -26282,16 +27551,20 @@ ja:
     shop=golf: JA:Tag:shop=golf
     shop=greengrocer: JA:Tag:shop=greengrocer
     shop=grocery: JA:Tag:shop=grocery
+    shop=groundskeeping: JA:Tag:shop=groundskeeping
     shop=hairdresser: JA:Tag:shop=hairdresser
+    shop=hairdresser_supply: JA:Tag:shop=hairdresser supply
     shop=hardware: JA:Tag:shop=hardware
     shop=health: JA:Tag:shop=health
     shop=health_food: JA:Tag:shop=health food
     shop=hearing_aids: JA:Tag:shop=hearing aids
     shop=herbalist: JA:Tag:shop=herbalist
     shop=hifi: JA:Tag:shop=hifi
+    shop=honey: JA:Tag:shop=honey
     shop=household_linen: JA:Tag:shop=household linen
     shop=houseware: JA:Tag:shop=houseware
     shop=hunting: JA:Tag:shop=hunting
+    shop=hvac: JA:Tag:shop=hvac
     shop=ice_cream: JA:Tag:shop=ice cream
     shop=insurance: JA:Tag:shop=insurance
     shop=interior_decoration: JA:Tag:shop=interior decoration
@@ -26299,22 +27572,29 @@ ja:
     shop=junk_yard: JA:Tag:shop=junk yard
     shop=kiosk: JA:Tag:shop=kiosk
     shop=kitchen: JA:Tag:shop=kitchen
+    shop=knives: JA:Tag:shop=knives
     shop=lamps: JA:Tag:shop=lamps
     shop=laundry: JA:Tag:shop=laundry
     shop=leather: JA:Tag:shop=leather
     shop=lighting: JA:Tag:shop=lighting
     shop=locksmith: JA:Tag:shop=locksmith
     shop=lottery: JA:Tag:shop=lottery
+    shop=magic: JA:Tag:shop=magic
     shop=mall: JA:Tag:shop=mall
+    shop=maps: JA:Tag:shop=maps
     shop=massage: JA:Tag:shop=massage
     shop=medical: JA:Tag:shop=medical
     shop=medical_supply: JA:Tag:shop=medical supply
+    shop=military_surplus: JA:Tag:shop=military surplus
+    shop=mobile_industrial_equipment: JA:Tag:shop=mobile industrial equipment
     shop=mobile_phone: JA:Tag:shop=mobile phone
+    shop=mobile_phone_accessories: JA:Tag:shop=mobile phone accessories
     shop=mobility_scooter: JA:Tag:shop=mobility scooter
     shop=model: JA:Tag:shop=model
     shop=money_lender: JA:Tag:shop=money lender
     shop=moneylender: JA:Tag:shop=moneylender
     shop=motorcycle: JA:Tag:shop=motorcycle
+    shop=motorcycle_parts: JA:Tag:shop=motorcycle parts
     shop=motorcycle_repair: JA:Tag:shop=motorcycle repair
     shop=music: JA:Tag:shop=music
     shop=musical_instrument: JA:Tag:shop=musical instrument
@@ -26324,23 +27604,35 @@ ja:
     shop=optician: JA:Tag:shop=optician
     shop=organic: JA:Tag:shop=organic
     shop=outdoor: JA:Tag:shop=outdoor
+    shop=outpost: JA:Tag:shop=outpost
+    shop=packaging: JA:Tag:shop=packaging
     shop=paint: JA:Tag:shop=paint
+    shop=party: JA:Tag:shop=party
     shop=pasta: JA:Tag:shop=pasta
     shop=pastry: JA:Tag:shop=pastry
     shop=pawnbroker: JA:Tag:shop=pawnbroker
     shop=peanut_butter: JA:Tag:shop=peanut butter
     shop=perfumery: JA:Tag:shop=perfumery
+    shop=pest_control: JA:Tag:shop=pest control
     shop=pet: JA:Tag:shop=pet
     shop=pet_grooming: JA:Tag:shop=pet grooming
     shop=pharmacy: JA:Tag:shop=pharmacy
     shop=photo: JA:Tag:shop=photo
+    shop=photo_studio: JA:Tag:shop=photo studio
+    shop=piercing: JA:Tag:shop=piercing
+    shop=plant_hire: JA:Tag:shop=plant hire
+    shop=pottery: JA:Tag:shop=pottery
+    shop=power_tools: JA:Tag:shop=power tools
+    shop=printer_ink: JA:Tag:shop=printer ink
     shop=printing: JA:Tag:shop=printing
     shop=psychic: JA:Tag:shop=psychic
     shop=pyrotechnics: JA:Tag:shop=pyrotechnics
     shop=radiotechnics: JA:Tag:shop=radiotechnics
     shop=religion: JA:Tag:shop=religion
     shop=rental: JA:Tag:shop=rental
+    shop=repair: JA:Tag:shop=repair
     shop=rice: JA:Tag:shop=rice
+    shop=scooter: JA:Tag:shop=scooter
     shop=scuba_diving: JA:Tag:shop=scuba diving
     shop=seafood: JA:Tag:shop=seafood
     shop=second_hand: JA:Tag:shop=second hand
@@ -26349,29 +27641,44 @@ ja:
     shop=shoe_repair: JA:Tag:shop=shoe repair
     shop=shoes: JA:Tag:shop=shoes
     shop=shopping_centre: JA:Tag:shop=shopping centre
+    shop=ski: JA:Tag:shop=ski
+    shop=snack: JA:Tag:shop=snack
+    shop=snowmobile: JA:Tag:shop=snowmobile
     shop=souvenir: JA:Tag:shop=souvenir
     shop=spices: JA:Tag:shop=spices
     shop=sports: JA:Tag:shop=sports
     shop=stationery: JA:Tag:shop=stationery
     shop=storage_rental: JA:Tag:shop=storage rental
     shop=supermarket: JA:Tag:shop=supermarket
+    shop=surf: JA:Tag:shop=surf
     shop=swimming_pool: JA:Tag:shop=swimming pool
     shop=tailor: JA:Tag:shop=tailor
     shop=tattoo: JA:Tag:shop=tattoo
     shop=tea: JA:Tag:shop=tea
+    shop=telecommunication: JA:Tag:shop=telecommunication
     shop=ticket: JA:Tag:shop=ticket
+    shop=tiles: JA:Tag:shop=tiles
     shop=tobacco: JA:Tag:shop=tobacco
+    shop=tool_hire: JA:Tag:shop=tool hire
+    shop=tortilla: JA:Tag:shop=tortilla
     shop=toys: JA:Tag:shop=toys
+    shop=tractor: JA:Tag:shop=tractor
     shop=trade: JA:Tag:shop=trade
+    shop=trailer: JA:Tag:shop=trailer
     shop=travel_agency: JA:Tag:shop=travel agency
     shop=trophy: JA:Tag:shop=trophy
+    shop=truck: JA:Tag:shop=truck
+    shop=truck_repair: JA:Tag:shop=truck repair
     shop=tyres: JA:Tag:shop=tyres
     shop=vacant: JA:Tag:shop=vacant
     shop=vacuum_cleaner: JA:Tag:shop=vacuum cleaner
     shop=variety_store: JA:Tag:shop=variety store
+    shop=vending_machine: JA:Tag:shop=vending machine
     shop=video: JA:Tag:shop=video
     shop=video_games: JA:Tag:shop=video games
     shop=watches: JA:Tag:shop=watches
+    shop=water: JA:Tag:shop=water
+    shop=water_filter: JA:Tag:shop=water filter
     shop=weapons: JA:Tag:shop=weapons
     shop=wholesale: JA:Tag:shop=wholesale
     shop=wigs: JA:Tag:shop=wigs
@@ -26399,6 +27706,7 @@ ja:
     sport=basketball: JA:Tag:sport=basketball
     sport=billiards: JA:Tag:sport=billiards
     sport=climbing_adventure: JA:Tag:sport=climbing adventure
+    sport=disc_golf: JA:Tag:sport=disc golf
     sport=equestrian: JA:Tag:sport=equestrian
     sport=golf: JA:Tag:sport=golf
     sport=handball: JA:Tag:sport=handball
@@ -26406,6 +27714,7 @@ ja:
     sport=judo: JA:Tag:sport=judo
     sport=motocross: JA:Tag:sport=motocross
     sport=multi: JA:Tag:sport=multi
+    sport=rowing: JA:Tag:sport=rowing
     sport=sailing: JA:Tag:sport=sailing
     sport=shooting: JA:Tag:sport=shooting
     sport=ski_jumping: JA:Tag:sport=ski jumping
@@ -26440,6 +27749,7 @@ ja:
     surface=wood: JA:Tag:surface=wood
     telescope:type=optical: JA:Tag:telescope:type=optical
     telescope:type=radio: JA:Tag:telescope:type=radio
+    theatre:type=amphi: JA:Tag:theatre:type=amphi
     theatre:type=concert_hall: JA:Tag:theatre:type=concert hall
     tourism=alpine_hut: JA:Tag:tourism=alpine hut
     tourism=apartment: JA:Tag:tourism=apartment
@@ -26447,6 +27757,7 @@ ja:
     tourism=artwork: JA:Tag:tourism=artwork
     tourism=attraction: JA:Tag:tourism=attraction
     tourism=bed_and_breakfast: JA:Tag:tourism=bed and breakfast
+    tourism=camp_pitch: JA:Tag:tourism=camp pitch
     tourism=camp_site: JA:Tag:tourism=camp site
     tourism=caravan_site: JA:Tag:tourism=caravan site
     tourism=chalet: JA:Tag:tourism=chalet
@@ -26478,45 +27789,124 @@ ja:
     traffic_sign=city_limit: JA:Tag:traffic sign=city limit
     training=computer: JA:Tag:training=computer
     training=music: JA:Tag:training=music
+    trees=tea_plants: JA:Tag:trees=tea plants
     tunnel=avalanche_protector: JA:Tag:tunnel=avalanche protector
     tunnel=building_passage: JA:Tag:tunnel=building passage
     tunnel=culvert: JA:Tag:tunnel=culvert
+    tunnel=flooded: JA:Tag:tunnel=flooded
     type=public_transport: JA:Tag:type=public transport
     type=waterway: JA:Tag:type=waterway
+    usage=headrace: JA:Tag:usage=headrace
     usage=irrigation: JA:Tag:usage=irrigation
+    usage=penstock: JA:Tag:usage=penstock
+    usage=spillway: JA:Tag:usage=spillway
+    usage=tailrace: JA:Tag:usage=tailrace
     usage=test: JA:Tag:usage=test
+    usage=transmission: JA:Tag:usage=transmission
     usage=transportation: JA:Tag:usage=transportation
     utility=chemical: JA:Tag:utility=chemical
     utility=street_lighting: JA:Tag:utility=street lighting
     vehicle=destination: JA:Tag:vehicle=destination
+    vending=SIM_cards: JA:Tag:vending=SIM cards
+    vending=admission_tickets: JA:Tag:vending=admission tickets
+    vending=animal_feed: JA:Tag:vending=animal feed
+    vending=art: JA:Tag:vending=art
+    vending=bicycle_tube: JA:Tag:vending=bicycle tube
+    vending=books: JA:Tag:vending=books
+    vending=bottle_return: JA:Tag:vending=bottle return
     vending=bread: JA:Tag:vending=bread
+    vending=candles: JA:Tag:vending=candles
+    vending=chemist: JA:Tag:vending=chemist
+    vending=chewing_gums: JA:Tag:vending=chewing gums
+    vending=cigarettes: JA:Tag:vending=cigarettes
+    vending=coffee: JA:Tag:vending=coffee
+    vending=coin_change_machine: JA:Tag:vending=coin change machine
+    vending=coin_rolls: JA:Tag:vending=coin rolls
+    vending=condoms: JA:Tag:vending=condoms
+    vending=contact_lenses: JA:Tag:vending=contact lenses
+    vending=drinks: JA:Tag:vending=drinks
+    vending=e-cigarettes: JA:Tag:vending=e-cigarettes
+    vending=eggs: JA:Tag:vending=eggs
+    vending=electronics: JA:Tag:vending=electronics
+    vending=elongated_coin: JA:Tag:vending=elongated coin
     vending=excrement_bags: JA:Tag:vending=excrement bags
+    vending=feminine_hygiene: JA:Tag:vending=feminine hygiene
+    vending=first_aid: JA:Tag:vending=first aid
     vending=fishing_bait: JA:Tag:vending=fishing bait
+    vending=fishing_tackle: JA:Tag:vending=fishing tackle
+    vending=flower_seeds: JA:Tag:vending=flower seeds
+    vending=flowers: JA:Tag:vending=flowers
     vending=food: JA:Tag:vending=food
     vending=fuel: JA:Tag:vending=fuel
+    vending=gas: JA:Tag:vending=gas
+    vending=honey: JA:Tag:vending=honey
     vending=ice_cream: JA:Tag:vending=ice cream
+    vending=ice_cubes: JA:Tag:vending=ice cubes
+    vending=ink_cartridges: JA:Tag:vending=ink cartridges
+    vending=laundry_detergent: JA:Tag:vending=laundry detergent
+    vending=lottery: JA:Tag:vending=lottery
     vending=milk: JA:Tag:vending=milk
+    vending=newspapers: JA:Tag:vending=newspapers
     vending=parcel_pickup: JA:Tag:vending=parcel pickup
     vending=parcel_pickup;parcel_mail_in: JA:Tag:vending=parcel pickup;parcel mail
       in
     vending=parking_tickets: JA:Tag:vending=parking tickets
+    vending=pet_food: JA:Tag:vending=pet food
     vending=photo: JA:Tag:vending=photo
+    vending=pizza: JA:Tag:vending=pizza
+    vending=public_transport_plans: JA:Tag:vending=public transport plans
     vending=public_transport_tickets: JA:Tag:vending=public transport tickets
+    vending=raw_milk: JA:Tag:vending=raw milk
     vending=rice_polishing: JA:Tag:vending=rice polishing
+    vending=sex_toys: JA:Tag:vending=sex toys
+    vending=snacks: JA:Tag:vending=snacks
+    vending=stamps: JA:Tag:vending=stamps
+    vending=sweets: JA:Tag:vending=sweets
+    vending=syringes: JA:Tag:vending=syringes
+    vending=telephone_vouchers: JA:Tag:vending=telephone vouchers
+    vending=toll: JA:Tag:vending=toll
+    vending=toys: JA:Tag:vending=toys
+    vending=umbrellas: JA:Tag:vending=umbrellas
+    vending=water: JA:Tag:vending=water
+    vending=wood_pellet: JA:Tag:vending=wood pellet
+    volcano:status=active: JA:Tag:volcano:status=active
+    volcano:status=dormant: JA:Tag:volcano:status=dormant
+    volcano:status=extinct: JA:Tag:volcano:status=extinct
+    volcano:type=caldera: JA:Tag:volcano:type=caldera
+    volcano:type=lava_dome: JA:Tag:volcano:type=lava dome
+    volcano:type=maar: JA:Tag:volcano:type=maar
+    volcano:type=scoria: JA:Tag:volcano:type=scoria
+    volcano:type=shield: JA:Tag:volcano:type=shield
+    volcano:type=stratovolcano: JA:Tag:volcano:type=stratovolcano
     wall=no: JA:Tag:wall=no
     wall=noise_barrier: JA:Tag:wall=noise barrier
+    water=basin: JA:Tag:water=basin
+    water=canal: JA:Tag:water=canal
+    water=ditch: JA:Tag:water=ditch
+    water=drain: JA:Tag:water=drain
+    water=fish_pass: JA:Tag:water=fish pass
+    water=harbour: JA:Tag:water=harbour
     water=intermittent: JA:Tag:water=intermittent
+    water=lagoon: JA:Tag:water=lagoon
     water=lake: JA:Tag:water=lake
     water=lock: JA:Tag:water=lock
+    water=moat: JA:Tag:water=moat
+    water=oxbow: JA:Tag:water=oxbow
     water=pond: JA:Tag:water=pond
+    water=rapids: JA:Tag:water=rapids
+    water=reflecting_pool: JA:Tag:water=reflecting pool
     water=reservoir: JA:Tag:water=reservoir
     water=river: JA:Tag:water=river
+    water=stream: JA:Tag:water=stream
+    water=stream_pool: JA:Tag:water=stream pool
     water=wastewater: JA:Tag:water=wastewater
     waterway=boat_lift: JA:Tag:waterway=boat lift
     waterway=boatyard: JA:Tag:waterway=boatyard
     waterway=brook: JA:Tag:waterway=brook
     waterway=canal: JA:Tag:waterway=canal
+    waterway=canoe_pass: JA:Tag:waterway=canoe pass
     waterway=dam: JA:Tag:waterway=dam
+    waterway=debris_screen: JA:Tag:waterway=debris screen
     waterway=deep_well: JA:Tag:waterway=deep well
     waterway=ditch: JA:Tag:waterway=ditch
     waterway=dock: JA:Tag:waterway=dock
@@ -26525,15 +27915,22 @@ ja:
     waterway=drystream: JA:Tag:waterway=drystream
     waterway=fairway: JA:Tag:waterway=fairway
     waterway=fish_pass: JA:Tag:waterway=fish pass
+    waterway=floodgate: JA:Tag:waterway=floodgate
+    waterway=flowline: JA:Tag:waterway=flowline
     waterway=fuel: JA:Tag:waterway=fuel
+    waterway=link: JA:Tag:waterway=link
     waterway=lock_gate: JA:Tag:waterway=lock gate
     waterway=milestone: JA:Tag:waterway=milestone
     waterway=offshore_field: JA:Tag:waterway=offshore field
+    waterway=pressurised: JA:Tag:waterway=pressurised
+    waterway=rapids: JA:Tag:waterway=rapids
     waterway=river: JA:Tag:waterway=river
     waterway=riverbank: JA:Tag:waterway=riverbank
     waterway=seaway: JA:Tag:waterway=seaway
+    waterway=security_lock: JA:Tag:waterway=security lock
     waterway=sluice_gate: JA:Tag:waterway=sluice gate
     waterway=stream: JA:Tag:waterway=stream
+    waterway=tidal_channel: JA:Tag:waterway=tidal channel
     waterway=turning_point: JA:Tag:waterway=turning point
     waterway=water_point: JA:Tag:waterway=water point
     waterway=waterfall: JA:Tag:waterway=waterfall
@@ -26553,6 +27950,7 @@ ko:
     3dr:type: Ko:Key:3dr:type
     addr: Ko:Key:addr
     addr:*: Ko:Key:addr:*
+    admin_level: Ko:Key:admin level
     aerialway: Ko:Key:aerialway
     alt_name: Ko:Key:alt name
     amenity: Ko:Key:amenity
@@ -26584,6 +27982,7 @@ ko:
     drive_through: Ko:Key:drive through
     ele: Ko:Key:ele
     emergency: Ko:Key:emergency
+    end_date:edtf: Ko:Key:end date:edtf
     expressway: Ko:Key:expressway
     fire_mains: Ko:Key:fire mains
     fuel: Ko:Key:fuel
@@ -26605,6 +28004,7 @@ ko:
     name: Ko:Key:name
     name:ja: Ko:Key:name:ja
     name:ko: Ko:Key:name:ko
+    official_name: Ko:Key:official name
     operator:type: Ko:Key:operator:type
     overtaking: Ko:Key:overtaking
     place: Ko:Key:place
@@ -26624,6 +28024,7 @@ ko:
     shop: Ko:Key:shop
     smoothness: Ko:Key:smoothness
     social_facility: Ko:Key:social facility
+    start_date:edtf: Ko:Key:start date:edtf
     tenant: Ko:Key:tenant
     toll: Ko:Key:toll
     townhall:type: Ko:Key:townhall:type
@@ -26636,6 +28037,7 @@ ko:
     trolley:deposit: Ko:Key:trolley:deposit
     tunnel: Ko:Key:tunnel
     turn: Ko:Key:turn
+    type: Ko:Key:type
     was:amenity: Ko:Key:was:amenity
     water: Ko:Key:water
     waterway: Ko:Key:waterway
@@ -26825,17 +28227,20 @@ ko:
     office=cooperative: Ko:Tag:office=cooperative
     office=coworking: Ko:Tag:office=coworking
     parking=underground: Ko:Tag:parking=underground
+    place=country: Ko:Tag:place=country
     place=hamlet: Ko:Tag:place=hamlet
     place=town: Ko:Tag:place=town
     place=village: Ko:Tag:place=village
     power=catenary_mast: Ko:Tag:power=catenary mast
     public_transport=platform: Ko:Tag:public transport=platform
     public_transport=stop_area: Ko:Tag:public transport=stop area
+    railway=light_rail: Ko:Tag:railway=light rail
     railway=platform_edge: Ko:Tag:railway=platform edge
     railway=rail: Ko:Tag:railway=rail
     railway=signal: Ko:Tag:railway=signal
     railway=station: Ko:Tag:railway=station
     railway=switch: Ko:Tag:railway=switch
+    railway=tram: Ko:Tag:railway=tram
     religion=buddhist: Ko:Tag:religion=buddhist
     religion=confucian: Ko:Tag:religion=confucian
     religion=shamanic: Ko:Tag:religion=shamanic
@@ -28703,6 +30108,7 @@ pl:
     power=cable: Pl:Tag:power=cable
     power=cable_distribution_cabinet: Pl:Tag:power=cable distribution cabinet
     power=catenary_mast: Pl:Tag:power=catenary mast
+    power=catenary_portal: Pl:Tag:power=catenary portal
     power=converter: Pl:Tag:power=converter
     power=generator: Pl:Tag:power=generator
     power=heliostat: Pl:Tag:power=heliostat
@@ -29792,6 +31198,7 @@ pt:
     man_made=beacon: Pt:Tag:man made=beacon
     man_made=breakwater: Pt:Tag:man made=breakwater
     man_made=cairn: Pt:Tag:man made=cairn
+    man_made=clearcut: Pt:Tag:man made=clearcut
     man_made=crane: Pt:Tag:man made=crane
     man_made=cross: Pt:Tag:man made=cross
     man_made=cutline: Pt:Tag:man made=cutline
@@ -30845,6 +32252,8 @@ ro:
     religion=christian: Ro:Tag:religion=christian
 ru:
   key:
+    '*:backward': RU:Key:*:backward
+    '*:forward': RU:Key:*:forward
     3dmr: RU:Key:3dmr
     3dr:type: RU:Key:3dr:type
     4wd_only: RU:Key:4wd only
@@ -30913,6 +32322,7 @@ ru:
     armrest: RU:Key:armrest
     artist_name: RU:Key:artist name
     artwork_type: RU:Key:artwork type
+    ascent: RU:Key:ascent
     assembly_point:bombing: RU:Key:assembly point:bombing
     assisted_trail: RU:Key:assisted trail
     association: RU:Key:association
@@ -31003,6 +32413,7 @@ ru:
     cabin:rental: RU:Key:cabin:rental
     cabins: RU:Key:cabins
     cable_number: RU:Key:cable number
+    cables: RU:Key:cables
     cadet: RU:Key:cadet
     cafe: RU:Key:cafe
     camera:type: RU:Key:camera:type
@@ -31024,7 +32435,10 @@ ru:
     cash_withdrawal: RU:Key:cash withdrawal
     castle_type: RU:Key:castle type
     castle_type:de: RU:Key:castle type:de
+    catenary_mast:supporting: RU:Key:catenary mast:supporting
     cemetery: RU:Key:cemetery
+    change: RU:Key:change
+    change:lanes: RU:Key:change:lanes
     changing_table: RU:Key:changing table
     changing_table:count: RU:Key:changing table:count
     changing_table:fee: RU:Key:changing table:fee
@@ -31036,6 +32450,7 @@ ru:
     checkpoint: RU:Key:checkpoint
     church:type: RU:Key:church:type
     cinema:IMAX: RU:Key:cinema:IMAX
+    circuits: RU:Key:circuits
     circumference: RU:Key:circumference
     city_limit: RU:Key:city limit
     class:bicycle: RU:Key:class:bicycle
@@ -31044,6 +32459,7 @@ ru:
     club: RU:Key:club
     collection_times: RU:Key:collection times
     colour: RU:Key:colour
+    colour:*: RU:Key:colour:*
     comment: RU:Key:comment
     communication:*: RU:Key:communication:*
     communication:amateur_radio: RU:Key:communication:amateur radio
@@ -31063,6 +32479,7 @@ ru:
     contact:email: RU:Key:contact:email
     contact:facebook: RU:Key:contact:facebook
     contact:fax: RU:Key:contact:fax
+    contact:max: RU:Key:contact:max
     contact:phone: RU:Key:contact:phone
     contact:vk: RU:Key:contact:vk
     contact:website: RU:Key:contact:website
@@ -31115,15 +32532,18 @@ ru:
     departures_board: RU:Key:departures board
     depot: RU:Key:depot
     depth: RU:Key:depth
+    descent: RU:Key:descent
     description: RU:Key:description
     description:ru: RU:Key:description:ru
     design:code:SPb: RU:Key:design:code:SPb
     design:ref: RU:Key:design:ref
     designation: RU:Key:designation
+    detour: RU:Key:detour
     diplomatic: RU:Key:diplomatic
     direction: RU:Key:direction
     dispensing: RU:Key:dispensing
     dist: RU:Key:dist
+    distance: RU:Key:distance
     disused: RU:Key:disused
     'disused:': 'RU:Key:disused:'
     disused:*: RU:Key:disused:*
@@ -31132,6 +32552,7 @@ ru:
     disused:leisure: RU:Key:disused:leisure
     disused:place: RU:Key:disused:place
     disused:shop: RU:Key:disused:shop
+    divider: RU:Key:divider
     dog: RU:Key:dog
     dog:conditional: RU:Key:dog:conditional
     dog_washing: RU:Key:dog washing
@@ -31198,6 +32619,8 @@ ru:
     fortification_type: RU:Key:fortification type
     forward: RU:Key:forward
     fountain: RU:Key:fountain
+    frequency: RU:Key:frequency
+    from: RU:Key:from
     fuel: RU:Key:fuel
     fuel:cng: RU:Key:fuel:cng
     fuel:lpg: RU:Key:fuel:lpg
@@ -31209,6 +32632,7 @@ ru:
     generator:output: RU:Key:generator:output
     generator:source: RU:Key:generator:source
     genus: RU:Key:genus
+    geological: RU:Key:geological
     glideslope: RU:Key:glideslope
     golf:par: RU:Key:golf:par
     government: RU:Key:government
@@ -31220,6 +32644,7 @@ ru:
     guide_type: RU:Key:guide type
     guidepost: RU:Key:guidepost
     guidepost:hiking: RU:Key:guidepost:hiking
+    guyed: RU:Key:guyed
     gvr:code: RU:Key:gvr:code
     handrail: RU:Key:handrail
     hazard: RU:Key:hazard
@@ -31252,10 +32677,12 @@ ru:
     informal: RU:Key:informal
     information: RU:Key:information
     inlet: RU:Key:inlet
+    inline_skates: RU:Key:inline skates
     inscription: RU:Key:inscription
     int_name: RU:Key:int name
     intermittent: RU:Key:intermittent
     internet_access: RU:Key:internet access
+    interval: RU:Key:interval
     irrigation: RU:Key:irrigation
     is_in: RU:Key:is in
     isced:level: RU:Key:isced:level
@@ -31286,6 +32713,7 @@ ru:
     level:ref: RU:Key:level:ref
     license_classes: RU:Key:license classes
     lift_gate:type: RU:Key:lift gate:type
+    line: RU:Key:line
     listed_status: RU:Key:listed status
     lit: RU:Key:lit
     living_street: RU:Key:living street
@@ -31333,6 +32761,7 @@ ru:
     monitoring:groundwater: RU:Key:monitoring:groundwater
     moped: RU:Key:moped
     motor_vehicle: RU:Key:motor vehicle
+    motorboat: RU:Key:motorboat
     motorcar: RU:Key:motorcar
     motorcycle: RU:Key:motorcycle
     motorcycle:*: RU:Key:motorcycle:*
@@ -31350,6 +32779,7 @@ ru:
     motorcycle:type: RU:Key:motorcycle:type
     motorcycle:tyres: RU:Key:motorcycle:tyres
     motorroad: RU:Key:motorroad
+    motorway: RU:Key:motorway
     mountain_pass: RU:Key:mountain pass
     mtb:description: RU:Key:mtb:description
     mtb:name: RU:Key:mtb:name
@@ -31395,6 +32825,7 @@ ru:
     opening_hours:reception: RU:Key:opening hours:reception
     operator: RU:Key:operator
     operator:ref:inn: RU:Key:operator:ref:inn
+    operator:ref:kpp: RU:Key:operator:ref:kpp
     operator:ref:ogrn: RU:Key:operator:ref:ogrn
     operator:type: RU:Key:operator:type
     operator:wikipedia: RU:Key:operator:wikipedia
@@ -31405,6 +32836,7 @@ ru:
     overtaking: RU:Key:overtaking
     overtaking:motor_vehicle: RU:Key:overtaking:motor vehicle
     owner: RU:Key:owner
+    owner:wikidata: RU:Key:owner:wikidata
     ownership: RU:Key:ownership
     panoramax: RU:Key:panoramax
     park_ride: RU:Key:park ride
@@ -31520,6 +32952,8 @@ ru:
     rooms: RU:Key:rooms
     roundtrip: RU:Key:roundtrip
     route: RU:Key:route
+    route_master: RU:Key:route master
+    route_ref: RU:Key:route ref
     rtsa_scale: RU:Key:rtsa scale
     ruined: RU:Key:ruined
     'ruined:': 'RU:Key:ruined:'
@@ -31554,9 +32988,11 @@ ru:
     service:bicycle:retail: RU:Key:service:bicycle:retail
     service:vehicle:*: RU:Key:service:vehicle:*
     service:vehicle:car_repair: RU:Key:service:vehicle:car repair
+    service:vehicle:truck_repair: RU:Key:service:vehicle:truck repair
     service_times: RU:Key:service times
     shelter: RU:Key:shelter
     shelter_type: RU:Key:shelter type
+    ship: RU:Key:ship
     ship:type: RU:Key:ship:type
     shooting: RU:Key:shooting
     shop: RU:Key:shop
@@ -31564,6 +33000,7 @@ ru:
     shoulder: RU:Key:shoulder
     side_road: RU:Key:side road
     sidewalk: RU:Key:sidewalk
+    signed_direction: RU:Key:signed direction
     sinkhole: RU:Key:sinkhole
     small_electric_vehicle: RU:Key:small electric vehicle
     smoking: RU:Key:smoking
@@ -31583,9 +33020,12 @@ ru:
     speed_pedelec: RU:Key:speed pedelec
     sport: RU:Key:sport
     start_date: RU:Key:start date
+    state: RU:Key:state
+    station: RU:Key:station
     statue: RU:Key:statue
     step_count: RU:Key:step count
     stove: RU:Key:stove
+    structure: RU:Key:structure
     studio: RU:Key:studio
     substance: RU:Key:substance
     supervised: RU:Key:supervised
@@ -31605,12 +33045,14 @@ ru:
     tank_trap: RU:Key:tank trap
     taxon: RU:Key:taxon
     technology: RU:Key:technology
+    telecom: RU:Key:telecom
     television: RU:Key:television
     tents: RU:Key:tents
     terrace: RU:Key:terrace
     theatre:genre: RU:Key:theatre:genre
     theatre:type: RU:Key:theatre:type
     tidal: RU:Key:tidal
+    to: RU:Key:to
     todo: RU:Key:todo
     toilets: RU:Key:toilets
     toilets:*: RU:Key:toilets:*
@@ -31618,8 +33060,10 @@ ru:
     toll: RU:Key:toll
     tourism: RU:Key:tourism
     tourist_bus: RU:Key:tourist bus
+    tower:construction: RU:Key:tower:construction
     tower:type: RU:Key:tower:type
     townhall:type: RU:Key:townhall:type
+    tracks: RU:Key:tracks
     tracktype: RU:Key:tracktype
     traffic_calming: RU:Key:traffic calming
     traffic_sign: RU:Key:traffic sign
@@ -32035,6 +33479,7 @@ ru:
     association=sport: RU:Tag:association=sport
     association=student: RU:Tag:association=student
     athletics=long_jump: RU:Tag:athletics=long jump
+    athletics=running: RU:Tag:athletics=running
     atm=yes: RU:Tag:atm=yes
     attraction=alpine_coaster: RU:Tag:attraction=alpine coaster
     attraction=amusement_ride: RU:Tag:attraction=amusement ride
@@ -32433,6 +33878,7 @@ ru:
     craft=distillery: RU:Tag:craft=distillery
     craft=dressmaker: RU:Tag:craft=dressmaker
     craft=electrician: RU:Tag:craft=electrician
+    craft=electronics_repair: RU:Tag:craft=electronics repair
     craft=glaziery: RU:Tag:craft=glaziery
     craft=handicraft: RU:Tag:craft=handicraft
     craft=hvac: RU:Tag:craft=hvac
@@ -32500,6 +33946,7 @@ ru:
     display=sundial: RU:Tag:display=sundial
     disused:landuse=landfill: RU:Tag:disused:landuse=landfill
     disused:landuse=quarry: RU:Tag:disused:landuse=quarry
+    disused:tourism=hotel: RU:Tag:disused:tourism=hotel
     dog=designated: RU:Tag:dog=designated
     dog=leashed: RU:Tag:dog=leashed
     dog=no: RU:Tag:dog=no
@@ -32616,7 +34063,6 @@ ru:
     guest_house=bed_and_breakfast: RU:Tag:guest house=bed and breakfast
     guest_house=kontrakan: RU:Tag:guest house=kontrakan
     guest_house=student_accommodation: RU:Tag:guest house=student accommodation
-    guest_house=student_accomodation: RU:Tag:guest house=student accomodation
     hazard=animal_crossing: RU:Tag:hazard=animal crossing
     hazard=archery_range: RU:Tag:hazard=archery range
     hazard=children: RU:Tag:hazard=children
@@ -32987,6 +34433,9 @@ ru:
     leisure=wildlife_hide: RU:Tag:leisure=wildlife hide
     lifeguard=base: RU:Tag:lifeguard=base
     lifeguard=tower: RU:Tag:lifeguard=tower
+    line=bay: RU:Tag:line=bay
+    line=busbar: RU:Tag:line=busbar
+    line_attachment=pin: RU:Tag:line attachment=pin
     location=overground: RU:Tag:location=overground
     location=overhead: RU:Tag:location=overhead
     location=roof: RU:Tag:location=roof
@@ -32997,6 +34446,7 @@ ru:
     logistics=goods_distribution: RU:Tag:logistics=goods distribution
     man_made=adit: RU:Tag:man made=adit
     man_made=animal_trap: RU:Tag:man made=animal trap
+    man_made=antenna: RU:Tag:man made=antenna
     man_made=archimedes_screw: RU:Tag:man made=archimedes screw
     man_made=architecture_line: RU:Tag:man made=architecture line
     man_made=beacon: RU:Tag:man made=beacon
@@ -33270,6 +34720,7 @@ ru:
     parking_space=charging: RU:Tag:parking space=charging
     parking_space=disabled: RU:Tag:parking space=disabled
     parking_space=parent: RU:Tag:parking space=parent
+    path=crossing: RU:Tag:path=crossing
     path=desire: RU:Tag:path=desire
     path=sidewalk: RU:Tag:path=sidewalk
     pipeline=marker: RU:Tag:pipeline=marker
@@ -33332,17 +34783,26 @@ ru:
     police=barracks: RU:Tag:police=barracks
     police=car_pound: RU:Tag:police=car pound
     post_office=post_partner: RU:Tag:post office=post partner
+    power=cable: RU:Tag:power=cable
+    power=catenary_mast: RU:Tag:power=catenary mast
+    power=circuit: RU:Tag:power=circuit
     power=compensator: RU:Tag:power=compensator
+    power=connection: RU:Tag:power=connection
+    power=converter: RU:Tag:power=converter
     power=generator: RU:Tag:power=generator
     power=heliostat: RU:Tag:power=heliostat
+    power=insulator: RU:Tag:power=insulator
     power=line: RU:Tag:power=line
     power=minor_line: RU:Tag:power=minor line
     power=outlet: RU:Tag:power=outlet
     power=plant: RU:Tag:power=plant
     power=pole: RU:Tag:power=pole
+    power=portal: RU:Tag:power=portal
     power=station: RU:Tag:power=station
     power=sub_station: RU:Tag:power=sub station
     power=substation: RU:Tag:power=substation
+    power=switch: RU:Tag:power=switch
+    power=switchgear: RU:Tag:power=switchgear
     power=terminal: RU:Tag:power=terminal
     power=tower: RU:Tag:power=tower
     power=transformer: RU:Tag:power=transformer
@@ -33375,6 +34835,7 @@ ru:
     railway=level_crossing: RU:Tag:railway=level crossing
     railway=light_rail: RU:Tag:railway=light rail
     railway=miniature: RU:Tag:railway=miniature
+    railway=monorail: RU:Tag:railway=monorail
     railway=narrow_gauge: RU:Tag:railway=narrow gauge
     railway=platform: RU:Tag:railway=platform
     railway=preserved: RU:Tag:railway=preserved
@@ -33386,6 +34847,7 @@ ru:
     railway=stop: RU:Tag:railway=stop
     railway=subway: RU:Tag:railway=subway
     railway=subway_entrance: RU:Tag:railway=subway entrance
+    railway=train_station_entrance: RU:Tag:railway=train station entrance
     railway=tram: RU:Tag:railway=tram
     railway=tram_stop: RU:Tag:railway=tram stop
     railway=turntable: RU:Tag:railway=turntable
@@ -33421,22 +34883,43 @@ ru:
     roller_coaster=station: RU:Tag:roller coaster=station
     roller_coaster=support: RU:Tag:roller coaster=support
     roller_coaster=track: RU:Tag:roller coaster=track
+    route=atv: RU:Tag:route=atv
     route=bicycle: RU:Tag:route=bicycle
+    route=boat: RU:Tag:route=boat
     route=bus: RU:Tag:route=bus
     route=canal: RU:Tag:route=canal
+    route=canoe: RU:Tag:route=canoe
+    route=detour: RU:Tag:route=detour
+    route=evacuation: RU:Tag:route=evacuation
     route=ferry: RU:Tag:route=ferry
+    route=fitness_trail: RU:Tag:route=fitness trail
+    route=foot: RU:Tag:route=foot
     route=hiking: RU:Tag:route=hiking
     route=horse: RU:Tag:route=horse
+    route=inline_skates: RU:Tag:route=inline skates
+    route=light_rail: RU:Tag:route=light rail
+    route=mobility_scooter: RU:Tag:route=mobility scooter
+    route=monorail: RU:Tag:route=monorail
+    route=motorboat: RU:Tag:route=motorboat
     route=mtb: RU:Tag:route=mtb
+    route=nordic_walking: RU:Tag:route=nordic walking
+    route=pipeline: RU:Tag:route=pipeline
     route=piste: RU:Tag:route=piste
+    route=power: RU:Tag:route=power
     route=railway: RU:Tag:route=railway
+    route=road: RU:Tag:route=road
+    route=running: RU:Tag:route=running
     route=share_taxi: RU:Tag:route=share taxi
     route=ski: RU:Tag:route=ski
+    route=snowmobile: RU:Tag:route=snowmobile
+    route=subway: RU:Tag:route=subway
     route=tracks: RU:Tag:route=tracks
     route=train: RU:Tag:route=train
     route=tram: RU:Tag:route=tram
     route=transhumance: RU:Tag:route=transhumance
     route=trolleybus: RU:Tag:route=trolleybus
+    route=waterway: RU:Tag:route=waterway
+    route=wheelchair: RU:Tag:route=wheelchair
     runway=displaced_threshold: RU:Tag:runway=displaced threshold
     school=entrance: RU:Tag:school=entrance
     seamark:wreck:category=dangerous: RU:Tag:seamark:wreck:category=dangerous
@@ -33569,10 +35052,12 @@ ru:
     shop=pet_grooming: RU:Tag:shop=pet grooming
     shop=photo: RU:Tag:shop=photo
     shop=power_tools: RU:Tag:shop=power tools
+    shop=printer_ink: RU:Tag:shop=printer ink
     shop=pyrotechnics: RU:Tag:shop=pyrotechnics
     shop=radiotechnics: RU:Tag:shop=radiotechnics
     shop=religion: RU:Tag:shop=religion
     shop=rental: RU:Tag:shop=rental
+    shop=repair: RU:Tag:shop=repair
     shop=safety_equipment: RU:Tag:shop=safety equipment
     shop=seafood: RU:Tag:shop=seafood
     shop=second_hand: RU:Tag:shop=second hand
@@ -33638,15 +35123,19 @@ ru:
     sport=motocross: RU:Tag:sport=motocross
     sport=motor: RU:Tag:sport=motor
     sport=pedal_car_racing: RU:Tag:sport=pedal car racing
+    sport=running: RU:Tag:sport=running
     sport=sailing: RU:Tag:sport=sailing
     sport=scuba_diving: RU:Tag:sport=scuba diving
     sport=shooting: RU:Tag:sport=shooting
     sport=swimming: RU:Tag:sport=swimming
     sport=ultralight_aviation: RU:Tag:sport=ultralight aviation
+    station=light_rail: RU:Tag:station=light rail
+    station=subway: RU:Tag:station=subway
     statue=animal: RU:Tag:statue=animal
     statue=equestrian: RU:Tag:statue=equestrian
     statue=virgin: RU:Tag:statue=virgin
     stone_type=conciliation_cross: RU:Tag:stone type=conciliation cross
+    structure=wall_mount: RU:Tag:structure=wall mount
     studio=audio: RU:Tag:studio=audio
     studio=radio: RU:Tag:studio=radio
     studio=television: RU:Tag:studio=television
@@ -33662,6 +35151,7 @@ ru:
     surface=concrete: RU:Tag:surface=concrete
     surface=stone: RU:Tag:surface=stone
     surface=unpaved: RU:Tag:surface=unpaved
+    surface=wood: RU:Tag:surface=wood
     survey_point:purpose=both: RU:Tag:survey point:purpose=both
     survey_point:purpose=horizontal: RU:Tag:survey point:purpose=horizontal
     survey_point:purpose=vertical: RU:Tag:survey point:purpose=vertical
@@ -33680,6 +35170,12 @@ ru:
     tank_trap=czech_hedgehog: RU:Tag:tank trap=czech hedgehog
     taxi_type=motorcycle: RU:Tag:taxi type=motorcycle
     taxi_vehicle=motorcycle: RU:Tag:taxi vehicle=motorcycle
+    telecom=connection_point: RU:Tag:telecom=connection point
+    telecom=data_center: RU:Tag:telecom=data center
+    telecom=distribution_point: RU:Tag:telecom=distribution point
+    telecom=exchange: RU:Tag:telecom=exchange
+    telecom=line: RU:Tag:telecom=line
+    telecom=service_device: RU:Tag:telecom=service device
     theatre:genre=philharmonic: RU:Tag:theatre:genre=philharmonic
     theatre:type=amphi: RU:Tag:theatre:type=amphi
     theatre:type=concert_hall: RU:Tag:theatre:type=concert hall
@@ -33733,6 +35229,7 @@ ru:
     tower:type=launch_tower: RU:Tag:tower:type=launch tower
     tower:type=lighting: RU:Tag:tower:type=lighting
     tower:type=lightning_protection: RU:Tag:tower:type=lightning protection
+    tower:type=watchtower: RU:Tag:tower:type=watchtower
     townhall:type=barangay: RU:Tag:townhall:type=barangay
     townhall:type=municipality: RU:Tag:townhall:type=municipality
     townhall:type=town: RU:Tag:townhall:type=town
@@ -33760,6 +35257,7 @@ ru:
     tunnel=building_passage: RU:Tag:tunnel=building passage
     tunnel=culvert: RU:Tag:tunnel=culvert
     type=health: RU:Tag:type=health
+    type=public_transport: RU:Tag:type=public transport
     type=site: RU:Tag:type=site
     type=waterway: RU:Tag:type=waterway
     usage=facility: RU:Tag:usage=facility
@@ -33771,6 +35269,7 @@ ru:
     usage=penstock: RU:Tag:usage=penstock
     usage=spillway: RU:Tag:usage=spillway
     utility=power: RU:Tag:utility=power
+    utility=telecom: RU:Tag:utility=telecom
     vehicle=destination: RU:Tag:vehicle=destination
     vehicle=no: RU:Tag:vehicle=no
     vehicle=private: RU:Tag:vehicle=private
@@ -34191,6 +35690,7 @@ sk:
     service:bicycle:ebike: Sk:Key:service:bicycle:ebike
     service:bicycle:sales: Sk:Key:service:bicycle:sales
     shooting: Sk:Key:shooting
+    shop: Sk:Key:shop
     source:destination: Sk:Key:source:destination
     source:imagery: Sk:Key:source:imagery
     source:loc: Sk:Key:source:loc
@@ -35123,8 +36623,8 @@ sv:
     maxspeed: Sv:Key:maxspeed
     name: Sv:Key:name
     operator: Sv:Key:operator
+    ref:NRVID: Sv:Key:ref:NRVID
     ref:NVRID: Sv:Key:ref:NVRID
-    ref:SE:nvrid: Sv:Key:ref:SE:nvrid
     ref:SE:raa: Sv:Key:ref:SE:raa
     ref:grillplatser.nu: Sv:Key:ref:grillplatser.nu
     ref:hjartstartarregistret.se: Sv:Key:ref:hjartstartarregistret.se
@@ -35149,6 +36649,8 @@ sv:
     cycleway=track: Sv:Tag:cycleway=track
     emergency=suction_point: Sv:Tag:emergency=suction point
     ford=stepping_stones: Sv:Tag:ford=stepping stones
+    generator:source=solar: Sv:Tag:generator:source=solar
+    generator:source=wind: Sv:Tag:generator:source=wind
     genus=Acer: Sv:Tag:genus=Acer
     genus=Platanus: Sv:Tag:genus=Platanus
     highway=emergency_bay: Sv:Tag:highway=emergency bay
@@ -35164,8 +36666,11 @@ sv:
     leisure=fitness_station: Sv:Tag:leisure=fitness station
     leisure=pitch: Sv:Tag:leisure=pitch
     man_made=planter: Sv:Tag:man made=planter
+    man_made=wastewater_plant: Sv:Tag:man made=wastewater plant
+    parking_space=bus: Sv:Tag:parking space=bus
     place=locality: Sv:Tag:place=locality
     place=square: Sv:Tag:place=square
+    power=generator: Sv:Tag:power=generator
     railway=rail: Sv:Tag:railway=rail
     route=ferry: Sv:Tag:route=ferry
     shelter_type=public_transport: Sv:Tag:shelter type=public transport
@@ -35435,9 +36940,11 @@ uk:
     name:prefix: Uk:Key:name:prefix
     name:pronunciation: Uk:Key:name:pronunciation
     name:right: Uk:Key:name:right
+    name:ru:word_stress: Uk:Key:name:ru:word stress
     name:suffix: Uk:Key:name:suffix
     name:uk: Uk:Key:name:uk
     name:uk-Latn: Uk:Key:name:uk-Latn
+    name:uk:word_stress: Uk:Key:name:uk:word stress
     name:wikipedia: Uk:Key:name:wikipedia
     nat_name: Uk:Key:nat name
     natural: Uk:Key:natural
@@ -36329,6 +37836,7 @@ zh-hans:
     cycleway: Zh-hans:Key:cycleway
     cycleway:both: Zh-hans:Key:cycleway:both
     denomination: Zh-hans:Key:denomination
+    distance: Zh-hans:Key:distance
     ele: Zh-hans:Key:ele
     entrance: Zh-hans:Key:entrance
     exit_to: Zh-hans:Key:exit to
@@ -36341,6 +37849,7 @@ zh-hans:
     height: Zh-hans:Key:height
     highspeed: Zh-hans:Key:highspeed
     highway: Zh-hans:Key:highway
+    ice_cream: Zh-hans:Key:ice cream
     information: Zh-hans:Key:information
     landuse: Zh-hans:Key:landuse
     lanes:psv: Zh-hans:Key:lanes:psv
@@ -36354,11 +37863,14 @@ zh-hans:
     name: Zh-hans:Key:name
     name:etymology: Zh-hans:Key:name:etymology
     name:ug: Zh-hans:Key:name:ug
+    name:zh-Hans: Zh-hans:Key:name:zh-Hans
     network: Zh-hans:Key:network
     not:name: Zh-hans:Key:not:name
+    old_name: Zh-hans:Key:old name
     oneway: Zh-hans:Key:oneway
     opening_hours:covid19: Zh-hans:Key:opening hours:covid19
     operator: Zh-hans:Key:operator
+    origin: Zh-hans:Key:origin
     overtaking: Zh-hans:Key:overtaking
     parking: Zh-hans:Key:parking
     place: Zh-hans:Key:place
@@ -36374,8 +37886,10 @@ zh-hans:
     railway:lzb: Zh-hans:Key:railway:lzb
     ref: Zh-hans:Key:ref
     ref:CN:usci: Zh-hans:Key:ref:CN:usci
+    ref:colour: Zh-hans:Key:ref:colour
     removed:building: Zh-hans:Key:removed:building
     residential: Zh-hans:Key:residential
+    review_requested: Zh-hans:Key:review requested
     roof:direction: Zh-hans:Key:roof:direction
     roof:shape: Zh-hans:Key:roof:shape
     shop: Zh-hans:Key:shop
@@ -36403,6 +37917,7 @@ zh-hans:
     amenity=grave_yard: Zh-hans:Tag:amenity=grave yard
     amenity=karaoke_box: Zh-hans:Tag:amenity=karaoke box
     amenity=kindergarten: Zh-hans:Tag:amenity=kindergarten
+    amenity=lounger: Zh-hans:Tag:amenity=lounger
     amenity=mortuary: Zh-hans:Tag:amenity=mortuary
     amenity=parcel_locker: Zh-hans:Tag:amenity=parcel locker
     amenity=prison: Zh-hans:Tag:amenity=prison
@@ -36420,6 +37935,7 @@ zh-hans:
     building=apartments: Zh-hans:Tag:building=apartments
     building=detached: Zh-hans:Tag:building=detached
     building=hospital: Zh-hans:Tag:building=hospital
+    building=hotel: Zh-hans:Tag:building=hotel
     building=office: Zh-hans:Tag:building=office
     building=school: Zh-hans:Tag:building=school
     building=service: Zh-hans:Tag:building=service
@@ -36441,6 +37957,7 @@ zh-hans:
     genus=Platanus: Zh-hans:Tag:genus=Platanus
     genus=Quercus: Zh-hans:Tag:genus=Quercus
     genus=Tilia: Zh-hans:Tag:genus=Tilia
+    geological=dyke: Zh-hans:Tag:geological=dyke
     healthcare=physiotherapist: Zh-hans:Tag:healthcare=physiotherapist
     highway=bus_stop: Zh-hans:Tag:highway=bus stop
     highway=construction: Zh-hans:Tag:highway=construction
@@ -36474,10 +37991,12 @@ zh-hans:
     industrial=slaughterhouse: Zh-hans:Tag:industrial=slaughterhouse
     informal=yes: Zh-hans:Tag:informal=yes
     information=office: Zh-hans:Tag:information=office
+    junction=yes: Zh-hans:Tag:junction=yes
     landuse=allotments: Zh-hans:Tag:landuse=allotments
     landuse=brownfield: Zh-hans:Tag:landuse=brownfield
     landuse=commercial: Zh-hans:Tag:landuse=commercial
     landuse=construction: Zh-hans:Tag:landuse=construction
+    landuse=farmyard: Zh-hans:Tag:landuse=farmyard
     landuse=forest: Zh-hans:Tag:landuse=forest
     landuse=greenfield: Zh-hans:Tag:landuse=greenfield
     landuse=greenhouse_horticulture: Zh-hans:Tag:landuse=greenhouse horticulture
@@ -36489,6 +38008,7 @@ zh-hans:
     leaf_cycle=evergreen: Zh-hans:Tag:leaf cycle=evergreen
     leisure=nature_reserve: Zh-hans:Tag:leisure=nature reserve
     leisure=picnic_table: Zh-hans:Tag:leisure=picnic table
+    leisure=stadium: Zh-hans:Tag:leisure=stadium
     line=bay: Zh-hans:Tag:line=bay
     line=busbar: Zh-hans:Tag:line=busbar
     man_made=antenna: Zh-hans:Tag:man made=antenna
@@ -36534,8 +38054,10 @@ zh-hans:
     power=transformer: Zh-hans:Tag:power=transformer
     public_transport=platform: Zh-hans:Tag:public transport=platform
     public_transport=stop_position: Zh-hans:Tag:public transport=stop position
+    railway=disused: Zh-hans:Tag:railway=disused
     railway=light_rail: Zh-hans:Tag:railway=light rail
     railway=monorail: Zh-hans:Tag:railway=monorail
+    railway=narrow_gauge: Zh-hans:Tag:railway=narrow gauge
     railway=subway: Zh-hans:Tag:railway=subway
     railway=subway_entrance: Zh-hans:Tag:railway=subway entrance
     railway=traverser: Zh-hans:Tag:railway=traverser
@@ -36552,7 +38074,9 @@ zh-hans:
     route=subway: Zh-hans:Tag:route=subway
     service=drive-through: Zh-hans:Tag:service=drive-through
     service=parking_aisle: Zh-hans:Tag:service=parking aisle
+    shop=bakery: Zh-hans:Tag:shop=bakery
     shop=confectionery: Zh-hans:Tag:shop=confectionery
+    shop=funeral_directors: Zh-hans:Tag:shop=funeral directors
     shop=storage_rental: Zh-hans:Tag:shop=storage rental
     sport=karting: Zh-hans:Tag:sport=karting
     sport=motocross: Zh-hans:Tag:sport=motocross
@@ -36565,6 +38089,7 @@ zh-hans:
     surface=tartan: Zh-hans:Tag:surface=tartan
     tourism=aquarium: Zh-hans:Tag:tourism=aquarium
     tourism=attraction: Zh-hans:Tag:tourism=attraction
+    tourism=hotel: Zh-hans:Tag:tourism=hotel
     tourism=information: Zh-hans:Tag:tourism=information
     vending=ice_cream: Zh-hans:Tag:vending=ice cream
     waterway=ditch: Zh-hans:Tag:waterway=ditch
@@ -36622,6 +38147,7 @@ zh-hant:
     amenity=toilets: Zh-hant:Tag:amenity=toilets
     barrier=toll_booth: Zh-hant:Tag:barrier=toll booth
     building=roof: Zh-hant:Tag:building=roof
+    emergency=defibrillator: Zh-hant:Tag:emergency=defibrillator
     healthcare=postpartum_care: Zh-hant:Tag:healthcare=postpartum care
     highway=bus_guideway: Zh-hant:Tag:highway=bus guideway
     highway=bus_stop: Zh-hant:Tag:highway=bus stop


### PR DESCRIPTION
### Description
Link all current tag documentation wiki pages (including Key:name:en-boont, my motivation for doing this)

I did the following (derived from https://github.com/openstreetmap/openstreetmap-website/pull/3294):

```
$ sw_vers 
ProductName:		macOS
ProductVersion:		26.4.1
BuildVersion:		25E253
$ perl -v
This is perl 5, version 34, subversion 3 (v5.34.3) built for darwin-thread-multi-2level
...
# ↑ Perl 5 is already installed on my laptop
$ which perl
/opt/local/bin/perl
# ↑ My installation of perl is owned by root, so cpan will need to use sudo
$ cpan -I MediaWiki::API YAML::XS LWP::Protocol::https # I needed one more library than matkoniecz
# When prompted, tell cpan to be as automatic as possible, and to use sudo
# Fork https://github.com/openstreetmap/openstreetmap-website/
$ git clone git@github.com:dschweisguth/openstreetmap-website.git
$ cd openstreetmap-website
$ git checkout -b run-update-wiki-pages
$ date # next time I'd run 'time script/misc/update-wiki-pages' instead
$ script/misc/update-wiki-pages
...
ok 320 - Got a total of 16403 keys
ok 321 - Got a total of 1055 keyprefixs
ok 322 - Got a total of 145 changesetkeys
ok 323 - Got a total of 28608 values
1..323
$ date
# date - start date = 7:56:13
$ git commit -am "Run script/misc/update-wiki-pages"
[run-update-wiki-pages f1803757a] Run script/misc/update-wiki-pages
 1 file changed, 1551 insertions(+), 25 deletions(-)
$ git push -u origin HEAD
# On Github web site, follow prompts to create pull request
```

### How has this been tested?
I inspected the diff. Key:name:en-boont is now present. I spot-checked a couple of deletions; those wiki pages have indeed been removed or redirected.

I haven't been able to run tests. If someone else who's already set up to do so feels like running the tests on this branch, please comment. If the data-only nature of this change means that running the tests is unnecessary, please merge.