### PR TITLE
Fix listener leak in the link update listener of MapLibre.AttributionControl

### DIFF
--- a/app/assets/javascripts/maplibre/attribution.js
+++ b/app/assets/javascripts/maplibre/attribution.js
@@ -8,6 +8,7 @@ OSM.MapLibre.AttributionControl = class extends maplibregl.AttributionControl {
     this._container = null;
     this._includeReportLink = Boolean(includeReportLink);
     this._credit = credit;
+    this._boundUpdateReportLink = this._updateReportLink.bind(this);
   }
 
   _updateAttributions() {
@@ -91,7 +92,7 @@ OSM.MapLibre.AttributionControl = class extends maplibregl.AttributionControl {
 
     if (this._includeReportLink) {
       map.once("load", this._updateAttributions.bind(this));
-      map.on("moveend", this._updateReportLink.bind(this));
+      map.on("moveend", this._boundUpdateReportLink);
     }
 
     return super.onAdd(map);
@@ -101,7 +102,7 @@ OSM.MapLibre.AttributionControl = class extends maplibregl.AttributionControl {
     if (!this._map) return;
 
     if (this._includeReportLink) {
-      this._map.off("moveend", this._updateReportLink.bind(this));
+      this._map.off("moveend", this._boundUpdateReportLink);
     }
     this._map = null;
     super.onRemove();


### PR DESCRIPTION
### Description

Splits out another change from my branch that I should have added to #7189 but overlooked

`OSM.MapLibre.AttributionControl` does not properly clean up after itsself because the functions are considered differnt due to `this` being a differnt object.

### How has this been tested?

Attribution attributes on the export page 😉
