### PR TITLE
Split maplibre/dom_util.js into two better named files

### DIFF
--- a/app/assets/javascripts/maplibre/map.js
+++ b/app/assets/javascripts/maplibre/map.js
@@ -1,5 +1,6 @@
 //= require maplibre/controls
-//= require maplibre/dom_util
+//= require maplibre/marker
+//= require maplibre/popup
 
 maplibregl.Map.prototype._getUIString = function (key) {
   const snakeCaseKey = key.replaceAll(/(?<=\w)[A-Z]/g, "_$&").toLowerCase();

--- a/app/assets/javascripts/maplibre/marker.js
+++ b/app/assets/javascripts/maplibre/marker.js
@@ -73,23 +73,3 @@ OSM.MapLibre.Marker = class extends maplibregl.Marker {
     });
   }
 };
-
-OSM.MapLibre.Popup = class extends maplibregl.Popup {
-  constructor(options) {
-    // General offset 5px for each side, but the offset depends on the popup position:
-    // Popup above the marker -> lift it by height + 5px = 45px
-    // Popup left the marker -> lift it by width/2 + 5px = 22.5px ~= 17px
-    const offset = {
-      "bottom": [0, -45],
-      "bottom-left": [0, -45],
-      "bottom-right": [0, -45],
-      "top": [0, 5],
-      "top-left": [0, 5],
-      "top-right": [0, 5],
-      // our marker is bigger at the top, but this does not attach there -> tucked 2px more
-      "right": [-15, -10],
-      "left": [15, -10]
-    };
-    super({ offset, ...options });
-  }
-};

--- a/app/assets/javascripts/maplibre/popup.js
+++ b/app/assets/javascripts/maplibre/popup.js
@@ -1,0 +1,19 @@
+OSM.MapLibre.Popup = class extends maplibregl.Popup {
+  constructor(options) {
+    // General offset 5px for each side, but the offset depends on the popup position:
+    // Popup above the marker -> lift it by height + 5px = 45px
+    // Popup left the marker -> lift it by width/2 + 5px = 22.5px ~= 17px
+    const offset = {
+      "bottom": [0, -45],
+      "bottom-left": [0, -45],
+      "bottom-right": [0, -45],
+      "top": [0, 5],
+      "top-left": [0, 5],
+      "top-right": [0, 5],
+      // our marker is bigger at the top, but this does not attach there -> tucked 2px more
+      "right": [-15, -10],
+      "left": [15, -10]
+    };
+    super({ offset, ...options });
+  }
+};


### PR DESCRIPTION
The name `dom_util.js` doesn't really tell us anything and in fact seems to be actively misleading in that it's not really providing any sort of DOM utilities as far as I can see.

This splits the file into two, hopefully better named, files, one for each of the classes it provides.