### PR TITLE
Use flexbox for map layouts

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -234,6 +234,8 @@ nav.primary, nav.secondary {
     top: $headerHeight;
     bottom: 0;
     width: 100%;
+    display: flex;
+    flex-direction: column;
   }
 
   #sidebar, #map, #map-ui {
@@ -243,7 +245,6 @@ nav.primary, nav.secondary {
   }
 
   #sidebar {
-    float: left;
     overflow-x: hidden;
     overflow-y: auto;
   }
@@ -299,11 +300,14 @@ nav.primary, nav.secondary {
 
   #map-ui {
     display: none;
-    float: right;
     overflow: auto;
   }
 
   @include media-breakpoint-up(md) {
+    #content {
+      flex-direction: row;
+    }
+
     #sidebar, #map, #map-ui {
       height: 100%;
     }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -240,12 +240,12 @@ nav.primary, nav.secondary {
     position: relative;
     width: 100%;
     height: 50%;
-    overflow-x: hidden;
-    overflow-y: auto;
   }
 
   #sidebar {
     float: left;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
 
   .overlay-sidebar #sidebar {
@@ -308,8 +308,7 @@ nav.primary, nav.secondary {
   #map-ui {
     display: none;
     float: right;
-    overflow-x: auto;
-    overflow-y: scroll;
+    overflow: auto;
   }
 
   @include media-breakpoint-up(md) {
@@ -331,7 +330,6 @@ nav.primary, nav.secondary {
 
     #map-ui {
       width: 250px;
-      overflow-y: auto;
     }
   }
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -250,6 +250,7 @@ nav.primary, nav.secondary {
 
   .overlay-sidebar #sidebar {
     position: absolute;
+    width: $sidebarWidth;
     height: auto;
     overflow: hidden;
 
@@ -260,17 +261,8 @@ nav.primary, nav.secondary {
     }
   }
 
-  .overlay-sidebar.overlay-right-sidebar {
-    #sidebar {
-      position: absolute;
-      width: 350px;
-      height: auto;
-      overflow: hidden;
-    }
-
-    #map {
-      height: 100%;
-    }
+  .overlay-sidebar #map {
+    height: 100%;
   }
 
   #content:not(.overlay-sidebar) :is(.welcome, #banner) {
@@ -322,10 +314,6 @@ nav.primary, nav.secondary {
 
     #map {
       width: auto;
-    }
-
-    .overlay-sidebar.overlay-right-sidebar #sidebar {
-      width: $sidebarWidth;
     }
 
     #map-ui {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -260,10 +260,6 @@ nav.primary, nav.secondary {
     }
   }
 
-  .overlay-sidebar #map {
-    height: 100%;
-  }
-
   #content:not(.overlay-sidebar) :is(.welcome, #banner) {
     @extend .d-none;
   }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -236,7 +236,7 @@ nav.primary, nav.secondary {
     width: 100%;
   }
 
-  #sidebar, #map {
+  #sidebar, #map, #map-ui {
     position: relative;
     width: 100%;
     height: 50%;
@@ -307,16 +307,13 @@ nav.primary, nav.secondary {
 
   #map-ui {
     display: none;
-    position: relative;
     float: right;
-    width: 100%;
-    height: 50%;
     overflow-x: auto;
     overflow-y: scroll;
   }
 
   @include media-breakpoint-up(md) {
-    #sidebar, #map {
+    #sidebar, #map, #map-ui {
       height: 100%;
     }
 
@@ -334,7 +331,6 @@ nav.primary, nav.secondary {
 
     #map-ui {
       width: 250px;
-      height: 100%;
       overflow-y: auto;
     }
   }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -240,8 +240,7 @@ nav.primary, nav.secondary {
 
   #sidebar, #map, #map-ui {
     position: relative;
-    width: 100%;
-    height: 50%;
+    flex-basis: 50%;
   }
 
   #sidebar {
@@ -252,7 +251,6 @@ nav.primary, nav.secondary {
   .overlay-sidebar #sidebar {
     position: absolute;
     width: $sidebarWidth;
-    height: auto;
     overflow: hidden;
 
     .sidebar-close-controls,
@@ -308,20 +306,16 @@ nav.primary, nav.secondary {
       flex-direction: row;
     }
 
-    #sidebar, #map, #map-ui {
-      height: 100%;
-    }
-
     #sidebar {
-      width: $sidebarWidth;
+      flex-basis: $sidebarWidth;
     }
 
     #map {
-      width: auto;
+      flex-basis: auto;
     }
 
     #map-ui {
-      width: 250px;
+      flex-basis: 250px;
     }
   }
 }

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -63,7 +63,7 @@
     <%= render :partial => "layouts/sidebar_close" %>
   </div>
 
-  <div id="map" class="bg-body-secondary z-0">
+  <div id="map" class="bg-body-secondary flex-grow-1 z-0">
   </div>
 
   <div id="attribution" class="d-none">

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <% content_for :content do %>
-  <div id="sidebar" class="bg-body z-1">
+  <div id="sidebar" class="bg-body flex-shrink-0 z-1">
     <%= render :partial => "layouts/search", :locals => { :autofocus => true, :extra_classes => ["d-none d-md-block"] } %>
 
     <div id="flash">
@@ -59,7 +59,7 @@
     </div>
   </noscript>
 
-  <div id="map-ui" class="bg-body z-2">
+  <div id="map-ui" class="bg-body flex-shrink-0 order-md-1 z-2">
     <%= render :partial => "layouts/sidebar_close" %>
   </div>
 


### PR DESCRIPTION
An attempt to reduce custom CSS and clean up the `map-layout` by using `display: flex` in the container.