### PR TITLE
Compress plain GPX uploads with gzip

### DIFF
--- a/app/controllers/api/traces/data_controller.rb
+++ b/app/controllers/api/traces/data_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module Traces
     class DataController < ApiController
+      include GpxDownloadMethods
+
       before_action :set_locale
       before_action :authorize
 
@@ -19,7 +21,7 @@ module Api
           elsif request.format == Mime[:gpx]
             send_data(trace.xml_file.read, :filename => "#{trace.id}.gpx", :type => request.format.to_s, :disposition => "attachment")
           elsif trace.file.attached?
-            redirect_to rails_blob_path(trace.file, :disposition => "attachment")
+            send_trace_file(trace)
           else
             send_file(trace.trace_name, :filename => "#{trace.id}#{trace.extension_name}", :type => trace.mime_type, :disposition => "attachment")
           end

--- a/app/controllers/concerns/gpx_download_methods.rb
+++ b/app/controllers/concerns/gpx_download_methods.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module GpxDownloadMethods
+  extend ActiveSupport::Concern
+
+  private
+
+  # Send the stored trace file to the client. It can go back two ways.
+  # - If the store serves gzip (S3) and the client accepts it, redirect and let the client unzip it.
+  # - Otherwise the server unzips it first and sends plain GPX.
+  def send_trace_file(trace)
+    if trace.gzipped_by_server?
+      # The response depends on Accept-Encoding, so caches must vary on it.
+      response.headers["Vary"] = [response.headers["Vary"], "Accept-Encoding"].compact.join(", ")
+
+      if store_serves_gzip?(trace) && request_accepts_gzip?
+        redirect_to rails_blob_path(trace.file, :disposition => "attachment")
+      else
+        send_data(trace.xml_file.read,
+                  :filename => trace.file.filename.to_s,
+                  :type => "application/gpx+xml",
+                  :disposition => "attachment")
+      end
+    else
+      redirect_to rails_blob_path(trace.file, :disposition => "attachment")
+    end
+  end
+
+  # True when this file went to the store with a Content-Encoding: gzip header
+  # (GpxS3). The flag is set per file at upload time, so files without the
+  # header never get a redirect, even if the storage service changes later.
+  def store_serves_gzip?(trace)
+    trace.file.custom_metadata["gzip_content_encoding"].present?
+  end
+
+  # True when the client can read gzip, so we can send it without unzipping first.
+  def request_accepts_gzip?
+    request.accept_encoding.to_s.split(",").any? { |encoding| encoding.split(";").first.strip == "gzip" }
+  end
+end

--- a/app/controllers/traces/data_controller.rb
+++ b/app/controllers/traces/data_controller.rb
@@ -2,6 +2,8 @@
 
 module Traces
   class DataController < ApplicationController
+    include GpxDownloadMethods
+
     layout :site_layout
 
     before_action :authorize_web
@@ -23,7 +25,7 @@ module Traces
         elsif request.format == Mime[:gpx]
           send_data(trace.xml_file.read, :filename => "#{trace.id}.gpx", :type => request.format.to_s, :disposition => "attachment")
         elsif trace.file.attached?
-          redirect_to rails_blob_path(trace.file, :disposition => "attachment")
+          send_trace_file(trace)
         else
           send_file(trace.trace_name, :filename => "#{trace.id}#{trace.extension_name}", :type => trace.mime_type, :disposition => "attachment")
         end

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -76,10 +76,36 @@ class Trace < ApplicationRecord
   def file=(attachable)
     case attachable
     when ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile
