### PR TITLE
Add labels to nav elements and enable html-navigation-has-label

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -28,6 +28,8 @@ linter:
       enabled: false
     erb-strict-locals-required:
       enabled: true
+    html-navigation-has-label:
+      enabled: true
     html-no-space-in-tag:
       enabled: true
     html-no-title-attribute:

--- a/app/views/application/_pagination.html.erb
+++ b/app/views/application/_pagination.html.erb
@@ -3,7 +3,7 @@
 <% if paginator.older_items_cursor || paginator.newer_items_cursor %>
 
 <% translation_scope ||= "application.pagination.#{controller.controller_name}" %>
-<nav class="d-flex justify-content-between gap-2">
+<nav class="d-flex justify-content-between gap-2" aria-label="<%= t ".label" %>">
   <ul class="pagination">
     <%= pagination_item(paginator.newer_items_cursor && params.merge(:before => nil, :after => nil),
                         t(:newest, :scope => translation_scope)) do %>

--- a/app/views/dashboards/_contact.html.erb
+++ b/app/views/dashboards/_contact.html.erb
@@ -33,7 +33,7 @@
       <% end %>
     </p>
 
-    <nav class="secondary-actions">
+    <nav class="secondary-actions" aria-label="<%= t ".actions" %>">
       <ul class="text-body-secondary">
         <li><%= link_to t("users.show.send message"), new_message_path(contact) %></li>
         <li>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -29,7 +29,7 @@
     <% if @followings.empty? %>
       <%= t ".no followings" %>
     <% else %>
-      <nav class="secondary-actions mb-3">
+      <nav class="secondary-actions mb-3" aria-label="<%= t ".followed_actions" %>">
         <ul>
           <li><%= link_to t(".followed_changesets"), friend_changesets_path %></li>
           <li><%= link_to t(".followed_diaries"), friends_diary_entries_path %></li>
@@ -47,7 +47,7 @@
     <% if @nearby_users.empty? %>
       <%= t ".no nearby users" %>
     <% else %>
-      <nav class="secondary-actions mb-3">
+      <nav class="secondary-actions mb-3" aria-label="<%= t ".nearby_actions" %>">
         <ul>
           <li><%= link_to t(".nearby_changesets"), nearby_changesets_path %></li>
           <li><%= link_to t(".nearby_diaries"), nearby_diary_entries_path %></li>

--- a/app/views/diary_entries/_diary_entry.html.erb
+++ b/app/views/diary_entries/_diary_entry.html.erb
@@ -19,7 +19,7 @@
     <%= render :partial => "location", :object => diary_entry %>
   <% end %>
 
-  <nav class="secondary-actions">
+  <nav class="secondary-actions" aria-label="<%= t ".actions" %>">
     <ul>
       <% if params[:action] == 'index' %>
         <li><%= link_to t(".comment_link"), diary_entry_path(diary_entry.user, diary_entry, :anchor => "newcomment") %></li>

--- a/app/views/diary_entries/_navigation.html.erb
+++ b/app/views/diary_entries/_navigation.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (user:, languages: []) %>
 
-<nav class="secondary-actions">
+<nav class="secondary-actions" aria-label="<%= t ".actions" %>">
   <ul>
     <% unless params[:friends] or params[:nearby] -%>
       <li><%= rss_link_to :action => "rss", :language => params[:language] %></li>

--- a/app/views/elements/show.html.erb
+++ b/app/views/elements/show.html.erb
@@ -14,7 +14,7 @@
   </div>
 <% end %>
 
-<nav>
+<nav aria-label="<%= t "browse.versions_navigation.#{@type}_versions" %>">
   <ol class="breadcrumb mb-1">
     <li class="breadcrumb-item active" aria-current="page">
       <%= tag.span t(@type, :scope => "browse.versions_navigation"), :class => "py-1 px-2 rounded bg-body-secondary" %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -25,7 +25,7 @@
     <% end %>
   </small>
 </p>
-<nav class="secondary-actions">
+<nav class="secondary-actions" aria-label="<%= t ".actions" %>">
   <ul>
     <% if @issue.may_resolve? %>
       <li><%= link_to t(".resolve"), resolve_issue_url(@issue), :method => :post %></li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
   </h1>
   <section id="header-nav" class="flex-grow-1 collapse d-md-block">
     <%= content_for :header %>
