### PR TITLE
Fix crash due to cgi gem not fully loaded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,9 @@ gem "doorkeeper"
 gem "doorkeeper-i18n"
 gem "doorkeeper-openid_connect"
 
+# To parse complex referers for OAuth login
+gem "cgi"
+
 # Markdown formatting support
 gem "kramdown"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.5.1)
     childprocess (5.1.0)
       logger (~> 1.5)
     claide (1.1.0)
@@ -946,6 +947,7 @@ DEPENDENCIES
   cancancan
   canonical-rails!
   capybara
+  cgi
   config
   connection_pool
   dalli

--- a/test/integration/oauth2_test.rb
+++ b/test/integration/oauth2_test.rb
@@ -158,8 +158,12 @@ class OAuth2Test < ActionDispatch::IntegrationTest
       :scope => "read_prefs"
     }.merge(options)
 
-    get oauth_authorization_path(options)
-    assert_redirected_to login_path(:referer => request.fullpath)
+    oauth_path = oauth_authorization_path(options)
+    login_for_oauth_path = login_path(:referer => oauth_path)
+    cookies["_osm_session"] = "reassure the backend that cookies are enabled"
+    get oauth_path
+    assert_redirected_to login_for_oauth_path
+    get login_for_oauth_path
 
     post login_path(:username => user.email, :password => "s3cr3t")
     follow_redirect!


### PR DESCRIPTION
This has been bothering me for a while. I can't recall the specifics, but every now and then I get the following error in my local environment:
```
NoMethodError - undefined method 'parse' for class CGI:
app/controllers/concerns/session_methods.rb:14:in `parse_oauth_referer'
app/controllers/sessions_controller.rb:24:in `new'
config/initializers/policy_headers.rb:13:in `call'
config/initializers/compressed_requests.rb:33:in `call'
```
Typically when switching DBs (eg: between a Docker setup and a "normal" setup) or something like that. I tend to do a quick fix (can't be sure what I do, just smack it a bit until it works) and move on, always thinking I'll look into it later.

Finally yesterday I was playing with OAuth and got a very reproducible case, and here I am with a fix.

The problem: crash when attempting to login in with a `referer` query param that in turn includes query params. This is common with OAuth. No idea if it happens anywhere else in the app, which still has me scratching my head as I've seen it happen in less esoteric contexts.

The reason: we parse the referer param with `CGI.param`, but that function doesn't exist.

Why doesn't production break? Because the CGI library is fully present in Ruby 3.x. [It was removed in Ruby 4](https://bugs.ruby-lang.org/issues/21258) ([release notes](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/#stdlib-compatibility-issues)), so this is a crash waiting to happen.

The fix: add `cgi` to the Gemfile.