### PR TITLE
Replace marker shadow image with vector graphic

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -17,8 +17,6 @@
 
 //= link_tree ../../../vendor/assets/leaflet .png
 
-//= link leaflet/dist/images/marker-shadow.png
-
 //= link @mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js
 
 //= link make-plural/cardinals.js

--- a/app/views/layouts/_markers.html.erb
+++ b/app/views/layouts/_markers.html.erb
@@ -13,7 +13,8 @@
     <clipPath id="pin-clip">
       <path id="pin-path" d="M12.5 40 2.94 21.6448C1.47 18.8224 0 16 0 12.5a12.5 12.5 0 0 1 25 0c0 3.5-1.47 6.3224-2.94 9.1448z" />
     </clipPath>
-    <image id="pin-shadow" x="-1" href="<%= image_path("leaflet/dist/images/marker-shadow.png") %>" />
+    <filter id="pin-shadow-blur" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="4 2" /></filter>
+    <ellipse id="pin-shadow" cx="12.5" cy="40" rx="12.5" ry="3" fill-opacity="0.3" filter="url(#pin-shadow-blur)"></ellipse>
 
     <% markers = {
          "plus" => { :"stroke-linecap" => "round", :d => "M5.75 13h13.5m-6.75-6.75v13.5" },


### PR DESCRIPTION
I don't think we need to keep Leaflet's `marker-shadow.png` around for aesthetic reasons when we move completely to MapLibre. This also brings the appearance closer to MapLibre's simpler vector markers:
|Leaflet|MapLibre|
|-|-|
|<img src="https://github.com/user-attachments/assets/d2fdafcc-e75c-417f-a8c0-6c2d6f40a714"/>|<img src="https://github.com/user-attachments/assets/cae2e5c2-a74f-482e-8696-337b7eb19fce"/>| 