### PR TITLE
Split space-separated event handlers into individual `.on()` calls

### DIFF
--- a/app/assets/javascripts/index_modules/directions/endpoint.js
+++ b/app/assets/javascripts/index_modules/directions/endpoint.js
@@ -9,13 +9,15 @@ function Endpoint(map, input, marker, dragCallback, changeCallback) {
   });
 
   endpoint.enableListeners = function () {
-    endpoint.marker.on("drag dragend", markerDragListener);
+    endpoint.marker.on("drag", markerDragListener);
+    endpoint.marker.on("dragend", markerDragListener);
     input.on("keydown", inputKeydownListener);
     input.on("change", inputChangeListener);
   };
 
   endpoint.disableListeners = function () {
-    endpoint.marker.off("drag dragend", markerDragListener);
+    endpoint.marker.off("drag", markerDragListener);
+    endpoint.marker.off("dragend", markerDragListener);
     input.off("keydown", inputKeydownListener);
     input.off("change", inputChangeListener);
   };

--- a/app/assets/javascripts/index_modules/new_note.js
+++ b/app/assets/javascripts/index_modules/new_note.js
@@ -62,11 +62,10 @@ export default function (map) {
       draggable: true
     });
 
-    newNoteMarker.on("dragstart dragend", function (a) {
+    newNoteMarker.on("dragstart", removeHalo);
+    newNoteMarker.on("dragend", function () {
       removeHalo();
-      if (a.type === "dragend") {
-        addHalo(newNoteMarker.getLatLng());
-      }
+      addHalo(newNoteMarker.getLatLng());
     });
 
     newNoteMarker.addTo(map);


### PR DESCRIPTION
### Description

Small .on that I overlooked in https://github.com/openstreetmap/openstreetmap-website/pull/7189

### How has this been tested?

<img width="1920" height="1080" alt="Recording 2026-07-02 at 16 19 45" src="https://github.com/user-attachments/assets/8ed06a81-3d3f-4d77-9371-d20221d37c8b" />
