### PR TITLE
Improve parameter validation using rails parameter methods

### DIFF
--- a/app/controllers/api/changeset_comments/visibilities_controller.rb
+++ b/app/controllers/api/changeset_comments/visibilities_controller.rb
@@ -17,7 +17,7 @@ module Api
         raise OSM::APIBadUserInput, "No id was given" unless params[:changeset_comment_id]
 
         # Extract the arguments
-        changeset_comment_id = params[:changeset_comment_id].to_i
+        changeset_comment_id = params.expect(:changeset_comment_id).to_i
 
         # Find the changeset
         comment = ChangesetComment.find(changeset_comment_id)
@@ -41,7 +41,7 @@ module Api
         raise OSM::APIBadUserInput, "No id was given" unless params[:changeset_comment_id]
 
         # Extract the arguments
-        changeset_comment_id = params[:changeset_comment_id].to_i
+        changeset_comment_id = params.expect(:changeset_comment_id).to_i
 
         # Find the changeset
         comment = ChangesetComment.find(changeset_comment_id)

--- a/app/controllers/api/changeset_comments_controller.rb
+++ b/app/controllers/api/changeset_comments_controller.rb
@@ -31,7 +31,7 @@ module Api
       raise OSM::APIRateLimitExceeded if rate_limit_exceeded?
 
       # Extract the arguments
-      changeset_id = params[:changeset_id].to_i
+      changeset_id = params.expect(:changeset_id).to_i
       body = params[:text]
 
       # Find the changeset and check it is valid

--- a/app/controllers/api/changeset_subscriptions_controller.rb
+++ b/app/controllers/api/changeset_subscriptions_controller.rb
@@ -17,7 +17,7 @@ module Api
       raise OSM::APIBadUserInput, "No id was given" unless params[:changeset_id]
 
       # Extract the arguments
-      changeset_id = params[:changeset_id].to_i
+      changeset_id = params.expect(:changeset_id).to_i
 
       # Find the changeset and check it is valid
       @changeset = Changeset.find(changeset_id)
@@ -39,7 +39,7 @@ module Api
       raise OSM::APIBadUserInput, "No id was given" unless params[:changeset_id]
 
       # Extract the arguments
-      changeset_id = params[:changeset_id].to_i
+      changeset_id = params.expect(:changeset_id).to_i
 
       # Find the changeset and check it is valid
       @changeset = Changeset.find(changeset_id)

--- a/app/controllers/api/changesets/closes_controller.rb
+++ b/app/controllers/api/changesets/closes_controller.rb
@@ -17,7 +17,7 @@ module Api
       # marks a changeset as closed. this may be called multiple times
       # on the same changeset, so is idempotent.
       def update
-        changeset = Changeset.find(params[:changeset_id])
+        changeset = Changeset.find(params.expect(:changeset_id))
         check_changeset_consistency(changeset, current_user)
 
         # to close the changeset, we'll just set its closed_at time to

--- a/app/controllers/api/changesets/downloads_controller.rb
+++ b/app/controllers/api/changesets/downloads_controller.rb
@@ -22,7 +22,7 @@ module Api
       # behaviour cannot be guaranteed anyway and is the result of a design
       # choice.
       def show
-        changeset = Changeset.find(params[:changeset_id])
+        changeset = Changeset.find(params.expect(:changeset_id))
 
         # get all the elements in the changeset which haven't been redacted
         # and stick them in a big array.

--- a/app/controllers/api/changesets/uploads_controller.rb
+++ b/app/controllers/api/changesets/uploads_controller.rb
@@ -29,7 +29,7 @@ module Api
       # http://wiki.openstreetmap.org/wiki/OSM_Protocol_Version_0.6
       def create
         Changeset.transaction do
-          changeset = Changeset.lock.find(params[:changeset_id])
+          changeset = Changeset.lock.find(params.expect(:changeset_id))
           check_changeset_consistency(changeset, current_user)
 
           diff_reader = DiffReader.new(request.raw_post, changeset)

--- a/app/controllers/api/changesets_controller.rb
+++ b/app/controllers/api/changesets_controller.rb
@@ -60,7 +60,7 @@ module Api
     # Return XML giving the basic info about the changeset. Does not
     # return anything about the nodes, ways and relations in the changeset.
     def show
-      @changeset = Changeset.find(params[:id])
+      @changeset = Changeset.find(params.expect(:id))
       if params[:include_discussion].presence
         @comments = @changeset.comments
         @comments = @comments.unscope(:where => :visible) if params[:show_hidden_comments].presence && can?(:create, :changeset_comment_visibility)
@@ -96,7 +96,7 @@ module Api
     #
     # after succesful update, returns the XML of the changeset.
     def update
-      @changeset = Changeset.find(params[:id])
+      @changeset = Changeset.find(params.expect(:id))
       new_changeset = Changeset.from_xml(request.raw_post)
 
       check_changeset_consistency(@changeset, current_user)

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -14,7 +14,7 @@ module Api
 
     # Dump the details on a message given in params[:id]
     def show
-      @message = Message.includes(:sender, :recipient).find(params[:id])
+      @message = Message.includes(:sender, :recipient).find(params.expect(:id))
 
       raise OSM::APIAccessDenied if current_user.id != @message.from_user_id && current_user.id != @message.to_user_id
 
@@ -33,10 +33,10 @@ module Api
 
       # Extract the arguments
       if params[:recipient_id]
-        recipient_id = params[:recipient_id].to_i
+        recipient_id = params.expect(:recipient_id).to_i
         recipient = User.find(recipient_id)
       elsif params[:recipient]
-        recipient_display_name = params[:recipient]
+        recipient_display_name = params.expect(:recipient)
         recipient = User.find_by(:display_name => recipient_display_name)
       else
         raise OSM::APIBadUserInput, "No recipient was given"
@@ -63,7 +63,7 @@ module Api
 
     # Update read status of a message
     def update
