### PR TITLE
Display error message if note creation fails

### DIFF
--- a/app/assets/javascripts/index/new_note.js
+++ b/app/assets/javascripts/index/new_note.js
@@ -16,10 +16,12 @@ OSM.NewNote = function (map) {
         control = $(".control-note"),
         addNoteButton = control.find(".control-button");
   let newNoteMarker,
-      halo;
+      halo,
+      errorPanel,
+      errorPanelDetail;
 
-  function createNote(location, text, callback) {
-    fetch("/api/0.6/notes.json", {
+  function createNote(location, text) {
+    return fetch("/api/0.6/notes.json", {
       method: "POST",
       headers: { ...OSM.oauth },
       body: new URLSearchParams({
@@ -28,8 +30,10 @@ OSM.NewNote = function (map) {
         text
       })
     })
-      .then(response => response.json())
-      .then(callback);
+      .then(resp => {
+        if (resp.ok) return resp.json();
+        throw new Error(`Got response with status ${resp.status} ${resp.statusText}`);
+      });
   }
 
   function addCreatedNoteMarker(feature) {
@@ -141,20 +145,30 @@ OSM.NewNote = function (map) {
       const location = newNoteMarker.getLatLng().wrap();
       const text = content.find("textarea").val();
 
+      errorPanel = content.find(".new-note-error");
+      errorPanel.addClass("d-none");
+      errorPanelDetail = errorPanel.find(".new-note-error-detail");
+
       e.preventDefault();
       $(this).prop("disabled", true);
       newNoteMarker.options.draggable = false;
       newNoteMarker.dragging.disable();
 
-      createNote(location, text, (feature) => {
-        if (typeof OSM.user === "undefined") {
-          const anonymousNotesCount = Number(OSM.cookies.get("_osm_anonymous_notes_count")) || 0;
-          OSM.cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { expires: 14 });
-        }
-        content.find("textarea").val("");
-        addCreatedNoteMarker(feature);
-        OSM.router.route("/note/" + feature.properties.id);
-      });
+      createNote(location, text)
+        .then(feature => {
+          if (typeof OSM.user === "undefined") {
+            const anonymousNotesCount = Number(OSM.cookies.get("_osm_anonymous_notes_count")) || 0;
+            OSM.cookies.set("_osm_anonymous_notes_count", anonymousNotesCount + 1, { expires: 14 });
+          }
+          content.find("textarea").val("");
+          addCreatedNoteMarker(feature);
+          OSM.router.route("/note/" + feature.properties.id);
+        })
+        .catch(err => {
+          errorPanel.removeClass("d-none");
+          errorPanelDetail.text(err.message || err);
+          updateControls();
+        });
     });
 
     map.on("click", moveNewNoteMarkerToClick);

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -24,6 +24,12 @@
     <div class="mb-3">
       <%= text_area_tag "text", "", :class => "form-control", :size => "40x10", :maxlength => "2000", :placeholder => t(".advice") %>
     </div>
+    <div class="new-note-error alert alert-danger d-none">
+      <details>
+        <summary><%= t(".error") %></summary>
+        <p class="new-note-error-detail"></p>
+      </details>
+    </div>
     <div>
       <%= submit_tag t(".add"), :name => "add", :disabled => 1, :class => "btn btn-primary" %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3568,6 +3568,7 @@ en:
         url: https://community.openstreetmap.org/
       advice: "Your note is public and may be used to update the map, so don't enter personal information, or information from copyrighted maps or directory listings."
       add: Add Note
+      error: "There was an error when creating the note"
     new_readonly:
       title: "New Note"
       warning: "New notes cannot be created because the OpenStreetMap API is currently in read-only mode."

--- a/test/system/create_note_test.rb
+++ b/test/system/create_note_test.rb
@@ -132,6 +132,26 @@ class CreateNoteTest < ApplicationSystemTestCase
     check_no_encouragement_while_logging_out
   end
 
+  test "shows a message when there is an error creating a note" do
+    visit new_note_path(:anchor => "map=18/0/0")
+
+    execute_script <<~SCRIPT
+      window.fetch = (...args) => {
+        return Promise.reject("The test injected a forced error");
+      }
+    SCRIPT
+
+    within_sidebar do
+      fill_in "text", :with => "Some newly added note description"
+      click_on "Add Note"
+
+      assert_content "There was an error when creating the note"
+      find(".new-note-error summary").click
+      assert_content "The test injected a forced error"
+      assert_button "Add Note", :disabled => false
+    end
+  end
+
   private
 
   def check_encouragement_while_creating_notes(encouragement_threshold)


### PR DESCRIPTION
Working with Moderation Zones (PR to come), I had a test where I needed to tell if note creation had failed. Then I thought it actually should be clear to users too, so solving two problems at once here.

<img width="345" height="670" alt="The note creation form, showing a message notifying that a note wasn't created due to an error" src="https://github.com/user-attachments/assets/81eb853b-f33f-43ea-8533-9900e77e31c9" />