### PR TITLE
Make traces feature optional via traces_disabled setting

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -23,7 +23,7 @@ class Ability
       can [:create, :update], :password
       can :read, Redaction
       can [:create, :destroy], :session
-      can [:read, :data], Trace
+      can [:read, :data], Trace unless Settings.traces_disabled
       can [:read, :create, :suspended, :auth_success, :auth_failure], User
       can :read, UserBlock
     end
@@ -49,7 +49,7 @@ class Ability
         can [:read, :create, :destroy], Message
         can [:close, :reopen], Note
         can :create, Report
-        can [:mine, :create, :update, :destroy], Trace
+        can [:mine, :create, :update, :destroy], Trace unless Settings.traces_disabled
         can [:account, :go_public], User
         can [:read, :create, :destroy], UserMute
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,6 +52,8 @@ module ApplicationHelper
       [about_path, t("layouts.header.about")]
     ]
 
+    items.delete_at(2) if Settings.traces_disabled
+
     if Settings.status != "database_offline" && can?(:index, Issue)
       items.prepend([
                       issues_path(:status => "open"),

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -45,10 +45,12 @@
               <%= link_to t(".my notes"), user_notes_path(current_user) %>
               <span class="badge count-number"><%= number_with_delimiter(current_user.note_comments.size) %></span>
             </li>
-            <li>
-              <%= link_to t(".my traces"), :controller => "traces", :action => "mine" %>
-              <span class="badge count-number"><%= number_with_delimiter(current_user.traces.size) %></span>
-            </li>
+            <% unless Settings.traces_disabled %>
+              <li>
+                <%= link_to t(".my traces"), :controller => "traces", :action => "mine" %>
+                <span class="badge count-number"><%= number_with_delimiter(current_user.traces.size) %></span>
+              </li>
+            <% end %>
             <li>
               <%= link_to t(".my diary"), :controller => "diary_entries", :action => "index", :display_name => current_user.display_name %>
               <span class="badge count-number"><%= number_with_delimiter(current_user.diary_entries.size) %></span>
@@ -84,10 +86,12 @@
               <%= link_to t(".notes"), user_notes_path(@user) %>
               <span class="badge count-number"><%= number_with_delimiter(@user.note_comments.size) %></span>
             </li>
-            <li>
-              <%= link_to t(".traces"), :controller => "traces", :action => "index", :display_name => @user.display_name %>
-              <span class="badge count-number"><%= number_with_delimiter(@user.traces.size) %></span>
-            </li>
+            <% unless Settings.traces_disabled %>
+              <li>
+                <%= link_to t(".traces"), :controller => "traces", :action => "index", :display_name => @user.display_name %>
+                <span class="badge count-number"><%= number_with_delimiter(@user.traces.size) %></span>
+              </li>
+            <% end %>
 
             <!-- Displaying another user's profile page -->
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,11 +87,8 @@ OpenStreetMap::Application.routes.draw do
 
     resource :map, :only => :show
 
-    resources :tracepoints, :path => "trackpoints", :only => :index
-
     resources :users, :only => :index
     resources :users, :path => "user", :id => /\d+/, :only => :show
-    resources :user_traces, :path => "user/gpx_files", :module => :users, :controller => :traces, :only => :index
     get "user/details" => "users#details"
 
     resources :user_preferences, :except => [:new, :create, :edit], :param => :preference_key, :path => "user/preferences" do
@@ -107,13 +104,18 @@ OpenStreetMap::Application.routes.draw do
     end
     post "/user/messages/:id" => "messages#update", :as => nil
 
-    resources :traces, :path => "gpx", :only => [:create, :show, :update, :destroy], :id => /\d+/ do
-      scope :module => :traces do
-        resource :data, :only => :show
+    # Lambda constraint, rather than a static if, so tests can toggle the setting per-request with with_settings
+    constraints(->(_req) { !Settings.traces_disabled }) do
+      resources :tracepoints, :path => "trackpoints", :only => :index
+      resources :user_traces, :path => "user/gpx_files", :module => :users, :controller => :traces, :only => :index
+      resources :traces, :path => "gpx", :only => [:create, :show, :update, :destroy], :id => /\d+/ do
+        scope :module => :traces do
+          resource :data, :only => :show
+        end
       end
+      post "gpx/create" => "traces#create", :id => /\d+/, :as => :trace_create
+      get "gpx/:id/details" => "traces#show", :id => /\d+/, :as => :trace_details
     end
-    post "gpx/create" => "traces#create", :id => /\d+/, :as => :trace_create
-    get "gpx/:id/details" => "traces#show", :id => /\d+/, :as => :trace_details
 
     # Map notes API
     resources :notes, :except => [:new, :edit, :update], :id => /\d+/, :controller => "notes" do
@@ -244,32 +246,34 @@ OpenStreetMap::Application.routes.draw do
   post "/preview/:type" => "site#preview", :as => :preview
 
   # traces
-  resources :traces, :id => /\d+/, :except => [:show] do
-    resource :data, :module => :traces, :only => :show
-  end
-  get "/user/:display_name/traces/tag/:tag/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/user/%{display_name}/traces/tag/%{tag}")
-  get "/user/:display_name/traces/tag/:tag" => "traces#index"
-  get "/user/:display_name/traces/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/user/%{display_name}/traces")
-  get "/user/:display_name/traces" => "traces#index"
-  get "/user/:display_name/traces/:id" => "traces#show", :id => /\d+/, :as => "show_trace"
-  scope "/user/:display_name/traces/:trace_id", :module => :traces, :trace_id => /\d+/ do
-    get "picture" => "pictures#show", :as => "trace_picture"
-    get "icon" => "icons#show", :as => "trace_icon"
-  end
-  get "/traces/tag/:tag/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/traces/tag/%{tag}")
-  get "/traces/tag/:tag" => "traces#index"
-  get "/traces/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/traces")
-  get "/traces/mine/tag/:tag/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/traces/mine/tag/%{tag}")
-  get "/traces/mine/tag/:tag" => "traces#mine"
-  get "/traces/mine/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/traces/mine")
-  get "/traces/mine" => "traces#mine"
-  get "/trace/create", :to => redirect(:path => "/traces/new")
-  get "/trace/:id/data", :format => false, :id => /\d+/, :to => redirect(:path => "/traces/%{id}/data")
-  get "/trace/:id/data.:format", :id => /\d+/, :to => redirect(:path => "/traces/%{id}/data.%{format}")
-  get "/trace/:id/edit", :id => /\d+/, :to => redirect(:path => "/traces/%{id}/edit")
+  constraints(->(_req) { !Settings.traces_disabled }) do
+    resources :traces, :id => /\d+/, :except => [:show] do
+      resource :data, :module => :traces, :only => :show
+    end
+    get "/user/:display_name/traces/tag/:tag/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/user/%{display_name}/traces/tag/%{tag}")
+    get "/user/:display_name/traces/tag/:tag" => "traces#index"
+    get "/user/:display_name/traces/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/user/%{display_name}/traces")
+    get "/user/:display_name/traces" => "traces#index"
+    get "/user/:display_name/traces/:id" => "traces#show", :id => /\d+/, :as => "show_trace"
+    scope "/user/:display_name/traces/:trace_id", :module => :traces, :trace_id => /\d+/ do
+      get "picture" => "pictures#show", :as => "trace_picture"
+      get "icon" => "icons#show", :as => "trace_icon"
+    end
+    get "/traces/tag/:tag/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/traces/tag/%{tag}")
+    get "/traces/tag/:tag" => "traces#index"
+    get "/traces/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/traces")
+    get "/traces/mine/tag/:tag/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/traces/mine/tag/%{tag}")
+    get "/traces/mine/tag/:tag" => "traces#mine"
+    get "/traces/mine/page/:page", :page => /[1-9][0-9]*/, :to => redirect(:path => "/traces/mine")
+    get "/traces/mine" => "traces#mine"
+    get "/trace/create", :to => redirect(:path => "/traces/new")
+    get "/trace/:id/data", :format => false, :id => /\d+/, :to => redirect(:path => "/traces/%{id}/data")
+    get "/trace/:id/data.:format", :id => /\d+/, :to => redirect(:path => "/traces/%{id}/data.%{format}")
+    get "/trace/:id/edit", :id => /\d+/, :to => redirect(:path => "/traces/%{id}/edit")
 
