### PR TITLE
Switch from Versatiles Colorful to SVWD03

### DIFF
--- a/app/assets/javascripts/leaflet.shortbread.js
+++ b/app/assets/javascripts/leaflet.shortbread.js
@@ -1,22 +1,9 @@
 L.OSM.Shortbread = L.OSM.MaplibreGL.extend({
   onAdd: function (map) {
     L.OSM.MaplibreGL.prototype.onAdd.call(this, map);
-    const styleURL = "https://vector.openstreetmap.org/styles/shortbread/" + this.options.styleName;
-    this.getMaplibreMap().setStyle(styleURL);
+    this.getMaplibreMap().setStyle("https://vector.openstreetmap.org/styles/svwd/svwd03style.json");
   },
   onRemove: function (map) {
     L.OSM.MaplibreGL.prototype.onRemove.call(this, map);
-  }
-});
-
-L.OSM.ShortbreadColorful = L.OSM.Shortbread.extend({
-  options: {
-    styleName: "colorful.json"
-  }
-});
-
-L.OSM.ShortbreadEclipse = L.OSM.Shortbread.extend({
-  options: {
-    styleName: "eclipse.json"
   }
 });

--- a/config/layers.yml
+++ b/config/layers.yml
@@ -102,8 +102,7 @@
         id: "osm_france"
         href: "https://openstreetmap.fr/"
 
-- leafletOsmId: "ShortbreadColorful"
-  leafletOsmDarkId: "ShortbreadEclipse"
+- leafletOsmId: "Shortbread"
   code: "S"
   layerId: "shortbread"
   nameId: "shortbread"
@@ -111,8 +110,7 @@
   canEmbed: true
   maxZoom: 23
   isVectorStyle: true
-  styleUrl: "https://vector.openstreetmap.org/styles/shortbread/colorful.json"
-  styleUrlDark: "https://vector.openstreetmap.org/styles/shortbread/eclipse.json"
+  styleUrl: "https://vector.openstreetmap.org/styles/svwd/svwd03style.json"
   credit:
     id: "make_a_donation"
     href: "https://supporting.openstreetmap.org"


### PR DESCRIPTION
At the May 28th OWG meeting we decided to switch the shortbread featured layer to use the 

The SVWD03 style shows off more of what Shortbread has.

<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description

This changes the shortbread style from colorful to SVWD03. The Shortbread dark style is removed since SVWD03 doesn't have a dark mode version.

This is a draft because I want to tweak the fonts in vectortile-website first.

### How has this been tested?
Tested with local rails server. 