### PR TITLE
Make sure that the  zoom-in and zoom-out behaves the same when shift-clicked on leaflet and maplibre

### DIFF
--- a/app/assets/javascripts/maplibre/controls.js
+++ b/app/assets/javascripts/maplibre/controls.js
@@ -23,12 +23,20 @@ OSM.MapLibre.CombinedControlGroup = class CombinedControlGroup {
       };
 
       buttons.forEach(button => {
-      // Find the type of button (zoom-in, zoom-out, etc.) from its class name
+        // Find the type of button (zoom-in, zoom-out, etc.) from its class name
         const match = button.className.match(/maplibregl-ctrl-([\w-]+)/);
         if (match) {
           const type = match[1]; // e.g., "zoom-in"
-          const icon = iconMap[type];
 
+          if (type === "zoom-in" || type === "zoom-out") {
+            button.addEventListener("click", (e) => {
+              if (!e.shiftKey) return;
+              const delta = type === "zoom-in" ? 3 : -3;
+              map.zoomTo(Math.round(map.getZoom()) + delta);
+            });
+          }
+
+          const icon = iconMap[type];
           if (icon) {
             const iconElement = document.createElement("i");
             iconElement.className = `maplibregl-ctrl-icon fs-5 bi bi-${icon}`;


### PR DESCRIPTION
### Description

More of a discussion than an PR if the shift-click on the zoom button is intentional behaviour or if not.

I am not sure if this is behaviour that should be kept and given that nobody screamed that this is broken, it might not be used.

### How has this been tested?

<img width="1920" height="1080" alt="Recording 2026-07-02 at 16 51 00 (1)" src="https://github.com/user-attachments/assets/33a06e8a-2223-4401-b416-122f65675acb" />
