### PR TITLE
DRY and simplify notification templates

### DIFF
--- a/app/views/notifications/_changeset_comment.html.erb
+++ b/app/views/notifications/_changeset_comment.html.erb
@@ -14,7 +14,7 @@
       "notifications/notification_body",
       :author => record.author
     ) do %>
-  <p class="text-body-secondary mb-1 event-description">
+  <p class="text-body-secondary event-description">
     <% if record.changeset.comment %>
       <%= t(
             "notifications.changeset_comment.description_with_summary_html",
@@ -36,7 +36,5 @@
           ) %>
     <% end %>
   </p>
-  <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
-    <%= record.body.to_html %>
-  </blockquote>
+  <%= render "notifications/notification_quote", :body => record.body.to_html %>
 <% end %>

--- a/app/views/notifications/_changeset_comment.html.erb
+++ b/app/views/notifications/_changeset_comment.html.erb
@@ -1,53 +1,42 @@
 <%# locals: (notification:, record:) %>
 
-<article class="user-notification">
-  <div class="row align-items-center">
-    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
-      <%= link_to(
-            t(".headline"),
-            changeset_path(
-              record.changeset,
-              :anchor => "c#{record.id}"
-            )
-          ) %>
-    </h2>
-    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(record.created_at) %></p>
-  </div>
+<%= render(
+      "notifications/notification_header",
+      :title => t(".headline"),
+      :uri => changeset_path(
+        record.changeset,
+        :anchor => "c#{record.id}"
+      ),
+      :timestamp => record.created_at
+    ) %>
 
-  <div class="row">
-    <div class="col-1 text-center">
-      <%= link_to(
-            user_thumbnail(record.author, :class => "img-fluid"),
-            user_url(record.author),
-            :target => "_blank", :rel => "noopener"
+<%= render(
+      "notifications/notification_body",
+      :author => record.author
+    ) do %>
+  <p class="text-body-secondary mb-1 event-description">
+    <% if record.changeset.comment %>
+      <%= t(
+            "notifications.changeset_comment.description_with_summary_html",
+            :commenter_name_with_link => link_to(
+              record.author.display_name,
+              record.author
+            ),
+            :changeset_id_with_link => link_to("##{record.changeset_id}", record.changeset),
+            :changeset_summary => record.changeset.comment
           ) %>
-    </div>
-    <div class="col-11">
-      <p class="text-body-secondary mb-1 event-description">
-        <% if record.changeset.comment %>
-          <%= t(
-                ".description_with_summary_html",
-                :commenter_name_with_link => link_to(
-                  record.author.display_name,
-                  record.author
-                ),
-                :changeset_id_with_link => link_to("##{record.changeset_id}", record.changeset),
-                :changeset_summary => record.changeset.comment
-              ) %>
-        <% else %>
-          <%= t(
-                ".description_without_summary_html",
-                :commenter_name_with_link => link_to(
-                  record.author.display_name,
-                  record.author
-                ),
-                :changeset_id_with_link => link_to("##{record.changeset_id}", record.changeset)
-              ) %>
-        <% end %>
-      </p>
-      <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
-        <%= record.body.to_html %>
-      </blockquote>
-    </div>
-  </div>
-</article>
+    <% else %>
+      <%= t(
+            "notifications.changeset_comment.description_without_summary_html",
+            :commenter_name_with_link => link_to(
+              record.author.display_name,
+              record.author
+            ),
+            :changeset_id_with_link => link_to("##{record.changeset_id}", record.changeset)
+          ) %>
+    <% end %>
+  </p>
+  <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
+    <%= record.body.to_html %>
+  </blockquote>
+<% end %>

--- a/app/views/notifications/_diary_comment.html.erb
+++ b/app/views/notifications/_diary_comment.html.erb
@@ -1,48 +1,37 @@
 <%# locals: (notification:, record:) %>
 
-<article class="user-notification">
-  <div class="row align-items-center">
-    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
-      <%= link_to(
-            t(".headline"),
+<%= render(
+      "notifications/notification_header",
+      :title => t(".headline"),
+      :uri => diary_entry_path(
+        record.diary_entry.user,
+        record.diary_entry,
+        :anchor => "c#{record.id}"
+      ),
+      :timestamp => record.created_at
+    ) %>
+
+<%= render(
+      "notifications/notification_body",
+      :author => record.user
+    ) do %>
+  <p class="text-body-secondary mb-1">
+    <%= t(
+          "notifications.diary_comment.description_html",
+          :commenter_name_with_link => link_to(
+            record.user.display_name,
+            record.user
+          ),
+          :diary_entry_title_with_link => link_to(
+            record.diary_entry.title,
             diary_entry_path(
               record.diary_entry.user,
-              record.diary_entry,
-              :anchor => "c#{record.id}"
+              record.diary_entry
             )
-          ) %>
-    </h2>
-    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(record.created_at) %></p>
-  </div>
-
-  <div class="row">
-    <div class="col-1 text-center">
-      <%= link_to(
-            user_thumbnail(record.user, :class => "img-fluid"),
-            user_url(record.user),
-            :target => "_blank", :rel => "noopener"
-          ) %>
-    </div>
-    <div class="col-11">
-      <p class="text-body-secondary mb-1">
-        <%= t(
-              ".description_html",
-              :commenter_name_with_link => link_to(
-                record.user.display_name,
-                record.user
-              ),
-              :diary_entry_title_with_link => link_to(
-                record.diary_entry.title,
-                diary_entry_path(
-                  record.diary_entry.user,
-                  record.diary_entry
-                )
-              )
-            ) %>
-      </p>
-      <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
-        <%= record.body.to_html %>
-      </blockquote>
-    </div>
-  </div>
-</article>
+          )
+        ) %>
+  </p>
+  <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
+    <%= record.body.to_html %>
+  </blockquote>
+<% end %>

--- a/app/views/notifications/_diary_comment.html.erb
+++ b/app/views/notifications/_diary_comment.html.erb
@@ -15,7 +15,7 @@
       "notifications/notification_body",
       :author => record.user
     ) do %>