-      super(:io => attachable,
-            :filename => attachable.original_filename,
-            :content_type => content_type(attachable.path),
-            :identify => false)
+      type = content_type(attachable.path)
+
+      if type == Mime[:gpx]
+        # Gzip plain GPX before sending to storage service to save space.
+        gz = Tempfile.new(["trace", ".gpx.gz"])
+        gz.binmode
+
+        writer = Zlib::GzipWriter.new(gz)
+        File.open(attachable.path, "rb") { |source| IO.copy_stream(source, writer) }
+        writer.finish
+        gz.rewind
+        # Delete the temp file from disk now, but keep gz open. Active Storage still
+        # reads this open handle to upload on save same as xml_file.
+        gz.unlink
+
+        # Mark the file as gzipped by the server, so the download and xml_file
+        # know to decompress it.
+        metadata = { "server_gzipped" => true }
+
+        super(:io => gz,
+              :filename => attachable.original_filename,
+              :content_type => "application/gpx+xml",
+              :metadata => { "custom" => metadata },
+              :identify => false)
+      else
+        super(:io => attachable,
+              :filename => attachable.original_filename,
+              :content_type => type,
+              :identify => false)
+      end
     else
       super
     end
@@ -91,6 +117,12 @@ class Trace < ApplicationRecord
 
   def trackable?
     %w[trackable identifiable].include?(visibility)
+  end
+
+  # True when the server stored this GPX gzipped. Only new files, old traces
+  # return false.
+  def gzipped_by_server?
+    file.custom_metadata["server_gzipped"].present?
   end
 
   def identifiable?
@@ -166,7 +198,8 @@ class Trace < ApplicationRecord
   end
 
   def xml_file
-    gzipped = file.content_type.end_with?("gzip")
+    # Gzipped if the user sent a .gz or the server gzipped it.
+    gzipped = file.content_type.end_with?("gzip") || gzipped_by_server?
     bzipped = file.content_type.end_with?("bzip2")
     zipped = file.content_type.start_with?("application/zip")
     tarred = file.content_type.start_with?("application/x-tar")

--- a/config/example.storage.yml
+++ b/config/example.storage.yml
@@ -5,3 +5,6 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+
+# To serve gzipped GPX traces from S3 with Content-Encoding: gzip, use
+# service: GpxS3 with the usual S3 options.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -224,6 +224,7 @@ csp_enforce: false
 #csp_report_url: ""
 # Storage services to use in production mode
 avatar_storage: "local"
+# Use the GpxS3 service to automatically gzip plain GPX files before storing them in S3.
 trace_file_storage: "local"
 trace_image_storage: "local"
 trace_icon_storage: "local"

--- a/lib/active_storage/service/gpx_s3_service.rb
+++ b/lib/active_storage/service/gpx_s3_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Active Storage loads S3Service lazily, so we require it before subclassing.
+# Without this, eager loading fails with an uninitialized constant.
+require "active_storage/service/s3_service"
+
+# Plain GPX traces are stored gzipped, so they need Content-Encoding: gzip on S3.
+# That way the client unzips the file, not the server. This service adds that header
+# on upload and inherits the rest from the parent S3 service.
+
+module ActiveStorage
+  class Service::GpxS3Service < Service::S3Service
+    private
+
+    def upload_with_single_part(key, io, checksum: nil, content_type: nil, content_disposition: nil, custom_metadata: {})
+      # The model marks server-gzipped files with custom_metadata, because Active
+      # Storage's upload has no Content-Encoding argument. We keep the flags in the
+      # blob metadata for the download, but we don't write them to the S3 object as
+      # x-amz-meta.
+      return super unless custom_metadata["server_gzipped"]
+
+      # Record on the blob that this file goes to the store with a Content-Encoding
+      # header. The download reads this flag per file to decide if it can redirect.
+      custom_metadata["gzip_content_encoding"] = true
+
+      object_for(key).put(:body => io,
+                          :content_md5 => checksum,
+                          :content_type => content_type,
+                          :content_encoding => "gzip",
+                          :content_disposition => content_disposition,
+                          :metadata => custom_metadata.except("server_gzipped", "gzip_content_encoding"),
+                          **upload_options)
+    rescue Aws::S3::Errors::BadDigest
+      raise ActiveStorage::IntegrityError
+    end
+
+    def upload_with_multipart(key, io, content_type: nil, content_disposition: nil, custom_metadata: {})
+      return super unless custom_metadata["server_gzipped"]
+
+      custom_metadata["gzip_content_encoding"] = true
+
+      part_size = [io.size.fdiv(MAXIMUM_UPLOAD_PARTS_COUNT).ceil, MINIMUM_UPLOAD_PART_SIZE].max
+
+      upload_stream(:key => key,
+                    :content_type => content_type,
+                    :content_encoding => "gzip",
+                    :content_disposition => content_disposition,
+                    :part_size => part_size,
+                    :metadata => custom_metadata.except("server_gzipped", "gzip_content_encoding"),
+                    **upload_options) do |out|
+        IO.copy_stream(io, out)
+      end
+    end
+  end
+end

