### PR TITLE
Serve only trackable and identifiable points and add cursor pagination to the trackpoints API

### DIFF
--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -32,9 +32,10 @@ module Api
       end
 
       # get all the points
-      ordered_points = Tracepoint.bbox(bbox).joins(:trace).where(:gpx_files => { :visibility => %w[trackable identifiable] }).order(:gpx_id => :desc, :trackid => :asc, :timestamp => :asc)
-      unordered_points = Tracepoint.bbox(bbox).joins(:trace).where(:gpx_files => { :visibility => %w[public private] }).order("gps_points.latitude", "gps_points.longitude", "gps_points.timestamp")
-      @points = ordered_points.union_all(unordered_points).offset(offset).limit(Settings.tracepoints_per_page).preload(:trace)
+      @points = Tracepoint.bbox(bbox).joins(:trace)
+                          .where(:gpx_files => { :visibility => %w[trackable identifiable] })
+                          .order(:gpx_id => :desc, :trackid => :asc, :timestamp => :asc)
+                          .offset(offset).limit(Settings.tracepoints_per_page).preload(:trace)
 
       response.headers["Content-Disposition"] = "attachment; filename=\"tracks.gpx\""
 

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -5,18 +5,9 @@ module Api
     authorize_resource
 
     # Get an XML response containing a list of tracepoints that have been uploaded
-    # within the specified bounding box, and in the specified page.
+    # within the specified bounding box. To get the next batch of points, follow
+    # the URL given in the Link header of the response.
     def index
-      # retrieve the page number
-      page = params.fetch(:page, "0").to_i
-
-      unless page >= 0
-        report_error("Page number must be greater than or equal to 0")
-        return
-      end
-
-      offset = page * Settings.tracepoints_per_page
-
       # Figure out the bbox
       # check boundary is sane and area within defined
       # see /config/application.yml
@@ -31,15 +22,63 @@ module Api
         return
       end
 
-      # get all the points
-      @points = Tracepoint.bbox(bbox).joins(:trace)
-                          .where(:gpx_files => { :visibility => %w[trackable identifiable] })
-                          .order(:gpx_id => :desc, :trackid => :asc, :timestamp => :asc)
-                          .offset(offset).limit(Settings.tracepoints_per_page).preload(:trace)
+      points = Tracepoint.bbox(bbox).joins(:trace)
+                         .where(:gpx_files => { :visibility => %w[trackable identifiable] })
+                         .order(:gpx_id => :desc, :trackid => :asc, :timestamp => :asc)
+                         .limit(Settings.tracepoints_per_page).preload(:trace)
 
+      if params[:cursor]
+        begin
+          gpx_id, trackid, timestamp = parse_cursor(params[:cursor])
+        rescue ArgumentError, TypeError
+          report_error("The cursor parameter is invalid")
+          return
+        end
+
+        # Continue after the last point of the previous batch, following the
+        # gpx_id desc, trackid asc, timestamp asc ordering of the query above.
+        # The gpx_id <= bound is implied by the condition below it, but it gives
+        # the planner a single index range and a much better plan.
+        points = points.where(<<~SQL.squish, :gpx_id => gpx_id, :trackid => trackid, :timestamp => timestamp)
+          gps_points.gpx_id <= :gpx_id
+          AND (gps_points.gpx_id < :gpx_id
+               OR (gps_points.gpx_id = :gpx_id
+                   AND (gps_points.trackid > :trackid
+                        OR (gps_points.trackid = :trackid AND gps_points.timestamp > :timestamp))))
+        SQL
+      else
+        page = params.fetch(:page, "0").to_i
+
+        unless page >= 0
+          report_error("Page number must be greater than or equal to 0")
+          return
+        end
+
+        points = points.offset(page * Settings.tracepoints_per_page)
+      end
+
+      @points = points.load
+
+      # The Link header is only for cursor pagination, not for the old page parameter.
+      if params[:page].blank? && @points.size == Settings.tracepoints_per_page
+        next_url = api_tracepoints_url(:bbox => params[:bbox], :cursor => next_cursor(@points.last))
+        response.headers["Link"] = "<#{next_url}>; rel=\"next\""
+      end
       response.headers["Content-Disposition"] = "attachment; filename=\"tracks.gpx\""
 
       render :formats => [:gpx]
