### PR TITLE
Add more wiki prefixes

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -3,7 +3,7 @@
 module BrowseTagsHelper
   # https://wiki.openstreetmap.org/wiki/Key:wikipedia#Secondary_Wikipedia_links
   # https://wiki.openstreetmap.org/wiki/Key:wikidata#Secondary_Wikidata_links
-  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|manufacturer|model|name:etymology|network|operator|species|subject"
+  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|manufacturer|model|(?:official_|old_)?name:etymology|network|(?:heritage:|old_)?operator|owner|species|subject|taxon"
 
   def format_key(key)
     if url = wiki_link("key", key)


### PR DESCRIPTION
Following #4401 and #4574, I've added some more common (variations on existing) entries to resolve #7107.
A notable exception is `royal_cypher`, whose use isn't spread globally.