-  <p class="text-body-secondary mb-1">
+  <p class="text-body-secondary">
     <%= t(
           "notifications.diary_comment.description_html",
           :commenter_name_with_link => link_to(
@@ -31,7 +31,5 @@
           )
         ) %>
   </p>
-  <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
-    <%= record.body.to_html %>
-  </blockquote>
+  <%= render "notifications/notification_quote", :body => record.body.to_html %>
 <% end %>

--- a/app/views/notifications/_gpx_import_failure.html.erb
+++ b/app/views/notifications/_gpx_import_failure.html.erb
@@ -1,23 +1,19 @@
 <%# locals: (notification:, record:) %>
 
-<article class="user-notification">
-  <div class="row align-items-center">
-    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
-      <%= t(".headline") %>
-    </h2>
-    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(notification.created_at) %></p>
-  </div>
+<%= render(
+      "notifications/notification_header",
+      :title => t(".headline"),
+      :timestamp => notification.created_at
+    ) %>
 
+<%= render("notifications/notification_body") do %>
   <div class="row">
-    <div class="col-1 text-center">
-      <span class="text-danger"></span>
-    </div>
     <div class="col-4">
       <%= render "notifications/gpx_details", :details => GpxImportNotificationDetails::Failure.new(notification) %>
     </div>
-    <dl class="col-7">
-      <dt><%= t(".error_message") %></dt>
+    <dl class="col-8">
+      <dt><%= t("notifications.gpx_import_failure.error_message") %></dt>
       <dd><pre><%= notification.params[:error] %></pre></dd>
     </dl>
   </div>
-</article>
+<% end %>

