### PR TITLE
Notifications badge

### DIFF
--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -42,7 +42,7 @@ class Ability
         can :update, :account_terms
         can :create, :account_pd_declaration
         can :read, :dashboard
-        can :index, :notification
+        can [:index, :destroy], :notification
         can [:read, :update], [:preferences, :profile]
         can [:create, :subscribe, :unsubscribe], DiaryEntry
         can [:update, :hide, :unhide], DiaryEntry, :user => user

--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -1,0 +1,33 @@
+$(function () {
+  const selectPageCheckbox = $("#select_page");
+  const individualCheckboxes = $(".notification-mark-for-deletion");
+
+  individualCheckboxes.on("click", function () {
+    if (allInPageSelected()) {
+      selectPageCheckbox.prop("checked", true);
+      selectPageCheckbox.prop("indeterminate", false);
+    } else if (anyInPageSelected()) {
+      selectPageCheckbox.prop("checked", false);
+      selectPageCheckbox.prop("indeterminate", true);
+    } else {
+      selectPageCheckbox.prop("checked", false);
+      selectPageCheckbox.prop("indeterminate", false);
+    }
+  });
+
+  selectPageCheckbox.on("click", function (evt) {
+    if (evt.target.checked) {
+      individualCheckboxes.prop("checked", true);
+    } else {
+      individualCheckboxes.prop("checked", false);
+    }
+  });
+
+  function allInPageSelected() {
+    return individualCheckboxes.get().every(el => el.checked);
+  }
+
+  function anyInPageSelected() {
+    return individualCheckboxes.get().some(el => el.checked);
+  }
+});

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -20,10 +20,25 @@ class NotificationsController < ApplicationController
   authorize_resource :class => false
 
   before_action :check_database_readable
+  before_action :check_database_writable, :only => [:destroy]
 
   def index
     notifications = current_user.notifications.where(:type => LISTABLE_NOTIFICATIONS)
     @notifications = get_page_items(notifications)
     @params = params.permit
+  end
+
+  def destroy
+    ids_to_delete =
+      params
+      .expect(:notifications => {})
+      .to_unsafe_h
+      .select { |_k, v| v == "delete" }
+      .keys
+      .map { |id| Integer(id) }
+
+    current_user.notifications.where(:id => ids_to_delete).delete_all
+
+    redirect_back_or_to notifications_path
   end
 end

--- a/app/helpers/header_helper.rb
+++ b/app/helpers/header_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module HeaderHelper
+  def notifications_count(which = :all)
+    which = [:messages, :notifications] if which == :all
+    which = Array.wrap(which)
+
+    total = 0
+    total += current_user.new_messages.size if which.include?(:messages)
+    total += current_user.notifications.size if which.include?(:notifications)
+    total
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -50,8 +50,8 @@
         <div class="d-flex dropdown user-menu logged-in">
           <button class="d-flex gap-1 align-items-center justify-content-center dropdown-toggle btn btn-outline-secondary border-secondary-subtle bg-body text-secondary px-2 py-1 flex-grow-1 mw-100" type="button" data-bs-toggle="dropdown">
             <%= user_thumbnail_tiny(current_user, :class => "user_thumbnail_tiny rounded-1 bg-body") %>
-            <% if current_user.new_messages.size > 0 %>
-              <span class="badge count-number position-static m-1"><%= current_user.new_messages.size %></span>
+            <% if notifications_count.positive? %>
+              <span class="badge badge-user-total count-number position-static m-1"><%= notifications_count %></span>
             <% end %>
             <span class="username align-middle text-truncate" dir="auto">
               <%= current_user.display_name_was %>
@@ -61,10 +61,13 @@
             <%= link_to t("users.show.my_dashboard"), dashboard_path, :class => "dropdown-item" %>
             <%= link_to messages_inbox_path, :class => "dropdown-item" do %>
               <%= t("users.show.my messages") %>
-              <span class="badge count-number"><%= number_with_delimiter(current_user.new_messages.size) %></span>
+              <span class="badge badge-user-messages count-number"><%= number_with_delimiter(notifications_count(:messages)) %></span>
             <% end %>
             <%= link_to t("users.show.my profile"), current_user, :class => "dropdown-item" %>
-            <%= link_to t("users.show.my_notifications"), notifications_path, :class => "dropdown-item" %>
+            <%= link_to notifications_path, :class => "dropdown-item" do %>
+              <%= t("users.show.my_notifications") %>
+              <span class="badge badge-user-notifications count-number"><%= number_with_delimiter(notifications_count(:notifications)) %></span>
+            <% end %>
             <%= link_to t("users.show.my_account"), account_path, :class => "dropdown-item" %>
             <%= link_to t("users.show.my_preferences"), basic_preferences_path, :class => "dropdown-item" %>
             <div class="dropdown-divider"></div>

