### PR TITLE
Add early return for empty section in runQuery

### DIFF
--- a/app/assets/javascripts/index_modules/query.js
+++ b/app/assets/javascripts/index_modules/query.js
@@ -55,6 +55,7 @@ export default function (map) {
   }
 
   function runQuery(query, $section, merge, compare) {
+    if (!$section.length) return;
     const $ul = $section.find("ul");
 
     $ul.empty();


### PR DESCRIPTION
As learned in #7222, Turbo does some weird shit when navigation fails, even if we tell it not to.
This PR prevents queries if the result has nowhere to go, like when the page 503s.