--- a/app/views/notifications/_gpx_import_success.html.erb
+++ b/app/views/notifications/_gpx_import_success.html.erb
@@ -13,13 +13,11 @@
 <div class="row">
   <div class="col-1 text-center">
     <% if Settings.status != "gpx_offline" %>
-      <% if record.inserted %>
-        <%= link_to trace_icon(record),
-                    show_trace_path(record.user, record),
-                    :class => "d-inline-block" %>
-      <% else %>
-        <span class="text-danger"><%= t ".pending" %></span>
-      <% end %>
+      <%= link_to(
+            trace_icon(record),
+            show_trace_path(record.user, record),
+            :class => "d-inline-block"
+          ) %>
     <% end %>
   </div>
   <div class="col-11">

--- a/app/views/notifications/_gpx_import_success.html.erb
+++ b/app/views/notifications/_gpx_import_success.html.erb
@@ -1,29 +1,28 @@
 <%# locals: (notification:, record:) %>
 
-<article class="user-notification">
-  <div class="row align-items-center">
-    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
-      <%= link_to t(".headline"), show_trace_path(record.user, record) %>
-    </h2>
-    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(record.timestamp) %></p>
-  </div>
+<%= render(
+      "notifications/notification_header",
+      :title => t(".headline"),
+      :uri => show_trace_path(
+        record.user,
+        record
+      ),
+      :timestamp => record.timestamp
+    ) %>
 
-  <div class="row">
-    <div class="col-1 text-center">
-      <% if Settings.status != "gpx_offline" %>
-        <% if record.inserted %>
-          <%= link_to trace_icon(record),
-                      show_trace_path(record.user, record),
-                      :class => "d-inline-block" %>
-        <% else %>
-          <span class="text-danger"><%= t ".pending" %></span>
-        <% end %>
+<div class="row">
+  <div class="col-1 text-center">
+    <% if Settings.status != "gpx_offline" %>
+      <% if record.inserted %>
+        <%= link_to trace_icon(record),
+                    show_trace_path(record.user, record),
+                    :class => "d-inline-block" %>
+      <% else %>
+        <span class="text-danger"><%= t ".pending" %></span>
       <% end %>
-    </div>
-    <div class="col-11">
-      <%= render "notifications/gpx_details", :details => GpxImportNotificationDetails::Success.new(notification) %>
-    </div>
+    <% end %>
   </div>
-  <p class="col-3 text-center">
-  </p>
-</article>
+  <div class="col-11">
+    <%= render "notifications/gpx_details", :details => GpxImportNotificationDetails::Success.new(notification) %>
+  </div>
+</div>

--- a/app/views/notifications/_new_follower.html.erb
+++ b/app/views/notifications/_new_follower.html.erb
@@ -1,33 +1,26 @@
 <%# locals: (notification:, record:) %>
 
-<article class="user-notification">
-  <div class="row align-items-center">
-    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold"><%= t(".headline") %></h2>
-    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(record.created_at) %></p>
-  </div>
+<%= render(
+      "notifications/notification_header",
+      :title => t(".headline"),
+      :timestamp => record.created_at
+    ) %>
 
-  <div class="row">
-    <div class="col-1 text-center">
-      <%= link_to(
-            user_thumbnail(record.follower, :class => "img-fluid"),
-            user_url(record.follower),
-            :target => "_blank", :rel => "noopener"
-          ) %>
-    </div>
-    <div class="col-11">
-      <p class="text-body-secondary mb-1">
-        <%= t(
-              ".description_html",
-              :follower_name_with_link => link_to(
-                record.follower.display_name,
-                record.follower
-              ),
-              :link => link_to(
-                t(".link_text"),
-                follow_url(record.follower)
-              )
-            ) %>
-      </p>
-    </div>
-  </div>
-</article>
+<%= render(
+      "notifications/notification_body",
+      :author => record.follower
+    ) do %>
+  <p class="text-body-secondary mb-1">
+    <%= t(
+          "notifications.new_follower.description_html",
+          :follower_name_with_link => link_to(
+            record.follower.display_name,
+            record.follower
+          ),
+          :link => link_to(
+            t("notifications.new_follower.link_text"),
+            follow_url(record.follower)
+          )
+        ) %>
+  </p>
+<% end %>