+    end
+
+    private
+
+    def parse_cursor(cursor)
+      gpx_id, trackid, timestamp = Base64.urlsafe_decode64(cursor).split("|", 3)
+
+      [Integer(gpx_id), Integer(trackid), Time.at(Integer(timestamp)).utc]
+    end
+
+    def next_cursor(point)
+      Base64.urlsafe_encode64("#{point.gpx_id}|#{point.trackid}|#{point.timestamp.utc.to_i}", :padding => false)
     end
   end
 end

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -59,13 +59,21 @@ module Api
         points = points.offset(page * Settings.tracepoints_per_page)
       end
 
-      @points = points.order(:gpx_id => :desc, :trackid => :asc, :timestamp => :asc)
-                      .limit(Settings.tracepoints_per_page).preload(:trace).load
+      points = points.order(:gpx_id => :desc, :trackid => :asc, :timestamp => :asc).preload(:trace)
 
-      # The Link header is only for cursor pagination, not for the old page parameter.
-      if params[:page].blank? && @points.size == Settings.tracepoints_per_page
-        next_url = api_tracepoints_url(:bbox => params[:bbox], :cursor => next_cursor(@points.last))
-        response.headers["Link"] = "<#{next_url}>; rel=\"next\""
+      if params[:page].blank?
+        # One extra point tells if there is a next page.
+        loaded = points.limit(Settings.tracepoints_per_page + 1).load
+        @points = loaded.first(Settings.tracepoints_per_page)
+
+        # The Link header is only for cursor pagination.
+        if loaded.size > Settings.tracepoints_per_page
+          @points = without_split_group(points, @points, loaded.last)
+          next_url = api_tracepoints_url(:bbox => params[:bbox], :cursor => next_cursor(@points.last))
+          response.headers["Link"] = "<#{next_url}>; rel=\"next\""
+        end
+      else
+        @points = points.limit(Settings.tracepoints_per_page).load
       end
       response.headers["Content-Disposition"] = "attachment; filename=\"tracks.gpx\""
 
@@ -74,14 +82,36 @@ module Api
 
     private
 
+    # Cursor: gpx_id|trackid|unix microseconds. Some points have fractions of a second.
     def parse_cursor(cursor)
       gpx_id, trackid, timestamp = Base64.urlsafe_decode64(cursor).split("|", 3)
 
-      [Integer(gpx_id), Integer(trackid), Time.at(Integer(timestamp)).utc]
+      [Integer(gpx_id), Integer(trackid), Time.at(Rational(Integer(timestamp), 1_000_000)).utc]
     end
 
     def next_cursor(point)
-      Base64.urlsafe_encode64("#{point.gpx_id}|#{point.trackid}|#{point.timestamp.utc.to_i}", :padding => false)
+      timestamp = (point.timestamp.utc.to_r * 1_000_000).to_i
+
+      Base64.urlsafe_encode64("#{point.gpx_id}|#{point.trackid}|#{timestamp}", :padding => false)
+    end
+
+    # A page must not end inside a group of points with the same gpx_id,
+    # trackid and timestamp, since the cursor would skip the rest of the group.
+    def without_split_group(points, page, next_point)
+      last = page.last
+      return page unless same_position?(next_point, last)
+
+      first = page.index { |point| same_position?(point, last) }
+
+      if first.positive?
+        page[0...first]
+      else
+        points.where(:gps_points => { :gpx_id => last.gpx_id, :trackid => last.trackid, :timestamp => last.timestamp }).load
+      end
+    end
+
+    def same_position?(point, other)
+      point.gpx_id == other.gpx_id && point.trackid == other.trackid && point.timestamp == other.timestamp
     end
   end
 end