-      @message = Message.find(params[:id])
+      @message = Message.find(params.expect(:id))
       read_status_idx = %w[true false].index params[:read_status]
 
       raise OSM::APIBadUserInput, "Invalid value of `read_status` was given" if read_status_idx.nil?
@@ -81,7 +81,7 @@ module Api
 
     # Delete message by marking it as not visible for the current user
     def destroy
-      @message = Message.find(params[:id])
+      @message = Message.find(params.expect(:id))
       if current_user.id == @message.from_user_id
         @message.from_user_visible = false
       elsif current_user.id == @message.to_user_id

--- a/app/controllers/api/nodes_controller.rb
+++ b/app/controllers/api/nodes_controller.rb
@@ -15,9 +15,9 @@ module Api
 
     # Dump the details on many nodes whose ids are given in the "nodes" parameter.
     def index
-      raise OSM::APIBadUserInput, "The parameter nodes is required, and must be of the form nodes=id[,id[,id...]]" unless params["nodes"]
+      raise OSM::APIBadUserInput, "The parameter nodes is required, and must be of the form nodes=id[,id[,id...]]" unless params[:nodes]
 
-      ids = params["nodes"].split(",").collect(&:to_i)
+      ids = params.extract_value(:nodes, :delimiter => ",").collect(&:to_i)
 
       raise OSM::APIBadUserInput, "No nodes were given to search for" if ids.empty?
 
@@ -32,7 +32,7 @@ module Api
 
     # Dump the details on a node given in params[:id]
     def show
-      @node = Node.includes(:element_tags).find(params[:id])
+      @node = Node.includes(:element_tags).find(params.expect(:id))
 
       response.last_modified = @node.timestamp
 
@@ -60,7 +60,7 @@ module Api
 
     # Update a node from given XML
     def update
-      node = Node.find(params[:id])
+      node = Node.find(params.expect(:id))
       new_node = Node.from_xml(request.raw_post)
 
       raise OSM::APIBadUserInput, "The id in the url (#{node.id}) is not the same as provided in the xml (#{new_node.id})" unless new_node && new_node.id == node.id
@@ -76,7 +76,7 @@ module Api
     # in a wiki-like way. We therefore treat it like an update, so the delete
     # method returns the new version number.
     def destroy
-      node = Node.find(params[:id])
+      node = Node.find(params.expect(:id))
       new_node = Node.from_xml(request.raw_post)
 
       raise OSM::APIBadUserInput, "The id in the url (#{node.id}) is not the same as provided in the xml (#{new_node.id})" unless new_node && new_node.id == node.id

--- a/app/controllers/api/note_subscriptions_controller.rb
+++ b/app/controllers/api/note_subscriptions_controller.rb
@@ -8,7 +8,7 @@ module Api
     authorize_resource
 
     def create
-      note_id = params[:note_id].to_i
+      note_id = params.expect(:note_id).to_i
       note = Note.find(note_id)
       note.subscribers << current_user
     rescue ActiveRecord::RecordNotFound
@@ -18,7 +18,7 @@ module Api
     end
 
     def destroy
-      note_id = params[:note_id].to_i
+      note_id = params.expect(:note_id).to_i
       note = Note.find(note_id)
       count = note.subscriptions.where(:user => current_user).delete_all
       report_error "You are not subscribed to note #{note_id}.", :not_found if count.zero?

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -60,7 +60,7 @@ module Api
       raise OSM::APIBadUserInput, "No id was given" unless params[:id]
 
       # Find the note and check it is valid
-      @note = Note.find(params[:id])
+      @note = Note.find(params.expect(:id))
       raise OSM::APINotFoundError unless @note
       raise OSM::APIAlreadyDeletedError.new("note", @note.id) unless @note.visible? || current_user&.moderator?
 
@@ -121,7 +121,7 @@ module Api
       raise OSM::APIBadUserInput, "No id was given" unless params[:id]
 
       # Extract the arguments
-      id = params[:id].to_i
+      id = params.expect(:id).to_i
       comment = params[:text]
 
       # Find the note and check it is valid
@@ -152,8 +152,8 @@ module Api
       raise OSM::APIBadUserInput, "No text was given" if params[:text].blank?
 
       # Extract the arguments
-      id = params[:id].to_i
-      comment = params[:text]
+      id = params.expect(:id).to_i
+      comment = params.expect(:text)
 
       # Find the note and check it is valid
       Note.transaction do
@@ -180,7 +180,7 @@ module Api
       raise OSM::APIBadUserInput, "No id was given" unless params[:id]
 
       # Extract the arguments
-      id = params[:id].to_i
+      id = params.expect(:id).to_i
       comment = params[:text]
 
       # Find the note and check it is valid
@@ -210,7 +210,7 @@ module Api
       raise OSM::APIBadUserInput, "No id was given" unless params[:id]
 
       # Extract the arguments
-      id = params[:id].to_i
+      id = params.expect(:id).to_i
       comment = params[:text]
 
       # Find the note and check it is valid
@@ -318,7 +318,7 @@ module Api
     # on their status and the user's request parameters
     def closed_condition(notes)
       closed_since = if params[:closed]
-                       params[:closed].to_i.days
+                       params.expect(:closed).to_i.days
                      else
                        Note::DEFAULT_FRESHLY_CLOSED_LIMIT
                      end

--- a/app/controllers/api/old_nodes/redactions_controller.rb
+++ b/app/controllers/api/old_nodes/redactions_controller.rb
@@ -6,7 +6,7 @@ module Api
       private
 
       def lookup_old_element
-        @old_element = OldNode.find([params[:node_id], params[:version]])
+        @old_element = OldNode.find(params.expect(:node_id, :version))
       end
     end
   end

--- a/app/controllers/api/old_nodes_controller.rb
+++ b/app/controllers/api/old_nodes_controller.rb
@@ -7,7 +7,7 @@ module Api
     def lookup_old_element
       @old_element = OldNode
                      .includes(:old_tags)
-                     .find([params[:node_id], params[:version]])
+                     .find(params.expect(:node_id, :version))
     end
 
     def lookup_old_element_versions

