### PR TITLE
Use Turbo frames for sidebar loading

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -25,44 +25,36 @@ $(function () {
   });
 
   OSM.loadSidebarContent = function (path) {
-    const atomSelector = "link[type=\"application/atom+xml\"]";
-
     map.setSidebarOverlaid(false);
 
-    $("#sidebar_loader").prop("hidden", false).addClass("delayed-fade-in");
+    return new Promise((resolve, reject) => {
+      $("#sidebar_content_frame")
+        .one("turbo:frame-render", event => {
+          const response = event.originalEvent.detail.fetchResponse.response;
 
-    // Prevent caching the XHR response as a full-page URL
-    // https://github.com/openstreetmap/openstreetmap-website/issues/5663
-    const queryParamSeparator = path.includes("?") ? "&" : "?";
-    const xhrPath = `${path}${queryParamSeparator}xhr=1`;
+          const title = response.headers.get("X-Page-Title");
+          if (title) document.title = decodeURIComponent(title);
 
-    $("#sidebar_content")
-      .empty();
-
-    return fetch(xhrPath, { headers: { "accept": "text/html", "x-requested-with": "XMLHttpRequest" } })
-      .then(response => {
-        $("#flash").empty();
-        $("#sidebar_loader").removeClass("delayed-fade-in").prop("hidden", true);
-
-        return response.text().then(html => ({ response, html }));
-      })
-      .then(({ response, html }) => {
-        const content = $($.parseHTML(html));
-
-        const title = response.headers.get("X-Page-Title");
-        if (title) document.title = decodeURIComponent(title);
-
-        $("head").find(atomSelector).remove();
-
-        $("head").append(content.filter(atomSelector));
-
-        $("#sidebar_content").html(content.not(atomSelector));
-
-        if (!response.ok) {
-          throw new Error(`HTTP Error ${response.status} ${response.statusText}`);
-        }
-      });
+          if (response.ok) {
+            resolve();
+          } else {
+            reject(new Error(`HTTP Error ${response.status} ${response.statusText}`));
+          }
+        })
+        .prop("src", path);
+    });
   };
+
+  $("#sidebar_content_frame")
+    .on("turbo:before-fetch-response", () => $("#flash").empty())
+    .on("turbo:before-frame-render", event => {
+      const atomSelector = "link[type='application/atom+xml']";
+      $("head").find(atomSelector).remove();
+      $("head").append(
+        $(event.originalEvent.detail.newFrame)
+          .find(atomSelector)
+          .detach());
+    });
 
   const token = $("head").data("oauthToken");
   if (token) OSM.oauth = { authorization: "Bearer " + token };

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -237,6 +237,11 @@ header nav {
     }
   }
 
+  #sidebar_loader:has(+ #sidebar_content turbo-frame:not([busy])),
+  #sidebar_content turbo-frame[busy] {
+    display: none;
+  }
+
   #content:not(.overlay-sidebar) :is(.welcome, #banner) {
     @extend .d-none;
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -208,7 +208,7 @@ class ApplicationController < ActionController::Base
 
     I18n.locale = Locale.available.preferred(preferred_languages)
 
-    response.headers["Vary"] = "Accept-Language"
+    response.headers["Vary"] = response.headers["Vary"].present? ? "#{response.headers['Vary']}, Accept-Language" : "Accept-Language"
     response.headers["Content-Language"] = I18n.locale.to_s
   end
 
@@ -263,7 +263,8 @@ class ApplicationController < ActionController::Base
 
     flash.now[:warning] = { :partial => "layouts/offline_flash" } unless api_status == "online"
 
-    request.xhr? ? "xhr" : "map"
+    response.headers["Vary"] = response.headers["Vary"].present? ? "#{response.headers['Vary']}, Turbo-Frame" : "Turbo-Frame"
+    turbo_frame_request? ? "xhr" : "map"
   end
 
   def preferred_editor

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -20,10 +20,12 @@
 
     <%= render :partial => "layouts/sidebar_close" %>
 
-    <div id="sidebar_loader" class="my-3 text-center loader" hidden><%= render "loader" %></div>
+    <div id="sidebar_loader" class="my-3 text-center loader"><%= render "loader" %></div>
 
     <div id="sidebar_content" class="p-3 position-relative z-n1">
