### PR TITLE
Add `autoPan`-ing for draggin markers on the diary adding page

### DIFF
--- a/app/assets/javascripts/diary_entry.js
+++ b/app/assets/javascripts/diary_entry.js
@@ -14,7 +14,7 @@ $(function () {
     if (marker) {
       marker.setLngLat(coords);
     } else {
-      marker = new OSM.MapLibre.Marker({ draggable: true })
+      marker = new OSM.MapLibre.Marker({ draggable: true, autoPan: true })
         .setLngLat(coords)
         .setPopup(new OSM.MapLibre.Popup().setHTML(OSM.i18n.t("diary_entries.edit.marker_text")))
         .addTo(map);

--- a/app/assets/javascripts/maplibre/dom_util.js
+++ b/app/assets/javascripts/maplibre/dom_util.js
@@ -1,5 +1,5 @@
 OSM.MapLibre.Marker = class extends maplibregl.Marker {
-  constructor({ icon = "dot", color = "var(--marker-red)", ...options } = {}) {
+  constructor({ icon = "dot", color = "var(--marker-red)", autoPan = false, ...options } = {}) {
     const element = document.createElement("div");
     element.className = "maplibre-gl-marker";
     element.style.width = "25px";
@@ -30,6 +30,46 @@ OSM.MapLibre.Marker = class extends maplibregl.Marker {
       anchor: "bottom",
       offset: [0, 0],
       ...options
+    });
+
+    if (autoPan && options.draggable) this._enableAutoPan();
+  }
+
+  _enableAutoPan() {
+    const edgeDistance = 50,
+          maxPanStep = 10;
+
+    let frame = null;
+
+    const step = () => {
+      frame = requestAnimationFrame(step);
+
+      const map = this._map;
+      if (!map) return;
+
+      const point = map.project(this.getLngLat()),
+            { clientWidth, clientHeight } = map.getContainer();
+
+      let dx = 0,
+          dy = 0;
+      if (point.x < edgeDistance) dx = point.x - edgeDistance;
+      else if (point.x > clientWidth - edgeDistance) dx = point.x - (clientWidth - edgeDistance);
+      if (point.y < edgeDistance) dy = point.y - edgeDistance;
+      else if (point.y > clientHeight - edgeDistance) dy = point.y - (clientHeight - edgeDistance);
+      if (!dx && !dy) return;
+
+      const clamp = (v) => Math.max(-maxPanStep, Math.min(maxPanStep, v));
+      map.panBy([clamp(dx), clamp(dy)], { duration: 0 });
+      this.setLngLat(map.unproject(point));
+      this.fire("drag");
+    };
+
+    this.on("dragstart", () => {
+      if (frame === null) frame = requestAnimationFrame(step);
+    });
+    this.on("dragend", () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+      frame = null;
     });
   }
 };


### PR DESCRIPTION
### Description

This PR breaks out the `autoPan` functionality that markers have on the route page and adds it to the diary adding page.
(with the different maplibre core, but still same logic)

The hidden motivation is that this is another 40 lines shaved off the big 2.5k line PR that I can ship independently.

### How has this been tested?

<img width="1920" height="1080" alt="Recording 2026-06-27 at 17 08 23" src="https://github.com/user-attachments/assets/7710321e-b715-49d9-a22d-16d06dbdbadd" />