--- a/app/controllers/api/old_relations/redactions_controller.rb
+++ b/app/controllers/api/old_relations/redactions_controller.rb
@@ -6,7 +6,7 @@ module Api
       private
 
       def lookup_old_element
-        @old_element = OldRelation.find([params[:relation_id], params[:version]])
+        @old_element = OldRelation.find(params.expect(:relation_id, :version))
       end
     end
   end

--- a/app/controllers/api/old_relations_controller.rb
+++ b/app/controllers/api/old_relations_controller.rb
@@ -7,7 +7,7 @@ module Api
     def lookup_old_element
       @old_element = OldRelation
                      .includes(:old_members, :old_tags)
-                     .find([params[:relation_id], params[:version]])
+                     .find(params.expect(:relation_id, :version))
     end
 
     def lookup_old_element_versions

--- a/app/controllers/api/old_ways/redactions_controller.rb
+++ b/app/controllers/api/old_ways/redactions_controller.rb
@@ -6,7 +6,7 @@ module Api
       private
 
       def lookup_old_element
-        @old_element = OldWay.find([params[:way_id], params[:version]])
+        @old_element = OldWay.find(params.expect(:way_id, :version))
       end
     end
   end

--- a/app/controllers/api/old_ways_controller.rb
+++ b/app/controllers/api/old_ways_controller.rb
@@ -7,7 +7,7 @@ module Api
     def lookup_old_element
       @old_element = OldWay
                      .includes(:old_nodes, :old_tags)
-                     .find([params[:way_id], params[:version]])
+                     .find(params.expect(:way_id, :version))
     end
 
     def lookup_old_element_versions

--- a/app/controllers/api/relations_controller.rb
+++ b/app/controllers/api/relations_controller.rb
@@ -12,9 +12,9 @@ module Api
     before_action :check_rate_limit, :only => [:create, :update, :destroy]
 
     def index
-      raise OSM::APIBadUserInput, "The parameter relations is required, and must be of the form relations=id[,id[,id...]]" unless params["relations"]
+      raise OSM::APIBadUserInput, "The parameter relations is required, and must be of the form relations=id[,id[,id...]]" unless params[:relations]
 
-      ids = params["relations"].split(",").collect(&:to_i)
+      ids = params.extract_value(:relations, :delimiter => ",").collect(&:to_i)
 
       raise OSM::APIBadUserInput, "No relations were given to search for" if ids.empty?
 
@@ -28,7 +28,7 @@ module Api
     end
 
     def show
-      relation = Relation.includes(:relation_members, :element_tags).find(params[:id])
+      relation = Relation.includes(:relation_members, :element_tags).find(params.expect(:id))
 
       response.last_modified = relation.timestamp unless params[:full]
 
@@ -107,7 +107,7 @@ module Api
     end
 
     def update
-      relation = Relation.find(params[:id])
+      relation = Relation.find(params.expect(:id))
       new_relation = Relation.from_xml(request.raw_post)
 
       raise OSM::APIBadUserInput, "The id in the url (#{relation.id}) is not the same as provided in the xml (#{new_relation.id})" unless new_relation && new_relation.id == relation.id
@@ -120,7 +120,7 @@ module Api
     end
 
     def destroy
-      relation = Relation.find(params[:id])
+      relation = Relation.find(params.expect(:id))
       new_relation = Relation.from_xml(request.raw_post)
       if new_relation && new_relation.id == relation.id
         Changeset.transaction do

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -8,7 +8,7 @@ module Api
     # within the specified bounding box, and in the specified page.
     def index
       # retrieve the page number
-      page = params["page"].to_s.to_i
+      page = params.fetch(:page, "0").to_i
 
       unless page >= 0
         report_error("Page number must be greater than or equal to 0")

--- a/app/controllers/api/traces/data_controller.rb
+++ b/app/controllers/api/traces/data_controller.rb
@@ -11,7 +11,7 @@ module Api
       before_action :offline_error
 
       def show
-        trace = Trace.visible.find(params[:trace_id])
+        trace = Trace.visible.find(params.expect(:trace_id))
 
         if trace.public? || trace.user == current_user
           if request.format == Mime[:xml]

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -13,7 +13,7 @@ module Api
     skip_around_action :api_call_timeout, :only => :create
 
     def show
-      @trace = Trace.visible.find(params[:id])
+      @trace = Trace.visible.find(params.expect(:id))
 
       return head :forbidden unless @trace.public? || @trace.user == current_user
 
@@ -29,14 +29,14 @@ module Api
       visibility = params[:visibility]
 
       if visibility.nil?
-        visibility = if params[:public]&.to_i&.nonzero?
+        visibility = if params.fetch(:public, "0").to_i.nonzero?
                        "public"
                      else
                        "private"
                      end
       end
 
-      if params[:file].respond_to?(:read)
+      if params.expect(:file).respond_to?(:read)
         trace = do_create(params[:file], tags, description, visibility)
 
         if trace.id
@@ -53,7 +53,7 @@ module Api
     end
 
     def update
-      trace = Trace.visible.find(params[:id])
+      trace = Trace.visible.find(params.expect(:id))
 
       if trace.user == current_user
         trace.update_from_xml(request.raw_post)
@@ -66,7 +66,7 @@ module Api
     end
 
     def destroy
-      trace = Trace.visible.find(params[:id])
+      trace = Trace.visible.find(params.expect(:id))
 
       if trace.user == current_user
         trace.visible = false

--- a/app/controllers/api/user_blocks_controller.rb
+++ b/app/controllers/api/user_blocks_controller.rb
@@ -12,7 +12,7 @@ module Api
     def show
       raise OSM::APIBadUserInput, "No id was given" unless params[:id]
 
-      @user_block = UserBlock.find(params[:id])
+      @user_block = UserBlock.find(params.expect(:id))
     rescue ActiveRecord::RecordNotFound
       raise OSM::APINotFoundError
     end

