### PR TITLE
Use Bootstrap navbar for header

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -103,7 +103,7 @@ $(function () {
   Turbo.session.drive = false;
   Turbo.session.history.stop();
 
-  const $expandedSecondaryMenu = $("header nav.secondary > ul"),
+  const $expandedSecondaryMenu = $("header nav ul.nav"),
         $collapsedSecondaryMenu = $("#compact-secondary-nav > ul"),
         secondaryMenuItems = [],
         breakpointWidth = 768;
@@ -201,7 +201,7 @@ $(function () {
     menuIcon.prop("ariaExpanded", !header.hasClass("closed"));
   });
 
-  $("nav.primary li a").on("click", function () {
+  $("#edit_tab li a").on("click", function () {
     $("header").toggleClass("closed");
   });
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -158,7 +158,7 @@ $(function () {
   function expandSecondaryMenuItem($item) {
     $item.children("a")
       .removeClass("dropdown-item")
-      .addClass("nav-link px-1 py-0")
+      .addClass("nav-link px-1 py-2 py-md-1")
       .addClass(function () {
         return $(this).hasClass("active") ? "text-secondary-emphasis" : "text-secondary";
       });
@@ -169,7 +169,7 @@ $(function () {
   function collapseSecondaryMenuItem($item) {
     $item.children("a")
       .addClass("dropdown-item")
-      .removeClass("nav-link px-1 py-0 text-secondary text-secondary-emphasis");
+      .removeClass("nav-link px-1 py-2 py-md-1 text-secondary text-secondary-emphasis");
     $item.removeClass("nav-item").appendTo($collapsedSecondaryMenu);
     toggleCompactSecondaryNav();
   }
@@ -193,16 +193,8 @@ $(function () {
     $(document).on("turbo:render", updateHeader);
   }, 0);
 
-  const menuIcon = $("#menu-icon");
-  const header = $("header");
-  menuIcon.on("click", function (e) {
-    e.preventDefault();
-    header.toggleClass("closed");
-    menuIcon.prop("ariaExpanded", !header.hasClass("closed"));
-  });
-
   $("#edit_tab li a").on("click", function () {
-    $("header").toggleClass("closed");
+    $(".navbar-toggler:not(.collapsed)").trigger("click");
   });
 
   $("#edit_tab")

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -311,7 +311,7 @@ $(function () {
     if (OSM.router.route(url.pathname + url.search + url.hash)) {
       e.preventDefault();
       if (url.pathname !== "/directions") {
-        $("header").addClass("closed");
+        $(".navbar-toggler:not(.collapsed)").trigger("click");
       }
     }
   });

--- a/app/assets/javascripts/index/initializations.js
+++ b/app/assets/javascripts/index/initializations.js
@@ -9,7 +9,7 @@ OSM.initializations.push(function (map) {
 
   $(".search_form").on("submit", function (e) {
     e.preventDefault();
-    $("header").addClass("closed");
+    $(".navbar-toggler:not(.collapsed)").trigger("click");
     const bounds = map.getBounds();
     const params = new URLSearchParams({
       query: this.elements.query.value,
@@ -25,7 +25,7 @@ OSM.initializations.push(function (map) {
 
   $(".describe_location").on("click", function (e) {
     e.preventDefault();
-    $("header").addClass("closed");
+    $(".navbar-toggler:not(.collapsed)").trigger("click");
     const zoom = map.getZoom();
     const { lat, lng } = OSM.cropLocation(map.getCenter(), zoom);
 

--- a/app/assets/javascripts/index_modules/directions.js
+++ b/app/assets/javascripts/index_modules/directions.js
@@ -100,7 +100,7 @@ export default function (map) {
 
     if (!points[0] || !points[1]) return;
 
-    $("header").addClass("closed");
+    $(".navbar-toggler:not(.collapsed)").trigger("click");
 
     OSM.router.replace("/directions?" + new URLSearchParams({
       engine: chosenEngine.id,

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -106,7 +106,7 @@ OSM.Router = function (map, rts) {
   const router = {};
 
   function updateSecondaryNav() {
-    $("header nav.secondary > ul > li > a").each(function () {
+    $("header ul.nav > li > a").each(function () {
       const active = new URL($(this).attr("href"), location.href).pathname === location.pathname;
 
       $(this)

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -76,8 +76,8 @@ time[title] {
 header {
   font-size: 14px;
 
-  > .d-flex,
-  #edit_tab {
+  h1,
+  nav {
     padding: $lineheight * 0.5;
   }
 
@@ -91,13 +91,13 @@ header {
     font-size: 14px;
   }
 
-  &.closed nav {
+  &.closed #header-nav {
     @extend .d-none;
     @extend .d-md-flex;
   }
 }
 
-nav.primary {
+header nav {
   #edit_tab .btn-outline-primary {
     @include button-outline-variant($green, $color-hover: $white, $active-color: $white);
   }
@@ -123,15 +123,7 @@ nav.primary {
       box-shadow: 0 0 0 0.2rem fade-out($green, 0.5);
     }
   }
-}
 
-nav.secondary {
-  .user-menu, .login-menu {
-    width: 100%;
-  }
-}
-
-nav.primary, nav.secondary {
   .dropdown-item {
     &:hover, &:active {
       background-color: $green;
@@ -143,16 +135,6 @@ nav.primary, nav.secondary {
 @include media-breakpoint-up(md) {
   header .username {
     max-width: 12em;
-  }
-
-  nav.secondary {
-    > ul {
-      height: 1.5em;
-    }
-
-    .user-menu, .login-menu {
-      width: auto;
-    }
   }
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -69,11 +69,7 @@ time[title] {
 
 /* Rules for the header */
 
-#menu-icon i.bi {
-  font-size: 30px;
-}
-
-header {
+header.navbar {
   font-size: 14px;
 
   h1,
@@ -89,11 +85,6 @@ header {
 
   .btn {
     font-size: 14px;
-  }
-
-  &.closed #header-nav {
-    @extend .d-none;
-    @extend .d-md-flex;
   }
 }
 
@@ -434,7 +425,7 @@ legend {
 }
 
 .search_form {
-  .describe_location {
+  .describe_location.btn {
     font-size: 10px;
   }
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,19 +1,19 @@
 <%# locals: (hide_signup:) %>
 
-<header class="d-flex bg-body flex-column flex-md-row position-relative text-nowrap closed z-3">
+<header class="navbar navbar-expand-md bg-body flex-column flex-md-row align-items-stretch p-0 position-relative flex-nowrap z-3">
   <h1 class="d-flex m-0 align-items-center fw-semibold">
     <a href="<%= root_path %>" class="icon-link gap-1 me-auto text-body-emphasis text-decoration-none geolink">
       <%= image_tag "osm_logo.svg", :alt => t("layouts.logo.alt_text"), :size => 30 %>
       <%= t "layouts.project_name.title" %>
     </a>
     <%= render "layouts/select_language_button", :extra_classes => ["border-secondary border-opacity-10 d-md-none"] %>
-    <a href="#" id="menu-icon" class="d-md-none" aria-expanded="false" aria-label="<%= t("layouts.main_navigation") %>">
-      <i class="bi bi-list lh-1 text-body-secondary"></i>
-    </a>
+    <button class="navbar-toggler p-0 border-0" type="button" data-bs-toggle="collapse" data-bs-target="#header-nav" aria-controls="header-nav" aria-expanded="false" aria-label="<%= t("layouts.main_navigation") %>">
+      <span class="navbar-toggler-icon"></span>
+    </button>
   </h1>
-  <section id="header-nav" class="flex-grow-1">
+  <section id="header-nav" class="flex-grow-1 collapse d-md-block">
     <%= content_for :header %>
-    <nav class="d-flex flex-column flex-md-row gap-2 flex-grow-1">
+    <nav class="navbar-nav gap-2 flex-grow-1">
       <div id="edit_tab" class="btn-group">
         <%= link_to t(".edit"),
                     edit_path,
@@ -34,12 +34,12 @@
       </div>
       <ul id="secondary-nav-menu" class="nav flex-grow-1 ms-md-2 align-items-center justify-content-center justify-content-md-start" data-turbo-permanent>
         <% secondary_nav_items.each do |path, label, options = {}| %>
-          <li class="nav-item py-2 py-md-0">
-            <%= link_to label, path, :class => ["nav-link", "px-1", "py-0", current_page?(path) ? "active text-secondary-emphasis" : "text-secondary", options.delete(:class)], **options %>
+          <li class="nav-item">
+            <%= link_to label, path, :class => ["nav-link", "px-1", "py-2", "py-md-1", current_page?(path) ? "active text-secondary-emphasis" : "text-secondary", options.delete(:class)], **options %>
           </li>
         <% end %>
-        <li id="compact-secondary-nav" class="dropdown nav-item ms-auto py-2 py-md-0 collapse">
-          <button class="dropdown-toggle nav-link btn btn-outline-secondary px-1 py-0 border-0 bg-body text-secondary" type="button" data-bs-toggle="dropdown"><%= t ".more" %></button>
+        <li id="compact-secondary-nav" class="dropdown nav-item ms-auto collapse">
+          <button class="dropdown-toggle nav-link btn btn-outline-secondary px-1 py-2 py-md-1 border-0 bg-body text-secondary" type="button" data-bs-toggle="dropdown"><%= t ".more" %></button>
           <ul class="dropdown-menu">
           </ul>
         </li>
@@ -47,7 +47,7 @@
 
       <%= render "layouts/select_language_button", :extra_classes => ["d-none d-md-block py-0", { "border-secondary-subtle" => current_user&.id }] %>
       <% if current_user && current_user.id %>
-        <div class="d-inline-flex dropdown user-menu logged-in">
+        <div class="d-flex dropdown user-menu logged-in">
           <button class="d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1 mw-100" type="button" data-bs-toggle="dropdown">
             <%= user_thumbnail_tiny(current_user, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
             <% if current_user.new_messages.size > 0 %>
@@ -75,7 +75,7 @@
         </div>
       <% else %>
         <% unless hide_signup %>
-          <div class="d-inline-flex btn-group login-menu">
+          <div class="d-flex btn-group login-menu">
             <%= link_to t(".log_in"), login_path(:referer => request.fullpath), :class => "geolink btn btn-outline-secondary" %>
             <%= link_to t(".sign_up"), new_user_path, :class => "btn btn-outline-secondary" %>
           </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (hide_signup:) %>
 
-<header class="d-flex bg-body flex-column flex-md-row h-auto position-relative text-nowrap closed z-3">
+<header class="d-flex bg-body flex-column flex-md-row position-relative text-nowrap closed z-3">
   <h1 class="d-flex m-0 align-items-center fw-semibold">
     <a href="<%= root_path %>" class="icon-link gap-1 me-auto text-body-emphasis text-decoration-none geolink">
       <%= image_tag "osm_logo.svg", :alt => t("layouts.logo.alt_text"), :size => 30 %>
@@ -11,78 +11,78 @@
       <i class="bi bi-list lh-1 text-body-secondary"></i>
     </a>
   </h1>
-  <nav class="primary">
+  <section id="header-nav" class="flex-grow-1">
     <%= content_for :header %>
-    <div id="edit_tab" class="btn-group w-100">
-      <%= link_to t(".edit"),
-                  edit_path,
-                  :class => ["btn btn-outline-primary geolink editlink", { "active" => current_page?(edit_path) }],
-                  :id => "editanchor",
-                  :data => { :editor => preferred_editor } %>
-      <button class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split flex-grow-0" type="button" data-bs-toggle="dropdown"></button>
-      <ul class="dropdown-menu">
-        <% Editors::RECOMMENDED_EDITORS.each do |editor| %>
-          <li>
-            <%= link_to t(".edit_with", :editor => t("editor.#{editor}.description")),
-                        edit_path(:editor => editor),
-                        :data => { :editor => editor },
-                        :class => "geolink editlink dropdown-item" %>
+    <nav class="d-flex flex-column flex-md-row gap-2 flex-grow-1">
+      <div id="edit_tab" class="btn-group">
+        <%= link_to t(".edit"),
+                    edit_path,
+                    :class => ["btn btn-outline-primary geolink editlink", { "active" => current_page?(edit_path) }],
+                    :id => "editanchor",
+                    :data => { :editor => preferred_editor } %>
+        <button class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split flex-grow-0" type="button" data-bs-toggle="dropdown"></button>
+        <ul class="dropdown-menu">
+          <% Editors::RECOMMENDED_EDITORS.each do |editor| %>
+            <li>
+              <%= link_to t(".edit_with", :editor => t("editor.#{editor}.description")),
+                          edit_path(:editor => editor),
+                          :data => { :editor => editor },
+                          :class => "geolink editlink dropdown-item" %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+      <ul id="secondary-nav-menu" class="nav flex-grow-1 ms-md-2 align-items-center justify-content-center justify-content-md-start" data-turbo-permanent>
+        <% secondary_nav_items.each do |path, label, options = {}| %>
+          <li class="nav-item py-2 py-md-0">
+            <%= link_to label, path, :class => ["nav-link", "px-1", "py-0", current_page?(path) ? "active text-secondary-emphasis" : "text-secondary", options.delete(:class)], **options %>
           </li>
         <% end %>
-      </ul>
-    </div>
-  </nav>
-  <nav class="secondary d-flex flex-column flex-md-row gap-2 flex-grow-1 align-items-center">
-    <ul id="secondary-nav-menu" class="nav flex-grow-1 justify-content-center justify-content-md-start" data-turbo-permanent>
-      <% secondary_nav_items.each do |path, label, options = {}| %>
-        <li class="nav-item pb-2 pb-md-0">
-          <%= link_to label, path, :class => ["nav-link", "px-1", "py-0", current_page?(path) ? "active text-secondary-emphasis" : "text-secondary", options.delete(:class)], **options %>
+        <li id="compact-secondary-nav" class="dropdown nav-item ms-auto py-2 py-md-0 collapse">
+          <button class="dropdown-toggle nav-link btn btn-outline-secondary px-1 py-0 border-0 bg-body text-secondary" type="button" data-bs-toggle="dropdown"><%= t ".more" %></button>
+          <ul class="dropdown-menu">
+          </ul>
         </li>
-      <% end %>
-      <li id="compact-secondary-nav" class="dropdown nav-item ms-auto pb-2 pb-md-0 collapse">
-        <button class="dropdown-toggle nav-link btn btn-outline-secondary px-1 py-0 border-0 bg-body text-secondary" type="button" data-bs-toggle="dropdown"><%= t ".more" %></button>
-        <ul class="dropdown-menu">
-        </ul>
-      </li>
-    </ul>
+      </ul>
 
-    <%= render "layouts/select_language_button", :extra_classes => ["d-none d-md-block py-0", { "border-secondary-subtle" => current_user&.id }] %>
-    <% if current_user && current_user.id %>
-      <div class="d-inline-flex dropdown user-menu logged-in">
-        <button class="d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1 mw-100" type="button" data-bs-toggle="dropdown">
-          <%= user_thumbnail_tiny(current_user, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
-          <% if current_user.new_messages.size > 0 %>
-            <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
-          <% end %>
-          <span class="username align-middle text-truncate" dir="auto">
-            <%= current_user.display_name_was %>
-          </span>
-        </button>
-        <div class="dropdown-menu dropdown-menu-end">
-          <%= link_to t("users.show.my_dashboard"), dashboard_path, :class => "dropdown-item" %>
-          <%= link_to messages_inbox_path, :class => "dropdown-item" do %>
-            <%= t("users.show.my messages") %>
-            <span class="badge count-number"><%= number_with_delimiter(current_user.new_messages.size) %></span>
-          <% end %>
-          <%= link_to t("users.show.my profile"), current_user, :class => "dropdown-item" %>
-          <%= link_to t("users.show.my_account"), account_path, :class => "dropdown-item" %>
-          <%= link_to t("users.show.my_preferences"), basic_preferences_path, :class => "dropdown-item" %>
-          <div class="dropdown-divider"></div>
-          <% if current_user.home_location? %>
-            <%= link_to t(".home"), account_home_path, :class => "dropdown-item" %>
-          <% end %>
-          <%= link_to t(".log_out"), logout_path(:referer => request.fullpath), :method => "post", :class => "geolink dropdown-item" %>
+      <%= render "layouts/select_language_button", :extra_classes => ["d-none d-md-block py-0", { "border-secondary-subtle" => current_user&.id }] %>
+      <% if current_user && current_user.id %>
+        <div class="d-inline-flex dropdown user-menu logged-in">
+          <button class="d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1 mw-100" type="button" data-bs-toggle="dropdown">
+            <%= user_thumbnail_tiny(current_user, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
+            <% if current_user.new_messages.size > 0 %>
+              <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
+            <% end %>
+            <span class="username align-middle text-truncate" dir="auto">
+              <%= current_user.display_name_was %>
+            </span>
+          </button>
+          <div class="dropdown-menu dropdown-menu-end">
+            <%= link_to t("users.show.my_dashboard"), dashboard_path, :class => "dropdown-item" %>
+            <%= link_to messages_inbox_path, :class => "dropdown-item" do %>
+              <%= t("users.show.my messages") %>
+              <span class="badge count-number"><%= number_with_delimiter(current_user.new_messages.size) %></span>
+            <% end %>
+            <%= link_to t("users.show.my profile"), current_user, :class => "dropdown-item" %>
+            <%= link_to t("users.show.my_account"), account_path, :class => "dropdown-item" %>
+            <%= link_to t("users.show.my_preferences"), basic_preferences_path, :class => "dropdown-item" %>
+            <div class="dropdown-divider"></div>
+            <% if current_user.home_location? %>
+              <%= link_to t(".home"), account_home_path, :class => "dropdown-item" %>
+            <% end %>
+            <%= link_to t(".log_out"), logout_path(:referer => request.fullpath), :method => "post", :class => "geolink dropdown-item" %>
+          </div>
         </div>
-      </div>
-    <% else %>
-      <% unless hide_signup %>
-        <div class="d-inline-flex btn-group login-menu">
-          <%= link_to t(".log_in"), login_path(:referer => request.fullpath), :class => "geolink btn btn-outline-secondary" %>
-          <%= link_to t(".sign_up"), new_user_path, :class => "btn btn-outline-secondary" %>
-        </div>
+      <% else %>
+        <% unless hide_signup %>
+          <div class="d-inline-flex btn-group login-menu">
+            <%= link_to t(".log_in"), login_path(:referer => request.fullpath), :class => "geolink btn btn-outline-secondary" %>
+            <%= link_to t(".sign_up"), new_user_path, :class => "btn btn-outline-secondary" %>
+          </div>
+        <% end %>
       <% end %>
-    <% end %>
-  </nav>
+    </nav>
+  </section>
 </header>
 
 <div class="modal fade" id="select_language_dialog" tabindex="-1" aria-labelledby="select_language_dialog_label" aria-hidden="true">


### PR DESCRIPTION
A way to get started on #7238 that has a pretty significant portion of cleanup is to use the Bootstrap navbar toggler in the header.
Closing open navbars across the SPA via Bootstrap also takes care of the cases #7008 missed.