-      <%= yield %>
+      <turbo-frame id="sidebar_content_frame" target="_top" data-turbo="false">
+        <%= yield %>
+      </turbo-frame>
     </div>
 
     <% unless current_user %>

--- a/app/views/layouts/xhr.html.erb
+++ b/app/views/layouts/xhr.html.erb
@@ -1,2 +1,4 @@
-<%= content_for :auto_discovery_link_tag %>
-<%= yield %>
+<turbo-frame id="sidebar_content_frame" target="_top" data-turbo="false">
+  <%= content_for :auto_discovery_link_tag %>
+  <%= yield %>
+</turbo-frame>

--- a/test/controllers/changesets_controller_test.rb
+++ b/test/controllers/changesets_controller_test.rb
@@ -62,7 +62,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
   def test_index_xhr
     changesets = create_list(:changeset, 30, :num_changes => 1)
 
-    get history_path(:format => "html"), :xhr => true
+    get history_path(:format => "html"), :headers => { "Turbo-Frame" => "sidebar_content_frame" }
     assert_response :success
     assert_template "history"
     assert_template :layout => "xhr"
@@ -351,7 +351,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     changeset1 = create(:changeset, :num_changes => 1)
     changeset2 = create(:changeset, :num_changes => 1)
 
-    get history_path(:format => "html", :before => changeset2.id), :xhr => true
+    get history_path(:format => "html", :before => changeset2.id), :headers => { "Turbo-Frame" => "sidebar_content_frame" }
     assert_response :success
     assert_template "history"
     assert_template :layout => "xhr"
@@ -368,7 +368,7 @@ class ChangesetsControllerTest < ActionDispatch::IntegrationTest
     changeset1 = create(:changeset, :num_changes => 1)
     changeset2 = create(:changeset, :num_changes => 1)
 
-    get history_path(:format => "html", :after => changeset1.id), :xhr => true
+    get history_path(:format => "html", :after => changeset1.id), :headers => { "Turbo-Frame" => "sidebar_content_frame" }
     assert_response :success
     assert_template "history"
     assert_template :layout => "xhr"

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -126,7 +126,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_template "browse/not_found"
     assert_template :layout => "map"
 
-    get note_path(hidden_note_with_comment), :xhr => true
+    get note_path(hidden_note_with_comment), :headers => { "Turbo-Frame" => "sidebar_content_frame" }
     assert_response :not_found
     assert_template "browse/not_found"
     assert_template :layout => "xhr"

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -342,7 +342,7 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_in_delta lat, @controller.params[:lat].to_f
     assert_in_delta lon, @controller.params[:lon].to_f
 
-    get search_path(:query => query), :xhr => true
+    get search_path(:query => query), :headers => { "Turbo-Frame" => "sidebar_content_frame" }
     assert_response :success
     assert_template :show
     assert_template :layout => "xhr"
@@ -361,7 +361,7 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_template :layout => "map"
     assert_equal sources, assigns(:sources).pluck(:name)
 
-    get search_path(:query => query), :xhr => true
+    get search_path(:query => query), :headers => { "Turbo-Frame" => "sidebar_content_frame" }
     assert_response :success
     assert_template :show
     assert_template :layout => "xhr"

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -470,7 +470,7 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     assert_template "export"
     assert_template :layout => "map"
 
-    get export_path, :xhr => true
+    get export_path, :headers => { "Turbo-Frame" => "sidebar_content_frame" }
     assert_response :success
     assert_template "export"
     assert_template :layout => "xhr"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -404,7 +404,7 @@ module ActiveSupport
       assert_template "browse/not_found"
       assert_template :layout => "map"
 
-      get path_method.call(:id => 0), :xhr => true
+      get path_method.call(:id => 0), :headers => { "Turbo-Frame" => "sidebar_content_frame" }
       assert_response :not_found
       assert_template "browse/not_found"
       assert_template :layout => "xhr"
@@ -414,7 +414,7 @@ module ActiveSupport
       assert_template template
       assert_template :layout => "map"
 
-      get path_method.call(:id => id), :xhr => true
+      get path_method.call(:id => id), :headers => { "Turbo-Frame" => "sidebar_content_frame" }
       assert_response :success
       assert_template template
       assert_template :layout => "xhr"


### PR DESCRIPTION
Now that we have `OSM.loadSidebarContent` nicely promise-based, let's throw that simplicity out the window by involving Turbo.

Closes #6112.
