### PR TITLE
Add support for sentry error logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,8 @@ gem "canonical-rails", :github => "commonlit/canonical-rails", :ref => "bump-rai
 gem "opentelemetry-exporter-otlp", :require => false
 gem "opentelemetry-instrumentation-all", :require => false
 gem "opentelemetry-sdk", :require => false
+gem "sentry-rails"
+gem "sentry-ruby"
 
 # Used to generate images for traces
 gem "bzip2-ffi"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -858,6 +858,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sentry-rails (7.0.0)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 7.0.0)
+    sentry-ruby (7.0.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     simplecov (1.1.1)
     simplecov-lcov (0.9.0)
     simpleidn (0.2.3)
@@ -1027,6 +1034,8 @@ DEPENDENCIES
   sanitize
   sass-embedded (~> 1.64.0)
   selenium-webdriver
+  sentry-rails
+  sentry-ruby
   simplecov
   simplecov-lcov
   sprockets-exporters_pack

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+if Settings.key?(:sentry_dsn)
+  Sentry.init do |config|
+    config.dsn = Settings.sentry_dsn
+    config.traces_sample_rate = Settings.sentry_traces_sample_rate if Settings.key?(:sentry_traces_sample_rate)
+    config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -259,3 +259,6 @@ smtp_password: null
 # Credentials for optional cloudflare turnstile widget
 #turnstile_site_key:
 #turnstile_secret_key:
+# Sentry error logging
+#sentry_dsn:
+#sentry_traces_sample_rate:


### PR DESCRIPTION
This enables support for sentry error logging so that we can capture error reports to our new [GlitchTip](https://glitchtip.com/) server.