### PR TITLE
API to tell if notes are allowed in a given point

### DIFF
--- a/app/abilities/api_ability.rb
+++ b/app/abilities/api_ability.rb
@@ -7,7 +7,7 @@ class ApiAbility
     can :read, [:version, :capability, :permission, :map]
 
     if Settings.status != "database_offline"
-      can [:read, :feed, :search], Note
+      can [:read, :feed, :search, :allowed], Note
       can :create, Note unless user
 
       can :read, Changeset

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -74,9 +74,7 @@ module Api
     end
 
     def allowed
-      lon = OSM.parse_float(params[:lon], OSM::APIBadUserInput, "lon was not a number")
-      lat = OSM.parse_float(params[:lat], OSM::APIBadUserInput, "lat was not a number")
-
+      lon, lat = read_lon_lat_params
       raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any?(:lon => lon, :lat => lat)
 
       head :ok
@@ -94,8 +92,7 @@ module Api
       raise OSM::APIBadUserInput, "No text was given" if params[:text].blank?
 
       # Extract the arguments
-      lon = OSM.parse_float(params[:lon], OSM::APIBadUserInput, "lon was not a number")
-      lat = OSM.parse_float(params[:lat], OSM::APIBadUserInput, "lat was not a number")
+      lon, lat = read_lon_lat_params
       description = params[:text]
 
       raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any?(:lon => lon, :lat => lat)
@@ -393,6 +390,13 @@ module Api
       NoteCommentNotifier.with(:record => comment).deliver_later if notify
 
       NoteSubscription.find_or_create_by(:note => note, :user => current_user) if current_user
+    end
+
+    def read_lon_lat_params
+      lon = OSM.parse_float(params[:lon], OSM::APIBadUserInput, "lon was not a number")
+      lat = OSM.parse_float(params[:lat], OSM::APIBadUserInput, "lat was not a number")
+
+      [lon, lat]
     end
   end
 end

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -74,8 +74,7 @@ module Api
     end
 
     def allowed
-      lon, lat = read_lon_lat_params
-      raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any?(:lon => lon, :lat => lat)
+      check_for_moderation_zones
 
       head :ok
     end
@@ -95,7 +94,7 @@ module Api
       lon, lat = read_lon_lat_params
       description = params[:text]
 
-      raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any?(:lon => lon, :lat => lat)
+      check_for_moderation_zones
 
       # Get note's author info (for logged in users - user_id, for logged out users - IP address)
       note_author_info = author_info
@@ -397,6 +396,11 @@ module Api
       lat = OSM.parse_float(params[:lat], OSM::APIBadUserInput, "lat was not a number")
 
       [lon, lat]
+    end
+
+    def check_for_moderation_zones
+      lon, lat = read_lon_lat_params
+      raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any?(:lon => lon, :lat => lat)
     end
   end
 end

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -5,7 +5,7 @@ module Api
     include QueryMethods
 
     before_action :check_api_writable, :only => [:create, :comment, :close, :reopen, :destroy]
-    before_action :setup_user_auth, :only => [:create, :show]
+    before_action :setup_user_auth, :only => [:create, :show, :allowed]
     before_action :authorize, :only => [:close, :reopen, :destroy, :comment]
 
     authorize_resource
@@ -71,6 +71,15 @@ module Api
         format.json
         format.gpx
       end
+    end
+
+    def allowed
+      lon = OSM.parse_float(params[:lon], OSM::APIBadUserInput, "lon was not a number")
+      lat = OSM.parse_float(params[:lat], OSM::APIBadUserInput, "lat was not a number")
+
+      raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any?(:lon => lon, :lat => lat)
+
+      head :ok
     end
 
     ##

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ OpenStreetMap::Application.routes.draw do
       collection do
         get "search"
         get "feed", :defaults => { :format => "rss" }
+        get "allowed"
       end
 
       member do

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -204,6 +204,31 @@ module Api
       assert_response :bad_request
     end
 
+    def test_allowed_outside_moderation_zone_as_anonymous
+      point = coordinates_outside_seville_cathedral
+      create(:moderation_zone, :seville_cathedral)
+
+      get allowed_api_notes_path(:lat => point.lat, :lon => point.lon)
+
+      assert_response :ok
+    end
+
+    def test_allowed_within_moderation_zone_as_anonymous
+      point = coordinates_inside_seville_cathedral
+      create(:moderation_zone, :seville_cathedral)
+
+      get allowed_api_notes_path(:lat => point.lat, :lon => point.lon)
+
+      assert_response :forbidden
+      assert_equal "You don't have permissions to make changes in this zone, as it is currently protected by moderators", response.headers["Error"]
+    end
+
+    def test_allowed_garbage_as_anonymous
+      get allowed_api_notes_path(:lat => "abc", :lon => 0)
+
+      assert_response :bad_request
+    end
+
     def test_create_anonymous_in_moderation_zone
       point = coordinates_inside_seville_cathedral
       create(:moderation_zone, :seville_cathedral)
@@ -214,6 +239,37 @@ module Api
       end
       assert_response :forbidden
       assert_equal "You don't have permissions to make changes in this zone, as it is currently protected by moderators", response.headers["Error"]
+    end
+
+    def test_allowed_outside_moderation_zone_as_authenticated
+      user = create(:user)
+      auth_header = bearer_authorization_header(user)
+      point = coordinates_outside_seville_cathedral
+      create(:moderation_zone, :seville_cathedral)
+
+      get allowed_api_notes_path(:lat => point.lat, :lon => point.lon), :headers => auth_header
+
+      assert_response :ok
+    end
+
+    def test_allowed_within_moderation_zone_as_authenticated
+      user = create(:user)
+      auth_header = bearer_authorization_header(user)
+      point = coordinates_inside_seville_cathedral
+      create(:moderation_zone, :seville_cathedral)
+
+      get allowed_api_notes_path(:lat => point.lat, :lon => point.lon), :headers => auth_header
+
+      assert_response :ok
+    end
+
+    def test_allowed_garbage_as_authenticated
+      user = create(:user)
+      auth_header = bearer_authorization_header(user)
+
+      get allowed_api_notes_path(:lat => "abc", :lon => 0), :headers => auth_header
+
+      assert_response :bad_request
     end
 
     def test_create_success
@@ -1284,6 +1340,10 @@ module Api
 
     def coordinates_inside_seville_cathedral
       Struct.new(:lat, :lon).new(37.385972, -5.993149)
+    end
+
+    def coordinates_outside_seville_cathedral
+      Struct.new(:lat, :lon).new(37.386769, -5.994185)
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/6794

Clients have a right to know if a note will be allowed in a specific point before they submit it. Let's give them a way to check.

I'm going with `GET /api/0.6/notes/allowed?lat=&lon=`. I considered making it into something more generic, to provide for a future where moderation zones cover other elements. However I decided this was premature, and anything more generic can be added in a back-compatible way when the time comes.

At the moment, any authenticated request will receive `200 OK`. Unauthenticated requests will get `403 Forbidden` if they point within a moderation zone, and `200 OK` otherwise.