--- a/app/controllers/api/tracepoints_controller.rb
+++ b/app/controllers/api/tracepoints_controller.rb
@@ -24,8 +24,6 @@ module Api
 
       points = Tracepoint.bbox(bbox).joins(:trace)
                          .where(:gpx_files => { :visibility => %w[trackable identifiable] })
-                         .order(:gpx_id => :desc, :trackid => :asc, :timestamp => :asc)
-                         .limit(Settings.tracepoints_per_page).preload(:trace)
 
       if params[:cursor]
         begin
@@ -35,17 +33,21 @@ module Api
           return
         end
 
+        # Read the bbox in a subquery so the planner uses the tile index.
+        # Otherwise the ORDER BY ... LIMIT makes it walk the gpx_id index
+        # backwards from the cursor, which can take minutes on a sparse bbox.
+        # OFFSET 0 stops PostgreSQL from flattening the subquery.
+        candidates = points.where(:gps_points => { :gpx_id => ..gpx_id }).offset(0)
+
         # Continue after the last point of the previous batch, following the
-        # gpx_id desc, trackid asc, timestamp asc ordering of the query above.
-        # The gpx_id <= bound is implied by the condition below it, but it gives
-        # the planner a single index range and a much better plan.
-        points = points.where(<<~SQL.squish, :gpx_id => gpx_id, :trackid => trackid, :timestamp => timestamp)
-          gps_points.gpx_id <= :gpx_id
-          AND (gps_points.gpx_id < :gpx_id
-               OR (gps_points.gpx_id = :gpx_id
-                   AND (gps_points.trackid > :trackid
-                        OR (gps_points.trackid = :trackid AND gps_points.timestamp > :timestamp))))
-        SQL
+        # gpx_id desc, trackid asc, timestamp asc ordering of the query below.
+        points = Tracepoint.from(candidates, :gps_points)
+                           .where(<<~SQL.squish, :gpx_id => gpx_id, :trackid => trackid, :timestamp => timestamp)
+                             gps_points.gpx_id < :gpx_id
+                             OR (gps_points.gpx_id = :gpx_id
+                                 AND (gps_points.trackid > :trackid
+                                      OR (gps_points.trackid = :trackid AND gps_points.timestamp > :timestamp)))
+                           SQL
       else
         page = params.fetch(:page, "0").to_i
 
@@ -57,7 +59,8 @@ module Api
         points = points.offset(page * Settings.tracepoints_per_page)
       end
 
-      @points = points.load
+      @points = points.order(:gpx_id => :desc, :trackid => :asc, :timestamp => :asc)
+                      .limit(Settings.tracepoints_per_page).preload(:trace).load
 
       # The Link header is only for cursor pagination, not for the old page parameter.
       if params[:page].blank? && @points.size == Settings.tracepoints_per_page

