### PR TITLE
Make future-tense block time text translatable

### DIFF
--- a/app/helpers/user_blocks_helper.rb
+++ b/app/helpers/user_blocks_helper.rb
@@ -54,7 +54,7 @@ module UserBlocksHelper
              :datetime => time.xmlschema,
              :title => t("user_blocks.helper.short.time_in_future_title",
                          :time_absolute => l(time, :format => :friendly),
-                         :time_relative => time_ago_in_words(time))
+                         :time_relative => time_ago_in_words(time, :scope => :"datetime.distance_in_words_in"))
   end
 
   def block_short_time_in_past(time)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,44 @@ en:
       x_years:
         one: "%{count} year ago"
         other: "%{count} years ago"
+    distance_in_words_in:
+      about_x_hours:
+        one: in about %{count} hour
+        other: in about %{count} hours
+      about_x_months:
+        one: in about %{count} month
+        other: in about %{count} months
+      about_x_years:
+        one: in about %{count} year
+        other: in about %{count} years
+      almost_x_years:
+        one: in almost %{count} year
+        other: in almost %{count} years
+      half_a_minute: in half a minute
+      less_than_x_seconds:
+        one: in less than %{count} second
+        other: in less than %{count} seconds
+      less_than_x_minutes:
+        one: in less than %{count} minute
+        other: in less than %{count} minutes
+      over_x_years:
+        one: in over %{count} year
+        other: in over %{count} years
+      x_seconds:
+        one: "in %{count} second"
+        other: "in %{count} seconds"
+      x_minutes:
+        one: "in %{count} minute"
+        other: "in %{count} minutes"
+      x_days:
+        one: "in %{count} day"
+        other: "in %{count} days"
+      x_months:
+        one: "in %{count} month"
+        other: "in %{count} months"
+      x_years:
+        one: "in %{count} year"
+        other: "in %{count} years"
   printable_name:
     version: "v%{version}"
     with_name_html: "%{name} (%{id})"
@@ -3501,7 +3539,7 @@ en:
         active: "active"
         active_until_read: "active until read"
         read_html: "read at %{time}"
-        time_in_future_title: "%{time_absolute}; in %{time_relative}"
+        time_in_future_title: "%{time_absolute}; %{time_relative}"
         time_in_past_title: "%{time_absolute}; %{time_relative}"
     show:
       title: "%{block_on} blocked by %{block_by}"

--- a/test/helpers/user_blocks_helper_test.rb
+++ b/test/helpers/user_blocks_helper_test.rb
@@ -73,6 +73,29 @@ class UserBlocksHelperTest < ActionView::TestCase
     end
   end
 
+  def test_block_short_time_in_future
+    freeze_time do
+      html = block_short_time_in_future(Time.now.utc + 1.hour)
+      assert_match(/title="[^"]*; in about 1 hour"/, html)
+
+      html = block_short_time_in_future(Time.now.utc + 1.year)
+      assert_match(/title="[^"]*; in about 1 year"/, html)
+
+      html = block_short_time_in_future(Time.now.utc + 20.seconds)
+      assert_match(/title="[^"]*; in less than 1 minute"/, html)
+    end
+  end
+
+  def test_block_short_time_in_past
+    freeze_time do
+      html = block_short_time_in_past(Time.now.utc - 1.hour)
+      assert_match(/title="[^"]*; about 1 hour ago"/, html)
+
+      html = block_short_time_in_past(Time.now.utc - 1.year)
+      assert_match(/title="[^"]*; about 1 year ago"/, html)
+    end
+  end
+
   def test_block_duration_in_words
     words = block_duration_in_words(364.days)
     assert_equal "11 months", words


### PR DESCRIPTION
Fixes #5769.

`block_short_time_in_future` rendered its relative-duration text via `time_ago_in_words(time)` with no `:scope`, so it fell back to Rails' bundled gem-default locale data instead of this app's own translatable `config/locales/en.yml` — invisible to Translatewiki. The sibling `block_short_time_in_past` already avoids this via `:scope => :"datetime.distance_in_words_ago"`.

This mirrors that existing pattern:
- Adds a `datetime.distance_in_words_in` scope to `config/locales/en.yml`, covering the same buckets as `distance_in_words_ago`.
- Points `block_short_time_in_future` at the new scope.
- Drops the hardcoded literal `"in "` from `time_in_future_title` so the direction word is fully translator-controlled, matching `time_in_past_title`.