--- a/app/views/notifications/_new_follower.html.erb
+++ b/app/views/notifications/_new_follower.html.erb
@@ -10,7 +10,7 @@
       "notifications/notification_body",
       :author => record.follower
     ) do %>
-  <p class="text-body-secondary mb-1">
+    <p>
     <%= t(
           "notifications.new_follower.description_html",
           :follower_name_with_link => link_to(
@@ -22,5 +22,5 @@
             follow_url(record.follower)
           )
         ) %>
-  </p>
+    </p>
 <% end %>

--- a/app/views/notifications/_note_comment.html.erb
+++ b/app/views/notifications/_note_comment.html.erb
@@ -26,8 +26,6 @@
         ) %>
   </p>
   <% if record.body.present? %>
-    <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
-      <%= record.body.to_html %>
-    </blockquote>
+    <%= render "notifications/notification_quote", :body => record.body.to_html %>
   <% end %>
 <% end %>

--- a/app/views/notifications/_note_comment.html.erb
+++ b/app/views/notifications/_note_comment.html.erb
@@ -1,44 +1,33 @@
 <%# locals: (notification:, record:) %>
 
-<article class="user-notification">
-  <div class="row align-items-center">
-    <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold">
-      <%= link_to(
-            t(".headline.#{record.event}"),
-            note_path(
-              record.note,
-              :anchor => "c#{record.id}"
-            )
-          ) %>
-    </h2>
-    <p class="col-4 lh-sm text-end"><%= friendly_date_ago(record.created_at) %></p>
-  </div>
+<%= render(
+      "notifications/notification_header",
+      :title => t(".headline.#{record.event}"),
+      :uri => note_path(
+        record.note,
+        :anchor => "c#{record.id}"
+      ),
+      :timestamp => record.created_at
+    ) %>
 
-  <div class="row">
-    <div class="col-1 text-center">
-      <%= link_to(
-            user_thumbnail(record.author, :class => "img-fluid"),
-            user_url(record.author),
-            :target => "_blank", :rel => "noopener"
-          ) %>
-    </div>
-    <div class="col-11">
-      <p class="text-body-secondary mb-1">
-      <%= t(
-            ".description.#{record.event}_html",
-            :commenter_name_with_link => link_to(
-              record.author.display_name,
-              record.author
-            ),
-            :note_id_with_link => link_to("##{record.note_id}", record.note),
-            :note_text => record.note.description
-          ) %>
-      </p>
-      <% if record.body.present? %>
-        <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
-          <%= record.body.to_html %>
-        </blockquote>
-      <% end %>
-    </div>
-  </div>
-</article>
+<%= render(
+      "notifications/notification_body",
+      :author => record.author
+    ) do %>
+  <p class="text-body-secondary mb-1">
+    <%= t(
+          "notifications.note_comment.description.#{record.event}_html",
+          :commenter_name_with_link => link_to(
+            record.author.display_name,
+            record.author
+          ),
+          :note_id_with_link => link_to("##{record.note_id}", record.note),
+          :note_text => record.note.description
+        ) %>
+  </p>
+  <% if record.body.present? %>
+    <blockquote class="col-10 fst-italic border-start border-light-subtle border-3 ps-2">
+      <%= record.body.to_html %>
+    </blockquote>
+  <% end %>
+<% end %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,9 @@
+<%# locals: (notification:) %>
+
+<article class="web-notification">
+  <%= render(
+        partial_path_for_notification(notification),
+        :notification => notification,
+        :record => notification.record
+      ) %>
+</article>

