### PR TITLE
Further hardening of legal text validation

### DIFF
--- a/app/controllers/accounts/terms_controller.rb
+++ b/app/controllers/accounts/terms_controller.rb
@@ -13,7 +13,7 @@ module Accounts
     authorize_resource :class => :account_terms
 
     def show
-      param! :legale, String, :format => /^[A-Z]+$/
+      param! :legale, String, :format => /\A[A-Z]+\z/
 
       @legale = params[:legale] || OSM.ip_to_country(request.remote_ip) || Settings.default_legale
       @text = OSM.legal_text_for_country(@legale)

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -537,11 +537,14 @@ module OSM
       "AND #{prefix}longitude BETWEEN #{bbox.min_lon} AND #{bbox.max_lon}"
   end
 
+  # The jurisdictions for which we have contributor terms
+  LEGALES = Rails.root.glob("config/legales/*.yml").map { |path| path.basename(".yml").to_s }.freeze
+
   # Return the terms and conditions text for a given country
   def self.legal_text_for_country(country_code)
-    file_name = Rails.root.join("config", "legales", "#{country_code}.yml")
-    file_name = Rails.root.join("config", "legales", "#{Settings.default_legale}.yml") unless File.exist? file_name
-    YAML.load_file(file_name).transform_values!(&:html_safe)
+    country_code = Settings.default_legale unless LEGALES.include?(country_code)
+
+    YAML.load_file(Rails.root.join("config/legales/#{country_code}.yml")).transform_values(&:html_safe)
   end
 
   # Return the HTTP client to use

--- a/test/controllers/accounts/terms_controller_test.rb
+++ b/test/controllers/accounts/terms_controller_test.rb
@@ -67,6 +67,15 @@ module Accounts
       assert_redirected_to :controller => "/errors", :action => :bad_request
     end
 
+    def test_show_with_multiline_legale
+      user = create(:user, :terms_seen => true, :terms_agreed => Date.yesterday)
+      session_for(user)
+
+      get account_terms_path(:legale => "../../config/settings\nGB")
+      assert_response :redirect
+      assert_redirected_to :controller => "/errors", :action => :bad_request
+    end
+
     def test_update_decline_by_not_checking_the_boxes
       freeze_time do
         user = create(:user, :terms_seen => false, :terms_agreed => nil, :tou_agreed => nil)

--- a/test/lib/osm_test.rb
+++ b/test/lib/osm_test.rb
@@ -14,4 +14,21 @@ class OsmTest < ActiveSupport::TestCase
     assert_in_delta(50, proj.x(0), 0.01)
     assert_in_delta(100, proj.y(0), 0.01)
   end
+
+  def test_legal_text_for_country
+    OSM::LEGALES.each do |legale|
+      text = OSM.legal_text_for_country(legale)
+
+      assert_predicate text["intro"], :html_safe?
+    end
+  end
+
+  def test_legal_text_for_unknown_country
+    default_text = OSM.legal_text_for_country(Settings.default_legale)
+
+    ["ZZ", "..", "../../config/settings", "/etc/passwd", "GB\n../../config/settings", nil]
+      .each do |legale|
+      assert_equal default_text, OSM.legal_text_for_country(legale)
+    end
+  end
 end


### PR DESCRIPTION
This PR makes two further changes to the legale loading, building on 08eaa40b9cbb3b838cf99e6ec229c31526cf8707. Although I can't see any way to exploit the latest validation work, this closes some minor potential loopholes:

* It uses input anchors for the regexp, instead of line anchors. There's probably no exploit here because the File.exists? would fail anyway.
* It reworks the legale testing to first build a list of known locales, and then validate against that, rather than building a filename first and testing if that exists. This removes the chance of any other path traversal slipping through somehow. 
* Since this is done within the `legal_text_for_country` method, there is also a side-benefit of a guard against unexpected returns from OSM.ip_to_country.
* Since we now avoid Rails.root.join against a not-positively-validated path fragment, we avoid the situation that an absolute input discards anything to the left e.g. `Rails.root.join("config", "legales", "/etc/passwd.yml") # -> /etc/passwd.yml`

I'm not a huge fan of the `&:html_safe` bit, since that's risk to use with translator-controlled strings, but since these files are under direct control it's unlikely to be a real problem.

Disclosure: I used Claude Code to write the code, tests and commits, but not this PR description. Claude found the regexp anchors and absolute fragment topics without my assistance and the absolute path fragment stuff is completely new to me (and somewhat surprising).