-  namespace :traces, :path => "" do
-    resource :feed, :path => "(/user/:display_name)/traces(/tag/:tag)/rss", :only => :show, :defaults => { :format => :rss }
+    namespace :traces, :path => "" do
+      resource :feed, :path => "(/user/:display_name)/traces(/tag/:tag)/rss", :only => :show, :defaults => { :format => :rss }
+    end
   end
 
   # diary pages

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,6 +29,8 @@ status: "online"
 #status_announcement_url: "https://en.osm.town/@osm_tech"
 # The maximum area you're allowed to request, in square degrees
 max_request_area: 0.25
+# Traces/tracks feature - set to true to disable entirely
+#traces_disabled: false
 # Number of GPS trace/trackpoints returned per-page
 tracepoints_per_page: 5000
 # Default limit on the number of changesets returned by the changeset query api method

--- a/test/controllers/api/tracepoints_controller_test.rb
+++ b/test/controllers/api/tracepoints_controller_test.rb
@@ -101,6 +101,13 @@ module Api
       end
     end
 
+    def test_tracepoints_disabled
+      with_settings(:traces_disabled => true) do
+        get api_tracepoints_path(:bbox => "-0.1,-0.1,0.1,0.1")
+        assert_response :not_found
+      end
+    end
+
     def test_index_without_bbox
       get api_tracepoints_path
       assert_response :bad_request

