### PR TITLE
CRUD interface for moderation zones

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -64,6 +64,7 @@ class Ability
           can :update, UserBlock, :creator => user
           can :update, UserBlock, :revoker => user
           can :update, UserBlock, :active? => true
+          can :manage, ModerationZone
         end
 
         if user.administrator?

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -64,7 +64,10 @@ class Ability
           can :update, UserBlock, :creator => user
           can :update, UserBlock, :revoker => user
           can :update, UserBlock, :active? => true
-          can :manage, ModerationZone
+          can [:read, :create, :destroy], ModerationZone
+          can :update, ModerationZone, :creator => user
+          can :update, ModerationZone, :revoker => user
+          can :update, ModerationZone, :active? => true
         end
 
         if user.administrator?

--- a/app/assets/javascripts/moderation_zone.js
+++ b/app/assets/javascripts/moderation_zone.js
@@ -77,6 +77,7 @@ $(function () {
     const feature = readFormField(COORDINATES_FIELD_ID);
     if (feature) {
       startTerraDrawForEdit(draw, feature);
+      map.fitBounds(featureToBox(feature), { radius: 100 });
     } else {
       startTerraDrawForNew(draw);
     }
@@ -141,5 +142,11 @@ $(function () {
       .join(",\n");
     const target = document.getElementById(fieldId);
     target.value = `POLYGON((\n${coordinatesString}\n))`;
+  }
+
+  function featureToBox(feature) {
+    const points = feature.geometry.coordinates[0];
+    const seed = new maplibregl.LngLatBounds(points[0], points[0]);
+    return points.reduce((bounds, point) => bounds.extend(point), seed);
   }
 });

--- a/app/assets/javascripts/moderation_zone.js
+++ b/app/assets/javascripts/moderation_zone.js
@@ -1,0 +1,145 @@
+//= require maplibre/map
+//= require terra-draw/dist/terra-draw.umd
+//= require terra-draw-maplibre-gl-adapter/dist/terra-draw-maplibre-gl-adapter.umd
+
+/* globals terraDraw, terraDrawMaplibreGlAdapter */
+
+$(function () {
+  const COORDINATES_FIELD_ID = "moderation_zone_zone";
+  const POSTGIS_LINE_POINTS_REGEXP = /[0-9-][ 0-9.,-]+/;
+  const SELECT_MODE_OPTIONS = {
+    flags: {
+      polygon: {
+        feature: {
+          draggable: false,
+          coordinates: {
+            midpoints: { draggable: true },
+            draggable: true,
+            snappable: true,
+            deletable: true,
+
+            // Disallow resizing of the geometry from a given origin.
+            resizable: false
+          }
+        }
+      }
+    }
+  };
+
+  const baseMap = new OSM.MapLibre.SecondaryMap();
+
+  baseMap.once("style.load", () => {
+    try {
+      const draw = createTerraDrawInstance(baseMap);
+      draw.on("finish", createTerraDrawFinishHandler(draw));
+      loadData(baseMap, draw);
+    } catch (e) {
+      // MapLibre is swallowing these exceptions silently, so I had
+      // to add this to know why my code was failing as I went.
+      console.error(e); // eslint-disable-line no-console
+      throw e;
+    }
+  });
+
+  function createTerraDrawInstance(map) {
+    return new terraDraw.TerraDraw({
+      adapter: new terraDrawMaplibreGlAdapter.TerraDrawMapLibreGLAdapter({
+        map,
+        lib: maplibregl
+      }),
+      modes: [
+        new terraDraw.TerraDrawPolygonMode(),
+        new terraDraw.TerraDrawSelectMode(SELECT_MODE_OPTIONS)
+      ]
+    });
+  }
+
+  function createTerraDrawFinishHandler(draw) {
+    return function (id, { mode, action }) {
+      if (mode === "polygon") {
+        draw.setMode("select");
+      } else if (mode === "select") {
+        // Nothing to do
+      } else {
+        throw new Error(`Unexpected mode "${mode}" (action: "${action}")`);
+      }
+
+      const feature = draw.getSnapshotFeature(id);
+      if (!feature) {
+        throw new Error(`Could not find feature with id ${id}`);
+      }
+
+      writeFormField(COORDINATES_FIELD_ID, feature);
+    };
+  }
+
+  function loadData(map, draw) {
+    const feature = readFormField(COORDINATES_FIELD_ID);
+    if (feature) {
+      startTerraDrawForEdit(draw, feature);
+    } else {
+      startTerraDrawForNew(draw);
+    }
+  }
+
+  function readFormField(fieldId) {
+    const target = document.getElementById(fieldId);
+    if (!target) {
+      throw new Error(`Could not find field #${fieldId}`);
+    }
+
+    const cleanValue = target.value.trim();
+    if (cleanValue === "") {
+      return null;
+    }
+
+    const match = POSTGIS_LINE_POINTS_REGEXP.exec(cleanValue);
+    if (!match) {
+      throw new Error(`Unexpected value in field #${fieldId}. Expected a WKT geometry, but found: ${target.value}`);
+    }
+
+    const coordinatesString = match[0];
+    const pointStrings = coordinatesString.split(",").map(s => s.trim());
+    const points = pointStrings.map(s => s.split(" ")).map(pairs => pairs.map(parseFloat));
+    return {
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [points]
+      },
+      properties: {
+        mode: "polygon"
+      }
+    };
+  }
+
+  function startTerraDrawForEdit(draw, feature) {
+    draw.start();
+    draw.setMode("polygon");
+    const results = draw.addFeatures([feature]);
+    const invalidFeatures = [];
+    results.forEach(r => {
+      if (!r.valid) {
+        invalidFeatures.push(r);
+      }
+    });
+    if (invalidFeatures.length > 0) {
+      const invalidFeaturesString = invalidFeatures.map(JSON.stringify).join("\n");
+      throw new Error(`Failed to load features into TerraDraw:\n${invalidFeaturesString}`);
+    }
+    draw.setMode("select");
+  }
+
+  function startTerraDrawForNew(draw) {
+    draw.start();
+    draw.setMode("polygon");
+  }
+
+  function writeFormField(fieldId, feature) {
+    const coordinatesString = feature.geometry.coordinates[0]
+      .map(([lon, lat]) => `${lon} ${lat}`)
+      .join(",\n");
+    const target = document.getElementById(fieldId);
+    target.value = `POLYGON((\n${coordinatesString}\n))`;
+  }
+});

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -89,7 +89,7 @@ module Api
       lat = OSM.parse_float(params[:lat], OSM::APIBadUserInput, "lat was not a number")
       description = params[:text]
 
