### PR TITLE
Update dependabot configuration to allow all gem upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: "bundler"
     versioning-strategy: "lockfile-only"
     directory: "/"
+    allow:
+      - dependency-type: "all"
     groups:
       rails:
         applies-to: version-updates

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ gem "turbo-rails"
 gem "activerecord-postgis"
 gem "pg"
 
-# Sprockets does not support json 3.x yet
+# active_support does not support json 3.x yet
+# https://github.com/rails/rails/pull/58601 (merged but not yet released)
 gem "json", "< 3.0.0"
 
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -873,8 +873,8 @@ GEM
     snaky_hash (2.0.7)
       hashie (>= 0.1.0, < 6)
       version_gem (~> 1.1, >= 1.1.14)
-    sprockets (4.2.2)
-      concurrent-ruby (~> 1.0)
+    sprockets (4.4.1)
+      concurrent-ruby (~> 1.1)
       logger
       rack (>= 2.2.4, < 4)
     sprockets-exporters_pack (0.1.2)


### PR DESCRIPTION
I was surprised looking at 7629f9a0780e11215711748f00dd8384d95842f7 because the linked issue was merged a month ago and there's already been several releases of sprockets since.

So the key question is why dependabot seems to be ignoring sprockets. This is because by default it only looks at "top-level" gems (specified in the Gemfile) and only the dependencies of top-levels gem that are being updated. So if the top-level gem hasn't been updated, none of its dependencies are considered. This is a problem for wrapper gems (like `dartsass-sprockets`) which don't get updated very often, even if the underlying dependency (e.g. `sprockets`) is where the action happens.

This PR changes the dependabot configuration to [consider all gem dependencies](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#dependency-type-allow). There's no similar configuration for npm/yarn so there is nothing that needs changing here.

In this PR I also updated sprockets, to a version that supports json 3, but it turns out that we still need to wait on a rails/active_support release too. I've updated the Gemfile with this information.