### PR TITLE
handle API errors with no content

### DIFF
--- a/app/assets/javascripts/index/layers/data.js
+++ b/app/assets/javascripts/index/layers/data.js
@@ -113,7 +113,7 @@ OSM.initializeDataLayer = function (map) {
               return response.json();
             }
 
-            const status = response.statusText || response.status;
+            const status = `HTTP Error ${response.status} ${response.statusText}`;
             if (response.status !== 400 && response.status !== 509) {
               throw new Error(status);
             }

--- a/app/assets/javascripts/index_modules/new_note.js
+++ b/app/assets/javascripts/index_modules/new_note.js
@@ -21,7 +21,7 @@ export default function (map) {
     })
       .then(resp => {
         if (resp.ok) return resp.json();
-        throw new Error(`Got response with status ${resp.status} ${resp.statusText}`);
+        throw new Error(`HTTP Error ${resp.status} ${resp.statusText}`);
       });
   }
 

--- a/app/assets/javascripts/index_modules/note.js
+++ b/app/assets/javascripts/index_modules/note.js
@@ -38,7 +38,7 @@ export default function (map) {
         .then(response => {
           if (response.ok) return response;
           return response.text().then(text => {
-            throw new Error(text);
+            throw new Error(text || `HTTP Error ${response.status} ${response.statusText}`);
           });
         })
         .then(() => {

--- a/app/assets/javascripts/index_modules/query.js
+++ b/app/assets/javascripts/index_modules/query.js
@@ -77,7 +77,7 @@ export default function (map) {
         if (response.ok) {
           return response.json();
         }
-        throw new Error(response.statusText || response.status);
+        throw new Error(`HTTP Error ${response.status} ${response.statusText}`);
       })
       .then(function (results) {
         let elements = results.elements;

--- a/app/assets/javascripts/leaflet.map.js
+++ b/app/assets/javascripts/leaflet.map.js
@@ -304,7 +304,7 @@ L.OSM.Map = L.Map.extend({
             throw new ElementGoneError();
           }
 
-          const status = response.statusText || response.status;
+          const status = `HTTP Error ${response.status} ${response.statusText}`;
           if (response.status !== 400 && response.status !== 509) {
             throw new Error(status);
           }


### PR DESCRIPTION

### Description

Closes #7186 by showing the HTTP status code + status text. For example: `503 Service Unavailable`.

### How has this been tested?

these 503 errors are coming from some intermediary, not from the ruby code in this repository. Therefore, it's tricky to test. the [browser devtools' overrides](https://developer.chrome.com/docs/devtools/overrides) isn't powerful enough, so I setup a local HTTP server, and manually overwrote the URL in the JS code.