### PR TITLE
Ignore invalid object IDs in various redirects

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -44,13 +44,13 @@ class SiteController < ApplicationController
 
     options = new_params.to_unsafe_h.to_options
 
-    path = if params.key? :node
+    path = if valid_id?(params[:node])
              node_path(params[:node], options)
-           elsif params.key? :way
+           elsif valid_id?(params[:way])
              way_path(params[:way], options)
-           elsif params.key? :relation
+           elsif valid_id?(params[:relation])
              relation_path(params[:relation], options)
-           elsif params.key? :changeset
+           elsif valid_id?(params[:changeset])
              changeset_path(params[:changeset], options)
            else
              root_url(options)
@@ -145,13 +145,13 @@ class SiteController < ApplicationController
   private
 
   def redirect_browse_params
-    if params[:node]
+    if valid_id?(params[:node])
       redirect_to node_path(params[:node])
-    elsif params[:way]
+    elsif valid_id?(params[:way])
       redirect_to way_path(params[:way])
-    elsif params[:relation]
+    elsif valid_id?(params[:relation])
       redirect_to relation_path(params[:relation])
-    elsif params[:note]
+    elsif valid_id?(params[:note])
       redirect_to note_path(params[:note])
     elsif params[:query]
       redirect_to search_path(:query => params[:query])
@@ -170,5 +170,9 @@ class SiteController < ApplicationController
     end
 
     redirect_to params.to_unsafe_h.merge(:only_path => true, :anchor => anchor.join("&")) if anchor.present?
+  end
+
+  def valid_id?(candidate)
+    candidate&.match?(/\A\d+\Z/)
   end
 end

--- a/test/controllers/site_controller_test.rb
+++ b/test/controllers/site_controller_test.rb
@@ -89,14 +89,30 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     get root_path(:node => 123)
     assert_redirected_to node_path(123)
 
+    get root_path(:node => "x")
+    assert_response :success
+    assert_template "index"
+
     get root_path(:way => 123)
     assert_redirected_to way_path(123)
+
+    get root_path(:way => "x")
+    assert_response :success
+    assert_template "index"
 
     get root_path(:relation => 123)
     assert_redirected_to relation_path(123)
 
+    get root_path(:relation => "x")
+    assert_response :success
+    assert_template "index"
+
     get root_path(:note => 123)
     assert_redirected_to :controller => :notes, :action => :show, :id => 123
+
+    get root_path(:note => "x")
+    assert_response :success
+    assert_template "index"
 
     get root_path(:query => "test")
     assert_redirected_to search_path(:query => "test")
@@ -131,14 +147,26 @@ class SiteControllerTest < ActionDispatch::IntegrationTest
     get permalink_path(:code => "wBz3--", :node => 1)
     assert_redirected_to node_path(1, :anchor => "map=3/4.8779296875/3.955078125")
 
+    get permalink_path(:code => "wBz3--", :node => "x")
+    assert_redirected_to :controller => :site, :action => :index, :anchor => "map=3/4.8779296875/3.955078125"
+
     get permalink_path(:code => "wBz3--", :way => 2)
     assert_redirected_to way_path(2, :anchor => "map=3/4.8779296875/3.955078125")
+
+    get permalink_path(:code => "wBz3--", :way => "x")
+    assert_redirected_to :controller => :site, :action => :index, :anchor => "map=3/4.8779296875/3.955078125"
 
     get permalink_path(:code => "wBz3--", :relation => 3)
     assert_redirected_to relation_path(3, :anchor => "map=3/4.8779296875/3.955078125")
 
+    get permalink_path(:code => "wBz3--", :relation => "x")
+    assert_redirected_to :controller => :site, :action => :index, :anchor => "map=3/4.8779296875/3.955078125"
+
     get permalink_path(:code => "wBz3--", :changeset => 4)
     assert_redirected_to changeset_path(4, :anchor => "map=3/4.8779296875/3.955078125")
+
+    get permalink_path(:code => "wBz3--", :changeset => "x")
+    assert_redirected_to :controller => :site, :action => :index, :anchor => "map=3/4.8779296875/3.955078125"
   end
 
   # Test the edit page redirects when you aren't logged in


### PR DESCRIPTION
This fixes some exceptions seen in glitchtip when people pass invalid node/way/relation IDs and we try and build URLs from them causing a `ActionController::UrlGenerationError` exception.