--- a/app/views/api/tracepoints/index.gpx.builder
+++ b/app/views/api/tracepoints/index.gpx.builder
@@ -13,48 +13,27 @@ xml.gpx("version" => "1.0",
   tracks = []
   track = nil
   trkseg = nil
-  anon_track = nil
-  anon_trkseg = nil
 
   @points.each do |point|
     if gpx_id != point.gpx_id
       gpx_id = point.gpx_id
       trackid = -1
 
-      if point.trace.trackable?
-        track = {}
-        track["trksegs"] = []
-        tracks << track
+      track = {}
+      track["trksegs"] = []
+      tracks << track
 
-        if point.trace.identifiable?
-          track["name"] = point.trace.name
-          track["desc"] = point.trace.description
-          track["url"] = url_for(:controller => "/traces", :action => "show", :display_name => point.trace.user.display_name, :id => point.trace.id)
-        end
-      else
-        # use the anonymous track segment if the user hasn't allowed
-        # their GPX points to be tracked.
-        if anon_track.nil?
-          anon_track = {}
-          anon_track["trksegs"] = []
-          tracks << anon_track
-        end
-        track = anon_track
+      if point.trace.identifiable?
+        track["name"] = point.trace.name
+        track["desc"] = point.trace.description
+        track["url"] = url_for(:controller => "/traces", :action => "show", :display_name => point.trace.user.display_name, :id => point.trace.id)
       end
     end
 
     if trackid != point.trackid
-      if point.trace.trackable?
-        trkseg = []
-        track["trksegs"] << trkseg
-        trackid = point.trackid
-      else
-        if anon_trkseg.nil?
-          anon_trkseg = []
-          anon_track["trksegs"] << anon_trkseg
-        end
-        trkseg = anon_trkseg
-      end
+      trkseg = []
+      track["trksegs"] << trkseg
+      trackid = point.trackid
     end
 
     trkseg << point
@@ -71,7 +50,7 @@ xml.gpx("version" => "1.0",
         xml.trkseg do
           trksg.each do |tracepoint|
             xml.trkpt("lat" => tracepoint.lat.to_s, "lon" => tracepoint.lon.to_s) do
-              xml.time tracepoint.timestamp.xmlschema if tracepoint.trace.trackable?
+              xml.time tracepoint.timestamp.xmlschema
             end
           end
         end

--- a/test/controllers/api/tracepoints_controller_test.rb
+++ b/test/controllers/api/tracepoints_controller_test.rb
@@ -27,7 +27,7 @@ module Api
       )
     end
 
-    def test_tracepoints_public
+    def test_tracepoints_public_not_served
       point = create(:trace, :without_validations, :visibility => "public", :latitude => 1, :longitude => 1) do |trace|
         create(:tracepoint, :trace => trace, :latitude => 1 * GeoRecord::SCALE, :longitude => 1 * GeoRecord::SCALE)
       end
@@ -39,12 +39,23 @@ module Api
       get api_tracepoints_path(:bbox => bbox)
       assert_response :success
       assert_select "gpx[version='1.0'][creator='OpenStreetMap.org']", :count => 1 do
-        assert_select "trk" do
-          assert_select "name", :count => 0
-          assert_select "desc", :count => 0
-          assert_select "url", :count => 0
-          assert_select "trkseg", :count => 1
-        end
+        assert_select "trk", :count => 0
+      end
+    end
+
+    def test_tracepoints_private_not_served
+      point = create(:trace, :without_validations, :visibility => "private", :latitude => 1, :longitude => 1) do |trace|
+        create(:tracepoint, :trace => trace, :latitude => 1 * GeoRecord::SCALE, :longitude => 1 * GeoRecord::SCALE)
+      end
+      minlon = point.longitude - 0.001
+      minlat = point.latitude - 0.001
+      maxlon = point.longitude + 0.001
+      maxlat = point.latitude + 0.001
+      bbox = "#{minlon},#{minlat},#{maxlon},#{maxlat}"
+      get api_tracepoints_path(:bbox => bbox)
+      assert_response :success
+      assert_select "gpx[version='1.0'][creator='OpenStreetMap.org']", :count => 1 do
+        assert_select "trk", :count => 0
       end
     end
 

--- a/test/controllers/api/tracepoints_controller_test.rb
+++ b/test/controllers/api/tracepoints_controller_test.rb
@@ -112,6 +112,116 @@ module Api
       end
     end
 
+    def test_tracepoints_cursor_pagination
+      create(:trace, :visibility => "trackable") do |trace|
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 0))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 1))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 2))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 3))
+      end
+
+      with_settings(:tracepoints_per_page => 3) do
+        get api_tracepoints_path(:bbox => "0.9,0.9,1.1,1.1")
+        assert_response :success
+        assert_select "trkpt", :count => 3
+        next_url = @response.headers["Link"][/<(.*)>; rel="next"/, 1]
+        assert_not_nil next_url
+
+        get next_url
+        assert_response :success
+        assert_select "trkpt", :count => 1
+        assert_nil @response.headers["Link"]
+      end
+    end
+
+    def test_tracepoints_cursor_pagination_across_traces
+      create(:trace, :visibility => "trackable") do |trace|
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 0))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 1))
+      end
+      create(:trace, :visibility => "trackable") do |trace|
+        create(:tracepoint, :trace => trace, :latitude => (1.05 * GeoRecord::SCALE).to_i, :timestamp => Time.utc(2026, 1, 2, 0, 0, 0))
+        create(:tracepoint, :trace => trace, :latitude => (1.05 * GeoRecord::SCALE).to_i, :timestamp => Time.utc(2026, 1, 2, 0, 0, 1))
+      end
+
+      with_settings(:tracepoints_per_page => 2) do
+        # the first page has all the points of the newest trace
+        get api_tracepoints_path(:bbox => "0.9,0.9,1.1,1.1")
+        assert_response :success
+        assert_select "trkpt", :count => 2
+        assert_match(/lat="1.0500000"/, response.body)
+        assert_no_match(/lat="1.0000000"/, response.body)
+
+        # the second page continues with the older trace
+        next_url = @response.headers["Link"][/<(.*)>; rel="next"/, 1]
+        get next_url
+        assert_response :success
+        assert_select "trkpt", :count => 2
+        assert_match(/lat="1.0000000"/, response.body)
+        assert_no_match(/lat="1.0500000"/, response.body)
+
+        # following the link once more returns an empty document
+        next_url = @response.headers["Link"][/<(.*)>; rel="next"/, 1]
+        get next_url
+        assert_response :success
+        assert_select "trkpt", :count => 0
+        assert_nil @response.headers["Link"]
+      end
+    end
+
+    def test_tracepoints_cursor_pagination_across_track_segments
+      create(:trace, :visibility => "trackable") do |trace|
+        create(:tracepoint, :trace => trace, :trackid => 1, :timestamp => Time.utc(2026, 1, 1, 0, 0, 0))
+        create(:tracepoint, :trace => trace, :trackid => 1, :timestamp => Time.utc(2026, 1, 1, 0, 0, 1))
+        create(:tracepoint, :trace => trace, :trackid => 2, :timestamp => Time.utc(2026, 1, 1, 0, 0, 2))
+        create(:tracepoint, :trace => trace, :trackid => 2, :timestamp => Time.utc(2026, 1, 1, 0, 0, 3))
+      end
+
+      with_settings(:tracepoints_per_page => 2) do
+        # the first page has the two points of the first track segment
+        get api_tracepoints_path(:bbox => "0.9,0.9,1.1,1.1")
+        assert_response :success
+        assert_select "trkseg", :count => 1
+        assert_select "trkpt", :count => 2
+
+        # the second page has the two points of the second track segment
+        next_url = @response.headers["Link"][/<(.*)>; rel="next"/, 1]
+        get next_url
+        assert_response :success
+        assert_select "trkseg", :count => 1
+        assert_select "trkpt", :count => 2
+      end
+    end
+
+    def test_tracepoints_paged_mode_has_no_link_header
+      create(:trace, :visibility => "trackable") do |trace|
+        create(:tracepoint, :trace => trace)
+      end
+
+      with_settings(:tracepoints_per_page => 1) do
+        get api_tracepoints_path(:page => 0, :bbox => "0.9,0.9,1.1,1.1")
+        assert_response :success
+        assert_select "trkpt", :count => 1
+        assert_nil @response.headers["Link"]
+      end
+    end
+
+    def test_tracepoints_invalid_cursor
+      get api_tracepoints_path(:bbox => "-0.1,-0.1,0.1,0.1", :cursor => "not a cursor")
+      assert_response :bad_request
+      assert_equal "The cursor parameter is invalid", @response.body
+    end
+
+    def test_tracepoints_cursor_with_invalid_values
+      get api_tracepoints_path(:bbox => "-0.1,-0.1,0.1,0.1", :cursor => Base64.urlsafe_encode64("hello"))
+      assert_response :bad_request
+      assert_equal "The cursor parameter is invalid", @response.body
+
+      get api_tracepoints_path(:bbox => "-0.1,-0.1,0.1,0.1", :cursor => Base64.urlsafe_encode64("1|2|not a time"))
+      assert_response :bad_request
+      assert_equal "The cursor parameter is invalid", @response.body
+    end
+
     def test_tracepoints_disabled
       with_settings(:traces_disabled => true) do
         get api_tracepoints_path(:bbox => "-0.1,-0.1,0.1,0.1")