--- a/test/controllers/api/traces/data_controller_test.rb
+++ b/test/controllers/api/traces/data_controller_test.rb
@@ -29,15 +29,40 @@ module Api
         # Now with some other user, which should work since the trace is public
         auth_header = bearer_authorization_header
         get api_trace_data_path(public_trace_file), :headers => auth_header
-        follow_redirect!
-        follow_redirect!
         check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
 
         # And finally we should be able to do it with the owner of the trace
         auth_header = bearer_authorization_header public_trace_file.user
         get api_trace_data_path(public_trace_file), :headers => auth_header
-        follow_redirect!
-        follow_redirect!
+        check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
+      end
+
+      # A trace uploaded before GpxS3 was enabled is stored gzipped but has no
+      # gzip_content_encoding flag, so the server must unzip it even when the
+      # client accepts gzip.
+      def test_show_gzipped_by_server_without_store_header
+        public_trace_file = create(:trace, :visibility => "identifiable", :fixture => "a")
+        auth_header = bearer_authorization_header
+
+        get api_trace_data_path(public_trace_file), :headers => auth_header.merge("Accept-Encoding" => "gzip")
+
+        check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
+        assert_includes response.headers["Vary"].to_s, "Accept-Encoding"
+      end
+
+      # A trace stored with a Content-Encoding: gzip header goes out as a
+      # redirect when the client accepts gzip, and the server unzips it when
+      # the client doesn't.
+      def test_show_gzipped_by_server_with_store_header
+        public_trace_file = create(:trace, :visibility => "identifiable", :fixture => "a")
+        blob = public_trace_file.file.blob
+        blob.update!(:custom_metadata => blob.custom_metadata.merge("gzip_content_encoding" => true))
+        auth_header = bearer_authorization_header
+
+        get api_trace_data_path(public_trace_file), :headers => auth_header.merge("Accept-Encoding" => "gzip")
+        assert_response :redirect
+
+        get api_trace_data_path(public_trace_file), :headers => auth_header.merge("Accept-Encoding" => "identity")
         check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
       end
 
@@ -79,8 +104,6 @@ module Api
         # And finally we should be able to do it with the owner of the trace
         auth_header = bearer_authorization_header anon_trace_file.user
         get api_trace_data_path(anon_trace_file), :headers => auth_header
-        follow_redirect!
-        follow_redirect!
         check_trace_data anon_trace_file, "db4cb5ed2d7d2b627b3b504296c4f701"
       end
 

--- a/test/controllers/api/traces_controller_test.rb
+++ b/test/controllers/api/traces_controller_test.rb
@@ -138,7 +138,8 @@ module Api
       assert_equal %w[new trace], trace.tags.order(:tag).collect(&:tag)
       assert_equal "trackable", trace.visibility
       assert trace.inserted
-      assert_equal File.new(fixture).read, trace.file.blob.download
+      # Plain GPX is gzipped on upload, so decompress before comparing.
+      assert_equal File.new(fixture).read, trace.xml_file.read
 
       # Validate tracepoints
       assert_equal 1, trace.points.size
@@ -167,7 +168,8 @@ module Api
       assert_equal %w[new trace], trace.tags.order(:tag).collect(&:tag)
       assert_equal "public", trace.visibility
       assert_not trace.inserted
-      assert_equal File.new(fixture).read, trace.file.blob.download
+      # Plain GPX is gzipped on upload, so decompress before comparing.
+      assert_equal File.new(fixture).read, trace.xml_file.read
       trace.destroy
       assert_equal "public", user.preferences.find_by(:k => "gps.trace.visibility").v
 
