### PR TITLE
Overlay routing markers without setting position

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -459,6 +459,10 @@ tr.turn {
   margin-right: .35rem;
   width: 15px;
 
+  &, & + input {
+    grid-area: 1/1;
+  }
+
   svg {
     cursor: move;
   }

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -47,8 +47,8 @@
       </div>
       <div class="d-flex gap-2 align-items-center">
         <div class="d-flex flex-column gap-1 flex-grow-1">
-          <div class="d-flex align-items-center">
-            <div class="routing_marker_column position-absolute">
+          <div class="d-grid align-items-center">
+            <div class="routing_marker_column z-0">
               <span data-type="from" draggable="true">
                 <svg viewBox="0 0 25 40">
                   <use href="#pin-start" color="var(--marker-green)" />
@@ -57,8 +57,8 @@
             </div>
             <%= text_field_tag "route_from", params[:from], :placeholder => t("site.search.from"), :autocomplete => "on", :class => "form-control py-1 px-2 ps-4", :dir => "auto" %>
           </div>
-          <div class="d-flex align-items-center">
-            <div class="routing_marker_column position-absolute">
+          <div class="d-grid align-items-center">
+            <div class="routing_marker_column z-0">
               <span data-type="to" draggable="true">
                 <svg viewBox="0 0 25 40">
                   <use href="#pin-destination" color="var(--marker-red)" />


### PR DESCRIPTION
Addendum to #7239.
I just noticed that when the navbar is clipped on expansion and contraction, the directions pins aren't clipped, as they are positioned absolutely.
Using `display: grid` to overlay them fixes this.