### PR TITLE
Update CD:NGI link to correct department

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2608,7 +2608,7 @@ en:
           %{south_africa}: Contains data sourced from %{ngi_link}, State copyright reserved.
         contributors_za_south_africa: South Africa
         contributors_za_ngi: "Chief Directorate: National Geo-Spatial Information"
-        contributors_za_ngi_url: https://ngi.dalrrd.gov.za/
+        contributors_za_ngi_url: https://ngi.dlrrd.gov.za/
         contributors_gb_credit_html: |
           %{united_kingdom}: Contains Ordnance
           Survey data &copy; Crown copyright and database right


### PR DESCRIPTION
### Description
Fix the CD:NGI (NGI) link. NGI is part of the Department of Land Reform and Rural Development (dlrrd), which was previously known as Department of Agriculture, Land Reform and Rural Development (DALRRD). The ngi sub-domain changed when the department was renamed.

### How has this been tested?
Minor URL change. Not tested.