-      raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any?(:lon => lon, :lat => lat)
+      raise OSM::APIModerationZoneError if current_user.nil? && ModerationZone.falls_within_any_active?(:lon => lon, :lat => lat)
 
       # Get note's author info (for logged in users - user_id, for logged out users - IP address)
       note_author_info = author_info

--- a/app/controllers/moderation_zones_controller.rb
+++ b/app/controllers/moderation_zones_controller.rb
@@ -36,7 +36,16 @@ class ModerationZonesController < ApplicationController
   def update
     check_revocation(@moderation_zone, moderation_zone_params)
 
-    if @moderation_zone.update(moderation_zone_params)
+    if cannot?(:update, @moderation_zone)
+      flash[:error] = @moderation_zone.revoker ? t(".only_creator_or_revoker_can_edit") : t(".only_creator_can_edit")
+      redirect_to moderation_zones_url
+    elsif current_user != @moderation_zone.creator && updating_without_revoking?(@moderation_zone, moderation_zone_params)
+      flash[:error] = t(".only_creator_can_edit_without_revoking")
+      redirect_to moderation_zones_url
+    elsif reactivating?(@moderation_zone, moderation_zone_params)
+      flash[:error] = t(".no_reactivation")
+      redirect_to moderation_zones_url
+    elsif @moderation_zone.update(moderation_zone_params)
       redirect_to moderation_zones_url, :notice => t(".success"), :status => :see_other
     else
       render :edit, :status => :unprocessable_content
@@ -60,5 +69,19 @@ class ModerationZonesController < ApplicationController
     previously_active = duplicate.active?
     duplicate.assign_attributes(modzone_params)
     modzone.revoker = current_user if previously_active && !duplicate.active?
+  end
+
+  def updating_without_revoking?(modzone, modzone_params)
+    duplicate = modzone.dup
+    previously_active = duplicate.active?
+    duplicate.assign_attributes(modzone_params)
+    previously_active && duplicate.active?
+  end
+
+  def reactivating?(modzone, modzone_params)
+    duplicate = modzone.dup
+    previously_active = duplicate.active?
+    duplicate.assign_attributes(modzone_params)
+    !previously_active && duplicate.active?
   end
 end

--- a/app/controllers/moderation_zones_controller.rb
+++ b/app/controllers/moderation_zones_controller.rb
@@ -34,6 +34,8 @@ class ModerationZonesController < ApplicationController
   end
 
   def update
+    check_revocation(@moderation_zone, moderation_zone_params)
+
     if @moderation_zone.update(moderation_zone_params)
       redirect_to moderation_zones_url, :notice => t(".success"), :status => :see_other
     else
@@ -51,5 +53,12 @@ class ModerationZonesController < ApplicationController
     params.expect(:moderation_zone => [:name, :reason, :zone, :period]).tap do |safe_params|
       safe_params[:ends_at] = safe_params.delete("period").to_i.hours.from_now
     end
+  end
+
+  def check_revocation(modzone, modzone_params)
+    duplicate = modzone.dup
+    previously_active = duplicate.active?
+    duplicate.assign_attributes(modzone_params)
+    modzone.revoker = current_user if previously_active && !duplicate.active?
   end
 end

--- a/app/controllers/moderation_zones_controller.rb
+++ b/app/controllers/moderation_zones_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class ModerationZonesController < ApplicationController
+  layout :site_layout
+
+  before_action :authorize_web
+  before_action :set_locale
+
+  authorize_resource
+
+  before_action :check_database_readable
+  before_action :check_database_writable, :except => [:index]
+  before_action :set_moderation_zone, :only => [:edit, :update]
+
+  def index
+    @moderation_zones = ModerationZone.all
+  end
+
+  def new
+    @moderation_zone = ModerationZone.new
+  end
+
+  def edit; end
+
+  def create
+    @moderation_zone = ModerationZone.new(moderation_zone_params)
+    @moderation_zone.creator = current_user
+
+    if @moderation_zone.save
+      redirect_to moderation_zones_url, :notice => t(".success")
+    else
+      render :new, :status => :unprocessable_content
+    end
+  end
+
+  def update
+    if @moderation_zone.update(moderation_zone_params)
+      redirect_to moderation_zones_url, :notice => t(".success"), :status => :see_other
+    else
+      render :edit, :status => :unprocessable_content
+    end
+  end
+
+  private
+
+  def set_moderation_zone
+    @moderation_zone = ModerationZone.find(params.expect(:id))
+  end
+
+  def moderation_zone_params
+    params.expect(:moderation_zone => [:name, :reason, :zone, :period]).tap do |safe_params|
+      safe_params[:ends_at] = safe_params.delete("period").to_i.hours.from_now
+    end
+  end
+end

