### PR TITLE
Make Moderation Zone Note Error more user friendly

### DIFF
--- a/app/assets/javascripts/index_modules/new_note.js
+++ b/app/assets/javascripts/index_modules/new_note.js
@@ -21,7 +21,8 @@ export default function (map) {
     })
       .then(resp => {
         if (resp.ok) return resp.json();
-        throw new Error(`HTTP Error ${resp.status} ${resp.statusText}`);
+        const message = resp.headers.get("Error") || `HTTP Error ${resp.status} ${resp.statusText}`;
+        throw new Error(message);
       });
   }
 

--- a/lib/osm.rb
+++ b/lib/osm.rb
@@ -29,7 +29,7 @@ module OSM
   end
 
   class APIModerationZoneError < APIAccessDenied
-    def initialize(message = "You don't have permissions to make changes in this zone, as it is currently protected by moderators")
+    def initialize(message = "You don't have permissions to make changes here. Please either sign in or create an OpenStreetMap account")
       super
     end
 

--- a/test/controllers/api/notes_controller_test.rb
+++ b/test/controllers/api/notes_controller_test.rb
@@ -213,7 +213,7 @@ module Api
         end
       end
       assert_response :forbidden
-      assert_equal "You don't have permissions to make changes in this zone, as it is currently protected by moderators", response.headers["Error"]
+      assert_equal "You don't have permissions to make changes here. Please either sign in or create an OpenStreetMap account", response.headers["Error"]
     end
 
     def test_create_success


### PR DESCRIPTION
### Description
Resolves #7276.
API sends a more explicit message than 403 in the HTTP-header already, this is now displayed.

Additionally, that message is now a bit more generic and encourages login/account creation.

<img width="358" height="196" alt="image" src="https://github.com/user-attachments/assets/fab38b6a-590a-4408-9173-50545da9cda2" />

### How has this been tested?
Local DEVCONTAINER instance.
