### PR TITLE
Preserve hash for map element navigation

### DIFF
--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -204,6 +204,7 @@ OSM.Router = function (map, rts) {
     const clickEvent = new (event.constructor)("click", eventOptions);
     const link = document.createElement("a");
     link.href = href;
+    link.hash = location.hash;
     document.body.appendChild(link);
     link.dispatchEvent(clickEvent);
     document.body.removeChild(link);


### PR DESCRIPTION
### Description
At least since we retired `jquery-simulate`, clicks on map elements forget the map state. #6281 delegated the clicking back to the browser, but without forwarding this information too. This patch adds this info and resolves #6755. I don't think it does for #7184 tho.
### How has this been tested?
little devTools override