### PR TITLE
Change "New Note" information texts and placements

### DIFF
--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -22,7 +22,12 @@
     <input type="hidden" name="lon" autocomplete="off">
     <input type="hidden" name="lat" autocomplete="off">
     <div class="mb-3">
-      <%= text_area_tag "text", "", :class => "form-control", :size => "40x10", :maxlength => "2000", :placeholder => t(".advice") %>
+      <%= text_area_tag "text",
+                        "",
+                        :class => "form-control",
+                        :size => "40x10",
+                        :maxlength => "2000",
+                        :placeholder => [t(".advice_good_note"), t(".advice_conduct")].join("\n\n") %>
     </div>
     <div class="new-note-error alert alert-danger d-none">
       <details>
@@ -34,5 +39,8 @@
       <%= submit_tag t(".add"), :name => "add", :disabled => 1, :class => "btn btn-primary" %>
     </div>
   </form>
+  <div class="alert alert-warning mt-3">
+    <p class="mb-0"><%= t(".advice") %></p>
+  </div>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3730,7 +3730,9 @@ en:
       counter_warning_forum_link:
         text: "the community can help you"
         url: https://community.openstreetmap.org/
-      advice: "Your note is public and may be used to update the map, so don't enter personal information, or information from copyrighted maps or directory listings."
+      advice: "Anyone in the public can see a note, even without an OpenStreetMap account!"
+      advice_good_note: "A good note is as descriptive as possible while avoiding personal information, or content from copyrighted maps or directory listings."
+      advice_conduct: "Please be kind, patient and respectful when communicating with community members."
       add: Add Note
       error: "There was an error when creating the note"
     new_readonly:


### PR DESCRIPTION
Moving advice out of textarea placeholder into a seperate warning box and adds discussed texts for quality-note encouragements.

### Description
Resolves #2415.
Text that warns about notes being completely public is now shown as a alert-warning box.
Advices on good notes and conduct towards the community are in an alert-information box.

<img width="390" height="890" alt="image" src="https://github.com/user-attachments/assets/711d062b-9bf9-49ae-af73-8e0a0a484627" />

### How has this been tested?
Local DEVCONTAINER instance