### PR TITLE
[iD] fix glitchy zoom level caused by out-of-order event handlers

### DIFF
--- a/app/assets/javascripts/edit/id.js.erb
+++ b/app/assets/javascripts/edit/id.js.erb
@@ -42,7 +42,7 @@ $(function () {
     }
   });
 
-  let hashChangedAutomatically = false;
+  const pendingHashes = new Set();
   window.addEventListener("message", function (event) {
     if (event.source !== id[0].contentWindow || event.origin !== location.origin) return;
     const msg = event.data;
@@ -62,7 +62,8 @@ $(function () {
     const hash = OSM.formatHash(data);
     if (hash === location.hash) return;
 
-    hashChangedAutomatically = true;
+    if (pendingHashes.has(hash)) return;
+    pendingHashes.add(hash);
     location.replace(location.href.replace(/(#.*|$)/, hash));
   }
 
@@ -80,8 +81,9 @@ $(function () {
   });
 
   addEventListener("hashchange", function (e) {
-    if (hashChangedAutomatically) {
-      hashChangedAutomatically = false;
+    const hash = new URL(e.newURL).hash;
+    if (pendingHashes.has(hash)) {
+      pendingHashes.delete(hash);
       return;
     }
     e.preventDefault();


### PR DESCRIPTION
see https://github.com/openstreetmap/iD/issues/10700#issuecomment-4615707609 for a slightly deeper analysis.

tldr; normally, the `onIframeHashChange` event is immediately followed by the respective `hashchange` event. But in some conditions (when the js main thread is busy with something else), it can happen that multiple `onIframeHashChange` events/messages are received right after each other, before the respective `hashchange` events are called. The mechanism that detects whether a hash change was "automatic" (set programmatically from inside the iframe by iD) relies on the order of events to always be consistent.

This makes the implementation more robust by remembering which concrete hashchanges were triggered by the incoming iframe messages, avoiding duplicate/nop changes, and only updating the editor's map location if the hash change really did not come from the iD iframe itself.

fixes https://github.com/openstreetmap/iD/issues/10700