--- a/test/controllers/api/traces/data_controller_test.rb
+++ b/test/controllers/api/traces/data_controller_test.rb
@@ -103,6 +103,17 @@ module Api
         assert_response :not_found
       end
 
+      # Check that trace data can't be downloaded through the api when the traces feature is disabled
+      def test_show_disabled
+        public_trace_file = create(:trace, :visibility => "public", :fixture => "a")
+        auth_header = bearer_authorization_header public_trace_file.user
+
+        with_settings(:traces_disabled => true) do
+          get api_trace_data_path(public_trace_file), :headers => auth_header
+          assert_response :not_found
+        end
+      end
+
       private
 
       def check_trace_data(trace, digest, content_type = "application/gpx+xml", extension = "gpx")

--- a/test/controllers/api/traces_controller_test.rb
+++ b/test/controllers/api/traces_controller_test.rb
@@ -105,6 +105,17 @@ module Api
       assert_response :not_found
     end
 
+    # Check that getting a trace through the api is not possible when the traces feature is disabled
+    def test_show_disabled
+      public_trace_file = create(:trace, :visibility => "public")
+      auth_header = bearer_authorization_header public_trace_file.user
+
+      with_settings(:traces_disabled => true) do
+        get api_trace_path(public_trace_file), :headers => auth_header
+        assert_response :not_found
+      end
+    end
+
     # Test creating a trace through the api
     def test_create
       # Get file to use

--- a/test/controllers/api/users/traces_controller_test.rb
+++ b/test/controllers/api/users/traces_controller_test.rb
@@ -66,6 +66,16 @@ module Api
         get api_user_traces_path, :headers => bad_auth
         assert_response :forbidden
       end
+
+      def test_index_disabled
+        user = create(:user)
+        auth_header = bearer_authorization_header user
+
+        with_settings(:traces_disabled => true) do
+          get api_user_traces_path, :headers => auth_header
+          assert_response :not_found
+        end
+      end
     end
   end
 end