-    <nav class="navbar-nav gap-2 flex-grow-1">
+    <nav class="navbar-nav gap-2 flex-grow-1" aria-label="<%= t ".navigation" %>">
       <div id="edit_tab" class="btn-group">
         <%= link_to t(".edit"),
                     edit_path,

--- a/app/views/moderation_zones/_navigation.html.erb
+++ b/app/views/moderation_zones/_navigation.html.erb
@@ -1,6 +1,6 @@
 <%# locals: () %>
 
-<nav class="secondary-actions">
+<nav class="secondary-actions" aria-label="<%= t ".actions" %>">
   <ul>
     <li>
       <%= link_to new_moderation_zone_path, :class => "icon-link", :title => t(".new_title") do %>

--- a/app/views/notes/_notes_paging_nav.html.erb
+++ b/app/views/notes/_notes_paging_nav.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (page:, next_page:, params:) %>
 
-<nav>
+<nav aria-label="<%= t ".label" %>">
   <% link_class = "page-link icon-link text-center text-nowrap" %>
   <ul class="pagination">
     <% previous_link_content = capture do %>

--- a/app/views/old_elements/_actions.html.erb
+++ b/app/views/old_elements/_actions.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 </div>
 
-<nav>
+<nav aria-label="<%= t "browse.versions_navigation.#{type}_versions" %>">
   <ol class="breadcrumb mb-1">
     <li class="breadcrumb-item">
       <%= link_to t(type, :scope => "browse.versions_navigation"), current_feature %>

--- a/app/views/old_elements/index.html.erb
+++ b/app/views/old_elements/index.html.erb
@@ -40,7 +40,7 @@
   <% end %>
 </div>
 
-<nav>
+<nav aria-label="<%= t ".#{@type}.actions" %>">
   <ol class="breadcrumb mb-1">
     <li class="breadcrumb-item">
       <%= link_to t(@type, :scope => "browse.versions_navigation"), @current_feature %>

--- a/app/views/traces/_trace.html.erb
+++ b/app/views/traces/_trace.html.erb
@@ -45,7 +45,7 @@
   </td>
   <td>
     <% if trace.inserted? %>
-      <nav class="secondary-actions">
+      <nav class="secondary-actions" aria-label="<%= t ".trace_actions" %>">
         <ul>
           <li>
             <%= link_to t(".view_map"), root_path(:mlat => trace.latitude, :mlon => trace.longitude, :anchor => "map=14/#{trace.latitude}/#{trace.longitude}") %>

--- a/app/views/traces/index.html.erb
+++ b/app/views/traces/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :heading_class, "pb-0" %>
 <% content_for :heading do %>
   <h1><%= @title %></h1>
-  <nav class="secondary-actions mb-3">
+  <nav class="secondary-actions mb-3" aria-label="<%= t ".actions" %>">
     <ul>
       <li>
         <%= t(".description") %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,7 +33,7 @@
           <% end %>
         <% end %>
       </h1>
-      <nav class="secondary-actions">
+      <nav class="secondary-actions" aria-label="<%= t ".actions" %>">
         <ul>
           <% if current_user and @user.id == current_user.id %>
             <!-- Displaying user's own profile page -->
@@ -187,7 +187,7 @@
       </div>
 
       <% if can?(:update, :user_status) %>
-        <nav class="secondary-actions">
+        <nav class="secondary-actions" aria-label="<%= t ".admin_actions" %>">
           <ul>
             <% if @user.may_activate? %>
               <li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -655,10 +655,10 @@ en:
       no followings: You have not followed any user yet.
       nearby users: "Other nearby users"
       no nearby users: "There are no other users who admit to mapping nearby yet."
-      followed_actions: "actions for users you follow"
+      followed_actions: "Actions for users you follow"
       followed_changesets: "changesets"
       followed_diaries: "diary entries"
-      nearby_actions: "actions for nearby users"
+      nearby_actions: "Actions for nearby users"
       nearby_changesets: "nearby user changesets"
       nearby_diaries: "nearby user diary entries"
   notifications:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -471,6 +471,9 @@ en:
       colour_preview: "Colour %{colour_value} preview"
       email_link: "Email %{email}"
     versions_navigation:
+      node_versions: "Node versions"
+      way_versions: "Way versions"
+      relation_versions: "Relation versions"
       node: "Node"
       way: "Way"
       relation: "Relation"
