### PR TITLE
update iD to v2.41.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@mapbox/polyline": "^1.2.1",
     "@maplibre/maplibre-gl-leaflet": "^0.1.1",
     "@maptiler/maplibre-gl-omt-language": "^0.0.3",
-    "@openstreetmap/id": "2.40.0",
+    "@openstreetmap/id": "2.41.0",
     "bootstrap-icons": "^1.13.1",
     "i18n-js": "^4.5.1",
     "js-cookie": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,6 +227,15 @@
     "@types/geojson" "^7946.0.16"
     pbf "^4.0.1"
 
+"@mapbox/vector-tile@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz#71a75acb5ee20c20adca5c4e1ffb5ef95a56e351"
+  integrity sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==
+  dependencies:
+    "@mapbox/point-geometry" "~1.1.0"
+    "@types/geojson" "^7946.0.16"
+    pbf "^5.0.0"
+
 "@mapbox/whoots-js@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
@@ -287,21 +296,20 @@
   resolved "https://registry.yarnpkg.com/@maptiler/maplibre-gl-omt-language/-/maplibre-gl-omt-language-0.0.3.tgz#3069f4522e911e341d6b79b09ce2943c71b6ffd7"
   integrity sha512-Rv5IaFyh9GuFu2BEAGvVvlVGmXt5Jbjd0XhIu0D4Tek81DPQEQryIIwDFTDR27W4NyAtozy8QltB+8SFr2C7mQ==
 
-"@openstreetmap/id@2.40.0":
-  version "2.40.0"
-  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.40.0.tgz#ea00826a4536f1bd63d91265ac345d474788d190"
-  integrity sha512-RWlHzeRCTKb5mpDercvnAYOYQ64PVAggEy3Ckig6WSyZItFJ22Ai1JHRs9TZzSJhId0kWBmCbTJyiFrO3uW43A==
+"@openstreetmap/id@2.41.0":
+  version "2.41.0"
+  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.41.0.tgz#47239425471a4fd3e3951641efb3951b1b2b0299"
+  integrity sha512-osY4VTgYw6OPULcEu4EKPSt/J6fu3zPlDYiO7shof3rkbg25xMG/X2Ap2+K4edd2d93GbDaUAW+AJGLGXBIRtA==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/sexagesimal" "1.2.0"
-    "@mapbox/vector-tile" "^2.0.4"
+    "@mapbox/vector-tile" "^3.0.0"
     "@rapideditor/country-coder" "~5.6.0"
-    "@rapideditor/location-conflation" "~2.0.0"
+    "@rapideditor/location-conflation" "~3.0.0"
     "@tmcw/togeojson" "^7.1.2"
     "@turf/bbox" "^7.2.0"
     "@turf/bbox-clip" "^7.2.0"
     abortcontroller-polyfill "^1.7.8"
-    aes-js "^3.1.2"
     alif-toolkit "^1.3.0"
     diacritics "1.3.0"
     es-toolkit "^1.45.0"
@@ -313,37 +321,32 @@
     node-diff3 "~3.2.0"
     osm-auth "^3.1.1"
     pannellum "2.5.7"
-    pbf "^4.0.1"
-    polygon-clipping "~0.15.7"
+    pbf "^5.0.0"
+    polyclip-ts "^0.16.8"
     rbush "4.0.1"
     whatwg-fetch "^3.6.20"
     which-polygon "2.2.1"
 
-"@rapideditor/country-coder@^5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@rapideditor/country-coder/-/country-coder-5.6.0.tgz#a2ef182b7cd0665104813a05cdb9e76c2587c8eb"
-  integrity sha512-lqu2uyAHJWJ/E0j2ISF8HcGvior6wRxZRnvuCAQJBGtj+Ye2cqokqK4BGMWOCOE13QcZg6SOEiUevO+18NP3+g==
-  dependencies:
-    which-polygon "^2.2.1"
-
-"@rapideditor/country-coder@~5.6.0":
+"@rapideditor/country-coder@^5.6.1", "@rapideditor/country-coder@~5.6.0":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@rapideditor/country-coder/-/country-coder-5.6.1.tgz#f72b2903607526bcb7644c0693fb8b10d91208e1"
   integrity sha512-/3xCpRIyhGv0lKxk26qNJgBWU6UnvE6SmOvE2GWE1CKu6pxcUVukECg6XVJLfmesYWyKHmaj1ZXtNOpz3lJkWg==
   dependencies:
     which-polygon "^2.2.1"
 