--- a/app/views/notifications/_page.html.erb
+++ b/app/views/notifications/_page.html.erb
@@ -3,8 +3,8 @@
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <% notifications.items.each do |notification| %>
     <div class="row">
-      <div class="col-1">
-        <%= check_box_tag "notifications[#{notification.id}]", "delete", :class => "notification-mark-for-deletion" %>
+      <div class="col-1 text-center">
+        <%= check_box_tag "notifications[#{notification.id}]", "delete", :class => "notification-mark-for-deletion align-bottom" %>
       </div>
       <div class="col-11">
         <%= render "notification", :notification => notification %>

--- a/app/views/notifications/_page.html.erb
+++ b/app/views/notifications/_page.html.erb
@@ -2,7 +2,14 @@
 
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <% notifications.items.each do |notification| %>
-    <%= render "notification", :notification => notification %>
+    <div class="row">
+      <div class="col-1">
+        <%= check_box_tag "notifications[#{notification.id}]", "delete", :class => "notification-mark-for-deletion" %>
+      </div>
+      <div class="col-11">
+        <%= render "notification", :notification => notification %>
+      </div>
+    </div>
     <hr>
   <% end %>
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -12,7 +12,13 @@
   <p><%= t(".no_notifications") %></p>
 <% else %>
   <%= form_with :url => notifications_path, :method => :delete do |form| %>
-    <%= form.submit t(".delete_selected") %>
+    <div class="row">
+      <div class="col-1 text-center">
+        <%= check_box_tag "select_page", :class => "align-bottom" %>
+      </div>
+      <div class="col-11"><%= form.submit t(".delete_selected"), :class => "submit-read" %></div>
+    </div>
+    <hr>
     <%= render "page", :notifications => @notifications, :params => @params %>
   <% end %>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -11,5 +11,8 @@
 <% if @notifications.items.empty? %>
   <p><%= t(".no_notifications") %></p>
 <% else %>
-  <%= render "page", :notifications => @notifications, :params => @params %>
+  <%= form_with :url => notifications_path, :method => :delete do |form| %>
+    <%= form.submit t(".delete_selected") %>
+    <%= render "page", :notifications => @notifications, :params => @params %>
+  <% end %>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <%= javascript_include_tag "notifications" %>
+<% end %>
+
 <% content_for :heading do %>
   <h1><%= t ".title" %></h1>
   <p class="mb-0">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -654,6 +654,7 @@ en:
       no_notifications: You have no notifications at the moment
       point_to_preferences_html: "You can adjust how you receive notifications in %{link}."
       link_text: the preferences section
+      delete_selected: Delete selected
     changeset_comment:
       headline: Changeset comment
       description_with_summary_html: "User %{commenter_name_with_link} left a comment on changeset %{changeset_id_with_link} (\"%{changeset_summary}\")"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -357,6 +357,7 @@ OpenStreetMap::Application.routes.draw do
   get "/preferences/edit", :to => redirect(:path => "/preferences/basic"), :as => nil
 
   resources :notifications, :only => [:index]
+  delete "/notifications" => "notifications#destroy"
 
   # friendships
   scope "/user/:display_name" do

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -8,6 +8,10 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
       { :path => "/notifications", :method => :get },
       { :controller => "notifications", :action => "index" }
     )
+    assert_routing(
+      { :path => "/notifications", :method => :delete },
+      { :controller => "notifications", :action => "destroy" }
+    )
   end
 
   def test_index
@@ -22,5 +26,31 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     get notifications_path
 
     assert_redirected_to login_path(:referer => notifications_path)
+  end
+
+  def test_destroy_unauthorized
+    user1 = create(:user)
+    user2 = create(:user)
+    n1 = create(:changeset_comment_notification, :recipient => user1)
+    n2 = create(:changeset_comment_notification, :recipient => user2)
+
+    assert_difference -> { Noticed::Notification.count } => 0 do
+      delete notifications_path, :params => { :notifications => { n1.id => "delete", n2.id => "delete" } }
+    end
+    assert_response :forbidden
+  end
+
+  def test_destroy
+    user1 = create(:user)
+    user2 = create(:user)
+    n1 = create(:changeset_comment_notification, :recipient => user1)
+    n2 = create(:changeset_comment_notification, :recipient => user2)
+
+    session_for(user1)
+
+    assert_difference -> { Noticed::Notification.count } => -1 do
+      delete notifications_path, :params => { :notifications => { n1.id => "delete", n2.id => "delete" } }
+    end
+    assert_redirected_to notifications_path
   end
 end

