### PR TITLE
update iD to v2.41.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@mapbox/polyline": "^1.2.1",
     "@maplibre/maplibre-gl-leaflet": "^0.1.1",
     "@maptiler/maplibre-gl-omt-language": "^0.0.3",
-    "@openstreetmap/id": "2.41.0",
+    "@openstreetmap/id": "2.41.1",
     "bootstrap-icons": "^1.13.1",
     "i18n-js": "^4.5.1",
     "js-cookie": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,10 +296,10 @@
   resolved "https://registry.yarnpkg.com/@maptiler/maplibre-gl-omt-language/-/maplibre-gl-omt-language-0.0.3.tgz#3069f4522e911e341d6b79b09ce2943c71b6ffd7"
   integrity sha512-Rv5IaFyh9GuFu2BEAGvVvlVGmXt5Jbjd0XhIu0D4Tek81DPQEQryIIwDFTDR27W4NyAtozy8QltB+8SFr2C7mQ==
 
-"@openstreetmap/id@2.41.0":
-  version "2.41.0"
-  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.41.0.tgz#47239425471a4fd3e3951641efb3951b1b2b0299"
-  integrity sha512-osY4VTgYw6OPULcEu4EKPSt/J6fu3zPlDYiO7shof3rkbg25xMG/X2Ap2+K4edd2d93GbDaUAW+AJGLGXBIRtA==
+"@openstreetmap/id@2.41.1":
+  version "2.41.1"
+  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.41.1.tgz#a6dd7075091db94231db11acdea1474cddb61533"
+  integrity sha512-XKkSFpzfba8eapce/BoulQ23JkUyQUVbMx3fK51mpYFrBPEehpzM/lChYm/MA6jTp5P2Vg0g2FlB7cPP6WCGnQ==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/sexagesimal" "1.2.0"


### PR DESCRIPTION
* [fixes](https://github.com/openstreetmap/iD/commit/4d92370b4f00a14f4e7170b6d0f68be054033606) a bug which made obfuscated imagery layers not load correctly
* also includes fix to make `ui.hash` available immediately after `init()` for https://github.com/openstreetmap/openstreetmap-website/pull/6811#discussion_r3431330359