### PR TITLE
Avoid autolink patterns that trigger too easily

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -147,22 +147,22 @@ linkify:
     - patterns:
       - "node/(?<id>\\d+)"
       - "node (?<id>\\d{5,})"
-      - "n ?(?<id>\\d{5,})"
+      - "n(?<id>\\d{5,})"
       path_template: "node/\\k<id>"
     - patterns:
       - "way/(?<id>\\d+)"
       - "way (?<id>\\d{5,})"
-      - "w ?(?<id>\\d{5,})"
+      - "w(?<id>\\d{5,})"
       path_template: "way/\\k<id>"
     - patterns:
       - "relation/(?<id>\\d+)"
       - "relation (?<id>\\d{5,})"
-      - "r ?(?<id>\\d{5,})"
+      - "r(?<id>\\d{5,})"
       path_template: "relation/\\k<id>"
     - patterns:
       - "changeset/(?<id>\\d+)"
       - "changeset (?<id>\\d{5,})"
-      - "cs ?(?<id>\\d{5,})"
+      - "cs(?<id>\\d{5,})"
       path_template: "changeset/\\k<id>"
     - patterns:
       - "note/(?<id>\\d+)"

--- a/test/lib/rich_text_test.rb
+++ b/test/lib/rich_text_test.rb
@@ -487,6 +487,17 @@ class RichTextTest < ActiveSupport::TestCase
     end
   end
 
+  def test_text_to_html_dont_linkify_too_easily
+    # We used to allow this, but removed it because it
+    # caused issues in some languages.
+    # Eg: example below is Polish for "Reverted in 12345"
+    r = RichText.new("text", "Wycofane w 12345")
+
+    assert_html r do
+      assert_select "a", 0
+    end
+  end
+
   def test_deactivated_linkify_expansion_in_markdown
     t0 = "foo `surface=metal` bar"
 


### PR DESCRIPTION
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/7125

As mentioned in the linked issue, patterns such as "w 12345" can trigger the autolinker a bit too easily. The given example is "Wycofane w 12345", which in Polish translates to "Reverted in 12345" and should not be autolinked to "Wycofane [way/12345](https://www.openstreetmap.org/way/12345)"