### PR TITLE
Adding `delivery:partner:wikidata` as a secondary wiki prefix style

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -3,7 +3,7 @@
 module BrowseTagsHelper
   # https://wiki.openstreetmap.org/wiki/Key:wikipedia#Secondary_Wikipedia_links
   # https://wiki.openstreetmap.org/wiki/Key:wikidata#Secondary_Wikidata_links
-  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|manufacturer|model|(?:official_|old_)?name:etymology|network|(?:heritage:|old_)?operator|owner|species|subject|taxon|delivery:partner"
+  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|delivery:partner|flag|genus|manufacturer|model|(?:official_|old_)?name:etymology|network|(?:heritage:|old_)?operator|owner|species|subject|taxon"
 
   def format_key(key)
     if url = wiki_link("key", key)

--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -3,7 +3,7 @@
 module BrowseTagsHelper
   # https://wiki.openstreetmap.org/wiki/Key:wikipedia#Secondary_Wikipedia_links
   # https://wiki.openstreetmap.org/wiki/Key:wikidata#Secondary_Wikidata_links
-  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|manufacturer|model|(?:official_|old_)?name:etymology|network|(?:heritage:|old_)?operator|owner|species|subject|taxon"
+  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|manufacturer|model|(?:official_|old_)?name:etymology|network|(?:heritage:|old_)?operator|owner|species|subject|taxon|delivery:partner"
 
   def format_key(key)
     if url = wiki_link("key", key)


### PR DESCRIPTION
### Description
This PR added the key `delivery:partner:wikidata` to get the same Wikidata rendering as other Wikidata fields by adding `delivery:partner` to the variable `SECONDARY_WIKI_PREFIXES` following the precedent of other keys in the list.