@@ -186,7 +188,8 @@ module Api
       assert_equal %w[new trace], trace.tags.order(:tag).collect(&:tag)
       assert_equal "private", trace.visibility
       assert_not trace.inserted
-      assert_equal File.new(fixture).read, trace.file.blob.download
+      # Plain GPX is gzipped on upload, so decompress before comparing.
+      assert_equal File.new(fixture).read, trace.xml_file.read
       trace.destroy
       assert_equal "private", second_user.preferences.find_by(:k => "gps.trace.visibility").v
     end

--- a/test/controllers/traces/data_controller_test.rb
+++ b/test/controllers/traces/data_controller_test.rb
@@ -29,22 +29,43 @@ module Traces
 
       # First with no auth, which should work since the trace is public
       get trace_data_path(public_trace_file)
-      follow_redirect!
-      follow_redirect!
       check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
 
       # Now with some other user, which should work since the trace is public
       session_for(create(:user))
       get trace_data_path(public_trace_file)
-      follow_redirect!
-      follow_redirect!
       check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
 
       # And finally we should be able to do it with the owner of the trace
       session_for(public_trace_file.user)
       get trace_data_path(public_trace_file)
-      follow_redirect!
-      follow_redirect!
+      check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
+    end
+
+    # A trace uploaded before GpxS3 was enabled is stored gzipped but has no
+    # gzip_content_encoding flag, so the server must unzip it even when the
+    # client accepts gzip.
+    def test_show_gzipped_by_server_without_store_header
+      public_trace_file = create(:trace, :visibility => "identifiable", :fixture => "a")
+
+      get trace_data_path(public_trace_file), :headers => { "Accept-Encoding" => "gzip" }
+
+      check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
+      assert_includes response.headers["Vary"].to_s, "Accept-Encoding"
+    end
+
+    # A trace stored with a Content-Encoding: gzip header goes out as a
+    # redirect when the client accepts gzip, and the server unzips it when
+    # the client doesn't.
+    def test_show_gzipped_by_server_with_store_header
+      public_trace_file = create(:trace, :visibility => "identifiable", :fixture => "a")
+      blob = public_trace_file.file.blob
+      blob.update!(:custom_metadata => blob.custom_metadata.merge("gzip_content_encoding" => true))
+
+      get trace_data_path(public_trace_file), :headers => { "Accept-Encoding" => "gzip" }
+      assert_response :redirect
+
+      get trace_data_path(public_trace_file), :headers => { "Accept-Encoding" => "identity" }
       check_trace_data public_trace_file, "848caa72f2f456d1bd6a0fdf228aa1b9"
     end
 
@@ -83,8 +104,6 @@ module Traces
       # And finally we should be able to do it with the owner of the trace
       session_for(anon_trace_file.user)
       get trace_data_path(anon_trace_file)
-      follow_redirect!
-      follow_redirect!
       check_trace_data anon_trace_file, "db4cb5ed2d7d2b627b3b504296c4f701"
     end
 

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -424,7 +424,8 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     assert_equal %w[new trace], trace.tags.order(:tag).collect(&:tag)
     assert_equal "trackable", trace.visibility
     assert_not trace.inserted
-    assert_equal File.new(fixture).read, trace.file.blob.download
+    # Plain GPX is gzipped on upload, so decompress before comparing.
+    assert_equal File.new(fixture).read, trace.xml_file.read
     trace.destroy
     assert_equal "trackable", user.preferences.find_by(:k => "gps.trace.visibility").v
   end

