### PR TITLE
update iD to v2.42.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@mapbox/polyline": "*",
     "@maplibre/maplibre-gl-leaflet": "*",
     "@maptiler/maplibre-gl-omt-language": "*",
-    "@openstreetmap/id": "2.42.1",
+    "@openstreetmap/id": "2.42.2",
     "bootstrap-icons": "*",
     "i18n-js": "*",
     "js-cookie": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,10 +301,10 @@
   resolved "https://registry.yarnpkg.com/@maptiler/maplibre-gl-omt-language/-/maplibre-gl-omt-language-0.0.3.tgz#3069f4522e911e341d6b79b09ce2943c71b6ffd7"
   integrity sha512-Rv5IaFyh9GuFu2BEAGvVvlVGmXt5Jbjd0XhIu0D4Tek81DPQEQryIIwDFTDR27W4NyAtozy8QltB+8SFr2C7mQ==
 
-"@openstreetmap/id@2.42.1":
-  version "2.42.1"
-  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.42.1.tgz#03e51ea4271d209d5cf821c43accf313bdc7d62e"
-  integrity sha512-9V9AgW9KYXdNSn7HmgE4DdaL2TYW3vTiRJ5rR4wjl2wyBHd4ThqFzMDFClig5omYsOmXjv51rYN0qGc4VVhtlw==
+"@openstreetmap/id@2.42.2":
+  version "2.42.2"
+  resolved "https://registry.yarnpkg.com/@openstreetmap/id/-/id-2.42.2.tgz#d2a41901225b0dec1221f1f22858dd214c9c40ef"
+  integrity sha512-0fI0hNMd9cDHuWUczWRB4R19t230BRiMOAFI8Clo6m+sZHaAke6i0fu+TlhEzzhjYb2xu2Q07AczlyBCGXnFLg==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/sexagesimal" "1.2.0"


### PR DESCRIPTION
Fixes v2.42.1 (#7326) which was missing the compiled assets in the `dist` directory. Sorry for the oversight.