--- a/app/views/notifications/_notification_body.html.erb
+++ b/app/views/notifications/_notification_body.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (author: nil) %>
+
+<div class="row">
+  <div class="col-1 text-center">
+    <% if author %>
+      <%= link_to(
+            user_thumbnail(author, :class => "img-fluid"),
+            user_url(author),
+            :target => "_blank", :rel => "noopener"
+          ) %>
+    <% end %>
+  </div>
+  <div class="col-11">
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/notifications/_notification_header.html.erb
+++ b/app/views/notifications/_notification_header.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (title:, uri: nil, timestamp:) %>
 
-<div class="row align-items-center">
-  <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold"><%= link_to_if(uri, title, uri) %></h2>
-  <p class="col-4 lh-sm text-end"><%= friendly_date_ago(timestamp) %></p>
-</div>
+<header class="row align-items-center">
+  <h2 class="col-8 h6"><%= link_to_if(uri, title, uri) %></h2>
+  <p class="col-4 text-end"><%= friendly_date_ago(timestamp) %></p>
+</header>

--- a/app/views/notifications/_notification_header.html.erb
+++ b/app/views/notifications/_notification_header.html.erb
@@ -1,0 +1,6 @@
+<%# locals: (title:, uri: nil, timestamp:) %>
+
+<div class="row align-items-center">
+  <h2 class="col-8 fs-6 mb-3 lh-sm fw-bold"><%= link_to_if(uri, title, uri) %></h2>
+  <p class="col-4 lh-sm text-end"><%= friendly_date_ago(timestamp) %></p>
+</div>

--- a/app/views/notifications/_notification_quote.html.erb
+++ b/app/views/notifications/_notification_quote.html.erb
@@ -1,0 +1,5 @@
+<%# locals: (body: nil) %>
+
+<blockquote class="col-10 border-start border-light-subtle border-3 ps-2">
+  <%= body %>
+</blockquote>

--- a/app/views/notifications/_page.html.erb
+++ b/app/views/notifications/_page.html.erb
@@ -2,11 +2,7 @@
 
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <% notifications.items.each do |notification| %>
-    <%= render(
-          partial_path_for_notification(notification),
-          :notification => notification,
-          :record => notification.record
-        ) %>
+    <%= render "notification", :notification => notification %>
     <hr>
   <% end %>
 

--- a/test/controllers/notifications/changeset_comment_view_test.rb
+++ b/test/controllers/notifications/changeset_comment_view_test.rb
@@ -9,15 +9,15 @@ module Notifications
         :changeset_comment,
         :body => "Insightful comment"
       )