--- a/test/lib/active_storage/service/gpx_s3_service_test.rb
+++ b/test/lib/active_storage/service/gpx_s3_service_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GpxS3ServiceTest < ActiveSupport::TestCase
+  class MultipartTest < self
+    def setup
+      @service = ActiveStorage::Service::GpxS3Service.new(
+        :bucket => "test-bucket",
+        :region => "eu-west-1",
+        :stub_responses => true,
+        :upload => {
+          :multipart_threshold => 1.byte
+        }
+      )
+    end
+
+    private
+
+    def find_latest_upload_request
+      @service.client.client.api_requests.reverse_each.find { |request| request[:operation_name] == :create_multipart_upload }
+    end
+  end
+
+  def setup
+    @service = ActiveStorage::Service::GpxS3Service.new(
+      :bucket => "test-bucket",
+      :region => "eu-west-1",
+      :stub_responses => true
+    )
+  end
+
+  def test_sets_content_encoding_for_server_gzipped_flag
+    @service.upload("key", StringIO.new("data"),
+                    :content_type => "application/gpx+xml",
+                    :custom_metadata => { "server_gzipped" => true })
+
+    request = find_latest_upload_request
+    assert_equal "gzip", request[:params][:content_encoding]
+    # The flags drive the header, they aren't stored as S3 metadata.
+    assert_empty(request[:params][:metadata] || {})
+  end
+
+  def test_keeps_default_upload_without_server_gzipped_flag
+    @service.upload("key", StringIO.new("data"), :content_type => "application/gpx+xml")
+
+    assert_nil find_latest_upload_request[:params][:content_encoding]
+  end
+
+  def test_keeps_metadata_flag
+    custom_metadata = { "server_gzipped" => true }
+    @service.upload("key", StringIO.new("data"),
+                    :content_type => "application/gpx+xml",
+                    :custom_metadata => custom_metadata)
+
+    # The blob keeps the flag for the download, so the upload must not remove it.
+    assert custom_metadata["server_gzipped"]
+  end
+
+  def test_adds_gzip_content_encoding_flag
+    custom_metadata = { "server_gzipped" => true }
+    @service.upload("key", StringIO.new("data"),
+                    :content_type => "application/gpx+xml",
+                    :custom_metadata => custom_metadata)
+
+    # The service sets the Content-Encoding header on the upload, so it records
+    # the flag on the blob. The download reads it to decide if it can redirect.
+    assert custom_metadata["gzip_content_encoding"]
+  end
+
+  private
+
+  def find_latest_upload_request
+    @service.client.client.api_requests.reverse_each.find { |request| request[:operation_name] == :put_object }
+  end
+end

--- a/test/models/trace_test.rb
+++ b/test/models/trace_test.rb
@@ -167,6 +167,15 @@ class TraceTest < ActiveSupport::TestCase
     check_xml_file("i", "a7c05d676c77dc14369c21be216a3713")
   end
 
+  def test_file_flags_server_gzipped_without_encoding_store
+    trace = create(:trace, :inserted => false, :fixture => "a")
+
+    # The test store doesn't set a Content-Encoding header, so the file only
+    # gets the server_gzipped flag.
+    assert trace.file.custom_metadata["server_gzipped"]
+    assert_nil trace.file.custom_metadata["gzip_content_encoding"]
+  end
+
   def test_large_picture
     picture = Rails.root.join("test/gpx/fixtures/a.gif").read(:mode => "rb")
     trace = create(:trace, :fixture => "a")


### PR DESCRIPTION
This PR gzips plain GPX files before they go to S3, which reduce a big part of their size. Files that are already compressed (gzip, bzip2, zip, tar) are the same.

The user still gets a plain .gpx, so the download link doesn't change for them. When the app stores a plain GPX gzipped, it sets server_gzipped = true in the blob metadata. On download it works in two ways:



- If the client accepts gzip, the server sends the gzipped file as is with `Content-Encoding: gzip` and the client unzips it,  the server skips the decompression, so it saves CPU and most browsers support Content-Encoding: gzip today.

- If the client does not support  gzip, the server unzips it first and sends plain GPX. This is the same work the server already does today when a client requests  `/data.gpx`

For the server-side unzip I reused the existing [xml_file](https://github.com/openstreetmap/openstreetmap-website/blob/master/app/models/trace.rb#L187-L199) function, so there's no new decompression code. The web and API downloads share it through a small [concern](https://github.com/Rub21/openstreetmap-website/blob/compress-gpx-uploads/app/controllers/concerns/gpx_download_methods.rb).

Ref: https://github.com/openstreetmap/openstreetmap-website/issues/4188

cc. @1ec5 