### PR TITLE
Drain pending browser/app requests in tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -56,6 +56,11 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     Settings.oauth_application = osm_website_app.uid
   end
 
+  def before_teardown
+    super
+    Capybara.reset_sessions!
+  end
+
   def after_teardown
     Settings.reload!
     super


### PR DESCRIPTION
Resolves intermittent `WebMock::NetConnectNotAllowedError` in system tests.

```Error:
SearchTest#test_search_adds_zoom_param_to_reverse_Nominatim_link:
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET https://nominatim.openstreetmap.org/reverse?accept-language=en&format=xml&lat=60&lon=30&zoom=7 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'test.host'}

You can stub this request with the following snippet:

stub_request(:get, "https://nominatim.openstreetmap.org/reverse?accept-language=en&format=xml&lat=60&lon=30&zoom=7").
  with(
    headers: {
	  'Accept'=>'*/*',
	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
	  'User-Agent'=>'test.host'
    }).
  to_return(status: 200, body: "", headers: {})

============================================================
    app/controllers/searches/queries_controller.rb:12:in 'Searches::QueriesController#fetch_text'
    app/controllers/searches/queries_controller.rb:22:in 'Searches::QueriesController#fetch_xml'
    app/controllers/searches/nominatim_reverse_queries_controller.rb:15:in 'Searches::NominatimReverseQueriesController#create'
    config/initializers/policy_headers.rb:13:in 'OpenStreetMap::Rack::PolicyHeaders#call'
    config/initializers/compressed_requests.rb:33:in 'OpenStreetMap::CompressedRequests#call'

bin/rails test test/system/search_test.rb:82
```

### Description

#### Cause
The failing outbound request is made server-side while handling a browser-triggered request. 
WebMock stubs are registered per test and cleared on teardown. 
In teardown the stub registry is cleared before Capybara drains in-flight requests, so a request still in flight reaches the app after its stubs are gone -> treated as unregistered -> `NetConnectNotAllowedError`. 
This is a teardown-ordering race, not a missing stub.

#### Fix
Drain pending browser/app requests in `before_teardown` (after `super`, so failure screenshots are still taken), i.e. before WebMock clears its stubs.

### How has this been tested?
Running the failing test in a local DEVCONTAINER a max of 50 times
```
for i in $(seq 1 50); do echo "run $i"; bin/rails test test/system/search_test.rb:82 || break; done
```
failed at the first, second or third run the earliest. After adding the code in this PR, 50 runs of the test ran correctly.


