### PR TITLE
Add query parameter to suppress display of signup UI elements

### DIFF
--- a/app/controllers/concerns/session_methods.rb
+++ b/app/controllers/concerns/session_methods.rb
@@ -15,6 +15,8 @@ module SessionMethods
     preferred = ref_params["preferred_auth_provider"].first
     @preferred_auth_provider = preferred if preferred && Settings.key?(:"#{preferred}_auth_id")
     @client_app_name = Oauth2Application.where(:uid => ref_params["client_id"].first).pick(:name)
+
+    @hide_signup = ref_params["allow_signup"].first == "false"
   end
 
   ##

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<%# locals: () %>
+<%# locals: (hide_signup:) %>
 
 <header class="d-flex bg-body flex-column flex-md-row h-auto position-relative text-nowrap closed z-3">
   <h1 class="d-flex m-0 align-items-center fw-semibold">
@@ -75,10 +75,12 @@
         </div>
       </div>
     <% else %>
-      <div class="d-inline-flex btn-group login-menu">
-        <%= link_to t(".log_in"), login_path(:referer => request.fullpath), :class => "geolink btn btn-outline-secondary" %>
-        <%= link_to t(".sign_up"), new_user_path, :class => "btn btn-outline-secondary" %>
-      </div>
+      <% unless hide_signup %>
+        <div class="d-inline-flex btn-group login-menu">
+          <%= link_to t(".log_in"), login_path(:referer => request.fullpath), :class => "geolink btn btn-outline-secondary" %>
+          <%= link_to t(".sign_up"), new_user_path, :class => "btn btn-outline-secondary" %>
+        </div>
+      <% end %>
     <% end %>
   </nav>
 </header>

--- a/app/views/layouts/site.html.erb
+++ b/app/views/layouts/site.html.erb
@@ -5,7 +5,7 @@
   <%= render "layouts/head", :title => @title, :opengraph_properties => @opengraph_properties %>
   <%= tag.body :class => body_class,
                :data => { :map_theme => current_user&.preferred_color_scheme(:map, :site) } do %>
-    <%= render :partial => "layouts/header" %>
+    <%= render :partial => "layouts/header", :locals => { :hide_signup => @hide_signup } %>
     <%= render :partial => "layouts/content" %>
     <% if defined?(Settings.matomo) -%>
     <noscript><p><%= image_tag "#{request.protocol}#{Settings.matomo['location']}/matomo.php?idsite=#{Settings.matomo['site']}", :class => "matomo", :alt => "" %></p></noscript>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,14 +11,16 @@
   <% end %>
 
   <div class="d-flex align-items-end">
-    <ul class="nav nav-tabs fs-6">
-      <li class="nav-item">
-        <%= link_to t("sessions.new.tab_title"), "#", :class => "nav-link active" %>
-      </li>
-      <li class="nav-item">
-        <%= link_to t("users.new.tab_title"), url_for(:action => :new, :controller => :users, :referer => params[:referer]), :class => "nav-link" %>
-      </li>
-    </ul>
+    <% unless @hide_signup %>
+      <ul class="nav nav-tabs fs-6">
+        <li class="nav-item">
+          <%= link_to t("sessions.new.tab_title"), "#", :class => "nav-link active" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to t("users.new.tab_title"), url_for(:action => :new, :controller => :users, :referer => params[:referer]), :class => "nav-link" %>
+        </li>
+      </ul>
+    <% end %>
     <div class="flex-grow-1 header-illustration new-user-main"></div>
   </div>
 <% end %>

--- a/test/integration/oauth2_test.rb
+++ b/test/integration/oauth2_test.rb
@@ -148,6 +148,45 @@ class OAuth2Test < ActionDispatch::IntegrationTest
     assert_equal Doorkeeper::OpenidConnect.signing_key.kid, key_info["keys"][0]["kid"]
   end
 
+  def test_allow_signup_not_set
+    client = create(:oauth_application, :redirect_uri => "https://some.web.app.example.org/callback", :scopes => "read_prefs write_api read_gpx")
+
+    options = {
+      :client_id => client.uid,
+      :redirect_uri => client.redirect_uri,
+      :response_type => "code",
+      :scope => "read_prefs"
+    }
+
+    oauth_path = oauth_authorization_path(options)
+    login_for_oauth_path = login_path(:referer => oauth_path)
+    cookies["_osm_session"] = "reassure the backend that cookies are enabled"
+    get oauth_path
+    assert_redirected_to login_for_oauth_path
+    get login_for_oauth_path
+    assert_match "Sign Up", response.body
+  end
+
+  def test_allow_signup_false
+    client = create(:oauth_application, :redirect_uri => "https://some.web.app.example.org/callback", :scopes => "read_prefs write_api read_gpx")
+
+    options = {
+      :client_id => client.uid,
+      :redirect_uri => client.redirect_uri,
+      :response_type => "code",
+      :scope => "read_prefs",
+      :allow_signup => "false"
+    }
+
+    oauth_path = oauth_authorization_path(options)
+    login_for_oauth_path = login_path(:referer => oauth_path)
+    cookies["_osm_session"] = "reassure the backend that cookies are enabled"
+    get oauth_path
+    assert_redirected_to login_for_oauth_path
+    get login_for_oauth_path
+    assert_no_match "Sign Up", response.body
+  end
+
   private
 
   def authorize_client(user, client, options = {})


### PR DESCRIPTION
This adds support for a query parameter "allow_signup" that will suppress the rendering of signup UI elements during the OAuth2 authorisation flow.

This is the same solution as github implements for their "webflow" OAuth2 process.

Resolves https://github.com/openstreetmap/openstreetmap-website/issues/5118

### Description

With _allow_signup_ set to "true" or absent there are no visual changes, with _allow_signup_ set to "false" during authorisation, the log in/sign up tabs are removed, including the similar buttons when the hamburger menu is clicked. Screenshots from authorisation with allow_signup=false.

<img width="1440" height="3120" alt="Screenshot_1780827477" src="https://github.com/user-attachments/assets/19205201-3e48-42d3-a879-babf7bd83889" />

<img width="1440" height="3120" alt="Screenshot_1780827664" src="https://github.com/user-attachments/assets/b2db0f6d-832d-4e22-99bf-c62559e66122" />


### How has this been tested?
Not at all yet ... this needs to have an integration test.