--- a/app/controllers/api/user_preferences_controller.rb
+++ b/app/controllers/api/user_preferences_controller.rb
@@ -24,7 +24,7 @@ module Api
     ##
     # return the value for a single preference
     def show
-      pref = UserPreference.find([current_user.id, params[:preference_key]])
+      pref = UserPreference.find([current_user.id, params.expect(:preference_key)])
 
       render :plain => pref.v.to_s
     end
@@ -60,7 +60,7 @@ module Api
     # update the value of a single preference
     def update
       begin
-        pref = UserPreference.find([current_user.id, params[:preference_key]])
+        pref = UserPreference.find([current_user.id, params.expect(:preference_key)])
       rescue ActiveRecord::RecordNotFound
         pref = UserPreference.new
         pref.user = current_user
@@ -76,7 +76,7 @@ module Api
     ##
     # delete a single preference
     def destroy
-      UserPreference.find([current_user.id, params[:preference_key]]).delete
+      UserPreference.find([current_user.id, params.expect(:preference_key)]).delete
 
       render :plain => ""
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -12,9 +12,9 @@ module Api
     before_action :set_request_formats
 
     def index
-      raise OSM::APIBadUserInput, "The parameter users is required, and must be of the form users=id[,id[,id...]]" unless params["users"]
+      raise OSM::APIBadUserInput, "The parameter users is required, and must be of the form users=id[,id[,id...]]" unless params[:users]
 
-      ids = params["users"].split(",").collect(&:to_i)
+      ids = params.extract_value(:users, :delimiter => ",").collect(&:to_i)
 
       raise OSM::APIBadUserInput, "No users were given to search for" if ids.empty?
 

--- a/app/controllers/api/ways_controller.rb
+++ b/app/controllers/api/ways_controller.rb
@@ -12,9 +12,9 @@ module Api
     before_action :check_rate_limit, :only => [:create, :update, :destroy]
 
     def index
-      raise OSM::APIBadUserInput, "The parameter ways is required, and must be of the form ways=id[,id[,id...]]" unless params["ways"]
+      raise OSM::APIBadUserInput, "The parameter ways is required, and must be of the form ways=id[,id[,id...]]" unless params[:ways]
 
-      ids = params["ways"].split(",").collect(&:to_i)
+      ids = params.extract_value(:ways, :delimiter => ",").collect(&:to_i)
 
       raise OSM::APIBadUserInput, "No ways were given to search for" if ids.empty?
 
@@ -31,7 +31,7 @@ module Api
       @way = Way
       @way = @way.includes(:nodes, :element_tags)
       @way = @way.includes(:nodes => :element_tags) if params[:full]
-      @way = @way.find(params[:id])
+      @way = @way.find(params.expect(:id))
 
       response.last_modified = @way.timestamp unless params[:full]
 
@@ -64,7 +64,7 @@ module Api
     end
 
     def update
-      way = Way.find(params[:id])
+      way = Way.find(params.expect(:id))
       new_way = Way.from_xml(request.raw_post)
 
       raise OSM::APIBadUserInput, "The id in the url (#{way.id}) is not the same as provided in the xml (#{new_way.id})" unless new_way && new_way.id == way.id
@@ -78,7 +78,7 @@ module Api
 
     # This is the API call to delete a way
     def destroy
-      way = Way.find(params[:id])
+      way = Way.find(params.expect(:id))
       new_way = Way.from_xml(request.raw_post)
 
       if new_way && new_way.id == way.id

--- a/app/controllers/changeset_comments/feeds_controller.rb
+++ b/app/controllers/changeset_comments/feeds_controller.rb
@@ -17,7 +17,7 @@ module ChangesetComments
     def show
       if params[:changeset_id]
         # Extract the arguments
-        changeset_id = params[:changeset_id].to_i
+        changeset_id = params.expect(:changeset_id).to_i
 
         # Find the changeset
         changeset = Changeset.find(changeset_id)

--- a/app/controllers/changeset_subscriptions_controller.rb
+++ b/app/controllers/changeset_subscriptions_controller.rb
@@ -12,14 +12,14 @@ class ChangesetSubscriptionsController < ApplicationController
   around_action :web_timeout
 
   def show
-    @changeset = Changeset.find(params[:changeset_id])
+    @changeset = Changeset.find(params.expect(:changeset_id))
     @subscribed = @changeset.subscribers.include?(current_user)
   rescue ActiveRecord::RecordNotFound
     render :action => "no_such_entry", :status => :not_found
   end
 
   def create
-    @changeset = Changeset.find(params[:changeset_id])
+    @changeset = Changeset.find(params.expect(:changeset_id))
 
     @changeset.subscribers << current_user unless @changeset.subscribers.include?(current_user)
 
@@ -29,7 +29,7 @@ class ChangesetSubscriptionsController < ApplicationController
   end
 
   def destroy
-    @changeset = Changeset.find(params[:changeset_id])
+    @changeset = Changeset.find(params.expect(:changeset_id))
 
     @changeset.subscribers.delete(current_user)
 

--- a/app/controllers/changesets_controller.rb
+++ b/app/controllers/changesets_controller.rb
@@ -82,7 +82,7 @@ class ChangesetsController < ApplicationController
 
   def show
     @type = "changeset"
-    @changeset = Changeset.find(params[:id])
+    @changeset = Changeset.find(params.expect(:id))
     case turbo_frame_request_id
     when "changeset_nodes"
       load_nodes
@@ -160,7 +160,7 @@ class ChangesetsController < ApplicationController
 
   def load_nodes
     @nodes_count = @changeset.actual_num_changed_nodes
-    @current_node_page = params[:node_page].to_i.clamp(1, element_pages_count(@nodes_count))
+    @current_node_page = params.fetch(:node_page, "1").to_i.clamp(1, element_pages_count(@nodes_count))
     @nodes = @changeset.old_nodes
                        .order(:node_id, :version)
                        .offset(ELEMENTS_PER_PAGE * (@current_node_page - 1))
