### PR TITLE
Fix navbar toggler button class

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
       <%= t "layouts.project_name.title" %>
     </a>
     <%= render "layouts/select_language_button", :extra_classes => ["border-secondary border-opacity-10 d-md-none"] %>
-    <button class="navbar-toggler p-0 border-0" type="button" data-bs-toggle="collapse" data-bs-target="#header-nav" aria-controls="header-nav" aria-expanded="false" aria-label="<%= t("layouts.main_navigation") %>">
+    <button class="navbar-toggler p-0 border-0 collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#header-nav" aria-controls="header-nav" aria-expanded="false" aria-label="<%= t("layouts.main_navigation") %>">
       <span class="navbar-toggler-icon"></span>
     </button>
   </h1>


### PR DESCRIPTION
In #7239, for the actions that should close the header navbar, the toggler class isn't initialised correctly.
This leads to certain actions opening the nav instead of closing it on a freshly reloaded page:
- Getting directions via the context menu
- Navigating to a note by clicking on the map
- Navigating between elements, changesets, and the user history from the sidebar

Thanks @GA-Kevin-Codes for the heads up.