--- a/test/system/navigation_test.rb
+++ b/test/system/navigation_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class NavigationTest < ApplicationSystemTestCase
+  test "Profile badge count" do
+    user = create(:user)
+
+    # There should be two notifications from changeset comments
+    create(:changeset_comment_notification, :recipient => user)
+    create(:changeset_comment_notification, :recipient => user)
+
+    # There should be one notification from a direct message
+    create(:message, :recipient => user)
+
+    sign_in_as(user)
+
+    find(".user-menu.dropdown [data-bs-toggle]").click
+    assert_selector ".badge-user-total", :text => 3
+    assert_selector ".badge-user-messages", :text => 1
+    assert_selector ".badge-user-notifications", :text => 2
+  end
+end

--- a/test/system/web_notifications_test.rb
+++ b/test/system/web_notifications_test.rb
@@ -59,6 +59,30 @@ class WebNotificationsTest < ApplicationSystemTestCase
     assert_text "This is comment number 10"
   end
 
+  test "delete individual notifications" do
+    changeset_author = create(:user)
+    commenter = create(:user, :display_name => "Commenter")
+    1.upto(7).map do |i|
+      setup_changeset_comment(
+        :changeset_author => changeset_author,
+        :commenter => commenter,
+        :comment_attrs => {
+          :body => "This is comment number #{i}"
+        }
+      )
+    end
+
+    sign_in_as(changeset_author)
+
+    visit notifications_path
+    assert_selector ".web-notification", :count => 7
+    checkboxes = all(".notification-mark-for-deletion")
+    checkboxes.first.click
+    checkboxes.last.click
+    click_on "Delete selected"
+    assert_selector ".web-notification", :count => 5
+  end
+
   private
 
   def setup_changeset_comment(changeset_author:, commenter:, comment_attrs: {})

--- a/test/system/web_notifications_test.rb
+++ b/test/system/web_notifications_test.rb
@@ -83,6 +83,32 @@ class WebNotificationsTest < ApplicationSystemTestCase
     assert_selector ".web-notification", :count => 5
   end
 
+  test "checkbox to select all notifications in current page" do
+    changeset_author = create(:user)
+    commenter = create(:user, :display_name => "Commenter")
+    1.upto(7).map do |i|
+      setup_changeset_comment(
+        :changeset_author => changeset_author,
+        :commenter => commenter,
+        :comment_attrs => {
+          :body => "This is comment number #{i}"
+        }
+      )
+    end
+
+    sign_in_as(changeset_author)
+
+    visit notifications_path
+    assert_selector ".web-notification", :count => 7
+    checkbox_for_all = find_by_id("select_page")
+    checkbox_for_all.click
+    checkboxes = all(".notification-mark-for-deletion")
+    checkboxes.first.click
+    checkboxes.last.click
+    click_on "Delete selected"
+    assert_selector ".web-notification", :count => 2
+  end
+
   private
 
   def setup_changeset_comment(changeset_author:, commenter:, comment_attrs: {})


### PR DESCRIPTION
Partially addresses https://github.com/openstreetmap/openstreetmap-website/issues/7286 (not addressed: API change).

This is a very first iteration of the concept of a "notifications badge", with a count of the number of notifications currently waiting to be addressed by the user. It might feel a bit crude, but it's an attempt at iteratively progressing towards an optimal solution.

This is what the badge looks like:

<img width="209" height="315" alt="The top dropdown showing the user display name. It has a badge with number 4. The dropdown is open and we can see that there are additional badges for messages (1) and notifications (3)" src="https://github.com/user-attachments/assets/c39c3ef3-ff51-472f-815b-6014c32771c7" />

The first thing thing that will be evident: the count next to the display name is the sum of notifications and unread messages.

What notifications are counted? All. There's no concept of read/unread/seen/unseen at the moment. The count is of any notifications that are listed under "My Notifications". To reduce/eliminate the number, users have to delete the notifications with no recourse. This is the interface for that:

<img width="1536" height="1411" alt="The notifications page, showing the checkboxes described below" src="https://github.com/user-attachments/assets/1da00e5c-29b8-41ae-91d4-658acfc630c1" />

Check the boxes to select notifications to delete. Click the button to perform the deletion. Check the top checkbox to select all notifications on the page (but not those hidden by the pagination). This last one will also go into "indeterminate" state if some but not all notifications are selected.

## Why so crude?

These are some alternatives:
- We could have a concept of read/unread where we send notifications to a different "folder" and allow later retrieval. This would require building that interface, etc, so better discuss it first.
- We could mark them as read when the user "visits" the notifications, but there are two notification types that can't just be "visited": failed GPX upload and new follower. Therefore some sort of checkbox/button is still required.
- We could mark notifications as seen/read when "My Notifications" is visited. But what if I visit for a moment, all get marked read, but I don't have time now, and later I forget to return because the count is now zero.
- Other...?

So it's not a simple problem. Here's a first step. Thoughts?