### PR TITLE
Document step to generate i18n files

### DIFF
--- a/doc/MANUAL_INSTALL.md
+++ b/doc/MANUAL_INSTALL.md
@@ -160,6 +160,14 @@ touch config/settings.local.yml
 cp config/example.storage.yml config/storage.yml
 ```
 
+### Generate i18n files
+
+This step runs automatically as part of some of the following steps. Still there will be circumstances where you skip some of those, for example if you already have a DB in place and don't need to create/migrate. Then you will see the tests fail with `The asset "i18n/en.js" is not present in the asset pipeline` or similar. Just in case, run this to generate those expected files:
+
+```bash
+bundle exec i18n export
+```
+
 ## Step 5: Database Setup
 
 `openstreetmap-website` uses three databases - one for development, one for testing, and one for production. The database-specific configuration options are stored in `config/database.yml`, which we need to create from the example template.


### PR DESCRIPTION
Say that you clone the repo for the second time in a different location in your machine[^git-worktree]. Since the DB is already set up, you don't need to `db:create` or `db:migrate` or anything like that, you just copy the same `database.yml` file and run the tests.

Unfortunately, in that case you will have a few of tests failing with this:

```
bin/rails test test/controllers/site_controller_test.rb:419

E

Error:
SiteControllerTest#test_copyright:
ActionView::Template::Error: The asset "i18n/en.js" is not present in the asset pipeline.

    app/views/layouts/_head.html.erb:7
    app/views/layouts/_head.html.erb:3
    app/views/layouts/site.html.erb:5
    app/views/layouts/site.html.erb:2
    config/initializers/policy_headers.rb:13:in 'OpenStreetMap::Rack::PolicyHeaders#call'
    config/initializers/compressed_requests.rb:33:in 'OpenStreetMap::CompressedRequests#call'
    test/controllers/site_controller_test.rb:402:in 'SiteControllerTest#test_copyright'
```

Today I learned that some of our scripts, including the DB rake scripts, generate the files in `app/assets/javascripts/i18n/`. But if you don't run the DB rake scripts, those won't be generated, causing this failure.

[^git-worktree]: probably will happen to users of [git worktree](https://git-scm.com/docs/git-worktree) but I haven't used it in a while and haven't checked. I was doing this manually when I came across the issue.