### PR TITLE
No need to call Yarn within Bundler

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,11 +58,11 @@ jobs:
       with:
         cache: yarn
     - name: Install node modules
-      run: bundle exec bin/yarn install
+      run: bin/yarn install
     - name: Create dummy database configuration
       run: cp config/example.database.yml config/database.yml
     - name: Run herb linter
-      run: bundle exec bin/yarn run herb-lint
+      run: bin/yarn run herb-lint
   eslint:
     name: ESLint
     runs-on: ubuntu-latest
@@ -80,7 +80,7 @@ jobs:
       with:
         cache: yarn
     - name: Install node modules
-      run: bundle exec bin/yarn install
+      run: bin/yarn install
     - name: Create dummy database configuration
       run: cp config/example.database.yml config/database.yml
     - name: Run eslint
@@ -122,7 +122,7 @@ jobs:
       with:
         cache: yarn
     - name: Install node modules
-      run: bundle exec bin/yarn install
+      run: bin/yarn install
     - name: Install packages
       run: |
         sudo apt-get -yqq update
@@ -160,7 +160,7 @@ jobs:
       with:
         cache: yarn
     - name: Install node modules
-      run: bundle exec bin/yarn install
+      run: bin/yarn install
     - name: Install packages
       run: |
         sudo apt-get -yqq update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         cp config/example.storage.yml config/storage.yml
         touch config/settings.local.yml
     - name: Install node modules
-      run: bundle exec bin/yarn install
+      run: bin/yarn install
     - name: Populate database
       run: |
         sed -f script/normalise-structure db/structure.sql > db/structure.expected

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN bundle install
 # Install NodeJS packages using yarn
 COPY package.json yarn.lock /app/
 COPY bin/yarn /app/bin/
-RUN bundle exec bin/yarn install
+RUN bin/yarn install
 
 # Copy and set entrypoint
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -212,7 +212,7 @@ We use [ActionMailer Previews](https://guides.rubyonrails.org/action_mailer_basi
 >
 > - **Update Node.js modules:** If Node.js modules have been updated, run:
 >   ```bash
->   bundle exec bin/yarn install
+>   bin/yarn install
 >   ```
 >
 > - **Run database migrations:** The OSM database schema is changed periodically. To keep up with improvements:

--- a/doc/MANUAL_INSTALL.md
+++ b/doc/MANUAL_INSTALL.md
@@ -138,7 +138,7 @@ bundle install
 We use [Yarn](https://yarnpkg.com/) to manage the Node.js modules required for the project.
 
 ```bash
-bundle exec bin/yarn install
+bin/yarn install
 ```
 
 ## Step 4: Prepare Configuration Files


### PR DESCRIPTION
A subset of https://github.com/openstreetmap/openstreetmap-website/pull/6874 that might be more agreeable 😄 

In several places, we call (or advise to call) Yarn with Bundler. At the very least this is two unnecessary extra words to type. More generally, this is mixing up two different runtimes, one JS and one Ruby, which work independently.