--- a/app/controllers/moderation_zones_controller.rb
+++ b/app/controllers/moderation_zones_controller.rb
@@ -64,24 +64,21 @@ class ModerationZonesController < ApplicationController
     end
   end
 
-  def check_revocation(modzone, modzone_params)
-    duplicate = modzone.dup
-    previously_active = duplicate.active?
-    duplicate.assign_attributes(modzone_params)
-    modzone.revoker = current_user if previously_active && !duplicate.active?
+  def check_revocation(original, changes)
+    original.revoker = current_user if original.active? && !projected_record(original, changes).active?
   end
 
-  def updating_without_revoking?(modzone, modzone_params)
-    duplicate = modzone.dup
-    previously_active = duplicate.active?
-    duplicate.assign_attributes(modzone_params)
-    previously_active && duplicate.active?
+  def updating_without_revoking?(original, changes)
+    original.active? && projected_record(original, changes).active?
   end
 
-  def reactivating?(modzone, modzone_params)
-    duplicate = modzone.dup
-    previously_active = duplicate.active?
-    duplicate.assign_attributes(modzone_params)
-    !previously_active && duplicate.active?
+  def reactivating?(original, changes)
+    !original.active? && projected_record(original, changes).active?
+  end
+
+  def projected_record(original, changes)
+    original.dup.tap do |duplicate|
+      duplicate.assign_attributes(changes)
+    end
   end
 end

--- a/app/helpers/moderation_zones_helper.rb
+++ b/app/helpers/moderation_zones_helper.rb
@@ -22,4 +22,22 @@ module ModerationZonesHelper
       end
     end
   end
+
+  def moderation_zone_short_status(moderation_zone)
+    if moderation_zone.active?
+      t("moderation_zones.helper.short.active")
+    elsif moderation_zone.revoker_id
+      t(
+        "moderation_zones.helper.short.revoked_html",
+        :name => link_to(
+          moderation_zone.revoker.display_name,
+          moderation_zone.revoker,
+          :class => "username d-inline-block text-truncate text-wrap align-bottom",
+          :dir => "auto"
+        )
+      )
+    else
+      t("moderation_zones.helper.short.ended")
+    end
+  end
 end

--- a/app/helpers/moderation_zones_helper.rb
+++ b/app/helpers/moderation_zones_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ModerationZonesHelper
+  def options_for_moderation_zone_period
+    ModerationZone::PERIODS.collect do |h|
+      [block_duration_in_words(h.hours), h.to_s]
+    end
+  end
+
+  def selected_option_for_moderation_zone_period(moderation_zone)
+    param_value = params.dig(:moderation_zone, :period)
+    value_to_compare =
+      if param_value
+        param_value.to_i
+      elsif moderation_zone.ends_at
+        ((moderation_zone.ends_at - Time.now.utc) / 1.hour).ceil
+      end
+
+    if value_to_compare
+      ModerationZone::PERIODS.min_by do |h|
+        (value_to_compare - h).abs
+      end
+    end
+  end
+end

--- a/app/models/moderation_zone.rb
+++ b/app/models/moderation_zone.rb
@@ -26,6 +26,8 @@
 #  fk_rails_...  (revoker_id => users.id)
 #
 class ModerationZone < ApplicationRecord
+  PERIODS = Settings.user_block_periods.excluding(0).freeze
+
   belongs_to :creator, :class_name => "User"
   belongs_to :revoker, :class_name => "User", :optional => true
 

--- a/app/models/moderation_zone.rb
+++ b/app/models/moderation_zone.rb
@@ -36,12 +36,16 @@ class ModerationZone < ApplicationRecord
   validates :zone, :presence => true
   validates :ends_at, :presence => true
 
-  def self.falls_within_any?(lon:, lat:)
+  def self.falls_within_any_active?(lon:, lat:)
     factory = RGeo::Cartesian.simple_factory(:srid => 4326)
     point = factory.point(lon, lat)
 
     where(
       arel_table[:zone].st_contains(point)
-    ).exists?
+    ).any?(&:active?)
+  end
+
+  def active?
+    ends_at.future?
   end
 end

--- a/app/views/moderation_zones/_form.html.erb
+++ b/app/views/moderation_zones/_form.html.erb
@@ -1,0 +1,17 @@
+<%# locals: (moderation_zone:) %>
+
+<%= bootstrap_form_with(:model => moderation_zone) do |form| %>
+  <%= form.text_field :name %>
+
+  <%= form.richtext_field :reason, :cols => 80, :rows => 20, :format => moderation_zone.reason_format %>
+
+  <%= form.text_area :zone %>
+
+  <%= form.select(
+        :period,
+        options_for_moderation_zone_period,
+        :selected => selected_option_for_moderation_zone_period(moderation_zone)
+      ) %>
+
+  <%= form.primary %>
+<% end %>