-"@rapideditor/location-conflation@~2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@rapideditor/location-conflation/-/location-conflation-2.0.1.tgz#5f4d7386fba833bab92b7a613def9b9bb5f58ce4"
-  integrity sha512-B4tYyaKAcKgnX1XtZ2YZ6lhDF8IMnk1+vVK7JrIMBE71kSiavn5SBua/tKXjm2wFbPTzAD0juAvjIX5ilDxxfA==
+"@rapideditor/location-conflation@~3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@rapideditor/location-conflation/-/location-conflation-3.0.1.tgz#989edf371dd291430b477ec3992dc24f807ee704"
+  integrity sha512-+PyAx2nmqCWMhv7/K1GLOp4Svegl5IUzj2EwhcQZ4ZtSGWLjNu7e87HJw8a4BwtEkl8PZlTdL/iIcuovZThamw==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
-    "@rapideditor/country-coder" "^5.6.0"
+    "@rapideditor/country-coder" "^5.6.1"
+    "@types/geojson" "^7946.0.16"
     circle-to-polygon "^2.2.0"
     geojson-precision "^1.0.0"
     json-stringify-pretty-compact "^4.0.0"
     polyclip-ts "~0.16.8"
+    which-polygon "^2.2.1"
 
 "@stylistic/eslint-plugin@^5.2.3":
   version "5.10.0"
@@ -480,11 +483,6 @@ acorn@^8.16.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
-
-aes-js@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.1.2.tgz#db9aabde85d5caabbfc0d4f2a4446960f627146a"
-  integrity sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==
 
 ajv@^6.14.0:
   version "6.14.0"
@@ -1282,6 +1280,13 @@ pbf@^4.0.1:
   dependencies:
     resolve-protobuf-schema "^2.1.0"
 
+pbf@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/pbf/-/pbf-5.1.0.tgz#669221946f675ea6e893743b34f2d68d1f7b6c12"
+  integrity sha512-Wv0yo0+uZepnoNEKsquhar1F18LogB8oeEikIhUXG16udbiXG7JecHGySwoo6kuMgjmbQYzdrTZlO+/K9t8eZg==
+  dependencies:
+    resolve-protobuf-schema "^2.1.0"
+
 picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -1297,21 +1302,13 @@ pify@^2.3.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
-polyclip-ts@~0.16.8:
+polyclip-ts@^0.16.8, polyclip-ts@~0.16.8:
   version "0.16.8"
   resolved "https://registry.yarnpkg.com/polyclip-ts/-/polyclip-ts-0.16.8.tgz#503160d05e9d56380533aab0bc2dae835d6da5f9"
   integrity sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==
   dependencies:
     bignumber.js "^9.1.0"
     splaytree-ts "^1.0.2"
-
-polygon-clipping@~0.15.7:
-  version "0.15.7"
-  resolved "https://registry.yarnpkg.com/polygon-clipping/-/polygon-clipping-0.15.7.tgz#3823ca1e372566f350795ce9dd9a7b19e97bdaad"
-  integrity sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==
-  dependencies:
-    robust-predicates "^3.0.2"
-    splaytree "^3.1.0"
 
 postcss-import@^16.1.1:
   version "16.1.1"
@@ -1450,11 +1447,6 @@ resolve@^1.10.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-robust-predicates@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
-  integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
-
 rw@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
@@ -1517,11 +1509,6 @@ splaytree-ts@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/splaytree-ts/-/splaytree-ts-1.0.2.tgz#34963704587aff45eaa09c24713f552bbf56e8f0"
   integrity sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==
-
-splaytree@^3.1.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-3.1.2.tgz#d1db2691665a3c69d630de98d55145a6546dc166"
-  integrity sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A==
 
 strip-indent@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
release notes: https://github.com/openstreetmap/iD/releases/tag/v2.41.0

This also unblocks #6811 by adding the hash-change event (https://github.com/openstreetmap/iD/pull/12429).