### PR TITLE
Fix flaky EmbedTests

### DIFF
--- a/test/system/embed_test.rb
+++ b/test/system/embed_test.rb
@@ -5,6 +5,6 @@ require "application_system_test_case"
 class EmbedTest < ApplicationSystemTestCase
   test "shows localized report link" do
     visit export_embed_path
-    assert_link "Report a problem"
+    assert_link "Report a problem", :wait => 30
   end
 end

--- a/test/system/german_embed_test.rb
+++ b/test/system/german_embed_test.rb
@@ -12,6 +12,6 @@ class GermanEmbedTest < ApplicationSystemTestCase
 
   test "shows localized report link" do
     visit export_embed_path
-    assert_link "Ein Problem melden"
+    assert_link "Ein Problem melden", :wait => 30
   end
 end

--- a/test/system/unknown_language_embed_test.rb
+++ b/test/system/unknown_language_embed_test.rb
@@ -12,6 +12,6 @@ class UnknownLanguageEmbedTest < ApplicationSystemTestCase
 
   test "shows report link in fallback language" do
     visit export_embed_path
-    assert_link "Report a problem"
+    assert_link "Report a problem", :wait => 30
   end
 end


### PR DESCRIPTION
### Description
test "shows localized report link" in `EmbedTest` and `GermanEmbedTest`, test "shows report link in fallback language" in `UnknownLanguageEmbedTest` fail intermittently only in GH actions, not locally.

#### Cause
The embed is a MapLibre GL (WebGL) map, and the "Report a problem" link is added client-side by the attribution control after the map initializes (`app/assets/javascripts/maplibre/attribution.js`). 
`assert_link` only auto-waits up to `Capybara.default_max_wait_time` (2 s). Locally this control appears in ~0.3 s, so the test always passes. In CI (parallel workers, slower runners, headless Firefox with software WebGL) the map/control init occasionally takes longer than 2 s, so the assertion times out. 
It is a timing race against WebGL init, not a logic error, confirmed by lowering `default_max_wait_time` to 0.1 s locally, which reproduces the failure.

#### Fix
Give this WebGL-dependent assertion a larger, explicit wait instead of relying on the 2 s 

### How has this been tested?
Local DEVCONTAINER instance, passed the test when running on the default value, but lowering the timeout to a ridiciously low value resulted in the same error. Maximum wait time (now 30 s) is up for debate.