@@ -487,10 +490,13 @@ en:
     index:
       node:
         title_html: "Node History: %{name}"
+        actions: "Node actions"
       way:
         title_html: "Way History: %{name}"
+        actions: "Way actions"
       relation:
         title_html: "Relation History: %{name}"
+        actions: "Relation actions"
       older_versions: Older Versions
       newer_versions: Newer Versions
     actions:
@@ -636,6 +642,7 @@ en:
       latest_edit_html: "Latest edit (%{ago}):"
       no_edits: "(no edits)"
       view_changeset_details: "View changeset details"
+      actions: "User actions"
     popup:
       your location: "Your location"
       nearby mapper: "Nearby mapper"
@@ -648,8 +655,10 @@ en:
       no followings: You have not followed any user yet.
       nearby users: "Other nearby users"
       no nearby users: "There are no other users who admit to mapping nearby yet."
+      followed_actions: "actions for users you follow"
       followed_changesets: "changesets"
       followed_diaries: "diary entries"
+      nearby_actions: "actions for nearby users"
       nearby_changesets: "nearby user changesets"
       nearby_diaries: "nearby user diary entries"
   notifications:
@@ -724,6 +733,7 @@ en:
       posted_by_html: "Posted by %{link_user} on %{created} in %{language_link}."
       updated_at_html: "Last updated on %{updated}."
       full_entry: See full entry
+      actions: Diary entry actions
       comment_link: Comment on this entry
       reply_link: Send a message to the author
       comment_count:
@@ -761,6 +771,7 @@ en:
       heading: Unsubscribe from the following diary entry discussion?
       button: Unsubscribe from discussion
     navigation:
+      actions: Diary actions
       in_language: "Diary Entries in %{language}"
       my_diary: My Diary
       new: New Diary Entry
@@ -1735,6 +1746,7 @@ en:
       report_created_at_html: "First reported at %{datetime}"
       last_resolved_at_html: "Last resolved at %{datetime}"
       last_updated_at_html: "Last updated at %{datetime} by %{displayname}"
+      actions: Issue actions
       resolve: Resolve
       ignore: Ignore
       reopen: Reopen
@@ -1960,6 +1972,7 @@ en:
       select_language: Select Language
       sign_up: Sign Up
       user_diaries: User Diaries
+      navigation: Main navigation
     meta:
       openstreetmap_search: OpenStreetMap Search
     select_language_button:
@@ -3049,6 +3062,7 @@ en:
         other: "%{count} points"
       more: "more"
       trace_details: "View Trace Details"
+      trace_actions: "Trace actions"
       view_map: "View location on map"
       edit_map: "Open in editor"
       public: "PUBLIC"
@@ -3062,6 +3076,7 @@ en:
       my_gps_traces: "My GPS Traces"
       public_traces_from: "Public GPS Traces from %{user}"
       description: "Browse recent GPS trace uploads"
+      actions: "Trace list actions"
       tagged_with: " tagged with %{tags}"
       empty_title: Nothing here yet
       empty_upload_html: "%{upload_link} or learn more about GPS tracing on the %{wiki_link}."
@@ -3167,6 +3182,7 @@ en:
       preview: Preview
       help: Help
     pagination:
+      label: Page navigation
       changeset_comments:
         older: Older Comments
         newer: Newer Comments
@@ -3316,6 +3332,8 @@ en:
       body: "Sorry, there is no user with the name %{user}. Please check your spelling, or maybe the link you clicked is wrong."
       deleted: "deleted"
     show:
+      actions: Actions
+      admin_actions: Administrative actions
       my diary: My Diary
       my edits: My Edits
       my traces: My Traces
@@ -3672,6 +3690,7 @@ en:
       title: "New Note"
       warning: "New notes cannot be created because the OpenStreetMap API is currently in read-only mode."
     notes_paging_nav:
+      label: "Page navigation"
       showing_page: "Page %{page}"
       next: "Next"
       previous: "Previous"
@@ -3903,6 +3922,7 @@ en:
     navigation:
       new_title: Define a new moderation zone
       new: New Moderation Zone
+      actions: Moderation zone actions
     index:
       title: Moderation Zones
       heading: Moderation Zones


### PR DESCRIPTION
This enables the `html-navigation-has-label` herb linter and adds the missing labels it reports to `nav` elements.