+
       notification = build_stubbed(:notification, :record => changeset_comment)
 
       render(
-        "notifications/changeset_comment",
-        :notification => notification,
-        :record => changeset_comment
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification" do
+      assert_dom ".web-notification" do
         assert_dom "h2", "Changeset comment"
         assert_not_dom "p", /\("/
         assert_dom "time", "less than 1 minute ago"
@@ -40,12 +40,11 @@ module Notifications
       notification = build_stubbed(:notification, :record => changeset_comment)
 
       render(
-        "notifications/changeset_comment",
-        :notification => notification,
-        :record => changeset_comment
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification" do
+      assert_dom ".web-notification" do
         assert_dom "h2", "Changeset comment"
         assert_dom "time", "less than 1 minute ago"
         assert_dom ".event-description", /\("This is a summary"\)/

--- a/test/controllers/notifications/diary_comment_view_test.rb
+++ b/test/controllers/notifications/diary_comment_view_test.rb
@@ -9,14 +9,15 @@ module Notifications
       notification = build_stubbed(:notification, :record => diary_comment)
 
       render(
-        "notifications/diary_comment",
-        :notification => notification,
-        :record => diary_comment
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification h2", "Diary comment"
-      assert_dom ".user-notification time", "less than 1 minute ago"
-      assert_dom ".user-notification blockquote", diary_comment.body
+      assert_dom ".web-notification" do
+        assert_dom "h2", "Diary comment"
+        assert_dom "time", "less than 1 minute ago"
+        assert_dom "blockquote", diary_comment.body
+      end
     end
   end
 end

--- a/test/controllers/notifications/gpx_import_failure_view_test.rb
+++ b/test/controllers/notifications/gpx_import_failure_view_test.rb
@@ -17,17 +17,18 @@ module Notifications
       )
 
       render(
-        "notifications/gpx_import_failure",
-        :notification => notification,
-        :record => nil
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification h2", "GPS trace could not be imported"
-      assert_dom ".user-notification time", "less than 1 minute ago"
-      assert_dom ".user-notification dd", "random-file.jpg"
-      assert_dom ".user-notification dd", "Random file"
-      assert_dom ".user-notification dd", "random, file"
-      assert_dom ".user-notification pre", "Ooops, wrong file"
+      assert_dom ".web-notification" do
+        assert_dom "h2", "GPS trace could not be imported"
+        assert_dom "time", "less than 1 minute ago"
+        assert_dom "dd", "random-file.jpg"
+        assert_dom "dd", "Random file"
+        assert_dom "dd", "random, file"
+        assert_dom "pre", "Ooops, wrong file"
+      end
     end
   end
 end

--- a/test/controllers/notifications/gpx_import_success_view_test.rb
+++ b/test/controllers/notifications/gpx_import_success_view_test.rb
@@ -20,16 +20,17 @@ module Notifications
       )
 
       render(
-        "notifications/gpx_import_success",
-        :notification => notification,
-        :record => trace
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification h2", "GPS trace imported successfully"
-      assert_dom ".user-notification time", "less than 1 minute ago"
-      assert_dom ".user-notification dd", "test-trace-file.gpx"
-      assert_dom ".user-notification dd", "Test trace file"
-      assert_dom ".user-notification dd", "5"
+      assert_dom ".web-notification" do
+        assert_dom "h2", "GPS trace imported successfully"
+        assert_dom "time", "less than 1 minute ago"
+        assert_dom "dd", "test-trace-file.gpx"
+        assert_dom "dd", "Test trace file"
+        assert_dom "dd", "5"
+      end
     end
   end
 end

--- a/test/controllers/notifications/new_follower_view_test.rb
+++ b/test/controllers/notifications/new_follower_view_test.rb
@@ -8,17 +8,22 @@ module Notifications
       follower = build_stubbed(:user, :display_name => "Follower")
       follow = build_stubbed(:follow, :follower => follower)
 
-      notification = build_stubbed(:notification, :record => follow, :notifier_class => NewFollowerNotifier)
-
-      render(
-        "notifications/new_follower",
-        :notification => notification,
-        :record => follow
+      notification = build_stubbed(
+        :notification,
+        :record => follow,
+        :notifier_class => NewFollowerNotifier
       )
 
-      assert_dom ".user-notification h2", "New follower"
-      assert_dom ".user-notification time", "less than 1 minute ago"
-      assert_dom ".user-notification p", "User Follower started following you. You can follow them back if you wish."
+      render(
+        "notifications/notification",
+        :notification => notification
+      )
+
+      assert_dom ".web-notification" do
+        assert_dom "h2", "New follower"
+        assert_dom "time", "less than 1 minute ago"
+        assert_dom "p", "User Follower started following you. You can follow them back if you wish."
+      end
     end
   end
 end

--- a/test/controllers/notifications/note_comment_view_test.rb
+++ b/test/controllers/notifications/note_comment_view_test.rb
@@ -13,14 +13,15 @@ module Notifications
       notification = build_stubbed(:notification, :record => note_comment)
 
       render(
-        "notifications/note_comment",
-        :notification => notification,
-        :record => note_comment
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification h2", "Note comment"
-      assert_dom ".user-notification time", "less than 1 minute ago"
-      assert_dom ".user-notification blockquote", note_comment.body
+      assert_dom ".web-notification" do
+        assert_dom "h2", "Note comment"
+        assert_dom "time", "less than 1 minute ago"
+        assert_dom "blockquote", note_comment.body
+      end
     end
 
     def test_render_closed_with_comment
@@ -38,14 +39,15 @@ module Notifications
       notification = build_stubbed(:notification, :record => note_comment)
 
       render(
-        "notifications/note_comment",
-        :notification => notification,
-        :record => note_comment
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification h2", "Note resolved"
-      assert_dom ".user-notification time", "less than 1 minute ago"
-      assert_dom ".user-notification blockquote", note_comment.body
+      assert_dom ".web-notification" do
+        assert_dom "h2", "Note resolved"
+        assert_dom "time", "less than 1 minute ago"
+        assert_dom "blockquote", note_comment.body
+      end
     end
 
     def test_render_closed_without_comment
@@ -64,14 +66,15 @@ module Notifications
       notification = build_stubbed(:notification, :record => note_comment)
 
       render(
-        "notifications/note_comment",
-        :notification => notification,
-        :record => note_comment
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification h2", "Note resolved"
-      assert_dom ".user-notification time", "less than 1 minute ago"
-      assert_not_dom ".user-notification blockquote"
+      assert_dom ".web-notification" do
+        assert_dom "h2", "Note resolved"
+        assert_dom "time", "less than 1 minute ago"
+        assert_not_dom "blockquote"
+      end
     end
 
     def test_render_reopened
@@ -90,14 +93,15 @@ module Notifications
       notification = build_stubbed(:notification, :record => note_comment)
 
       render(
-        "notifications/note_comment",
-        :notification => notification,
-        :record => note_comment
+        "notifications/notification",
+        :notification => notification
       )
 
-      assert_dom ".user-notification h2", "Note reopened"
-      assert_dom ".user-notification time", "less than 1 minute ago"
-      assert_not_dom ".user-notification blockquote"
+      assert_dom ".web-notification" do
+        assert_dom "h2", "Note reopened"
+        assert_dom "time", "less than 1 minute ago"
+        assert_not_dom "blockquote"
+      end
     end
   end
 end

--- a/test/system/web_notifications_test.rb
+++ b/test/system/web_notifications_test.rb
@@ -50,9 +50,11 @@ class WebNotificationsTest < ApplicationSystemTestCase
     click_on changeset_author.display_name
     click_on "My Notifications"
 
+    assert_selector ".web-notification", :count => 20
     assert_text "This is comment number 30"
     assert_no_text "This is comment number 10"
     click_on "Older Notifications"
+    assert_selector ".web-notification", :count => 10
     assert_no_text "This is comment number 30"
     assert_text "This is comment number 10"
   end


### PR DESCRIPTION
Another follow-up to https://github.com/openstreetmap/openstreetmap-website/pull/7030

This removes duplication from the notification templates, plus reduces the number of Bootstrap classes in use.

There's a slight difference in appearance as a result of the change in BS classes:

 Production | This PR
---|---
<img width="436" height="628" alt="Screenshot of the notifications page" src="https://github.com/user-attachments/assets/edc67178-35a8-4c50-b17d-7f8edccc2d8c" /> | <img width="436" height="628" alt="Another screenshot of the notifications page, with slight but not significant differences" src="https://github.com/user-attachments/assets/59be9e92-93c0-4392-aadc-90f436d415e4" />

One of the changes resulted in the blockquotes having some bottom spacing that is not great. See the note comment example above. I think removing it would require custom CSS. How bothered are reviewers about this?

Ruby-wise, I added a parent class for the view tests, `test/controllers/notifications/view_test.rb`, which sets up the template lookup context so that partials can find other partials correctly.

Also DRY'd up the view tests a bit, as well as added a couple of assertions to `test/system/web_notifications_test.rb` to further check that things are loading correctly end-to-end.