--- a/test/controllers/traces/data_controller_test.rb
+++ b/test/controllers/traces/data_controller_test.rb
@@ -111,6 +111,16 @@ module Traces
       end
     end
 
+    # Check that trace data can't be downloaded when the traces feature is disabled
+    def test_show_disabled
+      public_trace_file = create(:trace, :visibility => "public", :fixture => "a")
+
+      with_settings(:traces_disabled => true) do
+        get trace_data_path(public_trace_file)
+        assert_response :not_found
+      end
+    end
+
     private
 
     def check_trace_data(trace, digest, content_type = "application/gpx+xml", extension = "gpx")

--- a/test/controllers/traces/feeds_controller_test.rb
+++ b/test/controllers/traces/feeds_controller_test.rb
@@ -78,6 +78,13 @@ module Traces
       check_trace_feed []
     end
 
+    def test_show_disabled
+      with_settings(:traces_disabled => true) do
+        get traces_feed_path(:format => :rss)
+        assert_response :not_found
+      end
+    end
+
     private
 
     def check_trace_feed(traces)

--- a/test/controllers/traces/icons_controller_test.rb
+++ b/test/controllers/traces/icons_controller_test.rb
@@ -65,6 +65,16 @@ module Traces
       assert_response :not_found
     end
 
+    # Check that trace icons can't be downloaded when the traces feature is disabled
+    def test_show_disabled
+      public_trace_file = create(:trace, :visibility => "public", :fixture => "a")
+
+      with_settings(:traces_disabled => true) do
+        get trace_icon_path(public_trace_file.user, public_trace_file)
+        assert_response :not_found
+      end
+    end
+
     private
 
     def check_trace_icon(trace)

--- a/test/controllers/traces/pictures_controller_test.rb
+++ b/test/controllers/traces/pictures_controller_test.rb
@@ -65,6 +65,16 @@ module Traces
       assert_response :not_found
     end
 
+    # Check that trace pictures can't be downloaded when the traces feature is disabled
+    def test_show_disabled
+      public_trace_file = create(:trace, :visibility => "public", :fixture => "a")
+
+      with_settings(:traces_disabled => true) do
+        get trace_picture_path(public_trace_file.user, public_trace_file)
+        assert_response :not_found
+      end
+    end
+
     private
 
     def check_trace_picture(trace)

--- a/test/controllers/traces_controller_test.rb
+++ b/test/controllers/traces_controller_test.rb
@@ -312,6 +312,14 @@ class TracesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Check that the traces index is not displayed when the traces feature is disabled
+  def test_index_disabled
+    with_settings(:traces_disabled => true) do
+      get traces_path
+      assert_response :not_found
+    end
+  end
+
   # Test showing a trace
   def test_show
     public_trace_file = create(:trace, :visibility => "public")


### PR DESCRIPTION
Add a `traces_disabled` boolean setting (default: unset, `false`) that can be set to `true` to disable the  traces/tracks feature entirely. When disabled, all trace routes return 404, nav links and user profile trace counts are hidden, and CanCan abilities for Trace are not granted. Motivated by OpenGeofiction, where  tracks have no meaning on a fictional world. Setting `traces_disabled: true` in `config/settings.local.yml` is all that is needed to disable the feature.

### Description
Addresses #7155:
  - Commented out new setting `traces_disabled` added to `config/settings.yml`
  - When disabled, all trace routes are removed in `config/routes.rb`
  - Nav item and user profile links guarded with `unless Settings.traces_disabled`
  - Test coverage: one `*_disabled` test per trace controller test file verifying 404 responses

### How has this been tested?
 - All existing tests pass unchanged. New tests verify that each trace controller returns 404 when `traces_disabled` is `true`.
 - Confirmed the links are present, or not, based on the setting