@@ -169,7 +169,7 @@ class ChangesetsController < ApplicationController
 
   def load_ways
     @ways_count = @changeset.actual_num_changed_ways
-    @current_way_page = params[:way_page].to_i.clamp(1, element_pages_count(@ways_count))
+    @current_way_page = params.fetch(:way_page, "1").to_i.clamp(1, element_pages_count(@ways_count))
     @ways = @changeset.old_ways
                       .order(:way_id, :version)
                       .offset(ELEMENTS_PER_PAGE * (@current_way_page - 1))
@@ -178,7 +178,7 @@ class ChangesetsController < ApplicationController
 
   def load_relations
     @relations_count = @changeset.actual_num_changed_relations
-    @current_relation_page = params[:relation_page].to_i.clamp(1, element_pages_count(@relations_count))
+    @current_relation_page = params.fetch(:relation_page, "1").to_i.clamp(1, element_pages_count(@relations_count))
     @relations = @changeset.old_relations
                            .order(:relation_id, :version)
                            .offset(ELEMENTS_PER_PAGE * (@current_relation_page - 1))

--- a/app/controllers/concerns/query_methods.rb
+++ b/app/controllers/concerns/query_methods.rb
@@ -82,8 +82,8 @@ module QueryMethods
     max_limit = Settings["max_#{name}_query_limit"]
     default_limit = Settings["default_#{name}_query_limit"]
     if params[:limit]
-      if params[:limit].to_i.positive? && params[:limit].to_i <= max_limit
-        params[:limit].to_i
+      if params.expect(:limit).to_i.positive? && params.expect(:limit).to_i <= max_limit
+        params.expect(:limit).to_i
       else
         raise OSM::APIBadUserInput, "#{controller_name.classify} limit must be between 1 and #{max_limit}"
       end

--- a/app/controllers/diary_comments_controller.rb
+++ b/app/controllers/diary_comments_controller.rb
@@ -14,7 +14,7 @@ class DiaryCommentsController < ApplicationController
   allow_thirdparty_images :only => :create
 
   def create
-    @diary_entry = DiaryEntry.find(params[:id])
+    @diary_entry = DiaryEntry.find(params.expect(:id))
     @comments = @diary_entry.visible_comments
     @diary_comment = @diary_entry.comments.build(comment_params)
     @diary_comment.user = current_user
@@ -35,13 +35,13 @@ class DiaryCommentsController < ApplicationController
   end
 
   def hide
-    comment = DiaryComment.find(params[:comment])
+    comment = DiaryComment.find(params.expect(:comment))
     comment.update(:visible => false)
     redirect_to diary_entry_path(comment.diary_entry.user, comment.diary_entry)
   end
 
   def unhide
-    comment = DiaryComment.find(params[:comment])
+    comment = DiaryComment.find(params.expect(:comment))
     comment.update(:visible => true)
     redirect_to diary_entry_path(comment.diary_entry.user, comment.diary_entry)
   end

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -41,7 +41,7 @@ class DiaryEntriesController < ApplicationController
       entries = DiaryEntry.joins(:user).where(:users => { :status => %w[active confirmed] })
 
       if params[:language]
-        @title = t ".in_language_title", :language => Language.find(params[:language]).english_name
+        @title = t ".in_language_title", :language => Language.find(params.expect(:language)).english_name
         entries = entries.where(:language_code => params[:language])
       else
         candidate_codes = preferred_languages.flat_map(&:candidates).uniq.map(&:to_s)
@@ -86,7 +86,7 @@ class DiaryEntriesController < ApplicationController
 
   def edit
     @title = t ".title"
-    @diary_entry = DiaryEntry.find(params[:id])
+    @diary_entry = DiaryEntry.find(params.expect(:id))
 
     redirect_to diary_entry_path(@diary_entry.user, @diary_entry) if current_user != @diary_entry.user
 
@@ -115,7 +115,7 @@ class DiaryEntriesController < ApplicationController
 
   def update
     @title = t "diary_entries.edit.title"
-    @diary_entry = DiaryEntry.find(params[:id])
+    @diary_entry = DiaryEntry.find(params.expect(:id))
 
     if cannot?(:update, @diary_entry) ||
        (params[:diary_entry] && @diary_entry.update(entry_params))
@@ -129,7 +129,7 @@ class DiaryEntriesController < ApplicationController
   end
 
   def subscribe
-    @diary_entry = DiaryEntry.find(params[:id])
+    @diary_entry = DiaryEntry.find(params.expect(:id))
 
     if request.post?
       @diary_entry.subscriptions.create(:user => current_user) unless @diary_entry.subscribers.exists?(current_user.id)
@@ -141,7 +141,7 @@ class DiaryEntriesController < ApplicationController
   end
 
   def unsubscribe
-    @diary_entry = DiaryEntry.find(params[:id])
+    @diary_entry = DiaryEntry.find(params.expect(:id))
 
     if request.post?
       @diary_entry.subscriptions.where(:user => current_user).delete_all if @diary_entry.subscribers.exists?(current_user.id)
@@ -174,8 +174,8 @@ class DiaryEntriesController < ApplicationController
 
       if params[:language]
         @entries = @entries.where(:language_code => params[:language])
-        @title = t("diary_entries.feed.language.title", :language_name => Language.find(params[:language]).english_name)
-        @description = t("diary_entries.feed.language.description", :language_name => Language.find(params[:language]).english_name)
+        @title = t("diary_entries.feed.language.title", :language_name => Language.find(params.expect(:language)).english_name)
+        @description = t("diary_entries.feed.language.description", :language_name => Language.find(params.expect(:language)).english_name)
         @link = url_for :action => "index", :language => params[:language], :host => Settings.server_url, :protocol => Settings.server_protocol
       else
         @title = t("diary_entries.feed.all.title")
@@ -187,13 +187,13 @@ class DiaryEntriesController < ApplicationController
   end
 
   def hide
