### PR TITLE
Make `PaginationMethods` work with subclasses of a common AR model

### DIFF
--- a/app/controllers/concerns/pagination_methods.rb
+++ b/app/controllers/concerns/pagination_methods.rb
@@ -24,7 +24,7 @@ module PaginationMethods
 
     page_items = page_items.limit(limit)
     page_items = page_items.includes(includes)
-    page_items = page_items.sort.reverse
+    page_items = page_items.sort_by(&cursor_column).reverse
 
     newer_items_cursor = page_items.first&.send cursor_column
     older_items_cursor = page_items.last&.send cursor_column

--- a/test/controllers/concerns/pagination_methods_test.rb
+++ b/test/controllers/concerns/pagination_methods_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PaginationMethodsTest < ActiveSupport::TestCase
+  include PaginationMethods
+
+  test "#get_page_items can sort any records with compatible ids" do
+    n1 = create(:changeset_comment_notification)
+    n2 = create(:gpx_import_failure_notification)
+    items = Noticed::Notification.all
+
+    paged_items = get_page_items(items)
+
+    assert_equal [n2, n1], paged_items.items
+  end
+
+  test "#get_page_items can sort records by an arbitrary column" do
+    create(:user, :display_name => "Alba")
+    create(:user, :display_name => "Calle")
+    create(:user, :display_name => "Berhane")
+    items = User.all
+
+    paged_items = get_page_items(items, :cursor_column => :display_name)
+    actual_names = paged_items.items.map(&:display_name)
+    assert_equal %w[Calle Berhane Alba], actual_names
+  end
+
+  private
+
+  #
+  # Methods below are stubs for controller methods
+  # that the PaginationMethods concern requires to work.
+  #
+
+  def param!(*)
+    nil
+  end
+
+  def params
+    {}
+  end
+end

--- a/test/factories/notifications.rb
+++ b/test/factories/notifications.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :changeset_comment_notification, :class => "ChangesetCommentNotifier::Notification" do
+    event :factory => :changeset_comment_notifier
+    recipient :factory => :user
+  end
+
+  factory :changeset_comment_notifier, :class => "ChangesetCommentNotifier" do
+    record :factory => :changeset_comment
+  end
+
+  factory :gpx_import_failure_notification, :class => "GpxImportFailureNotifier::Notification" do
+    event :factory => :gpx_import_failure_notifier
+    recipient :factory => :user
+  end
+
+  factory :gpx_import_failure_notifier, :class => "GpxImportFailureNotifier"
+end


### PR DESCRIPTION
This is extracted from https://github.com/openstreetmap/openstreetmap-website/pull/7030, with view to reducing the size of that PR as well as clarify something.

Currently, `get_page_items` simply uses `sort` to order the items. This appears to work. However it doesn't work when the items are of different classes, even if they share an ActiveRecord superclass and DB table. This is going to be a problem when paginating notifications, which are of different classes that inherit from `Noticed::Notification` and share the `noticed_notifications` table.

This is because of how ActiveRecord defines `<=>`, see https://github.com/rails/rails/blob/9ecc4a5ca6fb9a93a1f243e8f23d8ba592f41600/activerecord/lib/active_record/core.rb#L674-L680. If I'm understanding correctly, it allows comparing records of a class and a subclass, but not of two subclasses of the same abstract superclass.

Anyway, not a big deal if we just are explicit and order by `cursor_column`, as introduced in this PR...

...which while looking into this, I realised surely we should have been doing in the first place? From what I can see, the argument `cursor_column` was not being used correctly and needed this change I'm making here anyway. This led me to add a second test which is relevant without the context of the upcoming notifications page.