--- a/app/views/moderation_zones/_form.html.erb
+++ b/app/views/moderation_zones/_form.html.erb
@@ -1,11 +1,19 @@
 <%# locals: (moderation_zone:) %>
 
+<% content_for :head do %>
+  <%= javascript_include_tag "moderation_zone" %>
+<% end %>
+
 <%= bootstrap_form_with(:model => moderation_zone) do |form| %>
   <%= form.text_field :name %>
 
   <%= form.richtext_field :reason, :cols => 80, :rows => 20, :format => moderation_zone.reason_format %>
 
-  <%= form.text_area :zone %>
+  <%= form.form_group do %>
+    <%= form.label :zone %>
+    <div id="map" class="content_map border rounded z-0"></div>
+    <%= form.hidden_field :zone %>
+  <% end %>
 
   <%= form.select(
         :period,

--- a/app/views/moderation_zones/_navigation.html.erb
+++ b/app/views/moderation_zones/_navigation.html.erb
@@ -1,0 +1,12 @@
+<%# locals: () %>
+
+<nav class="secondary-actions">
+  <ul>
+    <li>
+      <%= link_to new_moderation_zone_path, :class => "icon-link", :title => t(".new_title") do %>
+        <i class="align-self-baseline bi bi-plus-square-fill fs-6" aria-hidden="true"></i>
+        <%= t(".new") %>
+      <% end %>
+    </li>
+  </ul>
+</nav>

--- a/app/views/moderation_zones/_row.html.erb
+++ b/app/views/moderation_zones/_row.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (moderation_zone:) %>
+
+<tr>
+  <td><%= moderation_zone.name %></td>
+  <td><%= moderation_zone.reason %></td>
+  <td><%= moderation_zone.creator.display_name %></td>
+  <td><%= block_short_time_in_past(moderation_zone.created_at) %></td>
+  <td>
+    <% if moderation_zone.ends_at.future? %>
+      <%= block_short_time_in_future(moderation_zone.ends_at) %>
+    <% else %>
+      <%= block_short_time_in_past(moderation_zone.ends_at) %>
+    <% end %>
+  </td>
+  <td><%= link_to t(".edit"), edit_moderation_zone_path(moderation_zone) %></td>
+</tr>

--- a/app/views/moderation_zones/_row.html.erb
+++ b/app/views/moderation_zones/_row.html.erb
@@ -12,5 +12,6 @@
       <%= block_short_time_in_past(moderation_zone.ends_at) %>
     <% end %>
   </td>
+  <td><%= moderation_zone_short_status(moderation_zone) %></td>
   <td><%= link_to t(".edit"), edit_moderation_zone_path(moderation_zone) %></td>
 </tr>

--- a/app/views/moderation_zones/edit.html.erb
+++ b/app/views/moderation_zones/edit.html.erb
@@ -1,0 +1,8 @@
+<% @title = t ".title", :name => @moderation_zone.name %>
+
+<% content_for :heading_class, "pb-0" %>
+<% content_for :heading do %>
+  <h1><%= t(".heading", :name => @moderation_zone.name) %></h1>
+<% end %>
+
+<%= render "form", :moderation_zone => @moderation_zone %>

--- a/app/views/moderation_zones/index.html.erb
+++ b/app/views/moderation_zones/index.html.erb
@@ -14,6 +14,7 @@
       <th><%= t(".creator") %></th>
       <th><%= t(".start") %></th>
       <th><%= t(".end") %></th>
+      <th><%= t(".status") %></th>
       <th></th>
     </tr>
   </thead>

--- a/app/views/moderation_zones/index.html.erb
+++ b/app/views/moderation_zones/index.html.erb
@@ -1,0 +1,25 @@
+<% @title = t(".title") %>
+
+<% content_for :heading_class, "pb-0" %>
+<% content_for :heading do %>
+  <h1><%= t(".heading") %></h1>
+  <%= render "navigation" %>
+<% end %>
+
+<table class="table table-borderless table-striped table-sm">
+  <thead>
+    <tr>
+      <th><%= t(".name") %></th>
+      <th><%= t(".reason") %></th>
+      <th><%= t(".creator") %></th>
+      <th><%= t(".start") %></th>
+      <th><%= t(".end") %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @moderation_zones.each do |moderation_zone| %>
+      <%= render "row", :moderation_zone => moderation_zone %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/moderation_zones/new.html.erb
+++ b/app/views/moderation_zones/new.html.erb
@@ -1,0 +1,8 @@
+<% @title = t ".title", :name => @moderation_zone.name %>
+
+<% content_for :heading_class, "pb-0" %>
+<% content_for :heading do %>
+  <h1><%= t(".heading", :name => @moderation_zone.name) %></h1>
+<% end %>
+
+<%= render "form", :moderation_zone => @moderation_zone %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,11 @@ en:
         gpx_file: Choose GPS Trace File
         visibility: Visibility
         tagstring: Tags
+      moderation_zone:
+        name: Name
+        reason: Reason
+        zone: Zone
+        period: Period
       message:
         sender: "Sender"
         title: "Subject"
@@ -3846,3 +3851,27 @@ en:
     trailing_whitespace: "has trailing whitespace"
     invalid_characters: "contains invalid characters"
     url_characters: "contains special URL characters (%{characters})"
+  moderation_zones:
+    navigation:
+      new_title: Define a new moderation zone
+      new: New Moderation Zone
+    index:
+      title: Moderation Zones
+      heading: Moderation Zones
+      name: Name
+      reason: Reason
+      creator: Creator
+      start: Start
+      end: End
+    row:
+      edit: Edit
+    new:
+      title: New Moderation Zone
+      heading: New Moderation Zone
+    create:
+      success: "Moderation zone created."
+    edit:
+      title: "Editing moderation zone %{name}"
+      heading: "Editing moderation zone %{name}"
+    update:
+      success: "Moderation zone updated."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3876,6 +3876,10 @@ en:
       heading: "Editing moderation zone %{name}"
     update:
       success: "Moderation zone updated."
+      only_creator_can_edit: "Only the moderator who created this moderation zone can edit it."
+      only_creator_can_edit_without_revoking: "Only the moderator who created this moderation zone can edit it without revoking."
+      only_creator_or_revoker_can_edit: "Only the moderators who created or revoked this moderation zone can edit it."
+      no_reactivation: "This moderation zone is inactive and cannot be reactivated."
     helper:
       short:
         ended: "ended"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3863,6 +3863,7 @@ en:
       creator: Creator
       start: Start
       end: End
+      status: Status
     row:
       edit: Edit
     new:
@@ -3875,3 +3876,8 @@ en:
       heading: "Editing moderation zone %{name}"
     update:
       success: "Moderation zone updated."
+    helper:
+      short:
+        ended: "ended"
+        active: "active"
+        revoked_html: "revoked by %{name}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -432,6 +432,9 @@ OpenStreetMap::Application.routes.draw do
   # redactions
   resources :redactions
 
+  # moderation zones
+  resources :moderation_zones, :only => [:index, :new, :create, :edit, :update]
+
   # errors
   match "/400", :to => "errors#bad_request", :via => :all
   match "/403", :to => "errors#forbidden", :via => :all

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "make-plural": "^8.1.0",
     "maplibre-gl": "^5.22.0",
     "osm-community-index": "^6.0.0",
-    "tag2link": "^2026.1.21"
+    "tag2link": "^2026.1.21",
+    "terra-draw": "^1.30.1",
+    "terra-draw-maplibre-gl-adapter": "^1.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/test/controllers/moderation_zones_controller_test.rb
+++ b/test/controllers/moderation_zones_controller_test.rb
@@ -38,9 +38,17 @@ class ModerationZonesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index, as moderator" do
+    create(:moderation_zone, :ends_at => 1.week.ago)
+    create(:moderation_zone, :ends_at => 1.week.from_now)
+    revoker = create(:moderator_user, :display_name => "Revokator")
+    create(:moderation_zone, :ends_at => 1.week.ago, :revoker => revoker)
+
     session_for(create(:moderator_user))
     get moderation_zones_url
     assert_response :success
+    assert_dom "td", :text => "active"
+    assert_dom "td", :text => "ended"
+    assert_dom "td", :text => "revoked by Revokator"
   end
 
   test "new, unauthenticated" do

--- a/test/controllers/moderation_zones_controller_test.rb
+++ b/test/controllers/moderation_zones_controller_test.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ModerationZonesControllerTest < ActionDispatch::IntegrationTest
+  test "routes" do
+    assert_routing(
+      { :path => "/moderation_zones", :method => :get },
+      { :controller => "moderation_zones", :action => "index" }
+    )
+    assert_routing(
+      { :path => "/moderation_zones/new", :method => :get },
+      { :controller => "moderation_zones", :action => "new" }
+    )
+    assert_routing(
+      { :path => "/moderation_zones/123/edit", :method => :get },
+      { :controller => "moderation_zones", :action => "edit", :id => "123" }
+    )
+    assert_routing(
+      { :path => "/moderation_zones", :method => :post },
+      { :controller => "moderation_zones", :action => "create" }
+    )
+    assert_routing(
+      { :path => "/moderation_zones/123", :method => :put },
+      { :controller => "moderation_zones", :action => "update", :id => "123" }
+    )
+  end
+
+  test "index, unauthenticated" do
+    get moderation_zones_url
+    assert_redirected_to login_url(:referer => moderation_zones_path)
+  end
+
+  test "index, as normal user" do
+    session_for(create(:user))
+    get moderation_zones_url
+    assert_redirected_to "/403"
+  end
+
+  test "index, as moderator" do
+    session_for(create(:moderator_user))
+    get moderation_zones_url
+    assert_response :success
+  end
+
+  test "new, unauthenticated" do
+    get new_moderation_zone_url
+    assert_redirected_to login_url(:referer => new_moderation_zone_path)
+  end
+
+  test "new, as normal user" do
+    session_for(create(:user))
+    get new_moderation_zone_url
+    assert_redirected_to "/403"
+  end
+
+  test "new, as moderator" do
+    session_for(create(:moderator_user))
+    get new_moderation_zone_url
+    assert_response :success
+  end
+
+  test "create, unauthenticated" do
+    post(
+      moderation_zones_url,
+      :params => { :moderation_zone => {} }
+    )
+    assert_response :forbidden
+  end
+
+  test "create, as normal user" do
+    session_for(create(:user))
+    post(
+      moderation_zones_url,
+      :params => {
+        :moderation_zone => {
+          **attributes_for(:moderation_zone)
+            .slice(:name, :reason, :zone),
+          :period => 2.days.in_hours
+        }
+      }
+    )
+    assert_redirected_to "/403"
+  end
+
+  test "create, as moderator" do
+    moderator = create(:moderator_user)
+    session_for(moderator)
+
+    assert_difference("ModerationZone.count") do
+      post(
+        moderation_zones_url,
+        :params => {
+          :moderation_zone => {
+            **attributes_for(:moderation_zone)
+              .slice(:name, :reason, :zone),
+            :period => 2.days.in_hours
+          }
+        }
+      )
+    end
+
+    moderation_zone = ModerationZone.last
+    assert_redirected_to moderation_zones_url
+
+    assert_in_delta moderation_zone.ends_at, 2.days.from_now, 10.seconds
+  end
+
+  test "create, with errors" do
+    moderator = create(:moderator_user)
+    session_for(moderator)
+
+    assert_no_difference("ModerationZone.count") do
+      post(
+        moderation_zones_url,
+        :params => {
+          :moderation_zone => {
+            **attributes_for(:moderation_zone)
+              .slice(:name, :zone),
+            :period => 6.months.in_hours
+          }
+        }
+      )
+    end
+
+    assert_response :unprocessable_content
+    assert_dom "option[selected]", :text => "6 months"
+  end
+
+  test "edit, unauthenticated" do
+    get edit_moderation_zone_url(123)
+    assert_redirected_to login_path(:referer => edit_moderation_zone_path(123))
+  end
+
+  test "edit, as normal user" do
+    session_for(create(:user))
+    moderation_zone = create(:moderation_zone, :ends_at => 1.year.from_now)
+    get edit_moderation_zone_url(moderation_zone)
+    assert_redirected_to "/403"
+  end
+
+  test "edit, as moderator" do
+    session_for(create(:moderator_user))
+    moderation_zone = create(:moderation_zone, :ends_at => 1.year.from_now)
+    get edit_moderation_zone_url(moderation_zone)
+    assert_response :success
+    assert_dom "option[selected]", :text => "1 year"
+  end
+
+  test "update, unauthenticated" do
+    patch(
+      moderation_zone_url(123),
+      :params => { :moderation_zone => {} }
+    )
+    assert_response :forbidden
+  end
+
+  test "update, as normal user" do
+    # This is an edge case: a normal user has a moderation zone to their name.
+    # Perhaps they used to be a moderator, but no longer. The important
+    # bit is that they shouldn't be able to update it any more.
+    #
+    # Instead of this we could just have a test for "normal user can't update"
+    # with a simpler request (eg: with empty params) but, for the sake of
+    # doing it properly, let's have everyting in place except for the only detail
+    # that the user is not a moderator.
+    session_for(create(:user))
+    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :name => moderation_zone.name,
+          :reason => moderation_zone.reason,
+          :zone => moderation_zone.zone,
+          :period => 2.weeks.in_hours
+        }
+      }
+    )
+    assert_redirected_to "/403"
+  end
+
+  test "update, as moderator" do
+    session_for(create(:moderator_user))
+    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :name => moderation_zone.name,
+          :reason => moderation_zone.reason,
+          :zone => moderation_zone.zone,
+          :period => 2.weeks.in_hours
+        }
+      }
+    )
+    assert_redirected_to moderation_zones_url
+
+    moderation_zone.reload
+    assert_in_delta moderation_zone.ends_at, 2.weeks.from_now, 10.seconds
+  end
+
+  test "update, with errors" do
+    session_for(create(:moderator_user))
+    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :name => moderation_zone.name,
+          :reason => "",
+          :zone => moderation_zone.zone,
+          :period => 4.days.in_hours
+        }
+      }
+    )
+
+    assert_response :unprocessable_content
+    assert_dom "option[selected]", :text => "4 days"
+  end
+end

