### PR TITLE
Fixed notifications reload error

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -40,7 +40,7 @@ class FollowsController < ApplicationController
 
   def destroy
     if current_user.follows?(@user)
-      Follow.where(:follower => current_user, :following => @user).delete_all
+      Follow.where(:follower => current_user, :following => @user).destroy_all
       flash[:notice] = t ".success", :name => @user.display_name
     else
       flash[:error] = t ".not_followed", :name => @user.display_name

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -25,4 +25,6 @@ class Follow < ApplicationRecord
 
   belongs_to :follower, :class_name => "User", :foreign_key => :user_id, :inverse_of => :follows
   belongs_to :following, :class_name => "User", :foreign_key => :friend_user_id, :inverse_of => :follows
+
+  has_many :noticed_events, :as => :record, :dependent => :destroy, :class_name => "Noticed::Event"
 end

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -33,6 +33,7 @@ class Trace < ApplicationRecord
   belongs_to :user, :counter_cache => true
   has_many :tags, :class_name => "Tracetag", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => :trace
   has_many :points, :class_name => "Tracepoint", :foreign_key => "gpx_id", :dependent => :delete_all, :inverse_of => :trace
+  has_many :noticed_events, :as => :record, :dependent => :destroy, :class_name => "Noticed::Event"
 
   scope :visible, -> { where(:visible => true) }
   scope :visible_to, ->(u) { visible.where(:visibility => %w[public identifiable]).or(visible.where(:user => u)) }

--- a/app/views/notifications/_page.html.erb
+++ b/app/views/notifications/_page.html.erb
@@ -2,6 +2,7 @@
 
 <turbo-frame id="pagination" target="_top" data-turbo="false">
   <% notifications.items.each do |notification| %>
+    <% next if notification.event.record_type.present? && notification.record.nil? %>
     <%= render "notification", :notification => notification %>
     <hr>
   <% end %>

--- a/test/system/web_notifications_test.rb
+++ b/test/system/web_notifications_test.rb
@@ -69,4 +69,91 @@ class WebNotificationsTest < ApplicationSystemTestCase
     create(:changeset_subscription, :changeset => changeset, :subscriber => commenter)
     ChangesetCommentNotifier.with(:record => comment).deliver
   end
+
+  test "follower notification is cleaned up after unfollow" do
+    follower = create(:user, :display_name => "Follower")
+    followed = create(:user)
+
+    follow = create(:follow, :follower => follower, :following => followed)
+    NewFollowerNotifier.with(:record => follow).deliver
+
+    sign_in_as(follower)
+    visit user_path(followed)
+    click_on "Unfollow"
+    assert_text "You successfully unfollowed"
+
+    sign_in_as(followed)
+
+    click_on followed.display_name
+    click_on "My Notifications"
+
+    assert_text "Notifications"
+    assert_text "You have no notifications"
+  end
+
+  test "historical orphaned follower notification is skipped" do
+    follower = create(:user, :display_name => "Follower")
+    followed = create(:user)
+
+    follow = create(:follow, :follower => follower, :following => followed)
+    NewFollowerNotifier.with(:record => follow).deliver
+
+    Follow.where(:id => follow.id).delete_all
+
+    sign_in_as(followed)
+
+    click_on followed.display_name
+    click_on "My Notifications"
+
+    assert_text "Notifications"
+    assert_no_selector ".web-notification"
+  end
+
+  test "GPX import success notification is cleaned up after trace is destroyed" do
+    user = create(:user)
+    trace = create(:trace, :user => user)
+    GpxImportSuccessNotifier.with(:record => trace, :possible_points => 100).deliver
+
+    trace.destroy
+
+    sign_in_as(user)
+    click_on user.display_name
+    click_on "My Notifications"
+
+    assert_text "Notifications"
+    assert_text "You have no notifications"
+  end
+
+  test "historical orphaned GPX import success notification is skipped" do
+    user = create(:user)
+    trace = create(:trace, :user => user)
+    GpxImportSuccessNotifier.with(:record => trace, :possible_points => 100).deliver
+
+    Trace.where(:id => trace.id).delete_all
+
+    sign_in_as(user)
+    click_on user.display_name
+    click_on "My Notifications"
+
+    assert_text "Notifications"
+    assert_no_selector ".web-notification"
+  end
+
+  test "GPX import failure notification without a record is still rendered" do
+    user = create(:user)
+    GpxImportFailureNotifier.with(
+      :trace_name => "bad_trace.gpx",
+      :trace_description => "bad",
+      :trace_tags => [],
+      :error => "0 points parsed ok"
+    ).deliver(user)
+
+    sign_in_as(user)
+    click_on user.display_name
+    click_on "My Notifications"
+
+    assert_text "Notifications"
+    assert_selector ".web-notification"
+    assert_text "bad_trace.gpx"
+  end
 end

--- a/test/system/web_notifications_test.rb
+++ b/test/system/web_notifications_test.rb
@@ -59,17 +59,6 @@ class WebNotificationsTest < ApplicationSystemTestCase
     assert_text "This is comment number 10"
   end
 
-  private
-
-  def setup_changeset_comment(changeset_author:, commenter:, comment_attrs: {})
-    changeset = create(:changeset, :user => changeset_author)
-    create(:changeset_subscription, :changeset => changeset, :subscriber => changeset_author)
-
-    comment = create(:changeset_comment, :changeset => changeset, :author => commenter, **comment_attrs)
-    create(:changeset_subscription, :changeset => changeset, :subscriber => commenter)
-    ChangesetCommentNotifier.with(:record => comment).deliver
-  end
-
   test "follower notification is cleaned up after unfollow" do
     follower = create(:user, :display_name => "Follower")
     followed = create(:user)
@@ -155,5 +144,16 @@ class WebNotificationsTest < ApplicationSystemTestCase
     assert_text "Notifications"
     assert_selector ".web-notification"
     assert_text "bad_trace.gpx"
+  end
+
+  private
+
+  def setup_changeset_comment(changeset_author:, commenter:, comment_attrs: {})
+    changeset = create(:changeset, :user => changeset_author)
+    create(:changeset_subscription, :changeset => changeset, :subscriber => changeset_author)
+
+    comment = create(:changeset_comment, :changeset => changeset, :author => commenter, **comment_attrs)
+    create(:changeset_subscription, :changeset => changeset, :subscriber => commenter)
+    ChangesetCommentNotifier.with(:record => comment).deliver
   end
 end


### PR DESCRIPTION
Fixes #7354

### What was happening

I found that when a user unfollows someone, the `Follow` record gets deleted but the follower notification can stick around. Since the notification is still there but its associated record is gone, opening the notifications page ends up throwing a `NoMethodError`.

While looking into this, I also noticed the same kind of issue with `GpxSuccessNotifier` when the associated trace is deleted.

### What I changed

I updated the cleanup so that notifications are removed along with their associated `Follow` or `Trace` records. I also changed the unfollow flow to use `destroy_all` so the cleanup callbacks actually run.

For older notifications that were already left orphaned, I added a guard so they are simply skipped instead of crashing the page. Record-less notifications that are valid by design, like GPX import failures, are still shown normally.

### Tests

I added regression tests for the different cases, including:
- follower notifications after unfollowing
- existing orphaned follower notifications
- GPX success notifications after deleting a trace
- existing orphaned GPX success notifications
- GPX failure notifications without an associated record

All the relevant tests are passing locally.