### PR TITLE
Add ::1 (IPv6 local) to allowed http redirect_uris for OAuth

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -267,7 +267,7 @@ Doorkeeper.configure do
   # redirects to localhost for example).
 
   force_ssl_in_redirect_uri do |uri|
-    !Rails.env.development? && uri.host != "127.0.0.1"
+    !Rails.env.development? && ["127.0.0.1", "::1"].exclude?(uri.host)
   end
 
   # Specify what redirect URI's you want to block during Application creation.


### PR DESCRIPTION
Allows one to do local testing and to use IPv6. Previously only IPv4 was supported (127.0.0.1), but not ::1.

Related discussions:
https://github.com/openstreetmap/openstreetmap-website/pull/4287
https://github.com/openstreetmap/openstreetmap-website/issues/3613

I have not tested this.

Unlike other suggestions, this patch does not add support for `localhost` domains, so the previous security concerns are not relevant. (I think?)