--- a/test/controllers/moderation_zones_controller_test.rb
+++ b/test/controllers/moderation_zones_controller_test.rb
@@ -200,6 +200,7 @@ class ModerationZonesControllerTest < ActionDispatch::IntegrationTest
 
     moderation_zone.reload
     assert_in_delta moderation_zone.ends_at, 2.weeks.from_now, 10.seconds
+    assert_nil moderation_zone.revoker
   end
 
   test "update, with errors" do
@@ -220,5 +221,27 @@ class ModerationZonesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_content
     assert_dom "option[selected]", :text => "4 days"
+  end
+
+  test "update to revoke" do
+    revoker = create(:moderator_user)
+    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now)
+    session_for(revoker)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :name => moderation_zone.name,
+          :reason => moderation_zone.reason,
+          :zone => moderation_zone.zone,
+          :period => 0
+        }
+      }
+    )
+    assert_redirected_to moderation_zones_url
+
+    moderation_zone.reload
+    assert_equal revoker, moderation_zone.revoker
   end
 end

--- a/test/controllers/moderation_zones_controller_test.rb
+++ b/test/controllers/moderation_zones_controller_test.rb
@@ -172,8 +172,9 @@ class ModerationZonesControllerTest < ActionDispatch::IntegrationTest
     # with a simpler request (eg: with empty params) but, for the sake of
     # doing it properly, let's have everyting in place except for the only detail
     # that the user is not a moderator.
