### PR TITLE
Complete MapLibre zoom conversion method overrides

### DIFF
--- a/app/assets/javascripts/maplibre/map.js
+++ b/app/assets/javascripts/maplibre/map.js
@@ -58,6 +58,14 @@ OSM.MapLibre.Map = class extends maplibregl.Map {
     // Convert MapLibre's 512px based zoom to OSM's 256px based zoom.
     return super.getZoom() + 1;
   }
+
+  setZoom(zoom, ...args) {
+    return super.setZoom(zoom - 1, ...args);
+  }
+
+  zoomTo(zoom, ...args) {
+    return super.zoomTo(zoom - 1, ...args);
+  }
 };
 
 OSM.MapLibre.SecondaryMap = class extends OSM.MapLibre.Map {


### PR DESCRIPTION
Add the other side of #7216 which closes #7305 and fixes #7287.