### PR TITLE
Remove secondary wiki prefix list

### DIFF
--- a/app/helpers/browse_tags_helper.rb
+++ b/app/helpers/browse_tags_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module BrowseTagsHelper
-  # https://wiki.openstreetmap.org/wiki/Key:wikipedia#Secondary_Wikipedia_links
-  # https://wiki.openstreetmap.org/wiki/Key:wikidata#Secondary_Wikidata_links
-  SECONDARY_WIKI_PREFIXES = "architect|artist|brand|buried|flag|genus|manufacturer|model|(?:official_|old_)?name:etymology|network|(?:heritage:|old_)?operator|owner|species|subject|taxon"
+  SECONDARY_WIKI_PREFIX_PATTERN = /[a-z:_-]+:/
+  QID_PATTERN = /[Qq][1-9][0-9]*/
+
+  # regex to match all wikipedia locale project identifiers
+  WIKIPEDIA_PROJECT_IDENTIFIER_PATTERN = /[a-z]{2,3}(?:-[a-z]{2,3})?|be-tarask|roa-tara|simple|zh-classical|zh-min-nan/
 
   def format_key(key)
     if url = wiki_link("key", key)
@@ -80,10 +82,7 @@ module BrowseTagsHelper
     # Some k/v's are wikipedia=http://en.wikipedia.org/wiki/Full%20URL
     return nil if %r{^https?://}.match?(value)
 
-    case key
-    when "wikipedia", /^(#{SECONDARY_WIKI_PREFIXES}):wikipedia/o
-      lang = "en"
-    when /^wikipedia:(\S+)$/
+    if key =~ /^(?:#{SECONDARY_WIKI_PREFIX_PATTERN})?wikipedia(?::(#{WIKIPEDIA_PROJECT_IDENTIFIER_PATTERN}))?$/o
       lang = Regexp.last_match(1)
     else
       return nil
@@ -93,13 +92,13 @@ module BrowseTagsHelper
     value.split(";").map do |wiki_value|
       wiki_value = wiki_value.strip
 
-      # This regex should match Wikipedia language codes, everything
-      # from de to zh-classical
-      if wiki_value =~ /^([a-z-]{2,12}):(.+)$/i
+      if wiki_value =~ /^(#{WIKIPEDIA_PROJECT_IDENTIFIER_PATTERN}):(.+)$/oi
         page_lang = Regexp.last_match(1)
         title_section = Regexp.last_match(2)
       else
         page_lang = lang
+        return nil unless page_lang
+
         title_section = wiki_value
       end
 
@@ -117,15 +116,14 @@ module BrowseTagsHelper
 
   def wikidata_links(key, value)
     # The simple wikidata-tag (this is limited to only one value)
-    if key == "wikidata" && value =~ /^[Qq][1-9][0-9]*$/
+    if key == "wikidata" && value =~ /^#{QID_PATTERN}$/o
       return [{
         :url => "//www.wikidata.org/entity/#{value}?uselang=#{I18n.locale}",
         :title => value
       }]
-    # Key has to be one of the accepted wikidata-tags
-    elsif key =~ /(#{SECONDARY_WIKI_PREFIXES}):wikidata/o &&
+    elsif key =~ /^#{SECONDARY_WIKI_PREFIX_PATTERN}wikidata$/o &&
           # Value has to be a semicolon-separated list of wikidata-IDs (whitespaces allowed before and after semicolons)
-          value =~ /^[Qq][1-9][0-9]*(\s*;\s*[Qq][1-9][0-9]*)*$/
+          value =~ /^#{QID_PATTERN}(?:\s*;\s*#{QID_PATTERN})*$/o
       # Splitting at every semicolon to get a separate hash for each wikidata-ID
       return value.split(";").map do |id|
         { :title => id, :url => "//www.wikidata.org/entity/#{id.strip}?uselang=#{I18n.locale}" }

--- a/test/helpers/browse_tags_helper_test.rb
+++ b/test/helpers/browse_tags_helper_test.rb
@@ -39,8 +39,8 @@ class BrowseTagsHelperTest < ActionView::TestCase
     html = format_value("phone", "+1 (234) 567-890 ;  +22334455")
     assert_dom_equal "<a href=\"tel:+1(234)567-890\" title=\"Call +1 (234) 567-890\">+1 (234) 567-890</a>; <a href=\"tel:+22334455\" title=\"Call +22334455\">+22334455</a>", html
 
-    html = format_value("wikipedia", "Test")
-    assert_dom_equal "<a title=\"The Test article on Wikipedia\" href=\"https://en.wikipedia.org/wiki/Test?uselang=en\">Test</a>", html
+    html = format_value("wikipedia", "en:Test")
+    assert_dom_equal "<a title=\"The en:Test article on Wikipedia\" href=\"https://en.wikipedia.org/wiki/Test?uselang=en\">en:Test</a>", html
 
     html = format_value("wikipedia", "de:Berlin;en:London")
     assert_dom_equal "<a title=\"The de:Berlin article on Wikipedia\" href=\"https://de.wikipedia.org/wiki/Berlin?uselang=en\">de:Berlin</a>;<a title=\"The en:London article on Wikipedia\" href=\"https://en.wikipedia.org/wiki/London?uselang=en\">en:London</a>",
@@ -160,16 +160,11 @@ class BrowseTagsHelperTest < ActionView::TestCase
 
     ### Prefixed wikidata-tags
 
-    # Not anything is accepted as prefix (only limited set)
-    links = wikidata_links("anything:wikidata", "Q13")
-    assert_nil links
-
-    # This for example is an allowed key
+    # examples for secondary wikidata keys
     links = wikidata_links("operator:wikidata", "Q24")
     assert_equal "//www.wikidata.org/entity/Q24?uselang=en", links[0][:url]
     assert_equal "Q24", links[0][:title]
 
-    # This verified buried is working
     links = wikidata_links("buried:wikidata", "Q24")
     assert_equal "//www.wikidata.org/entity/Q24?uselang=en", links[0][:url]
     assert_equal "Q24", links[0][:title]
@@ -178,7 +173,11 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_equal "//www.wikidata.org/entity/Q26899?uselang=en", links[0][:url]
     assert_equal "Q26899", links[0][:title]
 
-    # Another allowed key, this time with multiple values and I18n
+    links = wikidata_links("name:etymology:wikidata", "Q121745508")
+    assert_equal "//www.wikidata.org/entity/Q121745508?uselang=en", links[0][:url]
+    assert_equal "Q121745508", links[0][:title]
+
+    # Another one with multiple values and I18n
     I18n.with_locale "dsb" do
       links = wikidata_links("brand:wikidata", "Q936;Q2013;Q1568346")
       assert_equal 3, links.length
@@ -201,6 +200,9 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_equal "\rQ364\t\n\r ", links[2][:title]
     assert_equal "//www.wikidata.org/entity/Q4006?uselang=en", links[3][:url]
     assert_equal "\nQ4006", links[3][:title]
+
+    links = wikidata_links("source:species:wikidata", "PlantNet.org AI")
+    assert_nil links
   end
 
   def test_wikipedia_links
@@ -211,9 +213,7 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_nil links
 
     links = wikipedia_links("wikipedia", "Test")
-    assert_equal 1, links.length
-    assert_equal "https://en.wikipedia.org/wiki/Test?uselang=en", links[0][:url]
-    assert_equal "Test", links[0][:title]
+    assert_nil links
 
     links = wikipedia_links("wikipedia", "de:Test")
     assert_equal 1, links.length
@@ -282,11 +282,7 @@ class BrowseTagsHelperTest < ActionView::TestCase
 
     # Multiple values separated by ;
     links = wikipedia_links("wikipedia", "Test;Hello")
-    assert_equal 2, links.length
-    assert_equal "https://en.wikipedia.org/wiki/Test?uselang=en", links[0][:url]
-    assert_equal "Test", links[0][:title]
-    assert_equal "https://en.wikipedia.org/wiki/Hello?uselang=en", links[1][:url]
-    assert_equal "Hello", links[1][:title]
+    assert_nil links
 
     links = wikipedia_links("wikipedia", "de:Berlin;en:London;fr:Paris")
     assert_equal 3, links.length
@@ -296,6 +292,9 @@ class BrowseTagsHelperTest < ActionView::TestCase
     assert_equal "en:London", links[1][:title]
     assert_equal "https://fr.wikipedia.org/wiki/Paris?uselang=en", links[2][:url]
     assert_equal "fr:Paris", links[2][:title]
+
+    links = wikipedia_links("fixme:wikipedia", "The wikipedia tag links to a list article, not an article about this specific feature.")
+    assert_nil links
   end
 
   def test_wikimedia_commons_link


### PR DESCRIPTION
Simplify the implementation of the secondary wiki link linkification similarly to #1779, where no iterations on the loose key selection criteria have been requested in the years since then.

This closes #7127 as well as future PRs trying to replicate intricacies of a global database in a regular expression. 