-    session_for(create(:user))
-    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now)
+    creator = create(:user)
+    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now, :creator => creator)
+    session_for(creator)
 
     patch(
       moderation_zone_url(moderation_zone),
@@ -190,8 +191,9 @@ class ModerationZonesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update, as moderator" do
-    session_for(create(:moderator_user))
-    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now)
+    creator = create(:moderator_user)
+    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now, :creator => creator)
+    session_for(creator)
 
     patch(
       moderation_zone_url(moderation_zone),
@@ -212,8 +214,9 @@ class ModerationZonesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update, with errors" do
-    session_for(create(:moderator_user))
-    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now)
+    creator = create(:moderator_user)
+    moderation_zone = create(:moderation_zone, :ends_at => 1.week.from_now, :creator => creator)
+    session_for(creator)
 
     patch(
       moderation_zone_url(moderation_zone),
@@ -251,5 +254,108 @@ class ModerationZonesControllerTest < ActionDispatch::IntegrationTest
 
     moderation_zone.reload
     assert_equal revoker, moderation_zone.revoker
+  end
+
+  test "update, by non-creator, of inactive+unrevoked record" do
+    updater = create(:moderator_user)
+    moderation_zone = create(:moderation_zone, :reason => "Initial reason", :ends_at => 1.week.ago)
+    session_for(updater)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :reason => "Updated reason"
+        }
+      }
+    )
+    assert_redirected_to moderation_zones_url
+    assert_equal "Only the moderator who created this moderation zone can edit it.", flash[:error]
+
+    moderation_zone.reload
+    assert_equal "Initial reason", moderation_zone.reason
+  end
+
+  test "update, by creator, of inactive+revoked record" do
+    creator = create(:moderator_user)
+    moderation_zone = create(:moderation_zone, :reason => "Initial reason", :creator => creator, :ends_at => 1.week.ago)
+    session_for(creator)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :reason => "Updated reason"
+        }
+      }
+    )
+
+    assert_redirected_to moderation_zones_url
+    assert_nil flash[:error]
+
+    moderation_zone.reload
+    assert_equal "Updated reason", moderation_zone.reason
+  end
+
+  test "update, by non-creator, of revoked record" do
+    updater = create(:moderator_user)
+    revoker = create(:moderator_user)
+    moderation_zone = create(:moderation_zone, :reason => "Initial reason", :ends_at => 1.week.ago, :revoker => revoker)
+    session_for(updater)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :reason => "Updated reason"
+        }
+      }
+    )
+    assert_redirected_to moderation_zones_url
+    assert_equal "Only the moderators who created or revoked this moderation zone can edit it.", flash[:error]
+
+    moderation_zone.reload
+    assert_equal "Initial reason", moderation_zone.reason
+  end
+
+  test "update, by non-creator, of active record" do
+    updater = create(:moderator_user)
+    moderation_zone = create(:moderation_zone, :reason => "Initial reason", :ends_at => 1.week.from_now)
+    session_for(updater)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :reason => "Updated reason",
+          :period => 1.week.from_now
+        }
+      }
+    )
+    assert_redirected_to moderation_zones_url
+    assert_equal "Only the moderator who created this moderation zone can edit it without revoking.", flash[:error]
+
+    moderation_zone.reload
+    assert_equal "Initial reason", moderation_zone.reason
+  end
+
+  test "update to reactivate" do
+    creator = create(:moderator_user)
+    moderation_zone = create(:moderation_zone, :creator => creator, :ends_at => 1.week.ago)
+    session_for(creator)
+
+    patch(
+      moderation_zone_url(moderation_zone),
+      :params => {
+        :moderation_zone => {
+          :period => 1.week.from_now
+        }
+      }
+    )
+    assert_redirected_to moderation_zones_url
+    assert_equal "This moderation zone is inactive and cannot be reactivated.", flash[:error]
+
+    moderation_zone.reload
+    assert_not_predicate moderation_zone, :active?
   end
 end