--- a/test/controllers/api/tracepoints_controller_test.rb
+++ b/test/controllers/api/tracepoints_controller_test.rb
@@ -159,12 +159,6 @@ module Api
         assert_select "trkpt", :count => 2
         assert_match(/lat="1.0000000"/, response.body)
         assert_no_match(/lat="1.0500000"/, response.body)
-
-        # following the link once more returns an empty document
-        next_url = @response.headers["Link"][/<(.*)>; rel="next"/, 1]
-        get next_url
-        assert_response :success
-        assert_select "trkpt", :count => 0
         assert_nil @response.headers["Link"]
       end
     end
@@ -190,6 +184,57 @@ module Api
         assert_response :success
         assert_select "trkseg", :count => 1
         assert_select "trkpt", :count => 2
+      end
+    end
+
+    def test_tracepoints_cursor_pagination_with_fractional_seconds
+      create(:trace, :visibility => "trackable") do |trace|
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 0))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 0.5))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 1))
+      end
+
+      with_settings(:tracepoints_per_page => 2) do
+        get api_tracepoints_path(:bbox => "0.9,0.9,1.1,1.1")
+        assert_response :success
+        assert_select "trkpt", :count => 2
+
+        # the point at half a second is not repeated on the second page
+        next_url = @response.headers["Link"][/<(.*)>; rel="next"/, 1]
+        get next_url
+        assert_response :success
+        assert_select "trkpt", :count => 1 do
+          assert_select "time", :text => "2026-01-01T00:00:01Z"
+        end
+        assert_nil @response.headers["Link"]
+      end
+    end
+
+    def test_tracepoints_cursor_pagination_does_not_split_same_timestamp
+      create(:trace, :visibility => "trackable") do |trace|
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 0))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 1))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 1))
+        create(:tracepoint, :trace => trace, :timestamp => Time.utc(2026, 1, 1, 0, 0, 1))
+      end
+
+      with_settings(:tracepoints_per_page => 2) do
+        # the page would end inside the group at second 1, so it stops before it
+        get api_tracepoints_path(:bbox => "0.9,0.9,1.1,1.1")
+        assert_response :success
+        assert_select "trkpt", :count => 1
+
+        # the whole group is bigger than a page, so it comes in one page
+        next_url = @response.headers["Link"][/<(.*)>; rel="next"/, 1]
+        get next_url
+        assert_response :success
+        assert_select "trkpt", :count => 3
+
+        next_url = @response.headers["Link"][/<(.*)>; rel="next"/, 1]
+        get next_url
+        assert_response :success
+        assert_select "trkpt", :count => 0
+        assert_nil @response.headers["Link"]
       end
     end
 


### PR DESCRIPTION
Since #7146 the API no longer accepts new traces with the legacy public and private visibilities, but the trackpoints endpoint was still serving those points. This PR reduces the endpoint to serve only trackable and identifiable points. It also removes the UNION ALL between two queries with different sort orders, which is an expensive part of the query.

The endpoint still uses page number pagination, which gets slower with every page on a table of ~32 billion rows (openstreetmap/operations#1358). This PR replaces the offset with a cursor, the same idea that #4089 applied to the traces web index. When a response contains a full page of points, it includes a standard `Link` header with `rel="next"` pointing to the next batch. The cursor is a base64 token with the position of the last point (`gpx_id`, `trackid` and `timestamp`), so the database can use an index instead of an offset. The `page` parameter still works, so current clients are not affected. Later we can update the docs and let clients know about the new cursor option.


*Note: This work is independent of the [linestring storage proposal](https://hackmd.io/61pAPKpuRSeXxqyLn4K6Ag). This only changes how the current `gps_points` table is read, so it is useful now and stays valid whatever happens with the storage later.*
