### PR TITLE
Do not show logos from Wikidata with deprecated rank

### DIFF
--- a/app/assets/javascripts/index_modules/element.js
+++ b/app/assets/javascripts/index_modules/element.js
@@ -93,9 +93,9 @@ function previewWikidataValue($btn) {
 
 function getLocalizedResponse(entity) {
   const siteScheme = OSM.isDark("bs") ? "Q6545942" : "Q101608434";
-  const scheme = ({ qualifiers }) => qualifiers?.P8798?.some(q => q?.datavalue?.value?.id === siteScheme) ?? 0;
-  const rank = ({ rank }) => ({ preferred: 2, normal: 0, deprecated: -2 })[rank] ?? 0;
-  const toBestClaim = (out, claim) => (rank(claim) + scheme(claim) > rank(out) + scheme(out)) ? claim : out;
+  const scheme = ({ qualifiers } = {}) => qualifiers?.P8798?.some(q => q?.datavalue?.value?.id === siteScheme) ?? 0;
+  const rank = ({ rank } = {}) => ({ preferred: 2, normal: 0 })[rank] ?? 0;
+  const toBestClaim = (out, claim) => (!out || rank(claim) + scheme(claim) > rank(out) + scheme(out)) ? claim : out;
   const toFirstOf = (property) => (out, localization) => out ?? property[localization];
   const data = {
     qid: entity.id,
@@ -104,7 +104,7 @@ function getLocalizedResponse(entity) {
       "P8972", // small logo or icon
       "P154", // logo image
       "P14" // traffic sign
-    ].reduce((out, prop) => out ?? entity.claims[prop]?.reduce(toBestClaim)?.mainsnak?.datavalue?.value, null),
+    ].reduce((out, prop) => out ?? entity.claims[prop]?.filter(claim => claim.rank !== "deprecated").reduce(toBestClaim, null)?.mainsnak?.datavalue?.value, null),
     description: languagesToRequest.reduce(toFirstOf(entity.descriptions), null),
     article: wikisToRequest.reduce(toFirstOf(entity.sitelinks), null)
   };


### PR DESCRIPTION
Fixes #7292

### Description
When rendering preview rows for Wikidata entities in the sidebar, `element.js` was previously selecting claims for icons/logos (`P8972`, `P154`, `P14`) without excluding claims marked with `"rank": "deprecated"`. Additionally, when an entity only had a single claim (or only deprecated claims), `reduce(toBestClaim)` returned the claim directly without an initial accumulator.

This PR:
- Filters out any claims where `claim.rank === "deprecated"` so that deprecated/obsolete Wikidata logos and icons are ignored.
- Updates `toBestClaim` and rank handling to support an initial accumulator (`null`), ensuring that entities with only deprecated claims do not display a logo.

### How has this been tested?
- Tested with Wikidata entity `Q104831094` (which only contains a deprecated `P154` logo claim) to verify that no deprecated logo is rendered.
- Tested entities containing multiple claims (combinations of `deprecated`, `normal`, and `preferred` ranks) to ensure valid logos are selected according to rank and scheme qualifiers.
- Verified that entities with empty or missing claims continue to be handled gracefully without errors.