--- a/test/factories/moderation_zones.rb
+++ b/test/factories/moderation_zones.rb
@@ -7,6 +7,18 @@ FactoryBot.define do
     creator { association :user }
     ends_at { 1.day.from_now }
 
+    zone do
+      <<~GEOMETRY
+        POLYGON((
+          -1 -1,
+          -1  1,
+           1  1,
+           1 -1,
+          -1 -1
+        ))
+      GEOMETRY
+    end
+
     trait :seville_cathedral do
       zone do
         <<~GEOMETRY

--- a/test/models/moderation_zone_test.rb
+++ b/test/models/moderation_zone_test.rb
@@ -3,16 +3,29 @@
 require "test_helper"
 
 class ModerationZoneTest < ActiveSupport::TestCase
-  def test_falls_within_any
-    create(:moderation_zone, :seville_cathedral)
+  def test_falls_within_any_active
+    create(:moderation_zone, :seville_cathedral, :ends_at => 1.day.from_now)
 
-    # Dead center
-    assert ModerationZone.falls_within_any?(:lat => 37.385972, :lon => -5.993149)
+    dead_center = { :lat => 37.385972, :lon => -5.993149 }
+
+    assert ModerationZone.falls_within_any_active?(**dead_center)
 
     # Inside, near the boundary
-    assert ModerationZone.falls_within_any?(:lat => 37.386658, :lon => -5.994024)
+    assert ModerationZone.falls_within_any_active?(:lat => 37.386658, :lon => -5.994024)
 
     # Outside, near the boundary
