### PR TITLE
update iD to v2.42.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@mapbox/polyline": "*",
     "@maplibre/maplibre-gl-leaflet": "*",
     "@maptiler/maplibre-gl-omt-language": "*",
-    "@openstreetmap/id": "2.42.0",
+    "@openstreetmap/id": "2.42.1",
     "bootstrap-icons": "*",
     "i18n-js": "*",
     "js-cookie": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,10 +301,10 @@
   resolved "https://registry.yarnpkg.com/@maptiler/maplibre-gl-omt-language/-/maplibre-gl-omt-language-0.0.3.tgz#3069f4522e911e341d6b79b09ce2943c71b6ffd7"
   integrity sha512-Rv5IaFyh9GuFu2BEAGvVvlVGmXt5Jbjd0XhIu0D4Tek81DPQEQryIIwDFTDR27W4NyAtozy8QltB+8SFr2C7mQ==
 
-"@openstreetmap/id@2.42.0":
-  version "2.42.0"
-  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.42.0.tgz#13f70b8e92284a6b76d1715a137b2517eeff3fe2"
-  integrity sha512-IzhCTYLH3/rlbbryAsT3GNYjU0lAVAbKspVQLOnZzKEo+S8b8cLJBqVa4heDrL+v06gLYyiA5uxe2YSIjd9ehw==
+"@openstreetmap/id@2.42.1":
+  version "2.42.1"
+  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.42.1.tgz#03e51ea4271d209d5cf821c43accf313bdc7d62e"
+  integrity sha512-9V9AgW9KYXdNSn7HmgE4DdaL2TYW3vTiRJ5rR4wjl2wyBHd4ThqFzMDFClig5omYsOmXjv51rYN0qGc4VVhtlw==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/sexagesimal" "1.2.0"


### PR DESCRIPTION
fixes a few regressions from the last release, see https://github.com/openstreetmap/iD/releases/tag/v2.42.1