### PR TITLE
Unify OAuth scope rendering

### DIFF
--- a/app/helpers/authorization_helper.rb
+++ b/app/helpers/authorization_helper.rb
@@ -10,7 +10,17 @@ module AuthorizationHelper
       html << " "
       html << role_icon(:classes => "bi-star-fill role-moderator", :title => t("oauth.for_roles.moderator"))
     end
+    html << " "
+    html << tag.code("(#{scope})", :class => "text-body-secondary")
     safe_join(html)
+  end
+
+  def scopes_list(scopes)
+    tag.ul(:class => "list-unstyled mb-0") do
+      safe_join(scopes.map do |scope|
+        tag.li authorization_scope(scope)
+      end)
+    end
   end
 
   def role_icon(classes: "", title: "")

--- a/app/views/oauth2_applications/_application.html.erb
+++ b/app/views/oauth2_applications/_application.html.erb
@@ -10,11 +10,7 @@
     </ul>
   </td>
   <td class="align-middle">
-    <ul class="list-unstyled mb-0">
-      <% application.scopes.each do |scope| -%>
-        <li><%= authorization_scope(scope) %> <code class="text-body-secondary">(<%= scope %>)</code></li>
-      <% end -%>
-    </ul>
+    <%= scopes_list(application.scopes) %>
   </td>
   <td class="align-middle">
     <%= link_to t(".edit"), edit_oauth_application_path(application), :class => "btn btn-outline-primary" %>

--- a/app/views/oauth2_applications/_form.html.erb
+++ b/app/views/oauth2_applications/_form.html.erb
@@ -5,5 +5,5 @@
 <%= f.form_group :confidential do %>
   <%= f.check_box :confidential %>
 <% end %>
-<%= f.collection_check_boxes :scopes, Oauth.scopes(:privileged => current_user.administrator?), :name, :description %>
+<%= f.collection_check_boxes :scopes, Oauth.scopes(:privileged => current_user.administrator?), :name, ->(scope) { authorization_scope(scope.name) } %>
 <%= f.primary %>

--- a/app/views/oauth2_applications/show.html.erb
+++ b/app/views/oauth2_applications/show.html.erb
@@ -26,11 +26,7 @@
   <tr>
     <th><%= t ".permissions" %></th>
     <td>
-      <ul class="list-unstyled mb-0">
-        <% @application.scopes.each do |scope| -%>
-          <li><%= t "oauth.scopes.#{scope}" %> <code class="text-body-secondary">(<%= scope %>)</code></li>
-        <% end -%>
-      </ul>
+      <%= scopes_list(@application.scopes) %>
     </td>
   </tr>
   <tr>

--- a/app/views/oauth2_authorizations/new.html.erb
+++ b/app/views/oauth2_authorizations/new.html.erb
@@ -4,11 +4,7 @@
 
 <p><%= t ".introduction", :application => @pre_auth.client.name %></p>
 
-<ul>
-  <% @pre_auth.scopes.each do |scope| -%>
-    <li><%= authorization_scope(scope) %></li>
-  <% end -%>
-</ul>
+<%= scopes_list(@pre_auth.scopes) %>
 
 <div class="row justify-content-start g-0 mx-n1">
   <div class="col-auto mx-1">

--- a/app/views/oauth2_authorized_applications/_application.html.erb
+++ b/app/views/oauth2_authorized_applications/_application.html.erb
@@ -5,11 +5,7 @@
     <%= application.name %>
   </td>
   <td class="align-middle">
-    <ul class="list-unstyled mb-0">
-      <% application.authorized_scopes_for(current_user).each do |scope| -%>
-        <li><%= authorization_scope(scope) %></li>
-      <% end -%>
-    </ul>
+    <%= scopes_list(application.authorized_scopes_for(current_user)) %>
   </td>
   <td class="align-middle">
     <%= friendly_date_ago(application.authorized_tokens.where(:resource_owner_id => current_user).maximum(:created_at)) %>

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -15,10 +15,6 @@ module Oauth
     def initialize(name)
       @name = name
     end
-
-    def description
-      I18n.t("oauth.scopes.#{name}")
-    end
   end
 
   def self.scopes(privileged: false)

--- a/test/controllers/oauth2_applications_controller_test.rb
+++ b/test/controllers/oauth2_applications_controller_test.rb
@@ -191,6 +191,7 @@ class Oauth2ApplicationsControllerTest < ActionDispatch::IntegrationTest
       assert_select "input#oauth2_application_confidential", 1
       Oauth.scopes.each do |scope|
         assert_select "input#oauth2_application_scopes_#{scope.name}", 1
+        assert_select "label[for='oauth2_application_scopes_#{scope.name}'] code", :text => "(#{scope.name})"
       end
     end
   end

--- a/test/controllers/oauth2_authorized_applications_controller_test.rb
+++ b/test/controllers/oauth2_authorized_applications_controller_test.rb
@@ -56,9 +56,12 @@ class Oauth2AuthorizedApplicationsControllerTest < ActionDispatch::IntegrationTe
     assert_select "tbody tr", 1
     assert_select "tbody tr td ul" do
       assert_select "li", :count => 3
-      assert_select "li", :text => "Read user preferences"
-      assert_select "li", :text => "Modify user preferences"
-      assert_select "li", :text => "Create diary entries and comments"
+      assert_select "li", :text => /^Read user preferences/
+      assert_select "li", :text => /^Modify user preferences/
+      assert_select "li", :text => /^Create diary entries and comments/
+      assert_select "li code", :text => "(read_prefs)"
+      assert_select "li code", :text => "(write_prefs)"
+      assert_select "li code", :text => "(write_diary)"
     end
   end
 


### PR DESCRIPTION
We had many variations of the scopes being displayed, with or without mod star and with or without scope code.
There should be only one all-inclusive render path.
This fixes #7291 and closes #7306, which is where I snatched a test amendment from.