### PR TITLE
Fix location control toggle behavior

### DIFF
--- a/app/assets/javascripts/leaflet.locate.js
+++ b/app/assets/javascripts/leaflet.locate.js
@@ -2,6 +2,11 @@
 
 L.OSM.locate = function (options) {
   const control = L.control.locate({
+    clickBehavior: {
+      inView: "stop",
+      outOfView: "stop",
+      inViewNotFollowing: "stop"
+    },
     strings: {
       title: OSM.i18n.t("javascripts.map.geolocate_control.find_my_location"),
       popup: function (options) {


### PR DESCRIPTION
### Description

Fixes #7284.

When "Show My Location" is enabled and the map is then moved somewhere else, clicking the location button again moves the map back to the user's location instead of simply turning the feature off.

This happens because the location control uses `setView` when the user's location is outside the current map view. I changed the `clickBehavior` configuration so that clicking the button stops the location control instead, without moving the map.

### How has this been tested?

I tested the location control both when the user's location is visible and after moving the map away from it. In both cases, clicking the button turns off the location control without moving the map.

I also ran ESLint on `app/assets/javascripts/leaflet.locate.js` and the JavaScript assets, with no errors.