### PR TITLE
Antimeridian wraparound flashing fix

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require leaflet.osm
 //= require maplibre-gl/dist/maplibre-gl
 //= require leaflet.maplibre
+//= require leaflet.worldcopy
 //= require leaflet.shortbread
 //= require leaflet.thunderforest
 //= require i18n

--- a/app/assets/javascripts/leaflet.worldcopy.js
+++ b/app/assets/javascripts/leaflet.worldcopy.js
@@ -1,0 +1,74 @@
+// worldCopyJump moves the map pane by a whole world at the antimeridian without
+// notifying layers of the discontinuity. Rebase wrapped tiles and update the
+// MapLibre canvas immediately so they remain in the viewport during the jump.
+{
+  const worldTileColumns = function (layer, zoom) {
+    const bounds = layer._map.getPixelWorldBounds(zoom),
+          columns = bounds && (bounds.getSize().x / layer.getTileSize().x);
+    // Only reuse tiles when a world contains a whole number of columns.
+    return Number.isInteger(columns) ? columns : null;
+  };
+
+  const shiftGridLayer = function (layer, worlds) {
+    // Tiles from noWrap layers are not interchangeable between world copies.
+    if (!layer._wrapX) return;
+
+    const columns = {};
+    for (const key in layer._tiles) {
+      const zoom = layer._tiles[key].coords.z;
+      if (!(zoom in columns)) columns[zoom] = worldTileColumns(layer, zoom);
+      if (columns[zoom] === null) return;
+    }
+
+    const tiles = {};
+    for (const key in layer._tiles) {
+      const tile = layer._tiles[key],
+            columnShift = worlds * columns[tile.coords.z],
+            position = L.DomUtil.getPosition(tile.el);
+
+      tile.coords.x -= columnShift;
+      tiles[layer._tileCoordsToKey(tile.coords)] = tile;
+      L.DomUtil.setPosition(tile.el, position.subtract([columnShift * layer.getTileSize().x, 0]));
+    }
+    layer._tiles = tiles;
+  };
+
+  const followWorldCopyJump = function (map, worlds) {
+    map.eachLayer(function (layer) {
+      if (layer instanceof L.GridLayer) {
+        shiftGridLayer(layer, worlds);
+      } else if (L.MaplibreGL && layer instanceof L.MaplibreGL) {
+        layer._update();
+      }
+    });
+  };
+
+  const onDragStart = L.Map.Drag.prototype._onDragStart,
+        onPreDragWrap = L.Map.Drag.prototype._onPreDragWrap,
+        onDrag = L.Map.Drag.prototype._onDrag;
+
+  L.Map.Drag.include({
+    _onDragStart: function () {
+      this._wrapOffset = 0;
+      this._wrappedWorlds = 0;
+      onDragStart.call(this);
+    },
+
+    _onPreDragWrap: function () {
+      const unwrappedX = this._draggable._newPos.x;
+      onPreDragWrap.call(this);
+      const offset = this._draggable._newPos.x - unwrappedX;
+      this._wrappedWorlds += Math.round((offset - this._wrapOffset) / this._worldWidth);
+      this._wrapOffset = offset;
+    },
+
+    _onDrag: function (e) {
+      // Draggable moves the pane after predrag and before drag.
+      if (this._wrappedWorlds) {
+        followWorldCopyJump(this._map, this._wrappedWorlds);
+        this._wrappedWorlds = 0;
+      }
+      onDrag.call(this, e);
+    }
+  });
+}

--- a/test/javascripts/leaflet_worldcopy_test.js
+++ b/test/javascripts/leaflet_worldcopy_test.js
@@ -1,0 +1,54 @@
+describe("Leaflet worldCopyJump", function () {
+  let container, map;
+
+  beforeEach(function () {
+    container = document.createElement("div");
+    container.style.width = "512px";
+    container.style.height = "512px";
+    document.body.appendChild(container);
+
+    map = L.map(container, {
+      fadeAnimation: false,
+      inertia: false,
+      worldCopyJump: true,
+      zoomAnimation: false
+    }).setView([0, 0], 2);
+  });
+
+  afterEach(function () {
+    map.remove();
+    container.remove();
+  });
+
+  it("rebases retained tiles from every zoom level", function () {
+    const layer = L.gridLayer().addTo(map),
+          zoomTwoTile = document.createElement("div"),
+          zoomThreeTile = document.createElement("div"),
+          zoomTwoCoords = L.point(1, 1),
+          zoomThreeCoords = L.point(2, 2),
+          zoomTwo = { coords: zoomTwoCoords, el: zoomTwoTile },
+          zoomThree = { coords: zoomThreeCoords, el: zoomThreeTile };
+
+    zoomTwoCoords.z = 2;
+    zoomThreeCoords.z = 3;
+    L.DomUtil.setPosition(zoomTwoTile, L.point(10, 20));
+    L.DomUtil.setPosition(zoomThreeTile, L.point(30, 40));
+    layer._tiles = {
+      "1:1:2": zoomTwo,
+      "2:2:3": zoomThree
+    };
+
+    const dragging = map.dragging;
+    dragging._onDragStart();
+    dragging._draggable._newPos = L.point(600, 0);
+    dragging._onPreDragWrap();
+    dragging._onDrag({});
+
+    expect(zoomTwoCoords.x).to.equal(5);
+    expect(zoomThreeCoords.x).to.equal(10);
+    expect(L.DomUtil.getPosition(zoomTwoTile)).to.deep.equal(L.point(1034, 20));
+    expect(L.DomUtil.getPosition(zoomThreeTile)).to.deep.equal(L.point(2078, 40));
+    expect(layer._tiles["5:1:2"]).to.equal(zoomTwo);
+    expect(layer._tiles["10:2:3"]).to.equal(zoomThree);
+  });
+});


### PR DESCRIPTION
### Description

Fix the screen flashing to black for about 250ms when panning across ±180°.

I noticed this while working on [this](https://github.com/openstreetmap-carto/openstreetmap-carto/issues/3504#issuecomment-5401977453) issue.

Before
<img width="780" height="467" alt="before" src="https://github.com/user-attachments/assets/664d128e-93b0-4bb0-99c0-f009bf71333e" />

After
<img width="780" height="467" alt="after" src="https://github.com/user-attachments/assets/98b930ce-4c9b-4ad1-b2fd-610e2e6464d2" />

<details><summary>Higher quality screen recordings (click to expand)</summary>


https://github.com/user-attachments/assets/6dd08ae8-ccca-47cd-84c1-2339d43c4c76


https://github.com/user-attachments/assets/e0e6f92f-0f11-442e-83af-81e897e857be

</details>

### Why not Leaflet?

The immediate question is "why implement this here, with a `_onPreDragWrap` listener like this? why not fix it in Leaflet as suggested [here](https://github.com/openstreetmap/openstreetmap-website/issues/1153#issuecomment-183646654)"? Answer:

1. Leaflet has been aware of this for over a decade: https://github.com/Leaflet/Leaflet/issues/4141
2. And it is challenging to make a generic solution. IvanSanchez, who is the second-most prolific human committer to Leaflet, said `I'm unsure if this can be solved gracefully.` the last time this was brought up with specific reference to openstreetmap.org: https://github.com/Leaflet/Leaflet/issues/9878#issuecomment-3287116479

### How has this been tested?

Verified visually, and with unit tests. Please see screen recordings above. You may also try it yourself at https://osm.leijurv.com/#map=4/63.41/171.04