-    assert_not ModerationZone.falls_within_any?(:lat => 37.386769, :lon => -5.994185)
+    assert_not ModerationZone.falls_within_any_active?(:lat => 37.386769, :lon => -5.994185)
+
+    travel_to 2.days.from_now do
+      assert_not ModerationZone.falls_within_any_active?(**dead_center)
+    end
+  end
+
+  def test_active?
+    modzone1 = create(:moderation_zone, :ends_at => 1.day.from_now)
+    assert_predicate modzone1, :active?
+
+    modzone2 = create(:moderation_zone, :ends_at => 1.day.ago)
+    assert_not_predicate modzone2, :active?
   end
 end

--- a/test/system/manage_moderation_zones_test.rb
+++ b/test/system/manage_moderation_zones_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class ManageModerationZones < ApplicationSystemTestCase
+  test "Create a moderation zone and fail to put an anonymous note within it" do
+    sign_in_as(create(:moderator_user))
+
+    visit moderation_zones_path
+    click_on "New Moderation Zone"
+
+    fill_in "Name", :with => "Test zone"
+    fill_in "Reason", :with => "He's a very naughty boy"
+
+    map = find_by_id("map")
+    map.click(:offset => :center, :x => -50, :y => -50)
+    map.click(:offset => :center, :x =>   0, :y => -50)
+    map.click(:offset => :center, :x =>   0, :y =>   0)
+    map.click(:offset => :center, :x => -50, :y =>   0)
+    map.click(:offset => :center, :x => -50, :y => -50)
+
+    select "1 week", :from => :moderation_zone_period
+    click_on "Create Moderation zone"
+    assert_content "Moderation zone created"
+
+    sign_out
+    visit new_note_path(:anchor => "map=18/7.15/-9.23")
+    within_sidebar do
+      fill_in "text", :with => "Hahaha! Nobody expects the Spanish anonymous notes!"
+      click_on "Add Note"
+
+      assert_content "There was an error when creating the note"
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,6 +1534,16 @@ tag2link@^2026.1.21:
   resolved "https://registry.yarnpkg.com/tag2link/-/tag2link-2026.6.26.tgz#2d37fe961a73f8e469e6103d47d2d7f3c3a4388e"
   integrity sha512-3HXYkASxzeCidEnbY6b3LZ+oN6tKFOK1kHWgaxpLt2zONwn64r7EEInRxmBXGMreMJm2OJH0TMBFwqjdaIDNZA==
 
+terra-draw-maplibre-gl-adapter@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/terra-draw-maplibre-gl-adapter/-/terra-draw-maplibre-gl-adapter-1.4.1.tgz#ba346d0f7ba4a08a30bd978485482f41b02abc3d"
+  integrity sha512-qZ/bc9bVPnyt0keLVTofV8xiTPkdkbO6RzqrfNLe9zH/edW5PsjvJw97m1EksPZeXNJtFxsVbhi12cPaoNiWfg==
+
+terra-draw@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/terra-draw/-/terra-draw-1.30.1.tgz#194e620b12621c763d59f5817a362aa9a894d578"
+  integrity sha512-EvX2iQANF6/c4HIbVJ5XCdWus/rRv9onwIpqWU4iaWkQHAjqQAh2RtH+OicUXVRrAFyELjYbZBh9iWlsYnUzoA==
+
 tinyglobby@^0.2.15, tinyglobby@^0.2.16:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"


### PR DESCRIPTION
Closes https://github.com/openstreetmap/openstreetmap-website/issues/6795. Does what it says on the title.

https://github.com/user-attachments/assets/749763c0-08e4-4a3f-bf1e-0b35adb4329b

This is largely based on the interface to manage user blocks, for consistency and because we already baked in concepts like "creator", "revoker", or "ends_at" in the DB table.

Misc details:
- I haven't implemented a "show" page, for simplicity and because I'm not sure it's necessary. Happy to add one if others think otherwise.
- No pagination. If it becomes crowded, we can add it.
- `reason` is a RichText field for consistency, because we have `reason` and `reason_format`, and because it was trivial to do. It feels overkill though.
- I'm reusing a few things from user blocks, including `UserBlock::PERIODS` and template helpers.
- Using [Terra Draw](https://terradraw.io/) for defining the geography of the moderation zone. I probably could have added more options, but keeping it simple for now.

Details of the Terra Draw integration:
 - It's all located at `app/assets/javascripts/moderation_zone.js`
- The general idea is that only one single polygon can be drawn. If a polygon exists, it can be edited.
- The relevant form field is `#moderation_zone_zone`. It's a hidden field that stores the value (the drawn geometry) as a PostGIS object.
- If the page loads and the form field is empty, we go into `polygon` mode.
- If the page loads and the field already has a value, this is expected to be in PostGIS format. We go into `polygon` mode for a moment, parse the value in the form field, add it to the geometry (`readFormField`), and finally go into `select` mode.
- After parsing and adding the figure to the geometry, we also zoom in on the figure, as it can be too small to see in at the top zoom level (`featureToBox`).
- On `finish`, we go into `select` mode. Then the code reads the geometry and formats it as a PostGIS string which is then stored in the form field (`writeFormField`).


Happy to iterate on those (or anything else). Just wanted to start simple.