-    entry = DiaryEntry.find(params[:id])
+    entry = DiaryEntry.find(params.expect(:id))
     entry.update(:visible => false)
     redirect_to :action => "index", :display_name => entry.user.display_name
   end
 
   def unhide
-    entry = DiaryEntry.find(params[:id])
+    entry = DiaryEntry.find(params.expect(:id))
     entry.update(:visible => true)
     redirect_to :action => "index", :display_name => entry.user.display_name
   end

--- a/app/controllers/issue_comments_controller.rb
+++ b/app/controllers/issue_comments_controller.rb
@@ -12,7 +12,7 @@ class IssueCommentsController < ApplicationController
   before_action :check_database_writable, :only => [:create]
 
   def create
-    @issue = Issue.find(params[:issue_id])
+    @issue = Issue.find(params.expect(:issue_id))
     comment = @issue.comments.build(issue_comment_params)
     comment.user = current_user
     comment.save!

--- a/app/controllers/issues/reporters_controller.rb
+++ b/app/controllers/issues/reporters_controller.rb
@@ -11,7 +11,7 @@ module Issues
     authorize_resource :issue
 
     def index
-      @issue = Issue.visible_to(current_user).find(params[:issue_id])
+      @issue = Issue.visible_to(current_user).find(params.expect(:issue_id))
 
       user_ids = @issue.reports.reorder(:created_at => :desc).pluck(:user_id).uniq
       @unique_reporters = {

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -41,7 +41,7 @@ class IssuesController < ApplicationController
     @issues = @issues.where(:reportable_type => params[:issue_type]) if params[:issue_type].present?
 
     if params[:last_updated_by].present?
-      last_updated_by = params[:last_updated_by].to_s == "nil" ? nil : params[:last_updated_by].to_i
+      last_updated_by = params.expect(:last_updated_by).to_s == "nil" ? nil : params.expect(:last_updated_by).to_i
       @issues = @issues.where(:updated_by => last_updated_by)
     end
 
@@ -100,7 +100,7 @@ class IssuesController < ApplicationController
   private
 
   def find_issue
-    @issue = Issue.visible_to(current_user).find(params[:id])
+    @issue = Issue.visible_to(current_user).find(params.expect(:id))
   rescue ActiveRecord::RecordNotFound
     redirect_to :controller => "errors", :action => "not_found"
   end

--- a/app/controllers/messages/mutes_controller.rb
+++ b/app/controllers/messages/mutes_controller.rb
@@ -14,7 +14,7 @@ module Messages
 
     # Moves message into Inbox by unsetting the muted-flag
     def destroy
-      message = current_user.muted_messages.find(params[:message_id])
+      message = current_user.muted_messages.find(params.expect(:message_id))
 
       if message.unmute
         flash[:notice] = t(".notice")

--- a/app/controllers/messages/read_marks_controller.rb
+++ b/app/controllers/messages/read_marks_controller.rb
@@ -23,7 +23,7 @@ module Messages
     private
 
     def mark(message_read)
-      @message = current_user.messages.unscope(:where => :muted).find(params[:message_id])
+      @message = current_user.messages.unscope(:where => :muted).find(params.expect(:message_id))
       @message.message_read = message_read
       if @message.save
         flash[:notice] = t ".notice"

--- a/app/controllers/messages/replies_controller.rb
+++ b/app/controllers/messages/replies_controller.rb
@@ -16,7 +16,7 @@ module Messages
 
     # Allow the user to reply to another message.
     def new
-      message = Message.find(params[:message_id])
+      message = Message.find(params.expect(:message_id))
 
       if message.recipient == current_user
         message.update(:message_read => true)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,7 +19,7 @@ class MessagesController < ApplicationController
   # Show a message
   def show
     @title = t ".title"
-    @message = Message.find(params[:id])
+    @message = Message.find(params.expect(:id))
 
     if @message.recipient == current_user || @message.sender == current_user
       @message.message_read = true if @message.recipient == current_user
@@ -60,7 +60,7 @@ class MessagesController < ApplicationController
 
   # Destroy the message.
   def destroy
-    @message = Message.where(:recipient => current_user).or(Message.where(:sender => current_user.id)).find(params[:id])
+    @message = Message.where(:recipient => current_user).or(Message.where(:sender => current_user.id)).find(params.expect(:id))
     @message.from_user_visible = false if @message.sender == current_user
     @message.to_user_visible = false if @message.recipient == current_user
     if @message.save

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -3,7 +3,7 @@
 class NodesController < ElementsController
   def show
     @type = "node"
-    @feature = Node.preload(:element_tags, :containing_relation_members, :changeset => [:changeset_tags, :user], :ways => :element_tags).find(params[:id])
+    @feature = Node.preload(:element_tags, :containing_relation_members, :changeset => [:changeset_tags, :user], :ways => :element_tags).find(params.expect(:id))
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -42,10 +42,10 @@ class NotesController < ApplicationController
     @type = "note"
 
     if current_user&.moderator?
-      @note = Note.find(params[:id])
+      @note = Note.find(params.expect(:id))
       @note_comments = @note.comments.unscope(:where => :visible)
     else
-      @note = Note.visible.find(params[:id])
+      @note = Note.visible.find(params.expect(:id))
       @note_comments = @note.comments
     end
 

--- a/app/controllers/oauth2_applications_controller.rb
+++ b/app/controllers/oauth2_applications_controller.rb
@@ -16,7 +16,7 @@ class Oauth2ApplicationsController < Doorkeeper::ApplicationsController
   private
 
   def set_application
-    @application = current_resource_owner&.oauth2_applications&.find(params[:id])
+    @application = current_resource_owner&.oauth2_applications&.find(params.expect(:id))
   rescue ActiveRecord::RecordNotFound
     render :action => "not_found", :status => :not_found
   end

--- a/app/controllers/old_nodes_controller.rb
+++ b/app/controllers/old_nodes_controller.rb
@@ -3,7 +3,7 @@
 class OldNodesController < OldElementsController
   def index
     @type = "node"
-    @current_feature = @feature = Node.preload(:element_tags).find(params[:id])
+    @current_feature = @feature = Node.preload(:element_tags).find(params.expect(:id))
     @old_features = get_page_items(
       OldNode.where(:node_id => params[:id]),
       :cursor_column => :version,
@@ -20,8 +20,8 @@ class OldNodesController < OldElementsController
 
   def show
     @type = "node"
-    @current_feature = Node.find(params[:id])
-    @feature = OldNode.preload(:old_tags, :changeset => [:changeset_tags, :user]).find([params[:id], params[:version]])
+    @current_feature = Node.find(params.expect(:id))
+    @feature = OldNode.preload(:old_tags, :changeset => [:changeset_tags, :user]).find(params.expect(:id, :version))
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/controllers/old_relation_members_controller.rb
+++ b/app/controllers/old_relation_members_controller.rb
@@ -3,11 +3,11 @@
 class OldRelationMembersController < OldElementsController
   def show
     @type = "relation"
-    @current_feature = Relation.find(params[:id])
-    @feature = OldRelation.preload(:old_members => { :member => :element_tags }).find([params[:id], params[:version]])
+    @current_feature = Relation.find(params.expect(:id))
+    @feature = OldRelation.preload(:old_members => { :member => :element_tags }).find(params.expect(:id, :version))
     @frame_id = "member_relation_#{@feature.id}"
 
-    return deny_access(nil) if @feature.redacted? && !params[:show_redactions]
+    return deny_access(nil) if @feature.redacted? && params[:show_redactions].blank?
 
     render :partial => "browse/relation_member_frame", :locals => { :relation => @feature, :frame_id => @frame_id }
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/old_relations_controller.rb
+++ b/app/controllers/old_relations_controller.rb
@@ -3,7 +3,7 @@
 class OldRelationsController < OldElementsController
   def index
     @type = "relation"
-    @current_feature = @feature = Relation.preload(:element_tags).find(params[:id])
+    @current_feature = @feature = Relation.preload(:element_tags).find(params.expect(:id))
     @old_features = get_page_items(
       OldRelation.where(:relation_id => params[:id]),
       :cursor_column => :version,
@@ -15,8 +15,8 @@ class OldRelationsController < OldElementsController
 
   def show
     @type = "relation"
-    @current_feature = Relation.find(params[:id])
-    @feature = OldRelation.preload(:old_tags, :changeset => [:changeset_tags, :user]).find([params[:id], params[:version]])
+    @current_feature = Relation.find(params.expect(:id))
+    @feature = OldRelation.preload(:old_tags, :changeset => [:changeset_tags, :user]).find(params.expect(:id, :version))
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/controllers/old_ways_controller.rb
+++ b/app/controllers/old_ways_controller.rb
@@ -3,7 +3,7 @@
 class OldWaysController < OldElementsController
   def index
     @type = "way"
-    @current_feature = @feature = Way.preload(:element_tags).find(params[:id])
+    @current_feature = @feature = Way.preload(:element_tags).find(params.expect(:id))
     @old_features = get_page_items(
       OldWay.where(:way_id => params[:id]),
       :cursor_column => :version,
@@ -15,8 +15,8 @@ class OldWaysController < OldElementsController
 
   def show
     @type = "way"
-    @current_feature = Way.find(params[:id])
-    @feature = OldWay.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:element_tags, :ways] }).find([params[:id], params[:version]])
+    @current_feature = Way.find(params.expect(:id))
+    @feature = OldWay.preload(:old_tags, :changeset => [:changeset_tags, :user], :old_nodes => { :node => [:element_tags, :ways] }).find(params.expect(:id, :version))
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/controllers/redactions_controller.rb
+++ b/app/controllers/redactions_controller.rb
@@ -72,6 +72,6 @@ class RedactionsController < ApplicationController
   private
 
   def lookup_redaction
-    @redaction = Redaction.find(params[:id])
+    @redaction = Redaction.find(params.expect(:id))
   end
 end

--- a/app/controllers/relation_members_controller.rb
+++ b/app/controllers/relation_members_controller.rb
@@ -3,7 +3,7 @@
 class RelationMembersController < ElementsController
   def show
     @type = "relation"
-    @feature = Relation.preload(:relation_members => { :member => :element_tags }).find(params[:id])
+    @feature = Relation.preload(:relation_members => { :member => :element_tags }).find(params.expect(:id))
     @frame_id = "member_relation_#{@feature.id}"
 
     render :partial => "browse/relation_member_frame", :locals => { :relation => @feature, :frame_id => @frame_id }

--- a/app/controllers/relations_controller.rb
+++ b/app/controllers/relations_controller.rb
@@ -3,7 +3,7 @@
 class RelationsController < ElementsController
   def show
     @type = "relation"
-    @feature = Relation.preload(:element_tags, :containing_relation_members, :changeset => [:changeset_tags, :user]).find(params[:id])
+    @feature = Relation.preload(:element_tags, :containing_relation_members, :changeset => [:changeset_tags, :user]).find(params.expect(:id))
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end

--- a/app/controllers/searches/latlon_queries_controller.rb
+++ b/app/controllers/searches/latlon_queries_controller.rb
@@ -3,8 +3,8 @@
 module Searches
   class LatlonQueriesController < QueriesController
     def create
-      lat = params[:lat].to_f
-      lon = params[:lon].to_f
+      lat = params.expect(:lat).to_f
+      lon = params.expect(:lon).to_f
 
       if params[:latlon_digits]
         # We've got two nondescript numbers for a query, which can mean both "lat, lon" or "lon, lat".

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,7 @@ class SessionsController < ApplicationController
 
     referer = safe_referer(params[:referer]) if params[:referer]
 
-    password_authentication(params[:username].strip, params[:password], referer)
+    password_authentication(params.expect(:username).strip, params.expect(:password), referer)
   end
 
   def destroy

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -72,22 +72,22 @@ class SiteController < ApplicationController
 
     begin
       if params[:node]
-        bbox = Node.visible.find(params[:node]).bbox.to_unscaled
+        bbox = Node.visible.find(params.expect(:node)).bbox.to_unscaled
         @lat = bbox.centre_lat
         @lon = bbox.centre_lon
         @zoom = 18
       elsif params[:way]
-        bbox = Way.visible.find(params[:way]).bbox.to_unscaled
+        bbox = Way.visible.find(params.expect(:way)).bbox.to_unscaled
         @lat = bbox.centre_lat
         @lon = bbox.centre_lon
         @zoom = 17
       elsif params[:note]
-        note = Note.visible.find(params[:note])
+        note = Note.visible.find(params.expect(:note))
         @lat = note.lat
         @lon = note.lon
         @zoom = 17
       elsif params[:gpx] && current_user
-        trace = Trace.visible_to(current_user).find(params[:gpx])
+        trace = Trace.visible_to(current_user).find(params.expect(:gpx))
         @lat = trace.latitude
         @lon = trace.longitude
         @zoom = 16

--- a/app/controllers/traces/data_controller.rb
+++ b/app/controllers/traces/data_controller.rb
@@ -13,7 +13,7 @@ module Traces
     before_action :offline_redirect
 
     def show
-      trace = Trace.visible.find(params[:trace_id])
+      trace = Trace.visible.find(params.expect(:trace_id))
 
       if trace.public? || (current_user && current_user == trace.user)
         if Acl.no_trace_download?(request.remote_ip)

--- a/app/controllers/traces/icons_controller.rb
+++ b/app/controllers/traces/icons_controller.rb
@@ -8,7 +8,7 @@ module Traces
     authorize_resource :trace
 
     def show
-      trace = Trace.visible.imported.find(params[:trace_id])
+      trace = Trace.visible.imported.find(params.expect(:trace_id))
 
       if trace.public? || (current_user && current_user == trace.user)
         redirect_to rails_blob_path(trace.icon, :disposition => "inline")

--- a/app/controllers/traces/pictures_controller.rb
+++ b/app/controllers/traces/pictures_controller.rb
@@ -8,7 +8,7 @@ module Traces
     authorize_resource :trace
 
     def show
-      trace = Trace.visible.imported.find(params[:trace_id])
+      trace = Trace.visible.imported.find(params.expect(:trace_id))
 
       if trace.public? || (current_user && current_user == trace.user)
         redirect_to rails_blob_path(trace.image, :disposition => "inline")

--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -70,7 +70,7 @@ class TracesController < ApplicationController
   end
 
   def show
-    @trace = Trace.visible.find(params[:id])
+    @trace = Trace.visible.find(params.expect(:id))
 
     if @trace.public? || @trace.user == current_user
       @title = t ".title", :name => @trace.name
@@ -89,7 +89,7 @@ class TracesController < ApplicationController
   end
 
   def edit
-    @trace = Trace.visible.find(params[:id])
+    @trace = Trace.visible.find(params.expect(:id))
 
     if current_user.nil? || @trace.user != current_user
       head :forbidden
@@ -135,7 +135,7 @@ class TracesController < ApplicationController
   end
 
   def update
-    @trace = Trace.visible.find(params[:id])
+    @trace = Trace.visible.find(params.expect(:id))
 
     if current_user.nil? || @trace.user != current_user
       head :forbidden
@@ -151,7 +151,7 @@ class TracesController < ApplicationController
   end
 
   def destroy
-    trace = Trace.visible.find(params[:id])
+    trace = Trace.visible.find(params.expect(:id))
 
     if current_user.nil? || (trace.user != current_user && !current_user.administrator? && !current_user.moderator?)
       head :forbidden

--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -110,7 +110,7 @@ class UserBlocksController < ApplicationController
   ##
   # ensure that there is a "user_block" instance variable
   def lookup_user_block
-    @user_block = UserBlock.find(params[:id])
+    @user_block = UserBlock.find(params.expect(:id))
   rescue ActiveRecord::RecordNotFound
     render :action => "not_found", :status => :not_found
   end
@@ -121,7 +121,7 @@ class UserBlocksController < ApplicationController
   # called before two different actions, each of which should redirect
   # to a different place.
   def require_valid_params
-    @block_period = params[:user_block_period].to_i
+    @block_period = params.expect(:user_block_period).to_i
     @valid_params = false
 
     if UserBlock::PERIODS.exclude?(@block_period)

--- a/app/controllers/users/statuses_controller.rb
+++ b/app/controllers/users/statuses_controller.rb
@@ -30,7 +30,7 @@ module Users
     ##
     # ensure that there is a "user" instance variable
     def lookup_user_by_name
-      @user = User.find_by!(:display_name => params[:user_display_name])
+      @user = User.find_by!(:display_name => params.expect(:user_display_name))
     rescue ActiveRecord::RecordNotFound
       redirect_to user_path(params[:user_display_name]) unless @user
     end

--- a/app/controllers/ways_controller.rb
+++ b/app/controllers/ways_controller.rb
@@ -3,7 +3,7 @@
 class WaysController < ElementsController
   def show
     @type = "way"
-    @feature = Way.preload(:element_tags, :containing_relation_members, :changeset => [:changeset_tags, :user], :nodes => [:element_tags, { :ways => :element_tags }]).find(params[:id])
+    @feature = Way.preload(:element_tags, :containing_relation_members, :changeset => [:changeset_tags, :user], :nodes => [:element_tags, { :ways => :element_tags }]).find(params.expect(:id))
   rescue ActiveRecord::RecordNotFound
     render "browse/not_found", :status => :not_found
   end


### PR DESCRIPTION
This addresses the new rubcop warnings from #7087 by making use of `.permit` and other rails parameter handling methods.

It was true as @gravitystorm suggested thaty in some come cases rubocop was making incorrect changes but in most cases there was a better way to do it just not always using the `.permit` method.

With this patch applied the new rubocop rule no longer reports any warnings for me.