### PR TITLE
Fix zoom-out button doing nothing on embeddable iframe maps

### DIFF
--- a/app/assets/javascripts/maplibre/map.js
+++ b/app/assets/javascripts/maplibre/map.js
@@ -55,8 +55,36 @@ OSM.MapLibre.Map = class extends maplibregl.Map {
   }
 
   getZoom() {
-    // Convert MapLibre's 512px based zoom to OSM's 256px based zoom.
     return super.getZoom() + 1;
+  }
+
+  // maplibregl's zoomIn()/zoomOut() compute their target as
+  // `getZoom() +/- 1` and pass it straight to zoomTo(), which expects a
+  // raw zoom. Since getZoom() above already adds 1, that cancels out
+  // zoomOut()'s -1 and doubles zoomIn()'s +1. Delegate to the original
+  // implementation with getZoom() temporarily unshadowed instead of
+  // reimplementing its zoomSnap rounding ourselves.
+  zoomIn(options, eventData) {
+    return this._withRawZoom(() => super.zoomIn(options, eventData));
+  }
+
+  zoomOut(options, eventData) {
+    return this._withRawZoom(() => super.zoomOut(options, eventData));
+  }
+
+  _withRawZoom(fn) {
+    const hadOwnGetZoom = Object.prototype.hasOwnProperty.call(this, "getZoom");
+    const previousGetZoom = this.getZoom;
+    this.getZoom = () => super.getZoom();
+    try {
+      return fn();
+    } finally {
+      if (hadOwnGetZoom) {
+        this.getZoom = previousGetZoom;
+      } else {
+        delete this.getZoom;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #7287

### Description

`OSM.MapLibre.Map` overrides `getZoom()` to add 1 (converting MapLibre's
512px-tile zoom to OSM's 256px convention), but MapLibre's own
`zoomIn()`/`zoomOut()` (used by `NavigationControl`'s +/- buttons) compute
their target zoom as `getZoom() +/- 1` and pass it straight to `zoomTo()`,
which expects a raw, un-adjusted zoom value.

Since `getZoom()` already adds 1, that offset cancelled `zoomOut()`'s -1
entirely, so the zoom-out button did nothing, while `zoomIn()` jumped by
2 levels instead of 1. This PR overrides `zoomIn()`/`zoomOut()` to use the
underlying raw zoom instead, so both buttons move the map by exactly one
level in either direction.

### How has this been tested?

Verified in a standalone MapLibre GL JS sandbox reproducing the exact
class hierarchy used in this repo: with only `getZoom()` overridden (the
current behavior), calling `zoomOut()` produces a 0 change in zoom and
`zoomIn()` produces a +2 change; with the patch applied, both produce the
expected ±1 change. Also manually verified by loading `/export/embed.html`
locally and clicking the +/- buttons.