### PR TITLE
Fix double load of the language selector

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -225,18 +225,18 @@ $(function () {
   });
 
   $("#select_language_dialog").on("shown.bs.modal", function () {
+    $("#language_search").trigger("focus");
+  });
+
+  $("#select_language_dialog").on("show.bs.modal", function () {
     $("#language_search")
       .val("")
-      .trigger("input")
-      .trigger("focus");
+      .trigger("input");
     const $frame = $("#select_language_list");
-    const originalSrc = new URL($frame.attr("src"), window.location.origin);
-
-    // Set `source` query param to current page path + query string
-    originalSrc.searchParams.set("source", window.location.pathname + window.location.search);
-
-    if ($frame.attr("src") !== originalSrc.toString()) {
-      $frame.attr("src", originalSrc.toString());
+    const src = new URL($frame.data("src"), window.location.origin);
+    src.searchParams.set("source", window.location.pathname + window.location.search);
+    if ($frame.attr("src") !== src.toString()) {
+      $frame.attr("src", src.toString());
     }
   });
 });

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -94,7 +94,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t "javascripts.close" %>"></button>
       </div>
       <div class="modal-body px-1">
-        <turbo-frame id="select_language_list" src="<%= languages_pane_path %>?source=<%= ERB::Util.url_encode(request.fullpath) %>" loading="lazy">
+        <turbo-frame id="select_language_list" data-src="<%= languages_pane_path %>">
           <div class="text-center py-3"><%= render "loader" %></div>
         </turbo-frame>
       </div>


### PR DESCRIPTION
### Description
Resolves intermittent SelectLanguageTest errors and fixes #6712.

#### Problem
Opening the language selector loaded its Turbo Frame (`#select_language_list`) twice: once when the frame became visible, and again when `shown.bs.modal` rewrote `src` to add the current `source`. Every `turbo:frame-load` resets the search field, so the second (late) load could clear a query the user had already typed and the list snapped back to all languages. 
Besides the redundant request, this made `test/system/select_language_test.rb` flaky (the `"fra"` filter was wiped before the assertion).

#### Cause
- The frame auto-loaded via `src` (its `source` param baked in server-side, and stale after Turbo navigations).
- `shown.bs.modal` then set `src` again with the current `source` -> a second load, whose `turbo:frame-load` reset the search after the user could already interact.

#### Fix
Load the frame once, on `show.bs.modal` (before the dialog is interactive), with the current `source`, and only when it actually changes.

### How has this been tested?

Running the failing test in a local DEVCONTAINER a max of 30 times
```
for i in $(seq 1 30); do echo "run $i"; bin/rails test test/system/select_language_test.rb:6 || break; done
```
failed at the first the earliest or seventh the latest time. After adding to code of this PR this test ran 30 times without a problem.